### PR TITLE
Fix auto-discovery for latest versions on Kubernetes

### DIFF
--- a/kube_apiserver_metrics/assets/configuration/spec.yaml
+++ b/kube_apiserver_metrics/assets/configuration/spec.yaml
@@ -32,9 +32,24 @@ files:
     options: []
   - template: instances
     options:
-    - name: prometheus_url
+    - name: prometheus_possible_urls
       required: true
-      description: The URL where your application metrics are exposed by Prometheus.
+      description: |
+        The URLs to try to get your application metrics that are exposed by Prometheus.
+        The check will try each URLs in the list and will use the first working one.
+        One of prometheus_possible_urls or prometheus_url parameter is required.
+      value:
+        type: array
+        items:
+          type: string
+        example:
+          - https://%%host%%:6443/metrics
+          - https://%%host%%:8443/metrics
+    - name: prometheus_url
+      required: false
+      description: |
+        The URL where your application metrics are exposed by Prometheus.
+        One of prometheus_possible_urls or prometheus_url parameter is required.
       value:
         example: https://%%host%%:6443/metrics
         type: string

--- a/kube_apiserver_metrics/assets/configuration/spec.yaml
+++ b/kube_apiserver_metrics/assets/configuration/spec.yaml
@@ -32,12 +32,12 @@ files:
     options: []
   - template: instances
     options:
-    - name: prometheus_possible_urls
+    - name: possible_prometheus_urls
       required: true
       description: |
         The URLs to try to get your application metrics that are exposed by Prometheus.
         The check will try each URLs in the list and will use the first working one.
-        One of prometheus_possible_urls or prometheus_url parameter is required.
+        One of possible_prometheus_urls or prometheus_url parameter is required.
       value:
         type: array
         items:
@@ -49,7 +49,7 @@ files:
       required: false
       description: |
         The URL where your application metrics are exposed by Prometheus.
-        One of prometheus_possible_urls or prometheus_url parameter is required.
+        One of possible_prometheus_urls or prometheus_url parameter is required.
       value:
         example: https://%%host%%:6443/metrics
         type: string

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
@@ -14,18 +14,18 @@ init_config:
 #
 instances:
 
-    ## @param prometheus_possible_urls - list of strings - required
+    ## @param possible_prometheus_urls - list of strings - required
     ## The URLs to try to get your application metrics that are exposed by Prometheus.
     ## The check will try each URLs in the list and will use the first working one.
-    ## One of prometheus_possible_urls or prometheus_url parameter is required.
+    ## One of possible_prometheus_urls or prometheus_url parameter is required.
     #
-  - prometheus_possible_urls:
+  - possible_prometheus_urls:
       - https://%%host%%:6443/metrics
       - https://%%host%%:8443/metrics
 
     ## @param prometheus_url - string - optional - default: https://%%host%%:6443/metrics
     ## The URL where your application metrics are exposed by Prometheus.
-    ## One of prometheus_possible_urls or prometheus_url parameter is required.
+    ## One of possible_prometheus_urls or prometheus_url parameter is required.
     #
     # prometheus_url: https://%%host%%:6443/metrics
 

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
@@ -14,10 +14,20 @@ init_config:
 #
 instances:
 
-    ## @param prometheus_url - string - required
-    ## The URL where your application metrics are exposed by Prometheus.
+    ## @param prometheus_possible_urls - list(string) - optional
+    ## The URLs to try to get your application metrics that are exposed by Prometheus.
+    ## The check will try each URLs in the list and will use the first working one.
+    ## One of prometheus_possible_urls or prometheus_url parameter is required.
     #
-  - prometheus_url: https://%%host%%:6443/metrics
+  - prometheus_possible_urls:
+      - https://%%host%%:6443/metrics
+      - https://%%host%%:8443/metrics
+
+    ## @param prometheus_url - string - optional
+    ## The URL where your application metrics are exposed by Prometheus.
+    ## One of prometheus_possible_urls or prometheus_url parameter is required.
+    #
+    # prometheus_url: https://%%host%%:6443/metrics
 
     ## @param bearer_token_auth - boolean - optional - default: true
     ## Used if you are using RBACs and need the Agent to authenticate

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
@@ -14,7 +14,7 @@ init_config:
 #
 instances:
 
-    ## @param prometheus_possible_urls - list(string) - optional
+    ## @param prometheus_possible_urls - list of strings - required
     ## The URLs to try to get your application metrics that are exposed by Prometheus.
     ## The check will try each URLs in the list and will use the first working one.
     ## One of prometheus_possible_urls or prometheus_url parameter is required.
@@ -23,7 +23,7 @@ instances:
       - https://%%host%%:6443/metrics
       - https://%%host%%:8443/metrics
 
-    ## @param prometheus_url - string - optional
+    ## @param prometheus_url - string - optional - default: https://%%host%%:6443/metrics
     ## The URL where your application metrics are exposed by Prometheus.
     ## One of prometheus_possible_urls or prometheus_url parameter is required.
     #


### PR DESCRIPTION
### What does this PR do?

Leverages the `possible_prometheus_urls` parameter introduced by #9573 in the auto-discovery configuration file.

### Motivation

Make the agent able to automatically monitor the Kube API server on most recent versions of Kubernetes without requiring too much user setup.
The goad is to simplify the Kubernetes control plane monitoring setup described in DataDog/documentation#10828.

### Additional Notes

Depending on the Kubernetes distribution, the API server can listen on two different default ports: `8443` and `6443`.
We need to try both in the auto-discovery configuration.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
