### PR TITLE
Fix auto-discovery for latest versions on Kubernetes

### DIFF
--- a/etcd/assets/configuration/spec.yaml
+++ b/etcd/assets/configuration/spec.yaml
@@ -44,12 +44,32 @@ files:
     options: []
   - template: instances
     options:
+    - name: prometheus_possible_urls
+      required: true
+      description: |
+        The URLs to try to get your application metrics that are exposed by Prometheus.
+        The check will try each URLs in the list and will use the first working one.
+        One of prometheus_possible_urls or prometheus_url parameter is required.
+      value:
+        type: array
+        items:
+          type: string
+        example:
+          - https://%%host%%:2379/metrics
+          - http://%%host%%:2379/metrics
     - name: prometheus_url
       description: |
         Prometheus endpoint of your etcd instance.
+        One of prometheus_possible_urls or prometheus_url parameter is required.
 
         Note: To monitor ETCD versions pre-3.x.x, set `use_preview` to `false` and use the `url` configuration option.
-      required: true
+      required: false
       value:
         example: http://%%host%%:2379/metrics
         type: string
+    - name: ssl_verify
+      required: true
+      description: Used to verify self signed certificates.
+      value:
+        type: boolean
+        example: false

--- a/etcd/assets/configuration/spec.yaml
+++ b/etcd/assets/configuration/spec.yaml
@@ -44,12 +44,12 @@ files:
     options: []
   - template: instances
     options:
-    - name: prometheus_possible_urls
+    - name: possible_prometheus_urls
       required: true
       description: |
         The URLs to try to get your application metrics that are exposed by Prometheus.
         The check will try each URLs in the list and will use the first working one.
-        One of prometheus_possible_urls or prometheus_url parameter is required.
+        One of possible_prometheus_urls or prometheus_url parameter is required.
       value:
         type: array
         items:
@@ -60,7 +60,7 @@ files:
     - name: prometheus_url
       description: |
         Prometheus endpoint of your etcd instance.
-        One of prometheus_possible_urls or prometheus_url parameter is required.
+        One of possible_prometheus_urls or prometheus_url parameter is required.
 
         Note: To monitor ETCD versions pre-3.x.x, set `use_preview` to `false` and use the `url` configuration option.
       required: false

--- a/etcd/datadog_checks/etcd/data/auto_conf.yaml
+++ b/etcd/datadog_checks/etcd/data/auto_conf.yaml
@@ -14,7 +14,7 @@ init_config:
 #
 instances:
 
-    ## @param prometheus_possible_urls - list(string) - optional
+    ## @param prometheus_possible_urls - list of strings - required
     ## The URLs to try to get your application metrics that are exposed by Prometheus.
     ## The check will try each URLs in the list and will use the first working one.
     ## One of prometheus_possible_urls or prometheus_url parameter is required.
@@ -23,7 +23,7 @@ instances:
       - https://%%host%%:2379/metrics
       - http://%%host%%:2379/metrics
 
-    ## @param prometheus_url - string - optional
+    ## @param prometheus_url - string - optional - default: http://%%host%%:2379/metrics
     ## Prometheus endpoint of your etcd instance.
     ## One of prometheus_possible_urls or prometheus_url parameter is required.
     ##
@@ -31,7 +31,7 @@ instances:
     #
     # prometheus_url: http://%%host%%:2379/metrics
 
-    ## @param ssl_verify - boolean - optional - default: true
+    ## @param ssl_verify - boolean - required
     ## Used to verify self signed certificates.
     #
     ssl_verify: false

--- a/etcd/datadog_checks/etcd/data/auto_conf.yaml
+++ b/etcd/datadog_checks/etcd/data/auto_conf.yaml
@@ -14,18 +14,18 @@ init_config:
 #
 instances:
 
-    ## @param prometheus_possible_urls - list of strings - required
+    ## @param possible_prometheus_urls - list of strings - required
     ## The URLs to try to get your application metrics that are exposed by Prometheus.
     ## The check will try each URLs in the list and will use the first working one.
-    ## One of prometheus_possible_urls or prometheus_url parameter is required.
+    ## One of possible_prometheus_urls or prometheus_url parameter is required.
     #
-  - prometheus_possible_urls:
+  - possible_prometheus_urls:
       - https://%%host%%:2379/metrics
       - http://%%host%%:2379/metrics
 
     ## @param prometheus_url - string - optional - default: http://%%host%%:2379/metrics
     ## Prometheus endpoint of your etcd instance.
-    ## One of prometheus_possible_urls or prometheus_url parameter is required.
+    ## One of possible_prometheus_urls or prometheus_url parameter is required.
     ##
     ## Note: To monitor ETCD versions pre-3.x.x, set `use_preview` to `false` and use the `url` configuration option.
     #

--- a/etcd/datadog_checks/etcd/data/auto_conf.yaml
+++ b/etcd/datadog_checks/etcd/data/auto_conf.yaml
@@ -14,9 +14,24 @@ init_config:
 #
 instances:
 
-    ## @param prometheus_url - string - required
+    ## @param prometheus_possible_urls - list(string) - optional
+    ## The URLs to try to get your application metrics that are exposed by Prometheus.
+    ## The check will try each URLs in the list and will use the first working one.
+    ## One of prometheus_possible_urls or prometheus_url parameter is required.
+    #
+  - prometheus_possible_urls:
+      - https://%%host%%:2379/metrics
+      - http://%%host%%:2379/metrics
+
+    ## @param prometheus_url - string - optional
     ## Prometheus endpoint of your etcd instance.
+    ## One of prometheus_possible_urls or prometheus_url parameter is required.
     ##
     ## Note: To monitor ETCD versions pre-3.x.x, set `use_preview` to `false` and use the `url` configuration option.
     #
-  - prometheus_url: http://%%host%%:2379/metrics
+    # prometheus_url: http://%%host%%:2379/metrics
+
+    ## @param ssl_verify - boolean - optional - default: true
+    ## Used to verify self signed certificates.
+    #
+    ssl_verify: false


### PR DESCRIPTION
### What does this PR do?

Leverages the `prometheus_possible_urls` parameter introduced by #9573 in the auto-discovery configuration file.

### Motivation

The goad is to simplify the Kubernetes control plane monitoring setup described in DataDog/documentation#10828.

### Additional Notes

On older versions of Kubernetes, the etcd metrics were available at `http://%%host%%:2379/metrics` where `%%host%%` is the node IP.
On most recent version of Kubernetes, the etcd port is exposed only on secure `https` endpoint and requires ssl client certificate for authentication.

Whereas a client can decide to ignore a server certificate validation, a client has (thankfully) no way to ask the server to ignore client certificate validation.

That’s why the client ssl certificates needed to talk to etcd will need to be mounted from the host as described in DataDog/documentation#10828.

For `etcd`, there’s unfortunately no way to make integration work out-of-the-box without any user configuration.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
