### PR TITLE
Extend forbidden generic tag list

### DIFF
--- a/amazon_msk/tox.ini
+++ b/amazon_msk/tox.ini
@@ -24,3 +24,6 @@ passenv =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
+setenv =
+    ; OpenmetricsChecks sends generic tags
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/azure_iot_edge/tox.ini
+++ b/azure_iot_edge/tox.ini
@@ -33,3 +33,5 @@ setenv =
     IOT_EDGE_E2E_IOTEDGE_URL = https://github.com/Azure/azure-iotedge/releases/download/1.0.10-rc2/iotedge_1.0.10.rc2-1_ubuntu16.04_amd64.deb
     IOT_EDGE_E2E_IMAGE = mcr.microsoft.com/azureiotedge-agent:1.0.10-rc2
     tls: IOT_EDGE_E2E_TLS_ENABLED = true
+    ; OpenmetricsChecks sends generic tags
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/cilium/tox.ini
+++ b/cilium/tox.ini
@@ -26,4 +26,5 @@ commands =
     pytest -v {posargs}
 setenv =
     CILIUM_VERSION = 1.6.90
+    ; OpenmetricsChecks sends generic tags
     DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/confluent_platform/tox.ini
+++ b/confluent_platform/tox.ini
@@ -24,3 +24,6 @@ passenv =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
+setenv =
+    ; JMX check sends generic tags
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -177,7 +177,7 @@ def test_consul_request(aggregator, instance, mocker):
 
 
 def test_service_checks(aggregator):
-    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])
+    consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG_DISABLE_SERVICE_TAG])
     my_mocks = consul_mocks._get_consul_mocks()
     my_mocks['consul_request'] = consul_mocks.mock_get_health_check
     consul_mocks.mock_check(consul_check, my_mocks)
@@ -187,7 +187,6 @@ def test_service_checks(aggregator):
         "consul_datacenter:dc1",
         "check:server-loadbalancer",
         "consul_service_id:server-loadbalancer",
-        "service:server-loadbalancer",
         "consul_service:server-loadbalancer",
     ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.CRITICAL, tags=expected_tags, count=1)
@@ -196,7 +195,6 @@ def test_service_checks(aggregator):
         "consul_datacenter:dc1",
         "check:server-api",
         "consul_service_id:server-loadbalancer",
-        "service:server-loadbalancer",
         "consul_service:server-loadbalancer",
     ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.OK, tags=expected_tags, count=1)
@@ -204,7 +202,6 @@ def test_service_checks(aggregator):
     expected_tags = [
         "consul_datacenter:dc1",
         "check:server-api",
-        "service:server-loadbalancer",
         "consul_service:server-loadbalancer",
     ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.OK, tags=expected_tags, count=1)
@@ -216,7 +213,6 @@ def test_service_checks(aggregator):
         "consul_datacenter:dc1",
         "check:server-status-empty",
         "consul_service_id:server-empty",
-        "service:server-empty",
         "consul_service:server-empty",
     ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.UNKNOWN, tags=expected_tags, count=1)

--- a/coredns/tox.ini
+++ b/coredns/tox.ini
@@ -17,6 +17,8 @@ platform = linux|darwin|win32
 setenv =
     1.2.0: COREDNS_VERSION=1.2.0
     1.7.0: COREDNS_VERSION=1.7.0
+    ; OpenmetricsChecks sends generic tags
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true
 passenv =
     DOCKER*
     COMPOSE*
@@ -26,6 +28,3 @@ deps =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
-setenv =
-    ; OpenmetricsChecks sends generic tags
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/coredns/tox.ini
+++ b/coredns/tox.ini
@@ -26,3 +26,6 @@ deps =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
+setenv =
+    ; OpenmetricsChecks sends generic tags
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -43,9 +43,12 @@ def check_tag_names(metric, tags):
         'cluster_name',
         'clustername',
         'cluster',
+        'env',
         'host_name',
         'hostname',
         'host',
+        'service',
+        'version',
     ]
 
     if not os.environ.get('DDEV_SKIP_GENERIC_TAGS_CHECK'):

--- a/datadog_checks_base/tox.ini
+++ b/datadog_checks_base/tox.ini
@@ -30,6 +30,9 @@ passenv =
 commands =
     pip install --extra-index-url https://datadoghq.dev/ci-wheels/bin -r requirements.in
     pytest -v {posargs} --benchmark-skip
+setenv =
+    ; OpenmetricsChecks sending generic tags
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true
 
 [testenv:bench]
 basepython = python3.8

--- a/etcd/tox.ini
+++ b/etcd/tox.ini
@@ -30,3 +30,5 @@ setenv =
     3.3.8: ETCD_VERSION=v3.3.8
     3.3.9: ETCD_VERSION=v3.3.9
     3.3.10: V3_PREVIEW=true
+    ; OpenmetricsChecks sends generic tags
+    3.3.10: DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/gitlab_runner/tox.ini
+++ b/gitlab_runner/tox.ini
@@ -25,3 +25,5 @@ commands =
     pytest -v {posargs}
 setenv =
     GITLAB_RUNNER_VERSION=10.8.0
+    ; OpenmetricsChecks sends generic tags
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/hdfs_namenode/tests/common.py
+++ b/hdfs_namenode/tests/common.py
@@ -24,7 +24,7 @@ NAME_SYSTEM_URL = NAMENODE_JMX_URI + '?qry=Hadoop:service=NameNode,name=FSNamesy
 # Namesystem metadata url
 NAME_SYSTEM_METADATA_URL = NAMENODE_JMX_URI + '?qry=Hadoop:service=NameNode,name=NameNodeInfo'
 
-CUSTOM_TAGS = ["cluster_name:hdfs_dev", "instance:level_tags"]
+CUSTOM_TAGS = ["hdfs_cluster:hdfs_dev", "instance:level_tags"]
 
 # Authentication Parameters
 TEST_USERNAME = 'Picard'

--- a/hdfs_namenode/tox.ini
+++ b/hdfs_namenode/tox.ini
@@ -21,7 +21,6 @@ passenv =
     DOCKER*
     COMPOSE*
 setenv =
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true
     2.7.1: HDFS_RAW_VERSION=2.7.1
     2.7.1: HDFS_IMAGE_TAG=1.1.0-hadoop2.7.1-java8
 commands =

--- a/kong/tox.ini
+++ b/kong/tox.ini
@@ -22,6 +22,8 @@ deps =
     -rrequirements-dev.txt
 setenv =
     1.5: KONG_VERSION=1.5.0
+    ; OpenmetricsChecks sends generic tags
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true
 commands =
     pip install -r requirements.in
     pytest -v {posargs}

--- a/kubernetes_state/tox.ini
+++ b/kubernetes_state/tox.ini
@@ -18,3 +18,6 @@ deps =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
+setenv =
+    ; OpenmetricsChecks sends generic tags
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/marathon/tox.ini
+++ b/marathon/tox.ini
@@ -23,3 +23,5 @@ passenv =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
+setenv =
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/php_fpm/tests/test_e2e.py
+++ b/php_fpm/tests/test_e2e.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.e2e
 
 
 def test_status(dd_agent_check, instance, ping_url_tag):
-    instance['tags'] = ['cluster:forums']
+    instance['tags'] = ['fpm_cluster:forums']
 
     aggregator = dd_agent_check(instance, rate=True)
 
@@ -23,16 +23,16 @@ def test_status(dd_agent_check, instance, ping_url_tag):
         'php_fpm.processes.max_reached',
     ]
 
-    expected_tags = ['cluster:forums', 'pool:www']
+    expected_tags = ['fpm_cluster:forums', 'pool:www']
     for metric in metrics:
         aggregator.assert_metric(metric, tags=expected_tags)
 
-    expected_tags = [ping_url_tag, 'cluster:forums']
+    expected_tags = [ping_url_tag, 'fpm_cluster:forums']
     aggregator.assert_service_check('php_fpm.can_ping', status=ServiceCheck.OK, tags=expected_tags)
 
 
 def test_status_fastcgi(dd_agent_check, instance_fastcgi, ping_url_tag_fastcgi):
-    instance_fastcgi['tags'] = ['cluster:forums']
+    instance_fastcgi['tags'] = ['fpm_cluster:forums']
 
     aggregator = dd_agent_check(instance_fastcgi, rate=True)
 
@@ -46,9 +46,9 @@ def test_status_fastcgi(dd_agent_check, instance_fastcgi, ping_url_tag_fastcgi):
         'php_fpm.processes.max_reached',
     ]
 
-    expected_tags = ['cluster:forums', 'pool:www']
+    expected_tags = ['fpm_cluster:forums', 'pool:www']
     for metric in metrics:
         aggregator.assert_metric(metric, tags=expected_tags)
 
-    expected_tags = [ping_url_tag_fastcgi, 'cluster:forums']
+    expected_tags = [ping_url_tag_fastcgi, 'fpm_cluster:forums']
     aggregator.assert_service_check('php_fpm.can_ping', status=ServiceCheck.OK, tags=expected_tags)

--- a/php_fpm/tests/test_php_fpm.py
+++ b/php_fpm/tests/test_php_fpm.py
@@ -19,7 +19,7 @@ def test_bad_ping_reply(check, instance, aggregator, ping_url_tag):
 
 
 def test_status(check, instance, aggregator, ping_url_tag):
-    instance['tags'] = ['cluster:forums']
+    instance['tags'] = ['fpm_cluster:forums']
     check.check(instance)
 
     metrics = [
@@ -32,16 +32,16 @@ def test_status(check, instance, aggregator, ping_url_tag):
         'php_fpm.processes.max_reached',
     ]
 
-    expected_tags = ['cluster:forums', 'pool:www']
+    expected_tags = ['fpm_cluster:forums', 'pool:www']
     for metric in metrics:
         aggregator.assert_metric(metric, tags=expected_tags)
 
-    expected_tags = [ping_url_tag, 'cluster:forums']
+    expected_tags = [ping_url_tag, 'fpm_cluster:forums']
     aggregator.assert_service_check('php_fpm.can_ping', status=check.OK, tags=expected_tags)
 
 
 def test_status_fastcgi(check, instance_fastcgi, aggregator, ping_url_tag_fastcgi):
-    instance_fastcgi['tags'] = ['cluster:forums']
+    instance_fastcgi['tags'] = ['fpm_cluster:forums']
     check.check(instance_fastcgi)
 
     metrics = [
@@ -54,9 +54,9 @@ def test_status_fastcgi(check, instance_fastcgi, aggregator, ping_url_tag_fastcg
         'php_fpm.processes.max_reached',
     ]
 
-    expected_tags = ['cluster:forums', 'pool:www']
+    expected_tags = ['fpm_cluster:forums', 'pool:www']
     for metric in metrics:
         aggregator.assert_metric(metric, tags=expected_tags)
 
-    expected_tags = [ping_url_tag_fastcgi, 'cluster:forums']
+    expected_tags = [ping_url_tag_fastcgi, 'fpm_cluster:forums']
     aggregator.assert_service_check('php_fpm.can_ping', status=check.OK, tags=expected_tags)

--- a/php_fpm/tox.ini
+++ b/php_fpm/tox.ini
@@ -24,5 +24,3 @@ deps =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
-setenv =
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/process/tests/common.py
+++ b/process/tests/common.py
@@ -96,7 +96,7 @@ def get_config_stubs():
                 'name': 'test_tags',
                 # index in the array for our find_pids mock
                 'search_string': ['test_5'],
-                'tags': ['onetag', 'env:prod'],
+                'tags': ['onetag', 'environment:prod'],
             },
             'mocked_processes': set([2]),
         },

--- a/rethinkdb/tests/common.py
+++ b/rethinkdb/tests/common.py
@@ -19,7 +19,7 @@ IS_RETHINKDB_2_3 = RAW_VERSION.startswith('2.3.')
 
 HOST = get_docker_hostname()
 
-TAGS = ['env:testing']
+TAGS = ['rethinkdb_env:testing']
 
 # Servers.
 # NOTE: server information is tightly coupled to the Docker Compose setup.

--- a/rethinkdb/tests/unit/test_config.py
+++ b/rethinkdb/tests/unit/test_config.py
@@ -32,7 +32,7 @@ def test_config(port_28016, min_collection_interval_10):
         'username': 'datadog-agent',
         'password': 's3kr3t',
         'tls_ca_cert': '/path/to/client.cert',
-        'tags': ['env:testing'],
+        'tags': ['rethinkdb_env:testing'],
     }  # type: Instance
 
     config = Config(instance)
@@ -40,7 +40,7 @@ def test_config(port_28016, min_collection_interval_10):
     assert config.port == 28016
     assert config.user == 'datadog-agent'
     assert config.tls_ca_cert == '/path/to/client.cert'
-    assert config.tags == ['env:testing']
+    assert config.tags == ['rethinkdb_env:testing']
 
 
 @pytest.mark.parametrize('value', [42, True, object()])

--- a/rethinkdb/tox.ini
+++ b/rethinkdb/tox.ini
@@ -27,7 +27,6 @@ commands =
     pip install -r requirements.in
     pytest -v {posargs}
 setenv =
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true
     ; Can't support lower 2.3 patch versions due to: https://github.com/rethinkdb/rethinkdb/issues/6108
     2.3: RETHINKDB_IMAGE = rethinkdb:2.3.6
     2.3: RETHINKDB_RAW_VERSION = 2.3.6

--- a/rethinkdb/tox.ini
+++ b/rethinkdb/tox.ini
@@ -27,6 +27,7 @@ commands =
     pip install -r requirements.in
     pytest -v {posargs}
 setenv =
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true
     ; Can't support lower 2.3 patch versions due to: https://github.com/rethinkdb/rethinkdb/issues/6108
     2.3: RETHINKDB_IMAGE = rethinkdb:2.3.6
     2.3: RETHINKDB_RAW_VERSION = 2.3.6

--- a/scylla/tox.ini
+++ b/scylla/tox.ini
@@ -28,3 +28,5 @@ setenv =
     3.1: SCYLLA_VERSION=3.1.2
     3.2: SCYLLA_VERSION=3.2.1
     3.3: SCYLLA_VERSION=3.3.1
+    ; OpenmetricsChecks sends generic tags
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/snowflake/tox.ini
+++ b/snowflake/tox.ini
@@ -22,3 +22,5 @@ passenv =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
+setenv =
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/varnish/tests/common.py
+++ b/varnish/tests/common.py
@@ -381,7 +381,7 @@ VARNISH_VERSION = os.getenv('VARNISH_VERSION')
 
 
 def get_config_by_version(name=None):
-    config = {"varnishstat": get_varnish_stat_path(), "tags": ["cluster:webs"]}
+    config = {"varnishstat": get_varnish_stat_path(), "tags": ["varnish_cluster:webs"]}
 
     if name:
         config["name"] = name

--- a/varnish/tests/test_e2e.py
+++ b/varnish/tests/test_e2e.py
@@ -11,4 +11,4 @@ from . import common
 def test_check(dd_agent_check, instance):
     aggregator = dd_agent_check(instance, rate=True)
     for mname in common.COMMON_METRICS:
-        aggregator.assert_metric(mname, tags=['cluster:webs', 'varnish_name:default'])
+        aggregator.assert_metric(mname, tags=['varnish_cluster:webs', 'varnish_name:default'])

--- a/varnish/tests/test_unit.py
+++ b/varnish/tests/test_unit.py
@@ -89,7 +89,7 @@ def test_command_line_manually_unhealthy(mock_subprocess, mock_version, mock_get
     args, _ = mock_subprocess.call_args
     assert args[0] == [common.VARNISHADM_PATH, '-S', common.SECRETFILE_PATH, 'debug.health']
     aggregator.assert_service_check(
-        "varnish.backend_healthy", status=check.CRITICAL, tags=['backend:default', 'cluster:webs'], count=1
+        "varnish.backend_healthy", status=check.CRITICAL, tags=['backend:default', 'varnish_cluster:webs'], count=1
     )
 
     mock_version.return_value = LooseVersion('4.1.0'), 'xml'
@@ -126,7 +126,7 @@ def test_command_line_post_varnish4(mock_subprocess, mock_version, mock_geteuid,
     args, _ = mock_subprocess.call_args
     assert args[0] == [common.VARNISHADM_PATH, '-S', common.SECRETFILE_PATH, 'debug.health']
     aggregator.assert_service_check(
-        "varnish.backend_healthy", status=check.OK, tags=['backend:backend2', 'cluster:webs'], count=1
+        "varnish.backend_healthy", status=check.OK, tags=['backend:backend2', 'varnish_cluster:webs'], count=1
     )
 
     mock_version.return_value = LooseVersion('4.1.0'), 'xml'
@@ -171,7 +171,7 @@ def test_command_line_post_varnish5(mock_subprocess, mock_version, mock_geteuid,
         '-p',
     ]
     aggregator.assert_service_check(
-        "varnish.backend_healthy", status=check.OK, tags=['backend:backend2', 'cluster:webs'], count=1
+        "varnish.backend_healthy", status=check.OK, tags=['backend:backend2', 'varnish_cluster:webs'], count=1
     )
 
     mock_version.return_value = LooseVersion('5.0.0'), 'json'
@@ -216,7 +216,7 @@ def test_command_line_post_varnish6_5(mock_subprocess, mock_version, mock_geteui
         '-p',
     ]
     aggregator.assert_service_check(
-        "varnish.backend_healthy", status=check.OK, tags=['backend:backend2', 'cluster:webs'], count=1
+        "varnish.backend_healthy", status=check.OK, tags=['backend:backend2', 'varnish_cluster:webs'], count=1
     )
 
     mock_version.return_value = LooseVersion('6.5.0'), 'json'
@@ -253,5 +253,5 @@ def test_command_line(mock_subprocess, mock_version, mock_geteuid, aggregator, c
     args, _ = mock_subprocess.call_args
     assert args[0] == [common.VARNISHADM_PATH, '-S', common.SECRETFILE_PATH, 'debug.health']
     aggregator.assert_service_check(
-        "varnish.backend_healthy", status=check.OK, tags=['backend:default', 'cluster:webs'], count=1
+        "varnish.backend_healthy", status=check.OK, tags=['backend:default', 'varnish_cluster:webs'], count=1
     )

--- a/varnish/tests/test_varnish.py
+++ b/varnish/tests/test_varnish.py
@@ -20,7 +20,7 @@ def test_check(aggregator, check, instance):
         metrics_to_check = common.COMMON_METRICS + common.METRICS_6
 
     for mname in metrics_to_check:
-        aggregator.assert_metric(mname, count=1, tags=['cluster:webs', 'varnish_name:default'])
+        aggregator.assert_metric(mname, count=1, tags=['varnish_cluster:webs', 'varnish_name:default'])
 
     aggregator.assert_all_metrics_covered()
     metadata_metrics = get_metadata_metrics()
@@ -33,9 +33,9 @@ def test_inclusion_filter(aggregator, check, instance):
     check.check(instance)
     for mname in common.COMMON_METRICS:
         if 'SMA.' in mname:
-            aggregator.assert_metric(mname, count=1, tags=['cluster:webs', 'varnish_name:default'])
+            aggregator.assert_metric(mname, count=1, tags=['varnish_cluster:webs', 'varnish_name:default'])
         else:
-            aggregator.assert_metric(mname, count=0, tags=['cluster:webs', 'varnish_name:default'])
+            aggregator.assert_metric(mname, count=0, tags=['varnish_cluster:webs', 'varnish_name:default'])
 
 
 def test_exclusion_filter(aggregator, check, instance):
@@ -44,9 +44,9 @@ def test_exclusion_filter(aggregator, check, instance):
     check.check(instance)
     for mname in common.COMMON_METRICS:
         if 'SMA.Transient.c_req' in mname:
-            aggregator.assert_metric(mname, count=0, tags=['cluster:webs', 'varnish_name:default'])
+            aggregator.assert_metric(mname, count=0, tags=['varnish_cluster:webs', 'varnish_name:default'])
         elif 'varnish.uptime' not in mname:
-            aggregator.assert_metric(mname, count=1, tags=['cluster:webs', 'varnish_name:default'])
+            aggregator.assert_metric(mname, count=1, tags=['varnish_cluster:webs', 'varnish_name:default'])
 
 
 def test_version_metadata(aggregator, check, instance, datadog_agent):

--- a/varnish/tox.ini
+++ b/varnish/tox.ini
@@ -21,7 +21,6 @@ deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true
     521: VARNISH_VERSION=5_2_1
     651: VARNISH_VERSION=6_5_1
 commands =


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Extend the forbidden generic tag list introduced in #9431  with https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/?tab=kubernetes as suggested here https://github.com/DataDog/integrations-core/pull/9431#discussion_r651921032

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Non-openmetrics/jmx integration to fix:
* Apache (`host`)
* Consul (`service`)
* Lighttpd (`host`)
* Mapr (`clustername`)
* Marathon (`version`)
* Mongo (at least `host`)
* Nginx (`host` in service_check)
* pgbouncer (`host` in service_check)
* postgres (at least `host`)
* rethinkdb (`host` in service_check)
* Snowflake (`service`)
* Sqlserver (at least `host` in service checks)
* Tokumx (at least `host` in service checks)
* Twemproxy (at least `host` in service checks)
* vertica (`host_name`)
* Voltdb (at least `host` in service checks)
* zk (`host`)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
