### PR TITLE
Fix insufficient rate limiting of statement samples 

### DIFF
--- a/postgres/setup.py
+++ b/postgres/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=20.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=20.0.1'
 
 setup(
     name='datadog-postgres',

--- a/postgres/setup.py
+++ b/postgres/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=18.3.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=20.0.0'
 
 setup(
     name='datadog-postgres',


### PR DESCRIPTION
### What does this PR do?

Fixes the previously incorrect rate limiting behavior which would allow ingestion of extra statement samples beyond the `maxsize` limit. The same problem existed for the `explained_statements` rate limit.

### Additional Notes

Depends on https://github.com/DataDog/integrations-core/pull/9582

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
