### PR TITLE
Add `RateLimitingTTLCache` to `db.utils`

### DIFF
--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -1,6 +1,7 @@
 aws-requests-auth==0.4.2
 binary==1.0.0
 botocore==1.13.42
+cachetools==3.1.1
 contextlib2==0.6.0; python_version < '3.0'
 cryptography==3.3.2; python_version < '3.0'
 cryptography==3.4.6; python_version > '3.0'

--- a/datadog_checks_base/tests/test_db_util.py
+++ b/datadog_checks_base/tests/test_db_util.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import time
+
+from datadog_checks.base.utils.db.utils import RateLimitingTTLCache
+
+
+def test_ratelimiting_ttl_cache():
+    ttl = 0.1
+    cache = RateLimitingTTLCache(maxsize=5, ttl=ttl)
+
+    for i in range(5):
+        assert cache.acquire(i), "cache is empty so the first set of keys should pass"
+    for i in range(5, 10):
+        assert not cache.acquire(i), "cache is full so we do not expect any more new keys to pass"
+    for i in range(5):
+        assert not cache.acquire(i), "none of the first set of keys should pass because they're still under TTL"
+
+    assert len(cache) == 5, "cache should be at the max size"
+    time.sleep(ttl * 2)
+    assert len(cache) == 0, "cache should be empty after the TTL has kicked in"
+
+    for i in range(5, 10):
+        assert cache.acquire(i), "cache should be empty again so these keys should go in OK"


### PR DESCRIPTION
### What does this PR do?

Add a new `RateLimitingTTLCache` for rate limiting by key during collection of statement samples and execution plans.

This ensures correct usage of the underlying `TTLCache` for the purpose of rate limiting.

### Motivation

Add a util for usage within the `postgres` and `mysql` checks to ensure they do rate limiting correctly. 

See example usage in https://github.com/DataDog/integrations-core/pull/9581 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
