### PR TITLE
Fix insufficient rate limiting of statement samples 

### DIFF
--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=18.3.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=20.0.0'
 
 setup(
     name='datadog-mysql',

--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=20.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=20.0.1'
 
 setup(
     name='datadog-mysql',

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -493,22 +493,61 @@ def test_statement_samples_collect(
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_statement_samples_rate_limit(aggregator, bob_conn, dbm_instance):
+def test_statement_samples_main_collection_rate_limit(aggregator, dbm_instance):
+    # test rate limiting of the main collection loop
+    collections_per_second = 10
+    dbm_instance['statement_samples']['collections_per_second'] = collections_per_second
     dbm_instance['statement_samples']['run_sync'] = False
-    dbm_instance['statement_samples']['collections_per_second'] = 0.5
-    query = "select name as nam from testdb.users where name = 'hello'"
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+    mysql_check.check(dbm_instance)
+    sleep_time = 1
+    time.sleep(sleep_time)
+    max_collections = int(collections_per_second * sleep_time) + 1
+    mysql_check.cancel()
+    metrics = aggregator.metrics("dd.mysql.collect_statement_samples.time")
+    assert max_collections / 2.0 <= len(metrics) <= max_collections
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_statement_samples_unique_plans_rate_limits(aggregator, bob_conn, dbm_instance):
+    # test unique sample ingestion rate limiting
+    cache_max_size = 20
+    dbm_instance['statement_samples']['run_sync'] = True
+    # fix the table to 'events_statements_current' to ensure we don't pull in historical queries from other tests
+    dbm_instance['statement_samples']['events_statements_table'] = 'events_statements_current'
+    dbm_instance['statement_samples']['seen_samples_cache_maxsize'] = cache_max_size
+    # samples_per_hour_per_query set very low so that within this test we will have at most one sample per
+    # (query, plan)
+    dbm_instance['statement_samples']['samples_per_hour_per_query'] = 1
+    dbm_instance['statement_samples']['collections_per_second'] = 100
+    query_template = "select {} from testdb.users where name = 'hello'"
+    # queries that have different numbers of columns are considered different queries
+    # i.e. "SELECT city, city FROM persons where city= 'hello'"
+    queries = [query_template.format(','.join(["name"] * i)) for i in range(1, 20)]
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
     with closing(bob_conn.cursor()) as cursor:
-        for _ in range(5):
-            cursor.execute(query)
-            mysql_check.check(dbm_instance)
-            time.sleep(1)
-    events = aggregator.get_event_platform_events("dbm-samples")
-    matching = [e for e in events if e['db']['statement'] == query]
-    assert len(matching) == 1, "should have collected exactly one event due to sample rate limit"
-    metrics = aggregator.metrics("dd.mysql.collect_statement_samples.time")
-    assert 2 < len(metrics) < 6
-    mysql_check.cancel()
+        for _ in range(3):
+            # repeat the same set of queries multiple times to ensure we're testing the per-query TTL rate limit
+            for q in queries:
+                cursor.execute(q)
+                mysql_check.check(dbm_instance)
+
+    def _sample_key(e):
+        return e['db']['query_signature'], e['db'].get('plan', {}).get('signature')
+
+    dbm_samples = [e for e in aggregator.get_event_platform_events("dbm-samples") if e.get('dbm_type') != 'fqt']
+    statement_counts = Counter(_sample_key(e) for e in dbm_samples)
+    assert len(statement_counts) == cache_max_size, "expected to collect at {} unique statements".format(cache_max_size)
+
+    for _, count in statement_counts.items():
+        assert count == 1, "expected to collect exactly one sample per (query, plan)"
+
+    # in addition to the test query, dbm_samples will also contain samples from other queries that the postgres
+    # integration is running
+    pattern = query_template.format("(name,?)+")
+    matching = [e for e in dbm_samples if re.match(pattern, e['db']['statement'])]
+    assert len(matching) > 0, "should have collected at least one matching event"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### What does this PR do?

Fixes the previously incorrect rate limiting behavior which would allow ingestion of extra statement samples beyond the `maxsize` limit. The same problem existed for the `explained_statements` rate limit.

### Additional Notes

Depends on https://github.com/DataDog/integrations-core/pull/9582

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
