### PR TITLE
Upgrade `psycopg2` on Python 3

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -44,7 +44,8 @@ ply==3.10
 prometheus-client==0.9.0
 protobuf==3.7.0
 psutil==5.7.2
-psycopg2-binary==2.8.6
+psycopg2-binary==2.8.6; python_version < "3.0"
+psycopg2-binary==2.9.1; python_version > "3.0"
 pyasn1==0.4.6
 pycryptodomex==3.10.1
 pydantic==1.8.2; python_version > "3.0"

--- a/postgres/requirements.in
+++ b/postgres/requirements.in
@@ -1,4 +1,5 @@
 cachetools==3.1.1
-psycopg2-binary==2.8.6
+psycopg2-binary==2.8.6; python_version < '3.0'
+psycopg2-binary==2.9.1; python_version > '3.0'
 semver==2.9.0
 futures==3.3.0; python_version < '3.0'


### PR DESCRIPTION
### Motivation

Ensure pin for continued Python 2 support