### PR TITLE
Fix Python 2 integer division bug in db.util `ConstantRateLimiter`

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -76,7 +76,7 @@ class ConstantRateLimiter:
         :param rate_limit_s: rate limit in seconds
         """
         self.rate_limit_s = rate_limit_s
-        self.period_s = 1 / rate_limit_s if rate_limit_s > 0 else 0
+        self.period_s = 1.0 / rate_limit_s if rate_limit_s > 0 else 0
         self.last_event = 0
 
     def sleep(self):

--- a/datadog_checks_base/tests/test_db_util.py
+++ b/datadog_checks_base/tests/test_db_util.py
@@ -2,9 +2,23 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import math
 import time
 
-from datadog_checks.base.utils.db.utils import RateLimitingTTLCache
+from datadog_checks.base.utils.db.utils import RateLimitingTTLCache, ConstantRateLimiter
+
+
+def test_constant_rate_limiter():
+    rate_limit = 8
+    test_duration_s = 0.5
+    ratelimiter = ConstantRateLimiter(rate_limit)
+    start = time.time()
+    sleep_count = 0
+    while time.time() - start < test_duration_s:
+        ratelimiter.sleep()
+        sleep_count += 1
+    max_expected_count = rate_limit * test_duration_s
+    assert max_expected_count - 1 <= sleep_count <= max_expected_count + 1
 
 
 def test_ratelimiting_ttl_cache():


### PR DESCRIPTION
### What does this PR do?

Explicitly do float division so the sleep duration is correctly calculated in python2.

### Motivation

Fix broken behavior. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
