### PR TITLE
Add truncated statement indicator to postgres query sample events

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -397,7 +397,7 @@ class PostgresStatementSamples(object):
         if not self._can_explain_statement(obfuscated_statement):
             return None, DBExplainError.no_plans_possible, None
 
-        if self._is_statement_truncated(max_query_size, statement) == StatementTruncationState.truncated:
+        if self._get_truncation_state(max_query_size, statement) == StatementTruncationState.truncated:
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 1,
@@ -494,7 +494,7 @@ class PostgresStatementSamples(object):
                     "application": row.get('application_name', None),
                     "user": row['usename'],
                     "statement": obfuscated_statement,
-                    "statement_truncated": self._is_statement_truncated(self._max_query_size, row['query']).value,
+                    "statement_truncated": self._get_truncation_state(self._max_query_size, row['query']).value,
                 },
                 'postgres': {k: v for k, v in row.items() if k not in pg_stat_activity_sample_exclude_keys},
             }
@@ -543,7 +543,7 @@ class PostgresStatementSamples(object):
             )
 
     @staticmethod
-    def _is_statement_truncated(max_query_size, statement):
+    def _get_truncation_state(max_query_size, statement):
         # Only check is a statement is truncated if the value of track_activity_query_size was loaded correctly
         # to avoid confusingly reporting a wrong indicator by using a default that might be wrong for the database
         if max_query_size == UNKNOWN_VALUE:

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -9,6 +9,7 @@ from typing import Dict, Optional, Tuple
 
 import psycopg2
 from cachetools import TTLCache
+from six import PY2
 
 try:
     import datadog_agent
@@ -26,6 +27,10 @@ from datadog_checks.base.utils.db.utils import (
 )
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.time import get_timestamp
+
+# according to https://unicodebook.readthedocs.io/unicode_encodings.html, the max supported size of a UTF-8 encoded
+# character is 6 bytes
+MAX_CHARACTER_SIZE_IN_BYTES = 6
 
 SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update', 'with'})
 
@@ -56,6 +61,20 @@ PG_STAT_ACTIVITY_QUERY = re.sub(
 
 EXPLAIN_VALIDATION_QUERY = "SELECT * FROM pg_stat_activity"
 
+MAX_ACTIVITY_QUERY_SIZE_QUERY = "SELECT setting FROM pg_settings WHERE name='track_activity_query_size'"
+
+UNKNOWN_VALUE = -1
+
+
+class StatementTruncationState(Enum):
+    """
+    Denotes the various possible states of a statement's truncation
+    """
+
+    truncated = 'truncated'
+    not_truncated = 'not_truncated'
+    unknown = 'unknown'
+
 
 class DBExplainError(Enum):
     """
@@ -76,6 +95,9 @@ class DBExplainError(Enum):
 
     # there could be a problem with the EXPLAIN function (missing, invalid permissions, or an incorrect definition)
     failed_function = 'failed_function'
+
+    # a truncated statement can't be explained
+    statement_truncated = "statement_truncated"
 
 
 class PostgresStatementSamples(object):
@@ -100,6 +122,8 @@ class PostgresStatementSamples(object):
         self._db_hostname = resolve_db_host(self._config.host)
         self._enabled = is_affirmative(self._config.statement_samples_config.get('enabled', False))
         self._run_sync = is_affirmative(self._config.statement_samples_config.get('run_sync', False))
+        # The value is loaded when connecting to the main database
+        self._max_query_size = UNKNOWN_VALUE
         self._rate_limiter = ConstantRateLimiter(
             float(self._config.statement_samples_config.get('collections_per_second', 1))
         )
@@ -226,6 +250,9 @@ class PostgresStatementSamples(object):
             db = self._check._new_connection(dbname)
             db.set_session(autocommit=True)
             self._db_pool[dbname] = db
+            # Reload the track_activity_query_size setting on a new connection to the main db
+            if self._config.dbname == dbname:
+                self._load_query_max_text_size(db)
         if db.status != psycopg2.extensions.STATUS_READY:
             # Some transaction went wrong and the connection is in an unhealthy state. Let's fix that
             db.rollback()
@@ -365,10 +392,22 @@ class PostgresStatementSamples(object):
                 return None
             return result[0][0]
 
-    def _run_explain_safe(self, dbname, statement, obfuscated_statement):
-        # type: (str, str, str) -> Tuple[Optional[Dict], Optional[DBExplainError], Optional[Exception]]
+    def _run_explain_safe(self, max_query_size, dbname, statement, obfuscated_statement):
+        # type: (int, str, str, str) -> Tuple[Optional[Dict], Optional[DBExplainError], Optional[str]]
         if not self._can_explain_statement(obfuscated_statement):
             return None, DBExplainError.no_plans_possible, None
+
+        if self._is_statement_truncated(max_query_size, statement) == StatementTruncationState.truncated:
+            self._check.count(
+                "dd.postgres.statement_samples.error",
+                1,
+                tags=self._dbtags(dbname, "error:explain-{}".format(DBExplainError.statement_truncated)),
+            )
+            return (
+                None,
+                DBExplainError.statement_truncated,
+                "track_activity_query_size={}".format(max_query_size),
+            )
 
         db_explain_error, err = self._get_db_explain_setup_state_cached(dbname)
         if db_explain_error is not None:
@@ -377,7 +416,7 @@ class PostgresStatementSamples(object):
                 1,
                 tags=self._dbtags(dbname, "error:explain-{}".format(db_explain_error)),
             )
-            return None, db_explain_error, err
+            return None, db_explain_error, type(err)
 
         try:
             return self._run_explain(dbname, statement, obfuscated_statement), None, None
@@ -388,7 +427,7 @@ class PostgresStatementSamples(object):
                 1,
                 tags=self._dbtags(dbname, "error:explain-{}".format(type(e))),
             )
-            return None, DBExplainError.database_error, e
+            return None, DBExplainError.database_error, type(e)
 
     def _collect_plan_for_statement(self, row):
         try:
@@ -411,10 +450,12 @@ class PostgresStatementSamples(object):
         # - `plan_signature` - hash computed from the normalized JSON plan to group identical plan trees
         # - `resource_hash` - hash computed off the raw sql text to match apm resources
         # - `query_signature` - hash computed from the raw sql text to match query metrics
-        plan_dict, explain_err_code, err = self._run_explain_safe(row['datname'], row['query'], obfuscated_statement)
+        plan_dict, explain_err_code, err_msg = self._run_explain_safe(
+            self._max_query_size, row['datname'], row['query'], obfuscated_statement
+        )
         collection_error = None
         if explain_err_code:
-            collection_error = {'code': explain_err_code.value, 'message': '{}'.format(type(err)) if err else None}
+            collection_error = {'code': explain_err_code.value, 'message': '{}'.format(err_msg) if err_msg else None}
 
         plan, normalized_plan, obfuscated_plan, plan_signature, plan_cost = None, None, None, None, None
         if plan_dict:
@@ -453,6 +494,7 @@ class PostgresStatementSamples(object):
                     "application": row.get('application_name', None),
                     "user": row['usename'],
                     "statement": obfuscated_statement,
+                    "statement_truncated": self._is_statement_truncated(self._max_query_size, row['query']).value,
                 },
                 'postgres': {k: v for k, v in row.items() if k not in pg_stat_activity_sample_exclude_keys},
             }
@@ -484,3 +526,35 @@ class PostgresStatementSamples(object):
                     1,
                     tags=self._tags + ["error:collect-plan-for-statement-crash"],
                 )
+
+    def _load_query_max_text_size(self, db):
+        try:
+            with db.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
+                self._log.debug("Running query [%s]", MAX_ACTIVITY_QUERY_SIZE_QUERY)
+                cursor.execute(MAX_ACTIVITY_QUERY_SIZE_QUERY)
+                row = cursor.fetchone()
+                self._max_query_size = int(row['setting'])
+        except (psycopg2.DatabaseError, psycopg2.OperationalError) as e:
+            self._log.warning("cannot read track_activity_query_size from pg_settings: %s", repr(e))
+            self._check.count(
+                "dd.postgres.statement_samples.error",
+                1,
+                tags=self._tags + ["error:load-track-activity-query-size"],
+            )
+
+    @staticmethod
+    def _is_statement_truncated(max_query_size, statement):
+        # Only check is a statement is truncated if the value of track_activity_query_size was loaded correctly
+        # to avoid confusingly reporting a wrong indicator by using a default that might be wrong for the database
+        if max_query_size == UNKNOWN_VALUE:
+            return StatementTruncationState.unknown
+
+        # Compare the query length (in bytes to match Postgres) to the configured max query size to determine
+        # if the query has been truncated. Note that the length of a truncated statement
+        # can be less than the value of 'track_activity_query_size' by MAX_CHARACTER_SIZE_IN_BYTES + 1 because
+        # multi-byte characters that fall on the limit are left out. One caveat is that if a statement's length
+        # happens to be greater or equal to the threshold below but isn't actually truncated, this
+        # would falsely report it as a truncated statement
+        statement_bytes = bytes(statement) if PY2 else bytes(statement, "utf-8")
+        truncated = len(statement_bytes) >= max_query_size - (MAX_CHARACTER_SIZE_IN_BYTES + 1)
+        return StatementTruncationState.truncated if truncated else StatementTruncationState.not_truncated

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -416,7 +416,7 @@ class PostgresStatementSamples(object):
                 1,
                 tags=self._dbtags(dbname, "error:explain-{}".format(db_explain_error)),
             )
-            return None, db_explain_error, type(err)
+            return None, db_explain_error, '{}'.format(type(err))
 
         try:
             return self._run_explain(dbname, statement, obfuscated_statement), None, None
@@ -427,7 +427,7 @@ class PostgresStatementSamples(object):
                 1,
                 tags=self._dbtags(dbname, "error:explain-{}".format(type(e))),
             )
-            return None, DBExplainError.database_error, type(e)
+            return None, DBExplainError.database_error, '{}'.format(type(err))
 
     def _collect_plan_for_statement(self, row):
         try:
@@ -455,7 +455,7 @@ class PostgresStatementSamples(object):
         )
         collection_error = None
         if explain_err_code:
-            collection_error = {'code': explain_err_code.value, 'message': '{}'.format(err_msg) if err_msg else None}
+            collection_error = {'code': explain_err_code.value, 'message': err_msg if err_msg else None}
 
         plan, normalized_plan, obfuscated_plan, plan_signature, plan_cost = None, None, None, None, None
         if plan_dict:


### PR DESCRIPTION
### What does this PR do?
This adds a boolean field to postgres query sample events so we can later surface this to users. 

### Motivation
We'd like to be able to surface when a statement has been truncated so we can advise uses on how to proceed to prevent truncation (which would be increasing `track_activity_query_size`).

### Additional Notes
The detection of a truncated statement is done by reading the `track_activity_query_size` postgres setting and checking the size of the query. Note that the length of queries is actually 1 less than the value of the setting as illustrated by this example below where the configuration was set to `100`:
```
select length(query), query from pg_stat_activity;
 length |                                                query
--------+-----------------------------------------------------------------------------------------------------
     99 | SELECT * FROM pg_stat_activity WHERE datname = 'postgres' AND coalesce(TRIM(query), '') != '' AND q
```

Also, note that this current version uses `sys.getsizeof` to get the size in bytes because that's how [postgres defines it](https://www.postgresql.org/docs/9.5/runtime-config-statistics.html).

```
track_activity_query_size (integer)
Specifies the number of bytes reserved to track the currently executing command for each active session, for the pg_stat_activity.query field. The default value is 1024. This parameter can only be set at server start.
```

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
