### PR TITLE
Add negative-lookahead example for `exclude_metrics` OpenMetrics option

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -135,6 +135,9 @@
   description: |
     A list of metrics to exclude, with each entry being either
     the exact metric name or a regular expression.
+    In order to exclude all metrics but the one matching a specific filter,
+    you can use a negative lookahead regex like so:
+      - ^(?!foo).*$
   value:
     type: array
     items:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -135,8 +135,8 @@
   description: |
     A list of metrics to exclude, with each entry being either
     the exact metric name or a regular expression.
-    In order to exclude all metrics but the one matching a specific filter,
-    you can use a negative lookahead regex like so:
+    In order to exclude all metrics but the ones matching a specific filter,
+    you can use a negative lookahead regex like:
       - ^(?!foo).*$
   value:
     type: array

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -107,6 +107,9 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
+    ## In order to exclude all metrics but the one matching a specific filter,
+    ## you can use a negative lookahead regex like so:
+    ##   - ^(?!foo).*$
     #
     # exclude_metrics: []
 

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -107,8 +107,8 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
-    ## In order to exclude all metrics but the one matching a specific filter,
-    ## you can use a negative lookahead regex like so:
+    ## In order to exclude all metrics but the ones matching a specific filter,
+    ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$
     #
     # exclude_metrics: []


### PR DESCRIPTION
Add a brief example to the openmetrics.yaml file to show how to exclude all metrics but the one matching a filter.