### PR TITLE
Update k8s dashboards to use `kube_cluster_name` tags instead of `cluster_name`

### DIFF
--- a/coredns/assets/dashboards/coredns.json
+++ b/coredns/assets/dashboards/coredns.json
@@ -654,7 +654,7 @@
       }
     ],
     "template_variables": [
-      { "name": "cluster", "default": "*", "prefix": "cluster_name" },
+      { "name": "cluster", "default": "*", "prefix": "kube_cluster_name" },
       { "name": "deployment", "default": "*", "prefix": "kube_deployment" },
       { "name": "service", "default": "*", "prefix": "kube_service" },
       { "name": "namespace", "default": "*", "prefix": "kube_namespace" },

--- a/kube_controller_manager/assets/dashboards/overview.json
+++ b/kube_controller_manager/assets/dashboards/overview.json
@@ -323,7 +323,7 @@
     {
       "name": "cluster_name",
       "default": "*",
-      "prefix": "cluster_name"
+      "prefix": "kube_cluster_name"
     },
     {
       "name": "quantile",

--- a/kube_scheduler/assets/dashboards/overview.json
+++ b/kube_scheduler/assets/dashboards/overview.json
@@ -632,7 +632,7 @@
     {
       "name": "cluster_name",
       "default": "*",
-      "prefix": "cluster_name"
+      "prefix": "kube_cluster_name"
     }
   ],
   "layout_type": "free",

--- a/kubernetes/assets/dashboards/kubernetes_dashboard.json
+++ b/kubernetes/assets/dashboards/kubernetes_dashboard.json
@@ -1204,7 +1204,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes.pods.running{$scope,$cluster,$namespace,$deployment,$daemonset,$label,$node,$service} by {cluster_name,kube_namespace}",
+                        "q": "sum:kubernetes.pods.running{$scope,$cluster,$namespace,$deployment,$daemonset,$label,$node,$service} by {kube_cluster_name,kube_namespace}",
                         "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
@@ -1245,7 +1245,7 @@
                 "type": "toplist",
                 "requests": [
                     {
-                        "q": "top(sum:kubernetes_state.pod.status_phase{$scope,$cluster,$namespace,$deployment,$daemonset,!phase:running,!phase:succeeded,$label,$node,$service} by {cluster_name,kube_namespace,phase}, 100, 'last', 'desc')",
+                        "q": "top(sum:kubernetes_state.pod.status_phase{$scope,$cluster,$namespace,$deployment,$daemonset,!phase:running,!phase:succeeded,$label,$node,$service} by {kube_cluster_name,kube_namespace,phase}, 100, 'last', 'desc')",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
@@ -1321,7 +1321,7 @@
                 "type": "toplist",
                 "requests": [
                     {
-                        "q": "top(sum:kubernetes.pods.running{$scope,$namespace,$deployment,$cluster,$daemonset,$label,$node,$service} by {cluster_name,kube_namespace}, 100, 'max', 'desc')",
+                        "q": "top(sum:kubernetes.pods.running{$scope,$namespace,$deployment,$cluster,$daemonset,$label,$node,$service} by {kube_cluster_name,kube_namespace}, 100, 'max', 'desc')",
                         "conditional_formats": [
                             {
                                 "comparator": ">",
@@ -1397,7 +1397,7 @@
                 "type": "query_value",
                 "requests": [
                     {
-                        "q": "count_nonzero(avg:kubernetes.pods.running{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster} by {cluster_name})",
+                        "q": "count_nonzero(avg:kubernetes.pods.running{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster} by {kube_cluster_name})",
                         "aggregator": "avg"
                     }
                 ],
@@ -1420,7 +1420,7 @@
                 "type": "query_value",
                 "requests": [
                     {
-                        "q": "count_nonzero(avg:kubernetes.pods.running{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster} by {cluster_name,kube_namespace})",
+                        "q": "count_nonzero(avg:kubernetes.pods.running{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster} by {kube_cluster_name,kube_namespace})",
                         "aggregator": "avg"
                     }
                 ],
@@ -1443,7 +1443,7 @@
                 "type": "query_value",
                 "requests": [
                     {
-                        "q": "count_nonzero(avg:kubernetes_state.deployment.replicas{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster} by {cluster_name,kube_namespace,kube_deployment})",
+                        "q": "count_nonzero(avg:kubernetes_state.deployment.replicas{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster} by {kube_cluster_name,kube_namespace,kube_deployment})",
                         "aggregator": "avg"
                     }
                 ],
@@ -1489,7 +1489,7 @@
                 "type": "query_value",
                 "requests": [
                     {
-                        "q": "count_nonzero(avg:kubernetes_state.daemonset.desired{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster} by {cluster_name,kube_namespace,kube_daemon_set})",
+                        "q": "count_nonzero(avg:kubernetes_state.daemonset.desired{$scope,$label,$node,$service,$daemonset,$deployment,$namespace,$cluster} by {kube_cluster_name,kube_namespace,kube_daemon_set})",
                         "aggregator": "avg"
                     }
                 ],
@@ -1638,7 +1638,7 @@
         {
             "name": "cluster",
             "default": "*",
-            "prefix": "cluster_name"
+            "prefix": "kube_cluster_name"
         },
         {
             "name": "namespace",

--- a/kubernetes/assets/dashboards/kubernetes_nodes.json
+++ b/kubernetes/assets/dashboards/kubernetes_nodes.json
@@ -8,7 +8,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "top(sum:kubernetes_state.nodes.by_condition{$cluster,status:true,$host,!condition:ready} by {status,condition,cluster_name}, 10, 'last', 'desc')",
+                        "q": "top(sum:kubernetes_state.nodes.by_condition{$cluster,status:true,$host,!condition:ready} by {status,condition,kube_cluster_name}, 10, 'last', 'desc')",
                         "display_type": "line",
                         "style": {
                             "palette": "warm",
@@ -827,7 +827,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.nodes.by_condition{$cluster,$host,condition:ready,status:true} by {condition,status,cluster_name}",
+                        "q": "sum:kubernetes_state.nodes.by_condition{$cluster,$host,condition:ready,status:true} by {condition,status,kube_cluster_name}",
                         "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
@@ -931,7 +931,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "avg:kubernetes.memory.usage_pct{$cluster,$host} by {cluster_name}, avg:kubernetes.memory.usage_pct{$cluster,$host} by {cluster_name}*100",
+                        "q": "avg:kubernetes.memory.usage_pct{$cluster,$host} by {kube_cluster_name}, avg:kubernetes.memory.usage_pct{$cluster,$host} by {kube_cluster_name}*100",
                         "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
@@ -978,7 +978,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes.filesystem.usage_pct{$cluster,$host} by {cluster_name}, sum:kubernetes.filesystem.usage_pct{$cluster,$host} by {cluster_name}*100",
+                        "q": "sum:kubernetes.filesystem.usage_pct{$cluster,$host} by {kube_cluster_name}, sum:kubernetes.filesystem.usage_pct{$cluster,$host} by {kube_cluster_name}*100",
                         "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
@@ -1019,7 +1019,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes.cpu.requests{$cluster,$host} by {cluster_name}/sum:kubernetes.cpu.capacity{$cluster,$host} by {cluster_name}*100",
+                        "q": "sum:kubernetes.cpu.requests{$cluster,$host} by {kube_cluster_name}/sum:kubernetes.cpu.capacity{$cluster,$host} by {kube_cluster_name}*100",
                         "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
@@ -1159,7 +1159,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "100-avg:system.cpu.idle{$host,$cluster} by {cluster_name}",
+                        "q": "100-avg:system.cpu.idle{$host,$cluster} by {kube_cluster_name}",
                         "display_type": "line",
                         "style": {
                             "palette": "warm",
@@ -1477,7 +1477,7 @@
         {
             "name": "cluster",
             "default": "*",
-            "prefix": "cluster_name"
+            "prefix": "kube_cluster_name"
         },
         {
             "name": "host",

--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -160,7 +160,7 @@
                     "response_format": "timeseries",
                     "queries": [
                       {
-                        "query": "sum:kubernetes.pods.running{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job} by {cluster_name,kube_namespace}",
+                        "query": "sum:kubernetes.pods.running{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job} by {kube_cluster_name,kube_namespace}",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -881,7 +881,7 @@
     ],
     "template_variables": [
       { "name": "scope", "default": "*" },
-      { "name": "cluster", "default": "*", "prefix": "cluster_name" },
+      { "name": "cluster", "default": "*", "prefix": "kube_cluster_name" },
       { "name": "namespace", "default": "*", "prefix": "kube_namespace" },
       { "name": "deployment", "default": "*", "prefix": "kube_deployment" },
       { "name": "statefulset", "default": "*", "prefix": "kube_stateful_set" },


### PR DESCRIPTION
### What does this PR do?

Update several kubernetes related integrations to use `kube_cluster_name` instead
of `cluster_name`.

### Motivation

Several integrations already use `kube_cluster_name` tags. To be more align between
the different integrations, this PR update the remaining reference to `cluster_name`
in favour of `kube_cluster_name`.


### Additional Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
