### PR TITLE
Add Vault route metrics to be fetched from the Prometheus endpoint

### DIFF
--- a/vault/datadog_checks/vault/metrics.py
+++ b/vault/datadog_checks/vault/metrics.py
@@ -248,3 +248,11 @@ METRIC_ROLLBACK_COMPAT_MAP = {
     'vault_route_rollback_sys_': 'vault.route.rollback.sys',
     'vault_route_rollback_secret_': 'vault.route.rollback.secret',
 }
+
+ROUTE_METRICS_TO_TRANSFORM = [
+    'vault_route_create_',
+    'vault_route_delete_',
+    'vault_route_list_',
+    'vault_route_read_',
+    'vault_route_rollback_',
+]

--- a/vault/datadog_checks/vault/metrics.py
+++ b/vault/datadog_checks/vault/metrics.py
@@ -241,7 +241,7 @@ METRIC_MAP = {
 
 METRIC_ROLLBACK_COMPAT_MAP = {
     'vault_route_rollback_auth_jwt_': 'vault.route.rollback.auth.jwt',
-    'vault_route_rollback_auth_ldap': 'vault.route.rollback.auth.ldap',
+    'vault_route_rollback_auth_ldap_': 'vault.route.rollback.auth.ldap',
     'vault_route_rollback_auth_token_': 'vault.route.rollback.auth.token',
     'vault_route_rollback_cubbyhole_': 'vault.route.rollback.cubbyhole',
     'vault_route_rollback_identity_': 'vault.route.rollback.identity',

--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -10,7 +10,7 @@ from six import PY2
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck, is_affirmative
 
 from .errors import ApiUnreachable
-from .metrics import METRIC_MAP, METRIC_ROLLBACK_COMPAT_MAP
+from .metrics import METRIC_MAP, METRIC_ROLLBACK_COMPAT_MAP, ROUTE_METRICS_TO_TRANSFORM
 
 try:
     from json import JSONDecodeError
@@ -57,7 +57,9 @@ class Vault(OpenMetricsBaseCheck):
             name,
             init_config,
             instances,
-            default_instances={self.CHECK_NAME: {'namespace': self.CHECK_NAME, 'metrics': [METRIC_MAP]}},
+            default_instances={
+                self.CHECK_NAME: {'namespace': self.CHECK_NAME, 'metrics': [METRIC_MAP] + ROUTE_METRICS_TO_TRANSFORM},
+            },
             default_namespace=self.CHECK_NAME,
         )
 
@@ -339,13 +341,15 @@ class Vault(OpenMetricsBaseCheck):
         if metric.name in METRIC_ROLLBACK_COMPAT_MAP:
             self.submit_openmetric(METRIC_ROLLBACK_COMPAT_MAP[metric.name], metric, scraper_config)
 
-        metricname = transformerkey.replace('_', '.')[:-2]
-        metrictag = metric.name[len(transformerkey) - 1 : -1]
+        metric_name = metric.name.replace('_', '.').rstrip('.')
 
         # Remove extra vault prefix
-        if metricname.startswith('vault.'):
-            metricname = metricname[len('vault.') :]
+        if metric_name.startswith('vault.'):
+            metric_name = metric_name[len('vault.') :]
 
+        metric_tag = metric.name[len(transformerkey) - 1 : -1]
         for i in metric.samples:
-            i.labels['mountpoint'] = metrictag
-        self.submit_openmetric(metricname, metric, scraper_config)
+            i.labels['mountpoint'] = metric_tag
+
+        normalized_metric_name = metric_name.replace('.' + metric_tag, '')
+        self.submit_openmetric(normalized_metric_name, metric, scraper_config)

--- a/vault/tests/test_vault.py
+++ b/vault/tests/test_vault.py
@@ -618,8 +618,8 @@ class TestVault:
             'vault_route_rollback_sys_{quantile="0.5"} 3\n'
             'vault_route_rollback_sys_{quantile="0.9"} 3\n'
             'vault_route_rollback_sys_{quantile="0.99"} 4\n'
-            'vault_route_rollback_sys_ 3.2827999591827393\n'
-            'vault_route_rollback_sys_ 1'
+            'vault_route_rollback_sys__sum 3.2827999591827393\n'
+            'vault_route_rollback_sys__count 1'
         )
 
         def iter_lines(**_):
@@ -633,8 +633,14 @@ class TestVault:
             for quantile in [0.5, 0.9, 0.99]:
                 quantile_tag = 'quantile:{}'.format(quantile)
                 aggregator.assert_metric('vault.vault.route.rollback.sys.quantile', tags=global_tags + [quantile_tag])
-                aggregator.assert_metric(
-                    'vault.route.rollback.quantile', tags=global_tags + [quantile_tag, 'mountpoint:sys']
-                )
+                aggregator.assert_metric('vault.route.rollback.quantile',
+                                         tags=global_tags + [quantile_tag, 'mountpoint:sys'])
+                aggregator.assert_metric('vault.route.rollback.quantile',
+                                         tags=global_tags + [quantile_tag, 'mountpoint:sys'])
+
+            aggregator.assert_metric('vault.vault.route.rollback.sys.sum', tags=global_tags)
+            aggregator.assert_metric('vault.vault.route.rollback.sys.count', tags=global_tags)
+            aggregator.assert_metric('vault.route.rollback.sum', tags=global_tags + ['mountpoint:sys'])
+            aggregator.assert_metric('vault.route.rollback.count', tags=global_tags + ['mountpoint:sys'])
 
         aggregator.assert_all_metrics_covered()

--- a/vault/tests/test_vault.py
+++ b/vault/tests/test_vault.py
@@ -613,6 +613,13 @@ class TestVault:
         c.parse_config()
 
         content = (
+            '# HELP vault_route_create_foobar_ vault_route_create_foobar_\n'
+            '# TYPE vault_route_create_foobar_ summary\n'
+            'vault_route_create_foobar_{quantile="0.5"} 1\n'
+            'vault_route_create_foobar_{quantile="0.9"} 2\n'
+            'vault_route_create_foobar_{quantile="0.99"} 3\n'
+            'vault_route_create_foobar__sum 571.073808670044\n'
+            'vault_route_create_foobar__count 18\n'
             '# HELP vault_route_rollback_sys_ vault_route_rollback_sys_\n'
             '# TYPE vault_route_rollback_sys_ summary\n'
             'vault_route_rollback_sys_{quantile="0.5"} 3\n'
@@ -633,14 +640,21 @@ class TestVault:
             for quantile in [0.5, 0.9, 0.99]:
                 quantile_tag = 'quantile:{}'.format(quantile)
                 aggregator.assert_metric('vault.vault.route.rollback.sys.quantile', tags=global_tags + [quantile_tag])
-                aggregator.assert_metric('vault.route.rollback.quantile',
-                                         tags=global_tags + [quantile_tag, 'mountpoint:sys'])
-                aggregator.assert_metric('vault.route.rollback.quantile',
-                                         tags=global_tags + [quantile_tag, 'mountpoint:sys'])
+                aggregator.assert_metric(
+                    'vault.route.rollback.quantile', tags=global_tags + [quantile_tag, 'mountpoint:sys']
+                )
+                aggregator.assert_metric(
+                    'vault.route.rollback.quantile', tags=global_tags + [quantile_tag, 'mountpoint:sys']
+                )
+                aggregator.assert_metric(
+                    'vault.route.create.quantile', tags=global_tags + [quantile_tag, 'mountpoint:foobar']
+                )
 
             aggregator.assert_metric('vault.vault.route.rollback.sys.sum', tags=global_tags)
             aggregator.assert_metric('vault.vault.route.rollback.sys.count', tags=global_tags)
             aggregator.assert_metric('vault.route.rollback.sum', tags=global_tags + ['mountpoint:sys'])
             aggregator.assert_metric('vault.route.rollback.count', tags=global_tags + ['mountpoint:sys'])
+            aggregator.assert_metric('vault.route.create.sum', tags=global_tags + ['mountpoint:foobar'])
+            aggregator.assert_metric('vault.route.create.count', tags=global_tags + ['mountpoint:foobar'])
 
         aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
Vault route metrics had a function for transforming them and a `METRIC_ROLLBACK_COMPAT_MAP` existed to capture pre-defined metrics for specific Vault mounts that are common in getting started with Vault but did not capture all the Vault route metrics from any Vault mount.

Relates to https://github.com/DataDog/integrations-core/pull/8761

### Motivation
There is a need to see these per mount metrics to better understand our systems.

### Additional Notes
Also fixed the LDAP metric defined in `METRIC_ROLLBACK_COMPAT_MAP`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
