### PR TITLE
Fix Fluentbit documentation link in eks_fargate integration

### DIFF
--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -413,7 +413,7 @@ Need help? Contact [Datadog support][22].
 [15]: https://docs.datadoghq.com/integrations/#cat-autodiscovery
 [16]: https://docs.datadoghq.com/developers/dogstatsd/
 [17]: http://docs.datadoghq.com/tracing/setup
-[18]: http://docs.datadoghq.com/agent/cluster_agent/setup
+[18]: https://aws.amazon.com/blogs/containers/fluent-bit-for-amazon-eks-on-aws-fargate-is-here/
 [19]: http://docs.datadoghq.com/agent/cluster_agent/event_collection
 [20]: https://docs.datadoghq.com/help
 [21]: https://app.datadoghq.com/containers


### PR DESCRIPTION
### What does this PR do?

Update fluentbit configuration doc link on the `eks_fargate` README.md. 

### Motivation

the previous link in that section: https://docs.datadoghq.com/integrations/eks_fargate/#collecting-logs-from-eks-on-fargate-with-fluent-bit was pointing to the "cluster-agent" configuration.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
