### PR TITLE
Support multiple instances in config specs

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/example.py
@@ -181,11 +181,10 @@ def write_option(option, writer, indent='', start_list=False):
 
         if 'options' in option:
             multiple = option['multiple']
-            metadata_tags = option.get('metadata_tags', [])
-            multiple_instances = 'multiple_instances:true' in metadata_tags
+            multiple_instances_defined = option.get('multiple_instances_defined')
 
             writer.write(indent, option_name, ':', '\n')
-            if multiple and multiple_instances:
+            if multiple and multiple_instances_defined:
                 for instance in option['options']:
                     write_sub_option(instance, writer, indent, multiple, include_top_description=True)
             else:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/example.py
@@ -181,25 +181,15 @@ def write_option(option, writer, indent='', start_list=False):
 
         if 'options' in option:
             multiple = option['multiple']
-            options = sorted(option['options'], key=lambda opt: -opt['display_priority'])
-            next_indent = indent + '    '
-            writer.write(indent, option_name, ':', '\n')
-            if options:
-                for i, opt in enumerate(options):
-                    if opt['hidden']:
-                        continue
+            metadata_tags = option.get('metadata_tags', [])
+            multiple_instances = 'multiple_instances:true' in metadata_tags
 
-                    writer.write('\n')
-                    if i == 0 and multiple:
-                        if option_enabled(opt):
-                            write_option(opt, writer, next_indent, start_list=True)
-                        else:
-                            writer.write(next_indent[:-2], '-\n')
-                            write_option(opt, writer, next_indent)
-                    else:
-                        write_option(opt, writer, next_indent)
-            elif multiple:
-                writer.write('\n', next_indent[:-2], '- {}\n')
+            writer.write(indent, option_name, ':', '\n')
+            if multiple and multiple_instances:
+                for instance in option['options']:
+                    write_sub_option(instance, writer, indent, multiple, include_top_description=True)
+            else:
+                write_sub_option(option, writer, indent, multiple)
 
         # For sections that prefer to document everything in the description, like `logs`
         else:
@@ -215,6 +205,30 @@ def write_option(option, writer, indent='', start_list=False):
                     writer.write(example_indent)
 
                 writer.write(line, '\n')
+
+
+def write_sub_option(option, writer, indent, multiple, include_top_description=False):
+    options = sorted(option['options'], key=lambda opt: -opt['display_priority'])
+    next_indent = indent + '    '
+
+    if options:
+        for i, opt in enumerate(options):
+            if opt['hidden']:
+                continue
+
+            writer.write('\n')
+            if i == 0 and multiple:
+                if include_top_description and option.get('description'):
+                    write_description(option, writer, next_indent, 'option')
+                if option_enabled(opt):
+                    write_option(opt, writer, next_indent, start_list=True)
+                else:
+                    writer.write(next_indent[:-2], '-\n')
+                    write_option(opt, writer, next_indent)
+            else:
+                write_option(opt, writer, next_indent)
+    elif multiple:
+        writer.write('\n', next_indent[:-2], '- {}\n')
 
 
 class ExampleConsumer(object):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/model.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/model.py
@@ -101,7 +101,6 @@ class ModelConsumer:
 
             for section in sorted(file['options'], key=lambda s: s['name']):
                 errors = []
-                metadata_tags = section.get('metadata_tags', [])
 
                 section_name = section['name']
                 if section_name == 'init_config':
@@ -112,7 +111,7 @@ class ModelConsumer:
                     model_id = 'instance'
                     model_file_name = f'{model_id}.py'
                     schema_name = 'InstanceConfig'
-                    if 'multiple_instances:true' in metadata_tags:
+                    if section['multiple_instances_defined']:
                         section = self._merge_instances(section, errors)
                 # Skip anything checks don't use directly
                 else:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/model.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/model.py
@@ -101,6 +101,7 @@ class ModelConsumer:
 
             for section in sorted(file['options'], key=lambda s: s['name']):
                 errors = []
+                metadata_tags = section.get('metadata_tags', [])
 
                 section_name = section['name']
                 if section_name == 'init_config':
@@ -111,6 +112,8 @@ class ModelConsumer:
                     model_id = 'instance'
                     model_file_name = f'{model_id}.py'
                     schema_name = 'InstanceConfig'
+                    if 'multiple_instances:true' in metadata_tags:
+                        section = self._merge_instances(section, errors)
                 # Skip anything checks don't use directly
                 else:
                     continue
@@ -384,6 +387,35 @@ class ModelConsumer:
             files[file['name']] = {file_name: model_files[file_name] for file_name in sorted(model_files)}
 
         return files
+
+    def _merge_instances(self, section, errors):
+        new_section = {
+            'name': section['name'],
+            'options': [],
+        }
+        # If one of these option is different for 2 options with the same name, an error is raised
+        required_consistent_options = ['required', 'deprecation', 'metadata_tags']
+        # Cache the option index to ease option checking before merging
+        options_name_idx = {}
+
+        for instance in section['options']:
+            for opt in instance['options']:
+                if options_name_idx.get(opt['name']) is not None:
+                    cached_opt = new_section['options'][options_name_idx[opt['name']]]
+
+                    for opt_name in required_consistent_options:
+                        if cached_opt[opt_name] != opt[opt_name]:
+                            errors.append(
+                                f'Options {cached_opt} and {opt} have a different value for attribute `{opt_name}`'
+                            )
+                    if cached_opt['value']['type'] != opt['value']['type']:
+                        errors.append(f'Options {cached_opt} and {opt} have a different value for attribute `type`')
+
+                else:
+                    new_section['options'].append(opt)
+                    options_name_idx[opt['name']] = len(new_section['options']) - 1
+
+        return new_section
 
     @staticmethod
     def create_code_formatter():

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/spec.py
@@ -344,6 +344,14 @@ def options_validator(options, loader, file_name, *sections):
                     )
                 )
 
+            option.setdefault('multiple_instances_defined', False)
+            if not isinstance(option['multiple_instances_defined'], bool):
+                loader.errors.append(
+                    '{}, {}, {}{}: Attribute `multiple` must be true or false'.format(
+                        loader.source, file_name, sections_display, option_name
+                    )
+                )
+
             previous_sections = list(sections)
             previous_sections.append(option_name)
             options_validator(nested_options, loader, file_name, *previous_sections)

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_merge_instances.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_merge_instances.py
@@ -7,6 +7,7 @@ from ...utils import get_model_consumer, normalize_yaml
 
 pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
+
 def test():
     consumer = get_model_consumer(
         """

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_merge_instances.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_merge_instances.py
@@ -1,0 +1,129 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from ...utils import get_model_consumer, normalize_yaml
+
+pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
+
+def test():
+    consumer = get_model_consumer(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - template: instances
+            multiple_instances_defined: true
+            options:
+            - name: instance_1
+              description: words
+              options:
+              - name: foo
+                description: words
+                value:
+                  type: string
+            - name: instance_2
+              description: words
+              options:
+              - name: bar
+                description: description
+                required: true
+                value:
+                  type: string
+              - name: foo
+                description: another description
+                value:
+                  type: string
+                  example: foofoo
+
+        """
+    )
+
+    model_definitions = consumer.render()
+    assert len(model_definitions) == 1
+
+    files = model_definitions['test.yaml']
+    assert len(files) == 4
+
+    validators_contents, validators_errors = files['validators.py']
+    assert not validators_errors
+    assert validators_contents == ''
+
+    package_root_contents, package_root_errors = files['__init__.py']
+    assert not package_root_errors
+    assert package_root_contents == normalize_yaml(
+        """
+        from .instance import InstanceConfig
+
+
+        class ConfigMixin:
+            _config_model_instance: InstanceConfig
+
+            @property
+            def config(self) -> InstanceConfig:
+                return self._config_model_instance
+        """
+    )
+
+    defaults_contents, defaults_errors = files['defaults.py']
+    assert not defaults_errors
+    assert defaults_contents == normalize_yaml(
+        """
+        from datadog_checks.base.utils.models.fields import get_default_field_value
+
+
+        def instance_foo(field, value):
+            return get_default_field_value(field, value)
+        """
+    )
+
+    instance_model_contents, instance_model_errors = files['instance.py']
+    assert not instance_model_errors
+    assert instance_model_contents == normalize_yaml(
+        """
+        from __future__ import annotations
+
+        from typing import Optional
+
+        from pydantic import BaseModel, root_validator, validator
+
+        from datadog_checks.base.utils.functions import identity
+        from datadog_checks.base.utils.models import validation
+
+        from . import defaults, validators
+
+
+        class InstanceConfig(BaseModel):
+            class Config:
+                allow_mutation = False
+
+            bar: str
+            foo: Optional[str]
+
+            @root_validator(pre=True)
+            def _initial_validation(cls, values):
+                return validation.core.initialize_config(getattr(validators, 'initialize_instance', identity)(values))
+
+            @validator('*', pre=True, always=True)
+            def _ensure_defaults(cls, v, field):
+                if v is not None or field.required:
+                    return v
+
+                return getattr(defaults, f'instance_{field.name}')(field, v)
+
+            @validator('*')
+            def _run_validations(cls, v, field):
+                if not v:
+                    return v
+
+                return getattr(validators, f'instance_{field.name}', identity)(v, field=field)
+
+            @root_validator(pre=False)
+            def _final_validation(cls, values):
+                return validation.core.finalize_config(getattr(validators, 'finalize_instance', identity)(values))
+        """
+    )

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -1514,3 +1514,62 @@ def test_option_multiple_types_nested():
             # foo: <FOO>
         """
     )
+
+
+def test_option_multiple_instances_defined():
+    consumer = get_example_consumer(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - template: instances
+            multiple_instances_defined: true
+            options:
+            - name: instance_1
+              description: Description of the first instance
+              options:
+              - name: foo
+                description: words
+                value:
+                  type: string
+            - name: instance_2
+              description: |
+                Description of the second instance
+                Multiple lines
+              options:
+              - name: bar
+                description: description
+                value:
+                  type: string
+
+        """
+    )
+
+    files = consumer.render()
+    contents, errors = files['test.yaml.example']
+    assert not errors
+    assert contents == normalize_yaml(
+        """
+        ## Every instance is scheduled independent of the others.
+        #
+        instances:
+
+            ## Description of the first instance
+          -
+            ## @param foo - string - optional
+            ## words
+            #
+            # foo: <FOO>
+
+            ## Description of the second instance
+            ## Multiple lines
+          -
+            ## @param bar - string - optional
+            ## description
+            #
+            # bar: <BAR>
+        """
+    )

--- a/docs/developer/meta/config-specs.md
+++ b/docs/developer/meta/config-specs.md
@@ -65,8 +65,8 @@ Every option has 10 possible attributes:
 
 - `multiple` - Whether or not options may be selected multiple times like `instances` or just once
   like `init_config`
-- `metadata_tags` - A list of tags that can serve for unexpected use cases. Tags currently supported:
-    - `multiple_instances:true`: used to split the configuration options into multiple instances. Helpful for the `conf.yaml.example` generation to be more readable.
+- `metadata_tags` - A list of tags that can be used for unexpected use cases. Tags currently supported:
+    - `multiple_instances:true` - Used to split the configuration options into multiple instances. Helpful for the `conf.yaml.example` generation to be more readable.
 - `options` - Nested options, indicating that this is a section like `instances` or `logs`
 - `value` - The expected type data
 

--- a/docs/developer/meta/config-specs.md
+++ b/docs/developer/meta/config-specs.md
@@ -65,7 +65,8 @@ Every option has 10 possible attributes:
 
 - `multiple` - Whether or not options may be selected multiple times like `instances` or just once
   like `init_config`
-- `metadata_tags` - A list of tags (like `docs:foo`) that can serve for unexpected use cases in the future
+- `metadata_tags` - A list of tags that can serve for unexpected use cases. Tags currently supported:
+    - `multiple_instances:true`: used to split the configuration options into multiple instances. Helpful for the `conf.yaml.example` generation to be more readable.
 - `options` - Nested options, indicating that this is a section like `instances` or `logs`
 - `value` - The expected type data
 

--- a/docs/developer/meta/config-specs.md
+++ b/docs/developer/meta/config-specs.md
@@ -65,8 +65,8 @@ Every option has 10 possible attributes:
 
 - `multiple` - Whether or not options may be selected multiple times like `instances` or just once
   like `init_config`
-- `metadata_tags` - A list of tags that can be used for unexpected use cases. Tags currently supported:
-    - `multiple_instances:true` - Used to split the configuration options into multiple instances. Helpful for the `conf.yaml.example` generation to be more readable.
+- `multiple_instances_defined` - Whether or not we separate the definition into multiple instances or just one
+- `metadata_tags` - A list of tags (like `docs:foo`) that can be used for unexpected use cases
 - `options` - Nested options, indicating that this is a section like `instances` or `logs`
 - `value` - The expected type data
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The goal of this PR is to be able to have multiple instances in a single `conf.yaml.example`.

This PR respects the following constraints:
- Every existing `spec.yaml` generating `conf.yaml.example` is still correct, pass validation, and don't need a new sync
- Every existing `spec.yaml` generating `config_models/*` files is still correct, pass validation and don't need a new sync
- When a `spec.yaml` has multiple instances defined:
    - Each instance has its own description
    - A configuration option can appear in as many instances as we want
    - A configuration option appearing in more than one instance must have the same `required`, `deprecation`, `metadata_tags` and `value.type` values across all the instances, but can have different descriptions or example
    - The `conf.yaml.example` generated follow the exact `spec.yaml` ; if a config option needs to appear in 2 different instances, it should be defined twice
    - The model validation generated merges the instances to get the total set of available attribute, that's why some configuration option attributes need to be exactly the same across the different definitions

### How to use it

The multiple instances configuration can be enabled using the new `multiple_instances_defined` flag. Note that `multiple` is a tag that already exists (see https://datadoghq.dev/integrations-core/meta/config-specs/#options).

Example of a single instance `spec.yaml` (same as before):
```yaml
- template: instances
   options:
   - name: attribute_1
     description: description_1
     value:
       type: string
       example: example_1
```

Example of a multiple instances `spec.yaml` (https://github.com/DataDog/integrations-core/commit/a1865838addba1e35ee2066f928d2544e5d8c0a8):
```yaml
- template: instances
  multiple_instances_defined: true
  options:
  - name: instance_A
   description: This is a description for the first instance example
   options:
   - name: attribute_1
     description: description_1
     value:
       type: string
       example: example_1
  - name: instance_B
    description: This is a description for another instance example
    options:
    - name: attribute_1
      description: description different from description_1
      value:
        type: string
        example: new example
```

### Note

Another option would have been to support the `example` attribute of `instances`.
Pros:
* Keep every configuration option in the same instance options (no change in the models validation needed)
* No redundancy definition between instances

Cons:
* Does not natively support description or example override
* No instance-level description