### PR TITLE
DBM statement_samples enabled by default, rename DBM-enabled key

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -225,12 +225,9 @@ files:
       value:
         type: string
         example: "datadog-agent"
-    - name: deep_database_monitoring
+    - name: dbm
       description: |
-        Set to `true` to enable the ALPHA features for Deep Database Monitoring.
-
-        If you would like to hear more about Deep Database Monitoring, please reach out to your customer
-        success manager or Datadog support.
+        Set to `true` to enable Database Monitoring.
       value:
         type: boolean
         example: false
@@ -248,10 +245,10 @@ files:
       options:
         - name: enabled
           description: |
-            Enable collection of statement samples. Requires `deep_database_monitoring: true`.
+            Enable collection of statement samples. Requires `dbm: true`.
           value:
             type: boolean
-            example: false
+            example: true
         - name: collections_per_second
           description: |
             Set the maximum statement sample collection rate. Each collection involves a single query to

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -69,9 +69,8 @@ class PostgresConfig:
         self.custom_metrics = self._get_custom_metrics(instance.get('custom_metrics', []))
         self.max_relations = int(instance.get('max_relations', 300))
         self.min_collection_interval = instance.get('min_collection_interval', 15)
-
-        # Deep Database monitoring adds additional telemetry for statement metrics
-        self.deep_database_monitoring = is_affirmative(instance.get('deep_database_monitoring', False))
+        # database monitoring adds additional telemetry for query metrics & samples
+        self.dbm_enabled = is_affirmative(instance.get('dbm', instance.get('deep_database_monitoring', False)))
         self.full_statement_text_cache_max_size = instance.get('full_statement_text_cache_max_size', 10000)
         self.full_statement_text_samples_per_hour_per_query = instance.get(
             'full_statement_text_samples_per_hour_per_query', 1

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -36,15 +36,15 @@ def instance_custom_queries(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_dbm(field, value):
+    return False
+
+
 def instance_dbname(field, value):
     return get_default_field_value(field, value)
 
 
 def instance_dbstrict(field, value):
-    return False
-
-
-def instance_deep_database_monitoring(field, value):
     return False
 
 

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -48,9 +48,9 @@ class InstanceConfig(BaseModel):
     collect_default_database: Optional[bool]
     collect_function_metrics: Optional[bool]
     custom_queries: Optional[Sequence[Mapping[str, Any]]]
+    dbm: Optional[bool]
     dbname: Optional[str]
     dbstrict: Optional[bool]
-    deep_database_monitoring: Optional[bool]
     empty_default_hostname: Optional[bool]
     host: str
     ignore_databases: Optional[Sequence[str]]

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -186,13 +186,10 @@ instances:
     #
     # application_name: datadog-agent
 
-    ## @param deep_database_monitoring - boolean - optional - default: false
-    ## Set to `true` to enable the ALPHA features for Deep Database Monitoring.
-    ##
-    ## If you would like to hear more about Deep Database Monitoring, please reach out to your customer
-    ## success manager or Datadog support.
+    ## @param dbm - boolean - optional - default: false
+    ## Set to `true` to enable Database Monitoring.
     #
-    # deep_database_monitoring: false
+    # dbm: false
 
     ## @param pg_stat_statements_view - string - optional - default: show_pg_stat_statements()
     ## Set this value if you want to define a custom view or function to allow the datadog user to query the
@@ -205,10 +202,10 @@ instances:
     #
     statement_samples:
 
-        ## @param enabled - boolean - optional - default: false
-        ## Enable collection of statement samples. Requires `deep_database_monitoring: true`.
+        ## @param enabled - boolean - optional - default: true
+        ## Enable collection of statement samples. Requires `dbm: true`.
         #
-        # enabled: false
+        # enabled: true
 
         ## @param collections_per_second - number - optional - default: 1
         ## Set the maximum statement sample collection rate. Each collection involves a single query to

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -397,7 +397,7 @@ class PostgreSql(AgentCheck):
             self.log.debug("Running check against version %s: is_aurora: %s", str(self.version), str(self.is_aurora))
             self._collect_stats(tags)
             self._collect_custom_queries(tags)
-            if self._config.deep_database_monitoring:
+            if self._config.dbm_enabled:
                 self.statement_metrics.collect_per_statement_metrics(self.db, self.version, tags)
                 self.statement_samples.run_sampler(tags)
 

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -120,7 +120,7 @@ class PostgresStatementSamples(object):
         self._tags = None
         self._tags_no_db = None
         self._db_hostname = resolve_db_host(self._config.host)
-        self._enabled = is_affirmative(self._config.statement_samples_config.get('enabled', False))
+        self._enabled = is_affirmative(self._config.statement_samples_config.get('enabled', True))
         self._run_sync = is_affirmative(self._config.statement_samples_config.get('run_sync', False))
         # The value is loaded when connecting to the main database
         self._max_query_size = UNKNOWN_VALUE

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -249,6 +249,20 @@ def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance)
         assert check._config.tags == expected_tags
 
 
+dbm_enabled_keys = ["dbm", "deep_database_monitoring"]
+
+
+@pytest.mark.parametrize("dbm_enabled_key", dbm_enabled_keys)
+@pytest.mark.parametrize("dbm_enabled", [True, False])
+def test_dbm_enabled_config(integration_check, dbm_instance, dbm_enabled_key, dbm_enabled):
+    # test to make sure we continue to support the old key
+    for k in dbm_enabled_keys:
+        dbm_instance.pop(k, None)
+    dbm_instance[dbm_enabled_key] = dbm_enabled
+    check = integration_check(dbm_instance)
+    assert check._config.dbm_enabled == dbm_enabled
+
+
 @pytest.mark.parametrize("dbstrict", [True, False])
 @pytest.mark.parametrize("pg_stat_statements_view", ["pg_stat_statements", "datadog.pg_stat_statements()"])
 def test_statement_metrics(aggregator, integration_check, dbm_instance, dbstrict, pg_stat_statements_view):
@@ -339,7 +353,7 @@ def test_statement_metrics(aggregator, integration_check, dbm_instance, dbstrict
 
 
 def test_statement_metrics_with_duplicates(aggregator, integration_check, pg_instance, datadog_agent):
-    pg_instance['deep_database_monitoring'] = True
+    pg_instance['dbm'] = True
 
     # The query signature matches the normalized query returned by the mock agent and would need to be
     # updated if the normalized query is updated
@@ -386,7 +400,7 @@ def bob_conn():
 
 @pytest.fixture
 def dbm_instance(pg_instance):
-    pg_instance['deep_database_monitoring'] = True
+    pg_instance['dbm'] = True
     pg_instance['min_collection_interval'] = 1
     pg_instance['pg_stat_activity_view'] = "datadog.pg_stat_activity()"
     pg_instance['statement_samples'] = {'enabled': True, 'run_sync': True, 'collections_per_second': 1}


### PR DESCRIPTION
### What does this PR do?

* `statement_samples.enabled` now defaults to `true`
* `deep_database_monitoring` renamed to `dbm` (while still supporting the old key)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
