### PR TITLE
DBM statement_samples enabled by default, rename DBM-enabled key

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -237,12 +237,9 @@ files:
                   type: boolean
                   example: false
 
-          - name: deep_database_monitoring
+          - name: dbm
             description: |
-              Set to `true` to enable the ALPHA features for Deep Database Monitoring.
-
-              If you would like to hear more about Deep Database Monitoring, please reach out to your customer
-              success manager or Datadog support.
+              Set to `true` enable Database Monitoring.
             enabled: false
             value:
               type: boolean
@@ -253,10 +250,10 @@ files:
             options:
               - name: enabled
                 description: |
-                  Enables collection of statement samples. Requires `deep_database_monitoring: true`.
+                  Enables collection of statement samples. Requires `dbm: true`.
                 value:
                   type: boolean
-                  example: false
+                  example: true
               - name: collections_per_second
                 description: |
                   Sets the maximum statement sample collection rate. Each collection involves a single query to one

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -28,7 +28,7 @@ class MySQLConfig(object):
         self.connect_timeout = instance.get('connect_timeout', 10)
         self.max_custom_queries = instance.get('max_custom_queries', DEFAULT_MAX_CUSTOM_QUERIES)
         self.charset = instance.get('charset')
-        self.deep_database_monitoring = is_affirmative(instance.get('deep_database_monitoring', False))
+        self.dbm_enabled = is_affirmative(instance.get('dbm', instance.get('deep_database_monitoring', False)))
         self.statement_metrics_limits = instance.get('statement_metrics_limits', None)
         self.full_statement_text_cache_max_size = instance.get('full_statement_text_cache_max_size', 10000)
         self.full_statement_text_samples_per_hour_per_query = instance.get(

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -24,7 +24,7 @@ def instance_custom_queries(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_deep_database_monitoring(field, value):
+def instance_dbm(field, value):
     return False
 
 

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -73,7 +73,7 @@ class InstanceConfig(BaseModel):
     charset: Optional[str]
     connect_timeout: Optional[float]
     custom_queries: Optional[Sequence[CustomQuery]]
-    deep_database_monitoring: Optional[bool]
+    dbm: Optional[bool]
     defaults_file: Optional[str]
     empty_default_hostname: Optional[bool]
     host: Optional[str]

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -226,22 +226,19 @@ instances:
         #
         # extra_performance_metrics: false
 
-    ## @param deep_database_monitoring - boolean - optional - default: false
-    ## Set to `true` to enable the ALPHA features for Deep Database Monitoring.
-    ##
-    ## If you would like to hear more about Deep Database Monitoring, please reach out to your customer
-    ## success manager or Datadog support.
+    ## @param dbm - boolean - optional - default: false
+    ## Set to `true` enable Database Monitoring.
     #
-    # deep_database_monitoring: false
+    # dbm: false
 
     ## Configure collection of statement samples
     #
     statement_samples:
 
-        ## @param enabled - boolean - optional - default: false
-        ## Enables collection of statement samples. Requires `deep_database_monitoring: true`.
+        ## @param enabled - boolean - optional - default: true
+        ## Enables collection of statement samples. Requires `dbm: true`.
         #
-        # enabled: false
+        # enabled: true
 
         ## @param collections_per_second - number - optional - default: 1
         ## Sets the maximum statement sample collection rate. Each collection involves a single query to one

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -126,7 +126,7 @@ class MySql(AgentCheck):
                 # Metric collection
                 self._collect_metrics(db, tags=tags)
                 self._collect_system_metrics(self._config.host, db, tags)
-                if self._config.deep_database_monitoring:
+                if self._config.dbm_enabled:
                     dbm_tags = list(set(self.service_check_tags) | set(tags))
                     self._statement_metrics.collect_per_statement_metrics(db, dbm_tags)
                     self._statement_samples.run_sampler(dbm_tags)

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -248,7 +248,7 @@ class MySQLStatementSamples(object):
         self._rate_limiter = ConstantRateLimiter(1)
         self._config = config
         self._db_hostname = resolve_db_host(self._config.host)
-        self._enabled = is_affirmative(self._config.statement_samples_config.get('enabled', False))
+        self._enabled = is_affirmative(self._config.statement_samples_config.get('enabled', True))
         self._run_sync = is_affirmative(self._config.statement_samples_config.get('run_sync', False))
         self._collections_per_second = self._config.statement_samples_config.get('collections_per_second', -1)
         self._events_statements_row_limit = self._config.statement_samples_config.get(

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.fixture
 def dbm_instance(instance_complex):
-    instance_complex['deep_database_monitoring'] = True
+    instance_complex['dbm'] = True
     instance_complex['statement_samples'] = {
         'enabled': True,
         # set the default for tests to run sychronously to ensure we don't have orphaned threads running around
@@ -41,6 +41,20 @@ def dbm_instance(instance_complex):
         'collections_per_second': 1,
     }
     return instance_complex
+
+
+dbm_enabled_keys = ["dbm", "deep_database_monitoring"]
+
+
+@pytest.mark.parametrize("dbm_enabled_key", dbm_enabled_keys)
+@pytest.mark.parametrize("dbm_enabled", [True, False])
+def test_dbm_enabled_config(dbm_instance, dbm_enabled_key, dbm_enabled):
+    # test to make sure we continue to support the old key
+    for k in dbm_enabled_keys:
+        dbm_instance.pop(k, None)
+    dbm_instance[dbm_enabled_key] = dbm_enabled
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+    assert mysql_check._config.dbm_enabled == dbm_enabled
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### What does this PR do?

* `statement_samples.enabled` now defaults to `true`
* `deep_database_monitoring` renamed to `dbm` (while still supporting the old key)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
