### PR TITLE
Add truncated statement indicator to mysql query sample events

### DIFF
--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -204,6 +204,15 @@ PYMYSQL_NON_RETRYABLE_ERRORS = frozenset(
 )
 
 
+class StatementTruncationState(Enum):
+    """
+    Denotes the various possible states of a statement's truncation
+    """
+
+    truncated = 'truncated'
+    not_truncated = 'not_truncated'
+
+
 class DBExplainError(Enum):
     """
     Denotes the various reasons a query may not have an explain statement.
@@ -223,6 +232,9 @@ class DBExplainError(Enum):
 
     # agent may not have access to the default schema
     use_schema_error = 'use_schema_error'
+
+    # a truncated statement can't be explained
+    statement_truncated = 'statement_truncated'
 
 
 class MySQLStatementSamples(object):
@@ -452,7 +464,6 @@ class MySQLStatementSamples(object):
 
     def _filter_valid_statement_rows(self, rows):
         num_sent = 0
-        num_truncated = 0
 
         for row in rows:
             if not row or not all(row):
@@ -461,26 +472,12 @@ class MySQLStatementSamples(object):
             sql_text = row['sql_text']
             if not sql_text:
                 continue
-            # The SQL_TEXT column will store 1024 chars by default. Plans cannot be captured on truncated
-            # queries, so the `performance_schema_max_sql_text_length` variable must be raised.
-            if sql_text[-3:] == '...':
-                num_truncated += 1
-                continue
             yield row
             # only save the checkpoint for rows that we have successfully processed
             # else rows that we ignore can push the checkpoint forward causing us to miss some on the next run
             if row['timer_start'] > self._checkpoint:
                 self._checkpoint = row['timer_start']
             num_sent += 1
-
-        if num_truncated > 0:
-            self._log.warning(
-                'Unable to collect %d/%d statement samples due to truncated SQL text. Consider raising '
-                '`performance_schema_max_sql_text_length` to capture these queries.',
-                num_truncated,
-                num_truncated + num_sent,
-            )
-            self._check.count("dd.mysql.statement_samples.error", 1, tags=self._tags + ["error:truncated-sql-text"])
 
     def _collect_plan_for_statement(self, row):
         # Plans have several important signatures to tag events with:
@@ -506,16 +503,30 @@ class MySQLStatementSamples(object):
             return None
 
         plan, explain_errors = None, None
-        with closing(self._get_db_connection().cursor()) as cursor:
-            try:
-                plan, explain_errors = self._explain_statement(
-                    cursor, row['sql_text'], row['current_schema'], obfuscated_statement
+        if self._is_statement_truncated(row['sql_text']) == StatementTruncationState.truncated:
+            self._check.count(
+                "dd.mysql.statement_samples.error",
+                1,
+                tags=self._tags + ["error:explain-{}".format(DBExplainError.statement_truncated)],
+            )
+            explain_errors = [
+                (
+                    None,
+                    DBExplainError.statement_truncated,
+                    None,
                 )
-            except Exception as e:
-                self._check.count(
-                    "dd.mysql.statement_samples.error", 1, tags=self._tags + ["error:explain-{}".format(type(e))]
-                )
-                self._log.exception("Failed to explain statement: %s", obfuscated_statement)
+            ]
+        else:
+            with closing(self._get_db_connection().cursor()) as cursor:
+                try:
+                    plan, explain_errors = self._explain_statement(
+                        cursor, row['sql_text'], row['current_schema'], obfuscated_statement
+                    )
+                except Exception as e:
+                    self._check.count(
+                        "dd.mysql.statement_samples.error", 1, tags=self._tags + ["error:explain-{}".format(type(e))]
+                    )
+                    self._log.exception("Failed to explain statement: %s", obfuscated_statement)
 
         collection_errors = []
         if explain_errors:
@@ -559,6 +570,7 @@ class MySQLStatementSamples(object):
                     "query_signature": query_signature,
                     "resource_hash": apm_resource_hash,
                     "statement": obfuscated_statement,
+                    "statement_truncated": self._is_statement_truncated(row['sql_text']).value,
                 },
                 'mysql': {k: v for k, v in row.items() if k not in EVENTS_STATEMENTS_SAMPLE_EXCLUDE_KEYS},
             }
@@ -834,3 +846,10 @@ class MySQLStatementSamples(object):
         """
         cost = json.loads(execution_plan).get('query_block', {}).get('cost_info', {}).get('query_cost', 0.0)
         return float(cost or 0.0)
+
+    @staticmethod
+    def _is_statement_truncated(statement):
+        # Mysql adds 3 dots at the end of truncated statements so we use this to check if
+        # a statement is truncated
+        truncated = statement[-3:] == '...'
+        return StatementTruncationState.truncated if truncated else StatementTruncationState.not_truncated

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -503,7 +503,7 @@ class MySQLStatementSamples(object):
             return None
 
         plan, explain_errors = None, None
-        truncated = self._is_statement_truncated(row['sql_text'])
+        truncated = self._get_truncation_state(row['sql_text'])
         if truncated == StatementTruncationState.truncated:
             self._check.count(
                 "dd.mysql.statement_samples.error",
@@ -849,7 +849,7 @@ class MySQLStatementSamples(object):
         return float(cost or 0.0)
 
     @staticmethod
-    def _is_statement_truncated(statement):
+    def _get_truncation_state(statement):
         # Mysql adds 3 dots at the end of truncated statements so we use this to check if
         # a statement is truncated
         truncated = statement[-3:] == '...'

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -22,7 +22,7 @@ from datadog_checks.base.utils.platform import Platform
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.mysql import MySql, statements
-from datadog_checks.mysql.statement_samples import MySQLStatementSamples
+from datadog_checks.mysql.statement_samples import MySQLStatementSamples, StatementTruncationState
 from datadog_checks.mysql.version_utils import get_version
 
 from . import common, tags, variables
@@ -406,17 +406,19 @@ def test_statement_metrics_with_duplicates(aggregator, dbm_instance, datadog_age
 )
 @pytest.mark.parametrize("explain_strategy", ['PROCEDURE', 'FQ_PROCEDURE', 'STATEMENT', None])
 @pytest.mark.parametrize(
-    "schema,statement,expected_collection_errors",
+    "schema,statement,expected_collection_errors,expected_statement_truncated",
     [
         (
             None,
             'select name as nam from testdb.users',
             [{'strategy': 'PROCEDURE', 'code': 'procedure_strategy_requires_default_schema', 'message': None}],
+            StatementTruncationState.not_truncated.value,
         ),
         (
             'information_schema',
             'select * from testdb.users',
             [{'strategy': 'PROCEDURE', 'code': 'database_error', 'message': "<class 'pymysql.err.OperationalError'>"}],
+            StatementTruncationState.not_truncated.value,
         ),
         (
             'testdb',
@@ -428,6 +430,22 @@ def test_statement_metrics_with_duplicates(aggregator, dbm_instance, datadog_age
                     'message': "<class 'pymysql.err.ProgrammingError'>",
                 }
             ],
+            StatementTruncationState.not_truncated.value,
+        ),
+        (
+            'testdb',
+            'SELECT {} FROM users where '
+            'name=\'Johannes Chrysostomus Wolfgangus Theophilus Mozart\''.format(
+                ", ".join("name as name{}".format(i) for i in range(243))
+            ),
+            [
+                {
+                    'strategy': None,
+                    'code': 'statement_truncated',
+                    'message': None,
+                }
+            ],
+            StatementTruncationState.truncated.value,
         ),
     ],
 )
@@ -441,6 +459,7 @@ def test_statement_samples_collect(
     schema,
     statement,
     expected_collection_errors,
+    expected_statement_truncated,
     aurora_replication_role,
     caplog,
 ):
@@ -486,8 +505,24 @@ def test_statement_samples_collect(
         logger.debug("done second check")
 
     events = aggregator.get_event_platform_events("dbm-samples")
-    matching = [e for e in events if e['db']['statement'] == statement]
+
+    # Match against the statement itself if it's below the statement length limit or its truncated form
+    # (the first 1024/4096 bytes (depending on the mysql version) with the last 3 replaced by '...')
+    expected_statement_prefixes = [
+        statement[:1021] + '...' if len(statement) > 1024 else statement,
+        statement[:4093] + '...' if len(statement) > 4096 else statement,
+    ]
+
+    matching = []
+    for e in events:
+        for p in expected_statement_prefixes:
+            print("trying match of \n{}\nagainst \n{}".format(e['db']['statement'], p))
+            if p.startswith(e['db']['statement']):
+                matching.append(e)
+                break
+
     assert len(matching) > 0, "should have collected an event"
+
     with_plans = [e for e in matching if e['db']['plan']['definition'] is not None]
     if schema == 'testdb' and explain_strategy == 'FQ_PROCEDURE':
         # explain via the FQ_PROCEDURE will fail if a query contains non-fully-qualified tables because it will
@@ -500,13 +535,14 @@ def test_statement_samples_collect(
     elif not schema and explain_strategy == 'PROCEDURE':
         # if there is no default schema then we cannot use the non-fully-qualified procedure strategy
         assert not with_plans, "should not have collected any plans"
-    else:
+    elif not expected_statement_truncated:
         event = with_plans[0]
         assert 'query_block' in json.loads(event['db']['plan']['definition']), "invalid json execution plan"
         assert set(event['ddtags'].split(',')) == expected_tags
 
     # Validate the events to ensure we've provided an explanation for not providing an exec plan
     for event in matching:
+        assert e['db']['statement_truncated'] == expected_statement_truncated
         if event['db']['plan']['definition'] is None:
             assert event['db']['plan']['collection_errors'] == expected_collection_errors
         else:


### PR DESCRIPTION
### What does this PR do?
This adds a boolean field to mysql query sample events so we can later surface this to users.

### Motivation
We'd like to be able to surface when a statement has been truncated so we can advise uses on how to proceed to prevent truncation (which would be increasing `performance_schema_max_sql_text_length`).

### Additional Notes
The detection of a truncated statement is done by checking for the presence of `...` at the end of a statement. This works for all supported versions (as the tests show).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
