### PR TITLE
Add is_jmx instance flag documentation

### DIFF
--- a/cassandra/assets/configuration/spec.yaml
+++ b/cassandra/assets/configuration/spec.yaml
@@ -17,6 +17,7 @@ files:
         example: true
     - template: instances/jmx
       overrides:
+        is_jmx.value.default: true
         host.value.example: localhost
         host.display_priority: 1
         port.value.example: 7199

--- a/cassandra/datadog_checks/cassandra/config_models/defaults.py
+++ b/cassandra/datadog_checks/cassandra/config_models/defaults.py
@@ -32,6 +32,10 @@ def instance_empty_default_hostname(field, value):
     return False
 
 
+def instance_is_jmx(field, value):
+    return False
+
+
 def instance_java_bin_path(field, value):
     return get_default_field_value(field, value)
 

--- a/cassandra/datadog_checks/cassandra/config_models/defaults.py
+++ b/cassandra/datadog_checks/cassandra/config_models/defaults.py
@@ -33,7 +33,7 @@ def instance_empty_default_hostname(field, value):
 
 
 def instance_is_jmx(field, value):
-    return False
+    return True
 
 
 def instance_java_bin_path(field, value):

--- a/cassandra/datadog_checks/cassandra/config_models/instance.py
+++ b/cassandra/datadog_checks/cassandra/config_models/instance.py
@@ -21,6 +21,7 @@ class InstanceConfig(BaseModel):
     collect_default_jvm_metrics: Optional[bool]
     empty_default_hostname: Optional[bool]
     host: str
+    is_jmx: Optional[bool]
     java_bin_path: Optional[str]
     java_options: Optional[str]
     jmx_url: Optional[str]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
@@ -10,6 +10,15 @@
   value:
     type: integer
 
+- name: is_jmx
+  description: |
+   Whether or not this instance is a configuration for a JMX integration.
+   If `is_jmx` flag is set to true at init_config level, this flag is ignored.
+  hidden: true
+  value:
+    example: false
+    type: boolean
+
 - name: jmx_url
   description: JMX URL to connect to. Can be used instead of host/port configs.
   hidden: true

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
@@ -13,7 +13,7 @@
 - name: is_jmx
   description: |
    Whether or not this instance is a configuration for a JMX integration.
-   If `is_jmx` flag is set to true at init_config level, this flag is ignored.
+   If `is_jmx` is set to true at the init_config level, this flag is ignored.
   hidden: true
   value:
     example: false

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
@@ -16,7 +16,7 @@
    If `is_jmx` is set to true at the init_config level, this flag is ignored.
   hidden: true
   value:
-    example: false
+    example: true
     type: boolean
 
 - name: jmx_url

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
@@ -16,7 +16,7 @@
    If `is_jmx` is set to true at the init_config level, this flag is ignored.
   hidden: true
   value:
-    example: true
+    example: false
     type: boolean
 
 - name: jmx_url

--- a/kafka/assets/configuration/spec.yaml
+++ b/kafka/assets/configuration/spec.yaml
@@ -9,6 +9,7 @@ files:
     options:
     - template: instances/jmx
       overrides:
+        is_jmx.value.default: true
         host.description: Kafka host to connect to.
         host.value.example: localhost
         port.value.example: 9999

--- a/kafka/datadog_checks/kafka/config_models/defaults.py
+++ b/kafka/datadog_checks/kafka/config_models/defaults.py
@@ -32,6 +32,10 @@ def instance_empty_default_hostname(field, value):
     return False
 
 
+def instance_is_jmx(field, value):
+    return False
+
+
 def instance_java_bin_path(field, value):
     return get_default_field_value(field, value)
 

--- a/kafka/datadog_checks/kafka/config_models/defaults.py
+++ b/kafka/datadog_checks/kafka/config_models/defaults.py
@@ -33,7 +33,7 @@ def instance_empty_default_hostname(field, value):
 
 
 def instance_is_jmx(field, value):
-    return False
+    return True
 
 
 def instance_java_bin_path(field, value):

--- a/kafka/datadog_checks/kafka/config_models/instance.py
+++ b/kafka/datadog_checks/kafka/config_models/instance.py
@@ -20,6 +20,7 @@ class InstanceConfig(BaseModel):
     collect_default_jvm_metrics: Optional[bool]
     empty_default_hostname: Optional[bool]
     host: str
+    is_jmx: Optional[bool]
     java_bin_path: Optional[str]
     java_options: Optional[str]
     jmx_url: Optional[str]

--- a/sonarqube/assets/configuration/spec.yaml
+++ b/sonarqube/assets/configuration/spec.yaml
@@ -88,7 +88,6 @@ files:
     - template: instances/jmx
       overrides:
         is_jmx.hidden: false
-        is_jmx.value.example: false
         host.required: false
         port.required: false
         is_jmx.description: |

--- a/sonarqube/assets/configuration/spec.yaml
+++ b/sonarqube/assets/configuration/spec.yaml
@@ -90,6 +90,11 @@ files:
         is_jmx.hidden: false
         host.required: false
         port.required: false
+        is_jmx.description: |
+          Whether or not this instance is a configuration for a JMX integration.
+          If `is_jmx` is set to true at the init_config level, this flag is ignored.
+
+          NOTE: Setting `is_jmx` to true disables some configuration options.
         user.description: |
           User name to use when connecting to JMX (or HTTP if `is_jmx = false`).
         password.description: |

--- a/sonarqube/assets/configuration/spec.yaml
+++ b/sonarqube/assets/configuration/spec.yaml
@@ -87,6 +87,7 @@ files:
             type: string
     - template: instances/jmx
       overrides:
+        is_jmx.hidden: false
         host.required: false
         port.required: false
         user.description: |

--- a/sonarqube/assets/configuration/spec.yaml
+++ b/sonarqube/assets/configuration/spec.yaml
@@ -88,6 +88,7 @@ files:
     - template: instances/jmx
       overrides:
         is_jmx.hidden: false
+        is_jmx.value.example: false
         host.required: false
         port.required: false
         is_jmx.description: |

--- a/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
+++ b/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
@@ -101,7 +101,7 @@ def instance_host(field, value):
 
 
 def instance_is_jmx(field, value):
-    return True
+    return False
 
 
 def instance_java_bin_path(field, value):

--- a/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
+++ b/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
@@ -100,6 +100,10 @@ def instance_host(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_is_jmx(field, value):
+    return False
+
+
 def instance_java_bin_path(field, value):
     return get_default_field_value(field, value)
 

--- a/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
+++ b/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
@@ -101,7 +101,7 @@ def instance_host(field, value):
 
 
 def instance_is_jmx(field, value):
-    return False
+    return True
 
 
 def instance_java_bin_path(field, value):

--- a/sonarqube/datadog_checks/sonarqube/config_models/instance.py
+++ b/sonarqube/datadog_checks/sonarqube/config_models/instance.py
@@ -58,6 +58,7 @@ class InstanceConfig(BaseModel):
     extra_headers: Optional[Mapping[str, Any]]
     headers: Optional[Mapping[str, Any]]
     host: Optional[str]
+    is_jmx: Optional[bool]
     java_bin_path: Optional[str]
     java_options: Optional[str]
     jmx_url: Optional[str]

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -154,11 +154,13 @@ instances:
     #
     # port: <PORT>
 
-    ## @param is_jmx - boolean - optional - default: false
+    ## @param is_jmx - boolean - optional - default: true
     ## Whether or not this instance is a configuration for a JMX integration.
     ## If `is_jmx` is set to true at the init_config level, this flag is ignored.
+    ##
+    ## NOTE: Setting `is_jmx` to true disables some configuration options.
     #
-    # is_jmx: false
+    # is_jmx: true
 
     ## @param user - string - optional
     ## User name to use when connecting to JMX (or HTTP if `is_jmx = false`).

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -154,6 +154,12 @@ instances:
     #
     # port: <PORT>
 
+    ## @param is_jmx - boolean - optional - default: false
+    ## Whether or not this instance is a configuration for a JMX integration.
+    ## If `is_jmx` flag is set to true at init_config level, this flag is ignored.
+    #
+    # is_jmx: false
+
     ## @param user - string - optional
     ## User name to use when connecting to JMX (or HTTP if `is_jmx = false`).
     #

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -154,13 +154,13 @@ instances:
     #
     # port: <PORT>
 
-    ## @param is_jmx - boolean - optional - default: true
+    ## @param is_jmx - boolean - optional - default: false
     ## Whether or not this instance is a configuration for a JMX integration.
     ## If `is_jmx` is set to true at the init_config level, this flag is ignored.
     ##
     ## NOTE: Setting `is_jmx` to true disables some configuration options.
     #
-    # is_jmx: true
+    # is_jmx: false
 
     ## @param user - string - optional
     ## User name to use when connecting to JMX (or HTTP if `is_jmx = false`).

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -156,7 +156,7 @@ instances:
 
     ## @param is_jmx - boolean - optional - default: false
     ## Whether or not this instance is a configuration for a JMX integration.
-    ## If `is_jmx` flag is set to true at init_config level, this flag is ignored.
+    ## If `is_jmx` is set to true at the init_config level, this flag is ignored.
     #
     # is_jmx: false
 

--- a/tomcat/assets/configuration/spec.yaml
+++ b/tomcat/assets/configuration/spec.yaml
@@ -9,6 +9,7 @@ files:
     options:
     - template: instances/jmx
       overrides:
+        is_jmx.value.default: true
         host.value.example: localhost
         host.description: Tomcat JMX hostname to connect to.
         port.value.example: 9012

--- a/tomcat/datadog_checks/tomcat/config_models/defaults.py
+++ b/tomcat/datadog_checks/tomcat/config_models/defaults.py
@@ -32,6 +32,10 @@ def instance_empty_default_hostname(field, value):
     return False
 
 
+def instance_is_jmx(field, value):
+    return False
+
+
 def instance_java_bin_path(field, value):
     return get_default_field_value(field, value)
 

--- a/tomcat/datadog_checks/tomcat/config_models/defaults.py
+++ b/tomcat/datadog_checks/tomcat/config_models/defaults.py
@@ -33,7 +33,7 @@ def instance_empty_default_hostname(field, value):
 
 
 def instance_is_jmx(field, value):
-    return False
+    return True
 
 
 def instance_java_bin_path(field, value):

--- a/tomcat/datadog_checks/tomcat/config_models/instance.py
+++ b/tomcat/datadog_checks/tomcat/config_models/instance.py
@@ -20,6 +20,7 @@ class InstanceConfig(BaseModel):
     collect_default_jvm_metrics: Optional[bool]
     empty_default_hostname: Optional[bool]
     host: str
+    is_jmx: Optional[bool]
     java_bin_path: Optional[str]
     java_options: Optional[str]
     jmx_url: Optional[str]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Setting `is_jmx` at instance level is supported since https://github.com/DataDog/datadog-agent/pull/5141.
Having `is_jmx: true` at instance level is useful in a few set of JMX integration only, such as `sonarqube` which is both a JMX and a Python integration.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
