### PR TITLE
Add better error handling/reporting for database errors when querying pg_stat_statements

### DIFF
--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -205,6 +205,7 @@ class PostgresStatementMetrics(object):
                     "dd.postgres.statement_metrics.error", 1, tags=tags + ["error:database-{}".format(type(e).__name__)]
                 )
                 self._log.warning("Unable to collect statement metrics because of an error running queries: %s", e)
+            return []
         except psycopg2.Error as e:
             self._check.count(
                 "dd.postgres.statement_metrics.error", 1, tags=tags + ["error:database-{}".format(type(e).__name__)]

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -138,12 +138,12 @@ class PostgresStatementMetrics(object):
         # exclude the default "db" tag from statement metrics & FQT events because this data is collected from
         # all databases on the host. For metrics the "db" tag is added during ingestion based on which database
         # each query came from.
-        tags = [t for t in tags if not t.startswith("db:")]
+        tags_no_db = [t for t in tags if not t.startswith("db:")]
         try:
             rows = self._collect_metrics_rows(db, tags)
             if not rows:
                 return
-            for event in self._rows_to_fqt_events(rows, tags):
+            for event in self._rows_to_fqt_events(rows, tags_no_db):
                 self._check.database_monitoring_query_sample(json.dumps(event, default=default_json_event_encoding))
             # truncate query text to the maximum length supported by metrics tags
             for row in rows:
@@ -152,7 +152,7 @@ class PostgresStatementMetrics(object):
                 'host': self._db_hostname_cached(),
                 'timestamp': time.time() * 1000,
                 'min_collection_interval': self._config.min_collection_interval,
-                'tags': tags,
+                'tags': tags_no_db,
                 'postgres_rows': rows,
                 'postgres_version': 'v{major}.{minor}.{patch}'.format(
                     major=db_version.major, minor=db_version.minor, patch=db_version.patch
@@ -164,47 +164,67 @@ class PostgresStatementMetrics(object):
             self._log.exception('Unable to collect statement metrics due to an error')
             return []
 
-    def _load_pg_stat_statements_safe(self, db, tags):
+    def _load_pg_stat_statements(self, db, tags):
         try:
-            self._load_pg_stat_statements(db)
-        except psycopg2.errors.ObjectNotInPrerequisiteState as e:
-            if 'pg_stat_statements must be loaded via shared_preload_librarie' in str(e):
-                self._check.count("postgresql.setup.error", 1, tags=tags + ["reason:pg_stat_statements_not_enabled"])
-                self._log.warning("Unable to collect statement metrics because pg_stat_statements must be loaded "
-                                  "via shared_preload_libraries")
+            available_columns = set(self._get_pg_stat_statements_columns(db))
+            missing_columns = PG_STAT_STATEMENTS_REQUIRED_COLUMNS - available_columns
+            if len(missing_columns) > 0:
+                self._log.warning(
+                    'Unable to collect statement metrics because required fields are unavailable: %s',
+                    ', '.join(list(missing_columns)),
+                )
                 return []
-            else:
-                raise
 
-    def _load_pg_stat_statements(self, db):
-        available_columns = set(self._get_pg_stat_statements_columns(db))
-        missing_columns = PG_STAT_STATEMENTS_REQUIRED_COLUMNS - available_columns
-        if len(missing_columns) > 0:
-            self._log.warning(
-                'Unable to collect statement metrics because required fields are unavailable: %s',
-                ', '.join(list(missing_columns)),
+            query_columns = sorted(list(available_columns & PG_STAT_ALL_DESIRED_COLUMNS))
+            params = ()
+            filters = ""
+            if self._config.dbstrict:
+                filters = "AND pg_database.datname = %s"
+                params = (self._config.dbname,)
+            return self._execute_query(
+                db.cursor(cursor_factory=psycopg2.extras.DictCursor),
+                STATEMENTS_QUERY.format(
+                    cols=', '.join(query_columns),
+                    pg_stat_statements_view=self._config.pg_stat_statements_view,
+                    filters=filters,
+                    limit=DEFAULT_STATEMENTS_LIMIT,
+                ),
+                params=params,
             )
+        except psycopg2.errors.ObjectNotInPrerequisiteState as e:
+            if 'pg_stat_statements must be loaded' in str(e):
+                self._check.count(
+                    "dd.postgres.statement_metrics.error",
+                    1,
+                    tags=tags + ["error:pg_stat_statements_not_enabled"]
+                )
+                self._log.warning(
+                    "Unable to collect statement metrics because pg_stat_statements must be loaded via "
+                    "shared_preload_libraries"
+                )
+            else:
+                self._check.count(
+                    "dd.postgres.statement_metrics.error",
+                    1,
+                    tags=tags + ["error:database-{}".format(type(e).__name__)]
+                )
+                self._log.warning(
+                    "Unable to collect statement metrics because of an error running queries: %s", e
+                )
+        except psycopg2.Error as e:
+            self._check.count(
+                "dd.postgres.statement_metrics.error",
+                1,
+                tags=tags + ["error:database-{}".format(type(e).__name__)]
+            )
+            self._log.warning(
+                "Unable to collect statement metrics because of an error running queries: %s", e
+            )
+
             return []
 
-        query_columns = sorted(list(available_columns & PG_STAT_ALL_DESIRED_COLUMNS))
-        params = ()
-        filters = ""
-        if self._config.dbstrict:
-            filters = "AND pg_database.datname = %s"
-            params = (self._config.dbname,)
-        return self._execute_query(
-            db.cursor(cursor_factory=psycopg2.extras.DictCursor),
-            STATEMENTS_QUERY.format(
-                cols=', '.join(query_columns),
-                pg_stat_statements_view=self._config.pg_stat_statements_view,
-                filters=filters,
-                limit=DEFAULT_STATEMENTS_LIMIT,
-            ),
-            params=params,
-        )
-
     def _collect_metrics_rows(self, db, tags):
-        rows = self._load_pg_stat_statements_safe(db, tags)
+        rows = self._load_pg_stat_statements(db, tags)
 
         rows = self._normalize_queries(rows)
         if not rows:

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -198,7 +198,7 @@ class PostgresStatementMetrics(object):
             )
         except psycopg2.Error as e:
             error_tag = "error:database-{}".format(type(e).__name__)
-            self._log.warning("TYPE: %s, error: %s", type(e), e.pgerror)
+
             if (
                 isinstance(e, psycopg2.errors.ObjectNotInPrerequisiteState)
             ) and 'pg_stat_statements must be loaded' in str(e.pgerror):

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -194,9 +194,7 @@ class PostgresStatementMetrics(object):
         except psycopg2.errors.ObjectNotInPrerequisiteState as e:
             if 'pg_stat_statements must be loaded' in str(e):
                 self._check.count(
-                    "dd.postgres.statement_metrics.error",
-                    1,
-                    tags=tags + ["error:pg_stat_statements_not_enabled"]
+                    "dd.postgres.statement_metrics.error", 1, tags=tags + ["error:pg_stat_statements_not_enabled"]
                 )
                 self._log.warning(
                     "Unable to collect statement metrics because pg_stat_statements must be loaded via "
@@ -204,22 +202,14 @@ class PostgresStatementMetrics(object):
                 )
             else:
                 self._check.count(
-                    "dd.postgres.statement_metrics.error",
-                    1,
-                    tags=tags + ["error:database-{}".format(type(e).__name__)]
+                    "dd.postgres.statement_metrics.error", 1, tags=tags + ["error:database-{}".format(type(e).__name__)]
                 )
-                self._log.warning(
-                    "Unable to collect statement metrics because of an error running queries: %s", e
-                )
+                self._log.warning("Unable to collect statement metrics because of an error running queries: %s", e)
         except psycopg2.Error as e:
             self._check.count(
-                "dd.postgres.statement_metrics.error",
-                1,
-                tags=tags + ["error:database-{}".format(type(e).__name__)]
+                "dd.postgres.statement_metrics.error", 1, tags=tags + ["error:database-{}".format(type(e).__name__)]
             )
-            self._log.warning(
-                "Unable to collect statement metrics because of an error running queries: %s", e
-            )
+            self._log.warning("Unable to collect statement metrics because of an error running queries: %s", e)
 
             return []
 

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -194,7 +194,9 @@ class PostgresStatementMetrics(object):
         except psycopg2.errors.ObjectNotInPrerequisiteState as e:
             if 'pg_stat_statements must be loaded' in str(e):
                 self._check.count(
-                    "dd.postgres.statement_metrics.error", 1, tags=tags + ["error:pg_stat_statements_not_enabled"]
+                    "dd.postgres.statement_metrics.error",
+                    1,
+                    tags=tags + ["error:database-ObjectNotInPrerequisiteState-pg_stat_statements_not_enabled"],
                 )
                 self._log.warning(
                     "Unable to collect statement metrics because pg_stat_statements must be loaded via "

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -664,7 +664,7 @@ def test_statement_samples_config_invalid_number(integration_check, pg_instance,
             psycopg2.errors.ObjectNotInPrerequisiteState(
                 'pg_stat_statements must be loaded via shared_preload_libraries'
             ),
-            'error:pg_stat_statements_not_enabled',
+            'error:database-ObjectNotInPrerequisiteState-pg_stat_statements_not_enabled',
         ),
         (
             psycopg2.errors.ObjectNotInPrerequisiteState('cannot insert into view'),


### PR DESCRIPTION
### What does this PR do?
This adds better error handling of the case where `pg_stat_statements` isn't enabled as well as implement some generic handling for other errors. It does so by catching the error and logging a message as well as incrementing a counter tagged with the reason. 

### Motivation
Improve logging to help users diagnose misconfigurations as well as improve visibility on the setup error via metrics.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
