### PR TITLE
remove execution plan cost extraction

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -457,7 +457,7 @@ class PostgresStatementSamples(object):
         if explain_err_code:
             collection_error = {'code': explain_err_code.value, 'message': err_msg if err_msg else None}
 
-        plan, normalized_plan, obfuscated_plan, plan_signature, plan_cost = None, None, None, None, None
+        plan, normalized_plan, obfuscated_plan, plan_signature = None, None, None, None
         if plan_dict:
             plan = json.dumps(plan_dict)
             # if we're using the orjson implementation then json.dumps returns bytes

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -465,7 +465,6 @@ class PostgresStatementSamples(object):
             normalized_plan = datadog_agent.obfuscate_sql_exec_plan(plan, normalize=True)
             obfuscated_plan = datadog_agent.obfuscate_sql_exec_plan(plan)
             plan_signature = compute_exec_plan_signature(normalized_plan)
-            plan_cost = plan_dict.get('Plan', {}).get('Total Cost', 0.0) or 0.0
 
         statement_plan_sig = (query_signature, plan_signature)
         if self._seen_samples_ratelimiter.acquire(statement_plan_sig):
@@ -485,7 +484,6 @@ class PostgresStatementSamples(object):
                     "instance": row.get('datname', None),
                     "plan": {
                         "definition": obfuscated_plan,
-                        "cost": plan_cost,
                         "signature": plan_signature,
                         "collection_error": collection_error,
                     },


### PR DESCRIPTION
### What does this PR do?

Extraction of cost from execution plans is now being done during ingestion.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
