### PR TITLE
Document the minimum kernel version needed by the `oom_kill` check

### DIFF
--- a/oom_kill/README.md
+++ b/oom_kill/README.md
@@ -23,8 +23,8 @@ yum install -y kernel-headers-$(uname -r)
 yum install -y kernel-devel-$(uname -r)
 ```
 
-**Note**: A kernel version 4.9 or more recent is required for the OOM Kill check to work.
-In particular, CentOS/RHEL versions < 8 are not supported.
+**Note**: Kernel version 4.11 or later is required for the OOM Kill check to work.
+In addition, CentOS/RHEL versions earlier than 8 are not supported.
 
 ### Configuration
 

--- a/oom_kill/README.md
+++ b/oom_kill/README.md
@@ -23,7 +23,8 @@ yum install -y kernel-headers-$(uname -r)
 yum install -y kernel-devel-$(uname -r)
 ```
 
-**Note**: CentOS/RHEL versions < 8 are not supported.
+**Note**: A kernel version 4.9 or more recent is required for the OOM Kill check to work.
+In particular, CentOS/RHEL versions < 8 are not supported.
 
 ### Configuration
 


### PR DESCRIPTION
### What does this PR do?

Document the fact that the `oom_kill` check requires a kernel 4.9 or more recent.

### Motivation

People might be tempted to try the `oom_kill` check on old Linux versions. Let’s document when it’s not even worth trying !

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
