### PR TITLE
Fix `meta dash export`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/dashboard.py
@@ -13,7 +13,7 @@ from ...constants import get_root
 from ...utils import get_valid_integrations, load_manifest, write_manifest
 from ..console import CONTEXT_SETTINGS, abort, echo_success
 
-BOARD_ID_PATTERN = r'{site}/[^/]+/([^/]+)/.*'
+BOARD_ID_PATTERN = r'{site}/[^/]+/([^/]+)'
 DASHBOARD_API = 'https://api.{site}/api/v1/dashboard/{board_id}'
 REQUIRED_FIELDS = ["layout_type", "title", "description", "template_variables", "widgets"]
 


### PR DESCRIPTION
### Motivation

Need to be less restrictive to support new routes e.g.

```
$ ddev meta dash export https://app.datadoghq.com/dashboard/znc-pbv-mny amazon_msk
Invalid `url`
```