### PR TITLE
Fix AttributeError when filters are not set

### DIFF
--- a/win32_event_log/datadog_checks/win32_event_log/config_models/validators.py
+++ b/win32_event_log/datadog_checks/win32_event_log/config_models/validators.py
@@ -4,7 +4,7 @@
 
 
 def initialize_instance(values, **kwargs):
-    if filters := values.get('filters', {}):
+    if filters := values.get('filters', values.setdefault('filters', {})):
         if isinstance(filters, dict) and 'type' in filters:
             types = filters['type']
             if isinstance(types, list):

--- a/win32_event_log/datadog_checks/win32_event_log/config_models/validators.py
+++ b/win32_event_log/datadog_checks/win32_event_log/config_models/validators.py
@@ -4,7 +4,8 @@
 
 
 def initialize_instance(values, **kwargs):
-    if filters := values.get('filters', values.setdefault('filters', {})):
+    filters = values.setdefault('filters', {})
+    if filters:
         if isinstance(filters, dict) and 'type' in filters:
             types = filters['type']
             if isinstance(types, list):


### PR DESCRIPTION
### What does this PR do?
Fixes `AttributeError: 'NoneType' object has no attribute 'dict'` when no `filters:` are set.

### Motivation
AGENT-6573

### Additional Notes
Workaround is to set `filters: {}` in the config file

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
