### PR TITLE
decouple DBM query metrics interval from check run interval

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -240,6 +240,23 @@ files:
       value:
         type: string
         example: show_pg_stat_statements()
+    - name: statement_metrics
+      description: Configure collection of statement metrics
+      options:
+        - name: enabled
+          description: |
+            Enable collection of statement metrics. Requires `dbm: true`.
+          value:
+            type: boolean
+            example: true
+        - name: collection_interval
+          description: |
+            Set the statement metric collection interval (in seconds). Each collection involves a single query to
+            `pg_stat_statements`. If a non-default value is chosen then that exact same value must be used for *every*
+            check instance. Running different instances with different collection intervals is not supported.
+          value:
+            type: number
+            example: 10
     - name: statement_samples
       description: Configure collection of statement samples
       options:
@@ -249,9 +266,9 @@ files:
           value:
             type: boolean
             example: true
-        - name: collections_per_second
+        - name: collection_interval
           description: |
-            Set the maximum statement sample collection rate. Each collection involves a single query to
+            Set the statement sample collection interval (in seconds). Each collection involves a single query to
             `pg_stat_activity` followed by at most one `EXPLAIN` query per unique statement seen.
           value:
             type: number

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -81,6 +81,7 @@ class PostgresConfig:
         # statement samples & execution plans
         self.pg_stat_activity_view = instance.get('pg_stat_activity_view', 'pg_stat_activity')
         self.statement_samples_config = instance.get('statement_samples', {}) or {}
+        self.statement_metrics_config = instance.get('statement_metrics', {}) or {}
 
     def _build_tags(self, custom_tags):
         # Clean up tags in case there was a None entry in the instance

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -92,6 +92,10 @@ def instance_ssl(field, value):
     return 'false'
 
 
+def instance_statement_metrics(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_statement_samples(field, value):
     return get_default_field_value(field, value)
 

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -24,11 +24,19 @@ class Relation(BaseModel):
     schemas: Optional[Sequence[str]]
 
 
+class StatementMetrics(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    collection_interval: Optional[float]
+    enabled: Optional[bool]
+
+
 class StatementSamples(BaseModel):
     class Config:
         allow_mutation = False
 
-    collections_per_second: Optional[float]
+    collection_interval: Optional[float]
     enabled: Optional[bool]
     explain_function: Optional[str]
     explained_statements_cache_maxsize: Optional[int]
@@ -63,6 +71,7 @@ class InstanceConfig(BaseModel):
     relations: Optional[Sequence[Union[str, Relation]]]
     service: Optional[str]
     ssl: Optional[str]
+    statement_metrics: Optional[StatementMetrics]
     statement_samples: Optional[StatementSamples]
     table_count_limit: Optional[int]
     tag_replication_role: Optional[bool]

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -198,6 +198,22 @@ instances:
     #
     # pg_stat_statements_view: show_pg_stat_statements()
 
+    ## Configure collection of statement metrics
+    #
+    statement_metrics:
+
+        ## @param enabled - boolean - optional - default: true
+        ## Enable collection of statement metrics. Requires `dbm: true`.
+        #
+        # enabled: true
+
+        ## @param collection_interval - number - optional - default: 10
+        ## Set the statement metric collection interval (in seconds). Each collection involves a single query to
+        ## `pg_stat_statements`. If a non-default value is chosen then that exact same value must be used for *every*
+        ## check instance. Running different instances with different collection intervals is not supported.
+        #
+        # collection_interval: 10
+
     ## Configure collection of statement samples
     #
     statement_samples:
@@ -207,11 +223,11 @@ instances:
         #
         # enabled: true
 
-        ## @param collections_per_second - number - optional - default: 1
-        ## Set the maximum statement sample collection rate. Each collection involves a single query to
+        ## @param collection_interval - number - optional - default: 1
+        ## Set the statement sample collection interval (in seconds). Each collection involves a single query to
         ## `pg_stat_activity` followed by at most one `EXPLAIN` query per unique statement seen.
         #
-        # collections_per_second: 1
+        # collection_interval: 1
 
         ## @param explain_function - string - optional - default: datadog.explain_statement
         ## Override the default function used to collect execution plans for statements.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import copy
+import threading
 from contextlib import closing
 
 import psycopg2
@@ -18,6 +19,9 @@ from .util import CONNECTION_METRICS, FUNCTION_METRICS, REPLICATION_METRICS, fmt
 from .version_utils import V9, VersionUtils
 
 MAX_CUSTOM_RESULTS = 100
+
+TRACK_ACTIVITY_QUERY_SIZE_QUERY = "SELECT setting FROM pg_settings WHERE name='track_activity_query_size'"
+TRACK_ACTIVITY_QUERY_SIZE_UNKNOWN_VALUE = -1
 
 
 class PostgreSql(AgentCheck):
@@ -41,14 +45,21 @@ class PostgreSql(AgentCheck):
             )
         self._config = PostgresConfig(self.instance)
         self.metrics_cache = PostgresMetricsCache(self._config)
-        self.statement_metrics = PostgresStatementMetrics(self, self._config)
-        self.statement_samples = PostgresStatementSamples(self, self._config)
+        self.statement_metrics = PostgresStatementMetrics(self, self._config, shutdown_callback=self._close_db_pool)
+        self.statement_samples = PostgresStatementSamples(self, self._config, shutdown_callback=self._close_db_pool)
         self._relations_manager = RelationsManager(self._config.relations)
         self._clean_state()
         self.check_initializations.append(lambda: RelationsManager.validate_relations_config(self._config.relations))
+        # The value is loaded when connecting to the main database
+        self._db_configured_track_activity_query_size = TRACK_ACTIVITY_QUERY_SIZE_UNKNOWN_VALUE
+
+        # map[dbname -> psycopg connection]
+        self._db_pool = {}
+        self._db_pool_lock = threading.Lock()
 
     def cancel(self):
         self.statement_samples.cancel()
+        self.statement_metrics.cancel()
 
     def _clean_state(self):
         self.log.debug("Cleaning state")
@@ -290,6 +301,55 @@ class PostgreSql(AgentCheck):
         else:
             self.db = self._new_connection(self._config.dbname)
 
+    # Reload the track_activity_query_size setting on a new connection to the main db
+    def _load_query_max_text_size(self, db):
+        try:
+            with db.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
+                self.log.debug("Running query [%s]", TRACK_ACTIVITY_QUERY_SIZE_QUERY)
+                cursor.execute(TRACK_ACTIVITY_QUERY_SIZE_QUERY)
+                row = cursor.fetchone()
+                self._db_configured_track_activity_query_size = int(row['setting'])
+        except (psycopg2.DatabaseError, psycopg2.OperationalError) as e:
+            self.log.warning("cannot read track_activity_query_size from pg_settings: %s", repr(e))
+            self._check.count(
+                "dd.postgres.statement_samples.error",
+                1,
+                tags=self._tags + ["error:load-track-activity-query-size"],
+            )
+
+    def _get_db(self, dbname):
+        """
+        Returns a memoized psycopg2 connection to `dbname` with autocommit
+        Threadsafe as long as no transactions are used
+        :param dbname:
+        :return: a psycopg2 connection
+        """
+        # TODO: migrate the rest of this check to use a connection from this pool
+        with self._db_pool_lock:
+            db = self._db_pool.get(dbname)
+            if not db or db.closed:
+                self.log.debug("initializing connection to dbname=%s", dbname)
+                db = self._new_connection(dbname)
+                db.set_session(autocommit=True)
+                self._db_pool[dbname] = db
+            if db.status != psycopg2.extensions.STATUS_READY:
+                # Some transaction went wrong and the connection is in an unhealthy state. Let's fix that
+                db.rollback()
+            if self._config.dbname == dbname:
+                self._load_query_max_text_size(db)
+            return db
+
+    def _close_db_pool(self):
+        # TODO: add automatic aging out of connections after some time
+        with self._db_pool_lock:
+            for dbname, db in self._db_pool.items():
+                if db and not db.closed:
+                    try:
+                        db.close()
+                    except Exception:
+                        self._log.exception("failed to close DB connection for db=%s", dbname)
+                self._db_pool[dbname] = None
+
     def _collect_custom_queries(self, tags):
         """
         Given a list of custom_queries, execute each query and parse the result for metrics
@@ -398,11 +458,11 @@ class PostgreSql(AgentCheck):
             self._collect_stats(tags)
             self._collect_custom_queries(tags)
             if self._config.dbm_enabled:
-                self.statement_metrics.collect_per_statement_metrics(self.db, self.version, tags)
-                self.statement_samples.run_sampler(tags)
+                self.statement_metrics.run_job_loop(tags)
+                self.statement_samples.run_job_loop(tags)
 
         except Exception as e:
-            self.log.error("Unable to collect postgres metrics.")
+            self.log.exception("Unable to collect postgres metrics.")
             self._clean_state()
             self.db = None
             message = u'Error establishing connection to postgres://{}:{}/{}, error is {}'.format(

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -1,9 +1,5 @@
-import logging
-import os
 import re
-import threading
 import time
-from concurrent.futures.thread import ThreadPoolExecutor
 from enum import Enum
 from typing import Dict, Optional, Tuple
 
@@ -17,20 +13,16 @@ except ImportError:
     from ..stubs import datadog_agent
 
 from datadog_checks.base import is_affirmative
-from datadog_checks.base.log import get_check_logger
 from datadog_checks.base.utils.db.sql import compute_exec_plan_signature, compute_sql_signature
-from datadog_checks.base.utils.db.utils import (
-    ConstantRateLimiter,
-    RateLimitingTTLCache,
-    default_json_event_encoding,
-    resolve_db_host,
-)
+from datadog_checks.base.utils.db.utils import DBMAsyncJob, RateLimitingTTLCache, default_json_event_encoding
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.time import get_timestamp
 
 # according to https://unicodebook.readthedocs.io/unicode_encodings.html, the max supported size of a UTF-8 encoded
 # character is 6 bytes
 MAX_CHARACTER_SIZE_IN_BYTES = 6
+
+TRACK_ACTIVITY_QUERY_SIZE_UNKNOWN_VALUE = -1
 
 SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update', 'with'})
 
@@ -60,10 +52,6 @@ PG_STAT_ACTIVITY_QUERY = re.sub(
 ).strip()
 
 EXPLAIN_VALIDATION_QUERY = "SELECT * FROM pg_stat_activity"
-
-MAX_ACTIVITY_QUERY_SIZE_QUERY = "SELECT setting FROM pg_settings WHERE name='track_activity_query_size'"
-
-UNKNOWN_VALUE = -1
 
 
 class StatementTruncationState(Enum):
@@ -100,58 +88,56 @@ class DBExplainError(Enum):
     statement_truncated = "statement_truncated"
 
 
-class PostgresStatementSamples(object):
+DEFAULT_COLLECTION_INTERVAL = 1
+
+
+class PostgresStatementSamples(DBMAsyncJob):
     """
     Collects statement samples and execution plans.
     """
 
-    executor = ThreadPoolExecutor()
-
-    def __init__(self, check, config):
+    def __init__(self, check, config, shutdown_callback):
+        collection_interval = float(
+            config.statement_samples_config.get('collection_interval', DEFAULT_COLLECTION_INTERVAL)
+        )
+        if collection_interval <= 0:
+            collection_interval = DEFAULT_COLLECTION_INTERVAL
+        super(PostgresStatementSamples, self).__init__(
+            check,
+            rate_limit=1 / collection_interval,
+            run_sync=is_affirmative(config.statement_samples_config.get('run_sync', False)),
+            enabled=is_affirmative(config.statement_samples_config.get('enabled', True)),
+            dbms="postgres",
+            min_collection_interval=config.min_collection_interval,
+            config_host=config.host,
+            expected_db_exceptions=(psycopg2.errors.DatabaseError,),
+            job_name="statement-samples",
+            shutdown_callback=shutdown_callback,
+        )
         self._check = check
-        # map[dbname -> psycopg connection]
-        self._db_pool = {}
         self._config = config
-        self._log = get_check_logger()
         self._activity_last_query_start = None
-        self._last_check_run = 0
-        self._collection_loop_future = None
-        self._cancel_event = threading.Event()
-        self._tags = None
         self._tags_no_db = None
-        self._db_hostname = resolve_db_host(self._config.host)
-        self._enabled = is_affirmative(self._config.statement_samples_config.get('enabled', True))
-        self._run_sync = is_affirmative(self._config.statement_samples_config.get('run_sync', False))
-        # The value is loaded when connecting to the main database
-        self._max_query_size = UNKNOWN_VALUE
-        self._rate_limiter = ConstantRateLimiter(
-            float(self._config.statement_samples_config.get('collections_per_second', 1))
-        )
-        self._explain_function = self._config.statement_samples_config.get(
-            'explain_function', 'datadog.explain_statement'
-        )
+        self._explain_function = config.statement_samples_config.get('explain_function', 'datadog.explain_statement')
 
         self._collection_strategy_cache = TTLCache(
-            maxsize=self._config.statement_samples_config.get('collection_strategy_cache_maxsize', 1000),
-            ttl=self._config.statement_samples_config.get('collection_strategy_cache_ttl', 300),
+            maxsize=config.statement_samples_config.get('collection_strategy_cache_maxsize', 1000),
+            ttl=config.statement_samples_config.get('collection_strategy_cache_ttl', 300),
         )
 
         # explained_statements_ratelimiter: limit how often we try to re-explain the same query
         self._explained_statements_ratelimiter = RateLimitingTTLCache(
-            maxsize=int(self._config.statement_samples_config.get('explained_statements_cache_maxsize', 5000)),
-            ttl=60 * 60 / int(self._config.statement_samples_config.get('explained_statements_per_hour_per_query', 60)),
+            maxsize=int(config.statement_samples_config.get('explained_statements_cache_maxsize', 5000)),
+            ttl=60 * 60 / int(config.statement_samples_config.get('explained_statements_per_hour_per_query', 60)),
         )
 
         # seen_samples_ratelimiter: limit the ingestion rate per (query_signature, plan_signature)
         self._seen_samples_ratelimiter = RateLimitingTTLCache(
             # assuming ~100 bytes per entry (query & plan signature, key hash, 4 pointers (ordered dict), expiry time)
             # total size: 10k * 100 = 1 Mb
-            maxsize=int(self._config.statement_samples_config.get('seen_samples_cache_maxsize', 10000)),
-            ttl=60 * 60 / int(self._config.statement_samples_config.get('samples_per_hour_per_query', 15)),
+            maxsize=int(config.statement_samples_config.get('seen_samples_cache_maxsize', 10000)),
+            ttl=60 * 60 / int(config.statement_samples_config.get('samples_per_hour_per_query', 15)),
         )
-
-    def cancel(self):
-        self._cancel_event.set()
 
     def _dbtags(self, db, *extra_tags):
         """
@@ -163,30 +149,6 @@ class PostgresStatementSamples(object):
         if self._tags_no_db:
             t.extend(self._tags_no_db)
         return t
-
-    def run_sampler(self, tags):
-        """
-        start the sampler thread if not already running
-        :param tags:
-        :return:
-        """
-        if not self._enabled:
-            self._log.debug("Statement sampler not enabled")
-            return
-
-        # since statement samples are collected from all databases on this host we need to tag telemetry with the
-        # right "db" tag which may be different from the initial database that the check is configured to connect to
-        self._tags = tags
-        self._tags_str = ','.join(self._tags)
-        self._tags_no_db = [t for t in tags if not t.startswith('db:')]
-        self._last_check_run = time.time()
-        if self._run_sync or is_affirmative(os.environ.get('DBM_STATEMENT_SAMPLER_RUN_SYNC', "false")):
-            self._log.debug("Running statement sampler synchronously")
-            self._collect_statement_samples()
-        elif self._collection_loop_future is None or not self._collection_loop_future.running():
-            self._collection_loop_future = PostgresStatementSamples.executor.submit(self._collection_loop)
-        else:
-            self._log.debug("Statement sampler collection loop already running")
 
     def _get_new_pg_stat_activity(self):
         start_time = time.time()
@@ -201,7 +163,7 @@ class PostgresStatementSamples(object):
         if self._activity_last_query_start:
             query = query + " AND query_start > %s"
             params = params + (self._activity_last_query_start,)
-        with self._get_db(self._config.dbname).cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
+        with self._check._get_db(self._config.dbname).cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
             self._log.debug("Running query [%s] %s", query, params)
             cursor.execute(query, params)
             rows = cursor.fetchall()
@@ -238,70 +200,11 @@ class PostgresStatementSamples(object):
                 tags=self._tags + ["error:insufficient-privilege"],
             )
 
-    def _get_db(self, dbname):
-        # while psycopg2 is threadsafe (meaning in theory we should be able to use the same connection as the parent
-        # check), the parent doesn't use autocommit and instead calls commit() and rollback() explicitly, meaning
-        # it can cause strange clashing issues if we're trying to use the same connection from another thread here.
-        # since the statement sampler runs continuously it's best we have our own connection here with autocommit
-        # enabled
-        db = self._db_pool.get(dbname)
-        if not db or db.closed:
-            self._log.debug("initializing connection to dbname=%s", dbname)
-            db = self._check._new_connection(dbname)
-            db.set_session(autocommit=True)
-            self._db_pool[dbname] = db
-            # Reload the track_activity_query_size setting on a new connection to the main db
-            if self._config.dbname == dbname:
-                self._load_query_max_text_size(db)
-        if db.status != psycopg2.extensions.STATUS_READY:
-            # Some transaction went wrong and the connection is in an unhealthy state. Let's fix that
-            db.rollback()
-        return db
-
-    def _collection_loop(self):
-        try:
-            self._log.info("Starting statement sampler collection loop")
-            while True:
-                if self._cancel_event.isSet():
-                    self._log.info("Collection loop cancelled")
-                    self._check.count("dd.postgres.statement_samples.collection_loop_cancel", 1, tags=self._tags)
-                    break
-                if time.time() - self._last_check_run > self._config.min_collection_interval * 2:
-                    self._log.info("Sampler collection loop stopping due to check inactivity")
-                    self._check.count("dd.postgres.statement_samples.collection_loop_inactive_stop", 1, tags=self._tags)
-                    break
-                self._collect_statement_samples()
-        except psycopg2.errors.DatabaseError as e:
-            self._log.warning(
-                "Statement sampler database error: %s", e, exc_info=self._log.getEffectiveLevel() == logging.DEBUG
-            )
-            self._check.count(
-                "dd.postgres.statement_samples.error",
-                1,
-                tags=self._tags + ["error:database-{}".format(type(e))],
-            )
-        except Exception as e:
-            self._log.exception("Statement sampler collection loop crash")
-            self._check.count(
-                "dd.postgres.statement_samples.error",
-                1,
-                tags=self._tags + ["error:collection-loop-crash-{}".format(type(e))],
-            )
-        finally:
-            self._log.info("Shutting down statement sampler collection loop")
-            self._close_db_pool()
-
-    def _close_db_pool(self):
-        for dbname, db in self._db_pool.items():
-            if db and not db.closed:
-                try:
-                    db.close()
-                except Exception:
-                    self._log.exception("failed to close DB connection for db=%s", dbname)
-            self._db_pool[dbname] = None
+    def run_job(self):
+        self._tags_no_db = [t for t in self._tags if not t.startswith('db:')]
+        self._collect_statement_samples()
 
     def _collect_statement_samples(self):
-        self._rate_limiter.sleep()
         start_time = time.time()
         rows = self._get_new_pg_stat_activity()
         rows = self._filter_valid_statement_rows(rows)
@@ -338,7 +241,7 @@ class PostgresStatementSamples(object):
     def _get_db_explain_setup_state(self, dbname):
         # type: (str) -> Tuple[Optional[DBExplainError], Optional[Exception]]
         try:
-            self._get_db(dbname)
+            self._check._get_db(dbname)
         except (psycopg2.DatabaseError, psycopg2.OperationalError) as e:
             self._log.warning(
                 "cannot collect execution plans due to failed DB connection to dbname=%s: %s", dbname, repr(e)
@@ -377,7 +280,7 @@ class PostgresStatementSamples(object):
 
     def _run_explain(self, dbname, statement, obfuscated_statement):
         start_time = time.time()
-        with self._get_db(dbname).cursor() as cursor:
+        with self._check._get_db(dbname).cursor() as cursor:
             self._log.debug("Running query on dbname=%s: %s(%s)", dbname, self._explain_function, obfuscated_statement)
             cursor.execute(
                 """SELECT {explain_function}($stmt${statement}$stmt$)""".format(
@@ -392,12 +295,14 @@ class PostgresStatementSamples(object):
                 return None
             return result[0][0]
 
-    def _run_explain_safe(self, max_query_size, dbname, statement, obfuscated_statement):
-        # type: (int, str, str, str) -> Tuple[Optional[Dict], Optional[DBExplainError], Optional[str]]
+    def _run_explain_safe(self, dbname, statement, obfuscated_statement):
+        # type: (str, str, str) -> Tuple[Optional[Dict], Optional[DBExplainError], Optional[str]]
         if not self._can_explain_statement(obfuscated_statement):
             return None, DBExplainError.no_plans_possible, None
 
-        if self._get_truncation_state(max_query_size, statement) == StatementTruncationState.truncated:
+        track_activity_query_size = self._check._db_configured_track_activity_query_size
+
+        if self._get_truncation_state(track_activity_query_size, statement) == StatementTruncationState.truncated:
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 1,
@@ -406,7 +311,7 @@ class PostgresStatementSamples(object):
             return (
                 None,
                 DBExplainError.statement_truncated,
-                "track_activity_query_size={}".format(max_query_size),
+                "track_activity_query_size={}".format(track_activity_query_size),
             )
 
         db_explain_error, err = self._get_db_explain_setup_state_cached(dbname)
@@ -451,7 +356,7 @@ class PostgresStatementSamples(object):
         # - `resource_hash` - hash computed off the raw sql text to match apm resources
         # - `query_signature` - hash computed from the raw sql text to match query metrics
         plan_dict, explain_err_code, err_msg = self._run_explain_safe(
-            self._max_query_size, row['datname'], row['query'], obfuscated_statement
+            row['datname'], row['query'], obfuscated_statement
         )
         collection_error = None
         if explain_err_code:
@@ -494,7 +399,9 @@ class PostgresStatementSamples(object):
                     "application": row.get('application_name', None),
                     "user": row['usename'],
                     "statement": obfuscated_statement,
-                    "statement_truncated": self._get_truncation_state(self._max_query_size, row['query']).value,
+                    "statement_truncated": self._get_truncation_state(
+                        self._check._db_configured_track_activity_query_size, row['query']
+                    ).value,
                 },
                 'postgres': {k: v for k, v in row.items() if k not in pg_stat_activity_sample_exclude_keys},
             }
@@ -527,26 +434,11 @@ class PostgresStatementSamples(object):
                     tags=self._tags + ["error:collect-plan-for-statement-crash"],
                 )
 
-    def _load_query_max_text_size(self, db):
-        try:
-            with db.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
-                self._log.debug("Running query [%s]", MAX_ACTIVITY_QUERY_SIZE_QUERY)
-                cursor.execute(MAX_ACTIVITY_QUERY_SIZE_QUERY)
-                row = cursor.fetchone()
-                self._max_query_size = int(row['setting'])
-        except (psycopg2.DatabaseError, psycopg2.OperationalError) as e:
-            self._log.warning("cannot read track_activity_query_size from pg_settings: %s", repr(e))
-            self._check.count(
-                "dd.postgres.statement_samples.error",
-                1,
-                tags=self._tags + ["error:load-track-activity-query-size"],
-            )
-
     @staticmethod
-    def _get_truncation_state(max_query_size, statement):
+    def _get_truncation_state(track_activity_query_size, statement):
         # Only check is a statement is truncated if the value of track_activity_query_size was loaded correctly
         # to avoid confusingly reporting a wrong indicator by using a default that might be wrong for the database
-        if max_query_size == UNKNOWN_VALUE:
+        if track_activity_query_size == TRACK_ACTIVITY_QUERY_SIZE_UNKNOWN_VALUE:
             return StatementTruncationState.unknown
 
         # Compare the query length (in bytes to match Postgres) to the configured max query size to determine
@@ -556,5 +448,5 @@ class PostgresStatementSamples(object):
         # happens to be greater or equal to the threshold below but isn't actually truncated, this
         # would falsely report it as a truncated statement
         statement_bytes = bytes(statement) if PY2 else bytes(statement, "utf-8")
-        truncated = len(statement_bytes) >= max_query_size - (MAX_CHARACTER_SIZE_IN_BYTES + 1)
+        truncated = len(statement_bytes) >= track_activity_query_size - (MAX_CHARACTER_SIZE_IN_BYTES + 1)
         return StatementTruncationState.truncated if truncated else StatementTruncationState.not_truncated

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -10,10 +10,10 @@ import psycopg2
 import psycopg2.extras
 from cachetools import TTLCache
 
-from datadog_checks.base.log import get_check_logger
+from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.statement_metrics import StatementMetrics
-from datadog_checks.base.utils.db.utils import default_json_event_encoding, resolve_db_host
+from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, resolve_db_host
 from datadog_checks.base.utils.serialization import json
 
 try:
@@ -81,20 +81,37 @@ def _row_key(row):
     return row['query_signature'], row['datname'], row['rolname']
 
 
-class PostgresStatementMetrics(object):
+DEFAULT_COLLECTION_INTERVAL = 10
+
+
+class PostgresStatementMetrics(DBMAsyncJob):
     """Collects telemetry for SQL statements"""
 
-    def __init__(self, check, config):
-        self._check = check
+    def __init__(self, check, config, shutdown_callback):
+        collection_interval = float(
+            config.statement_metrics_config.get('collection_interval', DEFAULT_COLLECTION_INTERVAL)
+        )
+        if collection_interval <= 0:
+            collection_interval = DEFAULT_COLLECTION_INTERVAL
+        super(PostgresStatementMetrics, self).__init__(
+            check,
+            run_sync=is_affirmative(config.statement_metrics_config.get('run_sync', False)),
+            enabled=is_affirmative(config.statement_metrics_config.get('enabled', True)),
+            expected_db_exceptions=(psycopg2.errors.DatabaseError,),
+            min_collection_interval=config.min_collection_interval,
+            config_host=config.host,
+            dbms="postgres",
+            rate_limit=1 / float(collection_interval),
+            job_name="statement-metrics",
+            shutdown_callback=shutdown_callback,
+        )
         self._config = config
-        self._db_hostname = None
-        self._log = get_check_logger()
         self._state = StatementMetrics()
         self._stat_column_cache = []
         # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature
         self._full_statement_text_cache = TTLCache(
-            maxsize=self._config.full_statement_text_cache_max_size,
-            ttl=60 * 60 / self._config.full_statement_text_samples_per_hour_per_query,
+            maxsize=config.full_statement_text_cache_max_size,
+            ttl=60 * 60 / config.full_statement_text_samples_per_hour_per_query,
         )
 
     def _execute_query(self, cursor, query, params=()):
@@ -109,7 +126,7 @@ class PostgresStatementMetrics(object):
             self._log.warning('Statement-level metrics are unavailable: %s', e)
             return []
 
-    def _get_pg_stat_statements_columns(self, db):
+    def _get_pg_stat_statements_columns(self):
         """
         Load the list of the columns available under the `pg_stat_statements` table. This must be queried because
         version is not a reliable way to determine the available columns on `pg_stat_statements`. The database can
@@ -122,7 +139,7 @@ class PostgresStatementMetrics(object):
         query = STATEMENTS_QUERY.format(
             cols='*', pg_stat_statements_view=self._config.pg_stat_statements_view, limit=0, filters=""
         )
-        cursor = db.cursor()
+        cursor = self._check._get_db(self._config.dbname).cursor()
         self._execute_query(cursor, query, params=(self._config.dbname,))
         col_names = [desc[0] for desc in cursor.description] if cursor.description else []
         self._stat_column_cache = col_names
@@ -134,16 +151,19 @@ class PostgresStatementMetrics(object):
         self._db_hostname = resolve_db_host(self._config.host)
         return self._db_hostname
 
-    def collect_per_statement_metrics(self, db, db_version, tags):
+    def run_job(self):
+        self._tags_no_db = [t for t in self._tags if not t.startswith('db:')]
+        self.collect_per_statement_metrics()
+
+    def collect_per_statement_metrics(self):
         # exclude the default "db" tag from statement metrics & FQT events because this data is collected from
         # all databases on the host. For metrics the "db" tag is added during ingestion based on which database
         # each query came from.
-        tags_no_db = [t for t in tags if not t.startswith("db:")]
         try:
-            rows = self._collect_metrics_rows(db, tags)
+            rows = self._collect_metrics_rows()
             if not rows:
                 return
-            for event in self._rows_to_fqt_events(rows, tags_no_db):
+            for event in self._rows_to_fqt_events(rows):
                 self._check.database_monitoring_query_sample(json.dumps(event, default=default_json_event_encoding))
             # truncate query text to the maximum length supported by metrics tags
             for row in rows:
@@ -152,21 +172,20 @@ class PostgresStatementMetrics(object):
                 'host': self._db_hostname_cached(),
                 'timestamp': time.time() * 1000,
                 'min_collection_interval': self._config.min_collection_interval,
-                'tags': tags_no_db,
+                'tags': self._tags_no_db,
                 'postgres_rows': rows,
                 'postgres_version': 'v{major}.{minor}.{patch}'.format(
-                    major=db_version.major, minor=db_version.minor, patch=db_version.patch
+                    major=self._check._version.major, minor=self._check._version.minor, patch=self._check._version.patch
                 ),
             }
             self._check.database_monitoring_query_metrics(json.dumps(payload, default=default_json_event_encoding))
         except Exception:
-            db.rollback()
             self._log.exception('Unable to collect statement metrics due to an error')
             return []
 
-    def _load_pg_stat_statements(self, db, tags):
+    def _load_pg_stat_statements(self):
         try:
-            available_columns = set(self._get_pg_stat_statements_columns(db))
+            available_columns = set(self._get_pg_stat_statements_columns())
             missing_columns = PG_STAT_STATEMENTS_REQUIRED_COLUMNS - available_columns
             if len(missing_columns) > 0:
                 self._log.warning(
@@ -176,7 +195,7 @@ class PostgresStatementMetrics(object):
                 self._check.count(
                     "dd.postgres.statement_metrics.error",
                     1,
-                    tags=tags + ["error:database-missing_pg_stat_statements_required_columns"],
+                    tags=self._tags + ["error:database-missing_pg_stat_statements_required_columns"],
                 )
                 return []
 
@@ -187,7 +206,7 @@ class PostgresStatementMetrics(object):
                 filters = "AND pg_database.datname = %s"
                 params = (self._config.dbname,)
             return self._execute_query(
-                db.cursor(cursor_factory=psycopg2.extras.DictCursor),
+                self._check._get_db(self._config.dbname).cursor(cursor_factory=psycopg2.extras.DictCursor),
                 STATEMENTS_QUERY.format(
                     cols=', '.join(query_columns),
                     pg_stat_statements_view=self._config.pg_stat_statements_view,
@@ -210,12 +229,12 @@ class PostgresStatementMetrics(object):
             else:
                 self._log.warning("Unable to collect statement metrics because of an error running queries: %s", e)
 
-            self._check.count("dd.postgres.statement_metrics.error", 1, tags=tags + [error_tag])
+            self._check.count("dd.postgres.statement_metrics.error", 1, tags=self._tags + [error_tag])
 
             return []
 
-    def _collect_metrics_rows(self, db, tags):
-        rows = self._load_pg_stat_statements(db, tags)
+    def _collect_metrics_rows(self):
+        rows = self._load_pg_stat_statements()
 
         rows = self._normalize_queries(rows)
         if not rows:
@@ -244,13 +263,13 @@ class PostgresStatementMetrics(object):
 
         return normalized_rows
 
-    def _rows_to_fqt_events(self, rows, tags):
+    def _rows_to_fqt_events(self, rows):
         for row in rows:
             query_cache_key = _row_key(row)
             if query_cache_key in self._full_statement_text_cache:
                 continue
             self._full_statement_text_cache[query_cache_key] = True
-            row_tags = tags + [
+            row_tags = self._tags_no_db + [
                 "db:{}".format(row['datname']),
                 "rolname:{}".format(row['rolname']),
             ]

--- a/postgres/setup.py
+++ b/postgres/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=20.0.1'
+CHECKS_BASE_REQ = 'datadog-checks-base>=20.1.0'
 
 setup(
     name='datadog-postgres',

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -14,9 +14,10 @@ from semver import VersionInfo
 from six import string_types
 
 from datadog_checks.base.utils.db.sql import compute_sql_signature
+from datadog_checks.base.utils.db.utils import DBMAsyncJob
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.postgres import PostgreSql
-from datadog_checks.postgres.statement_samples import DBExplainError, PostgresStatementSamples, StatementTruncationState
+from datadog_checks.postgres.statement_samples import DBExplainError, StatementTruncationState
 from datadog_checks.postgres.statements import PG_STAT_STATEMENTS_METRICS_COLUMNS
 from datadog_checks.postgres.util import PartialFormatter, fmt
 
@@ -54,8 +55,8 @@ SAMPLE_QUERIES = [
 @pytest.fixture(autouse=True)
 def stop_orphaned_threads():
     # make sure we shut down any orphaned threads and create a new Executor for each test
-    PostgresStatementSamples.executor.shutdown(wait=True)
-    PostgresStatementSamples.executor = ThreadPoolExecutor()
+    DBMAsyncJob.executor.shutdown(wait=True)
+    DBMAsyncJob.executor = ThreadPoolExecutor()
 
 
 def test_common_metrics(aggregator, integration_check, pg_instance):
@@ -270,6 +271,8 @@ def test_statement_metrics(aggregator, integration_check, dbm_instance, dbstrict
     dbm_instance['pg_stat_statements_view'] = pg_stat_statements_view
     # don't need samples for this test
     dbm_instance['statement_samples'] = {'enabled': False}
+    # very low collection interval for test purposes
+    dbm_instance['statement_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
     connections = {}
 
     def _run_queries():
@@ -352,8 +355,11 @@ def test_statement_metrics(aggregator, integration_check, dbm_instance, dbstrict
         conn.close()
 
 
-def test_statement_metrics_with_duplicates(aggregator, integration_check, pg_instance, datadog_agent):
-    pg_instance['dbm'] = True
+def test_statement_metrics_with_duplicates(aggregator, integration_check, dbm_instance, datadog_agent):
+    # don't need samples for this test
+    dbm_instance['statement_samples'] = {'enabled': False}
+    # very low collection interval for test purposes
+    dbm_instance['statement_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
 
     # The query signature matches the normalized query returned by the mock agent and would need to be
     # updated if the normalized query is updated
@@ -366,7 +372,7 @@ def test_statement_metrics_with_duplicates(aggregator, integration_check, pg_ins
             return normalized_query
         return query
 
-    check = integration_check(pg_instance)
+    check = integration_check(dbm_instance)
     check._connect()
     cursor = check.db.cursor()
 
@@ -376,10 +382,10 @@ def test_statement_metrics_with_duplicates(aggregator, integration_check, pg_ins
         mock_agent.side_effect = obfuscate_sql
         cursor.execute(query, (['app1', 'app2'],))
         cursor.execute(query, (['app1', 'app2', 'app3'],))
-        check.check(pg_instance)
+        check.check(dbm_instance)
         cursor.execute(query, (['app1', 'app2'],))
         cursor.execute(query, (['app1', 'app2', 'app3'],))
-        check.check(pg_instance)
+        check.check(dbm_instance)
 
     events = aggregator.get_event_platform_events("dbm-metrics")
     assert len(events) == 1
@@ -403,8 +409,13 @@ def dbm_instance(pg_instance):
     pg_instance['dbm'] = True
     pg_instance['min_collection_interval'] = 1
     pg_instance['pg_stat_activity_view'] = "datadog.pg_stat_activity()"
-    pg_instance['statement_samples'] = {'enabled': True, 'run_sync': True, 'collections_per_second': 1}
+    pg_instance['statement_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 1}
+    pg_instance['statement_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 10}
     return pg_instance
+
+
+def _expected_dbm_instance_tags(dbm_instance):
+    return dbm_instance['tags'] + ['server:{}'.format(HOST), 'port:{}'.format(PORT), 'db:datadog_test']
 
 
 @pytest.mark.parametrize(
@@ -596,17 +607,38 @@ def test_statement_samples_dbstrict(aggregator, integration_check, dbm_instance,
         conn.close()
 
 
+@pytest.mark.parametrize("statement_samples_enabled", [True, False])
+@pytest.mark.parametrize("statement_metrics_enabled", [True, False])
+def test_async_job_enabled(integration_check, dbm_instance, statement_samples_enabled, statement_metrics_enabled):
+    dbm_instance['statement_samples'] = {'enabled': statement_samples_enabled, 'run_sync': False}
+    dbm_instance['statement_metrics'] = {'enabled': statement_metrics_enabled, 'run_sync': False}
+    check = integration_check(dbm_instance)
+    check._connect()
+    check.check(dbm_instance)
+    check.cancel()
+    if statement_samples_enabled:
+        assert check.statement_samples._job_loop_future is not None
+        check.statement_samples._job_loop_future.result()
+    else:
+        assert check.statement_samples._job_loop_future is None
+    if statement_metrics_enabled:
+        assert check.statement_metrics._job_loop_future is not None
+        check.statement_metrics._job_loop_future.result()
+    else:
+        assert check.statement_metrics._job_loop_future is None
+
+
 def test_statement_samples_main_collection_rate_limit(aggregator, integration_check, dbm_instance, bob_conn):
     # test the main collection loop rate limit
-    collections_per_second = 10
-    dbm_instance['statement_samples']['collections_per_second'] = collections_per_second
+    collection_interval = 0.1
+    dbm_instance['statement_samples']['collection_interval'] = collection_interval
     dbm_instance['statement_samples']['run_sync'] = False
     check = integration_check(dbm_instance)
     check._connect()
     check.check(dbm_instance)
     sleep_time = 1
     time.sleep(sleep_time)
-    max_collections = int(collections_per_second * sleep_time) + 1
+    max_collections = int(1 / collection_interval * sleep_time) + 1
     check.cancel()
     metrics = aggregator.metrics("dd.postgres.collect_statement_samples.time")
     assert max_collections / 2.0 <= len(metrics) <= max_collections
@@ -620,8 +652,9 @@ def test_statement_samples_unique_plans_rate_limits(aggregator, integration_chec
     # (query, plan)
     dbm_instance['statement_samples']['samples_per_hour_per_query'] = 1
     # run it synchronously with a high rate limit specifically for the test
-    dbm_instance['statement_samples']['collections_per_second'] = 100
+    dbm_instance['statement_samples']['collection_interval'] = 1.0 / 100
     dbm_instance['statement_samples']['run_sync'] = True
+    dbm_instance['statement_metrics']['enabled'] = False
     check = integration_check(dbm_instance)
     check._connect()
 
@@ -660,29 +693,41 @@ def test_statement_samples_unique_plans_rate_limits(aggregator, integration_chec
     assert len(matching) > 0, "should have collected exactly at least one matching event"
 
 
-def test_statement_samples_collection_loop_inactive_stop(aggregator, integration_check, dbm_instance):
+def test_async_job_inactive_stop(aggregator, integration_check, dbm_instance):
     dbm_instance['statement_samples']['run_sync'] = False
+    dbm_instance['statement_metrics']['run_sync'] = False
     check = integration_check(dbm_instance)
     check._connect()
     check.check(dbm_instance)
     # make sure there were no unhandled exceptions
-    check.statement_samples._collection_loop_future.result()
-    aggregator.assert_metric("dd.postgres.statement_samples.collection_loop_inactive_stop")
+    check.statement_samples._job_loop_future.result()
+    check.statement_metrics._job_loop_future.result()
+    for job in ['statement-metrics', 'statement-samples']:
+        aggregator.assert_metric(
+            "dd.postgres.async_job.inactive_stop",
+            tags=_expected_dbm_instance_tags(dbm_instance) + ['job:' + job],
+        )
 
 
-def test_statement_samples_collection_loop_cancel(aggregator, integration_check, dbm_instance):
+def test_async_job_cancel_cancel(aggregator, integration_check, dbm_instance):
     dbm_instance['statement_samples']['run_sync'] = False
+    dbm_instance['statement_metrics']['run_sync'] = False
     check = integration_check(dbm_instance)
     check._connect()
     check.check(dbm_instance)
     check.cancel()
     # wait for it to stop and make sure it doesn't throw any exceptions
-    check.statement_samples._collection_loop_future.result()
-    assert not check.statement_samples._collection_loop_future.running(), "thread should be stopped"
+    check.statement_samples._job_loop_future.result()
+    check.statement_metrics._job_loop_future.result()
+    assert not check.statement_samples._job_loop_future.running(), "samples thread should be stopped"
+    assert not check.statement_metrics._job_loop_future.running(), "metrics thread should be stopped"
     # if the thread doesn't start until after the cancel signal is set then the db connection will never
     # be created in the first place
-    assert check.statement_samples._db_pool.get(dbm_instance['dbname']) is None, "db connection should be gone"
-    aggregator.assert_metric("dd.postgres.statement_samples.collection_loop_cancel")
+    assert check._db_pool.get(dbm_instance['dbname']) is None, "db connection should be gone"
+    for job in ['statement-metrics', 'statement-samples']:
+        aggregator.assert_metric(
+            "dd.postgres.async_job.cancel", tags=_expected_dbm_instance_tags(dbm_instance) + ['job:' + job]
+        )
 
 
 def test_statement_samples_invalid_activity_view(aggregator, integration_check, dbm_instance):
@@ -701,8 +746,12 @@ def test_statement_samples_invalid_activity_view(aggregator, integration_check, 
     check._connect()
     check.check(dbm_instance)
     # make sure there were no unhandled exceptions
-    check.statement_samples._collection_loop_future.result()
-    aggregator.assert_metric_has_tag_prefix("dd.postgres.statement_samples.error", "error:database-")
+    check.statement_samples._job_loop_future.result()
+    aggregator.assert_metric(
+        "dd.postgres.async_job.error",
+        tags=_expected_dbm_instance_tags(dbm_instance)
+        + ['job:statement-samples', "error:database-<class 'psycopg2.errors.UndefinedTable'>"],
+    )
 
 
 @pytest.mark.parametrize(
@@ -711,7 +760,7 @@ def test_statement_samples_invalid_activity_view(aggregator, integration_check, 
         "explained_statements_cache_maxsize",
         "explained_statements_per_hour_per_query",
         "seen_samples_cache_maxsize",
-        "collections_per_second",
+        "collection_interval",
     ],
 )
 def test_statement_samples_config_invalid_number(integration_check, pg_instance, number_key):


### PR DESCRIPTION
### What does this PR do?

* decouple the DBM metrics collection interval from the check run interval
* set default DBM metrics collection interval to 10s 
* change `statement_samples.collections_per_second` to `statement_samples.collection_interval` so it matches the new `statement_metrics.collection_interval` key 

Depends on https://github.com/DataDog/integrations-core/pull/9656

### Motivation

Being able to configure the DBM metrics collection interval separately from the check run interval enables us to use a 10 second interval (by default) for the query metrics. There are various difficulties when querying metrics that have a 15 second interval (i.e. ensuring a correct rollup window for varying time ranges) that don't exist with a 10 second interval. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
