### PR TITLE
decouple DBM query metrics interval from check run interval

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -245,6 +245,23 @@ files:
               type: boolean
               example: false
               display_default: false
+          - name: statement_metrics
+            description: Configure collection of statement metrics
+            options:
+              - name: enabled
+                description: |
+                  Enable collection of statement metrics. Requires `dbm: true`.
+                value:
+                  type: boolean
+                  example: true
+              - name: collection_interval
+                description: |
+                  Set the statement metric collection interval (in seconds). Each collection involves a single query to
+                  `pg_stat_statements`. If a non-default value is chosen then that exact same value must be used for *every*
+                  check instance. Running different instances with different collection intervals is not supported.
+                value:
+                  type: number
+                  example: 10
           - name: statement_samples
             description: Configure collection of statement samples
             options:
@@ -254,9 +271,9 @@ files:
                 value:
                   type: boolean
                   example: true
-              - name: collections_per_second
+              - name: collection_interval
                 description: |
-                  Sets the maximum statement sample collection rate. Each collection involves a single query to one
+                  Sets the statement sample collection interval (in seconds). Each collection involves a single query to one
                   of the `performance_schema.events_statements_*` tables, followed by at most one `EXPLAIN` query per
                   unique statement seen.
                 value:

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -35,6 +35,7 @@ class MySQLConfig(object):
             'full_statement_text_samples_per_hour_per_query', 1
         )
         self.statement_samples_config = instance.get('statement_samples', {}) or {}
+        self.statement_metrics_config = instance.get('statement_metrics', {}) or {}
         self.min_collection_interval = instance.get('min_collection_interval', 15)
         self.configuration_checks()
 

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -76,6 +76,10 @@ def instance_ssl(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_statement_metrics(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_statement_samples(field, value):
     return get_default_field_value(field, value)
 

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -46,13 +46,21 @@ class Ssl(BaseModel):
     key: Optional[str]
 
 
+class StatementMetrics(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    collection_interval: Optional[float]
+    enabled: Optional[bool]
+
+
 class StatementSamples(BaseModel):
     class Config:
         allow_mutation = False
 
+    collection_interval: Optional[float]
     collection_strategy_cache_maxsize: Optional[int]
     collection_strategy_cache_ttl: Optional[int]
-    collections_per_second: Optional[float]
     enabled: Optional[bool]
     events_statements_enable_procedure: Optional[str]
     events_statements_row_limit: Optional[int]
@@ -86,6 +94,7 @@ class InstanceConfig(BaseModel):
     service: Optional[str]
     sock: Optional[str]
     ssl: Optional[Ssl]
+    statement_metrics: Optional[StatementMetrics]
     statement_samples: Optional[StatementSamples]
     tags: Optional[Sequence[str]]
     use_global_custom_queries: Optional[str]

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -231,6 +231,22 @@ instances:
     #
     # dbm: false
 
+    ## Configure collection of statement metrics
+    #
+    statement_metrics:
+
+        ## @param enabled - boolean - optional - default: true
+        ## Enable collection of statement metrics. Requires `dbm: true`.
+        #
+        # enabled: true
+
+        ## @param collection_interval - number - optional - default: 10
+        ## Set the statement metric collection interval (in seconds). Each collection involves a single query to
+        ## `pg_stat_statements`. If a non-default value is chosen then that exact same value must be used for *every*
+        ## check instance. Running different instances with different collection intervals is not supported.
+        #
+        # collection_interval: 10
+
     ## Configure collection of statement samples
     #
     statement_samples:
@@ -240,12 +256,12 @@ instances:
         #
         # enabled: true
 
-        ## @param collections_per_second - number - optional - default: 1
-        ## Sets the maximum statement sample collection rate. Each collection involves a single query to one
+        ## @param collection_interval - number - optional - default: 1
+        ## Sets the statement sample collection interval (in seconds). Each collection involves a single query to one
         ## of the `performance_schema.events_statements_*` tables, followed by at most one `EXPLAIN` query per
         ## unique statement seen.
         #
-        # collections_per_second: 1
+        # collection_interval: 1
 
         ## @param explained_statements_per_hour_per_query - integer - optional - default: 60
         ## Sets the rate limit for how many execution plans will be collected per hour per normalized statement.

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -84,7 +84,7 @@ class MySql(AgentCheck):
         self.check_initializations.append(self._query_manager.compile_queries)
         self.innodb_stats = InnoDBMetrics()
         self.check_initializations.append(self._config.configuration_checks)
-        self._statement_metrics = MySQLStatementMetrics(self, self._config)
+        self._statement_metrics = MySQLStatementMetrics(self, self._config, self._get_connection_args())
         self._statement_samples = MySQLStatementSamples(self, self._config, self._get_connection_args())
 
     def execute_query_raw(self, query):
@@ -128,8 +128,8 @@ class MySql(AgentCheck):
                 self._collect_system_metrics(self._config.host, db, tags)
                 if self._config.dbm_enabled:
                     dbm_tags = list(set(self.service_check_tags) | set(tags))
-                    self._statement_metrics.collect_per_statement_metrics(db, dbm_tags)
-                    self._statement_samples.run_sampler(dbm_tags)
+                    self._statement_metrics.run_job_loop(dbm_tags)
+                    self._statement_samples.run_job_loop(dbm_tags)
 
                 # keeping track of these:
                 self._put_qcache_stats()
@@ -145,6 +145,7 @@ class MySql(AgentCheck):
 
     def cancel(self):
         self._statement_samples.cancel()
+        self._statement_metrics.cancel()
 
     def _set_qcache_stats(self):
         host_key = self._get_host_key()

--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=20.0.1'
+CHECKS_BASE_REQ = 'datadog-checks-base>=20.1.0'
 
 setup(
     name='datadog-mysql',

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -18,11 +18,12 @@ import pytest
 from pkg_resources import parse_version
 
 from datadog_checks.base.utils.db.sql import compute_sql_signature
+from datadog_checks.base.utils.db.utils import DBMAsyncJob
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.mysql import MySql, statements
-from datadog_checks.mysql.statement_samples import MySQLStatementSamples, StatementTruncationState
+from datadog_checks.mysql.statement_samples import StatementTruncationState
 from datadog_checks.mysql.version_utils import get_version
 
 from . import common, tags, variables
@@ -34,12 +35,10 @@ logger = logging.getLogger(__name__)
 @pytest.fixture
 def dbm_instance(instance_complex):
     instance_complex['dbm'] = True
-    instance_complex['statement_samples'] = {
-        'enabled': True,
-        # set the default for tests to run sychronously to ensure we don't have orphaned threads running around
-        'run_sync': True,
-        'collections_per_second': 1,
-    }
+    # set the default for tests to run sychronously to ensure we don't have orphaned threads running around
+    instance_complex['statement_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 1}
+    # set a very small collection interval so the tests go fast
+    instance_complex['statement_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
     return instance_complex
 
 
@@ -60,8 +59,8 @@ def test_dbm_enabled_config(dbm_instance, dbm_enabled_key, dbm_enabled):
 @pytest.fixture(autouse=True)
 def stop_orphaned_threads():
     # make sure we shut down any orphaned threads and create a new Executor for each test
-    MySQLStatementSamples.executor.shutdown(wait=True)
-    MySQLStatementSamples.executor = ThreadPoolExecutor()
+    DBMAsyncJob.executor.shutdown(wait=True)
+    DBMAsyncJob.executor = ThreadPoolExecutor()
 
 
 @pytest.mark.integration
@@ -572,14 +571,14 @@ def test_statement_samples_collect(
 @pytest.mark.usefixtures('dd_environment')
 def test_statement_samples_main_collection_rate_limit(aggregator, dbm_instance):
     # test rate limiting of the main collection loop
-    collections_per_second = 10
-    dbm_instance['statement_samples']['collections_per_second'] = collections_per_second
+    collection_interval = 0.2
+    dbm_instance['statement_samples']['collection_interval'] = collection_interval
     dbm_instance['statement_samples']['run_sync'] = False
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
     mysql_check.check(dbm_instance)
     sleep_time = 1
     time.sleep(sleep_time)
-    max_collections = int(collections_per_second * sleep_time) + 1
+    max_collections = int(1 / collection_interval * sleep_time) + 1
     mysql_check.cancel()
     metrics = aggregator.metrics("dd.mysql.collect_statement_samples.time")
     assert max_collections / 2.0 <= len(metrics) <= max_collections
@@ -597,7 +596,7 @@ def test_statement_samples_unique_plans_rate_limits(aggregator, bob_conn, dbm_in
     # samples_per_hour_per_query set very low so that within this test we will have at most one sample per
     # (query, plan)
     dbm_instance['statement_samples']['samples_per_hour_per_query'] = 1
-    dbm_instance['statement_samples']['collections_per_second'] = 100
+    dbm_instance['statement_samples']['collection_interval'] = 1.0 / 100
     query_template = "select {} from testdb.users where name = 'hello'"
     # queries that have different numbers of columns are considered different queries
     # i.e. "SELECT city, city FROM persons where city= 'hello'"
@@ -627,31 +626,68 @@ def test_statement_samples_unique_plans_rate_limits(aggregator, bob_conn, dbm_in
     assert len(matching) > 0, "should have collected at least one matching event"
 
 
+def _expected_dbm_instance_tags(dbm_instance):
+    return dbm_instance['tags'] + ['server:{}'.format(common.HOST), 'port:{}'.format(common.PORT)]
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_statement_samples_loop_inactive_stop(aggregator, dbm_instance):
-    # confirm that the collection loop stops on its own after the check has not been run for a while
+def test_async_job_inactive_stop(aggregator, dbm_instance):
+    # confirm that async jobs stop on their own after the check has not been run for a while
     dbm_instance['statement_samples']['run_sync'] = False
+    dbm_instance['statement_metrics']['run_sync'] = False
+    # low collection interval for a faster test
+    dbm_instance['min_collection_interval'] = 1
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
     mysql_check.check(dbm_instance)
     # make sure there were no unhandled exceptions
-    mysql_check._statement_samples._collection_loop_future.result()
-    aggregator.assert_metric("dd.mysql.statement_samples.collection_loop_inactive_stop")
+    mysql_check._statement_samples._job_loop_future.result()
+    mysql_check._statement_metrics._job_loop_future.result()
+    for job in ['statement-metrics', 'statement-samples']:
+        aggregator.assert_metric(
+            "dd.mysql.async_job.inactive_stop", tags=_expected_dbm_instance_tags(dbm_instance) + ['job:' + job]
+        )
 
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_statement_samples_check_cancel(aggregator, dbm_instance):
-    # confirm that the collection loop stops on its own after the check has not been run for a while
+def test_async_job_cancel(aggregator, dbm_instance):
     dbm_instance['statement_samples']['run_sync'] = False
+    dbm_instance['statement_metrics']['run_sync'] = False
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
     mysql_check.check(dbm_instance)
     mysql_check.cancel()
     # wait for it to stop and make sure it doesn't throw any exceptions
-    mysql_check._statement_samples._collection_loop_future.result()
-    assert not mysql_check._statement_samples._collection_loop_future.running(), "thread should be stopped"
-    assert mysql_check._statement_samples._db is None, "db connection should be gone"
-    aggregator.assert_metric("dd.mysql.statement_samples.collection_loop_cancel")
+    mysql_check._statement_samples._job_loop_future.result()
+    mysql_check._statement_metrics._job_loop_future.result()
+    assert not mysql_check._statement_samples._job_loop_future.running(), "samples thread should be stopped"
+    assert not mysql_check._statement_metrics._job_loop_future.running(), "metrics thread should be stopped"
+    assert mysql_check._statement_samples._db is None, "samples db connection should be gone"
+    assert mysql_check._statement_metrics._db is None, "metrics db connection should be gone"
+    for job in ['statement-metrics', 'statement-samples']:
+        aggregator.assert_metric(
+            "dd.mysql.async_job.cancel", tags=_expected_dbm_instance_tags(dbm_instance) + ['job:' + job]
+        )
+
+
+@pytest.mark.parametrize("statement_samples_enabled", [True, False])
+@pytest.mark.parametrize("statement_metrics_enabled", [True, False])
+def test_async_job_enabled(dbm_instance, statement_samples_enabled, statement_metrics_enabled):
+    dbm_instance['statement_samples'] = {'enabled': statement_samples_enabled, 'run_sync': False}
+    dbm_instance['statement_metrics'] = {'enabled': statement_metrics_enabled, 'run_sync': False}
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+    mysql_check.check(dbm_instance)
+    mysql_check.cancel()
+    if statement_samples_enabled:
+        assert mysql_check._statement_samples._job_loop_future is not None
+        mysql_check._statement_samples._job_loop_future.result()
+    else:
+        assert mysql_check._statement_samples._job_loop_future is None
+    if statement_metrics_enabled:
+        assert mysql_check._statement_metrics._job_loop_future is not None
+        mysql_check._statement_metrics._job_loop_future.result()
+    else:
+        assert mysql_check._statement_metrics._job_loop_future is None
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### What does this PR do?

* decouple the DBM metrics collection interval from the check run interval
* set default DBM metrics collection interval to 10s 
* change `statement_samples.collections_per_second` to `statement_samples.collection_interval` so it matches the new `statement_metrics.collection_interval` key 

Depends on https://github.com/DataDog/integrations-core/pull/9656

### Motivation

Being able to configure the DBM metrics collection interval separately from the check run interval enables us to use a 10 second interval (by default) for the query metrics. There are various difficulties when querying metrics that have a 15 second interval (i.e. ensuring a correct rollup window for varying time ranges) that don't exist with a 10 second interval. 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
