### PR TITLE
Change DBM `statement` config keys and metric terminology to `query`

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -245,43 +245,43 @@ files:
               type: boolean
               example: false
               display_default: false
-          - name: statement_metrics
-            description: Configure collection of statement metrics
+          - name: query_metrics
+            description: Configure collection of query metrics
             options:
               - name: enabled
                 description: |
-                  Enable collection of statement metrics. Requires `dbm: true`.
+                  Enable collection of query metrics. Requires `dbm: true`.
                 value:
                   type: boolean
                   example: true
               - name: collection_interval
                 description: |
-                  Set the statement metric collection interval (in seconds). Each collection involves a single query to
+                  Set the query metric collection interval (in seconds). Each collection involves a single query to
                   `pg_stat_statements`. If a non-default value is chosen then that exact same value must be used for *every*
                   check instance. Running different instances with different collection intervals is not supported.
                 value:
                   type: number
                   example: 10
-          - name: statement_samples
-            description: Configure collection of statement samples
+          - name: query_samples
+            description: Configure collection of query samples
             options:
               - name: enabled
                 description: |
-                  Enables collection of statement samples. Requires `dbm: true`.
+                  Enables collection of query samples. Requires `dbm: true`.
                 value:
                   type: boolean
                   example: true
               - name: collection_interval
                 description: |
-                  Sets the statement sample collection interval (in seconds). Each collection involves a single query to one
+                  Sets the query sample collection interval (in seconds). Each collection involves a single query to one
                   of the `performance_schema.events_statements_*` tables, followed by at most one `EXPLAIN` query per
                   unique statement seen.
                 value:
                   type: number
                   example: 1
-              - name: explained_statements_per_hour_per_query
+              - name: explained_queries_per_hour_per_query
                 description: |
-                  Sets the rate limit for how many execution plans will be collected per hour per normalized statement.
+                  Sets the rate limit for how many execution plans will be collected per hour per normalized query.
                 value:
                   type: integer
                   example: 60
@@ -292,9 +292,9 @@ files:
                 value:
                   type: integer
                   example: 15
-              - name: explained_statements_cache_maxsize
+              - name: explained_queries_cache_maxsize
                 description: |
-                  Sets the max size of the cache used for the explained_statements_per_hour_per_query rate limit. This
+                  Sets the max size of the cache used for the explained_queries_per_hour_per_query rate limit. This
                   should be increased for databases with a very large number of unique normalized queries which exceed the
                   cache's limit.
                 value:

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -34,7 +34,7 @@ class MySQLConfig(object):
         self.full_statement_text_samples_per_hour_per_query = instance.get(
             'full_statement_text_samples_per_hour_per_query', 1
         )
-        self.statement_samples_config = instance.get('query_samples', {}) or {}
+        self.statement_samples_config = instance.get('query_samples', instance.get('statement_samples', {})) or {}
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}
         self.min_collection_interval = instance.get('min_collection_interval', 15)
         self.configuration_checks()

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -34,8 +34,8 @@ class MySQLConfig(object):
         self.full_statement_text_samples_per_hour_per_query = instance.get(
             'full_statement_text_samples_per_hour_per_query', 1
         )
-        self.statement_samples_config = instance.get('statement_samples', {}) or {}
-        self.statement_metrics_config = instance.get('statement_metrics', {}) or {}
+        self.statement_samples_config = instance.get('query_samples', {}) or {}
+        self.statement_metrics_config = instance.get('query_metrics', {}) or {}
         self.min_collection_interval = instance.get('min_collection_interval', 15)
         self.configuration_checks()
 

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -64,6 +64,14 @@ def instance_queries(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_query_metrics(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_query_samples(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_service(field, value):
     return get_default_field_value(field, value)
 
@@ -73,14 +81,6 @@ def instance_sock(field, value):
 
 
 def instance_ssl(field, value):
-    return get_default_field_value(field, value)
-
-
-def instance_statement_metrics(field, value):
-    return get_default_field_value(field, value)
-
-
-def instance_statement_samples(field, value):
     return get_default_field_value(field, value)
 
 

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -37,16 +37,7 @@ class Options(BaseModel):
     schema_size_metrics: Optional[bool]
 
 
-class Ssl(BaseModel):
-    class Config:
-        allow_mutation = False
-
-    ca: Optional[str]
-    cert: Optional[str]
-    key: Optional[str]
-
-
-class StatementMetrics(BaseModel):
+class QueryMetrics(BaseModel):
     class Config:
         allow_mutation = False
 
@@ -54,7 +45,7 @@ class StatementMetrics(BaseModel):
     enabled: Optional[bool]
 
 
-class StatementSamples(BaseModel):
+class QuerySamples(BaseModel):
     class Config:
         allow_mutation = False
 
@@ -67,11 +58,20 @@ class StatementSamples(BaseModel):
     events_statements_table: Optional[str]
     events_statements_temp_table_name: Optional[str]
     explain_procedure: Optional[str]
-    explained_statements_cache_maxsize: Optional[int]
-    explained_statements_per_hour_per_query: Optional[int]
+    explained_queries_cache_maxsize: Optional[int]
+    explained_queries_per_hour_per_query: Optional[int]
     fully_qualified_explain_procedure: Optional[str]
     samples_per_hour_per_query: Optional[int]
     seen_samples_cache_maxsize: Optional[int]
+
+
+class Ssl(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    ca: Optional[str]
+    cert: Optional[str]
+    key: Optional[str]
 
 
 class InstanceConfig(BaseModel):
@@ -91,11 +91,11 @@ class InstanceConfig(BaseModel):
     password: Optional[str]
     port: Optional[float]
     queries: Optional[Sequence[Mapping[str, Any]]]
+    query_metrics: Optional[QueryMetrics]
+    query_samples: Optional[QuerySamples]
     service: Optional[str]
     sock: Optional[str]
     ssl: Optional[Ssl]
-    statement_metrics: Optional[StatementMetrics]
-    statement_samples: Optional[StatementSamples]
     tags: Optional[Sequence[str]]
     use_global_custom_queries: Optional[str]
     username: Optional[str]

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -231,42 +231,42 @@ instances:
     #
     # dbm: false
 
-    ## Configure collection of statement metrics
+    ## Configure collection of query metrics
     #
-    statement_metrics:
+    query_metrics:
 
         ## @param enabled - boolean - optional - default: true
-        ## Enable collection of statement metrics. Requires `dbm: true`.
+        ## Enable collection of query metrics. Requires `dbm: true`.
         #
         # enabled: true
 
         ## @param collection_interval - number - optional - default: 10
-        ## Set the statement metric collection interval (in seconds). Each collection involves a single query to
+        ## Set the query metric collection interval (in seconds). Each collection involves a single query to
         ## `pg_stat_statements`. If a non-default value is chosen then that exact same value must be used for *every*
         ## check instance. Running different instances with different collection intervals is not supported.
         #
         # collection_interval: 10
 
-    ## Configure collection of statement samples
+    ## Configure collection of query samples
     #
-    statement_samples:
+    query_samples:
 
         ## @param enabled - boolean - optional - default: true
-        ## Enables collection of statement samples. Requires `dbm: true`.
+        ## Enables collection of query samples. Requires `dbm: true`.
         #
         # enabled: true
 
         ## @param collection_interval - number - optional - default: 1
-        ## Sets the statement sample collection interval (in seconds). Each collection involves a single query to one
+        ## Sets the query sample collection interval (in seconds). Each collection involves a single query to one
         ## of the `performance_schema.events_statements_*` tables, followed by at most one `EXPLAIN` query per
         ## unique statement seen.
         #
         # collection_interval: 1
 
-        ## @param explained_statements_per_hour_per_query - integer - optional - default: 60
-        ## Sets the rate limit for how many execution plans will be collected per hour per normalized statement.
+        ## @param explained_queries_per_hour_per_query - integer - optional - default: 60
+        ## Sets the rate limit for how many execution plans will be collected per hour per normalized query.
         #
-        # explained_statements_per_hour_per_query: 60
+        # explained_queries_per_hour_per_query: 60
 
         ## @param samples_per_hour_per_query - integer - optional - default: 15
         ## Sets the rate limit for how many statement sample events will be ingested per hour per normalized
@@ -274,12 +274,12 @@ instances:
         #
         # samples_per_hour_per_query: 15
 
-        ## @param explained_statements_cache_maxsize - integer - optional - default: 5000
-        ## Sets the max size of the cache used for the explained_statements_per_hour_per_query rate limit. This
+        ## @param explained_queries_cache_maxsize - integer - optional - default: 5000
+        ## Sets the max size of the cache used for the explained_queries_per_hour_per_query rate limit. This
         ## should be increased for databases with a very large number of unique normalized queries which exceed the
         ## cache's limit.
         #
-        # explained_statements_cache_maxsize: 5000
+        # explained_queries_cache_maxsize: 5000
 
         ## @param seen_samples_cache_maxsize - integer - optional - default: 10000
         ## Sets the max size of the cache used for the samples_per_hour_per_query rate limit. This should be

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -223,8 +223,8 @@ class DBExplainError(Enum):
     # agent may not have access to the default schema
     use_schema_error = 'use_schema_error'
 
-    # a truncated statement can't be explained
-    statement_truncated = 'statement_truncated'
+    # a truncated query can't be explained
+    query_truncated = 'query_truncated'
 
 
 class MySQLStatementSamples(DBMAsyncJob):
@@ -298,8 +298,8 @@ class MySQLStatementSamples(DBMAsyncJob):
 
         # explained_statements_cache: limit how often we try to re-explain the same query
         self._explained_statements_ratelimiter = RateLimitingTTLCache(
-            maxsize=self._config.statement_samples_config.get('explained_statements_cache_maxsize', 5000),
-            ttl=60 * 60 / self._config.statement_samples_config.get('explained_statements_per_hour_per_query', 60),
+            maxsize=self._config.statement_samples_config.get('explained_queries_cache_maxsize', 5000),
+            ttl=60 * 60 / self._config.statement_samples_config.get('explained_queries_per_hour_per_query', 60),
         )
 
         # seen_samples_cache: limit the ingestion rate per (query_signature, plan_signature)
@@ -365,7 +365,7 @@ class MySQLStatementSamples(DBMAsyncJob):
                 )
             except pymysql.err.DatabaseError as e:
                 self._check.count(
-                    "dd.mysql.statement_samples.error",
+                    "dd.mysql.query_samples.error",
                     1,
                     tags=self._tags + ["error:create-temp-table-{}".format(type(e))],
                 )
@@ -427,7 +427,7 @@ class MySQLStatementSamples(DBMAsyncJob):
             # do not log the raw sql_text to avoid leaking sensitive data into logs. digest_text is safe as parameters
             # are obfuscated by the database
             self._log.debug("Failed to obfuscate statement: %s", row['digest_text'])
-            self._check.count("dd.mysql.statement_samples.error", 1, tags=self._tags + ["error:sql-obfuscate"])
+            self._check.count("dd.mysql.query_samples.error", 1, tags=self._tags + ["error:sql-obfuscate"])
             return None
 
         apm_resource_hash = compute_sql_signature(obfuscated_statement)
@@ -441,14 +441,14 @@ class MySQLStatementSamples(DBMAsyncJob):
         truncated = self._get_truncation_state(row['sql_text'])
         if truncated == StatementTruncationState.truncated:
             self._check.count(
-                "dd.mysql.statement_samples.error",
+                "dd.mysql.query_samples.error",
                 1,
-                tags=self._tags + ["error:explain-{}".format(DBExplainError.statement_truncated)],
+                tags=self._tags + ["error:explain-{}".format(DBExplainError.query_truncated)],
             )
             explain_errors = [
                 (
                     None,
-                    DBExplainError.statement_truncated,
+                    DBExplainError.query_truncated,
                     'truncated length: {}'.format(len(row['sql_text'])),
                 )
             ]
@@ -460,7 +460,7 @@ class MySQLStatementSamples(DBMAsyncJob):
                     )
                 except Exception as e:
                     self._check.count(
-                        "dd.mysql.statement_samples.error", 1, tags=self._tags + ["error:explain-{}".format(type(e))]
+                        "dd.mysql.query_samples.error", 1, tags=self._tags + ["error:explain-{}".format(type(e))]
                     )
                     self._log.exception("Failed to explain statement: %s", obfuscated_statement)
 
@@ -506,7 +506,7 @@ class MySQLStatementSamples(DBMAsyncJob):
                     "query_signature": query_signature,
                     "resource_hash": apm_resource_hash,
                     "statement": obfuscated_statement,
-                    "statement_truncated": truncated.value,
+                    "query_truncated": truncated.value,
                 },
                 'mysql': {k: v for k, v in row.items() if k not in EVENTS_STATEMENTS_SAMPLE_EXCLUDE_KEYS},
             }
@@ -569,7 +569,7 @@ class MySQLStatementSamples(DBMAsyncJob):
                 "statement samples."
             )
             self._check.count(
-                "dd.mysql.statement_samples.error",
+                "dd.mysql.query_samples.error",
                 1,
                 tags=self._tags + ["error:no-enabled-events-statements-consumers"],
             )
@@ -684,7 +684,7 @@ class MySQLStatementSamples(DBMAsyncJob):
             if e.args[0] in PYMYSQL_NON_RETRYABLE_ERRORS:
                 self._collection_strategy_cache[strategy_cache_key] = explain_errors
             self._check.count(
-                "dd.mysql.statement_samples.error", 1, tags=tags + ["error:explain-use-schema-{}".format(type(e))]
+                "dd.mysql.query_samples.error", 1, tags=tags + ["error:explain-use-schema-{}".format(type(e))]
             )
             self._log.debug(
                 'Failed to collect execution plan because schema could not be accessed. error=%s, schema=%s, '
@@ -736,7 +736,7 @@ class MySQLStatementSamples(DBMAsyncJob):
                 # so we won't try to explain it again for the cache duration there.
                 explain_errors.append((strategy, DBExplainError.database_error, '{}'.format(type(e))))
                 self._check.count(
-                    "dd.mysql.statement_samples.error",
+                    "dd.mysql.query_samples.error",
                     1,
                     tags=tags + ["error:explain-attempt-{}-{}".format(strategy, type(e))],
                 )

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -56,6 +56,20 @@ def test_dbm_enabled_config(dbm_instance, dbm_enabled_key, dbm_enabled):
     assert mysql_check._config.dbm_enabled == dbm_enabled
 
 
+statement_samples_keys = ["query_samples", "statement_samples"]
+
+
+@pytest.mark.parametrize("statement_samples_key", statement_samples_keys)
+@pytest.mark.parametrize("statement_samples_enabled", [True, False])
+def test_statement_samples_enabled_config(dbm_instance, statement_samples_key, statement_samples_enabled):
+    # test to make sure we continue to support the old key
+    for k in statement_samples_keys:
+        dbm_instance.pop(k, None)
+    dbm_instance[statement_samples_key] = {'enabled': statement_samples_enabled}
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+    assert mysql_check._statement_samples._enabled == statement_samples_enabled
+
+
 @pytest.fixture(autouse=True)
 def stop_orphaned_threads():
     # make sure we shut down any orphaned threads and create a new Executor for each test


### PR DESCRIPTION
### What does this PR do?

Adjust terminology in config keys & related metrics to replace `statement` with `query`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
