### PR TITLE
Update obfuscator stub in agent

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -65,7 +65,7 @@ class DatadogAgentStub(object):
     def read_persistent_cache(self, key):
         return self._cache.get(key, '')
 
-    def obfuscate_sql(self, query):
+    def obfuscate_sql(self, query, options=None):
         # This is only whitespace cleanup, NOT obfuscation. Full obfuscation implementation is in go code.
         return re.sub(r'\s+', ' ', query or '').strip()
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the `obfuscate_sql` method stub in the agent to support a new `options` argument.

### Motivation
<!-- What inspired you to submit this pull request? -->
For more context as to why this argument was introduced, refer to one of these PRs:
- [PostgreSQL](https://github.com/DataDog/integrations-core/pull/9640)
- [MySQL](https://github.com/DataDog/integrations-core/pull/9639)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
