### PR TITLE
Change DBM `statement` config keys and metric terminology to `query`

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -240,61 +240,61 @@ files:
       value:
         type: string
         example: show_pg_stat_statements()
-    - name: statement_metrics
-      description: Configure collection of statement metrics
+    - name: query_metrics
+      description: Configure collection of query metrics
       options:
         - name: enabled
           description: |
-            Enable collection of statement metrics. Requires `dbm: true`.
+            Enable collection of query metrics. Requires `dbm: true`.
           value:
             type: boolean
             example: true
         - name: collection_interval
           description: |
-            Set the statement metric collection interval (in seconds). Each collection involves a single query to
+            Set the query metric collection interval (in seconds). Each collection involves a single query to
             `pg_stat_statements`. If a non-default value is chosen then that exact same value must be used for *every*
             check instance. Running different instances with different collection intervals is not supported.
           value:
             type: number
             example: 10
-    - name: statement_samples
-      description: Configure collection of statement samples
+    - name: query_samples
+      description: Configure collection of query samples
       options:
         - name: enabled
           description: |
-            Enable collection of statement samples. Requires `dbm: true`.
+            Enable collection of query samples. Requires `dbm: true`.
           value:
             type: boolean
             example: true
         - name: collection_interval
           description: |
-            Set the statement sample collection interval (in seconds). Each collection involves a single query to
-            `pg_stat_activity` followed by at most one `EXPLAIN` query per unique statement seen.
+            Set the query sample collection interval (in seconds). Each collection involves a single query to
+            `pg_stat_activity` followed by at most one `EXPLAIN` query per unique normalized query seen.
           value:
             type: number
             example: 1
         - name: explain_function
           description: |
-            Override the default function used to collect execution plans for statements.
+            Override the default function used to collect execution plans for queries.
           value:
             type: string
             example: datadog.explain_statement
-        - name: explained_statements_per_hour_per_query
+        - name: explained_queries_per_hour_per_query
           description: |
-            Set the rate limit for how many execution plans will be collected per hour per normalized statement.
+            Set the rate limit for how many execution plans will be collected per hour per normalized query.
           value:
             type: integer
             example: 60
         - name: samples_per_hour_per_query
           description: |
-            Set the rate limit for how many statement sample events will be ingested per hour per normalized execution
+            Set the rate limit for how many query sample events will be ingested per hour per normalized execution
             plan.
           value:
             type: integer
             example: 15
-        - name: explained_statements_cache_maxsize
+        - name: explained_queries_cache_maxsize
           description: |
-            Set the max size of the cache used for the explained_statements_per_hour_per_query rate limit. This should
+            Set the max size of the cache used for the explained_queries_per_hour_per_query rate limit. This should
             be increased for databases with a very large number unique normalized queries which exceed the cache's
             limit.
           value:

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -75,13 +75,12 @@ class PostgresConfig:
         self.full_statement_text_samples_per_hour_per_query = instance.get(
             'full_statement_text_samples_per_hour_per_query', 1
         )
-        self.statement_metrics_limits = instance.get('statement_metrics_limits', None)
         # Support a custom view when datadog user has insufficient privilege to see queries
         self.pg_stat_statements_view = instance.get('pg_stat_statements_view', 'pg_stat_statements')
         # statement samples & execution plans
         self.pg_stat_activity_view = instance.get('pg_stat_activity_view', 'pg_stat_activity')
-        self.statement_samples_config = instance.get('statement_samples', {}) or {}
-        self.statement_metrics_config = instance.get('statement_metrics', {}) or {}
+        self.statement_samples_config = instance.get('query_samples', {}) or {}
+        self.statement_metrics_config = instance.get('query_metrics', {}) or {}
 
     def _build_tags(self, custom_tags):
         # Clean up tags in case there was a None entry in the instance

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -79,7 +79,7 @@ class PostgresConfig:
         self.pg_stat_statements_view = instance.get('pg_stat_statements_view', 'pg_stat_statements')
         # statement samples & execution plans
         self.pg_stat_activity_view = instance.get('pg_stat_activity_view', 'pg_stat_activity')
-        self.statement_samples_config = instance.get('query_samples', {}) or {}
+        self.statement_samples_config = instance.get('query_samples', instance.get('statement_samples', {})) or {}
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}
 
     def _build_tags(self, custom_tags):

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -76,6 +76,14 @@ def instance_port(field, value):
     return 5432
 
 
+def instance_query_metrics(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_query_samples(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_query_timeout(field, value):
     return 1000
 
@@ -90,14 +98,6 @@ def instance_service(field, value):
 
 def instance_ssl(field, value):
     return 'false'
-
-
-def instance_statement_metrics(field, value):
-    return get_default_field_value(field, value)
-
-
-def instance_statement_samples(field, value):
-    return get_default_field_value(field, value)
 
 
 def instance_table_count_limit(field, value):

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -13,6 +13,27 @@ from datadog_checks.base.utils.models import validation
 from . import defaults, validators
 
 
+class QueryMetrics(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    collection_interval: Optional[float]
+    enabled: Optional[bool]
+
+
+class QuerySamples(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    collection_interval: Optional[float]
+    enabled: Optional[bool]
+    explain_function: Optional[str]
+    explained_queries_cache_maxsize: Optional[int]
+    explained_queries_per_hour_per_query: Optional[int]
+    samples_per_hour_per_query: Optional[int]
+    seen_samples_cache_maxsize: Optional[int]
+
+
 class Relation(BaseModel):
     class Config:
         allow_mutation = False
@@ -22,27 +43,6 @@ class Relation(BaseModel):
     relation_schema: Optional[str]
     relkind: Optional[Sequence[str]]
     schemas: Optional[Sequence[str]]
-
-
-class StatementMetrics(BaseModel):
-    class Config:
-        allow_mutation = False
-
-    collection_interval: Optional[float]
-    enabled: Optional[bool]
-
-
-class StatementSamples(BaseModel):
-    class Config:
-        allow_mutation = False
-
-    collection_interval: Optional[float]
-    enabled: Optional[bool]
-    explain_function: Optional[str]
-    explained_statements_cache_maxsize: Optional[int]
-    explained_statements_per_hour_per_query: Optional[int]
-    samples_per_hour_per_query: Optional[int]
-    seen_samples_cache_maxsize: Optional[int]
 
 
 class InstanceConfig(BaseModel):
@@ -67,12 +67,12 @@ class InstanceConfig(BaseModel):
     password: Optional[str]
     pg_stat_statements_view: Optional[str]
     port: Optional[int]
+    query_metrics: Optional[QueryMetrics]
+    query_samples: Optional[QuerySamples]
     query_timeout: Optional[int]
     relations: Optional[Sequence[Union[str, Relation]]]
     service: Optional[str]
     ssl: Optional[str]
-    statement_metrics: Optional[StatementMetrics]
-    statement_samples: Optional[StatementSamples]
     table_count_limit: Optional[int]
     tag_replication_role: Optional[bool]
     tags: Optional[Sequence[str]]

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -198,59 +198,59 @@ instances:
     #
     # pg_stat_statements_view: show_pg_stat_statements()
 
-    ## Configure collection of statement metrics
+    ## Configure collection of query metrics
     #
-    statement_metrics:
+    query_metrics:
 
         ## @param enabled - boolean - optional - default: true
-        ## Enable collection of statement metrics. Requires `dbm: true`.
+        ## Enable collection of query metrics. Requires `dbm: true`.
         #
         # enabled: true
 
         ## @param collection_interval - number - optional - default: 10
-        ## Set the statement metric collection interval (in seconds). Each collection involves a single query to
+        ## Set the query metric collection interval (in seconds). Each collection involves a single query to
         ## `pg_stat_statements`. If a non-default value is chosen then that exact same value must be used for *every*
         ## check instance. Running different instances with different collection intervals is not supported.
         #
         # collection_interval: 10
 
-    ## Configure collection of statement samples
+    ## Configure collection of query samples
     #
-    statement_samples:
+    query_samples:
 
         ## @param enabled - boolean - optional - default: true
-        ## Enable collection of statement samples. Requires `dbm: true`.
+        ## Enable collection of query samples. Requires `dbm: true`.
         #
         # enabled: true
 
         ## @param collection_interval - number - optional - default: 1
-        ## Set the statement sample collection interval (in seconds). Each collection involves a single query to
-        ## `pg_stat_activity` followed by at most one `EXPLAIN` query per unique statement seen.
+        ## Set the query sample collection interval (in seconds). Each collection involves a single query to
+        ## `pg_stat_activity` followed by at most one `EXPLAIN` query per unique normalized query seen.
         #
         # collection_interval: 1
 
         ## @param explain_function - string - optional - default: datadog.explain_statement
-        ## Override the default function used to collect execution plans for statements.
+        ## Override the default function used to collect execution plans for queries.
         #
         # explain_function: datadog.explain_statement
 
-        ## @param explained_statements_per_hour_per_query - integer - optional - default: 60
-        ## Set the rate limit for how many execution plans will be collected per hour per normalized statement.
+        ## @param explained_queries_per_hour_per_query - integer - optional - default: 60
+        ## Set the rate limit for how many execution plans will be collected per hour per normalized query.
         #
-        # explained_statements_per_hour_per_query: 60
+        # explained_queries_per_hour_per_query: 60
 
         ## @param samples_per_hour_per_query - integer - optional - default: 15
-        ## Set the rate limit for how many statement sample events will be ingested per hour per normalized execution
+        ## Set the rate limit for how many query sample events will be ingested per hour per normalized execution
         ## plan.
         #
         # samples_per_hour_per_query: 15
 
-        ## @param explained_statements_cache_maxsize - integer - optional - default: 5000
-        ## Set the max size of the cache used for the explained_statements_per_hour_per_query rate limit. This should
+        ## @param explained_queries_cache_maxsize - integer - optional - default: 5000
+        ## Set the max size of the cache used for the explained_queries_per_hour_per_query rate limit. This should
         ## be increased for databases with a very large number unique normalized queries which exceed the cache's
         ## limit.
         #
-        # explained_statements_cache_maxsize: 5000
+        # explained_queries_cache_maxsize: 5000
 
         ## @param seen_samples_cache_maxsize - integer - optional - default: 10000
         ## Set the max size of the cache used for the samples_per_hour_per_query rate limit. This should be increased

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -85,7 +85,7 @@ class DBExplainError(Enum):
     failed_function = 'failed_function'
 
     # a truncated statement can't be explained
-    statement_truncated = "statement_truncated"
+    query_truncated = "query_truncated"
 
 
 DEFAULT_COLLECTION_INTERVAL = 1
@@ -111,7 +111,7 @@ class PostgresStatementSamples(DBMAsyncJob):
             min_collection_interval=config.min_collection_interval,
             config_host=config.host,
             expected_db_exceptions=(psycopg2.errors.DatabaseError,),
-            job_name="statement-samples",
+            job_name="query-samples",
             shutdown_callback=shutdown_callback,
         )
         self._check = check
@@ -127,8 +127,8 @@ class PostgresStatementSamples(DBMAsyncJob):
 
         # explained_statements_ratelimiter: limit how often we try to re-explain the same query
         self._explained_statements_ratelimiter = RateLimitingTTLCache(
-            maxsize=int(config.statement_samples_config.get('explained_statements_cache_maxsize', 5000)),
-            ttl=60 * 60 / int(config.statement_samples_config.get('explained_statements_per_hour_per_query', 60)),
+            maxsize=int(config.statement_samples_config.get('explained_queries_cache_maxsize', 5000)),
+            ttl=60 * 60 / int(config.statement_samples_config.get('explained_queries_per_hour_per_query', 60)),
         )
 
         # seen_samples_ratelimiter: limit the ingestion rate per (query_signature, plan_signature)
@@ -306,11 +306,11 @@ class PostgresStatementSamples(DBMAsyncJob):
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 1,
-                tags=self._dbtags(dbname, "error:explain-{}".format(DBExplainError.statement_truncated)),
+                tags=self._dbtags(dbname, "error:explain-{}".format(DBExplainError.query_truncated)),
             )
             return (
                 None,
-                DBExplainError.statement_truncated,
+                DBExplainError.query_truncated,
                 "track_activity_query_size={}".format(track_activity_query_size),
             )
 
@@ -399,7 +399,7 @@ class PostgresStatementSamples(DBMAsyncJob):
                     "application": row.get('application_name', None),
                     "user": row['usename'],
                     "statement": obfuscated_statement,
-                    "statement_truncated": self._get_truncation_state(
+                    "query_truncated": self._get_truncation_state(
                         self._check._db_configured_track_activity_query_size, row['query']
                     ).value,
                 },

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -102,7 +102,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             config_host=config.host,
             dbms="postgres",
             rate_limit=1 / float(collection_interval),
-            job_name="statement-metrics",
+            job_name="query-metrics",
             shutdown_callback=shutdown_callback,
         )
         self._config = config

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -264,6 +264,22 @@ def test_dbm_enabled_config(integration_check, dbm_instance, dbm_enabled_key, db
     assert check._config.dbm_enabled == dbm_enabled
 
 
+statement_samples_keys = ["query_samples", "statement_samples"]
+
+
+@pytest.mark.parametrize("statement_samples_key", statement_samples_keys)
+@pytest.mark.parametrize("statement_samples_enabled", [True, False])
+def test_statement_samples_enabled_config(
+    integration_check, dbm_instance, statement_samples_key, statement_samples_enabled
+):
+    # test to make sure we continue to support the old key
+    for k in statement_samples_keys:
+        dbm_instance.pop(k, None)
+    dbm_instance[statement_samples_key] = {'enabled': statement_samples_enabled}
+    check = integration_check(dbm_instance)
+    assert check.statement_samples._enabled == statement_samples_enabled
+
+
 @pytest.mark.parametrize("dbstrict", [True, False])
 @pytest.mark.parametrize("pg_stat_statements_view", ["pg_stat_statements", "datadog.pg_stat_statements()"])
 def test_statement_metrics(aggregator, integration_check, dbm_instance, dbstrict, pg_stat_statements_view):


### PR DESCRIPTION
### What does this PR do?

Adjust terminology in config keys & related metrics to replace `statement` with `query`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
