### PR TITLE
fix broken error handling in reading of pg_settings

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -311,10 +311,10 @@ class PostgreSql(AgentCheck):
                 self._db_configured_track_activity_query_size = int(row['setting'])
         except (psycopg2.DatabaseError, psycopg2.OperationalError) as e:
             self.log.warning("cannot read track_activity_query_size from pg_settings: %s", repr(e))
-            self._check.count(
-                "dd.postgres.statement_samples.error",
+            self.count(
+                "dd.postgres.error",
                 1,
-                tags=self._tags + ["error:load-track-activity-query-size"],
+                tags=self._config.tags + ["error:load-track-activity-query-size"],
             )
 
     def _get_db(self, dbname):

--- a/postgres/tests/compose/resources/01_postgres.sql
+++ b/postgres/tests/compose/resources/01_postgres.sql
@@ -1,8 +1,12 @@
 CREATE USER datadog WITH PASSWORD 'datadog';
+CREATE USER datadog_no_catalog WITH PASSWORD 'datadog';
 CREATE USER bob WITH PASSWORD 'bob';
 CREATE USER dd_admin WITH PASSWORD 'dd_admin';
 ALTER USER dd_admin WITH SUPERUSER;
+REVOKE SELECT ON ALL tables IN SCHEMA pg_catalog from public;
 GRANT SELECT ON pg_stat_database TO datadog;
+GRANT SELECT ON pg_stat_database TO datadog_no_catalog;
+GRANT SELECT ON ALL tables IN SCHEMA pg_catalog to datadog;
 CREATE DATABASE datadog_test;
 GRANT ALL PRIVILEGES ON DATABASE datadog_test TO datadog;
 CREATE DATABASE dogs;


### PR DESCRIPTION
### What does this PR do?

Fix broken error handling introduced by a refactor of `load_query_max_text_size` in https://github.com/DataDog/integrations-core/pull/9657

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
