### PR TITLE
[kubernetes_state] allow collecting additional metrics

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/auto_conf.yaml
@@ -40,3 +40,10 @@ instances:
     ## will be attached to the host running KSM)
     #
     # hostname_override: true
+
+    ## @param additional_metrics - list - optional - default: []
+    ## Additional metrics that should be collected
+    #
+    # additional_metrics:
+    # - metric_name_a
+    # - metric_name_b: name_alias_b

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -69,3 +69,10 @@ instances:
     ##
     #
     # join_standard_tags: false
+
+    ## @param additional_metrics - list - optional - default: []
+    ## Additional metrics that should be collected
+    #
+    # additional_metrics:
+    # - metric_name_a
+    # - metric_name_b: name_alias_b

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -431,6 +431,8 @@ class KubernetesState(OpenMetricsBaseCheck):
         if 'labels_mapper' in ksm_instance and not isinstance(ksm_instance['labels_mapper'], dict):
             self.log.warning("Option labels_mapper should be a dictionary for %s", endpoint)
 
+        ksm_instance['metrics'].extend(ksm_instance.get('additional_metrics', []))
+
         return ksm_instance
 
     def _condition_to_service_check(self, sample, sc_name, mapping, tags=None):


### PR DESCRIPTION
### What does this PR do?
allow users to collect additional metrics from kubernetes state

### Motivation
currently the only way to do this is with fork to change [code](https://github.com/DataDog/integrations-core/blob/4afe8e448fec0e152e0e2a8deb70b1efff7b2128/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py#L197) or create a new prometheus check

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
