### PR TITLE
Fix obfuscator options being converted into bytes rather than string

### DIFF
--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -12,6 +12,7 @@ except ImportError:
     from ..stubs import datadog_agent
 
 from datadog_checks.base import is_affirmative
+from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.sql import compute_exec_plan_signature, compute_sql_signature
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, RateLimitingTTLCache, default_json_event_encoding
 from datadog_checks.base.utils.serialization import json
@@ -288,8 +289,8 @@ class MySQLStatementSamples(DBMAsyncJob):
             'STATEMENT': self._run_explain,
         }
         self._preferred_explain_strategies = ['PROCEDURE', 'FQ_PROCEDURE', 'STATEMENT']
-        self._obfuscate_options = json.dumps(
-            {'quantize_sql_tables': self._config.obfuscator_options.get('quantize_sql_tables', False)}
+        self._obfuscate_options = to_native_string(
+            json.dumps({'quantize_sql_tables': self._config.obfuscator_options.get('quantize_sql_tables', False)})
         )
         self._init_caches()
 

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -11,6 +11,7 @@ from cachetools import TTLCache
 
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.log import get_check_logger
+from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.statement_metrics import StatementMetrics
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding
@@ -77,8 +78,8 @@ class MySQLStatementMetrics(DBMAsyncJob):
         self._config = config
         self.log = get_check_logger()
         self._state = StatementMetrics()
-        self._obfuscate_options = json.dumps(
-            {'quantize_sql_tables': self._config.obfuscator_options.get('quantize_sql_tables', False)}
+        self._obfuscate_options = to_native_string(
+            json.dumps({'quantize_sql_tables': self._config.obfuscator_options.get('quantize_sql_tables', False)})
         )
         # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature
         self._full_statement_text_cache = TTLCache(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes obfuscator options being converted into bytes rather than string. Error found:
```
2021-07-12 17:14:20 UTC | CORE | WARN | (pkg/collector/python/datadog_agent.go:124 in LogMessage) | mysql:c94166e47fbb1ecc | (statements.py:190) | Failed to obfuscate query 'SELECT ?': argument 2 must be str, not bytes
```
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
