### PR TITLE
Revert cilium AD change

### DIFF
--- a/cilium/assets/configuration/spec.yaml
+++ b/cilium/assets/configuration/spec.yaml
@@ -35,7 +35,6 @@ files:
     overrides:
       value.example:
       - cilium-agent
-      - cilium
   - template: init_config
     options: []
   - template: instances

--- a/cilium/datadog_checks/cilium/data/auto_conf.yaml
+++ b/cilium/datadog_checks/cilium/data/auto_conf.yaml
@@ -5,7 +5,6 @@
 #
 ad_identifiers:
   - cilium-agent
-  - cilium
 
 ## All options defined here are available to all instances.
 #


### PR DESCRIPTION
Reverts the addition of `cilium` as an AD identifier from that PR: https://github.com/DataDog/integrations-core/pull/9512

The change is valid but triggers a bug with the agent and the default helm chart of cilium. The init container images are named "cilium" and the agent tries to monitor them indefinitely.

Revert this PR once the previously mentioned bug is fixed.