### PR TITLE
apache add missing assertions

### DIFF
--- a/apache/tests/test_apache.py
+++ b/apache/tests/test_apache.py
@@ -276,3 +276,4 @@ def test_scoreboard_values(aggregator, check, scoreboard, expected_metrics, data
 
     metadata_metrics = get_metadata_metrics()
     aggregator.assert_metrics_using_metadata({k: v for k, v in metadata_metrics if k in expected_metrics})
+    aggregator.assert_no_duplicate_metrics()

--- a/apache/tests/test_apache.py
+++ b/apache/tests/test_apache.py
@@ -271,5 +271,8 @@ def test_scoreboard_values(aggregator, check, scoreboard, expected_metrics, data
 
     check._submit_scoreboard(scoreboard, tags)
 
-    for metric, expectedValue in expected_metrics.items():
-        aggregator.assert_metric(metric, tags=tags, value=expectedValue)
+    for metric, expected_value in expected_metrics.items():
+        aggregator.assert_metric(metric, tags=tags, value=expected_value)
+
+    metadata_metrics = get_metadata_metrics()
+    aggregator.assert_metrics_using_metadata({k: v for k, v in metadata_metrics if k in expected_metrics})

--- a/apache/tests/test_apache.py
+++ b/apache/tests/test_apache.py
@@ -274,6 +274,5 @@ def test_scoreboard_values(aggregator, check, scoreboard, expected_metrics, data
     for metric, expected_value in expected_metrics.items():
         aggregator.assert_metric(metric, tags=tags, value=expected_value)
 
-    metadata_metrics = get_metadata_metrics()
-    aggregator.assert_metrics_using_metadata({k: v for k, v in metadata_metrics if k in expected_metrics})
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
     aggregator.assert_no_duplicate_metrics()


### PR DESCRIPTION
Followup of https://github.com/DataDog/integrations-core/pull/9355
Asserts metrics using metadata and asserts no duplicate metrics are emitted