### PR TITLE
Add test for SNMP v1 with oid batch size of 1

### DIFF
--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -36,6 +36,7 @@ def test_e2e_v1_with_apc_ups_profile_batch_size_1(dd_agent_check):
 
 
 def assert_apc_ups_metrics(dd_agent_check, config):
+    instance = config['instances'][0]
     aggregator = dd_agent_check(config, rate=True)
 
     profile_tags = [

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -18,7 +18,24 @@ def test_e2e_v1_with_apc_ups_profile(dd_agent_check):
         }
     )
     config['init_config']['loader'] = 'core'
+    assert_apc_ups_metrics(dd_agent_check, config)
 
+
+def test_e2e_v1_with_apc_ups_profile_batch_size_1(dd_agent_check):
+    config = common.generate_container_instance_config([])
+    instance = config['instances'][0]
+    instance.update(
+        {
+            'snmp_version': 1,
+            'community_string': 'apc_ups',
+            'oid_batch_size': 1,
+        }
+    )
+    config['init_config']['loader'] = 'core'
+    assert_apc_ups_metrics(dd_agent_check, config)
+
+
+def assert_apc_ups_metrics(dd_agent_check, config):
     aggregator = dd_agent_check(config, rate=True)
 
     profile_tags = [


### PR DESCRIPTION
Requires agent image with https://github.com/DataDog/datadog-agent/pull/8613 for tests to pass

### What does this PR do?

Add test for SNMP v1 with oid batch size of 1


### Motivation

https://github.com/DataDog/datadog-agent/pull/8613 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
