### PR TITLE
fix None-version crash for DBM statement metrics

### DIFF
--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -159,6 +159,12 @@ class PostgresStatementMetrics(DBMAsyncJob):
         self._tags_no_db = [t for t in self._tags if not t.startswith('db:')]
         self.collect_per_statement_metrics()
 
+    def _payload_pg_version(self):
+        version = self._check.version
+        if not version:
+            return ""
+        return 'v{major}.{minor}.{patch}'.format(major=version.major, minor=version.minor, patch=version.patch)
+
     def collect_per_statement_metrics(self):
         # exclude the default "db" tag from statement metrics & FQT events because this data is collected from
         # all databases on the host. For metrics the "db" tag is added during ingestion based on which database
@@ -178,9 +184,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 'min_collection_interval': self._config.min_collection_interval,
                 'tags': self._tags_no_db,
                 'postgres_rows': rows,
-                'postgres_version': 'v{major}.{minor}.{patch}'.format(
-                    major=self._check._version.major, minor=self._check._version.minor, patch=self._check._version.patch
-                ),
+                'postgres_version': self._payload_pg_version(),
             }
             self._check.database_monitoring_query_metrics(json.dumps(payload, default=default_json_event_encoding))
         except Exception:

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -6,6 +6,7 @@ import socket
 import time
 from collections import Counter
 from concurrent.futures.thread import ThreadPoolExecutor
+from unittest.mock import PropertyMock
 
 import mock
 import psycopg2
@@ -280,6 +281,29 @@ def test_statement_samples_enabled_config(
     assert check.statement_samples._enabled == statement_samples_enabled
 
 
+@pytest.mark.parametrize(
+    "version,expected_payload_version",
+    [
+        (VersionInfo(*[9, 6, 0]), "v9.6.0"),
+        (None, ""),
+    ],
+)
+def test_statement_metrics_version(integration_check, dbm_instance, version, expected_payload_version):
+    if version:
+        check = integration_check(dbm_instance)
+        check._version = version
+        check._connect()
+        assert check.statement_metrics._payload_pg_version() == expected_payload_version
+    else:
+        with mock.patch(
+            'datadog_checks.postgres.postgres.PostgreSql.version', new_callable=PropertyMock
+        ) as patched_version:
+            patched_version.return_value = None
+            check = integration_check(dbm_instance)
+            check._connect()
+            assert check.statement_metrics._payload_pg_version() == expected_payload_version
+
+
 @pytest.mark.parametrize("dbstrict", [True, False])
 @pytest.mark.parametrize("pg_stat_statements_view", ["pg_stat_statements", "datadog.pg_stat_statements()"])
 def test_statement_metrics(aggregator, integration_check, dbm_instance, dbstrict, pg_stat_statements_view):
@@ -323,6 +347,7 @@ def test_statement_metrics(aggregator, integration_check, dbm_instance, dbstrict
 
     assert event['host'] == 'stubbed.hostname'
     assert event['timestamp'] > 0
+    assert event['postgres_version'] == check.statement_metrics._payload_pg_version()
     assert event['min_collection_interval'] == dbm_instance['min_collection_interval']
     expected_dbm_metrics_tags = {'foo:bar', 'server:{}'.format(HOST), 'port:{}'.format(PORT)}
     assert set(event['tags']) == expected_dbm_metrics_tags

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -6,7 +6,6 @@ import socket
 import time
 from collections import Counter
 from concurrent.futures.thread import ThreadPoolExecutor
-from unittest.mock import PropertyMock
 
 import mock
 import psycopg2
@@ -296,7 +295,7 @@ def test_statement_metrics_version(integration_check, dbm_instance, version, exp
         assert check.statement_metrics._payload_pg_version() == expected_payload_version
     else:
         with mock.patch(
-            'datadog_checks.postgres.postgres.PostgreSql.version', new_callable=PropertyMock
+            'datadog_checks.postgres.postgres.PostgreSql.version', new_callable=mock.PropertyMock
         ) as patched_version:
             patched_version.return_value = None
             check = integration_check(dbm_instance)


### PR DESCRIPTION
### What does this PR do?
Fix crash caused by `None` version, which was introduced during a refactor in https://github.com/DataDog/integrations-core/pull/9657. Should have accessed `check.version` not `check._version`.

```
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/postgres/statements.py", line 182, in collect_per_statement_metrics
    major=self._check._version.major, minor=self._check._version.minor, patch=self._check._version.patch
AttributeError: 'NoneType' object has no attribute 'major'
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
