### PR TITLE
fix incorrect `min_collection_interval` on DBM metrics payload

### DIFF
--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -73,6 +73,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
             job_name="statement-metrics",
             shutdown_callback=self._close_db_conn,
         )
+        self._metric_collection_interval = collection_interval
         self._connection_args = connection_args
         self._db = None
         self._config = config
@@ -125,7 +126,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
             payload = {
                 'host': self._db_hostname,
                 'timestamp': time.time() * 1000,
-                'min_collection_interval': self._config.min_collection_interval,
+                'min_collection_interval': self._metric_collection_interval,
                 'tags': self._tags,
                 'mysql_rows': rows,
             }

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -346,7 +346,7 @@ def test_statement_metrics(aggregator, dbm_instance, query, default_schema, data
 
     assert event['host'] == 'stubbed.hostname'
     assert event['timestamp'] > 0
-    assert event['min_collection_interval'] == 15
+    assert event['min_collection_interval'] == dbm_instance['query_metrics']['collection_interval']
     expected_tags = set(tags.METRIC_TAGS + ['server:{}'.format(common.HOST), 'port:{}'.format(common.PORT)])
     if aurora_replication_role:
         expected_tags.add("replication_role:" + aurora_replication_role)


### PR DESCRIPTION
### What does this PR do?

As of https://github.com/DataDog/integrations-core/pull/9657 the DBM metrics interval is decoupled from the check's `min_collection_interval`. This new DBM-metrics-specific value needs to be set in the DBM metrics payloads.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
