### PR TITLE
fix incorrect `min_collection_interval` on DBM metrics payload

### DIFF
--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -106,6 +106,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             job_name="query-metrics",
             shutdown_callback=shutdown_callback,
         )
+        self._metrics_collection_interval = collection_interval
         self._config = config
         self._state = StatementMetrics()
         self._stat_column_cache = []
@@ -181,7 +182,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             payload = {
                 'host': self._db_hostname_cached(),
                 'timestamp': time.time() * 1000,
-                'min_collection_interval': self._config.min_collection_interval,
+                'min_collection_interval': self._metrics_collection_interval,
                 'tags': self._tags_no_db,
                 'postgres_rows': rows,
                 'postgres_version': self._payload_pg_version(),

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -347,7 +347,7 @@ def test_statement_metrics(aggregator, integration_check, dbm_instance, dbstrict
     assert event['host'] == 'stubbed.hostname'
     assert event['timestamp'] > 0
     assert event['postgres_version'] == check.statement_metrics._payload_pg_version()
-    assert event['min_collection_interval'] == dbm_instance['min_collection_interval']
+    assert event['min_collection_interval'] == dbm_instance['query_metrics']['collection_interval']
     expected_dbm_metrics_tags = {'foo:bar', 'server:{}'.format(HOST), 'port:{}'.format(PORT)}
     assert set(event['tags']) == expected_dbm_metrics_tags
     obfuscated_param = '?' if POSTGRES_VERSION.split('.')[0] == "9" else '$1'


### PR DESCRIPTION
### What does this PR do?

As of https://github.com/DataDog/integrations-core/pull/9657 the DBM metrics interval is decoupled from the check's `min_collection_interval`. This new DBM-metrics-specific value needs to be set in the DBM metrics payloads.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
