### PR TITLE
Use pattern for enforcing a URL structure for author->homepage in manifest

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/schema.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/schema.py
@@ -141,8 +141,9 @@ def get_manifest_schema():
                                     },
                                     "homepage": {
                                         "type": "string",
+                                        "format": "uri",
                                         "description": "The homepage of the company/product for this integration",
-                                        "pattern": "^[\u0000-\u007F]*$",
+                                        "pattern": "^(https?|http)://"
                                     },
                                 },
                             },

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/schema.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/schema.py
@@ -143,7 +143,7 @@ def get_manifest_schema():
                                         "type": "string",
                                         "format": "uri",
                                         "description": "The homepage of the company/product for this integration",
-                                        "pattern": "^(https?|http)://"
+                                        "pattern": "^(https|http)://",
                                     },
                                 },
                             },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
For the author homepage, enforce a full absolute URL structure

### Motivation
<!-- What inspired you to submit this pull request? -->
If the URL is relative, or just missing the protocol or `www.` it's possible the frontend will try to redirect to `app.datadoghq.com/<author_homepage>` instead. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
There isn't a URL format in jsonschema, so you have to use a combination of the `uri` format and a pattern including the protocols accepted. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
