### PR TITLE
Update Postgres collection error type to match MySQL

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -363,9 +363,9 @@ class PostgresStatementSamples(DBMAsyncJob):
         plan_dict, explain_err_code, err_msg = self._run_explain_safe(
             row['datname'], row['query'], obfuscated_statement
         )
-        collection_error = None
+        collection_errors = None
         if explain_err_code:
-            collection_error = {'code': explain_err_code.value, 'message': err_msg if err_msg else None}
+            collection_errors = [{'code': explain_err_code.value, 'message': err_msg if err_msg else None}]
 
         plan, normalized_plan, obfuscated_plan, plan_signature = None, None, None, None
         if plan_dict:
@@ -395,7 +395,7 @@ class PostgresStatementSamples(DBMAsyncJob):
                     "plan": {
                         "definition": obfuscated_plan,
                         "signature": plan_signature,
-                        "collection_error": collection_error,
+                        "collection_errors": collection_errors,
                     },
                     "query_signature": query_signature,
                     "resource_hash": query_signature,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the `collection_errors` type to match MySQL to keep it consistent.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
