### PR TITLE
Do not submit critical service check when there are no messages

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -91,10 +91,14 @@ class ChannelMetricCollector(object):
             response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(args)
             self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.OK, search_channel_tags)
         except pymqi.MQMIError as e:
-            self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.CRITICAL, search_channel_tags)
             if e.comp == pymqi.CMQC.MQCC_FAILED and e.reason == pymqi.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND:
+                self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.CRITICAL, search_channel_tags)
                 self.log.debug("Channel status not found for channel %s: %s", search_channel_name, e)
-            elif not (e.comp == pymqi.CMQC.MQCC_FAILED and e.reason == pymqi.CMQC.MQRC_NO_MSG_AVAILABLE):
+            elif e.comp == pymqi.CMQC.MQCC_FAILED and e.reason == pymqi.CMQC.MQRC_NO_MSG_AVAILABLE:
+                self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.UNKNOWN, search_channel_tags)
+                self.log.debug("There are no messages available for channel %s", search_channel_name)
+            else:
+                self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.CRITICAL, search_channel_tags)
                 self.log.warning("Error getting CHANNEL status for channel %s: %s", search_channel_name, e)
         else:
             for channel_info in response:


### PR DESCRIPTION
On https://github.com/DataDog/integrations-core/pull/9400 we stopped emitting misleading warning messages but we were still emitting a critical service check that is also misleading