### PR TITLE
SNMP profile validation is run only for 'core'

### DIFF
--- a/.azure-pipelines/templates/run-validations.yml
+++ b/.azure-pipelines/templates/run-validations.yml
@@ -44,16 +44,16 @@ steps:
     ddev validate dashboards
   displayName: 'Validate dashboard definition files'
 
-- script: |
-    echo "ddev meta snmp validate-profile"
-    ddev meta snmp validate-profile
-  displayName: 'Validate snmp profiles'
-
 - ${{ if and(eq(parameters.repo, 'core'), eq(parameters.ispr, 'true')) }}:
   - script: |
       echo "validate dep --require-base-check-version ${{ parameters.check }}"
       ddev validate dep --require-base-check-version ${{ parameters.check }}
     displayName: 'Validate dependencies'
+
+  - script: |
+      echo "ddev meta snmp validate-profile"
+      ddev meta snmp validate-profile
+    displayName: 'Validate snmp profiles'
 
 - ${{ if and(eq(parameters.repo, 'core'), eq(parameters.ispr, 'false')) }}:
     - script: |


### PR DESCRIPTION
### What does this PR do?
* Profile validation does not work on "integrations-extras" yet. 
* Let's put a condition in the Azure CI so that it runs only for "core", for now.

### Motivation
* We have blocked PR on integrtations-extra

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
