### PR TITLE
Allow float value for timeout

### DIFF
--- a/statsd/assets/configuration/spec.yaml
+++ b/statsd/assets/configuration/spec.yaml
@@ -21,7 +21,7 @@ files:
           - name: timeout
             description: Custom timeout for your check request.
             value:
-              type: integer
+              type: number
               example: 10
           - template: instances/default
       - template: logs

--- a/statsd/datadog_checks/statsd/config_models/instance.py
+++ b/statsd/datadog_checks/statsd/config_models/instance.py
@@ -23,7 +23,7 @@ class InstanceConfig(BaseModel):
     port: Optional[int]
     service: Optional[str]
     tags: Optional[Sequence[str]]
-    timeout: Optional[int]
+    timeout: Optional[float]
 
     @root_validator(pre=True)
     def _initial_validation(cls, values):

--- a/statsd/datadog_checks/statsd/data/conf.yaml.example
+++ b/statsd/datadog_checks/statsd/data/conf.yaml.example
@@ -24,7 +24,7 @@ instances:
     #
     # port: 8126
 
-    ## @param timeout - integer - optional - default: 10
+    ## @param timeout - number - optional - default: 10
     ## Custom timeout for your check request.
     #
     # timeout: 10


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We allow `float` values for timeout in code https://github.com/DataDog/integrations-core/blob/4b7527e9d4ae909ee9a777cb0d6d16e5b335d0a0/statsd/datadog_checks/statsd/statsd.py#L23
But we converted it to `int` anyway with the config models https://pydantic-docs.helpmanual.io/usage/types/

### Motivation
<!-- What inspired you to submit this pull request? -->
QA #8990 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
