### PR TITLE
[kubernetes][monitors] Fix statefulset monitor

### DIFF
--- a/kubernetes/assets/monitors/monitor_statefulset_replicas.json
+++ b/kubernetes/assets/monitors/monitor_statefulset_replicas.json
@@ -1,7 +1,7 @@
 {
 	"name": "[kubernetes] Monitor Kubernetes Statefulset Replicas",
 	"type": "query alert",
-	"query": "max(last_15m):sum:kubernetes_state.statefulset.replicas_desired{*} by {kube_stateful_set} - sum:kubernetes_state.statefulset.replicas_ready{*} by {kube_stateful_set} >= 2",
+	"query": "max(last_15m):sum:kubernetes_state.statefulset.replicas_desired{*} by {statefulset} - sum:kubernetes_state.statefulset.replicas_ready{*} by {statefulset} >= 2",
 	"message": "More than one Statefulset Replica's pods are down. This might present an unsafe situation for any further manual operations, such as killing other pods.",
 	"tags": [
 		"integration:kubernetes"


### PR DESCRIPTION
### What does this PR do?
Revert one change from https://github.com/DataDog/integrations-core/pull/9485/ that does not seem to work

### Motivation
Fix

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have `changelog/` and `integration/` labels attached
