### PR TITLE
Support old executable names

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -543,14 +543,15 @@ class MySql(AgentCheck):
             except IOError:
                 self.log.debug("Cannot read mysql pid file %s", pid_file)
 
+        process_name = [PROC_NAME]
+        if self.is_mariadb and self.version.version_compatible((10, 5, 0)):
+            process_name.append("mariadbd")
+
         # If pid has not been found, read it from ps
         if pid is None and PSUTIL_AVAILABLE:
             for proc in psutil.process_iter():
                 try:
-                    process_name = PROC_NAME
-                    if self.is_mariadb and self.version.version_compatible((10, 5, 0)):
-                        process_name = "mariadbd"
-                    if proc.name() == process_name:
+                    if proc.name() in process_name:
                         pid = proc.pid
                 except (psutil.AccessDenied, psutil.ZombieProcess, psutil.NoSuchProcess):
                     continue


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Old executable name is still supported, so we should still look for it https://mariadb.com/docs/whats-new/prior-series/whats-new-in-community-server-105/

### Motivation
<!-- What inspired you to submit this pull request? -->
QA #9543 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
