### PR TITLE
Bump `datadog-checks-base` version requirement

### DIFF
--- a/mysql/setup.py
+++ b/mysql/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=20.1.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=20.2.0'
 
 setup(
     name='datadog-mysql',


### PR DESCRIPTION
### What does this PR do?

Fixes broken nightly builds that were using an older version causing error `obfuscate_sql() takes 2 positional arguments but 3 were given`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
