### PR TITLE
Work around timeout issues in IBM i driver

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -52,8 +52,8 @@ class Query(object):
         query = self.query_data.get('query')
         if not query:
             raise ValueError('field `query` for {} is required'.format(query_name))
-        elif not isinstance(query, str):
-            raise ValueError('field `query` for {} must be a string'.format(query_name))
+        elif not isinstance(query, str) and not isinstance(query, dict):
+            raise ValueError('field `query` for {} must be a string or a mapping'.format(query_name))
 
         columns = self.query_data.get('columns')
         if not columns:

--- a/datadog_checks_base/tests/test_db.py
+++ b/datadog_checks_base/tests/test_db.py
@@ -96,10 +96,10 @@ class TestQueryCompilation:
         with pytest.raises(ValueError, match='^field `query` for test query is required$'):
             query_manager.compile_queries()
 
-    def test_query_not_string(self):
+    def test_query_not_string_or_dict(self):
         query_manager = create_query_manager({'name': 'test query', 'query': 5})
 
-        with pytest.raises(ValueError, match='^field `query` for test query must be a string$'):
+        with pytest.raises(ValueError, match='^field `query` for test query must be a string or a mapping$'):
             query_manager.compile_queries()
 
     def test_no_columns(self):

--- a/ibm_i/assets/configuration/spec.yaml
+++ b/ibm_i/assets/configuration/spec.yaml
@@ -45,4 +45,22 @@ files:
       value:
         type: integer
         example: 50
+    - name: job_query_timeout
+      description: |
+        The timeout (in seconds) applied to queries on job views (ACTIVE_JOB_INFO, JOB_INFO) made on the IBM i system.
+      value:
+        type: integer
+        example: 600
+    - name: system_mq_query_timeout
+      description: |
+        The timeout (in seconds) applied to queries on message queue views (MESSAGE_QUEUE_INFO) made on the IBM i system.
+      value:
+        type: integer
+        example: 60
+    - name: query_timeout
+      description: |
+        The timeout (in seconds) applied to queries made on the IBM i system.
+      value:
+        type: integer
+        example: 30
     - template: instances/default

--- a/ibm_i/datadog_checks/ibm_i/config_models/defaults.py
+++ b/ibm_i/datadog_checks/ibm_i/config_models/defaults.py
@@ -50,3 +50,15 @@ def instance_username(field, value):
 
 def instance_severity_threshold(field, value):
     return 50
+
+
+def instance_job_query_timeout(field, value):
+    return 600
+
+
+def instance_system_mq_query_timeout(field, value):
+    return 60
+
+
+def instance_query_timeout(field, value):
+    return 30

--- a/ibm_i/datadog_checks/ibm_i/config_models/instance.py
+++ b/ibm_i/datadog_checks/ibm_i/config_models/instance.py
@@ -28,6 +28,9 @@ class InstanceConfig(BaseModel):
     tags: Optional[Sequence[str]]
     username: Optional[str]
     severity_threshold: Optional[int]
+    job_query_timeout: Optional[int]
+    system_mq_query_timeout: Optional[int]
+    query_timeout: Optional[int]
 
     @root_validator(pre=True)
     def _initial_validation(cls, values):

--- a/ibm_i/datadog_checks/ibm_i/config_models/validators.py
+++ b/ibm_i/datadog_checks/ibm_i/config_models/validators.py
@@ -8,3 +8,8 @@ def instance_severity_threshold(value, *, field):
     if v < 0 or v > 99:
         raise ValueError("severity threshold must be in the range [0,99]")
     return v
+
+
+def instance_query_timeout(value, *, field):
+    v = int(value)
+    return v

--- a/ibm_i/datadog_checks/ibm_i/data/conf.yaml.example
+++ b/ibm_i/datadog_checks/ibm_i/data/conf.yaml.example
@@ -49,6 +49,21 @@ instances:
     #
     # severity_threshold: 50
 
+    ## @param job_query_timeout - integer - optional - default: 600
+    ## The timeout (in seconds) applied to queries on job views (ACTIVE_JOB_INFO, JOB_INFO) made on the IBM i system.
+    #
+    # job_query_timeout: 600
+
+    ## @param system_mq_query_timeout - integer - optional - default: 60
+    ## The timeout (in seconds) applied to queries on message queue views (MESSAGE_QUEUE_INFO) made on the IBM i system.
+    #
+    # system_mq_query_timeout: 60
+
+    ## @param query_timeout - integer - optional - default: 30
+    ## The default timeout (in seconds) applied to queries made on the IBM i system.
+    #
+    # query_timeout: 30
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/ibm_i/datadog_checks/ibm_i/queries.py
+++ b/ibm_i/datadog_checks/ibm_i/queries.py
@@ -2,181 +2,232 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-BaseDiskUsage = {
-    'name': 'base_disk_usage',
-    'query': (
-        # Use DISTINCT because one serial number can have multiple lines with different RESOURCE NAMEs,
-        # but we only want one metric per disk for disk space usage.
-        'SELECT DISTINCT ASP_NUMBER, UNIT_NUMBER, UNIT_TYPE, SERIAL_NUMBER, UNIT_STORAGE_CAPACITY, '
-        'UNIT_SPACE_AVAILABLE, PERCENT_USED FROM QSYS2.SYSDISKSTAT'
-    ),
-    'columns': [
-        {'name': 'asp_number', 'type': 'tag'},
-        {'name': 'unit_number', 'type': 'tag'},
-        {'name': 'unit_type', 'type': 'tag'},
-        {'name': 'serial_number', 'type': "tag"},
-        {'name': 'ibm_i.asp.unit_storage_capacity', 'type': 'gauge'},
-        {'name': 'ibm_i.asp.unit_space_available', 'type': 'gauge'},
-        {'name': 'ibm_i.asp.percent_used', 'type': 'gauge'},
-    ],
-}
 
-DiskUsage = {
-    'name': 'disk_usage',
-    'query': (
-        # For IO / busy metrics, tag per connection as each connection as its own metrics
-        "SELECT A.ASP_NUMBER, A.UNIT_NUMBER, A.UNIT_TYPE, A.SERIAL_NUMBER, A.RESOURCE_NAME, "
-        "A.ELAPSED_PERCENT_BUSY, A.ELAPSED_IO_REQUESTS "
-        # Two queries: one to fetch the stats, another to reset them
-        "FROM TABLE(QSYS2.SYSDISKSTAT('NO')) A INNER JOIN TABLE(QSYS2.SYSDISKSTAT('YES')) B "
-        "ON A.ASP_NUMBER = B.ASP_NUMBER AND A.UNIT_NUMBER = B.UNIT_NUMBER AND A.RESOURCE_NAME = B.RESOURCE_NAME"
-    ),
-    'columns': [
-        {'name': 'asp_number', 'type': 'tag'},
-        {'name': 'unit_number', 'type': 'tag'},
-        {'name': 'unit_type', 'type': 'tag'},
-        {'name': 'serial_number', 'type': "tag"},
-        {'name': 'resource_name', 'type': "tag"},
-        {'name': 'ibm_i.asp.percent_busy', 'type': 'gauge'},
-        {'name': 'ibm_i.asp.io_requests_per_s', 'type': 'gauge'},
-    ],
-}
-
-CPUUsage = {
-    'name': 'cpu_usage',
-    'query': 'SELECT AVERAGE_CPU_UTILIZATION FROM QSYS2.SYSTEM_STATUS_INFO',
-    'columns': [
-        {'name': 'ibm_i.system.cpu_usage', 'type': 'gauge'},
-    ],
-}
-
-InactiveJobStatus = {
-    'name': 'inactive_job_status',
-    'query': (
-        # TODO: try to move the JOB_NAME split logic to Python
-        "SELECT SUBSTR(JOB_NAME,1,POSSTR(JOB_NAME,'/')-1) AS JOB_ID, "
-        "SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1,POSSTR(SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1),'/')-1) AS JOB_USER, "
-        "SUBSTR(SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1),POSSTR(SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1),'/')+1) AS JOB_NAME, "  # noqa:E501
-        "JOB_SUBSYSTEM, JOB_STATUS, 1 "
-        "FROM TABLE(QSYS2.JOB_INFO('*ALL', '*ALL', '*ALL', '*ALL', '*ALL')) WHERE JOB_STATUS != 'ACTIVE'"
-    ),
-    'columns': [
-        {'name': 'job_id', 'type': 'tag'},
-        {'name': 'job_user', 'type': 'tag'},
-        {'name': 'job_name', 'type': 'tag'},
-        {'name': 'subsystem_name', 'type': 'tag'},
-        {'name': 'job_status', 'type': 'tag'},
-        {'name': 'ibm_i.job.status', 'type': 'gauge'},
-    ],
-}
-
-ActiveJobStatus = {
-    'name': 'active_job_status',
-    'query': (
-        # We prefer using ELAPSED_CPU_TIME / ELAPSED_TIME over ELAPSED_CPU_PERCENTAGE
-        # because the latter only has a precision of one decimal.
-        # ELAPSED_CPU_TIME is in milliseconds, while ELAPSED_TIME is in seconds
-        # -> / 1000 to convert into seconds / seconds
-        # -> * 100 to convert the resulting rate into a percentage
-        # TODO: figure out why there a x4 difference with the value
-        # given by ELAPSED_CPU_PERCENTAGE.
-        # TODO: try to move the JOB_NAME split logic to Python
-        "SELECT SUBSTR(A.JOB_NAME,1,POSSTR(A.JOB_NAME,'/')-1) AS JOB_ID, "
-        "SUBSTR(A.JOB_NAME,POSSTR(A.JOB_NAME,'/')+1,POSSTR(SUBSTR(A.JOB_NAME,POSSTR(A.JOB_NAME,'/')+1),'/')-1) AS JOB_USER, "  # noqa:E501
-        "SUBSTR(SUBSTR(A.JOB_NAME,POSSTR(A.JOB_NAME,'/')+1),POSSTR(SUBSTR(A.JOB_NAME,POSSTR(A.JOB_NAME,'/')+1),'/')+1) AS JOB_NAME, "  # noqa:E501
-        "A.SUBSYSTEM, 'ACTIVE', A.JOB_STATUS, 1, "
-        "CASE WHEN A.ELAPSED_TIME = 0 THEN 0 ELSE A.ELAPSED_CPU_TIME / (10 * A.ELAPSED_TIME) END AS CPU_RATE "
-        # Two queries: one to fetch the stats, another to reset them
-        "FROM TABLE(QSYS2.ACTIVE_JOB_INFO('NO', '', '', '')) A INNER JOIN TABLE(QSYS2.ACTIVE_JOB_INFO('YES', '', '', '')) B "  # noqa:E501
-        # Assumes that INTERNAL_JOB_ID is unique, which should be the case
-        "ON A.INTERNAL_JOB_ID = B.INTERNAL_JOB_ID"
-    ),
-    'columns': [
-        {'name': 'job_id', 'type': 'tag'},
-        {'name': 'job_user', 'type': 'tag'},
-        {'name': 'job_name', 'type': 'tag'},
-        {'name': 'subsystem_name', 'type': 'tag'},
-        {'name': 'job_status', 'type': 'tag'},
-        {'name': 'job_active_status', 'type': 'tag'},
-        {'name': 'ibm_i.job.status', 'type': 'gauge'},
-        {'name': 'ibm_i.job.cpu_usage', 'type': 'gauge'},
-    ],
-}
-
-JobMemoryUsage = {
-    'name': 'job_memory_usage',
-    'query': (
-        # TODO: try to move the JOB_NAME split logic to Python
-        "SELECT SUBSTR(JOB_NAME,1,POSSTR(JOB_NAME,'/')-1) AS JOB_ID, "
-        "SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1,POSSTR(SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1),'/')-1) AS JOB_USER, "
-        "SUBSTR(SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1),POSSTR(SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1),'/')+1) AS JOB_NAME, "  # noqa:E501
-        "SUBSYSTEM, JOB_STATUS, MEMORY_POOL, TEMPORARY_STORAGE FROM "
-        "TABLE(QSYS2.ACTIVE_JOB_INFO('NO', '', '', ''))"
-    ),
-    'columns': [
-        {'name': 'job_id', 'type': 'tag'},
-        {'name': 'job_user', 'type': 'tag'},
-        {'name': 'job_name', 'type': 'tag'},
-        {'name': 'subsystem_name', 'type': 'tag'},
-        {'name': 'job_active_status', 'type': 'tag'},
-        {'name': 'memory_pool_name', 'type': 'tag'},
-        {'name': 'ibm_i.job.temp_storage', 'type': 'gauge'},
-    ],
-}
-
-MemoryInfo = {
-    'name': 'memory_info',
-    'query': (
-        'SELECT POOL_NAME, SUBSYSTEM_NAME, CURRENT_SIZE, RESERVED_SIZE, DEFINED_SIZE FROM QSYS2.MEMORY_POOL_INFO'
-    ),
-    'columns': [
-        {'name': 'pool_name', 'type': 'tag'},
-        {'name': 'subsystem_name', 'type': 'tag'},
-        {'name': 'ibm_i.pool.size', 'type': 'gauge'},
-        {'name': 'ibm_i.pool.reserved_size', 'type': 'gauge'},
-        {'name': 'ibm_i.pool.defined_size', 'type': 'gauge'},
-    ],
-}
-
-SubsystemInfo = {
-    'name': 'subsystem',
-    'query': (
-        'SELECT SUBSYSTEM_DESCRIPTION, CASE WHEN STATUS = \'ACTIVE\' THEN '
-        '1 ELSE 0 END, CURRENT_ACTIVE_JOBS FROM QSYS2.SUBSYSTEM_INFO'
-    ),
-    'columns': [
-        {'name': 'subsystem_name', 'type': 'tag'},
-        {'name': 'ibm_i.subsystem.active', 'type': 'gauge'},
-        {'name': 'ibm_i.subsystem.active_jobs', 'type': 'gauge'},
-    ],
-}
-
-JobQueueInfo = {
-    'name': 'job_queue',
-    'query': (
-        'SELECT JOB_QUEUE_NAME, JOB_QUEUE_STATUS, SUBSYSTEM_NAME,'
-        'NUMBER_OF_JOBS, RELEASED_JOBS, SCHEDULED_JOBS, HELD_JOBS '
-        'FROM QSYS2.JOB_QUEUE_INFO'
-    ),
-    'columns': [
-        {'name': 'job_queue_name', 'type': 'tag'},
-        {'name': 'job_queue_status', 'type': 'tag'},
-        {'name': 'subsystem_name', 'type': 'tag'},
-        {'name': 'ibm_i.job_queue.size', 'type': 'gauge'},
-        {'name': 'ibm_i.job_queue.released_size', 'type': 'gauge'},
-        {'name': 'ibm_i.job_queue.scheduled_size', 'type': 'gauge'},
-        {'name': 'ibm_i.job_queue.held_size', 'type': 'gauge'},
-    ],
-}
+def get_base_disk_usage(timeout):
+    return {
+        'name': 'base_disk_usage',
+        'query': {
+            'text': (
+                # Use DISTINCT because one serial number can have multiple lines with different RESOURCE NAMEs,
+                # but we only want one metric per disk for disk space usage.
+                'SELECT DISTINCT ASP_NUMBER, UNIT_NUMBER, UNIT_TYPE, SERIAL_NUMBER, UNIT_STORAGE_CAPACITY, '
+                'UNIT_SPACE_AVAILABLE, PERCENT_USED FROM QSYS2.SYSDISKSTAT'
+            ),
+            'timeout': timeout,
+        },
+        'columns': [
+            {'name': 'asp_number', 'type': 'tag'},
+            {'name': 'unit_number', 'type': 'tag'},
+            {'name': 'unit_type', 'type': 'tag'},
+            {'name': 'serial_number', 'type': "tag"},
+            {'name': 'ibm_i.asp.unit_storage_capacity', 'type': 'gauge'},
+            {'name': 'ibm_i.asp.unit_space_available', 'type': 'gauge'},
+            {'name': 'ibm_i.asp.percent_used', 'type': 'gauge'},
+        ],
+    }
 
 
-def get_message_queue_info(sev):
+def get_disk_usage(timeout):
+    return {
+        'name': 'disk_usage',
+        'query': {
+            'text': (
+                # For IO / busy metrics, tag per connection as each connection as its own metrics
+                "SELECT A.ASP_NUMBER, A.UNIT_NUMBER, A.UNIT_TYPE, A.SERIAL_NUMBER, A.RESOURCE_NAME, "
+                "A.ELAPSED_PERCENT_BUSY, A.ELAPSED_IO_REQUESTS "
+                # Two queries: one to fetch the stats, another to reset them
+                "FROM TABLE(QSYS2.SYSDISKSTAT('NO')) A INNER JOIN TABLE(QSYS2.SYSDISKSTAT('YES')) B "
+                "ON A.ASP_NUMBER = B.ASP_NUMBER AND A.UNIT_NUMBER = B.UNIT_NUMBER AND A.RESOURCE_NAME = B.RESOURCE_NAME"
+            ),
+            'timeout': timeout,
+        },
+        'columns': [
+            {'name': 'asp_number', 'type': 'tag'},
+            {'name': 'unit_number', 'type': 'tag'},
+            {'name': 'unit_type', 'type': 'tag'},
+            {'name': 'serial_number', 'type': "tag"},
+            {'name': 'resource_name', 'type': "tag"},
+            {'name': 'ibm_i.asp.percent_busy', 'type': 'gauge'},
+            {'name': 'ibm_i.asp.io_requests_per_s', 'type': 'gauge'},
+        ],
+    }
+
+
+def get_cpu_usage(timeout):
+    return {
+        'name': 'cpu_usage',
+        'query': {
+            'text': 'SELECT AVERAGE_CPU_UTILIZATION FROM QSYS2.SYSTEM_STATUS_INFO',
+            'timeout': timeout,
+        },
+        'columns': [
+            {'name': 'ibm_i.system.cpu_usage', 'type': 'gauge'},
+        ],
+    }
+
+
+def get_jobq_job_status(timeout):
+    return {
+        'name': 'jobq_job_status',
+        'query': {
+            'text': (
+                # TODO: try to move the JOB_NAME split logic to Python
+                "SELECT SUBSTR(JOB_NAME,1,POSSTR(JOB_NAME,'/')-1) AS JOB_ID, "
+                "SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1,POSSTR(SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1),'/')-1) AS JOB_USER, "  # noqa:E501
+                "SUBSTR(SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1),POSSTR(SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1),'/')+1) AS JOB_NAME, "  # noqa:E501
+                "JOB_SUBSYSTEM, 'JOBQ', JOB_QUEUE_LIBRARY, JOB_QUEUE_NAME, JOB_QUEUE_STATUS, 1 "
+                "FROM TABLE(QSYS2.JOB_INFO('*JOBQ', '*ALL', '*ALL', '*ALL', '*ALL'))"
+            ),
+            'timeout': timeout,
+        },
+        'columns': [
+            {'name': 'job_id', 'type': 'tag'},
+            {'name': 'job_user', 'type': 'tag'},
+            {'name': 'job_name', 'type': 'tag'},
+            {'name': 'subsystem_name', 'type': 'tag'},
+            {'name': 'job_status', 'type': 'tag'},
+            {'name': 'job_queue_library', 'type': 'tag'},
+            {'name': 'job_queue_name', 'type': 'tag'},
+            {'name': 'job_queue_status', 'type': 'tag'},
+            {'name': 'ibm_i.job.status', 'type': 'gauge'},
+        ],
+    }
+
+
+def get_active_job_status(timeout):
+    return {
+        'name': 'active_job_status',
+        'query': {
+            'text': (
+                # We prefer using ELAPSED_CPU_TIME / ELAPSED_TIME over ELAPSED_CPU_PERCENTAGE
+                # because the latter only has a precision of one decimal.
+                # ELAPSED_CPU_TIME is in milliseconds, while ELAPSED_TIME is in seconds
+                # -> / 1000 to convert into seconds / seconds
+                # -> * 100 to convert the resulting rate into a percentage
+                # TODO: figure out why there a x4 difference with the value
+                # given by ELAPSED_CPU_PERCENTAGE.
+                # TODO: try to move the JOB_NAME split logic to Python
+                "SELECT SUBSTR(A.JOB_NAME,1,POSSTR(A.JOB_NAME,'/')-1) AS JOB_ID, "
+                "SUBSTR(A.JOB_NAME,POSSTR(A.JOB_NAME,'/')+1,POSSTR(SUBSTR(A.JOB_NAME,POSSTR(A.JOB_NAME,'/')+1),'/')-1) AS JOB_USER, "  # noqa:E501
+                "SUBSTR(SUBSTR(A.JOB_NAME,POSSTR(A.JOB_NAME,'/')+1),POSSTR(SUBSTR(A.JOB_NAME,POSSTR(A.JOB_NAME,'/')+1),'/')+1) AS JOB_NAME, "  # noqa:E501
+                "A.SUBSYSTEM, 'ACTIVE', A.JOB_STATUS, 1, "
+                "CASE WHEN A.ELAPSED_TIME = 0 THEN 0 ELSE A.ELAPSED_CPU_TIME / (10 * A.ELAPSED_TIME) END AS CPU_RATE "
+                # Two queries: one to fetch the stats, another to reset them
+                "FROM TABLE(QSYS2.ACTIVE_JOB_INFO('NO', '', '', '')) A INNER JOIN TABLE(QSYS2.ACTIVE_JOB_INFO('YES', '', '', '')) B "  # noqa:E501
+                # Assumes that INTERNAL_JOB_ID is unique, which should be the case
+                "ON A.INTERNAL_JOB_ID = B.INTERNAL_JOB_ID"
+            ),
+            'timeout': timeout,
+        },
+        'columns': [
+            {'name': 'job_id', 'type': 'tag'},
+            {'name': 'job_user', 'type': 'tag'},
+            {'name': 'job_name', 'type': 'tag'},
+            {'name': 'subsystem_name', 'type': 'tag'},
+            {'name': 'job_status', 'type': 'tag'},
+            {'name': 'job_active_status', 'type': 'tag'},
+            {'name': 'ibm_i.job.status', 'type': 'gauge'},
+            {'name': 'ibm_i.job.cpu_usage', 'type': 'gauge'},
+        ],
+    }
+
+
+def get_job_memory_usage(timeout):
+    return {
+        'name': 'job_memory_usage',
+        'query': {
+            'text': (
+                # TODO: try to move the JOB_NAME split logic to Python
+                "SELECT SUBSTR(JOB_NAME,1,POSSTR(JOB_NAME,'/')-1) AS JOB_ID, "
+                "SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1,POSSTR(SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1),'/')-1) AS JOB_USER, "  # noqa:E501
+                "SUBSTR(SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1),POSSTR(SUBSTR(JOB_NAME,POSSTR(JOB_NAME,'/')+1),'/')+1) AS JOB_NAME, "  # noqa:E501
+                "SUBSYSTEM, JOB_STATUS, MEMORY_POOL, TEMPORARY_STORAGE FROM "
+                "TABLE(QSYS2.ACTIVE_JOB_INFO('NO', '', '', ''))"
+            ),
+            'timeout': timeout,
+        },
+        'columns': [
+            {'name': 'job_id', 'type': 'tag'},
+            {'name': 'job_user', 'type': 'tag'},
+            {'name': 'job_name', 'type': 'tag'},
+            {'name': 'subsystem_name', 'type': 'tag'},
+            {'name': 'job_active_status', 'type': 'tag'},
+            {'name': 'memory_pool_name', 'type': 'tag'},
+            {'name': 'ibm_i.job.temp_storage', 'type': 'gauge'},
+        ],
+    }
+
+
+def get_memory_info(timeout):
+    return {
+        'name': 'memory_info',
+        'query': {
+            'text': (
+                'SELECT POOL_NAME, SUBSYSTEM_NAME, CURRENT_SIZE, RESERVED_SIZE, DEFINED_SIZE FROM QSYS2.MEMORY_POOL_INFO'  # noqa:E501
+            ),
+            'timeout': timeout,
+        },
+        'columns': [
+            {'name': 'pool_name', 'type': 'tag'},
+            {'name': 'subsystem_name', 'type': 'tag'},
+            {'name': 'ibm_i.pool.size', 'type': 'gauge'},
+            {'name': 'ibm_i.pool.reserved_size', 'type': 'gauge'},
+            {'name': 'ibm_i.pool.defined_size', 'type': 'gauge'},
+        ],
+    }
+
+
+def get_subsystem_info(timeout):
+    return {
+        'name': 'subsystem',
+        'query': {
+            'text': (
+                'SELECT SUBSYSTEM_DESCRIPTION, CASE WHEN STATUS = \'ACTIVE\' THEN '
+                '1 ELSE 0 END, CURRENT_ACTIVE_JOBS FROM QSYS2.SUBSYSTEM_INFO'
+            ),
+            'timeout': timeout,
+        },
+        'columns': [
+            {'name': 'subsystem_name', 'type': 'tag'},
+            {'name': 'ibm_i.subsystem.active', 'type': 'gauge'},
+            {'name': 'ibm_i.subsystem.active_jobs', 'type': 'gauge'},
+        ],
+    }
+
+
+def get_job_queue_info(timeout):
+    return {
+        'name': 'job_queue',
+        'query': {
+            'text': (
+                'SELECT JOB_QUEUE_NAME, JOB_QUEUE_STATUS, SUBSYSTEM_NAME,'
+                'NUMBER_OF_JOBS, RELEASED_JOBS, SCHEDULED_JOBS, HELD_JOBS '
+                'FROM QSYS2.JOB_QUEUE_INFO'
+            ),
+            'timeout': timeout,
+        },
+        'columns': [
+            {'name': 'job_queue_name', 'type': 'tag'},
+            {'name': 'job_queue_status', 'type': 'tag'},
+            {'name': 'subsystem_name', 'type': 'tag'},
+            {'name': 'ibm_i.job_queue.size', 'type': 'gauge'},
+            {'name': 'ibm_i.job_queue.released_size', 'type': 'gauge'},
+            {'name': 'ibm_i.job_queue.scheduled_size', 'type': 'gauge'},
+            {'name': 'ibm_i.job_queue.held_size', 'type': 'gauge'},
+        ],
+    }
+
+
+def get_message_queue_info(timeout, sev):
     return {
         'name': 'message_queue_info',
-        'query': (
-            f'SELECT MESSAGE_QUEUE_NAME, MESSAGE_QUEUE_LIBRARY, COUNT(*), SUM(CASE WHEN SEVERITY >= {sev} THEN 1 ELSE 0 END) '  # noqa:E501
-            'FROM QSYS2.MESSAGE_QUEUE_INFO GROUP BY MESSAGE_QUEUE_NAME, MESSAGE_QUEUE_LIBRARY'
-        ),
+        'query': {
+            'text': (
+                f'SELECT MESSAGE_QUEUE_NAME, MESSAGE_QUEUE_LIBRARY, COUNT(*), SUM(CASE WHEN SEVERITY >= {sev} THEN 1 ELSE 0 END) '  # noqa:E501
+                'FROM QSYS2.MESSAGE_QUEUE_INFO GROUP BY MESSAGE_QUEUE_NAME, MESSAGE_QUEUE_LIBRARY'
+            ),
+            'timeout': timeout,
+        },
         'columns': [
             {'name': 'message_queue_name', 'type': 'tag'},
             {'name': 'message_queue_library', 'type': 'tag'},
@@ -186,11 +237,15 @@ def get_message_queue_info(sev):
     }
 
 
-IBMMQInfo = {
-    'name': 'ibm_mq_info',
-    'query': 'SELECT QNAME, COUNT(*) FROM TABLE(MQREADALL()) GROUP BY QNAME',
-    'columns': [
-        {'name': 'message_queue_name', 'type': 'tag'},
-        {'name': 'ibm_i.ibm_mq.size', 'type': 'gauge'},
-    ],
-}
+def get_ibm_mq_info(timeout):
+    return {
+        'name': 'ibm_mq_info',
+        'query': {
+            'text': 'SELECT QNAME, COUNT(*) FROM TABLE(MQREADALL()) GROUP BY QNAME',
+            'timeout': timeout,
+        },
+        'columns': [
+            {'name': 'message_queue_name', 'type': 'tag'},
+            {'name': 'ibm_i.ibm_mq.size', 'type': 'gauge'},
+        ],
+    }

--- a/ibm_i/datadog_checks/ibm_i/query_script.py
+++ b/ibm_i/datadog_checks/ibm_i/query_script.py
@@ -1,0 +1,35 @@
+import sys
+from contextlib import closing
+
+import pyodbc
+
+from datadog_checks.base.utils.serialization import json
+
+
+def query():
+    connection = None
+
+    for string in sys.stdin:
+        if connection is None:
+            connection_string = string.strip()
+            try:
+                connection = pyodbc.connect(connection_string)
+            except Exception as e:
+                print("{}".format(e), file=sys.stderr, flush=True)
+                # Make the next query end immediately and fetch the error
+                print('ENDOFQUERY', flush=True)
+        else:
+            query = string.strip()
+            try:
+                rows = []
+                with closing(connection.execute(query)) as c:
+                    rows = c.fetchall()
+
+                for row in rows:
+                    print(
+                        json.dumps([item if item is None else str(item) for item in row]).decode("utf-8"),
+                        flush=True,
+                    )
+            except Exception as e:
+                print("{}".format(e), file=sys.stderr, flush=True)
+            print('ENDOFQUERY', flush=True)

--- a/ibm_i/tests/test_ibm_i.py
+++ b/ibm_i/tests/test_ibm_i.py
@@ -25,7 +25,7 @@ def test_fetch_system_info(instance):
     check = IbmICheck('ibm_i', {}, [instance])
     check.log = mock.MagicMock()
     with mock.patch('datadog_checks.ibm_i.IbmICheck.execute_query', return_value=[("hostname", "7", "3")]), mock.patch(
-        'datadog_checks.ibm_i.IbmICheck._delete_connection'
+        'datadog_checks.ibm_i.IbmICheck._delete_connection_subprocess'
     ) as delete_conn:
         system_info = check.fetch_system_info()
 
@@ -38,7 +38,7 @@ def test_failed_fetch_system_info(instance):
     check = IbmICheck('ibm_i', {}, [instance])
     check.log = mock.MagicMock()
     with mock.patch('datadog_checks.ibm_i.IbmICheck.execute_query', return_value=[]), mock.patch(
-        'datadog_checks.ibm_i.IbmICheck._delete_connection'
+        'datadog_checks.ibm_i.IbmICheck._delete_connection_subprocess'
     ) as delete_conn:
         system_info = check.fetch_system_info()
 
@@ -51,13 +51,10 @@ def test_query_error_system_info(instance):
     check = IbmICheck('ibm_i', {}, [instance])
     check.log = mock.MagicMock()
     exc = Exception("boom")
-    with mock.patch('datadog_checks.ibm_i.IbmICheck.execute_query', side_effect=exc), mock.patch(
-        'datadog_checks.ibm_i.IbmICheck._delete_connection'
-    ) as delete_conn:
+    with mock.patch('datadog_checks.ibm_i.IbmICheck.execute_query', side_effect=exc):
         system_info = check.fetch_system_info()
 
     assert system_info is None
-    delete_conn.assert_called_once_with(exc)
     check.log.error.assert_not_called()
 
 
@@ -78,7 +75,7 @@ def test_set_up_query_manager_7_2(instance):
     ), mock.patch('datadog_checks.ibm_i.IbmICheck.ibm_mq_check', return_value=True):
         check.set_up_query_manager()
     assert check._query_manager is not None
-    assert len(check._query_manager.queries) == 10
+    assert len(check._query_manager.queries) == 9
 
 
 def test_set_up_query_manager_7_2_no_ibm_mq(instance):
@@ -90,7 +87,7 @@ def test_set_up_query_manager_7_2_no_ibm_mq(instance):
     ), mock.patch('datadog_checks.ibm_i.IbmICheck.ibm_mq_check', return_value=False):
         check.set_up_query_manager()
     assert check._query_manager is not None
-    assert len(check._query_manager.queries) == 9
+    assert len(check._query_manager.queries) == 8
 
 
 def test_set_up_query_manager_7_4(instance):
@@ -102,7 +99,7 @@ def test_set_up_query_manager_7_4(instance):
     ), mock.patch('datadog_checks.ibm_i.IbmICheck.ibm_mq_check', return_value=True):
         check.set_up_query_manager()
     assert check._query_manager is not None
-    assert len(check._query_manager.queries) == 12
+    assert len(check._query_manager.queries) == 11
 
 
 def test_set_up_query_manager_7_4_no_ibm_mq(instance):
@@ -114,7 +111,7 @@ def test_set_up_query_manager_7_4_no_ibm_mq(instance):
     ), mock.patch('datadog_checks.ibm_i.IbmICheck.ibm_mq_check', return_value=False):
         check.set_up_query_manager()
     assert check._query_manager is not None
-    assert len(check._query_manager.queries) == 11
+    assert len(check._query_manager.queries) == 10
 
 
 def test_check_no_query_manager(aggregator, instance):
@@ -135,12 +132,9 @@ def test_check_query_error(aggregator, instance):
 
     with mock.patch(
         'datadog_checks.ibm_i.IbmICheck.fetch_system_info', return_value=SystemInfo("host", 7, 4)
-    ), mock.patch('datadog_checks.ibm_i.IbmICheck.execute_query', side_effect=Exception("boom")), mock.patch(
-        'datadog_checks.ibm_i.IbmICheck._delete_connection'
-    ) as delete_conn:
+    ), mock.patch('datadog_checks.ibm_i.IbmICheck.execute_query', side_effect=Exception("boom")):
         check.check(instance)
     assert check._query_manager is not None
-    delete_conn.assert_called_once_with("query error")
     aggregator.assert_service_check("ibm_i.can_connect", count=1, status=AgentCheck.CRITICAL)
     aggregator.assert_metric("ibm_i.check.duration", hostname="host", tags=["check_id:{}".format(check.check_id)])
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

Use a long-running script that performs queries on the IBM i system on behalf of the IBM i check.
The check communicates with the process through its `stdin`, `stdout` and `stderr` file descriptors.

### Motivation

Prevent the check from hanging if the IBM i driver hangs.

### Additional Notes

- Originally, I wanted to have a query script that would initialize the connection, do one query then terminate. However, that’s not possible because some of the metrics we get are statistics IBM i gives us as a diff between two queries (within the same connection). Resetting the connection after each query leads IBM i to return 0 or None for these stats. This is why I opted for a long-running script that would maintain the connection, and which would communicate with the Agent check to get queries and return results.
- I tested this for 1.5 days, the checks seems to be stable with 15 instances on 16 check runners (8-10% CPU usage, 7-11s check duration)
- Network disruptions seem to be handled fine (the check recovers after the given timeout, we don’t seem to leak threads / processes).

Benchmark: I created a bunch of jobs on the system to populate the `JOB_INFO` table, using:
`while [ 1 -eq 1 ]; do system "SBMJOB JOBD(QBATCH) JOB(WSYS) JOBQ(QBATCH) CMD(WRKSYSSTS)"; done`

which adds a bunch of jobs which print the current system status, in the job queue `QBATCH`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
