### PR TITLE
Set timeout for socket connection

### DIFF
--- a/php_fpm/datadog_checks/php_fpm/php_fpm.py
+++ b/php_fpm/datadog_checks/php_fpm/php_fpm.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import json
 import random
+import socket
 import time
 
 from flup.client.fcgi_app import FCGIApp
@@ -18,7 +19,6 @@ FCGIApp._environPrefixes.extend(('DOCUMENT_', 'SCRIPT_'))
 # This fixes that for our use case.
 # https://hg.saddi.com/flup-py3.0/file/tip/flup/client/fcgi_app.py
 if PY3:
-    import socket
 
     def get_connection(self):
         if self._connect is not None:
@@ -35,7 +35,7 @@ if PY3:
     FCGIApp._getConnection = get_connection
 
 
-DEFAULT_TIMEOUT = 20
+DEFAULT_TIMEOUT = 10
 
 
 class BadConfigError(Exception):
@@ -79,6 +79,7 @@ class PHPFPMCheck(AgentCheck):
         ping_url = instance.get('ping_url')
         use_fastcgi = is_affirmative(instance.get('use_fastcgi', False))
         ping_reply = instance.get('ping_reply')
+        sock_timeout = instance.get('timeout', DEFAULT_TIMEOUT)
 
         tags = instance.get('tags', [])
         http_host = instance.get('http_host')
@@ -86,6 +87,7 @@ class PHPFPMCheck(AgentCheck):
         if status_url is None and ping_url is None:
             raise BadConfigError("No status_url or ping_url specified for this instance")
 
+        socket.setdefaulttimeout(sock_timeout)
         pool = None
         if status_url is not None:
             try:


### PR DESCRIPTION
### What does this PR do?
Sets the `timeout` for socket-based connections.
Otherwise, the check will run for a very long timeout seemingly hung.

### Motivation
AGENT-6435

### Additional Notes
- `DEFAULT_TIMEOUT` was not being used and should actually default to 10 based on the config_models

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
