### PR TITLE
Enable CI validation for all repos

### DIFF
--- a/.azure-pipelines/templates/run-validations.yml
+++ b/.azure-pipelines/templates/run-validations.yml
@@ -4,9 +4,10 @@ parameters:
   ispr: false
   validate_changed: ''
   validate_codeowners: false
+  validate_ci: true
 
 steps:
-- ${{ if in(parameters.repo, 'core', 'extras', 'internal') }}:
+- ${{ if eq(parameters.validate_ci, 'true') }}:
   - script: |
       echo "ddev validate ci"
       ddev validate ci


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Enable `ddev validate ci` for all repos.  Makes the variable True by default since it seems all existing repositories were running this check. 

### Motivation
<!-- What inspired you to submit this pull request? -->
Support for the marketplace repository for `ddev validate ci` was released today. This enabled the validation to run in that CI

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
