### PR TITLE
Support empty config options for job or codecov

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/ci.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/ci.py
@@ -86,6 +86,10 @@ def get_attribute_from_job(job, attribute):
 
 def validate_master_jobs(fix, repo_data, testable_checks, cached_display_names):
     jobs_definition_relative_path = repo_data['jobs_definition_relative_path']
+    if not jobs_definition_relative_path:
+        echo_info("Skipping since jobs path isn't defined")
+        return
+
     jobs_definition_path = path_join(get_root(), *jobs_definition_relative_path.split('/'))
     if not file_exists(jobs_definition_path):
         abort('Unable to find the file defining all `master` jobs')
@@ -206,6 +210,10 @@ def validate_master_jobs(fix, repo_data, testable_checks, cached_display_names):
 
 def validate_coverage_flags(fix, repo_data, testable_checks, cached_display_names):
     codecov_config_relative_path = repo_data['codecov_config_relative_path']
+    if not codecov_config_relative_path:
+        echo_info("Skipping since codecov path isn't defined")
+        return
+
     codecov_config_path = path_join(get_root(), *codecov_config_relative_path.split('/'))
     if not file_exists(codecov_config_path):
         abort('Unable to find the Codecov config file')
@@ -374,5 +382,10 @@ def ci(ctx, fix):
     testable_checks = get_testable_checks()
     cached_display_names = {}
 
+    echo_info("Validating CI Configuration...", nl=False)
     validate_master_jobs(fix, repo_data, testable_checks, cached_display_names)
+    echo_success("Success", nl=True)
+
+    echo_info("Validating Code Coverage Configuration...", nl=False)
     validate_coverage_flags(fix, repo_data, testable_checks, cached_display_names)
+    echo_success("Success", nl=True)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Support an empty string option for the jobs and/or codecov part of `ddev validate ci`

### Motivation
<!-- What inspired you to submit this pull request? -->
Not all repositories may have codecov setup but still use the AZP templates. This ensures you can choose one or the other to have validated

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
