### PR TITLE
Support `SHUNNED_REPLICATION_LAG` status for `proxysql.backend.status` service check

### DIFF
--- a/proxysql/datadog_checks/proxysql/queries.py
+++ b/proxysql/datadog_checks/proxysql/queries.py
@@ -147,7 +147,7 @@ STATS_MYSQL_CONNECTION_POOL = {
         # the TCP endpoint on which the mysqld backend server is listening for connections
         {'name': 'srv_host', 'type': 'tag'},
         {'name': 'srv_port', 'type': 'tag'},
-        # the status of the backend server. Can be ONLINE, SHUNNED, OFFLINE_SOFT, OFFLINE_HARD and SHUNNED_REPLICATION_LAG
+        # the status of the backend server. Can be ONLINE, SHUNNED, OFFLINE_SOFT, OFFLINE_HARD, SHUNNED_REPLICATION_LAG
         # see https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers and
         # https://github.com/sysown/proxysql/blob/v2.x/include/proxysql_structs.h#L13-L19
         {

--- a/proxysql/datadog_checks/proxysql/queries.py
+++ b/proxysql/datadog_checks/proxysql/queries.py
@@ -147,8 +147,9 @@ STATS_MYSQL_CONNECTION_POOL = {
         # the TCP endpoint on which the mysqld backend server is listening for connections
         {'name': 'srv_host', 'type': 'tag'},
         {'name': 'srv_port', 'type': 'tag'},
-        # the status of the backend server. Can be ONLINE, SHUNNED, OFFLINE_SOFT, OFFLINE_HARD
-        # see https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers
+        # the status of the backend server. Can be ONLINE, SHUNNED, OFFLINE_SOFT, OFFLINE_HARD and SHUNNED_REPLICATION_LAG
+        # see https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers and
+        # https://github.com/sysown/proxysql/blob/v2.x/include/proxysql_structs.h#L13-L19
         {
             'name': 'backend.status',
             'type': 'service_check',

--- a/proxysql/datadog_checks/proxysql/queries.py
+++ b/proxysql/datadog_checks/proxysql/queries.py
@@ -157,6 +157,7 @@ STATS_MYSQL_CONNECTION_POOL = {
                 'SHUNNED': 'CRITICAL',
                 'OFFLINE_SOFT': 'WARNING',
                 'OFFLINE_HARD': 'CRITICAL',
+                'SHUNNED_REPLICATION_LAG': 'CRITICAL',
             },
         },
         # how many connections are currently used by ProxySQL for sending queries to the backend server


### PR DESCRIPTION
### What does this PR do?
Add a new service check mapping for `SHUNNED_REPLICATION_LAG` to `CRITICAL` for `proxysql.backend.status`. Current behavior maps it to `UNKNOWN`

### Motivation
Escalation/FR from a ticket

### Additional Notes
Link to proxysql statuses:
https://github.com/sysown/proxysql/blob/bd3e96a015da802320beb2ba96b0270cf00cb28e/include/proxysql_structs.h#L18

Sample output from proxysql:

```
MySQL [(none)]> SELECT status FROM stats_mysql_connection_pool\G

status: SHUNNED_REPLICATION_LAG
```


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
