### PR TITLE
Use `display_default` as a fallback for `default` when validating config models

### DIFF
--- a/cassandra/datadog_checks/cassandra/config_models/defaults.py
+++ b/cassandra/datadog_checks/cassandra/config_models/defaults.py
@@ -5,7 +5,7 @@ from datadog_checks.base.utils.models.fields import get_default_field_value
 
 
 def shared_collect_default_metrics(field, value):
-    return True
+    return False
 
 
 def shared_conf(field, value):
@@ -13,7 +13,7 @@ def shared_conf(field, value):
 
 
 def shared_new_gc_metrics(field, value):
-    return True
+    return False
 
 
 def shared_service(field, value):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/model.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/model.py
@@ -34,14 +34,14 @@ def example_looks_informative(example):
 
 
 def get_default_value(type_data):
-    if 'display_default' in type_data:
+    if 'default' in type_data:
+        return type_data['default']
+    elif 'display_default' in type_data:
         display_default = type_data['display_default']
         if display_default is None:
             return NO_DEFAULT
         else:
             return display_default
-    elif 'default' in type_data:
-        return type_data['default']
     elif 'type' not in type_data or type_data['type'] in ('array', 'object'):
         return NO_DEFAULT
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/model.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/specs/configuration/consumers/model.py
@@ -34,7 +34,13 @@ def example_looks_informative(example):
 
 
 def get_default_value(type_data):
-    if 'default' in type_data:
+    if 'display_default' in type_data:
+        display_default = type_data['display_default']
+        if display_default is None:
+            return NO_DEFAULT
+        else:
+            return display_default
+    elif 'default' in type_data:
         return type_data['default']
     elif 'type' not in type_data or type_data['type'] in ('array', 'object'):
         return NO_DEFAULT

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_defaults.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_defaults.py
@@ -32,7 +32,7 @@ def test():
               description: words
               value:
                 example: bar
-                display_default: baz
+                default: baz
                 type: string
             - name: example_ignored_array
               description: words
@@ -52,7 +52,7 @@ def test():
             - name: long_default_formatted
               description: words
               value:
-                display_default:
+                default:
                 - ["01", "02", "03", "04", "05"]
                 - ["06", "07", "08", "09", "10"]
                 - ["11", "12", "13", "14", "15"]

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_defaults.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_defaults.py
@@ -32,7 +32,7 @@ def test():
               description: words
               value:
                 example: bar
-                default: baz
+                display_default: baz
                 type: string
             - name: example_ignored_array
               description: words
@@ -52,7 +52,7 @@ def test():
             - name: long_default_formatted
               description: words
               value:
-                default:
+                display_default:
                 - ["01", "02", "03", "04", "05"]
                 - ["06", "07", "08", "09", "10"]
                 - ["11", "12", "13", "14", "15"]

--- a/elastic/datadog_checks/elastic/config_models/defaults.py
+++ b/elastic/datadog_checks/elastic/config_models/defaults.py
@@ -57,7 +57,7 @@ def instance_connect_timeout(field, value):
 
 
 def instance_disable_legacy_cluster_tag(field, value):
-    return True
+    return False
 
 
 def instance_empty_default_hostname(field, value):

--- a/envoy/datadog_checks/envoy/config_models/defaults.py
+++ b/envoy/datadog_checks/envoy/config_models/defaults.py
@@ -53,7 +53,7 @@ def instance_connect_timeout(field, value):
 
 
 def instance_disable_legacy_cluster_tag(field, value):
-    return True
+    return False
 
 
 def instance_empty_default_hostname(field, value):

--- a/go_expvar/datadog_checks/go_expvar/config_models/defaults.py
+++ b/go_expvar/datadog_checks/go_expvar/config_models/defaults.py
@@ -97,7 +97,7 @@ def instance_min_collection_interval(field, value):
 
 
 def instance_namespace(field, value):
-    return get_default_field_value(field, value)
+    return 'go_expvar'
 
 
 def instance_ntlm_domain(field, value):

--- a/haproxy/datadog_checks/haproxy/config_models/defaults.py
+++ b/haproxy/datadog_checks/haproxy/config_models/defaults.py
@@ -293,7 +293,7 @@ def instance_type_overrides(field, value):
 
 
 def instance_url(field, value):
-    return 'http://localhost/admin?stats'
+    return get_default_field_value(field, value)
 
 
 def instance_use_legacy_auth_encoding(field, value):

--- a/istio/datadog_checks/istio/config_models/defaults.py
+++ b/istio/datadog_checks/istio/config_models/defaults.py
@@ -49,7 +49,7 @@ def instance_bearer_token_path(field, value):
 
 
 def instance_citadel_endpoint(field, value):
-    return 'http://istio-citadel.istio-system:15014/metrics'
+    return get_default_field_value(field, value)
 
 
 def instance_connect_timeout(field, value):
@@ -69,7 +69,7 @@ def instance_extra_headers(field, value):
 
 
 def instance_galley_endpoint(field, value):
-    return 'http://istio-galley.istio-system:15014/metrics'
+    return get_default_field_value(field, value)
 
 
 def instance_headers(field, value):
@@ -93,11 +93,11 @@ def instance_ignore_tags(field, value):
 
 
 def instance_istio_mesh_endpoint(field, value):
-    return 'http://istio-proxy.istio-system:15090/stats/prometheus'
+    return get_default_field_value(field, value)
 
 
 def instance_istiod_endpoint(field, value):
-    return 'http://istiod.istio-system:15014/metrics'
+    return get_default_field_value(field, value)
 
 
 def instance_kerberos_auth(field, value):
@@ -153,7 +153,7 @@ def instance_min_collection_interval(field, value):
 
 
 def instance_mixer_endpoint(field, value):
-    return 'http://istio-telemetry.istio-system:15014/metrics'
+    return get_default_field_value(field, value)
 
 
 def instance_namespace(field, value):
@@ -173,7 +173,7 @@ def instance_persist_connections(field, value):
 
 
 def instance_pilot_endpoint(field, value):
-    return 'http://istio-pilot.istio-system:15014/metrics'
+    return get_default_field_value(field, value)
 
 
 def instance_prometheus_metrics_prefix(field, value):

--- a/kafka/datadog_checks/kafka/config_models/defaults.py
+++ b/kafka/datadog_checks/kafka/config_models/defaults.py
@@ -5,7 +5,7 @@ from datadog_checks.base.utils.models.fields import get_default_field_value
 
 
 def shared_collect_default_metrics(field, value):
-    return True
+    return False
 
 
 def shared_conf(field, value):
@@ -13,7 +13,7 @@ def shared_conf(field, value):
 
 
 def shared_new_gc_metrics(field, value):
-    return True
+    return False
 
 
 def shared_service(field, value):

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
@@ -29,7 +29,7 @@ def instance_empty_default_hostname(field, value):
 
 
 def instance_kafka_client_api_version(field, value):
-    return '2.3.0'
+    return get_default_field_value(field, value)
 
 
 def instance_kafka_consumer_offsets(field, value):
@@ -49,7 +49,7 @@ def instance_monitor_unlisted_consumer_groups(field, value):
 
 
 def instance_sasl_kerberos_domain_name(field, value):
-    return 'localhost'
+    return get_default_field_value(field, value)
 
 
 def instance_sasl_kerberos_service_name(field, value):
@@ -57,7 +57,7 @@ def instance_sasl_kerberos_service_name(field, value):
 
 
 def instance_sasl_mechanism(field, value):
-    return 'PLAIN'
+    return get_default_field_value(field, value)
 
 
 def instance_sasl_plain_password(field, value):

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -13,7 +13,7 @@ def shared_service(field, value):
 
 
 def instance_charset(field, value):
-    return 'utf8'
+    return get_default_field_value(field, value)
 
 
 def instance_connect_timeout(field, value):
@@ -37,7 +37,7 @@ def instance_empty_default_hostname(field, value):
 
 
 def instance_host(field, value):
-    return 'localhost'
+    return get_default_field_value(field, value)
 
 
 def instance_max_custom_queries(field, value):
@@ -97,4 +97,4 @@ def instance_use_global_custom_queries(field, value):
 
 
 def instance_username(field, value):
-    return 'datadog'
+    return get_default_field_value(field, value)

--- a/network/datadog_checks/network/config_models/defaults.py
+++ b/network/datadog_checks/network/config_models/defaults.py
@@ -9,7 +9,7 @@ def shared_service(field, value):
 
 
 def instance_blacklist_conntrack_metrics(field, value):
-    return get_default_field_value(field, value)
+    return []
 
 
 def instance_collect_aws_ena_metrics(field, value):
@@ -37,7 +37,7 @@ def instance_combine_connection_states(field, value):
 
 
 def instance_conntrack_path(field, value):
-    return '/usr/sbin/conntrack'
+    return get_default_field_value(field, value)
 
 
 def instance_empty_default_hostname(field, value):
@@ -69,4 +69,4 @@ def instance_use_sudo_conntrack(field, value):
 
 
 def instance_whitelist_conntrack_metrics(field, value):
-    return get_default_field_value(field, value)
+    return ['max', 'count']

--- a/nfsstat/datadog_checks/nfsstat/config_models/defaults.py
+++ b/nfsstat/datadog_checks/nfsstat/config_models/defaults.py
@@ -9,7 +9,7 @@ def shared_autofs_enabled(field, value):
 
 
 def shared_nfsiostat_path(field, value):
-    return '/usr/local/sbin/nfsiostat'
+    return get_default_field_value(field, value)
 
 
 def shared_service(field, value):

--- a/nginx/datadog_checks/nginx/config_models/defaults.py
+++ b/nginx/datadog_checks/nginx/config_models/defaults.py
@@ -105,7 +105,7 @@ def instance_persist_connections(field, value):
 
 
 def instance_plus_api_version(field, value):
-    return get_default_field_value(field, value)
+    return 2
 
 
 def instance_proxy(field, value):
@@ -165,7 +165,7 @@ def instance_use_plus_api(field, value):
 
 
 def instance_use_plus_api_stream(field, value):
-    return False
+    return True
 
 
 def instance_use_vts(field, value):

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -41,7 +41,7 @@ def instance_dbm(field, value):
 
 
 def instance_dbname(field, value):
-    return get_default_field_value(field, value)
+    return 'postgres'
 
 
 def instance_dbstrict(field, value):
@@ -89,7 +89,7 @@ def instance_query_samples(field, value):
 
 
 def instance_query_timeout(field, value):
-    return 1000
+    return get_default_field_value(field, value)
 
 
 def instance_relations(field, value):
@@ -101,7 +101,7 @@ def instance_service(field, value):
 
 
 def instance_ssl(field, value):
-    return 'false'
+    return False
 
 
 def instance_table_count_limit(field, value):

--- a/riakcs/datadog_checks/riakcs/config_models/defaults.py
+++ b/riakcs/datadog_checks/riakcs/config_models/defaults.py
@@ -21,7 +21,7 @@ def instance_empty_default_hostname(field, value):
 
 
 def instance_host(field, value):
-    return get_default_field_value(field, value)
+    return 'localhost'
 
 
 def instance_is_secure(field, value):
@@ -37,11 +37,11 @@ def instance_min_collection_interval(field, value):
 
 
 def instance_port(field, value):
-    return get_default_field_value(field, value)
+    return 8080
 
 
 def instance_s3_root(field, value):
-    return get_default_field_value(field, value)
+    return 's3.amazonaws.com'
 
 
 def instance_service(field, value):

--- a/sap_hana/datadog_checks/sap_hana/config_models/defaults.py
+++ b/sap_hana/datadog_checks/sap_hana/config_models/defaults.py
@@ -13,7 +13,7 @@ def shared_service(field, value):
 
 
 def instance_batch_size(field, value):
-    return get_default_field_value(field, value)
+    return 1000
 
 
 def instance_custom_queries(field, value):
@@ -29,7 +29,7 @@ def instance_min_collection_interval(field, value):
 
 
 def instance_port(field, value):
-    return get_default_field_value(field, value)
+    return 30015
 
 
 def instance_service(field, value):
@@ -41,7 +41,7 @@ def instance_tags(field, value):
 
 
 def instance_timeout(field, value):
-    return get_default_field_value(field, value)
+    return 10
 
 
 def instance_tls_ca_cert(field, value):

--- a/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
+++ b/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
@@ -5,7 +5,7 @@ from datadog_checks.base.utils.models.fields import get_default_field_value
 
 
 def shared_collect_default_metrics(field, value):
-    return True
+    return False
 
 
 def shared_conf(field, value):
@@ -17,7 +17,7 @@ def shared_is_jmx(field, value):
 
 
 def shared_new_gc_metrics(field, value):
-    return True
+    return False
 
 
 def shared_proxy(field, value):

--- a/spark/datadog_checks/spark/config_models/defaults.py
+++ b/spark/datadog_checks/spark/config_models/defaults.py
@@ -45,7 +45,7 @@ def instance_connect_timeout(field, value):
 
 
 def instance_disable_legacy_cluster_tag(field, value):
-    return True
+    return False
 
 
 def instance_empty_default_hostname(field, value):

--- a/tomcat/datadog_checks/tomcat/config_models/defaults.py
+++ b/tomcat/datadog_checks/tomcat/config_models/defaults.py
@@ -5,7 +5,7 @@ from datadog_checks.base.utils.models.fields import get_default_field_value
 
 
 def shared_collect_default_metrics(field, value):
-    return True
+    return False
 
 
 def shared_conf(field, value):
@@ -13,7 +13,7 @@ def shared_conf(field, value):
 
 
 def shared_new_gc_metrics(field, value):
-    return True
+    return False
 
 
 def shared_service(field, value):

--- a/varnish/datadog_checks/varnish/config_models/defaults.py
+++ b/varnish/datadog_checks/varnish/config_models/defaults.py
@@ -45,4 +45,4 @@ def instance_tags(field, value):
 
 
 def instance_varnishadm(field, value):
-    return '/usr/bin/varnishadm'
+    return get_default_field_value(field, value)

--- a/vault/datadog_checks/vault/config_models/defaults.py
+++ b/vault/datadog_checks/vault/config_models/defaults.py
@@ -57,7 +57,7 @@ def instance_detect_leader(field, value):
 
 
 def instance_disable_legacy_cluster_tag(field, value):
-    return True
+    return False
 
 
 def instance_empty_default_hostname(field, value):

--- a/vsphere/datadog_checks/vsphere/config_models/defaults.py
+++ b/vsphere/datadog_checks/vsphere/config_models/defaults.py
@@ -29,7 +29,7 @@ def instance_collect_attributes(field, value):
 
 
 def instance_collect_events(field, value):
-    return True
+    return 'depends on collection_type value'
 
 
 def instance_collect_events_only(field, value):
@@ -37,7 +37,7 @@ def instance_collect_events_only(field, value):
 
 
 def instance_collect_per_instance_filters(field, value):
-    return get_default_field_value(field, value)
+    return 'none'
 
 
 def instance_collect_tags(field, value):
@@ -53,7 +53,7 @@ def instance_collection_type(field, value):
 
 
 def instance_excluded_host_tags(field, value):
-    return get_default_field_value(field, value)
+    return []
 
 
 def instance_include_datastore_cluster_folder_tag(field, value):
@@ -65,11 +65,11 @@ def instance_max_historical_metrics(field, value):
 
 
 def instance_metric_filters(field, value):
-    return get_default_field_value(field, value)
+    return 'all metrics'
 
 
 def instance_metrics_per_query(field, value):
-    return 50
+    return 500
 
 
 def instance_min_collection_interval(field, value):
@@ -85,7 +85,7 @@ def instance_refresh_metrics_metadata_cache_interval(field, value):
 
 
 def instance_resource_filters(field, value):
-    return get_default_field_value(field, value)
+    return 'no filter'
 
 
 def instance_rest_api_options(field, value):

--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -302,7 +302,7 @@ files:
         Note: This is only used when `legacy_mode` is set to `true`.
       value:
         type: string
-        example: <REMOTE_HOSNAME>
+        example: <REMOTE_HOSTNAME>
         display_default: localhost
     - name: log_file
       description: |
@@ -336,9 +336,10 @@ files:
         type: array
         items:
           type: string
+        display_default:
+          - information
         example:
           - information
-        display_default: information
     - name: event_id
       description: |
         The `event_id` filter instructs the check to only capture events
@@ -379,7 +380,8 @@ files:
         type: array
         items:
           type: string
-        display_default: Message
+        display_default:
+          - Message
         example:
           - Message
     - template: instances/default

--- a/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
+++ b/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
@@ -33,7 +33,7 @@ def instance_auth_type(field, value):
 
 
 def instance_bookmark_frequency(field, value):
-    return get_default_field_value(field, value)
+    return '<PAYLOAD_SIZE>'
 
 
 def instance_domain(field, value):
@@ -45,7 +45,7 @@ def instance_empty_default_hostname(field, value):
 
 
 def instance_event_format(field, value):
-    return get_default_field_value(field, value)
+    return 'Message'
 
 
 def instance_event_id(field, value):
@@ -65,7 +65,7 @@ def instance_filters(field, value):
 
 
 def instance_host(field, value):
-    return get_default_field_value(field, value)
+    return 'localhost'
 
 
 def instance_included_messages(field, value):
@@ -77,7 +77,7 @@ def instance_interpret_messages(field, value):
 
 
 def instance_legacy_mode(field, value):
-    return False
+    return True
 
 
 def instance_log_file(field, value):
@@ -141,7 +141,7 @@ def instance_timeout(field, value):
 
 
 def instance_type(field, value):
-    return get_default_field_value(field, value)
+    return 'information'
 
 
 def instance_user(field, value):

--- a/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
+++ b/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
@@ -45,7 +45,7 @@ def instance_empty_default_hostname(field, value):
 
 
 def instance_event_format(field, value):
-    return 'Message'
+    return ['Message']
 
 
 def instance_event_id(field, value):
@@ -141,7 +141,7 @@ def instance_timeout(field, value):
 
 
 def instance_type(field, value):
-    return 'information'
+    return ['information']
 
 
 def instance_user(field, value):

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -249,7 +249,7 @@ instances:
     ##
     ## Note: This is only used when `legacy_mode` is set to `true`.
     #
-    # host: <REMOTE_HOSNAME>
+    # host: <REMOTE_HOSTNAME>
 
     ## @param log_file - list of strings - optional
     ## The `log_file` filter instructs the check to only capture events
@@ -268,7 +268,7 @@ instances:
     #
     # source_name: []
 
-    ## @param type - list of strings - optional - default: information
+    ## @param type - list of strings - optional - default: ['information']
     ## The `type` filter instructs the check to only capture events
     ## that have one of the specified Types.
     ## Standard values are: Critical, Error, Warning, Information, Audit Success, Audit Failure.
@@ -301,7 +301,7 @@ instances:
     #
     # message_filters: []
 
-    ## @param event_format - list of strings - optional - default: Message
+    ## @param event_format - list of strings - optional - default: ['Message']
     ## The `event_format` parameter instructs the check to generate
     ## Datadog's event bodies with the specified list of event properties.
     ## If unspecified, the EventLog's `Message` or `InsertionStrings` are used by default.

--- a/wmi_check/datadog_checks/wmi_check/config_models/defaults.py
+++ b/wmi_check/datadog_checks/wmi_check/config_models/defaults.py
@@ -41,7 +41,7 @@ def instance_service(field, value):
 
 
 def instance_tag_by(field, value):
-    return 'Name,Label'
+    return get_default_field_value(field, value)
 
 
 def instance_tag_queries(field, value):

--- a/yarn/datadog_checks/yarn/config_models/defaults.py
+++ b/yarn/datadog_checks/yarn/config_models/defaults.py
@@ -65,7 +65,7 @@ def instance_connect_timeout(field, value):
 
 
 def instance_disable_legacy_cluster_tag(field, value):
-    return True
+    return False
 
 
 def instance_empty_default_hostname(field, value):


### PR DESCRIPTION
### What does this PR do?
Use `display_default` instead of `default` when validating models.

#### Example
In kafka_consumer check, default for the optional `kafka_client_api_version` is `None` but an example value is shown as `2.3.0`. However, the generated `defaults.py` currently takes the value from `default` > then `example` > then falls back to NO_DEFAULT aka `<KAFKA_CLIENT_API_VERSION>`

 - `spec.yaml` - https://github.com/DataDog/integrations-core/blob/7.30.x/kafka_consumer/assets/configuration/spec.yaml
   ```
      - name: kafka_client_api_version
        ...
        value:
          type: string
          example: "2.3.0"
          display_default: null
   ```

 - `conf.yaml.example` - https://github.com/DataDog/integrations-core/blob/7.30.x/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example#L56-L65
    ```
        ## @param kafka_client_api_version - string - optional
        ## Specify the highest client protocol version supported by all brokers in the cluster.
        ...
        # kafka_client_api_version: 2.3.0
    ```
 - `defaults.py`
    - Expected: 
      ```
      def instance_kafka_client_api_version(field, value):
            return None
      ```
    - Actual: https://github.com/DataDog/integrations-core/blob/7.30.x/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py#L31-L32
      ```
      def instance_kafka_client_api_version(field, value):
            return '2.3.0'
      ```

#### Example 2: https://github.com/DataDog/integrations-core/pull/9699/files#r672222987


### Motivation
https://github.com/DataDog/integrations-core/pull/8593

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
