### PR TITLE
Enclose community string using single quote

### DIFF
--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -104,8 +104,9 @@ instances:
 
     ## @param community_string - string - optional
     ## Only useful for SNMP v1 & v2.
+    ## Enclose the community string with single quote like below (to avoid special character being interpreted).
     #
-    # community_string: public
+    # community_string: 'public'
 
     ## @param snmp_version - integer - optional - default: 2
     ## If you are using SNMP v1 set snmp_version to 1


### PR DESCRIPTION
### What does this PR do?

Enclose community string using single quote

### Motivation

If community string contain special character the actual community string being use to reach the device might be wrong.