### PR TITLE
Fix flaky test, add more assertions and missing metric

### DIFF
--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -42,6 +42,7 @@ redis.net.clients,gauge,,connection,,The number of connected clients (excluding 
 redis.net.commands,gauge,,command,,The number of commands processed by the server.,0,redis,net commands
 redis.net.commands.instantaneous_ops_per_sec,gauge,,command,second,The number of commands processed by the server per second.,0,redis,net commands
 redis.net.connections,gauge,,connection,,The number of connections tagged by client name.,0,redis,connections
+redis.net.instantaneous_ops_per_sec,gauge,,operation,second,Number of commands processed per second.,0,redis,ops per sec
 redis.net.rejected,gauge,,connection,,The number of rejected connections.,-1,redis,net rejected
 redis.net.slaves,gauge,,connection,,The number of connected slaves.,0,redis,slaves
 redis.net.maxclients,gauge,,connection,,The maximum number of connected clients.,0,redis,maxclients

--- a/redisdb/tests/test_e2e.py
+++ b/redisdb/tests/test_e2e.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from datadog_checks.base import is_affirmative
+from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.redisdb import Redis
 
 from . import common
@@ -77,7 +78,7 @@ def test_e2e_v_3_2(dd_agent_check, master_instance):
     aggregator.assert_metric('redis.clients.biggest_input_buf', count=2, tags=tags)
     aggregator.assert_metric('redis.clients.longest_output_list', count=2, tags=tags)
 
-    aggregator.assert_all_metrics_covered()
+    assert_all(aggregator)
 
 
 @pytest.mark.skipif(os.environ.get('REDIS_VERSION') != '4.0', reason='Test for redisdb v4.0')
@@ -97,7 +98,7 @@ def test_e2e_v_4_0(dd_agent_check, master_instance):
     aggregator.assert_metric('redis.active_defrag.key_hits', count=2, tags=tags)
     aggregator.assert_metric('redis.active_defrag.key_misses', count=2, tags=tags)
 
-    aggregator.assert_all_metrics_covered()
+    assert_all(aggregator)
 
 
 @pytest.mark.skipif(os.environ.get('REDIS_VERSION') != 'latest', reason='Test for the latest redisdb version')
@@ -122,10 +123,22 @@ def test_e2e_v_latest(dd_agent_check, master_instance):
     aggregator.assert_metric('redis.clients.recent_max_input_buffer', count=2, tags=tags)
     aggregator.assert_metric('redis.clients.recent_max_output_buffer', count=2, tags=tags)
 
-    aggregator.assert_all_metrics_covered()
+    # Optional slowlog metrics
+    aggregator.assert_metric('redis.slowlog.micros.95percentile', at_least=0)
+    aggregator.assert_metric('redis.slowlog.micros.avg', at_least=0)
+    aggregator.assert_metric('redis.slowlog.micros.count', at_least=0)
+    aggregator.assert_metric('redis.slowlog.micros.max', at_least=0)
+    aggregator.assert_metric('redis.slowlog.micros.median', at_least=0)
+
+    assert_all(aggregator)
 
 
 def assert_non_cloud_metrics(aggregator, tags):
     """Certain metrics cannot be collected in cloud environments due to disabled commands"""
     aggregator.assert_metric('redis.net.connections', count=2, tags=tags + ['source:unknown'])
     aggregator.assert_metric('redis.net.maxclients', count=2, tags=tags)
+
+
+def assert_all(aggregator):
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())


### PR DESCRIPTION
cannot include checking for duplicates because there are duplicates
Test flaked on https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=70750&view=logs&j=28d964ed-ced8-53cb-c786-cadbc5b4e9d8&t=01f908e0-b712-54ab-b4e6-5b3231df2d3c&l=225