### PR TITLE
Fix flake & add missing assertions

### DIFF
--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -12,10 +12,10 @@ from copy import deepcopy
 
 import pytest
 import requests
-from datadog_checks.dev.utils import get_metadata_metrics
 from six import PY2
 
 from datadog_checks.couch import CouchDb
+from datadog_checks.dev.utils import get_metadata_metrics
 
 from . import common
 

--- a/couch/tests/test_couchv2.py
+++ b/couch/tests/test_couchv2.py
@@ -12,6 +12,7 @@ from copy import deepcopy
 
 import pytest
 import requests
+from datadog_checks.dev.utils import get_metadata_metrics
 from six import PY2
 
 from datadog_checks.couch import CouchDb
@@ -121,6 +122,7 @@ def _assert_check(aggregator, gauges):
         aggregator.assert_metric(gauge)
 
     aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 @pytest.mark.usefixtures('dd_environment')
@@ -192,11 +194,15 @@ def test_check_without_names(aggregator, gauges):
         for gauge in gauges["cluster_gauges"]:
             aggregator.assert_metric(gauge, tags=expected_tags)
 
-        for gauge in gauges["erlang_gauges"]:
-            aggregator.assert_metric(gauge)
+    for gauge in gauges["erlang_gauges"]:
+        aggregator.assert_metric(gauge)
 
-        for gauge in gauges["replication_tasks_gauges"]:
-            aggregator.assert_metric(gauge)
+    for gauge in gauges["replication_tasks_gauges"]:
+        aggregator.assert_metric(gauge)
+
+    # Optional indexing metrics
+    for gauge in gauges["indexing_tasks_gauges"]:
+        aggregator.assert_metric(gauge, at_least=0)
 
     for db, dd in {"kennel": "dummy"}.items():
         expected_tags = ["design_document:{}".format(dd), "language:javascript", "db:{}".format(db)]
@@ -218,6 +224,7 @@ def test_check_without_names(aggregator, gauges):
         aggregator.assert_service_check(CouchDb.SERVICE_CHECK_NAME, status=CouchDb.OK, tags=expected_tags, count=1)
 
     aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 @pytest.mark.usefixtures('dd_environment')


### PR DESCRIPTION
Add missing optional metrics
Test flaked on https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=70820&view=logs&j=c73aedc7-d1f1-5bee-93b6-629007590bd5&t=622fd669-15c6-58d9-3442-b4f44bd24cfb&l=697

Also add missing metadata assertions