### PR TITLE
Document the max number of IDs that can be used for filtering per instance

### DIFF
--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -110,7 +110,7 @@ files:
           /\ WARNING /\
           Due to a limitation in the Windows events API, the maximum filtering on event IDs is 20 IDs per instance.
           Because of this, you may need to split the ID filtering into multiple instances.
-
+          
         For advanced and more granular filtering, define a `query`.
 
         If `filters` nor `query` is specified, then all events from the subscribed `path` will be collected.

--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -107,6 +107,10 @@ files:
           - type > https://docs.microsoft.com/en-us/windows/win32/eventlog/event-types
           - id > https://docs.microsoft.com/en-us/windows/win32/eventlog/event-identifiers
 
+          /\ WARNING /\
+          Due to a limitation in the Windows events API, the maximum filtering on event IDs is 20 IDs per instance.
+          Because of this, you may need to split the ID filtering into multiple instances.
+
         For advanced and more granular filtering, define a `query`.
 
         If `filters` nor `query` is specified, then all events from the subscribed `path` will be collected.

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -99,6 +99,10 @@ instances:
     ##   - type > https://docs.microsoft.com/en-us/windows/win32/eventlog/event-types
     ##   - id > https://docs.microsoft.com/en-us/windows/win32/eventlog/event-identifiers
     ##
+    ##   /\ WARNING /\
+    ##   Due to a limitation in the windows events API, filtering on event id should not consist of more than 20 event ids.
+    ##   Please consider splitting up the id filtering into multiple instances if necessary
+    ##
     ## For advanced and more granular filtering, define a `query`.
     ##
     ## If `filters` nor `query` is specified, then all events from the subscribed `path` will be collected.

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -102,7 +102,7 @@ instances:
     ##   /\ WARNING /\
     ##   Due to a limitation in the Windows events API, the maximum filtering on event IDs is 20 IDs per instance.
     ##   Because of this, you may need to split the ID filtering into multiple instances.
-    ##
+    ##   
     ## For advanced and more granular filtering, define a `query`.
     ##
     ## If `filters` nor `query` is specified, then all events from the subscribed `path` will be collected.

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -100,7 +100,7 @@ instances:
     ##   - id > https://docs.microsoft.com/en-us/windows/win32/eventlog/event-identifiers
     ##
     ##   /\ WARNING /\
-    ##   Due to a limitation in the windows events API, filtering on event ids can only be up to 20 ids at a time.
+    ##   Due to a limitation in the windows events API, filtering on event ids can only be up to 20 ids per instance.
     ##   Please consider splitting up the id filtering into multiple instances if necessary
     ##
     ## For advanced and more granular filtering, define a `query`.

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -101,7 +101,7 @@ instances:
     ##
     ##   /\ WARNING /\
     ##   Due to a limitation in the Windows events API, the maximum filtering on event IDs is 20 IDs per instance.
-    ##   Please consider splitting up the id filtering into multiple instances if necessary
+    ##   Because of this, you may need to split the ID filtering into multiple instances.
     ##
     ## For advanced and more granular filtering, define a `query`.
     ##

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -100,7 +100,7 @@ instances:
     ##   - id > https://docs.microsoft.com/en-us/windows/win32/eventlog/event-identifiers
     ##
     ##   /\ WARNING /\
-    ##   Due to a limitation in the windows events API, filtering on event id should not consist of more than 20 event ids.
+    ##   Due to a limitation in the windows events API, filtering on event ids can only be up to 20 ids at a time.
     ##   Please consider splitting up the id filtering into multiple instances if necessary
     ##
     ## For advanced and more granular filtering, define a `query`.

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -100,7 +100,7 @@ instances:
     ##   - id > https://docs.microsoft.com/en-us/windows/win32/eventlog/event-identifiers
     ##
     ##   /\ WARNING /\
-    ##   Due to a limitation in the windows events API, filtering on event ids can only be up to 20 ids per instance.
+    ##   Due to a limitation in the Windows events API, the maximum filtering on event IDs is 20 IDs per instance.
     ##   Please consider splitting up the id filtering into multiple instances if necessary
     ##
     ## For advanced and more granular filtering, define a `query`.


### PR DESCRIPTION
### What does this PR do?
Added a small note in the template conf.yaml to document that event filtering based on id can only be up to 20 ids long. If it's any longer, the API we query will return an error and therefore cause the check to also report and error.

### Motivation
Escalation

### Additional Notes
Didn't see any mention of this option in the main docs, so decided not to make any changes there. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
