### PR TITLE
Fix debug log formating

### DIFF
--- a/postgres/datadog_checks/postgres/metrics_cache.py
+++ b/postgres/datadog_checks/postgres/metrics_cache.py
@@ -159,7 +159,7 @@ class PostgresMetricsCache:
             return self.replication_metrics
 
         if is_aurora:
-            logger.debug("Detected Aurora {}. Won't collect replication metrics", version)
+            logger.debug("Detected Aurora %s. Won't collect replication metrics", version)
             self.replication_metrics = {}
         elif version >= V10:
             self.replication_metrics = dict(REPLICATION_METRICS_10)


### PR DESCRIPTION
### What does this PR do?
Fix string formatting in debug log for Postgres check

### Motivation
This causes the postgres check to fail when running with debug logs

### Additional Notes
Check fails with the following error:  
```
=========
Collector
=========

  Running Checks
  ==============

    postgres (7.0.2)
    ----------------
      Instance ID: postgres:c37d7deba49bb494 [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/postgres.d/conf_postgres.yaml
      Total Runs: 1
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 41ms
      Last Execution Date : 2021-07-12 09:11:18 UTC (1626081078000)
      Last Successful Execution Date : Never
      metadata:
        version.major: 10
        version.minor: 14
        version.patch: 0
        version.raw: 10.14
        version.scheme: semver
      Error: not all arguments converted during string formatting
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 999, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/postgres/postgres.py", line 411, in check
          raise e
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/postgres/postgres.py", line 395, in check
          self._collect_stats(tags)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/postgres/postgres.py", line 224, in _collect_stats
          replication_metrics = self.metrics_cache.get_replication_metrics(self.version, self.is_aurora)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/postgres/metrics_cache.py", line 162, in get_replication_metrics
          logger.debug("Detected Aurora {}. Won't collect replication metrics", version)
        File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 1434, in debug
          self._log(DEBUG, msg, args, **kwargs)
        File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 1589, in _log
          self.handle(record)
        File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 1599, in handle
          self.callHandlers(record)
        File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 1661, in callHandlers
          hdlr.handle(record)
        File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 954, in handle
          self.emit(record)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/log.py", line 102, in emit
          message = self.format(record)
        File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 929, in format
          return fmt.format(record)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/log.py", line 79, in format
          message = to_native_string(super(CheckLogFormatter, self).format(record))
        File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 668, in format
          record.message = record.getMessage()
        File "/opt/datadog-agent/embedded/lib/python3.8/logging/__init__.py", line 373, in getMessage
          msg = msg % self.args
      TypeError: not all arguments converted during string formatting
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
