### PR TITLE
[OLD] Add test for v3 default protocols

### DIFF
--- a/snmp/tests/compose/data/args_list.txt
+++ b/snmp/tests/compose/data/args_list.txt
@@ -1,3 +1,5 @@
+--v3-user=datadogNoAuthNoPriv
+--v3-user=datadogMD5NoPriv --v3-auth-key=doggiepass --v3-auth-proto=MD5
 --v3-user=datadogMD5DES --v3-auth-key=doggiepass --v3-priv-key=doggiePRIVkey --v3-auth-proto=MD5 --v3-priv-proto=DES
 --v3-user=datadogMD5AES --v3-auth-key=doggiepass --v3-priv-key=doggiePRIVkey --v3-auth-proto=MD5 --v3-priv-proto=AES
 --v3-user=datadogSHADES --v3-auth-key=doggiepass --v3-priv-key=doggiePRIVkey --v3-auth-proto=SHA --v3-priv-proto=DES

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -17,6 +17,24 @@ def test_e2e_v1_with_apc_ups_profile(dd_agent_check):
             'community_string': 'apc_ups',
         }
     )
+    assert_apc_ups_metrics(config, dd_agent_check, instance)
+
+
+def test_e2e_core_v3_no_auth_no_priv(dd_agent_check):
+    config = common.generate_container_instance_config([])
+    instance = config['instances'][0]
+    instance.update(
+        {
+            'user': 'datadogNoAuthNoPriv',
+            'snmp_version': 3,
+            'context_name': 'apc_ups',
+            'community_string': '',
+        }
+    )
+    assert_apc_ups_metrics(config, dd_agent_check, instance)
+
+
+def assert_apc_ups_metrics(config, dd_agent_check, instance):
     config['init_config']['loader'] = 'core'
 
     aggregator = dd_agent_check(config, rate=True)

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -84,9 +84,7 @@ def test_e2e_v3_no_auth_no_priv(dd_agent_check):
     config['instances'][0].update(
         {
             'user': 'datadogNoAuthNoPriv',
-            # 'authKey': 'doggiepass',
             'authProtocol': '',
-            # 'privKey': 'doggiePRIVkey',
             'privProtocol': '',
             'snmp_version': 3,
             'context_name': 'f5-big-ip',

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -79,6 +79,39 @@ def test_e2e_v3_default_auth_priv_protocols(dd_agent_check):
     assert_python_vs_core(dd_agent_check, config, expected_total_count=509 + 5)
 
 
+def test_e2e_v3_no_auth_no_priv(dd_agent_check):
+    config = common.generate_container_instance_config([])
+    config['instances'][0].update(
+        {
+            'user': 'datadogNoAuthNoPriv',
+            # 'authKey': 'doggiepass',
+            'authProtocol': '',
+            # 'privKey': 'doggiePRIVkey',
+            'privProtocol': '',
+            'snmp_version': 3,
+            'context_name': 'f5-big-ip',
+            'community_string': '',
+        }
+    )
+    assert_python_vs_core(dd_agent_check, config, expected_total_count=509 + 5)
+
+
+def test_e2e_v3_with_auth_no_priv(dd_agent_check):
+    config = common.generate_container_instance_config([])
+    config['instances'][0].update(
+        {
+            'user': 'datadogMD5NoPriv',
+            'authKey': 'doggiepass',
+            'authProtocol': 'MD5',
+            'privProtocol': '',
+            'snmp_version': 3,
+            'context_name': 'f5-big-ip',
+            'community_string': '',
+        }
+    )
+    assert_python_vs_core(dd_agent_check, config, expected_total_count=509 + 5)
+
+
 def test_e2e_regex_match(dd_agent_check, aggregator):
     metrics = [
         {

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -64,6 +64,21 @@ def test_e2e_v3_explicit_version(dd_agent_check):
     assert_python_vs_core(dd_agent_check, config, expected_total_count=509 + 5)
 
 
+def test_e2e_v3_default_auth_priv_protocols(dd_agent_check):
+    config = common.generate_container_instance_config([])
+    config['instances'][0].update(
+        {
+            'user': 'datadogMD5DES',
+            'authKey': 'doggiepass',
+            'privKey': 'doggiePRIVkey',
+            'snmp_version': 3,
+            'context_name': 'f5-big-ip',
+            'community_string': '',
+        }
+    )
+    assert_python_vs_core(dd_agent_check, config, expected_total_count=509 + 5)
+
+
 def test_e2e_regex_match(dd_agent_check, aggregator):
     metrics = [
         {


### PR DESCRIPTION
Superseded by https://github.com/DataDog/integrations-core/pull/9765

### What does this PR do?

Add test for v3 default protocols

### Motivation

Better coverage
