### PR TITLE
Link 22 (ECS Fargate) update

### DIFF
--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -416,7 +416,7 @@ Need help? Contact [Datadog support][22].
 [19]: http://docs.datadoghq.com/agent/cluster_agent/event_collection
 [20]: https://docs.datadoghq.com/help
 [21]: https://app.datadoghq.com/containers
-[22]: https://app.datadoghq.com/process
+[22]: https://docs.datadoghq.com/integrations/ecs_fargate/#?tab=fluentbitandfirelens
 [23]: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
 [24]: https://docs.datadoghq.com/agent/kubernetes/daemonset_setup/?tab=k8sfile#process-collection
 [25]: https://www.datadoghq.com/blog/tools-for-collecting-aws-fargate-metrics/


### PR DESCRIPTION
Updating link 22 to the ECS Fargate doc, not live processes page.

### What does this PR do?
Updates link 22 to the ECS Fargate doc, not live processes page.

### Motivation
The current link takes you to Datadog's live processes page in the app 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
