### PR TITLE
Validate snmp profiles for all core builds

### DIFF
--- a/.azure-pipelines/templates/run-validations.yml
+++ b/.azure-pipelines/templates/run-validations.yml
@@ -52,16 +52,17 @@ steps:
       ddev validate dep --require-base-check-version ${{ parameters.check }}
     displayName: 'Validate dependencies'
 
-  - script: |
-      echo "ddev meta snmp validate-profile"
-      ddev meta snmp validate-profile
-    displayName: 'Validate snmp profiles'
-
 - ${{ if and(eq(parameters.repo, 'core'), eq(parameters.ispr, 'false')) }}:
     - script: |
         echo "ddev validate dep ${{ parameters.validate_changed }}"
         ddev validate dep ${{ parameters.validate_changed }}
       displayName: 'Validate dependencies'
+
+- ${{ if eq(parameters.repo, 'core') }}:
+  - script: |
+      echo "ddev meta snmp validate-profile"
+      ddev meta snmp validate-profile
+    displayName: 'Validate snmp profiles'
 
 - script: |
     echo "ddev validate manifest ${{ parameters.validate_changed }}"


### PR DESCRIPTION
### What does this PR do?

Validate snmp profiles for all core builds

### Motivation

Makes `ddev meta snmp validate-profile` independent from `ispr`

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
