### PR TITLE
changelog/no-changelog log stream widget on iis overview dashboard should query source:iis

### DIFF
--- a/iis/assets/dashboards/iis_overview.json
+++ b/iis/assets/dashboards/iis_overview.json
@@ -717,7 +717,7 @@
                 ],
                 "indexes": [],
                 "message_display": "expanded-md",
-                "query": "\"iis\"",
+                "query": "source:iis",
                 "show_date_column": true,
                 "show_message_column": true,
                 "sort": {


### PR DESCRIPTION
### What does this PR do?
Changes the query of the Log Stream widget on the iis overview dashboard from "iis" to source:iis.

### Motivation
The log stream widget on this dashboard currently queries "iis" but it should query source:iis. Since there is an OOTB integration pipeline for IIS, any formally recognized IIS logs will have the source:iis facet and will not necessarily have "iis" free text in the message attribute of the log. source:iis is a better query.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
