### PR TITLE
Add service check for K8s API Server components

### DIFF
--- a/kube_controller_manager/assets/service_checks.json
+++ b/kube_controller_manager/assets/service_checks.json
@@ -28,5 +28,17 @@
         ],
         "name": "Kube Controller Manager leader election health",
         "description": "Returns `CRITICAL` if no replica is currently set as leader."
+    },
+    {
+        "agent_version": "6.0.0",
+        "integration": "Kubernetes Controller Manager",
+        "check": "kube_controller_manager.up",
+        "groups": [],
+        "statuses": [
+            "ok",
+            "critical"
+        ],
+        "name": "Kube Controller Manager health",
+        "description": "Returns `CRITICAL` if Kube Controller Manager is not healthy."
     }
 ]

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
@@ -31,6 +31,11 @@ instances:
     #
     # leader_election_kind: auto
 
+    ## @param health_url - string - optional - default: http://localhost:10252/healthz
+    ## URL for the kube-scheduler health endpoint.
+    #
+    # health_url: http://localhost:10252/healthz
+
     ## @param prometheus_timeout - integer - optional - default: 10
     ## Overrides the default timeout value in second
     #

--- a/kube_controller_manager/tests/test_kube_controller_manager.py
+++ b/kube_controller_manager/tests/test_kube_controller_manager.py
@@ -6,7 +6,9 @@ import os
 
 import mock
 import pytest
+import requests
 
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.kube_leader import ElectionRecordAnnotation
 from datadog_checks.kube_controller_manager import KubeControllerManagerCheck
 
@@ -123,3 +125,29 @@ def generic_check_metrics(aggregator, check_deprecated):
     aggregator.assert_service_check(NAMESPACE + ".leader_election.status", tags=expected_le_tags)
 
     aggregator.assert_all_metrics_covered()
+
+
+def test_service_check_ok(monkeypatch):
+    instance = {'prometheus_url': 'http://localhost:10252/metrics'}
+    instance_tags = []
+
+    check = KubeControllerManagerCheck(CHECK_NAME, {}, [instance])
+
+    monkeypatch.setattr(check, 'service_check', mock.Mock())
+
+    calls = [
+        mock.call('kube_controller_manager.up', AgentCheck.OK, tags=instance_tags),
+        mock.call('kube_controller_manager.up', AgentCheck.CRITICAL, tags=instance_tags, message='health check failed'),
+    ]
+
+    # successful health check
+    with mock.patch("requests.get", return_value=mock.MagicMock(status_code=200)):
+        check._perform_service_check(instance)
+
+    # failed health check
+    raise_error = mock.Mock()
+    raise_error.side_effect = requests.HTTPError('health check failed')
+    with mock.patch("requests.get", return_value=mock.MagicMock(raise_for_status=raise_error)):
+        check._perform_service_check(instance)
+
+    check.service_check.assert_has_calls(calls)

--- a/kube_scheduler/assets/configuration/spec.yaml
+++ b/kube_scheduler/assets/configuration/spec.yaml
@@ -25,6 +25,12 @@ files:
       value:
         type: string
         example: auto
+    - name: health_url
+      description: |
+        URL for the kube-scheduler health endpoint.
+      value:
+        type: string
+        example: http://localhost:10251/healthz
     - template: instances/openmetrics_legacy
       overrides:
         prometheus_url.value.example: http://localhost:10251/metrics

--- a/kube_scheduler/assets/service_checks.json
+++ b/kube_scheduler/assets/service_checks.json
@@ -28,5 +28,17 @@
         ],
         "name": "Kube Scheduler leader election health",
         "description": "Returns `CRITICAL` if no replica is currently set as leader."
+    },
+    {
+        "agent_version": "6.0.0",
+        "integration": "Kube_scheduler",
+        "check": "kube_scheduler.up",
+        "groups": [],
+        "statuses": [
+            "ok",
+            "critical"
+        ],
+        "name": "Kube Scheduler health",
+        "description": "Returns `CRITICAL` if Kube Scheduler is not healthy."
     }
 ]

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -66,6 +66,11 @@ instances:
     #
     # leader_election_kind: auto
 
+    ## @param health_url - string - optional - default: http://localhost:10251/healthz
+    ## URL for the kube-scheduler health endpoint.
+    #
+    # health_url: http://localhost:10251/healthz
+
     ## @param prometheus_metrics_prefix - string - optional
     ## Removes a given <PREFIX> from exposed Prometheus metrics.
     #

--- a/kube_scheduler/tests/test_kube_scheduler_1_14.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_14.py
@@ -6,7 +6,9 @@ import os
 
 import mock
 import pytest
+import requests
 
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.kube_leader import ElectionRecordAnnotation
 from datadog_checks.kube_scheduler import KubeSchedulerCheck
 
@@ -100,3 +102,29 @@ def test_check_metrics_1_14(aggregator, mock_metrics, mock_leader):
     assert_metric('.leader_election.lease_duration', value=15, tags=expected_le_tags)
     aggregator.assert_service_check(NAMESPACE + ".leader_election.status", tags=expected_le_tags)
     aggregator.assert_all_metrics_covered()
+
+
+def test_service_check_ok(monkeypatch):
+    instance = {'prometheus_url': 'http://localhost:10251/metrics'}
+    instance_tags = []
+
+    check = KubeSchedulerCheck(CHECK_NAME, {}, [instance])
+
+    monkeypatch.setattr(check, 'service_check', mock.Mock())
+
+    calls = [
+        mock.call('kube_scheduler.up', AgentCheck.OK, tags=instance_tags),
+        mock.call('kube_scheduler.up', AgentCheck.CRITICAL, tags=instance_tags, message='health check failed'),
+    ]
+
+    # successful health check
+    with mock.patch("requests.get", return_value=mock.MagicMock(status_code=200)):
+        check._perform_service_check(instance)
+
+    # failed health check
+    raise_error = mock.Mock()
+    raise_error.side_effect = requests.HTTPError('health check failed')
+    with mock.patch("requests.get", return_value=mock.MagicMock(raise_for_status=raise_error)):
+        check._perform_service_check(instance)
+
+    check.service_check.assert_has_calls(calls)


### PR DESCRIPTION
### What does this PR do?

Adds `kube_scheduler.up` and `kube_controller_manager.up` service checks
for the Kube Scheduler and Kube Controller Manager, respectively. This
is to support the deprecation of some of the
`kube_apiserver_controlplane.up` service checks backed by the
ComponentStatus API. See
https://github.com/DataDog/datadog-agent/pull/8577 for more context.

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have `changelog/` and `integration/` labels attached
