### PR TITLE
Add kube_job tag to job metrics

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -32,6 +32,7 @@ ALLOWED_TERMINATED_REASONS = ['oomkilled', 'containercannotrun', 'error']
 kube_labels_mapper = {
     'namespace': 'kube_namespace',
     'job': 'kube_job',
+    'job_name': 'kube_job',
     'cronjob': 'kube_cronjob',
     'pod': 'pod_name',
     'phase': 'pod_phase',

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -164,8 +164,8 @@ TAGS = {
     ],
     NAMESPACE + '.container.status_report.count.terminated': ['pod:pod2'],
     NAMESPACE + '.persistentvolumeclaim.request_storage': ['storageclass:manual'],
-    NAMESPACE + '.job.failed': ['job:hello', 'job_name:hello2'],
-    NAMESPACE + '.job.succeeded': ['job:hello', 'job_name:hello2'],
+    NAMESPACE + '.job.failed': ['job:hello', 'job_name:hello2', 'kube_job:hello2'],
+    NAMESPACE + '.job.succeeded': ['job:hello', 'job_name:hello2', 'kube_job:hello2'],
     NAMESPACE + '.hpa.condition': ['namespace:default', 'hpa:myhpa', 'condition:true', 'status:abletoscale'],
 }
 
@@ -605,6 +605,7 @@ def test_join_standard_tags_labels(aggregator, instance, check_with_join_standar
         NAMESPACE + '.job.succeeded',
         tags=[
             'job_name:curl-job',
+            'kube_job:curl-job',
             'kube_namespace:default',
             'namespace:default',
             'optional:tag1',
@@ -620,6 +621,7 @@ def test_join_standard_tags_labels(aggregator, instance, check_with_join_standar
         NAMESPACE + '.job.succeeded',
         tags=[
             'job_name:curl-cron-job',
+            'kube_job:curl-cron-job',
             'kube_namespace:default',
             'namespace:default',
             'optional:tag1',
@@ -720,12 +722,12 @@ def test_job_counts(aggregator, instance):
     # Test jobs
     aggregator.assert_metric(
         NAMESPACE + '.job.failed',
-        tags=['namespace:default', 'kube_namespace:default', 'job_name:test', 'optional:tag1'],
+        tags=['namespace:default', 'kube_namespace:default', 'job_name:test', 'kube_job:test', 'optional:tag1'],
         value=0,
     )
     aggregator.assert_metric(
         NAMESPACE + '.job.succeeded',
-        tags=['namespace:default', 'kube_namespace:default', 'job_name:test', 'optional:tag1'],
+        tags=['namespace:default', 'kube_namespace:default', 'job_name:test', 'kube_job:test', 'optional:tag1'],
         value=1,
     )
 
@@ -747,12 +749,12 @@ def test_job_counts(aggregator, instance):
     # Test jobs
     aggregator.assert_metric(
         NAMESPACE + '.job.failed',
-        tags=['namespace:default', 'kube_namespace:default', 'job_name:test', 'optional:tag1'],
+        tags=['namespace:default', 'kube_namespace:default', 'job_name:test', 'kube_job:test', 'optional:tag1'],
         value=0,
     )
     aggregator.assert_metric(
         NAMESPACE + '.job.succeeded',
-        tags=['namespace:default', 'kube_namespace:default', 'job_name:test', 'optional:tag1'],
+        tags=['namespace:default', 'kube_namespace:default', 'job_name:test', 'kube_job:test', 'optional:tag1'],
         value=1,
     )
 
@@ -799,7 +801,7 @@ def test_job_counts(aggregator, instance):
     # Test if we now have two as the value for the same job
     aggregator.assert_metric(
         NAMESPACE + '.job.succeeded',
-        tags=['namespace:default', 'kube_namespace:default', 'job_name:test', 'optional:tag1'],
+        tags=['namespace:default', 'kube_namespace:default', 'job_name:test', 'kube_job:test', 'optional:tag1'],
         value=2,
     )
 


### PR DESCRIPTION
### What does this PR do?

Adds `kube_job` tag, it takes the value of `job_name`.

### Motivation
Match what the tag key used by the tagger

### Additional Notes
fixes: https://github.com/DataDog/helm-charts/issues/327

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
