### PR TITLE
adding to schema required field tags

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/profile_schema.json
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/profile_schema.json
@@ -632,6 +632,81 @@
                                                 }
                                             },
                                             "additionalProperties": true
+                                        },
+                                        {
+                                            "$id": "#/properties/metrics/items/anyOf/1/properties/metric_tags/items/anyOf/0",
+                                            "type": "object",
+                                            "title": "The first anyOf schema",
+                                            "description": "An explanation about the purpose of this instance.",
+                                            "default": {},
+                                            "examples": [
+                                                {
+                                                    "column": {
+                                                        "OID": "1.3.6.1.2.1.31.1.1.1.18",
+                                                        "name": "ifAlias"
+                                                    },
+                                                    "match": ".*\b(cid|CID)\b.*",
+                                                    "table": "ifXTable",
+                                                    "tags": {"interface_type": "cid"}
+                                                    
+                                                }
+                                            ],
+                                            "required": [
+                                                "tags"
+                                            ],
+                                            "properties": {
+                                                "tag": {
+                                                    "$id": "#/properties/metrics/items/anyOf/2/properties/metric_tags/items/anyOf/0/properties/tag",
+                                                    "type": "string",
+                                                    "title": "Tag",
+                                                    "description": "Tag to be applied to the metrics in the table",
+                                                    "default": "",
+                                                    "examples": [
+                                                        "server"
+                                                    ]
+                                                },
+                                                "column": {
+                                                    "$id": "#/properties/metrics/items/anyOf/2/properties/metric_tags/items/anyOf/0/properties/column",
+                                                    "type": "object",
+                                                    "title": "Column",
+                                                    "description": "Column to collect metrics from",
+                                                    "default": {},
+                                                    "examples": [
+                                                        {
+                                                            "OID": "1.3.6.1.4.1.3375.2.2.10.1.2.1.1",
+                                                            "name": "ltmVirtualServName"
+                                                        }
+                                                    ],
+                                                    "required": [
+                                                        "OID",
+                                                        "name"
+                                                    ],
+                                                    "properties": {
+                                                        "OID": {
+                                                            "$id": "#/properties/metrics/items/anyOf/2/properties/metric_tags/items/anyOf/0/properties/column/properties/OID",
+                                                            "type": "string",
+                                                            "title": "OID",
+                                                            "description": "OID to collect metrics from",
+                                                            "default": "",
+                                                            "examples": [
+                                                                "1.3.6.1.4.1.3375.2.2.10.1.2.1.1"
+                                                            ]
+                                                        },
+                                                        "name": {
+                                                            "$id": "#/properties/metrics/items/anyOf/2/properties/metric_tags/items/anyOf/0/properties/column/properties/name",
+                                                            "type": "string",
+                                                            "title": "Name",
+                                                            "description": "Human-readable name",
+                                                            "default": "",
+                                                            "examples": [
+                                                                "ltmVirtualServName"
+                                                            ]
+                                                        }
+                                                    },
+                                                    "additionalProperties": true
+                                                }
+                                            },
+                                            "additionalProperties": true
                                         }
                                     ]
                                 }


### PR DESCRIPTION
### What does this PR do?
It adds a schema that allows profiles to have a `tags` field in metric_tags instead of only `tag`

### Motivation
Some metric_tags options uses `tags` instead of `tag, for exemple `match`:

- column:
    OID: 1.3.6.1.2.1.31.1.1.1.18
    name: ifAlias
  match: .*\b(cid|CID)\b.*
  table: ifXTable
  tags:
         interface_type: cid

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
