### PR TITLE
Fix database checks' failure caused by a hostname that is too long

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -18,6 +18,7 @@ class DatadogAgentStub(object):
         self._metadata = {}
         self._cache = {}
         self._config = self.get_default_config()
+        self._hostname = 'stubbed.hostname'
 
     def get_default_config(self):
         return {'enable_metadata_collection': True}
@@ -39,7 +40,13 @@ class DatadogAgentStub(object):
         assert len(self._metadata) == count
 
     def get_hostname(self):
-        return 'stubbed.hostname'
+        return self._hostname
+
+    def set_hostname(self, hostname):
+        self._hostname = hostname
+
+    def reset_hostname(self):
+        self._hostname = 'stubbed.hostname'
 
     def get_config(self, config_option):
         return self._config.get(config_option, '')

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -125,7 +125,7 @@ def resolve_db_host(db_host):
 
     try:
         host_ip = socket.gethostbyname(db_host)
-    except socket.gaierror as e:
+    except (socket.gaierror, UnicodeError) as e:
         # could be connecting via a unix domain socket
         logger.debug(
             "failed to resolve DB host '%s' due to %r. falling back to agent hostname: %s",
@@ -139,7 +139,7 @@ def resolve_db_host(db_host):
         agent_host_ip = socket.gethostbyname(agent_hostname)
         if agent_host_ip == host_ip:
             return agent_hostname
-    except socket.gaierror as e:
+    except (socket.gaierror, UnicodeError) as e:
         logger.debug(
             "failed to resolve agent host '%s' due to socket.gaierror(%s). using DB host: %s",
             agent_hostname,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

If a hostname is greater than or equal to 64 characters, `socket.gethostbyname()` raises UnicodeError and fails to initialize the mysql check. 
Therefore, in `datadog_checks.base.utils.db.utils resolve_db_host` has been changed to handle UnicodeError as an exception.

### Motivation
<!-- What inspired you to submit this pull request? -->

To fixes #9776

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
