### PR TITLE
Better handle vertica errors

### DIFF
--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -114,7 +114,8 @@ class VerticaCheck(AgentCheck):
 
             self.query_version()
             self.query_custom()
-
+        except vertica.errors.Error as e:
+            self.log.error("There was an error retrieving metrics: %s" % str(e))
         finally:
             self._view.clear()
 


### PR DESCRIPTION
Capture exception to avoid these stacktraces:

```
vertica (2.0.0)
    ---------------
      Instance ID: vertica:cdef0d19c394ac2a [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/vertica.d/conf.yaml
      Total Runs: 6
      Metric Samples: Last Run: 1, Total: 6
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 1
      Average Execution Time : 10.298s
      Last Execution Date : 2021-03-15 10:57:56.000000 PDT
      Last Successful Execution Date : Never
      Error: timed out
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/vertica_python/vertica/connection.py", line 592, in read_message
          type_ = self.read_bytes(1)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/vertica_python/vertica/connection.py", line 634, in read_bytes
          bytes_ = self._socket().recv(n - len(results))
      socket.timeout: timed out
      The above exception was the direct cause of the following exception:
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 901, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/vertica/vertica.py", line 110, in check
          method()
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/vertica/vertica.py", line 156, in query_system
          for system in self.iter_rows(views.System):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/vertica/vertica.py", line 591, in iter_rows
          cursor.execute(view.query)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/vertica_python/vertica/cursor.py", line 203, in execute
          self._execute_simple_query(operation)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/vertica_python/vertica/cursor.py", line 532, in _execute_simple_query
          self._message = self.connection.read_message()
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/vertica_python/vertica/connection.py", line 606, in read_message
          raise_from(errors.ConnectionError(str(e)), e)
        File "<string>", line 3, in raise_from
      vertica_python.errors.ConnectionError: timed out
```