### PR TITLE
Collect WAL file age metric

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -193,6 +193,13 @@ files:
       value:
         type: boolean
         example: false
+    - name: data_directory
+      description: |
+        The data directory of your postgres installation
+        Required when collecting WAL metrics.
+      value:
+        type: string
+        example: /var/lib/postgresql/data
     - name: tag_replication_role
       description: Tag metrics and checks with `replication_role:<master|standby>`.
       value:

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -199,7 +199,7 @@ files:
         Required when collecting WAL metrics.
       value:
         type: string
-        example: /var/lib/postgresql/data
+        example: /usr/local/pgsql/data
     - name: tag_replication_role
       description: Tag metrics and checks with `replication_role:<master|standby>`.
       value:

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -186,6 +186,13 @@ files:
       value:
         type: boolean
         example: false
+    - name: collect_wal_metrics
+      description: |
+        Collect metrics about WAL file age.
+        NOTE: You must be running the check local to your database if you want to enable this option.
+      value:
+        type: boolean
+        example: false
     - name: tag_replication_role
       description: Tag metrics and checks with `replication_role:<master|standby>`.
       value:

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -60,6 +60,7 @@ class PostgresConfig:
         self.collect_count_metrics = is_affirmative(instance.get('collect_count_metrics', True))
         self.collect_activity_metrics = is_affirmative(instance.get('collect_activity_metrics', False))
         self.collect_database_size_metrics = is_affirmative(instance.get('collect_database_size_metrics', True))
+        self.collect_wal_metrics = is_affirmative(instance.get('collect_wal_metrics', False))
         self.ignore_databases = instance.get('ignore_databases', DEFAULT_IGNORE_DATABASES)
         if is_affirmative(instance.get('collect_default_database', False)):
             self.ignore_databases = [d for d in self.ignore_databases if d != 'postgres']

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -61,6 +61,7 @@ class PostgresConfig:
         self.collect_activity_metrics = is_affirmative(instance.get('collect_activity_metrics', False))
         self.collect_database_size_metrics = is_affirmative(instance.get('collect_database_size_metrics', True))
         self.collect_wal_metrics = is_affirmative(instance.get('collect_wal_metrics', False))
+        self.data_directory = instance.get('data_directory', None)
         self.ignore_databases = instance.get('ignore_databases', DEFAULT_IGNORE_DATABASES)
         if is_affirmative(instance.get('collect_default_database', False)):
             self.ignore_databases = [d for d in self.ignore_databases if d != 'postgres']

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -32,6 +32,10 @@ def instance_collect_function_metrics(field, value):
     return False
 
 
+def instance_collect_wal_metrics(field, value):
+    return False
+
+
 def instance_custom_queries(field, value):
     return get_default_field_value(field, value)
 

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -40,6 +40,10 @@ def instance_custom_queries(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_data_directory(field, value):
+    return '/var/lib/postgresql/data'
+
+
 def instance_dbm(field, value):
     return False
 

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -41,7 +41,7 @@ def instance_custom_queries(field, value):
 
 
 def instance_data_directory(field, value):
-    return '/var/lib/postgresql/data'
+    return '/usr/local/pgsql/data'
 
 
 def instance_dbm(field, value):

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -62,6 +62,7 @@ class InstanceConfig(BaseModel):
     collect_database_size_metrics: Optional[bool]
     collect_default_database: Optional[bool]
     collect_function_metrics: Optional[bool]
+    collect_wal_metrics: Optional[bool]
     custom_queries: Optional[Sequence[Mapping[str, Any]]]
     dbm: Optional[bool]
     dbname: Optional[str]

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -64,6 +64,7 @@ class InstanceConfig(BaseModel):
     collect_function_metrics: Optional[bool]
     collect_wal_metrics: Optional[bool]
     custom_queries: Optional[Sequence[Mapping[str, Any]]]
+    data_directory: Optional[str]
     dbm: Optional[bool]
     dbname: Optional[str]
     dbstrict: Optional[bool]

--- a/postgres/datadog_checks/postgres/config_models/validators.py
+++ b/postgres/datadog_checks/postgres/config_models/validators.py
@@ -1,3 +1,11 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+def initialize_instance(values, **kwargs):
+    if values.get('collect_wal_metrics'):
+        if 'data_directory' not in values:
+            raise ValueError('Field `data_directory` is required when `collect_wal_metrics` is enabled')
+
+    return values

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -153,6 +153,12 @@ instances:
     #
     # collect_default_database: false
 
+    ## @param collect_wal_metrics - boolean - optional - default: false
+    ## Collect metrics about WAL file age.
+    ## NOTE: You must be running the check local to your database if you want to enable this option.
+    #
+    # collect_wal_metrics: false
+
     ## @param tag_replication_role - boolean - optional - default: false
     ## Tag metrics and checks with `replication_role:<master|standby>`.
     #

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -159,6 +159,12 @@ instances:
     #
     # collect_wal_metrics: false
 
+    ## @param data_directory - string - optional - default: /var/lib/postgresql/data
+    ## The data directory of your postgres installation
+    ## Required when collecting WAL metrics.
+    #
+    # data_directory: /var/lib/postgresql/data
+
     ## @param tag_replication_role - boolean - optional - default: false
     ## Tag metrics and checks with `replication_role:<master|standby>`.
     #

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -159,11 +159,11 @@ instances:
     #
     # collect_wal_metrics: false
 
-    ## @param data_directory - string - optional - default: /var/lib/postgresql/data
+    ## @param data_directory - string - optional - default: /usr/local/pgsql/data
     ## The data directory of your postgres installation
     ## Required when collecting WAL metrics.
     #
-    # data_directory: /var/lib/postgresql/data
+    # data_directory: /usr/local/pgsql/data
 
     ## @param tag_replication_role - boolean - optional - default: false
     ## Tag metrics and checks with `replication_role:<master|standby>`.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -80,7 +80,7 @@ class PostgreSql(AgentCheck):
         if wal_file_age is not None:
             self.gauge("postgresql.wal_age", wal_file_age, tags=[t for t in instance_tags if not t.startswith("db:")])
 
-    def _get_wal_file_age(self):
+    def _get_wal_dir(self):
         if self.version >= V10:
             wal_dir = "pg_wal"
         else:
@@ -88,12 +88,18 @@ class PostgreSql(AgentCheck):
 
         wal_log_dir = os.path.join("/var/lib/pgsql", str(self.version), "data", wal_dir)
 
+        return wal_log_dir
+
+    def _get_wal_file_age(self):
+        wal_log_dir = self._get_wal_dir(self)
         if not os.path.isdir(wal_log_dir):
             self.log.warning(
-                "Cannot access WAL log directory: %s. Ensure that you are running the agent on your local postgres database.",
+                "Cannot access WAL log directory: %s. Ensure that you are "
+                "running the agent on your local postgres database.",
                 wal_log_dir,
             )
             return None
+
         all_files = os.listdir(wal_log_dir)
 
         # files extentions that are not valid WAL files

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -86,12 +86,12 @@ class PostgreSql(AgentCheck):
         else:
             wal_dir = "pg_xlog"
 
-        wal_log_dir = os.path.join("/var/lib/pgsql", str(self.version), "data", wal_dir)
+        wal_log_dir = os.path.join(self._config.data_directory, wal_dir)
 
         return wal_log_dir
 
     def _get_wal_file_age(self):
-        wal_log_dir = self._get_wal_dir(self)
+        wal_log_dir = self._get_wal_dir()
         if not os.path.isdir(wal_log_dir):
             self.log.warning(
                 "Cannot access WAL log directory: %s. Ensure that you are "

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -86,11 +86,11 @@ class PostgreSql(AgentCheck):
         else:
             wal_dir = "pg_xlog"
 
-        wal_log_dir = os.path.join("/var/lib/pgsql/", str(self.version), "/data/", wal_dir)
+        wal_log_dir = os.path.join("/var/lib/pgsql", str(self.version), "data", wal_dir)
 
         if not os.path.isdir(wal_log_dir):
             self.log.warning(
-                "Cannot access WAL log directory %s; ensure you are running the agent on your local postgres database",
+                "Cannot access WAL log directory: %s. Ensure that you are running the agent on your local postgres database.",
                 wal_log_dir,
             )
             return None
@@ -104,7 +104,7 @@ class PostgreSql(AgentCheck):
             if all([ext for ext in exluded_file_exts if not file_name.endswith(ext)])
         ]
         if len(all_wal_files) < 1:
-            self.log.warning("No WAL files found in directory %s", wal_log_dir)
+            self.log.warning("No WAL files found in directory: %s.", wal_log_dir)
             return None
         oldest_file = min(all_wal_files, key=os.path.getctime)
         oldest_file_age = os.path.getctime(oldest_file)

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -74,4 +74,4 @@ postgresql.queries.local_blks_dirtied,count,,block,,Total number of local blocks
 postgresql.queries.local_blks_written,count,,block,,Total number of local blocks written by queries per statement. This metric is only available as part of the Deep Database Monitoring ALPHA.,0,postgres,postgres queries local blocks written
 postgresql.queries.temp_blks_read,count,,block,,Total number of temp blocks read by queries per statement. This metric is only available as part of the Deep Database Monitoring ALPHA.,0,postgres,postgres queries temp blocks read
 postgresql.queries.temp_blks_written,count,,block,,Total number of temp blocks written by queries per statement. This metric is only available as part of the Deep Database Monitoring ALPHA.,0,postgres,postgres queries temp blocks written
-postgresql.wal_age,count,gauge,,seconds,,The age in seconds of the oldest WAL file.,0,postgres,wal age
+postgresql.wal_age,gauge,,second,,The age in seconds of the oldest WAL file.,0,postgres,wal age

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -74,4 +74,4 @@ postgresql.queries.local_blks_dirtied,count,,block,,Total number of local blocks
 postgresql.queries.local_blks_written,count,,block,,Total number of local blocks written by queries per statement. This metric is only available as part of the Deep Database Monitoring ALPHA.,0,postgres,postgres queries local blocks written
 postgresql.queries.temp_blks_read,count,,block,,Total number of temp blocks read by queries per statement. This metric is only available as part of the Deep Database Monitoring ALPHA.,0,postgres,postgres queries temp blocks read
 postgresql.queries.temp_blks_written,count,,block,,Total number of temp blocks written by queries per statement. This metric is only available as part of the Deep Database Monitoring ALPHA.,0,postgres,postgres queries temp blocks written
-postgresql.wal_age,gauge,,second,,The age in seconds of the oldest WAL file.,0,postgres,wal age
+postgresql.wal_age,gauge,,second,,The age in seconds of the oldest WAL file,0,postgres,wal age

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -74,3 +74,4 @@ postgresql.queries.local_blks_dirtied,count,,block,,Total number of local blocks
 postgresql.queries.local_blks_written,count,,block,,Total number of local blocks written by queries per statement. This metric is only available as part of the Deep Database Monitoring ALPHA.,0,postgres,postgres queries local blocks written
 postgresql.queries.temp_blks_read,count,,block,,Total number of temp blocks read by queries per statement. This metric is only available as part of the Deep Database Monitoring ALPHA.,0,postgres,postgres queries temp blocks read
 postgresql.queries.temp_blks_written,count,,block,,Total number of temp blocks written by queries per statement. This metric is only available as part of the Deep Database Monitoring ALPHA.,0,postgres,postgres queries temp blocks written
+postgresql.wal_age,count,gauge,,seconds,,The age in seconds of the oldest WAL file.,0,postgres,wal age

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -218,12 +218,14 @@ def test_version_metadata(check, test_case, params):
 @pytest.mark.parametrize(
     'pg_version, wal_path',
     [
-        ('9.6.2', '/var/lib/pgsql/9.6.2/data/pg_xlog'),
-        ('10.0.0', '/var/lib/pgsql/10.0.0/data/pg_wal'),
+        ('9.6.2', '/var/lib/postgresql/data/pg_xlog'),
+        ('10.0.0', '/var/lib/postgresql/data/pg_wal'),
     ],
 )
-def test_get_wal_dir(check, pg_version, wal_path):
-    check.check_id = 'test:123'
+def test_get_wal_dir(integration_check, pg_instance, pg_version, wal_path):
+    pg_instance['data_directory'] = "/var/lib/postgresql/data/"
+    check = integration_check(pg_instance)
+
     version_utils = VersionUtils.parse_version(pg_version)
     with mock.patch('datadog_checks.postgres.PostgreSql.version', new_callable=PropertyMock) as mock_version:
         mock_version.return_value = version_utils


### PR DESCRIPTION
### What does this PR do?
Adds a metric that reports the WAL file age in seconds

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
You can test in the E2E env by adding the following block to dd environment:
```
E2E_METADATA = {
    'docker_volumes': ['{}/test_data_dir:/test_data_dir/data'.format(os.path.join(HERE, 'compose'))],
}

...
with docker_run(os.path.join(HERE, 'compose', 'docker-compose.yaml'), conditions=[WaitFor(connect_to_pg)]):
        yield e2e_instance, E2E_METADATA
```
and adding a corresponding volume in docker-compose.yaml:
`- ./test_data_dir:/var/lib/postgresql/data/
`
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
