### PR TITLE
Fix merge issue with assert_apc_ups_metrics

### DIFF
--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -17,7 +17,7 @@ def test_e2e_v1_with_apc_ups_profile(dd_agent_check):
             'community_string': 'apc_ups',
         }
     )
-    assert_apc_ups_metrics(config, dd_agent_check, instance)
+    assert_apc_ups_metrics(config, dd_agent_check)
 
 
 def test_e2e_core_v3_no_auth_no_priv(dd_agent_check):
@@ -31,7 +31,7 @@ def test_e2e_core_v3_no_auth_no_priv(dd_agent_check):
             'community_string': '',
         }
     )
-    assert_apc_ups_metrics(config, dd_agent_check, instance)
+    assert_apc_ups_metrics(config, dd_agent_check)
 
 
 def test_e2e_core_v3_with_auth_no_priv(dd_agent_check):
@@ -47,12 +47,7 @@ def test_e2e_core_v3_with_auth_no_priv(dd_agent_check):
             'community_string': '',
         }
     )
-    assert_apc_ups_metrics(config, dd_agent_check, instance)
-
-
-def assert_apc_ups_metrics(config, dd_agent_check, instance):
-    config['init_config']['loader'] = 'core'
-    assert_apc_ups_metrics(dd_agent_check, config)
+    assert_apc_ups_metrics(config, dd_agent_check)
 
 
 def test_e2e_v1_with_apc_ups_profile_batch_size_1(dd_agent_check):
@@ -70,6 +65,7 @@ def test_e2e_v1_with_apc_ups_profile_batch_size_1(dd_agent_check):
 
 
 def assert_apc_ups_metrics(dd_agent_check, config):
+    config['init_config']['loader'] = 'core'
     instance = config['instances'][0]
     aggregator = dd_agent_check(config, rate=True)
 

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -60,7 +60,6 @@ def test_e2e_v1_with_apc_ups_profile_batch_size_1(dd_agent_check):
             'oid_batch_size': 1,
         }
     )
-    config['init_config']['loader'] = 'core'
     assert_apc_ups_metrics(dd_agent_check, config)
 
 

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -17,7 +17,7 @@ def test_e2e_v1_with_apc_ups_profile(dd_agent_check):
             'community_string': 'apc_ups',
         }
     )
-    assert_apc_ups_metrics(config, dd_agent_check)
+    assert_apc_ups_metrics(dd_agent_check, config)
 
 
 def test_e2e_core_v3_no_auth_no_priv(dd_agent_check):
@@ -31,7 +31,7 @@ def test_e2e_core_v3_no_auth_no_priv(dd_agent_check):
             'community_string': '',
         }
     )
-    assert_apc_ups_metrics(config, dd_agent_check)
+    assert_apc_ups_metrics(dd_agent_check, config)
 
 
 def test_e2e_core_v3_with_auth_no_priv(dd_agent_check):
@@ -47,7 +47,7 @@ def test_e2e_core_v3_with_auth_no_priv(dd_agent_check):
             'community_string': '',
         }
     )
-    assert_apc_ups_metrics(config, dd_agent_check)
+    assert_apc_ups_metrics(dd_agent_check, config)
 
 
 def test_e2e_v1_with_apc_ups_profile_batch_size_1(dd_agent_check):


### PR DESCRIPTION
### What this PR does ?

Fix lint issue with assert_apc_ups_metrics

### Why it led to a broken master branch ?

The issue has been cause by the merge of those two PR at same moment:
- https://github.com/DataDog/integrations-core/pull/9765
- https://github.com/DataDog/integrations-core/pull/9687

Leading to a merged state with lint error and duplicate code. This PR is fixing that.