### PR TITLE
Allow extra 3rd party licenses 

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -172,6 +172,8 @@ async def scrape_license_data(urls):
 
 def validate_extra_licenses():
     """
+    Validates extra third party licenses.
+    
     An integration may use code from an outside source or origin that is not pypi-
     it will have a file in its check directory titled `LICENSE-3rdparty-extra.csv`
     """

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -171,7 +171,10 @@ async def scrape_license_data(urls):
 
 
 def validate_extra_licenses():
-    """ An integration may use code from an outside source or from a non-PYPI so it """
+    """
+    An integration may use code from an outside source or origin that is not pypi-
+    it will have a file in its check directory titled `LICENSE-3rdparty-extra.csv`
+    """
     checks = process_checks_option(None, source='valid_checks')
     lines = []
     any_errors = False

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -197,14 +197,13 @@ def validate_extra_licenses():
                 if all_keys != ALL_HEADERS:
                     invalid_headers = all_keys.difference(ALL_HEADERS)
                     if invalid_headers:
-                        errors = True
                         echo_failure(f'{check}:{line_no} Invalid column {invalid_headers}')
 
                     missing_headers = ALL_HEADERS.difference(all_keys)
                     if missing_headers:
-                        errors = True
                         echo_failure(f'{check}:{line_no} Missing columns {missing_headers}')
 
+                    errors = True
                     any_errors = True
                     continue
                 license_type = row['License']

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -60,7 +60,6 @@ KNOWN_LICENSES = {
     'bsd license': 'BSD-3-Clause',
     '3-clause bsd license': 'BSD-3-Clause',
     'new bsd license': 'BSD-3-Clause',
-    'simplified bsd license': 'BSD-2-Clause',
     'mit license': 'MIT',
     'psf': 'PSF',
     'psf license': 'PSF',
@@ -104,6 +103,15 @@ CLASSIFIER_TO_HIGHEST_SPDX = {
     'W3C License': 'W3C',
     'Zope Public License': 'ZPL-2.1',
 }
+
+EXTRA_LICENSES = {'BSD-2-Clause'}
+
+VALID_LICENSES = (
+    EXTRA_LICENSES
+    | set(KNOWN_LICENSES.values())
+    | set(CLASSIFIER_TO_HIGHEST_SPDX.values())
+    | set(KNOWN_CLASSIFIERS.values())
+)
 
 HEADERS = ['Component', 'Origin', 'License', 'Copyright']
 
@@ -197,7 +205,7 @@ def validate_extra_licenses():
                     any_errors = True
                     continue
                 license_type = row['License']
-                if license_type not in KNOWN_LICENSES.values():
+                if license_type not in VALID_LICENSES:
                     errors = True
                     any_errors = True
                     echo_failure(f'{check}:{line_no} Invalid license type {license_type}')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -173,7 +173,7 @@ async def scrape_license_data(urls):
 def validate_extra_licenses():
     """
     Validates extra third party licenses.
-    
+
     An integration may use code from an outside source or origin that is not pypi-
     it will have a file in its check directory titled `LICENSE-3rdparty-extra.csv`
     """

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -218,6 +218,11 @@ def get_tox_file(check_name):
     return os.path.join(get_root(), check_name, 'tox.ini')
 
 
+def get_extra_license_file(check_name):
+    path = os.path.join(get_root(), check_name, 'LICENSE-3rdparty-extra.csv')
+    return path, file_exists(path)
+
+
 def get_metadata_file(check_name):
     path = load_manifest(check_name).get('assets', {}).get("metrics_metadata", "metadata.csv")
     return os.path.join(get_root(), check_name, path)
@@ -401,6 +406,24 @@ def read_metadata_rows(metadata_file):
 
         for line_no, row in enumerate(reader, 2):
             yield line_no, row
+
+
+def read_license_file_rows(license_file):
+    """
+    Iterate over the rows of a `LICENSE-3rdparty-extra.csv` or `LICENSE-3rdparty.csv` file.
+    """
+    with io.open(license_file, 'r', encoding='utf-8') as f:
+        lines = f.readlines()
+        f.seek(0)
+        reader = csv.DictReader(f, delimiter=',')
+
+        # Read header
+        reader._fieldnames = reader.fieldnames
+
+        for line_no, row in enumerate(reader, 2):
+            # return the original line because it will be needed to append to the original file
+            line = lines[line_no - 1]
+            yield line_no, row, line
 
 
 def read_readme_file(check_name):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -218,9 +218,13 @@ def get_tox_file(check_name):
     return os.path.join(get_root(), check_name, 'tox.ini')
 
 
-def get_extra_license_file(check_name):
-    path = os.path.join(get_root(), check_name, 'LICENSE-3rdparty-extra.csv')
-    return path, file_exists(path)
+def get_extra_license_files():
+    for path in os.listdir(get_root()):
+        if not file_exists(get_manifest_file(path)):
+            continue
+        extra_license_file = os.path.join(get_root(), path, 'LICENSE-3rdparty-extra.csv')
+        if file_exists(extra_license_file):
+            yield extra_license_file
 
 
 def get_metadata_file(check_name):

--- a/postgres/LICENSE-3rdparty-extra.csv
+++ b/postgres/LICENSE-3rdparty-extra.csv
@@ -1,2 +1,2 @@
 Component,Origin,License,Copyright
-test,test,BSD-2-Clause,test
+test,BSD-2-Clause,test

--- a/postgres/LICENSE-3rdparty-extra.csv
+++ b/postgres/LICENSE-3rdparty-extra.csv
@@ -1,0 +1,2 @@
+Component,Origin,License,Copyright
+test,test,BSD-2-Clause,test

--- a/postgres/LICENSE-3rdparty-extra.csv
+++ b/postgres/LICENSE-3rdparty-extra.csv
@@ -1,2 +1,0 @@
-Component,Origin,License,Copyright
-test,BSD-2-Clause,test


### PR DESCRIPTION
### What does this PR do?
Updates the `validate license` command to add the ability for integrations to have 3rd party licenses which are not pulled directly from the requirements file and the origin is not PyPI.

### Motivation
https://github.com/DataDog/integrations-core/pull/9786

### Additional Notes
To test, add a `LICENSE-3rdparty-extra.csv` to the directory of any check. See https://github.com/DataDog/integrations-core/pull/9786 for an example.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
