### PR TITLE
Log message for invalid queries

### DIFF
--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -73,7 +73,7 @@ class IbmDb2Check(AgentCheck):
             try:
                 query_method()
             except Exception as e:
-                self.log.error('Unexpected error running `%s`: %s', query_method.__name__, str(e))
+                self.log.warning('Encountered error running `%s`: %s', query_method.__name__, str(e))
                 continue
 
     def collect_metadata(self):

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -5,9 +5,9 @@ from __future__ import division
 
 from itertools import chain
 from time import time as timestamp
-from requests import ConnectionError
 
 import ibm_db
+from requests import ConnectionError
 
 from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.containers import iter_unique

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -72,7 +72,7 @@ class IbmDb2Check(AgentCheck):
         ):
             try:
                 query_method()
-            except ConnectionError as e:
+            except ConnectionError:
                 raise
             except Exception as e:
                 self.log.warning('Encountered error running `%s`: %s', query_method.__name__, str(e))

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -5,6 +5,7 @@ from __future__ import division
 
 from itertools import chain
 from time import time as timestamp
+from requests import ConnectionError
 
 import ibm_db
 

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -60,13 +60,21 @@ class IbmDb2Check(AgentCheck):
 
             self._conn = connection
 
-        self.query_instance()
-        self.query_database()
-        self.query_buffer_pool()
-        self.query_table_space()
-        self.query_transaction_log()
-        self.query_custom()
         self.collect_metadata()
+
+        for query_method in (
+            self.query_instance,
+            self.query_database,
+            self.query_buffer_pool,
+            self.query_table_space,
+            self.query_transaction_log,
+            self.query_custom,
+        ):
+            try:
+                query_method()
+            except Exception as e:
+                self.log.error('Unexpected error running `%s`: %s', query_method.__name__, str(e))
+                continue
 
     def collect_metadata(self):
         try:

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -72,6 +72,8 @@ class IbmDb2Check(AgentCheck):
         ):
             try:
                 query_method()
+            except ConnectionError as e:
+                raise
             except Exception as e:
                 self.log.warning('Encountered error running `%s`: %s', query_method.__name__, str(e))
                 continue

--- a/ibm_db2/tests/test_unit.py
+++ b/ibm_db2/tests/test_unit.py
@@ -36,11 +36,11 @@ def test_retry_connection(aggregator, instance):
     exception_msg = "[IBM][CLI Driver] CLI0106E  Connection is closed. SQLSTATE=08003"
 
     def mock_exception(*args, **kwargs):
-        raise Exception(exception_msg)
+        raise ConnectionError(exception_msg)
 
     with mock.patch('ibm_db.exec_immediate', side_effect=mock_exception):
 
-        with pytest.raises(Exception, match='CLI0106E  Connection is closed. SQLSTATE=08003'):
+        with pytest.raises(ConnectionError, match='CLI0106E  Connection is closed. SQLSTATE=08003'):
             ibmdb2.check(instance)
         # new connection made
         assert ibmdb2._conn != conn1

--- a/ibm_db2/tests/test_unit.py
+++ b/ibm_db2/tests/test_unit.py
@@ -4,6 +4,8 @@
 import mock
 import pytest
 
+from requests import ConnectionError
+
 from datadog_checks.ibm_db2 import IbmDb2Check
 from datadog_checks.ibm_db2.utils import scrub_connection_string
 

--- a/ibm_db2/tests/test_unit.py
+++ b/ibm_db2/tests/test_unit.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import mock
 import pytest
-
 from requests import ConnectionError
 
 from datadog_checks.ibm_db2 import IbmDb2Check

--- a/ibm_db2/tests/test_unit.py
+++ b/ibm_db2/tests/test_unit.py
@@ -47,8 +47,10 @@ def test_retry_connection(aggregator, instance):
 
 
 def test_query_function_error(aggregator, instance):
-    exception_msg = '[IBM][CLI Driver][DB2/NT64] SQL0440N  No authorized routine named "MON_GET_INSTANCE" of type ' \
-                    '"FUNCTION" having compatible arguments was found.  SQLSTATE=42884'
+    exception_msg = (
+        '[IBM][CLI Driver][DB2/NT64] SQL0440N  No authorized routine named "MON_GET_INSTANCE" of type '
+        '"FUNCTION" having compatible arguments was found.  SQLSTATE=42884'
+    )
 
     def query_instance(*args, **kwargs):
         raise Exception(exception_msg)


### PR DESCRIPTION
### What does this PR do?
Certain queries are not available on IBM Db2 versions <11.1. This PR makes sure to log a warning message but continue running other queries. This behavior is similar to the DB manager.
### Motivation
Customer request
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
