### PR TITLE
Check if rest_api_options is empty

### DIFF
--- a/vsphere/datadog_checks/vsphere/config.py
+++ b/vsphere/datadog_checks/vsphere/config.py
@@ -48,7 +48,8 @@ class VSphereConfig(object):
             'tls_verify': self.ssl_verify,
             'tls_ignore_warning': self.tls_ignore_warning,
         }
-        self.rest_api_options.update(instance.get('rest_api_options', {}))
+        if isinstance(instance.get('rest_api_options'), dict):
+            self.rest_api_options.update(instance['rest_api_options'])
         self.shared_rest_api_options = init_config.get('rest_api_options', {})  # type: Dict[str, Any]
 
         # vSphere options

--- a/vsphere/tests/conftest.py
+++ b/vsphere/tests/conftest.py
@@ -30,6 +30,7 @@ def realtime_instance():
         'username': os.environ.get('VSPHERE_USERNAME', 'FAKE'),
         'password': os.environ.get('VSPHERE_PASSWORD', 'FAKE'),
         'ssl_verify': False,
+        'rest_api_options': None,
     }
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
By default, `rest_api_options` is uncommented with no option in the configuration example file, so it's parsed as `rest_api_options: None`, and fails when updating the default dict.

### Motivation
<!-- What inspired you to submit this pull request? -->
Support

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
