### PR TITLE
[OpenMetricsV2] Improve label sharing behavior

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/labels.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/labels.py
@@ -13,6 +13,9 @@ class LabelAggregator:
             self.populate = no_op
             return
 
+        self.cache_shared_labels = config.get('cache_shared_labels', True)
+        self.shared_labels_cached = False
+
         self.metric_config = {}
         for metric, config in share_labels.items():
             data = self.metric_config[metric] = {}
@@ -70,16 +73,40 @@ class LabelAggregator:
         self.unconditional_labels = {}
 
     def __call__(self, metrics):
-        # TODO: add new option to cache metrics until all configured ones are
-        # seen to avoid dependence on the order in which they are exposed
-        with self:
-            metric_config = self.metric_config.copy()
+        if self.cache_shared_labels:
+            if self.shared_labels_cached:
+                yield from metrics
+            else:
+                metric_config = self.metric_config.copy()
 
-            for metric in metrics:
-                if metric_config and metric.name in metric_config:
-                    self.collect(metric, metric_config.pop(metric.name))
+                for metric in metrics:
+                    if metric_config and metric.name in metric_config:
+                        self.collect(metric, metric_config.pop(metric.name))
 
-                yield metric
+                    yield metric
+
+                self.shared_labels_cached = True
+        else:
+            try:
+                metric_config = self.metric_config.copy()
+
+                # Cache every encountered metric until the desired labels have been collected
+                cached_metrics = []
+
+                for metric in metrics:
+                    if metric.name in metric_config:
+                        self.collect(metric, metric_config.pop(metric.name))
+
+                    cached_metrics.append(metric)
+
+                    if not metric_config:
+                        break
+
+                yield from cached_metrics
+                yield from metrics
+            finally:
+                self.label_sets.clear()
+                self.unconditional_labels.clear()
 
     def collect(self, metric, config):
         allowed_values = config.get('values')
@@ -146,13 +173,6 @@ class LabelAggregator:
     @property
     def configured(self):
         return self.populate is not no_op
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.label_sets.clear()
-        self.unconditional_labels.clear()
 
 
 def canonicalize_numeric_label(label):

--- a/datadog_checks_base/tests/openmetrics/test_options.py
+++ b/datadog_checks_base/tests/openmetrics/test_options.py
@@ -551,6 +551,96 @@ class TestShareLabels:
 
         aggregator.assert_all_metrics_covered()
 
+    def test_shared_labels_with_cache(self, aggregator, dd_run_check, mock_http_response):
+        mock_http_response(
+            """
+            # HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+            # TYPE go_memstats_gc_sys_bytes gauge
+            go_memstats_gc_sys_bytes{bar="foo"} 901120
+            # HELP go_memstats_free_bytes Number of bytes free and available for use.
+            # TYPE go_memstats_free_bytes gauge
+            go_memstats_free_bytes{bar="baz"} 6.396288e+06
+            # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+            # TYPE go_memstats_alloc_bytes gauge
+            go_memstats_alloc_bytes{foo="bar"} 6.396288e+06
+            """
+        )
+        check = get_check({'metrics': ['.+'], 'share_labels': {'go_memstats_alloc_bytes': True}})
+        dd_run_check(check)
+
+        aggregator.assert_metric(
+            'test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['endpoint:test', 'foo:bar']
+        )
+        aggregator.assert_metric(
+            'test.go_memstats_gc_sys_bytes',
+            901120,
+            metric_type=aggregator.GAUGE,
+            tags=['endpoint:test', 'bar:foo'],
+        )
+        aggregator.assert_metric(
+            'test.go_memstats_free_bytes',
+            6396288,
+            metric_type=aggregator.GAUGE,
+            tags=['endpoint:test', 'bar:baz'],
+        )
+
+        dd_run_check(check)
+
+        aggregator.assert_metric(
+            'test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['endpoint:test', 'foo:bar']
+        )
+        aggregator.assert_metric(
+            'test.go_memstats_gc_sys_bytes',
+            901120,
+            metric_type=aggregator.GAUGE,
+            tags=['endpoint:test', 'bar:foo', 'foo:bar'],
+        )
+        aggregator.assert_metric(
+            'test.go_memstats_free_bytes',
+            6396288,
+            metric_type=aggregator.GAUGE,
+            tags=['endpoint:test', 'bar:baz', 'foo:bar'],
+        )
+
+        aggregator.assert_all_metrics_covered()
+
+    def test_shared_labels_without_cache(self, aggregator, dd_run_check, mock_http_response):
+        mock_http_response(
+            """
+            # HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+            # TYPE go_memstats_gc_sys_bytes gauge
+            go_memstats_gc_sys_bytes{bar="foo"} 901120
+            # HELP go_memstats_free_bytes Number of bytes free and available for use.
+            # TYPE go_memstats_free_bytes gauge
+            go_memstats_free_bytes{bar="baz"} 6.396288e+06
+            # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+            # TYPE go_memstats_alloc_bytes gauge
+            go_memstats_alloc_bytes{foo="bar"} 6.396288e+06
+            """
+        )
+        check = get_check(
+            {'metrics': ['.+'], 'share_labels': {'go_memstats_alloc_bytes': True}, 'cache_shared_labels': False}
+        )
+        dd_run_check(check)
+
+        aggregator.assert_metric(
+            'test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['endpoint:test', 'foo:bar']
+        )
+        aggregator.assert_metric(
+            'test.go_memstats_gc_sys_bytes',
+            901120,
+            metric_type=aggregator.GAUGE,
+            tags=['endpoint:test', 'bar:foo', 'foo:bar'],
+        )
+        aggregator.assert_metric(
+            'test.go_memstats_free_bytes',
+            6396288,
+            metric_type=aggregator.GAUGE,
+            tags=['endpoint:test', 'bar:baz', 'foo:bar'],
+        )
+
+        aggregator.assert_all_metrics_covered()
+
 
 class TestIgnoreTags:
     def test_simple_match(self, aggregator, dd_run_check, mock_http_response):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -272,7 +272,7 @@
             type: string
 - name: cache_shared_labels
   description: |
-    When `share_labels` is set, this instructs the check to cache labels collected from the first payload
+    When `share_labels` is set, it instructs the check to cache labels collected from the first payload
     for increased performance.
 
     Set this to `false` to compute label sharing for every payload at the risk of potentially increased memory usage.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -270,6 +270,15 @@
           type: array
           items:
             type: string
+- name: cache_shared_labels
+  description: |
+    When `share_labels` is set, this instructs the check to cache labels collected from the first payload
+    for increased performance.
+
+    Set this to `false` to compute label sharing for every payload at the risk of potentially increased memory usage.
+  value:
+    type: boolean
+    example: true
 - name: request_size
   description: |
     The number of kibibytes (KiB) to read from the `openmetrics_endpoint` at a time.

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -213,6 +213,14 @@ instances:
     #
     # share_labels: {}
 
+    ## @param cache_shared_labels - boolean - optional - default: true
+    ## When `share_labels` is set, this instructs the check to cache labels collected from the first payload
+    ## for increased performance.
+    ##
+    ## Set this to `false` to compute label sharing for every payload at the risk of potentially increased memory usage.
+    #
+    # cache_shared_labels: true
+
     ## @param request_size - number - optional - default: 16
     ## The number of kibibytes (KiB) to read from the `openmetrics_endpoint` at a time.
     #

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -214,7 +214,7 @@ instances:
     # share_labels: {}
 
     ## @param cache_shared_labels - boolean - optional - default: true
-    ## When `share_labels` is set, this instructs the check to cache labels collected from the first payload
+    ## When `share_labels` is set, it instructs the check to cache labels collected from the first payload
     ## for increased performance.
     ##
     ## Set this to `false` to compute label sharing for every payload at the risk of potentially increased memory usage.


### PR DESCRIPTION
### What does this PR do?

1. Change default behavior of `share_labels` to v1 `label_joins` i.e. cache previous payloads
2. Add option `cache_shared_labels` to prevent inconsistences at the risk of potentially increased memory usage

### Motivation

Potential inconsistences are preferred over dependence on the order in which metrics are exposed in a payload