### PR TITLE
[NDM] Validate SysObjectID Consistency

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_snmp_profiles.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_snmp_profiles.py
@@ -2,7 +2,12 @@ import click
 
 from ...console import CONTEXT_SETTINGS, echo_failure, echo_info, echo_success, echo_warning
 from . import validators
-from .validators.utils import exist_profile_in_path, get_all_profiles_directory, get_default_snmp_profiles_path, initialize_path
+from .validators.utils import (
+    exist_profile_in_path,
+    get_all_profiles_directory,
+    get_default_snmp_profiles_path,
+    initialize_path,
+)
 
 MESSAGE_METHODS = {'success': echo_success, 'warning': echo_warning, 'failure': echo_failure, 'info': echo_info}
 
@@ -67,4 +72,3 @@ def show_report(report):
 
     for display_func, message in report['messages']:
         display_func(message)
-

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_snmp_profiles.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_snmp_profiles.py
@@ -1,11 +1,8 @@
-import glob
-import os
-
 import click
 
 from ...console import CONTEXT_SETTINGS, echo_failure, echo_info, echo_success, echo_warning
 from . import validators
-from .validators.utils import exist_profile_in_path, get_default_snmp_profiles_path, initialize_path
+from .validators.utils import exist_profile_in_path, get_all_profiles_directory, get_default_snmp_profiles_path, initialize_path
 
 MESSAGE_METHODS = {'success': echo_success, 'warning': echo_warning, 'failure': echo_failure, 'info': echo_info}
 
@@ -71,6 +68,3 @@ def show_report(report):
     for display_func, message in report['messages']:
         display_func(message)
 
-
-def get_all_profiles_directory(directory):
-    return glob.glob(os.path.join(directory, "*.yaml"))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_snmp_profiles.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_snmp_profiles.py
@@ -20,7 +20,7 @@ def validate_profile(file, directory, verbose):
     path = initialize_path(directory)
 
     if file:
-        _validate_single_profile(file, path, verbose)
+        _validate_profile(file, path)
 
     else:
         if not directory:
@@ -29,15 +29,23 @@ def validate_profile(file, directory, verbose):
         all_profiles_directory = get_all_profiles_directory(directory)
         for profile in all_profiles_directory:
             echo_info("Start validation of profile {profile}:".format(profile=profile))
-            _validate_single_profile(profile, path, verbose)
+            _validate_profile(profile, path)
+
+    echo_info("Starting validation of group of profiles")
+
+    _validate_profile(file, path, group=True)
 
 
-def _validate_single_profile(file, path, verbose):
-    if not exist_profile_in_path(file, path):
+def _validate_profile(file, path, group=False):
+    if not exist_profile_in_path(file, path) and not group:
         echo_failure("Profile file not found, or could not be read: " + str(file))
         return
 
-    all_validators = validators.get_all_validators()
+    all_validators = validators.get_all_single_validators()
+    if group:
+        all_validators = validators.get_all_group_validators()
+        if not file:
+            file = ''
 
     report = validate_profile_from_validators(all_validators, file, path)
 
@@ -68,7 +76,7 @@ def show_report(report):
     if report['failed']:
         echo_failure("FAILED")
     else:
-        echo_success("Profile successfuly validated")
+        echo_success("Successfuly validated")
 
     for display_func, message in report['messages']:
         display_func(message)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/__init__.py
@@ -1,1 +1,1 @@
-from .validator import get_all_validators
+from .validator import get_all_group_validators, get_all_single_validators

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/utils.py
@@ -1,3 +1,5 @@
+import glob
+
 from os.path import join
 
 import yaml
@@ -53,6 +55,8 @@ def exist_profile_in_path(profile_name, path):
 def get_default_snmp_profiles_path():
     return join(get_root(), 'snmp', 'datadog_checks', 'snmp', 'data', 'profiles')
 
+def get_all_profiles_directory(directory):
+    return glob.glob(join(directory, "*.yaml"))
 
 class SafeLineLoader(SafeLoader):
     def construct_mapping(self, node, deep=False):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/utils.py
@@ -52,6 +52,7 @@ def exist_profile_in_path(profile_name, path):
 
 
 def get_profile(profile_name, line=True):
+    file_contents = None
     if isfile(profile_name):
         try:
             with open(profile_name) as f:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/utils.py
@@ -1,5 +1,4 @@
 import glob
-
 from os.path import join
 
 import yaml
@@ -51,6 +50,7 @@ def exist_profile_in_path(profile_name, path):
                 return True
     return False
 
+
 def get_profile(profile_name, line=True):
     if isfile(profile_name):
         try:
@@ -59,7 +59,7 @@ def get_profile(profile_name, line=True):
                     file_contents = yaml.load(f.read(), Loader=SafeLineLoader)
                 else:
                     file_contents = yaml.safe_load(f.read())
-        except YAMLError as e:
+        except YAMLError:
             file_contents = None
     return file_contents
 
@@ -67,8 +67,10 @@ def get_profile(profile_name, line=True):
 def get_default_snmp_profiles_path():
     return join(get_root(), 'snmp', 'datadog_checks', 'snmp', 'data', 'profiles')
 
+
 def get_all_profiles_directory(directory):
     return glob.glob(join(directory, "*.yaml"))
+
 
 class SafeLineLoader(SafeLoader):
     def construct_mapping(self, node, deep=False):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/utils.py
@@ -51,6 +51,18 @@ def exist_profile_in_path(profile_name, path):
                 return True
     return False
 
+def get_profile(profile_name, line=True):
+    if isfile(profile_name):
+        try:
+            with open(profile_name) as f:
+                if line:
+                    file_contents = yaml.load(f.read(), Loader=SafeLineLoader)
+                else:
+                    file_contents = yaml.safe_load(f.read())
+        except YAMLError as e:
+            file_contents = None
+    return file_contents
+
 
 def get_default_snmp_profiles_path():
     return join(get_root(), 'snmp', 'datadog_checks', 'snmp', 'data', 'profiles')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/validator.py
@@ -5,7 +5,7 @@ import jsonschema
 
 from datadog_checks.dev.tooling.constants import get_root
 
-from .utils import find_profile_in_path, get_all_profiles_directory
+from .utils import find_profile_in_path, get_all_profiles_directory, get_profile
 
 
 class ValidationResult(object):
@@ -207,12 +207,44 @@ class SysobjectidValidator(ProfileValidator):
         super().__init__()
         self.used_sysobjid = {}
         self.duplicated = {}
+        self.seen_profiles = {}
 
     def validate(self, profile, path):
-        pass
-            
+        sysobjectids = self.extract_sysobjectids_profile(profile)
+        self.check_sysobjectids_are_duplicated( sysobjectids, profile)
+        for directory in path:
+            for profile in get_all_profiles_directory(directory):
+                sysobjectids = self.extract_sysobjectids_profile(profile)
+                self.check_sysobjectids_are_duplicated(sysobjectids, profile)
+        self.report_errors()
+    
+    def report_errors(self):
+        if len(self.duplicated) == 0:
+            self.success("No duplicated sysobjectid")
+        else:
+            for sysobjectid in self.duplicated:
+                error_message = "SysObjectId {} is duplicated in:\n".format(sysobjectid)
+                for profile in self.duplicated[sysobjectid]:
+                    error_message = error_message + "|------> {}\n".format(profile)
+                self.fail(error_message)
 
+    def extract_sysobjectids_profile(self, profile):
+        file_contents = get_profile(profile)
+        sysobjectid = file_contents.get('sysobjectid')
+        if (not isinstance(sysobjectid, list)) and sysobjectid != None:
+            sysobjectid = [sysobjectid]
+        return sysobjectid
             
+    def check_sysobjectids_are_duplicated(self, sysobjectids, profile):
+        if (not sysobjectids) or (profile in self.seen_profiles):
+            return
+        self.seen_profiles[profile] = True
+        for sysobjectid in sysobjectids:
+            if sysobjectid not in self.used_sysobjid:
+                self.used_sysobjid[sysobjectid] = [profile]
+            else:
+                self.used_sysobjid[sysobjectid].append(profile)
+                self.duplicated[sysobjectid] = self.used_sysobjid[sysobjectid]
 
 def get_all_validators():
     # type () -> list(ProfileValidator)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/validator.py
@@ -5,7 +5,7 @@ import jsonschema
 
 from datadog_checks.dev.tooling.constants import get_root
 
-from .utils import find_profile_in_path
+from .utils import find_profile_in_path, get_all_profiles_directory
 
 
 class ValidationResult(object):
@@ -199,7 +199,21 @@ class DuplicateOIDValidator(ProfileValidator):
             self.used_oid[OID].append((file, line))
             self.duplicated[OID] = self.used_oid[OID]
 
+class SysobjectidValidator(ProfileValidator):
+    """ 
+    Validator responsible to check if there are no duplicated sysobjectid in the profile.
+    """
+    def __init__(self):
+        super().__init__()
+        self.used_sysobjid = {}
+        self.duplicated = {}
+
+    def validate(self, profile, path):
+        pass
+            
+
+            
 
 def get_all_validators():
     # type () -> list(ProfileValidator)
-    return [SchemaValidator(), DuplicateOIDValidator()]
+    return [SchemaValidator(), DuplicateOIDValidator(), SysobjectidValidator()]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/validator.py
@@ -232,6 +232,8 @@ class SysobjectidValidator(ProfileValidator):
 
     def extract_sysobjectids_profile(self, profile):
         file_contents = get_profile(profile)
+        if not file_contents:
+            return []
         sysobjectid = file_contents.get('sysobjectid')
         if (not isinstance(sysobjectid, list)) and sysobjectid:
             sysobjectid = [sysobjectid]
@@ -249,6 +251,11 @@ class SysobjectidValidator(ProfileValidator):
                 self.duplicated[sysobjectid] = self.used_sysobjid[sysobjectid]
 
 
-def get_all_validators():
+def get_all_single_validators():
     # type () -> list(ProfileValidator)
-    return [SchemaValidator(), DuplicateOIDValidator(), SysobjectidValidator()]
+    return [SchemaValidator(), DuplicateOIDValidator()]
+
+
+def get_all_group_validators():
+    # type () -> list(ProfileValidator)
+    return [SysobjectidValidator()]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/validator.py
@@ -199,10 +199,12 @@ class DuplicateOIDValidator(ProfileValidator):
             self.used_oid[OID].append((file, line))
             self.duplicated[OID] = self.used_oid[OID]
 
+
 class SysobjectidValidator(ProfileValidator):
-    """ 
+    """
     Validator responsible to check if there are no duplicated sysobjectid in the profile.
     """
+
     def __init__(self):
         super().__init__()
         self.used_sysobjid = {}
@@ -211,13 +213,13 @@ class SysobjectidValidator(ProfileValidator):
 
     def validate(self, profile, path):
         sysobjectids = self.extract_sysobjectids_profile(profile)
-        self.check_sysobjectids_are_duplicated( sysobjectids, profile)
+        self.check_sysobjectids_are_duplicated(sysobjectids, profile)
         for directory in path:
             for profile in get_all_profiles_directory(directory):
                 sysobjectids = self.extract_sysobjectids_profile(profile)
                 self.check_sysobjectids_are_duplicated(sysobjectids, profile)
         self.report_errors()
-    
+
     def report_errors(self):
         if len(self.duplicated) == 0:
             self.success("No duplicated sysobjectid")
@@ -231,10 +233,10 @@ class SysobjectidValidator(ProfileValidator):
     def extract_sysobjectids_profile(self, profile):
         file_contents = get_profile(profile)
         sysobjectid = file_contents.get('sysobjectid')
-        if (not isinstance(sysobjectid, list)) and sysobjectid != None:
+        if (not isinstance(sysobjectid, list)) and sysobjectid:
             sysobjectid = [sysobjectid]
         return sysobjectid
-            
+
     def check_sysobjectids_are_duplicated(self, sysobjectids, profile):
         if (not sysobjectids) or (profile in self.seen_profiles):
             return
@@ -245,6 +247,7 @@ class SysobjectidValidator(ProfileValidator):
             else:
                 self.used_sysobjid[sysobjectid].append(profile)
                 self.duplicated[sysobjectid] = self.used_sysobjid[sysobjectid]
+
 
 def get_all_validators():
     # type () -> list(ProfileValidator)


### PR DESCRIPTION
### What does this PR do?
Adds a Validator to validate that there are no sysobjectids duplicates in the profiles.

### Motivation
To not have multiple sysobjectid defined in different profiles

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
