### PR TITLE
Add command to sync dependencies

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import os
 from collections import defaultdict
 
 import click
@@ -9,9 +8,9 @@ from packaging.markers import InvalidMarker, Marker
 from packaging.specifiers import SpecifierSet
 
 from ...fs import read_file_lines, write_file_lines
-from ..constants import get_agent_requirements, get_root
+from ..constants import get_agent_requirements
 from ..dependencies import read_agent_dependencies, read_check_dependencies
-from ..utils import get_valid_checks
+from ..utils import get_check_req_file, get_valid_checks
 from .console import CONTEXT_SETTINGS, abort, echo_failure, echo_info
 
 
@@ -117,7 +116,6 @@ def freeze():
     short_help="Update integrations' dependencies so that they match the Agent's static environment",
 )
 def sync():
-    root = get_root()
     all_agent_dependencies, errors = read_agent_dependencies()
 
     if errors:
@@ -149,7 +147,7 @@ def sync():
 
         if deps_to_update:
             files_updated += 1
-            check_req_file = os.path.join(root, check_name, 'requirements.in')
+            check_req_file = get_check_req_file(check_name)
             old_lines = read_file_lines(check_req_file)
             new_lines = old_lines.copy()
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -10,7 +10,7 @@ from packaging.specifiers import SpecifierSet
 
 from ...fs import read_file_lines, write_file_lines
 from ..constants import get_agent_requirements, get_root
-from ..dependencies import read_agent_dependencies, read_check_dependencies
+from ..dependencies import normalize_dependency_marker, read_agent_dependencies, read_check_dependencies
 from ..utils import get_valid_checks
 from .console import CONTEXT_SETTINGS, abort, echo_failure, echo_info
 
@@ -123,6 +123,7 @@ def sync():
             echo_failure(error)
         abort()
 
+    files_updated = 0
     checks = sorted(get_valid_checks())
     for check_name in checks:
         check_dependencies, check_errors = read_check_dependencies(check=check_name)
@@ -131,29 +132,34 @@ def sync():
             for error in check_errors:
                 echo_failure(error)
             abort()
-
-        for check_name, check_dependency_defs in check_dependencies.items():
-            agent_deps = agent_dependencies[check_name]
-            for check_dep_name, dependency_definitions in check_dependency_defs.items():
+        deps_to_update = {}
+        agent_deps = agent_dependencies[check_name]
+        for check_dep_nam, check_dependency_defs in check_dependencies.items():
+            agent_deps = agent_dependencies[check_dep_nam]
+            for version, dependency_definitions in check_dependency_defs.items():
                 for check_dependency_def in dependency_definitions:
-                    for agent_dep_name, agent_dependency_definitions in agent_deps.items():
+                    for agent_dep_version, agent_dependency_definitions in agent_deps.items():
                         for agent_dependency_definition in agent_dependency_definitions:
-                            if agent_dependency_definition.requirement == check_dependency_def.requirement:
-                                continue
-                            else:
-                                check_dependency_def.requirement = agent_dependency_definition.requirement
-
-            data = sorted(
-                (
-                    (dependency_definition.name, str(dependency_definition.requirement).lower())
-                    for versions in check_dependencies.values()
-                    for dependency_definitions in versions.values()
-                    for dependency_definition in dependency_definitions
-                ),
-                key=lambda d: d[0],
-            )
+                            if agent_dependency_definition.name == check_dependency_def.name and normalize_dependency_marker(check_dependency_def.requirement.marker) == normalize_dependency_marker(agent_dependency_definition.requirement.marker):
+                                if version != agent_dep_version:
+                                    # the agent requirement was bumped
+                                    deps_to_update[agent_dep_version] = check_dependency_def
+                                    
             root = get_root()
             check_req_file = os.path.join(root, check_name, 'requirements.in')
-            lines = sorted(set(f'{d[1]}\n' for d in data))
-            print(lines)
+            old_lines = read_file_lines(check_req_file)
+            new_lines = old_lines.copy()
+            for new_version, dependency_definition in deps_to_update.items():
+                dependency_definition.requirement.specifier = new_version
+                new_lines[dependency_definition.line_number] = f'{dependency_definition.requirement}\n'
+
+                if new_lines != old_lines:
+                    files_updated += 1
+                    write_file_lines(check_req_file, new_lines)
+
+    if not files_updated:
+        abort('No dependency definitions to update')
+
+    echo_info(f'Files updated: {files_updated}')
+
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -8,6 +8,7 @@ from packaging.markers import InvalidMarker, Marker
 from packaging.specifiers import SpecifierSet
 
 from ...fs import read_file_lines, write_file_lines
+from ...utils import parse_agent_req_file
 from ..constants import get_agent_requirements
 from ..dependencies import read_check_dependencies
 from .console import CONTEXT_SETTINGS, abort, echo_failure, echo_info
@@ -108,3 +109,13 @@ def freeze():
     lines = sorted(set(f'{d[1]}\n' for d in data))
 
     write_file_lines(static_file, lines)
+
+
+@dep.command(
+    context_settings=CONTEXT_SETTINGS, short_help="Update integrations' dependencies so that they match the Agent's static environment"
+)
+def sync():
+    agent_rec_file = get_agent_requirements()
+    all_reqs = parse_agent_req_file()
+
+    for check in checks:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
@@ -42,13 +42,15 @@ def load_dependency_data(req_file, dependencies, errors, check_name=None):
         dependency = dependencies[name][req.specifier]
         dependency.append(DependencyDefinition(name, req, req_file, i, check_name))
 
+
 def normalize_dependency_marker(marker):
     if marker is None:
         return marker
-        
+
     new_marker = str(marker).strip()
     new_marker = new_marker.replace('\'', "\"")
     return new_marker
+
 
 def load_base_check(req_file, dependencies, errors, check_name=None):
     for i, line in enumerate(stream_file_lines(req_file)):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
@@ -21,6 +21,19 @@ class DependencyDefinition:
     def __repr__(self):
         return f'<DependencyDefinition name={self.name} check_name={self.check_name} requirement={self.requirement}'
 
+    @property
+    def _normalized_marker(self):
+        if self.requirement.marker is None:
+            return self.requirement.marker
+
+        new_marker = str(self.requirement.marker).strip()
+        new_marker = new_marker.replace('\'', "\"")
+        return new_marker
+
+    def same_name_marker(self, other):
+        test = self.name == other.name and self._normalized_marker == other._normalized_marker
+        return test
+
 
 def create_dependency_data():
     return defaultdict(lambda: defaultdict(lambda: []))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
@@ -42,6 +42,13 @@ def load_dependency_data(req_file, dependencies, errors, check_name=None):
         dependency = dependencies[name][req.specifier]
         dependency.append(DependencyDefinition(name, req, req_file, i, check_name))
 
+def normalize_dependency_marker(marker):
+    if marker is None:
+        return marker
+        
+    new_marker = str(marker).strip()
+    new_marker = new_marker.replace('\'', "\"")
+    return new_marker
 
 def load_base_check(req_file, dependencies, errors, check_name=None):
     for i, line in enumerate(stream_file_lines(req_file)):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
@@ -31,8 +31,7 @@ class DependencyDefinition:
         return new_marker
 
     def same_name_marker(self, other):
-        test = self.name == other.name and self._normalized_marker == other._normalized_marker
-        return test
+        return self.name == other.name and self._normalized_marker == other._normalized_marker
 
 
 def create_dependency_data():
@@ -54,15 +53,6 @@ def load_dependency_data(req_file, dependencies, errors, check_name=None):
         name = req.name.lower()
         dependency = dependencies[name][req.specifier]
         dependency.append(DependencyDefinition(name, req, req_file, i, check_name))
-
-
-def normalize_dependency_marker(marker):
-    if marker is None:
-        return marker
-
-    new_marker = str(marker).strip()
-    new_marker = new_marker.replace('\'', "\"")
-    return new_marker
 
 
 def load_base_check(req_file, dependencies, errors, check_name=None):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -259,6 +259,10 @@ def get_config_file(check_name):
     return os.path.join(get_data_directory(check_name), 'conf.yaml.example')
 
 
+def get_check_req_file(check_name):
+    return os.path.join(get_root(), check_name, 'requirements.in')
+
+
 def get_config_spec(check_name):
     if check_name == 'agent':
         return os.path.join(get_root(), 'pkg', 'config', 'conf_spec.yaml')


### PR DESCRIPTION
### What does this PR do?
Adds a command to sync dependencies by updating individual check requirements based off of `agent-requirements.in`

### Motivation
Once dependabot updates dependencies in `agent-requirements.in`, this command can be run to sync the other requirements files.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
