### PR TITLE
Add `kubernetes_state.statefulset.count` metric

### DIFF
--- a/datadog_checks_base/tests/fixtures/prometheus/ksm.txt
+++ b/datadog_checks_base/tests/fixtures/prometheus/ksm.txt
@@ -867,7 +867,3 @@ kube_service_labels{label_addonmanager_kubernetes_io_mode="Reconcile",label_kube
 kube_service_labels{label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="glbc",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="GLBCDefaultBackend",namespace="kube-system",service="default-http-backend"} 1
 kube_service_labels{label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="kube-dns",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="KubeDNS",namespace="kube-system",service="kube-dns"} 1
 kube_service_labels{label_app="kube-state-metrics",label_chart="kube-state-metrics-0.5.0",label_heritage="Tiller",label_release="ungaged-panther",namespace="default",service="ungaged-panther-kube-state-metrics"} 1
-# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
-# TYPE kube_statefulset_status_observed_generation gauge
-kube_statefulset_status_observed_generation{namespace="datadog-agent",statefulset="web"} 1
-kube_statefulset_status_observed_generation{namespace="kube-system",statefulset="mysql"} 1

--- a/datadog_checks_base/tests/fixtures/prometheus/ksm.txt
+++ b/datadog_checks_base/tests/fixtures/prometheus/ksm.txt
@@ -867,3 +867,7 @@ kube_service_labels{label_addonmanager_kubernetes_io_mode="Reconcile",label_kube
 kube_service_labels{label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="glbc",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="GLBCDefaultBackend",namespace="kube-system",service="default-http-backend"} 1
 kube_service_labels{label_addonmanager_kubernetes_io_mode="Reconcile",label_k8s_app="kube-dns",label_kubernetes_io_cluster_service="true",label_kubernetes_io_name="KubeDNS",namespace="kube-system",service="kube-dns"} 1
 kube_service_labels{label_app="kube-state-metrics",label_chart="kube-state-metrics-0.5.0",label_heritage="Tiller",label_release="ungaged-panther",namespace="default",service="ungaged-panther-kube-state-metrics"} 1
+# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
+# TYPE kube_statefulset_status_observed_generation gauge
+kube_statefulset_status_observed_generation{namespace="datadog-agent",statefulset="web"} 1
+kube_statefulset_status_observed_generation{namespace="kube-system",statefulset="mysql"} 1

--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -1,9 +1,5 @@
 # CHANGELOG - kubernetes_state
 
-## 5.7.2 / 2021-08-02
-
-* [Added] KSM `kubernetes_state.statefulset.count` metric. See [#9813](https://github.com/DataDog/integrations-core/pull/9813).
-
 ## 5.7.1 / 2021-06-03
 
 * [Fixed] Fix `node.by_condition` metric. See [#9467](https://github.com/DataDog/integrations-core/pull/9467).

--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - kubernetes_state
 
+## 5.7.2 / 2021-08-02
+
+* [Added] KSM `kubernetes_state.statefulset.count` metric. See [#tbd](tbd).
+
 ## 5.7.1 / 2021-06-03
 
 * [Fixed] Fix `node.by_condition` metric. See [#9467](https://github.com/DataDog/integrations-core/pull/9467).

--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.7.2 / 2021-08-02
 
-* [Added] KSM `kubernetes_state.statefulset.count` metric. See [#tbd](tbd).
+* [Added] KSM `kubernetes_state.statefulset.count` metric. See [#9813](https://github.com/DataDog/integrations-core/pull/9813).
 
 ## 5.7.1 / 2021-06-03
 

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -105,6 +105,10 @@ class KubernetesState(OpenMetricsBaseCheck):
                 'metric_name': 'deployment.count',
                 'allowed_labels': ['namespace'],
             },
+            'kube_statefulset_status_observed_generation': {
+                'metric_name': 'statefulset.count',
+                'allowed_labels': ['namespace'],
+            },
         }
 
         self.METRIC_TRANSFORMERS = {
@@ -131,6 +135,7 @@ class KubernetesState(OpenMetricsBaseCheck):
             'kube_replicaset_owner': self.count_objects_by_tags,
             'kube_job_owner': self.count_objects_by_tags,
             'kube_deployment_status_observed_generation': self.count_objects_by_tags,
+            'kube_statefulset_status_observed_generation': self.count_objects_by_tags,
         }
 
         # Handling cron jobs succeeded/failed counts

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -328,7 +328,6 @@ class KubernetesState(OpenMetricsBaseCheck):
                     'kube_replicationcontroller_metadata_generation',
                     'kube_replicationcontroller_status_observed_generation',
                     'kube_statefulset_metadata_generation',
-                    'kube_statefulset_status_observed_generation',
                     'kube_hpa_metadata_generation',
                     # kube_node_status_phase has no use case as a service check
                     'kube_node_status_phase',

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -100,6 +100,7 @@ kubernetes_state.resourcequota.requests.storage.limit,gauge,,byte,,Hard limit on
 kubernetes_state.resourcequota.limits.cpu.limit,gauge,,cpu,,Hard limit on the sum of CPU core limits for a resource quota,0,kubernetes,k8s_state.resourcequota.limits.cpu.limit
 kubernetes_state.resourcequota.limits.memory.limit,gauge,,byte,,Hard limit on the sum of memory bytes limits for a resource quota,0,kubernetes,k8s_state.resourcequota.limits.mem.limit
 kubernetes_state.service.count,gauge,,,,Sum by namespace and type to count active services,0,kubernetes,k8s_state.svc.count
+kubernetes_state.statefulset.count,gauge,,,,The number of statefulsets,0,kubernetes,k8s_state.statefulset.count
 kubernetes_state.statefulset.replicas,gauge,,,,The number of replicas per statefulset,0,kubernetes,k8s_state.statefulset.replicas
 kubernetes_state.statefulset.replicas_desired,gauge,,,,The number of desired replicas per statefulset,0,kubernetes,k8s_state.statefulset.replicas_desired
 kubernetes_state.statefulset.replicas_current,gauge,,,,The number of current replicas per StatefulSet,0,kubernetes,k8s_state.statefulset.replicas_current

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -31,6 +31,12 @@ kube_cronjob_status_active{cronjob="hello",namespace="default"} 0
 # HELP kube_cronjob_status_last_schedule_time LastScheduleTime keeps information of when was the last time the job was successfully scheduled.
 # TYPE kube_cronjob_status_last_schedule_time gauge
 kube_cronjob_status_last_schedule_time{cronjob="hello",namespace="default"} 1.50999846e+09
+# HELP kube_statefulset_status_observed_generation The generation observed by the StatefulSet controller.
+# TYPE kube_statefulset_status_observed_generation gauge
+kube_statefulset_status_observed_generation{namespace="default",statefulset="web"} 1
+kube_statefulset_status_observed_generation{namespace="default",statefulset="nginx"} 4
+kube_statefulset_status_observed_generation{namespace="kube-system",statefulset="mysql"} 1
+kube_statefulset_status_observed_generation{namespace="kube-system",statefulset="redis"} 2
 # HELP kube_statefulset_status_replicas The number of replicas per StatefulSet.
 # TYPE kube_statefulset_status_replicas gauge
 kube_statefulset_status_replicas{namespace="ns3",statefulset="statefulset3"} 7

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -885,9 +885,9 @@ def test_telemetry(aggregator, instance):
 
     for _ in range(2):
         check.check(instance)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=93895.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=994.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1326.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=94412.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=1002.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1334.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.blacklist.count', tags=['optional:tag1'], value=24.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=332.0)
     aggregator.assert_metric(

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -441,6 +441,18 @@ def test_update_kube_state_metrics(aggregator, instance, check):
         value=2,
     )
 
+    # statefulset count
+    aggregator.assert_metric(
+        NAMESPACE + '.statefulset.count',
+        tags=['namespace:default', 'optional:tag1'],
+        value=2,
+    )
+    aggregator.assert_metric(
+        NAMESPACE + '.statefulset.count',
+        tags=['namespace:kube-system', 'optional:tag1'],
+        value=2,
+    )
+
     for metric in METRICS:
         aggregator.assert_metric(metric, hostname=HOSTNAMES.get(metric, None))
         for tag in TAGS.get(metric, []):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds `kubernetes_state.statefulset.count` based on generations, which is based on the same code and methods that `deployment.count` is using 

### Motivation
OOTB sts dashboard 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
