### PR TITLE
Make both tagging transformers share interface

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -64,7 +64,6 @@ class QueryManager(object):
         self.error_handler = error_handler
         self.queries = [Query(payload) for payload in queries or []]  # type: List[Query]
         self.hostname = hostname  # type: str
-        self.logger = self.check.log
 
         custom_queries = list(self.check.instance.get('custom_queries', []))  # type: List[str]
         use_global_custom_queries = self.check.instance.get('use_global_custom_queries', True)  # type: str
@@ -145,10 +144,9 @@ class QueryManager(object):
                     # anything but are collected into the row values for other columns to reference.
                     if transformer is None:
                         continue
-                    elif column_type == 'tag':
-                        tags.append(transformer(None, column_value))  # get_tag transformer
-                    elif column_type == 'tag_list':
-                        tags.extend(transformer(None, column_value))  # get_tag_list transformer
+                    elif column_type == 'tag' or column_type == 'tag_list':
+                        # get_tag transformer or  get_tag_list transformer
+                        tags.extend(transformer(None, column_value))
                     else:
                         submission_queue.append((transformer, column_value))
 

--- a/datadog_checks_base/datadog_checks/base/utils/db/transform.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/transform.py
@@ -8,7 +8,6 @@ import time
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Tuple
 
-from datadog_checks.base import AgentCheck
 from datadog_checks.base.types import ServiceCheckStatus
 from datadog_checks.base.utils.db.types import Transformer, TransformerFactory
 

--- a/datadog_checks_base/datadog_checks/base/utils/db/transform.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/transform.py
@@ -8,6 +8,7 @@ import time
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Tuple
 
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.types import ServiceCheckStatus
 from datadog_checks.base.utils.db.types import Transformer, TransformerFactory
 
@@ -47,11 +48,11 @@ def get_tag(transformers, column_name, **modifiers):
     boolean = is_affirmative(modifiers.pop('boolean', None))
 
     def tag(_, value, **kwargs):
-        # type: (List, str, Dict[str, Any]) -> str
+        # type: (List, str, Dict[str, Any]) -> List[str]
         if boolean:
             value = str(is_affirmative(value)).lower()
 
-        return template.format(value)
+        return [template.format(value)]
 
     return tag
 


### PR DESCRIPTION
When implementing the feature to disable generic tags we can have a 1->2 (for example, service will become service and integration_service) tag transformation so get_tag should return a list too.