### PR TITLE
Do not store previously discovered queues

### DIFF
--- a/ibm_mq/assets/configuration/spec.yaml
+++ b/ibm_mq/assets/configuration/spec.yaml
@@ -72,7 +72,8 @@ files:
       - name: queue_regex
         description: |
           Collect from queues that match a regex
-          Note: Do not use in conjuction with `auto_discover_queues` or `queue_patterns` as it may lead to unexpected results.
+          Note: Do not use in conjuction with `auto_discover_queues` or `queue_patterns` as it may lead to
+          unexpected results.
         value:
           example:
             - '^DEV\..*$'          # match queues starting with "DEV."

--- a/ibm_mq/assets/configuration/spec.yaml
+++ b/ibm_mq/assets/configuration/spec.yaml
@@ -59,7 +59,9 @@ files:
           items:
             type: string
       - name: queue_patterns
-        description: Collect from queues that match a MQ pattern
+        description: |
+          Collect from queues that match a MQ pattern
+          Note: Do not use in conjuction with `auto_discover_queues` or `queue_regex` as it may lead to unexpected results.
         value:
           example:
             - 'DEV.*'          # match queues starting with "DEV."
@@ -68,7 +70,9 @@ files:
           items:
             type: string
       - name: queue_regex
-        description: Collect from queues that match a regex
+        description: |
+          Collect from queues that match a regex
+          Note: Do not use in conjuction with `auto_discover_queues` or `queue_patterns` as it may lead to unexpected results.
         value:
           example:
             - '^DEV\..*$'          # match queues starting with "DEV."
@@ -107,7 +111,8 @@ files:
           properties: []
       - name: auto_discover_queues
         description: |
-          Autodiscover the queues to monitor
+          Autodiscover the queues to monitor.
+          Note: Do not use in conjuction with `queue_patterns` or `queue_regex` as it may lead to unexpected results.
           Warning: this will lead to some warnings in your logs
         value:
           example: false

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
@@ -29,10 +29,10 @@ class QueueMetricCollector(object):
     QUEUE_MANAGER_SERVICE_CHECK = 'ibm_mq.queue_manager'
 
     def __init__(self, config, service_check, warning, send_metric, send_metrics_from_properties, log):
-        # type: (IBMMQConfig, Callable, Callable, Callable, Callable, logging.LoggerAdapter) -> QueueMetricCollector
+        # type: (IBMMQConfig, Callable, Callable, Callable, Callable, logging.LoggerAdapter) -> None
         self.config = config  # type: IBMMQConfig
         self.service_check = service_check  # type: Callable[[str, ServiceCheck, List[str]], None]
-        self.warning = warning  # type: Callable[[str], None]
+        self.warning = warning  # type: Callable
         self.send_metric = send_metric  # type: Callable[[str, str, Any, List[str]], None]
         self.send_metrics_from_properties = (
             send_metrics_from_properties

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -88,7 +88,7 @@ class IBMMQConfig:
             instance.get('channel_status_mapping')
         )  # type: Dict[str, str]
 
-        self.convert_endianness = instance.get('convert_endianness', False)
+        self.convert_endianness = instance.get('convert_endianness', False)  # type: bool
 
         custom_tags = instance.get('tags', [])  # type: List[str]
         tags = [

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -64,6 +64,7 @@ instances:
 
     ## @param queue_patterns - list of strings - optional
     ## Collect from queues that match a MQ pattern
+    ## Note: Do not use in conjuction with `auto_discover_queues` or `queue_regex` as it may lead to unexpected results.
     #
     # queue_patterns:
     #   - DEV.*
@@ -71,6 +72,8 @@ instances:
 
     ## @param queue_regex - list of strings - optional
     ## Collect from queues that match a regex
+    ## Note: Do not use in conjuction with `auto_discover_queues` or `queue_patterns` as it may lead to
+    ## unexpected results.
     #
     # queue_regex:
     #   - ^DEV\..*$
@@ -103,7 +106,8 @@ instances:
     #   initializing: warning
 
     ## @param auto_discover_queues - boolean - optional - default: false
-    ## Autodiscover the queues to monitor
+    ## Autodiscover the queues to monitor.
+    ## Note: Do not use in conjuction with `queue_patterns` or `queue_regex` as it may lead to unexpected results.
     ## Warning: this will lead to some warnings in your logs
     #
     # auto_discover_queues: false

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -13,7 +13,7 @@ from .collectors import ChannelMetricCollector, MetadataCollector, QueueMetricCo
 from .config import IBMMQConfig
 
 try:
-    from typing import Any
+    from typing import Any, Dict, List
 except ImportError:
     pass
 
@@ -88,6 +88,7 @@ class IbmMqCheck(AgentCheck):
             self.log.debug('Could not retrieve ibm_mq version info: %s', e)
 
     def send_metrics_from_properties(self, properties, metrics_map, prefix, tags):
+        # type: (Dict, Dict, str, List[str]) -> None
         for metric_name, (pymqi_type, metric_type) in iteritems(metrics_map):
             metric_full_name = '{}.{}'.format(prefix, metric_name)
             if pymqi_type not in properties:


### PR DESCRIPTION
Autodiscovery can autodiscover dynamic queues that may disappear on later runs causing errors on the check.
Also because we were just adding discovered queues without removing deleted ones this also fixes a memory leak