### PR TITLE
[dashboard] update integration json with is_column_break properties

### DIFF
--- a/amazon_msk/assets/dashboards/overview.json
+++ b/amazon_msk/assets/dashboards/overview.json
@@ -2,6 +2,7 @@
     "author_name": "Datadog",
     "description": "## Amazon MSK (Agent) Overview\n\nThis is an example Amazon MSK dashboard demonstrating the metrics that the integration collects.",
     "layout_type": "ordered",
+    "reflow_type": "fixed",
     "template_variables": [
         {
             "default": "*",
@@ -486,8 +487,12 @@
             },
             "id": 8770755938983262,
             "layout": {
+                "x": 0,
+                "y": 10,
+                "width": 12,
+                "height": 7,
                 "is_column_break": true
-            }
+              }
         },
         {
             "definition": {

--- a/databricks/assets/dashboards/databricks_overview.json
+++ b/databricks/assets/dashboards/databricks_overview.json
@@ -2,6 +2,7 @@
     "author_name": "Datadog",
     "description": "This Dashboard provides a high-level overview of your Databricks clusters, alongside detailed Spark metrics and logs, so you can monitor your jobs in real-time.\n\n- [Monitor Databricks with Datadog](/blog/databricks-monitoring-datadog)\n- [Databricks integration docs](https://docs.datadoghq.com/integrations/databricks/?tab=driveronly)\n- [Spark integration docs](https://docs.datadoghq.com/integrations/spark/?tab=host)\n",
     "layout_type": "ordered",
+    "reflow_type": "fixed",
     "template_variables": [
         {
             "default": "*",
@@ -879,8 +880,12 @@
             },
             "id": 3770619620282260,
             "layout": {
+                "x": 0,
+                "y": 22,
+                "width": 12,
+                "height": 5,
                 "is_column_break": true
-            }
+              }
         },
         {
             "definition": {

--- a/elastic/assets/dashboards/overview.json
+++ b/elastic/assets/dashboards/overview.json
@@ -791,7 +791,13 @@
           }
         ]
       },
-      "layout": { "is_column_break": true }
+      "layout": {
+        "x": 0,
+        "y": 17,
+        "width": 12,
+        "height": 5,
+        "is_column_break": true
+      }
     },
     {
       "id": 5,

--- a/jmeter/assets/dashboards/JMeterOverview.json
+++ b/jmeter/assets/dashboards/JMeterOverview.json
@@ -327,7 +327,13 @@
           }
         ]
       },
-      "layout": { "is_column_break": true }
+      "layout": {
+        "x": 0,
+        "y": 10,
+        "width": 12,
+        "height": 8,
+        "is_column_break": true
+      }
     }
   ],
   "template_variables": [

--- a/kubernetes/assets/dashboards/kubernetes_jobs.json
+++ b/kubernetes/assets/dashboards/kubernetes_jobs.json
@@ -2,6 +2,7 @@
     "author_name": "Datadog",
     "description": "### This dashboard allows you to monitor Kubernetes Jobs and CronJobs.\n",
     "layout_type": "ordered",
+    "reflow_type": "fixed",
     "template_variables": [
         {
             "default": "*",
@@ -1459,8 +1460,12 @@
             },
             "id": 1991208644233094,
             "layout": {
+                "x": 0,
+                "y": 28,
+                "width": 12,
+                "height": 14,
                 "is_column_break": true
-            }
+              }
         }
     ]
 }

--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -876,7 +876,13 @@
             }
           ]
         },
-        "layout": { "is_column_break": true }
+        "layout": {
+          "x": 0,
+          "y": 14,
+          "width": 12,
+          "height": 13,
+          "is_column_break": true
+        }
       }
     ],
     "template_variables": [

--- a/mcache/assets/dashboards/memcached_screenboard.json
+++ b/mcache/assets/dashboards/memcached_screenboard.json
@@ -875,6 +875,10 @@
         ]
       },
       "layout": {
+        "x": 0,
+        "y": 16,
+        "width": 12,
+        "height": 4,
         "is_column_break": true
       }
     },

--- a/mysql/assets/dashboards/overview-screenboard.json
+++ b/mysql/assets/dashboards/overview-screenboard.json
@@ -980,6 +980,10 @@
         ]
       },
       "layout": {
+        "x": 0,
+        "y": 13,
+        "width": 12,
+        "height": 7,
         "is_column_break": true
       }
     },

--- a/nginx/assets/dashboards/plus_overview.json
+++ b/nginx/assets/dashboards/plus_overview.json
@@ -753,6 +753,10 @@
         ]
       },
       "layout": {
+        "x": 0,
+        "y": 12,
+        "width": 12,
+        "height": 5,
         "is_column_break": true
       }
     },

--- a/openldap/assets/dashboards/openldap_overview.json
+++ b/openldap/assets/dashboards/openldap_overview.json
@@ -538,6 +538,10 @@
         ]
       },
       "layout": {
+        "x": 0,
+        "y": 14,
+        "width": 12,
+        "height": 5,
         "is_column_break": true
       }
     },

--- a/postgres/assets/dashboards/postgresql_screenboard_dashboard.json
+++ b/postgres/assets/dashboards/postgresql_screenboard_dashboard.json
@@ -1057,6 +1057,10 @@
         ]
       },
       "layout": {
+        "x": 0,
+        "y": 22,
+        "width": 12,
+        "height": 5,
         "is_column_break": true
       }
     },

--- a/presto/assets/dashboards/overview.json
+++ b/presto/assets/dashboards/overview.json
@@ -947,7 +947,11 @@
           },
           "id": 7360116371450254,
           "layout": {
-              "is_column_break": true
+            "x": 0,
+            "y": 11,
+            "width": 12,
+            "height": 5,
+            "is_column_break": true
           }
       },
       {

--- a/redisdb/assets/dashboards/overview.json
+++ b/redisdb/assets/dashboards/overview.json
@@ -892,7 +892,13 @@
           }
         ]
       },
-      "layout": { "is_column_break": true }
+      "layout": {
+        "x": 0,
+        "y": 16,
+        "width": 12,
+        "height": 5,
+        "is_column_break": true
+      }
     },
     {
       "id": 5,

--- a/tomcat/assets/dashboards/overview.json
+++ b/tomcat/assets/dashboards/overview.json
@@ -550,7 +550,13 @@
             }
           ]
         },
-        "layout": { "is_column_break": true }
+        "layout": {
+          "x": 0,
+          "y": 12,
+          "width": 12,
+          "height": 5,
+          "is_column_break": true
+        }
       },
       {
         "id": 273973929660372,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the json of integration dashboards with the proper is_column_break layout properties

### Motivation
<!-- What inspired you to submit this pull request? -->

layout validation for dashboard widgets and groups have changed such that just `{is_column_break: true}` is no longer considered a valid layout. this is adding full layout properties for widgets with this.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
