### PR TITLE
Set a default statement timeout for postgres to 5s

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -94,8 +94,9 @@ files:
         Cancelled queries won't log any metrics.
       value:
         type: integer
-        example: 1000
-        display_default: null
+        example: 2000
+        default: 2000
+        display_default: 2000
     - name: relations
       description: |
         The list of relations/tables must be specified here to track per-relation (table, index , view, etc.) metrics.

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -95,8 +95,6 @@ files:
       value:
         type: integer
         example: 5000
-        default: 5000
-        display_default: 5000
     - name: relations
       description: |
         The list of relations/tables must be specified here to track per-relation (table, index , view, etc.) metrics.

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -94,9 +94,9 @@ files:
         Cancelled queries won't log any metrics.
       value:
         type: integer
-        example: 2000
-        default: 2000
-        display_default: 2000
+        example: 5000
+        default: 5000
+        display_default: 5000
     - name: relations
       description: |
         The list of relations/tables must be specified here to track per-relation (table, index , view, etc.) metrics.

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -41,7 +41,7 @@ class PostgresConfig:
         if not self.isascii(self.application_name):
             raise ConfigurationError("Application name can include only ASCII characters: %s", self.application_name)
 
-        self.query_timeout = int(instance.get('query_timeout', 2000))
+        self.query_timeout = int(instance.get('query_timeout', 5000))
         self.relations = instance.get('relations', [])
         if self.relations and not self.dbname:
             raise ConfigurationError('"dbname" parameter must be set when using the "relations" parameter.')

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -41,7 +41,7 @@ class PostgresConfig:
         if not self.isascii(self.application_name):
             raise ConfigurationError("Application name can include only ASCII characters: %s", self.application_name)
 
-        self.query_timeout = instance.get('query_timeout', 5000)
+        self.query_timeout = int(instance.get('query_timeout', 2000))
         self.relations = instance.get('relations', [])
         if self.relations and not self.dbname:
             raise ConfigurationError('"dbname" parameter must be set when using the "relations" parameter.')

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -41,7 +41,7 @@ class PostgresConfig:
         if not self.isascii(self.application_name):
             raise ConfigurationError("Application name can include only ASCII characters: %s", self.application_name)
 
-        self.query_timeout = instance.get('query_timeout')
+        self.query_timeout = instance.get('query_timeout', 5000)
         self.relations = instance.get('relations', [])
         if self.relations and not self.dbname:
             raise ConfigurationError('"dbname" parameter must be set when using the "relations" parameter.')

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -49,7 +49,7 @@ def instance_dbm(field, value):
 
 
 def instance_dbname(field, value):
-    return get_default_field_value(field, value)
+    return 'postgres'
 
 
 def instance_dbstrict(field, value):
@@ -109,7 +109,7 @@ def instance_service(field, value):
 
 
 def instance_ssl(field, value):
-    return 'false'
+    return False
 
 
 def instance_table_count_limit(field, value):

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -97,7 +97,7 @@ def instance_query_samples(field, value):
 
 
 def instance_query_timeout(field, value):
-    return 2000
+    return 5000
 
 
 def instance_relations(field, value):

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -49,7 +49,7 @@ def instance_dbm(field, value):
 
 
 def instance_dbname(field, value):
-    return 'postgres'
+    return get_default_field_value(field, value)
 
 
 def instance_dbstrict(field, value):
@@ -97,7 +97,7 @@ def instance_query_samples(field, value):
 
 
 def instance_query_timeout(field, value):
-    return get_default_field_value(field, value)
+    return 2000
 
 
 def instance_relations(field, value):
@@ -109,7 +109,7 @@ def instance_service(field, value):
 
 
 def instance_ssl(field, value):
-    return False
+    return 'false'
 
 
 def instance_table_count_limit(field, value):

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -77,13 +77,13 @@ instances:
     #
     # ssl: 'false'
 
-    ## @param query_timeout - integer - optional - default: 2000
+    ## @param query_timeout - integer - optional - default: 5000
     ## Adds a statement_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STATEMENT-TIMEOUT
     ## to all metric collection queries. Aborts any statement that takes more than the specified number of milliseconds,
     ## starting from the time the command arrives at the server from the client. A value of zero turns this off.
     ## Cancelled queries won't log any metrics.
     #
-    # query_timeout: 2000
+    # query_timeout: 5000
 
     ## @param relations - (list of string or mapping) - optional
     ## The list of relations/tables must be specified here to track per-relation (table, index , view, etc.) metrics.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -77,13 +77,13 @@ instances:
     #
     # ssl: 'false'
 
-    ## @param query_timeout - integer - optional
+    ## @param query_timeout - integer - optional - default: 2000
     ## Adds a statement_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STATEMENT-TIMEOUT
     ## to all metric collection queries. Aborts any statement that takes more than the specified number of milliseconds,
     ## starting from the time the command arrives at the server from the client. A value of zero turns this off.
     ## Cancelled queries won't log any metrics.
     #
-    # query_timeout: 1000
+    # query_timeout: 2000
 
     ## @param relations - (list of string or mapping) - optional
     ## The list of relations/tables must be specified here to track per-relation (table, index , view, etc.) metrics.


### PR DESCRIPTION
### What does this PR do?

This PR updates the Postgres integration to set a default timeout of 5s on queries. Based on internal benchmarking, this should be a wide margin to ensure we mitigate performance impact in the worst case scenarios, while still ensuring customers have metrics.

### Motivation

Datadog strives to provide high fidelity telemetry while guaranteeing the lowest possible performance impact by the agent. While the integrations do not run any queries that should exceed a 5s execution time, there are certain failure scenarios on databases that could result in all queries being slow and consuming more resources than a monitoring tool should–especially on a loaded database.

### Additional Notes

I believe the biggest risk in changing this behavior is the impact on long-running custom queries. However the benefit to risk ratio is very hight.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
