### PR TITLE
Improve release-hash-check modified files detection

### DIFF
--- a/.github/workflows/release-hash-check.yml
+++ b/.github/workflows/release-hash-check.yml
@@ -22,7 +22,8 @@ jobs:
     - id: files
       run: |
         git fetch origin master
-        FILES=$(git --no-pager diff --name-only origin/master -- .in-toto | xargs echo)
+        LAST_COMMON_COMMIT=$(git merge-base HEAD origin/master)
+        FILES=$(git --no-pager diff --name-only $LAST_COMMON_COMMIT -- .in-toto | xargs echo)
         echo "::set-output name=all::$FILES"
 
     - id: merge

--- a/.github/workflows/release-hash-check.yml
+++ b/.github/workflows/release-hash-check.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v2


### PR DESCRIPTION
Previously the `git diff` command was used to list all modified files between a PR and origin/master.
The issue with that approach is if another releaser releases something in between, his .in-toto file will show up in the diff as well.

To fix, we use `git merge-base` to find the last common ancestor between the tested branch and master, in order to only list `.in-toto` files **modified** by that PR.

Successfully tested here: https://github.com/DataDog/integrations-core/pull/9851