### PR TITLE
Bump openstacksdk and add missing metrics

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -37,7 +37,8 @@ lz4==2.2.1; python_version < "3.0"
 lz4==3.1.3; python_version > "3.0"
 mmh3==2.5.1; python_version < "3.0"
 mmh3==3.0.0; python_version > "3.0"
-openstacksdk==0.24.0
+openstacksdk==0.39.0; python_version < "3.0"
+openstacksdk==0.58.0; python_version > "3.0"
 orjson==2.6.1; python_version > "3.0"
 paramiko==2.6.0
 ply==3.10

--- a/openstack_controller/datadog_checks/openstack_controller/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api.py
@@ -259,13 +259,9 @@ class OpenstackSDKApi(AbstractApi):
         # With SimpleApi this method returns either the new or the old format depending on the hypervisor.
         # Because openstacksdk only supports the new format, this method either returns the new format with new
         # hypervisor, or an empty payload with older hypervisor.
-        if PY3:
-            self._check_authentication()
+        self._check_authentication()
 
-            return self.connection.compute.get_server_diagnostics(server_id)
-        else:
-            self.logger.warning("Server diagnostics is not available with this version of openstacksdk")
-            raise NotImplementedError()
+        return self.connection.compute.get_server_diagnostics(server_id)
 
 
 class SimpleApi(AbstractApi):

--- a/openstack_controller/datadog_checks/openstack_controller/api.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api.py
@@ -6,6 +6,7 @@ from os import environ
 
 import requests
 from openstack import connection
+from six import PY3
 from six.moves.urllib.parse import urljoin
 
 from .exceptions import (
@@ -64,7 +65,7 @@ class AbstractApi(object):
     def get_projects(self):
         raise NotImplementedError()
 
-    def get_os_hypervisor_uptime(self, hypervisor_id):
+    def get_os_hypervisor_uptime(self, hypervisor):
         raise NotImplementedError()
 
     def get_os_aggregates(self):
@@ -213,10 +214,16 @@ class OpenstackSDKApi(AbstractApi):
 
         return self.connection.list_hypervisors()
 
-    def get_os_hypervisor_uptime(self, hypervisor_id):
-        # Hypervisor uptime is not available in openstacksdk 0.24.0.
-        self.logger.warning("Hypervisor uptime is not available with this version of openstacksdk")
-        raise NotImplementedError()
+    def get_os_hypervisor_uptime(self, hypervisor):
+        if PY3:
+            if hypervisor.uptime is None:
+                self._check_authentication()
+                self.connection.compute.get_hypervisor_uptime(hypervisor)
+            return hypervisor.uptime
+        else:
+            # Hypervisor uptime is not available in openstacksdk 0.24.0.
+            self.logger.warning("Hypervisor uptime is not available with this version of openstacksdk")
+            raise NotImplementedError()
 
     def get_os_aggregates(self):
         # Each aggregate is missing the 'uuid' attribute compared to what is returned by SimpleApi
@@ -247,9 +254,18 @@ class OpenstackSDKApi(AbstractApi):
         return self.connection.list_servers(detailed=True, all_projects=True, filters=query_params)
 
     def get_server_diagnostics(self, server_id):
-        # Server diagnostics is not available in openstacksdk 0.24.0. It should be available in the next release.
-        self.logger.warning("Server diagnostics is not available with this version of openstacksdk")
-        raise NotImplementedError()
+        # With microversion 2.48 the format of server diagnostics changed
+        # https://docs.openstack.org/api-ref/compute/?expanded=show-server-diagnostics-detail
+        # With SimpleApi this method returns either the new or the old format depending on the hypervisor.
+        # Because openstacksdk only supports the new format, this method either returns the new format with new
+        # hypervisor, or an empty payload with older hypervisor.
+        if PY3:
+            self._check_authentication()
+
+            return self.connection.compute.get_server_diagnostics(server_id)
+        else:
+            self.logger.warning("Server diagnostics is not available with this version of openstacksdk")
+            raise NotImplementedError()
 
 
 class SimpleApi(AbstractApi):
@@ -308,7 +324,8 @@ class SimpleApi(AbstractApi):
     def get_neutron_endpoint(self):
         self._make_request(self.neutron_endpoint)
 
-    def get_os_hypervisor_uptime(self, hyp_id):
+    def get_os_hypervisor_uptime(self, hypervisor):
+        hyp_id = hypervisor['id']
         url = '{}/os-hypervisors/{}/uptime'.format(self.nova_endpoint, hyp_id)
         resp = self._make_request(url)
         return resp.get('hypervisor', {}).get('uptime')

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -196,8 +196,8 @@ class OpenStackControllerCheck(AgentCheck):
 
         return hypervisor_aggregate_map
 
-    def get_loads_for_single_hypervisor(self, hyp_id):
-        uptime = self.get_os_hypervisor_uptime(hyp_id)
+    def get_loads_for_single_hypervisor(self, hypervisor):
+        uptime = self.get_os_hypervisor_uptime(hypervisor)
         return self._parse_uptime_string(uptime)
 
     def collect_hypervisors_metrics(
@@ -287,7 +287,7 @@ class OpenStackControllerCheck(AgentCheck):
         # If the Agent is installed on the hypervisors, system.load.1/5/15 is available as a system metric
         if collect_hypervisor_load:
             try:
-                load_averages = self.get_loads_for_single_hypervisor(hyp['id'])
+                load_averages = self.get_loads_for_single_hypervisor(hyp)
             except Exception as e:
                 self.warning('Unable to get loads averages for hypervisor %s: %s', hyp['id'], e)
                 load_averages = []
@@ -453,6 +453,10 @@ class OpenStackControllerCheck(AgentCheck):
                         tags=tags + host_tags,
                         hostname=server_id,
                     )
+
+            # microversion post 2.48
+            # TODO: Server stats returned by newer hypervisors have a different format.
+            # https://docs.openstack.org/api-ref/compute/?expanded=show-server-diagnostics-detail
 
     def collect_project_limit(self, project, tags=None):
         # NOTE: starting from Version 3.10 (Queens)
@@ -793,8 +797,8 @@ class OpenStackControllerCheck(AgentCheck):
     def get_nova_endpoint(self):
         return self._api.get_nova_endpoint()
 
-    def get_os_hypervisor_uptime(self, hyp_id):
-        return self._api.get_os_hypervisor_uptime(hyp_id)
+    def get_os_hypervisor_uptime(self, hypervisor):
+        return self._api.get_os_hypervisor_uptime(hypervisor)
 
     def get_os_aggregates(self):
         return self._api.get_os_aggregates()

--- a/openstack_controller/requirements.in
+++ b/openstack_controller/requirements.in
@@ -1,1 +1,2 @@
-openstacksdk==0.24.0
+openstacksdk==0.58.0; python_version > "3.0"
+openstacksdk==0.39.0; python_version < "3.0"

--- a/openstack_controller/tests/terraform/main.tf
+++ b/openstack_controller/tests/terraform/main.tf
@@ -45,6 +45,7 @@ output "internal_ip" {
 
 output "ssh_private_key" {
   value = "${tls_private_key.ssh-key.private_key_pem}"
+  sensitive = true
 }
 
 output "ssh_public_key" {

--- a/openstack_controller/tests/test_simple_api.py
+++ b/openstack_controller/tests/test_simple_api.py
@@ -248,13 +248,15 @@ def get_os_hypervisor_uptime_post_v2_53_response(url, params=None, timeout=None)
 
 
 def test_get_os_hypervisor_uptime(aggregator, requests_wrapper):
+    hypervisor_mock = mock.MagicMock(id=1)
     with mock.patch(
         'datadog_checks.openstack_controller.api.SimpleApi._make_request',
         side_effect=get_os_hypervisor_uptime_pre_v2_52_response,
     ):
         api = SimpleApi(None, None, requests_wrapper)
         assert (
-            api.get_os_hypervisor_uptime(1) == " 08:32:11 up 93 days, 18:25, 12 users,  load average: 0.20, 0.12, 0.14"
+            api.get_os_hypervisor_uptime(hypervisor_mock)
+            == " 08:32:11 up 93 days, 18:25, 12 users,  load average: 0.20, 0.12, 0.14"
         )
 
     with mock.patch(
@@ -263,7 +265,8 @@ def test_get_os_hypervisor_uptime(aggregator, requests_wrapper):
     ):
         api = SimpleApi(None, None, requests_wrapper)
         assert (
-            api.get_os_hypervisor_uptime(1) == " 08:32:11 up 93 days, 18:25, 12 users,  load average: 0.20, 0.12, 0.14"
+            api.get_os_hypervisor_uptime(hypervisor_mock)
+            == " 08:32:11 up 93 days, 18:25, 12 users,  load average: 0.20, 0.12, 0.14"
         )
 
 


### PR DESCRIPTION
Bumping the openstacksdk dependencies to the latest on py2 and py3.

By bumping to 0.25.0+, the openstacksdk added the `get_server_diagnostics` method, we take that opportunity to fill the "NotImplementedException".

By bumping to 0.50.+ (py3 only), the openstacksdk added the `get_hypervisor_uptime` method. We take that opportunity to update the "NotImplementedException" only on py3.