### PR TITLE
fix Readiness check's description

### DIFF
--- a/gitlab/assets/service_checks.json
+++ b/gitlab/assets/service_checks.json
@@ -57,6 +57,6 @@
             "endpoint"
         ],
         "name": "Gitlab readiness",
-        "description": "Returns `CRITICAL` if the Gitlab instance is able to accept traffic via Rails Controllers."
+        "description": "Returns `CRITICAL` if the Gitlab instance is unable to accept traffic via Rails Controllers."
     }
 ]


### PR DESCRIPTION
Readiness check returns CRITICAL if gitlab instance is _unable_ to accept traffic

### What does this PR do?
Fixes a typo in the readme, reflecting that check will return CRITICAL if instance is _unable_ to accept traffic

### Motivation
Readme's should be accurate

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
