### PR TITLE
Send the correct hostname with postgres metrics when DBM is enabled

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -120,7 +120,7 @@ class RateLimitingTTLCache(TTLCache):
 
 def resolve_db_host(db_host):
     agent_hostname = datadog_agent.get_hostname()
-    if not db_host or db_host in {'localhost', '127.0.0.1'}:
+    if not db_host or db_host in {'localhost', '127.0.0.1'} or db_host.startswith('/'):
         return agent_hostname
 
     try:

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -67,7 +67,6 @@ class PostgresConfig:
             self.ignore_databases = [d for d in self.ignore_databases if d != 'postgres']
         self.custom_queries = instance.get('custom_queries', [])
         self.tag_replication_role = is_affirmative(instance.get('tag_replication_role', False))
-        self.service_check_tags = self._get_service_check_tags()
         self.custom_metrics = self._get_custom_metrics(instance.get('custom_metrics', []))
         self.max_relations = int(instance.get('max_relations', 300))
         self.min_collection_interval = instance.get('min_collection_interval', 15)
@@ -107,12 +106,6 @@ class PostgresConfig:
         if rds_tags:
             tags.extend(rds_tags)
         return tags
-
-    def _get_service_check_tags(self):
-        service_check_tags = ["host:%s" % self.host]
-        service_check_tags.extend(self.tags)
-        service_check_tags = list(set(service_check_tags))
-        return service_check_tags
 
     @staticmethod
     def _get_custom_metrics(custom_metrics):

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -81,7 +81,12 @@ class PostgreSql(AgentCheck):
     def _collect_wal_metrics(self, instance_tags):
         wal_file_age = self._get_wal_file_age()
         if wal_file_age is not None:
-            self.gauge("postgresql.wal_age", wal_file_age, tags=[t for t in instance_tags if not t.startswith("db:")], hostname=self.resolved_hostname)
+            self.gauge(
+                "postgresql.wal_age",
+                wal_file_age,
+                tags=[t for t in instance_tags if not t.startswith("db:")],
+                hostname=self.resolved_hostname,
+            )
 
     def _get_wal_dir(self):
         if self.version >= V10:
@@ -299,7 +304,12 @@ class PostgreSql(AgentCheck):
         cursor = self.db.cursor()
         results_len = self._query_scope(cursor, db_instance_metrics, instance_tags, False)
         if results_len is not None:
-            self.gauge("postgresql.db.count", results_len, tags=[t for t in instance_tags if not t.startswith("db:")], hostname=self.resolved_hostname)
+            self.gauge(
+                "postgresql.db.count",
+                results_len,
+                tags=[t for t in instance_tags if not t.startswith("db:")],
+                hostname=self.resolved_hostname,
+            )
 
         self._query_scope(cursor, bgw_instance_metrics, instance_tags, False)
         self._query_scope(cursor, archiver_instance_metrics, instance_tags, False)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -138,7 +138,7 @@ class PostgreSql(AgentCheck):
 
     @property
     def resolved_hostname(self):
-        if self._resolved_hostname is None:
+        if self._resolved_hostname is None and self._config.dbm_enabled:
             self._resolved_hostname = resolve_db_host(self._config.host)
         return self._resolved_hostname
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -536,7 +536,11 @@ class PostgreSql(AgentCheck):
                 self._config.host, self._config.port, self._config.dbname, str(e)
             )
             self.service_check(
-                self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=self._config.service_check_tags, message=message
+                self.SERVICE_CHECK_NAME,
+                AgentCheck.CRITICAL,
+                tags=self._config.service_check_tags,
+                message=message,
+                hostname=self.resolved_hostname,
             )
             raise e
         else:
@@ -546,7 +550,11 @@ class PostgreSql(AgentCheck):
                 self._config.dbname,
             )
             self.service_check(
-                self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=self._config.service_check_tags, message=message
+                self.SERVICE_CHECK_NAME,
+                AgentCheck.OK,
+                tags=self._config.service_check_tags,
+                message=message,
+                hostname=self.resolved_hostname,
             )
             try:
                 # commit to close the current query transaction

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -71,6 +71,13 @@ class PostgreSql(AgentCheck):
         self._is_aurora = None
         self.metrics_cache.clean_state()
 
+    def _get_service_check_tags(self):
+        host = self.resolved_hostname if self.resolved_hostname is not None else self._config.host
+        service_check_tags = ["host:%s" % host]
+        service_check_tags.extend(self._config.tags)
+        service_check_tags = list(set(service_check_tags))
+        return service_check_tags
+
     def _get_replication_role(self):
         cursor = self.db.cursor()
         cursor.execute('SELECT pg_is_in_recovery();')
@@ -538,7 +545,7 @@ class PostgreSql(AgentCheck):
             self.service_check(
                 self.SERVICE_CHECK_NAME,
                 AgentCheck.CRITICAL,
-                tags=self._config.service_check_tags,
+                tags=self._get_service_check_tags(),
                 message=message,
                 hostname=self.resolved_hostname,
             )
@@ -552,7 +559,7 @@ class PostgreSql(AgentCheck):
             self.service_check(
                 self.SERVICE_CHECK_NAME,
                 AgentCheck.OK,
-                tags=self._config.service_check_tags,
+                tags=self._get_service_check_tags(),
                 message=message,
                 hostname=self.resolved_hostname,
             )

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -11,6 +11,7 @@ import psycopg2
 from six import iteritems
 
 from datadog_checks.base import AgentCheck
+from datadog_checks.base.utils.db.utils import resolve_db_host
 from datadog_checks.postgres.metrics_cache import PostgresMetricsCache
 from datadog_checks.postgres.relationsmanager import RELATION_METRICS, RelationsManager
 from datadog_checks.postgres.statement_samples import PostgresStatementSamples
@@ -494,6 +495,7 @@ class PostgreSql(AgentCheck):
 
     def check(self, _):
         tags = copy.copy(self._config.tags)
+        tags.append('host:{}'.format(resolve_db_host(self._config.host)))
         # Collect metrics
         try:
             # Check version

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -173,9 +173,17 @@ class PostgresStatementSamples(DBMAsyncJob):
             cursor.execute(query, params)
             rows = cursor.fetchall()
         self._check.histogram(
-            "dd.postgres.get_new_pg_stat_activity.time", (time.time() - start_time) * 1000, tags=self._tags
+            "dd.postgres.get_new_pg_stat_activity.time",
+            (time.time() - start_time) * 1000,
+            tags=self._tags + self._check._get_debug_tags(),
+            hostname=self._check.resolved_hostname,
         )
-        self._check.histogram("dd.postgres.get_new_pg_stat_activity.rows", len(rows), tags=self._tags)
+        self._check.histogram(
+            "dd.postgres.get_new_pg_stat_activity.rows",
+            len(rows),
+            tags=self._tags + self._check._get_debug_tags(),
+            hostname=self._check.resolved_hostname,
+        )
         self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)
         return rows
 
@@ -202,7 +210,8 @@ class PostgresStatementSamples(DBMAsyncJob):
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 insufficient_privilege_count,
-                tags=self._tags + ["error:insufficient-privilege"],
+                tags=self._tags + ["error:insufficient-privilege"] + self._check._get_debug_tags(),
+                hostname=self._check.resolved_hostname,
             )
 
     def run_job(self):
@@ -219,19 +228,29 @@ class PostgresStatementSamples(DBMAsyncJob):
             self._check.database_monitoring_query_sample(json.dumps(e, default=default_json_event_encoding))
             submitted_count += 1
         elapsed_ms = (time.time() - start_time) * 1000
-        self._check.histogram("dd.postgres.collect_statement_samples.time", elapsed_ms, tags=self._tags)
+        self._check.histogram(
+            "dd.postgres.collect_statement_samples.time",
+            elapsed_ms,
+            tags=self._tags + self._check._get_debug_tags(),
+            hostname=self._check.resolved_hostname,
+        )
         self._check.count(
-            "dd.postgres.collect_statement_samples.events_submitted.count", submitted_count, tags=self._tags
+            "dd.postgres.collect_statement_samples.events_submitted.count",
+            submitted_count,
+            tags=self._tags + self._check._get_debug_tags(),
+            hostname=self._check.resolved_hostname,
         )
         self._check.gauge(
             "dd.postgres.collect_statement_samples.seen_samples_cache.len",
             len(self._seen_samples_ratelimiter),
-            tags=self._tags,
+            tags=self._tags + self._check._get_debug_tags(),
+            hostname=self._check.resolved_hostname,
         )
         self._check.gauge(
             "dd.postgres.collect_statement_samples.explained_statements_cache.len",
             len(self._explained_statements_ratelimiter),
-            tags=self._tags,
+            tags=self._tags + self._check._get_debug_tags(),
+            hostname=self._check.resolved_hostname,
         )
 
     def _can_explain_statement(self, obfuscated_statement):
@@ -294,7 +313,10 @@ class PostgresStatementSamples(DBMAsyncJob):
             )
             result = cursor.fetchone()
             self._check.histogram(
-                "dd.postgres.run_explain.time", (time.time() - start_time) * 1000, tags=self._dbtags(dbname)
+                "dd.postgres.run_explain.time",
+                (time.time() - start_time) * 1000,
+                tags=self._dbtags(dbname) + self._check._get_debug_tags(),
+                hostname=self._check.resolved_hostname,
             )
             if not result or len(result) < 1 or len(result[0]) < 1:
                 return None
@@ -311,7 +333,9 @@ class PostgresStatementSamples(DBMAsyncJob):
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 1,
-                tags=self._dbtags(dbname, "error:explain-{}".format(DBExplainError.query_truncated)),
+                tags=self._dbtags(dbname, "error:explain-{}".format(DBExplainError.query_truncated))
+                + self._check._get_debug_tags(),
+                hostname=self._check.resolved_hostname,
             )
             return (
                 None,
@@ -324,7 +348,8 @@ class PostgresStatementSamples(DBMAsyncJob):
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 1,
-                tags=self._dbtags(dbname, "error:explain-{}".format(db_explain_error)),
+                tags=self._dbtags(dbname, "error:explain-{}".format(db_explain_error)) + self._check._get_debug_tags(),
+                hostname=self._check.resolved_hostname,
             )
             return None, db_explain_error, '{}'.format(type(err))
 
@@ -335,7 +360,8 @@ class PostgresStatementSamples(DBMAsyncJob):
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 1,
-                tags=self._dbtags(dbname, "error:explain-{}".format(type(e))),
+                tags=self._dbtags(dbname, "error:explain-{}".format(type(e))) + self._check._get_debug_tags(),
+                hostname=self._check.resolved_hostname,
             )
             return None, DBExplainError.database_error, '{}'.format(type(err))
 
@@ -345,7 +371,10 @@ class PostgresStatementSamples(DBMAsyncJob):
         except Exception as e:
             self._log.debug("Failed to obfuscate statement: %s", e)
             self._check.count(
-                "dd.postgres.statement_samples.error", 1, tags=self._dbtags(row['datname'], "error:sql-obfuscate")
+                "dd.postgres.statement_samples.error",
+                1,
+                tags=self._dbtags(row['datname'], "error:sql-obfuscate") + self._check._get_debug_tags(),
+                hostname=self._check.resolved_hostname,
             )
             return None
 
@@ -434,7 +463,8 @@ class PostgresStatementSamples(DBMAsyncJob):
                 self._check.count(
                     "dd.postgres.statement_samples.error",
                     1,
-                    tags=self._tags + ["error:collect-plan-for-statement-crash"],
+                    tags=self._tags + ["error:collect-plan-for-statement-crash"] + self._check._get_debug_tags(),
+                    hostname=self._check.resolved_hostname,
                 )
 
     @staticmethod

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -14,7 +14,7 @@ from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.statement_metrics import StatementMetrics
-from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, resolve_db_host
+from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding
 from datadog_checks.base.utils.serialization import json
 
 try:
@@ -149,12 +149,6 @@ class PostgresStatementMetrics(DBMAsyncJob):
         self._stat_column_cache = col_names
         return col_names
 
-    def _db_hostname_cached(self):
-        if self._db_hostname:
-            return self._db_hostname
-        self._db_hostname = resolve_db_host(self._config.host)
-        return self._db_hostname
-
     def run_job(self):
         self._tags_no_db = [t for t in self._tags if not t.startswith('db:')]
         self.collect_per_statement_metrics()
@@ -179,7 +173,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             for row in rows:
                 row['query'] = row['query'][0:200]
             payload = {
-                'host': self._db_hostname_cached(),
+                'host': self._check.resolved_hostname,
                 'timestamp': time.time() * 1000,
                 'min_collection_interval': self._metrics_collection_interval,
                 'tags': self._tags_no_db,
@@ -203,7 +197,12 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 self._check.count(
                     "dd.postgres.statement_metrics.error",
                     1,
-                    tags=self._tags + ["error:database-missing_pg_stat_statements_required_columns"],
+                    tags=self._tags
+                    + [
+                        "error:database-missing_pg_stat_statements_required_columns",
+                    ]
+                    + self._check._get_debug_tags(),
+                    hostname=self._check.resolved_hostname,
                 )
                 return []
 
@@ -241,7 +240,12 @@ class PostgresStatementMetrics(DBMAsyncJob):
             else:
                 self._log.warning("Unable to collect statement metrics because of an error running queries: %s", e)
 
-            self._check.count("dd.postgres.statement_metrics.error", 1, tags=self._tags + [error_tag])
+            self._check.count(
+                "dd.postgres.statement_metrics.error",
+                1,
+                tags=self._tags + [error_tag] + self._check._get_debug_tags(),
+                hostname=self._check.resolved_hostname,
+            )
 
             return []
 
@@ -255,7 +259,12 @@ class PostgresStatementMetrics(DBMAsyncJob):
         available_columns = set(rows[0].keys())
         metric_columns = available_columns & PG_STAT_STATEMENTS_METRICS_COLUMNS
         rows = self._state.compute_derivative_rows(rows, metric_columns, key=_row_key)
-        self._check.gauge('dd.postgres.queries.query_rows_raw', len(rows))
+        self._check.gauge(
+            'dd.postgres.queries.query_rows_raw',
+            len(rows),
+            tags=self._tags + self._check._get_debug_tags(),
+            hostname=self._check.resolved_hostname,
+        )
         return rows
 
     def _normalize_queries(self, rows):
@@ -287,7 +296,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             ]
             yield {
                 "timestamp": time.time() * 1000,
-                "host": self._db_hostname_cached(),
+                "host": self._check.resolved_hostname,
                 "ddsource": "postgres",
                 "ddtags": ",".join(row_tags),
                 "dbm_type": "fqt",


### PR DESCRIPTION
### What does this PR do?

This change adds the correct resolved hostname to metrics and the service check when DBM is enabled. At some point, we should apply this change to all installations (not just when dbm is enabled), but that will require a more detailed rollout plan since that is potentially breaking to a small number of customers.

### Motivation

Currently if an agent is monitoring a remote host such as an Aurora, RDS, or CloudSQL host, only the agent hostname is available as the `host:` tag. The agent host tag has limited usefulness as an identifier because a single agent is often used to monitor many remote hosts. This change replaces the agent hostname with the remote host (such as `mydb.cfxxae8cilce.us-east-1.rds.amazonaws.com`).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
