### PR TITLE
Add note about dependencies

### DIFF
--- a/elastic/requirements.in
+++ b/elastic/requirements.in
@@ -1,1 +1,2 @@
-
+# If a client library is required use the one that supports the most variants, see:
+# https://aws.amazon.com/blogs/opensource/keeping-clients-of-opensearch-and-elasticsearch-compatible-with-open-source/


### PR DESCRIPTION
### Motivation

the official Elasticsearch Python library no longer works with forks