### PR TITLE
Add annotations to legacy agent signature

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -38,3 +38,7 @@ jobs:
     - name: Run HTTP wrapper validation
       run: |
         ddev validate http
+
+    - name: Run legacy signature validation
+      run: |
+        ddev validate legacy-signature

--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -39,7 +39,7 @@ class Couchbase(AgentCheck):
 
     HTTP_CONFIG_REMAPPER = {'user': {'name': 'username'}, 'ssl_verify': {'name': 'tls_verify'}}
 
-    def __init__(self, name, init_config, instances):
+    def __init__(self, name, init_config, agentConfig, instances):
         super(Couchbase, self).__init__(name, init_config, instances)
 
         self._sync_gateway_url = self.instance.get('sync_gateway_url', None)

--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -59,7 +59,6 @@ class Couchbase(AgentCheck):
                 if val is not None:
                     metric_name = 'couchbase.{}.{}'.format(key, self.camel_case_to_joined_lower(metric_name))
                     self.gauge(metric_name, val, tags=self._tags)
-                    a = requests.get("hi")
 
         # Get bucket metrics
         for bucket_name, bucket_stats in data['buckets'].items():

--- a/couchbase/datadog_checks/couchbase/couchbase.py
+++ b/couchbase/datadog_checks/couchbase/couchbase.py
@@ -39,7 +39,7 @@ class Couchbase(AgentCheck):
 
     HTTP_CONFIG_REMAPPER = {'user': {'name': 'username'}, 'ssl_verify': {'name': 'tls_verify'}}
 
-    def __init__(self, name, init_config, agentConfig, instances):
+    def __init__(self, name, init_config, instances):
         super(Couchbase, self).__init__(name, init_config, instances)
 
         self._sync_gateway_url = self.instance.get('sync_gateway_url', None)
@@ -59,6 +59,7 @@ class Couchbase(AgentCheck):
                 if val is not None:
                     metric_name = 'couchbase.{}.{}'.format(key, self.camel_case_to_joined_lower(metric_name))
                     self.gauge(metric_name, val, tags=self._tags)
+                    a = requests.get("hi")
 
         # Get bucket metrics
         for bucket_name, bucket_stats in data['buckets'].items():

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_signature.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_signature.py
@@ -39,7 +39,7 @@ def legacy_signature(check):
             print_github_annotation(
                 failed_file_path,
                 "Detected use of legacy agent signature, please use the new signature",
-                level="warning",
+                level="error",
                 line=failed_num,
             )
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_signature.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_signature.py
@@ -2,7 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import os
+
 import click
+
+from datadog_checks.dev.utils import print_github_annotation
 
 from ...testing import process_checks_option
 from ...utils import complete_valid_checks, find_legacy_signature
@@ -29,8 +33,15 @@ def legacy_signature(check):
         check_failed = find_legacy_signature(check)
         if check_failed is not None:
             has_failed = True
-            failed_file, failed_num = check_failed
+            failed_file_path, failed_num = check_failed
+            failed_file = os.path.basename(failed_file_path)
             echo_failure(f"Check `{check}` uses legacy agent signature in `{failed_file}` on line {failed_num}")
+            print_github_annotation(
+                failed_file_path,
+                "Detected use of legacy agent signature, please use the new signature",
+                level="warning",
+                line=failed_num,
+            )
 
     if not has_failed:
         if check:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_signature.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_signature.py
@@ -40,7 +40,7 @@ def legacy_signature(check):
                 failed_file_path,
                 "Detected use of legacy agent signature, please use the new signature",
                 level="error",
-                line=failed_num,
+                line=failed_num + 1,
             )
 
     if not has_failed:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_signature.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_signature.py
@@ -40,7 +40,7 @@ def legacy_signature(check):
                 failed_file_path,
                 "Detected use of legacy agent signature, please use the new signature",
                 level="error",
-                line=failed_num + 1,
+                line=failed_num,
             )
 
     if not has_failed:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -666,5 +666,5 @@ def find_legacy_signature(check):
                 with open(file_path) as test_file:
                     for num, line in enumerate(test_file):
                         if "__init__" in line and "agentConfig" in line:
-                            return file_path, num
+                            return file_path, num + 1
     return None

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -662,8 +662,9 @@ def find_legacy_signature(check):
     for path, _, files in os.walk(get_check_directory(check)):
         for f in files:
             if f.endswith('.py'):
-                with open(os.path.join(path, f)) as test_file:
+                file_path = os.path.join(path, f)
+                with open(file_path) as test_file:
                     for num, line in enumerate(test_file):
                         if "__init__" in line and "agentConfig" in line:
-                            return str(f), num
+                            return file_path, num
     return None


### PR DESCRIPTION
### What does this PR do?

This PR continues to add validations to Github actions workflow. This PR adds `ddev validate legacy-signature` validation.


### Motivation
This PR is a follow up to https://github.com/DataDog/integrations-core/pull/9868


### Additional Notes
When a PR contains a check using an outdated agent signature, the validations workflow should annotate the line with an error message and suggestion.

<!-- Anything else we should know when reviewing? -->
<img width="1222" alt="Screen Shot 2021-08-10 at 10 37 17 PM" src="https://user-images.githubusercontent.com/15065007/128961146-75a4fbf8-4ce0-4ce3-8504-4932fa47fab1.png">


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
