### PR TITLE
Extend `QueryManager` query type

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -59,8 +59,8 @@ class Query(object):
         query = self.query_data.get('query')
         if not query:
             raise ValueError('field `query` for {} is required'.format(query_name))
-        elif not isinstance(query, str):
-            raise ValueError('field `query` for {} must be a string'.format(query_name))
+        elif not isinstance(query, str) and not isinstance(query, dict):
+            raise ValueError('field `query` for {} must be a string or a mapping'.format(query_name))
 
         columns = self.query_data.get('columns')
         if not columns:

--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -59,8 +59,8 @@ class Query(object):
         query = self.query_data.get('query')
         if not query:
             raise ValueError('field `query` for {} is required'.format(query_name))
-        elif not isinstance(query, (str, dict)):
-            raise ValueError('field `query` for {} must be a string or a mapping'.format(query_name))
+        elif query_name.startswith('custom query #') and not isinstance(query, str):
+            raise ValueError('field `query` for {} must be a string'.format(query_name))
 
         columns = self.query_data.get('columns')
         if not columns:

--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -59,7 +59,7 @@ class Query(object):
         query = self.query_data.get('query')
         if not query:
             raise ValueError('field `query` for {} is required'.format(query_name))
-        elif not isinstance(query, str) and not isinstance(query, dict):
+        elif not isinstance(query, (str, dict)):
             raise ValueError('field `query` for {} must be a string or a mapping'.format(query_name))
 
         columns = self.query_data.get('columns')

--- a/datadog_checks_base/tests/base/utils/db/test_query_manager.py
+++ b/datadog_checks_base/tests/base/utils/db/test_query_manager.py
@@ -33,10 +33,10 @@ class TestQueryCompilation:
         with pytest.raises(ValueError, match='^field `query` for test query is required$'):
             query_manager.compile_queries()
 
-    def test_query_not_string(self):
+    def test_query_not_string_or_dict(self):
         query_manager = create_query_manager({'name': 'test query', 'query': 5})
 
-        with pytest.raises(ValueError, match='^field `query` for test query must be a string$'):
+        with pytest.raises(ValueError, match='^field `query` for test query must be a string or a mapping$'):
             query_manager.compile_queries()
 
     def test_no_columns(self):

--- a/datadog_checks_base/tests/base/utils/db/test_query_manager.py
+++ b/datadog_checks_base/tests/base/utils/db/test_query_manager.py
@@ -33,10 +33,10 @@ class TestQueryCompilation:
         with pytest.raises(ValueError, match='^field `query` for test query is required$'):
             query_manager.compile_queries()
 
-    def test_query_not_string_or_dict(self):
-        query_manager = create_query_manager({'name': 'test query', 'query': 5})
+    def test_custom_query_not_string(self):
+        query_manager = create_query_manager({'name': 'custom query #1', 'query': {'query': 'example'}})
 
-        with pytest.raises(ValueError, match='^field `query` for test query must be a string or a mapping$'):
+        with pytest.raises(ValueError, match='^field `query` for custom query #1 must be a string$'):
             query_manager.compile_queries()
 
     def test_no_columns(self):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Extends `QueryManager` query type to allow mappings.

### Motivation
<!-- What inspired you to submit this pull request? -->

Needed for IBM i integration, see #9720.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

As of now it should be a no-op.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
