### PR TITLE
[Synthetics][SSV-789] Support the `hop` metric unit

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -201,6 +201,7 @@ VALID_UNIT_NAMES = {
     'span',
     'exception',
     'run',
+    'hop',
 }
 
 ALLOWED_PREFIXES = ['system', 'jvm', 'http', 'datadog', 'sftp']


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Add `hop` metric unit to the documentation

### Motivation
<!-- What inspired you to submit this pull request?-->
The `hop` unit is needed for metadata support for the metric `synthetics.icmp.hops`, to count the number of hops involved in a ping request
https://datadoghq.atlassian.net/browse/SSV-789

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
