### PR TITLE
Send the correct hostname with metrics when DBM is enabled

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -228,10 +228,14 @@ class MySql(AgentCheck):
             db = pymysql.connect(**connect_args)
             self.log.debug("Connected to MySQL")
             self.service_check_tags = list(set(service_check_tags))
-            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags)
+            self.service_check(
+                self.SERVICE_CHECK_NAME, AgentCheck.OK, tags=service_check_tags, hostname=self.resolved_hostname
+            )
             yield db
         except Exception:
-            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags)
+            self.service_check(
+                self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=service_check_tags, hostname=self.resolved_hostname
+            )
             raise
         finally:
             if db:

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -59,6 +59,11 @@ try:
 except ImportError:
     PSUTIL_AVAILABLE = False
 
+try:
+    import datadog_agent
+except ImportError:
+    from ..stubs import datadog_agent
+
 
 if PY3:
     long = int
@@ -76,6 +81,7 @@ class MySql(AgentCheck):
         self.version = None
         self.is_mariadb = None
         self._resolved_hostname = None
+        self._agent_hostname = None
         self._is_aurora = None
         self._config = MySQLConfig(self.instance)
 
@@ -105,6 +111,9 @@ class MySql(AgentCheck):
         if self._resolved_hostname is None and self._config.dbm_enabled:
             self._resolved_hostname = resolve_db_host(self._config.host)
         return self._resolved_hostname
+
+    def _get_debug_tags(self):
+        return ['agent_hostname:{}'.format(datadog_agent.get_hostname())]
 
     @classmethod
     def get_library_versions(cls):

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -124,7 +124,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
                 row['digest_text'] = row['digest_text'][0:200]
 
             payload = {
-                'host': self._db_hostname,
+                'host': self._check.resolved_hostname,
                 'timestamp': time.time() * 1000,
                 'min_collection_interval': self._metric_collection_interval,
                 'tags': self._tags,
@@ -207,7 +207,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
             row_tags = self._tags + ["schema:{}".format(row['schema_name'])] if row['schema_name'] else self._tags
             yield {
                 "timestamp": time.time() * 1000,
-                "host": self._db_hostname,
+                "host": self._check.resolved_hostname,
                 "ddsource": "mysql",
                 "ddtags": ",".join(row_tags),
                 "dbm_type": "fqt",

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -233,6 +233,34 @@ def test_complex_config_replica(aggregator, dd_run_check, instance_complex):
     )
 
 
+@pytest.mark.parametrize('dbm_enabled', (True, False))
+def test_correct_hostname(dbm_enabled, aggregator, dd_run_check, instance_basic):
+    instance_basic['dbm'] = dbm_enabled
+    mysql_check = MySql(common.CHECK_NAME, {}, [instance_basic])
+    dd_run_check(mysql_check)
+
+    expected_hostname = 'stubbed.hostname' if dbm_enabled else None
+
+    aggregator.assert_service_check(
+        'mysql.can_connect', status=MySql.OK, tags=tags.SC_TAGS_MIN, count=1, hostname=expected_hostname
+    )
+
+    testable_metrics = variables.STATUS_VARS + variables.VARIABLES_VARS + variables.INNODB_VARS + variables.BINLOG_VARS
+    for metric_name in testable_metrics:
+        aggregator.assert_metric(metric_name, hostname=expected_hostname)
+
+    optional_metrics = (
+        variables.COMPLEX_STATUS_VARS
+        + variables.COMPLEX_VARIABLES_VARS
+        + variables.COMPLEX_INNODB_VARS
+        + variables.SYSTEM_METRICS
+        + variables.SYNTHETIC_VARS
+    )
+
+    for metric_name in optional_metrics:
+        aggregator.assert_metric(metric_name, hostname=expected_hostname, at_least=0)
+
+
 def _test_optional_metrics(aggregator, optional_metrics):
     """
     Check optional metrics - They can either be present or not


### PR DESCRIPTION
### What does this PR do?

Postgres version of the PR: https://github.com/DataDog/integrations-core/pull/9865

This change adds the correct resolved hostname to metrics and the service check when DBM is enabled. At some point, we should apply this change to all installations (not just when dbm is enabled), but that will require a more detailed rollout plan since that is potentially breaking to a small number of customers.

### Motivation
Currently if an agent is monitoring a remote host such as an Aurora, RDS, or CloudSQL host, only the agent hostname is available as the `host:` tag. The agent host tag has limited usefulness as an identifier because a single agent is often used to monitor many remote hosts. This change replaces the agent hostname with the remote host (such as `mydb.cfxxae8cilce.us-east-1.rds.amazonaws.com`).


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
