### PR TITLE
Fix documented default value of `use_legacy_auth_encoding`

### DIFF
--- a/rabbitmq/assets/configuration/spec.yaml
+++ b/rabbitmq/assets/configuration/spec.yaml
@@ -127,6 +127,8 @@ files:
           - <VHOST_NAME_1>
           - <VHOST_NAME_2>
     - template: instances/http
+      overrides:
+        use_legacy_auth_encoding.value.example: false
     - template: instances/default
   - template: logs
     example:

--- a/rabbitmq/datadog_checks/rabbitmq/config_models/defaults.py
+++ b/rabbitmq/datadog_checks/rabbitmq/config_models/defaults.py
@@ -185,7 +185,7 @@ def instance_tls_verify(field, value):
 
 
 def instance_use_legacy_auth_encoding(field, value):
-    return True
+    return False
 
 
 def instance_username(field, value):

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -202,10 +202,10 @@ instances:
     #
     # auth_type: basic
 
-    ## @param use_legacy_auth_encoding - boolean - optional - default: true
+    ## @param use_legacy_auth_encoding - boolean - optional - default: false
     ## When `auth_type` is set to `basic`, this determines whether to encode as `latin1` rather than `utf-8`.
     #
-    # use_legacy_auth_encoding: true
+    # use_legacy_auth_encoding: false
 
     ## @param username - string - optional
     ## The username to use if services are behind basic or digest auth.


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/integrations-core/pull/7451