### PR TITLE
Update conf.yaml.example

### DIFF
--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -44,12 +44,13 @@ instances:
     #
   - name: <NAME>
 
+    ## Note: One and only one of search_string, pid or pid_file must be specified per instance.
+    
     ## @param search_string - list of strings - optional
     ## If one of the elements in the list matches, it return the count of
     ## all the processes that match the string exactly by default. Change this behavior with the
     ## parameter `exact_match: false`.
     ##
-    ## Note: One and only one of search_string, pid or pid_file must be specified per instance.
     #
     # search_string:
     #   - <SEARCH_STRING_1>


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Moving ln 52 to 46 in order to make it clear that one and only one of search_string, pid or pid_file must be specified per instance.

### Motivation
<!-- What inspired you to submit this pull request? -->
Due to the level of the comment, it seems that all 3 options are optional and not required.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
