### PR TITLE
Update postgres obfuscator options config

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -323,9 +323,9 @@ files:
     - name: obfuscator_options
       description: Configure how the SQL obfuscator behaves.
       options:
-        - name: quantize_sql
+        - name: replace_digits
           description: |
-            Set to `true` to perform quantization on your SQL statements.
+            Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
 
             Note that this option only applies when `dbm` is enabled.
           value:

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -323,9 +323,9 @@ files:
     - name: obfuscator_options
       description: Configure how the SQL obfuscator behaves.
       options:
-        - name: quantize_sql_tables
+        - name: quantize_sql
           description: |
-            Set to `true` to perform quantization on your SQL tables.
+            Set to `true` to perform quantization on your SQL statements.
 
             Note that this option only applies when `dbm` is enabled.
           value:

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -83,7 +83,12 @@ class PostgresConfig:
         self.pg_stat_activity_view = instance.get('pg_stat_activity_view', 'pg_stat_activity')
         self.statement_samples_config = instance.get('query_samples', instance.get('statement_samples', {})) or {}
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}
-        self.obfuscator_options = instance.get('obfuscator_options', {}) or {}
+        obfuscator_options_config = instance.get('obfuscator_options', {}) or {}
+        self.obfuscator_options = {
+            'replace_digits': obfuscator_options_config.get(
+                'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
+            )
+        }
 
     def _build_tags(self, custom_tags):
         # Clean up tags in case there was a None entry in the instance

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -17,7 +17,7 @@ class ObfuscatorOptions(BaseModel):
     class Config:
         allow_mutation = False
 
-    quantize_sql: Optional[bool]
+    replace_digits: Optional[bool]
 
 
 class QueryMetrics(BaseModel):

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -17,7 +17,7 @@ class ObfuscatorOptions(BaseModel):
     class Config:
         allow_mutation = False
 
-    quantize_sql_tables: Optional[bool]
+    quantize_sql: Optional[bool]
 
 
 class QueryMetrics(BaseModel):

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -274,12 +274,12 @@ instances:
     #
     obfuscator_options:
 
-        ## @param quantize_sql - boolean - optional - default: false
-        ## Set to `true` to perform quantization on your SQL statements.
+        ## @param replace_digits - boolean - optional - default: false
+        ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
         ##
         ## Note that this option only applies when `dbm` is enabled.
         #
-        # quantize_sql: false
+        # replace_digits: false
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -316,7 +316,7 @@ instances:
 ## port / path / channel_path - required - Set port if type is tcp or udp.
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
-## source  - required - Attribute that defines which Integration sent the logs.
+## source  - required - Attribute that defines which integration sent the logs.
 ## encoding - optional - For file specifies the file encoding, default is utf-8, other
 ##                       possible values are utf-16-le and utf-16-be.
 ## service - optional - The name of the service that generates the log.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -274,12 +274,12 @@ instances:
     #
     obfuscator_options:
 
-        ## @param quantize_sql_tables - boolean - optional - default: false
-        ## Set to `true` to perform quantization on your SQL tables.
+        ## @param quantize_sql - boolean - optional - default: false
+        ## Set to `true` to perform quantization on your SQL statements.
         ##
         ## Note that this option only applies when `dbm` is enabled.
         #
-        # quantize_sql_tables: false
+        # quantize_sql: false
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
@@ -316,7 +316,7 @@ instances:
 ## port / path / channel_path - required - Set port if type is tcp or udp.
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
-## source  - required - Attribute that defines which integration sent the logs.
+## source  - required - Attribute that defines which Integration sent the logs.
 ## encoding - optional - For file specifies the file encoding, default is utf-8, other
 ##                       possible values are utf-16-le and utf-16-be.
 ## service - optional - The name of the service that generates the log.

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -121,15 +121,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         self._tags_no_db = None
         # The value is loaded when connecting to the main database
         self._explain_function = config.statement_samples_config.get('explain_function', 'datadog.explain_statement')
-        self._obfuscate_options = to_native_string(
-            json.dumps(
-                {
-                    'quantize_sql': self._config.obfuscator_options.get(
-                        'quantize_sql', self._config.obfuscator_options.get('quantize_sql_tables', False)
-                    )
-                }
-            )
-        )
+        self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
 
         self._collection_strategy_cache = TTLCache(
             maxsize=config.statement_samples_config.get('collection_strategy_cache_maxsize', 1000),

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -125,7 +125,7 @@ class PostgresStatementSamples(DBMAsyncJob):
             json.dumps(
                 {
                     'quantize_sql': self._config.obfuscator_options.get(
-                        'quantize_sql', self._config.get('quantize_sql_tables', False)
+                        'quantize_sql', self._config.obfuscator_options.get('quantize_sql_tables', False)
                     )
                 }
             )

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -122,7 +122,13 @@ class PostgresStatementSamples(DBMAsyncJob):
         # The value is loaded when connecting to the main database
         self._explain_function = config.statement_samples_config.get('explain_function', 'datadog.explain_statement')
         self._obfuscate_options = to_native_string(
-            json.dumps({'quantize_sql_tables': self._config.obfuscator_options.get('quantize_sql_tables', False)})
+            json.dumps(
+                {
+                    'quantize_sql': self._config.obfuscator_options.get(
+                        'quantize_sql', self._config.get('quantize_sql_tables', False)
+                    )
+                }
+            )
         )
 
         self._collection_strategy_cache = TTLCache(

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -110,15 +110,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
         self._config = config
         self._state = StatementMetrics()
         self._stat_column_cache = []
-        self._obfuscate_options = to_native_string(
-            json.dumps(
-                {
-                    'quantize_sql': self._config.obfuscator_options.get(
-                        'quantize_sql', self._config.obfuscator_options.get('quantize_sql_tables', False)
-                    )
-                }
-            )
-        )
+        self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
         # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature
         self._full_statement_text_cache = TTLCache(
             maxsize=config.full_statement_text_cache_max_size,

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -111,7 +111,13 @@ class PostgresStatementMetrics(DBMAsyncJob):
         self._state = StatementMetrics()
         self._stat_column_cache = []
         self._obfuscate_options = to_native_string(
-            json.dumps({'quantize_sql_tables': self._config.obfuscator_options.get('quantize_sql_tables', False)})
+            json.dumps(
+                {
+                    'quantize_sql': self._config.obfuscator_options.get(
+                        'quantize_sql', self._config.get('quantize_sql_tables', False)
+                    )
+                }
+            )
         )
         # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature
         self._full_statement_text_cache = TTLCache(

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -114,7 +114,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             json.dumps(
                 {
                     'quantize_sql': self._config.obfuscator_options.get(
-                        'quantize_sql', self._config.get('quantize_sql_tables', False)
+                        'quantize_sql', self._config.obfuscator_options.get('quantize_sql_tables', False)
                     )
                 }
             )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the Postgres integration config field `quantize_sql_tables` to `replace_digits` to reflect the changes being made in the datadog-agent. More information can be found in this PR: https://github.com/DataDog/datadog-agent/pull/8860

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
