### PR TITLE
Update mysql obfuscator options config

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -369,9 +369,9 @@ files:
           - name: obfuscator_options
             description: Configure how the SQL obfuscator behaves.
             options:
-              - name: quantize_sql
+              - name: replace_digits
                 description: |
-                  Set to `true` to perform quantization on your SQL statements.
+                  Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
 
                   Note that this option only applies when `dbm` is enabled.
                 value:

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -369,9 +369,9 @@ files:
           - name: obfuscator_options
             description: Configure how the SQL obfuscator behaves.
             options:
-              - name: quantize_sql_tables
+              - name: quantize_sql
                 description: |
-                  Set to `true` to perform quantization on your SQL tables.
+                  Set to `true` to perform quantization on your SQL statements.
 
                   Note that this option only applies when `dbm` is enabled.
                 value:

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -37,7 +37,12 @@ class MySQLConfig(object):
         self.statement_samples_config = instance.get('query_samples', instance.get('statement_samples', {})) or {}
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}
         self.min_collection_interval = instance.get('min_collection_interval', 15)
-        self.obfuscator_options = instance.get('obfuscator_options', {}) or {}
+        obfuscator_options_config = instance.get('obfuscator_options', {}) or {}
+        self.obfuscator_options = {
+            'replace_digits': obfuscator_options_config.get(
+                'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
+            )
+        }
         self.configuration_checks()
 
     def _build_tags(self, custom_tags):

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -26,7 +26,7 @@ class ObfuscatorOptions(BaseModel):
     class Config:
         allow_mutation = False
 
-    quantize_sql_tables: Optional[bool]
+    quantize_sql: Optional[bool]
 
 
 class Options(BaseModel):

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -26,7 +26,7 @@ class ObfuscatorOptions(BaseModel):
     class Config:
         allow_mutation = False
 
-    quantize_sql: Optional[bool]
+    replace_digits: Optional[bool]
 
 
 class Options(BaseModel):

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -383,7 +383,7 @@ instances:
 ## port / path / channel_path - required - Set port if type is tcp or udp.
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
-## source  - required - Attribute that defines which Integration sent the logs.
+## source  - required - Attribute that defines which integration sent the logs.
 ## encoding - optional - For file specifies the file encoding, default is utf-8, other
 ##                       possible values are utf-16-le and utf-16-be.
 ## service - optional - The name of the service that generates the log.

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -341,12 +341,12 @@ instances:
     #
     obfuscator_options:
 
-        ## @param quantize_sql_tables - boolean - optional - default: false
-        ## Set to `true` to perform quantization on your SQL tables.
+        ## @param quantize_sql - boolean - optional - default: false
+        ## Set to `true` to perform quantization on your SQL statements.
         ##
         ## Note that this option only applies when `dbm` is enabled.
         #
-        # quantize_sql_tables: false
+        # quantize_sql: false
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
@@ -383,7 +383,7 @@ instances:
 ## port / path / channel_path - required - Set port if type is tcp or udp.
 ##                                         Set path if type is file.
 ##                                         Set channel_path if type is windows_event.
-## source  - required - Attribute that defines which integration sent the logs.
+## source  - required - Attribute that defines which Integration sent the logs.
 ## encoding - optional - For file specifies the file encoding, default is utf-8, other
 ##                       possible values are utf-16-le and utf-16-be.
 ## service - optional - The name of the service that generates the log.

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -341,12 +341,12 @@ instances:
     #
     obfuscator_options:
 
-        ## @param quantize_sql - boolean - optional - default: false
-        ## Set to `true` to perform quantization on your SQL statements.
+        ## @param replace_digits - boolean - optional - default: false
+        ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
         ##
         ## Note that this option only applies when `dbm` is enabled.
         #
-        # quantize_sql: false
+        # replace_digits: false
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -293,7 +293,7 @@ class MySQLStatementSamples(DBMAsyncJob):
             json.dumps(
                 {
                     'quantize_sql': self._config.obfuscator_options.get(
-                        'quantize_sql', self._config.get('quantize_sql_tables', False)
+                        'quantize_sql', self._config.obfuscator_options.get('quantize_sql_tables', False)
                     )
                 }
             )

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -290,7 +290,13 @@ class MySQLStatementSamples(DBMAsyncJob):
         }
         self._preferred_explain_strategies = ['PROCEDURE', 'FQ_PROCEDURE', 'STATEMENT']
         self._obfuscate_options = to_native_string(
-            json.dumps({'quantize_sql_tables': self._config.obfuscator_options.get('quantize_sql_tables', False)})
+            json.dumps(
+                {
+                    'quantize_sql': self._config.obfuscator_options.get(
+                        'quantize_sql', self._config.get('quantize_sql_tables', False)
+                    )
+                }
+            )
         )
         self._init_caches()
 

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -289,15 +289,7 @@ class MySQLStatementSamples(DBMAsyncJob):
             'STATEMENT': self._run_explain,
         }
         self._preferred_explain_strategies = ['PROCEDURE', 'FQ_PROCEDURE', 'STATEMENT']
-        self._obfuscate_options = to_native_string(
-            json.dumps(
-                {
-                    'quantize_sql': self._config.obfuscator_options.get(
-                        'quantize_sql', self._config.obfuscator_options.get('quantize_sql_tables', False)
-                    )
-                }
-            )
-        )
+        self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
         self._init_caches()
 
     def _init_caches(self):

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -79,15 +79,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
         self._config = config
         self.log = get_check_logger()
         self._state = StatementMetrics()
-        self._obfuscate_options = to_native_string(
-            json.dumps(
-                {
-                    'quantize_sql': self._config.obfuscator_options.get(
-                        'quantize_sql', self._config.obfuscator_options.get('quantize_sql_tables', False)
-                    )
-                }
-            )
-        )
+        self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
         # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature
         self._full_statement_text_cache = TTLCache(
             maxsize=self._config.full_statement_text_cache_max_size,

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -80,7 +80,13 @@ class MySQLStatementMetrics(DBMAsyncJob):
         self.log = get_check_logger()
         self._state = StatementMetrics()
         self._obfuscate_options = to_native_string(
-            json.dumps({'quantize_sql_tables': self._config.obfuscator_options.get('quantize_sql_tables', False)})
+            json.dumps(
+                {
+                    'quantize_sql': self._config.obfuscator_options.get(
+                        'quantize_sql', self._config.get('quantize_sql_tables', False)
+                    )
+                }
+            )
         )
         # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature
         self._full_statement_text_cache = TTLCache(

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -83,7 +83,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
             json.dumps(
                 {
                     'quantize_sql': self._config.obfuscator_options.get(
-                        'quantize_sql', self._config.get('quantize_sql_tables', False)
+                        'quantize_sql', self._config.obfuscator_options.get('quantize_sql_tables', False)
                     )
                 }
             )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the MySQL integration config field `quantize_sql_tables` to `replace_digits` to reflect the changes being made in the datadog-agent. More information can be found in this PR: https://github.com/DataDog/datadog-agent/pull/8860

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
