### PR TITLE
[elastic] tag index stats by uuid

### DIFF
--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -172,6 +172,7 @@ class ESCheck(AgentCheck):
         reversed_health_stat = {'red': 0, 'yellow': 1, 'green': 2}
         for idx in index_resp:
             tags = base_tags + ['index_name:' + idx['index']]
+            tags = tags + ['uuid:' + idx['uuid']]
             # we need to remap metric names because the ones from elastic
             # contain dots and that would confuse `_process_metric()` (sic)
             index_data = {

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -172,7 +172,7 @@ class ESCheck(AgentCheck):
         reversed_health_stat = {'red': 0, 'yellow': 1, 'green': 2}
         for idx in index_resp:
             tags = base_tags + ['index_name:' + idx['index']]
-            tags = tags + ['uuid:' + idx['uuid']]
+            tags = tags + ['node_uuid:' + idx['uuid']]
             # we need to remap metric names because the ones from elastic
             # contain dots and that would confuse `_process_metric()` (sic)
             index_data = {


### PR DESCRIPTION
### What does this PR do?
- Tag index level metrics by UUID as well (`node_uuid`)

### Motivation
- Being able to find out which nodes has unbalanced number of shards at particular time frames

### Additional Notes
- The used endpoint only returns `uuid` which might not be as nice as names.
Example:
```
    {
        "health": "green",
        "status": "open",
        "index": "k8s.cronjobs.v1.2021.08.12.11",
        "uuid": "X-VE9ohkSpOnc-ur_ugz",
        "pri": "3",
        "rep": "2",
        "docs.count": "10090",
        "docs.deleted": "85",
        "store.size": "10080419",
        "pri.store.size": "3342539"
    },
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
