### PR TITLE
Use dedicated instance logger for connection messages

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/connection.py
+++ b/ibm_mq/datadog_checks/ibm_mq/connection.py
@@ -1,8 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
-import logging
+from typing import TYPE_CHECKING
 
 from datadog_checks.ibm_mq.config import IBMMQConfig
 
@@ -11,11 +10,12 @@ try:
 except ImportError:
     pymqi = None
 
-log = logging.getLogger(__file__)
+if TYPE_CHECKING:
+    from datadog_checks.base.log import CheckLoggingAdapter
 
 
-def get_queue_manager_connection(config):
-    # type: (IBMMQConfig) -> pymqi.QueueManager
+def get_queue_manager_connection(config, logger):
+    # type: (IBMMQConfig, CheckLoggingAdapter) -> pymqi.QueueManager
     """
     Get the queue manager connection
     """
@@ -25,18 +25,18 @@ def get_queue_manager_connection(config):
         # This does not fix the memory leak but mitigate its likelihood.
         # Details: https://github.com/dsuch/pymqi/issues/208
         try:
-            get_normal_connection(config)
+            get_normal_connection(config, logger)
         except pymqi.MQMIError as e:
-            log.debug("Tried normal connection before SSL connection. It failed with: %s", e)
+            logger.debug("Tried normal connection before SSL connection. It failed with: %s", e)
             if e.reason == pymqi.CMQC.MQRC_UNKNOWN_CHANNEL_NAME:
                 raise
-        return get_ssl_connection(config)
+        return get_ssl_connection(config, logger)
     else:
-        return get_normal_connection(config)
+        return get_normal_connection(config, logger)
 
 
-def get_normal_connection(config):
-    # type: (IBMMQConfig) -> pymqi.QueueManager
+def get_normal_connection(config, logger):
+    # type: (IBMMQConfig, CheckLoggingAdapter) -> pymqi.QueueManager
     """
     Get the connection either with a username and password or without
     """
@@ -44,19 +44,19 @@ def get_normal_connection(config):
     queue_manager = pymqi.QueueManager(None)
 
     if config.username and config.password:
-        log.debug("connecting with username and password")
+        logger.debug("connecting with username and password")
 
         kwargs = {'user': config.username, 'password': config.password, 'cd': channel_definition}
 
         queue_manager.connect_with_options(config.queue_manager_name, **kwargs)
     else:
-        log.debug("connecting without a username and password")
+        logger.debug("connecting without a username and password")
         queue_manager.connect_with_options(config.queue_manager_name, channel_definition)
     return queue_manager
 
 
-def get_ssl_connection(config):
-    # type: (IBMMQConfig) -> pymqi.QueueManager
+def get_ssl_connection(config, logger):
+    # type: (IBMMQConfig, CheckLoggingAdapter) -> pymqi.QueueManager
     """
     Get the connection with SSL
     """
@@ -78,7 +78,7 @@ def get_ssl_connection(config):
             }
         )
 
-    log.debug(
+    logger.debug(
         "Create SSL connection with ConnectionName=%s, ChannelName=%s, Version=%s, SSLCipherSpec=%s, "
         "KeyRepository=%s, CertificateLabel=%s, user=%s",
         cd.ConnectionName,

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -51,7 +51,7 @@ class IbmMqCheck(AgentCheck):
 
     def check(self, _):
         try:
-            queue_manager = connection.get_queue_manager_connection(self._config)
+            queue_manager = connection.get_queue_manager_connection(self._config, self.log)
             self.service_check(self.SERVICE_CHECK, AgentCheck.OK, self._config.tags)
         except Exception as e:
             self.warning("cannot connect to queue manager: %s", e)

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -203,8 +203,11 @@ def test_ssl_connection_creation(instance):
 
 
 def test_ssl_check_normal_connection_before_ssl_connection(instance_ssl_dummy):
+    import logging
+
     import pymqi
 
+    logger = logging.getLogger(__file__)
     config = IBMMQConfig(instance_ssl_dummy)
 
     error = pymqi.MQMIError(pymqi.CMQC.MQCC_FAILED, pymqi.CMQC.MQRC_UNKNOWN_CHANNEL_NAME)
@@ -213,9 +216,9 @@ def test_ssl_check_normal_connection_before_ssl_connection(instance_ssl_dummy):
     ) as get_normal_connection, mock.patch('datadog_checks.ibm_mq.connection.get_ssl_connection') as get_ssl_connection:
 
         with pytest.raises(pymqi.MQMIError):
-            get_queue_manager_connection(config)
+            get_queue_manager_connection(config, logger)
 
-        get_normal_connection.assert_called_with(config)
+        get_normal_connection.assert_called_with(config, logger)
         assert not get_ssl_connection.called
 
     # normal connection failed with with error other those listed in get_queue_manager_connection
@@ -227,17 +230,17 @@ def test_ssl_check_normal_connection_before_ssl_connection(instance_ssl_dummy):
             'datadog_checks.ibm_mq.connection.get_ssl_connection'
         ) as get_ssl_connection:
 
-            get_queue_manager_connection(config)
+            get_queue_manager_connection(config, logger)
 
-            get_normal_connection.assert_called_with(config)
-            get_ssl_connection.assert_called_with(config)
+            get_normal_connection.assert_called_with(config, logger)
+            get_ssl_connection.assert_called_with(config, logger)
 
     # no issue with normal connection
     with mock.patch('datadog_checks.ibm_mq.connection.get_normal_connection') as get_normal_connection, mock.patch(
         'datadog_checks.ibm_mq.connection.get_ssl_connection'
     ) as get_ssl_connection:
 
-        get_queue_manager_connection(config)
+        get_queue_manager_connection(config, logger)
 
-        get_normal_connection.assert_called_with(config)
-        get_ssl_connection.assert_called_with(config)
+        get_normal_connection.assert_called_with(config, logger)
+        get_ssl_connection.assert_called_with(config, logger)


### PR DESCRIPTION
### Motivation

Add ability to disambiguate, see:

```
2021-08-11 10:29:17 UTC | CORE | DEBUG | (pkg/collector/python/datadog_agent.go:126 in LogMessage) | - | (connection.py:53) | connecting without a username and password
```

vs:

```
2021-08-11 10:29:23 UTC | CORE | DEBUG | (pkg/collector/python/datadog_agent.go:126 in LogMessage) | ibm_mq:f53004b96cb7511a | (ibm_mq.py:86) | Could not retrieve ibm_mq version info
```