### PR TITLE
Add new metric for version 1.8.4 of CoreDNS

### DIFF
--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -80,6 +80,8 @@ NEW_METRICS = {
     'coredns_forward_healthcheck_failures_total': 'forward_healthcheck_failure_count',
     'coredns_forward_healthcheck_broken_total': 'forward_healthcheck_broken_count',
     'coredns_forward_max_concurrent_rejects_total': 'forward_max_concurrent_rejects',
+    'coredns_forward_conn_cache_hits_total': 'forward_conn_cache_hits',
+    'coredns_forward_conn_cache_misses_total': 'forward_conn_cache_misses',
     # grpc: https://github.com/coredns/coredns/tree/v1.7.0/plugin/grpc
     'coredns_grpc_requests_total': 'grpc.request_count',
     'coredns_grpc_responses_total': 'grpc.response_rcode_count',

--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -69,8 +69,9 @@ NEW_METRICS = {
     'coredns_acl_allowed_requests_total': 'acl.allowed_requests',
     # autopath: https://github.com/coredns/coredns/blob/v1.7.0/plugin/autopath/
     'coredns_autopath_success_total': 'autopath.success_count',
-    # cache: https://github.com/coredns/coredns/tree/v1.7.0/plugin/cache
+    # cache: https://github.com/coredns/coredns/tree/v1.8.4/plugin/cache
     'coredns_cache_entries': 'cache_size.count',
+    'coredns_cache_evictions_total': 'cache_evictions_count',
     # dnssec: https://github.com/coredns/coredns/tree/v1.7.0/plugin/dnssec
     'coredns_dnssec_cache_entries': 'dnssec.cache_size',
     # forward: https://github.com/coredns/coredns/tree/v1.7.0/plugin/forward

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -21,6 +21,8 @@ coredns.request_duration.seconds.sum,gauge,,second,,duration to process each que
 coredns.request_duration.seconds.count,gauge,,second,,duration to process each query,-1,coredns,request duration
 coredns.proxy_request_duration.seconds.sum,gauge,,second,,duration per upstream interaction,-1,coredns,proxy request duration
 coredns.proxy_request_duration.seconds.count,gauge,,second,,duration per upstream interaction,-1,coredns,proxy request duration
+coredns.forward_conn_cache_hits,count,,entry,,"counter of connection cache hits per upstream and protocol",-1,coredns,forward cache hits
+coredns.forward_conn_cache_misses,count,,entry,,"counter of connection cache misses per upstream and protocol",-1,coredns,forward cache misses
 coredns.forward_request_duration.seconds.sum,gauge,,second,,duration per upstream interaction,-1,coredns,forward request duration
 coredns.forward_request_duration.seconds.count,gauge,,second,,duration per upstream interaction,-1,coredns,forward request duration
 coredns.forward_request_count,count,,request,,query count per upstream,1,coredns,forward request count

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -6,6 +6,7 @@ coredns.build_info,gauge,,,,"A metric with a constant '1' value labeled by versi
 coredns.response_code_count,count,,,,number of responses per zone and rcode,1,coredns,response code
 coredns.proxy_request_count,count,,request,,query count per upstream.,1,coredns,proxy request count
 coredns.cache_drops_count,count,,response,,"Counter of responses excluded from the cache due to request/response question name mismatch.",0,coredns,cache drop
+coredns.cache_evictions_count,count,,eviction,,"Counter of cache evictions",1,coredns,cache eviction
 coredns.cache_hits_count,count,,hit,,Counter of cache hits by cache type,1,coredns,cache hit
 coredns.cache_misses_count,count,,miss,,Counter of cache misses.,1,coredns,cache miss
 coredns.cache_prefetch_count,count,,,,"The number of time the cache has prefetched a cached item.",1,coredns,cache prefetch

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -9,6 +9,7 @@ coredns.cache_drops_count,count,,response,,"Counter of responses excluded from t
 coredns.cache_hits_count,count,,hit,,Counter of cache hits by cache type,1,coredns,cache hit
 coredns.cache_misses_count,count,,miss,,Counter of cache misses.,1,coredns,cache miss
 coredns.cache_prefetch_count,count,,,,"The number of time the cache has prefetched a cached item.",1,coredns,cache prefetch
+coredns.cache_size.count,gauge,,entry,,,1,coredns,cache size
 coredns.cache_stale_count,count,,request,,"Counter of requests served from stale cache entries.",0,coredns,cache stale
 coredns.dnssec.cache_size,gauge,,,,"Total elements in the cache, type is signature.",0,coredns,dnssec cache size
 coredns.dnssec.cache_hits,count,,hit,,"Counter of cache hits.",0,coredns,dnssec cache hit
@@ -38,7 +39,6 @@ coredns.request_size.bytes.sum,gauge,,byte,,size of the request in bytes,0,cored
 coredns.request_size.bytes.count,gauge,,byte,,size of the request in bytes,0,coredns,request size
 coredns.response_size.bytes.sum,gauge,,byte,,size of the request in bytes,0,coredns,response size
 coredns.response_size.bytes.count,gauge,,byte,,size of the request in bytes,0,coredns,response size
-coredns.cache_size.count,gauge,,entry,,,1,coredns,cache size
 coredns.panic_count.count,count,,entry,,,1,coredns,total number of panics
 coredns.go.gc_duration_seconds.count,gauge,,second,,Count of the GC invocation durations.,0,coredns,
 coredns.go.gc_duration_seconds.sum,gauge,,second,,Sum of the GC invocation durations.,0,coredns,

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -9,7 +9,7 @@ coredns.cache_drops_count,count,,response,,"Counter of responses excluded from t
 coredns.cache_hits_count,count,,hit,,Counter of cache hits by cache type,1,coredns,cache hit
 coredns.cache_misses_count,count,,miss,,Counter of cache misses.,1,coredns,cache miss
 coredns.cache_prefetch_count,count,,,,"The number of time the cache has prefetched a cached item.",1,coredns,cache prefetch
-coredns.cache_size.count,gauge,,entry,,,1,coredns,cache size
+coredns.cache_size.count,gauge,,entry,,"Total elements in the cache by cache type.",1,coredns,cache size
 coredns.cache_stale_count,count,,request,,"Counter of requests served from stale cache entries.",0,coredns,cache stale
 coredns.dnssec.cache_size,gauge,,,,"Total elements in the cache, type is signature.",0,coredns,dnssec cache size
 coredns.dnssec.cache_hits,count,,hit,,"Counter of cache hits.",0,coredns,dnssec cache hit

--- a/coredns/tests/common.py
+++ b/coredns/tests/common.py
@@ -81,6 +81,8 @@ METRICS_V1_2 = COMMON_METRICS + [
 
 METRICS_V1_7 = COMMON_METRICS + [
     NAMESPACE + '.forward_max_concurrent_rejects',
+    NAMESPACE + '.forward_conn_cache_hits',
+    NAMESPACE + '.forward_conn_cache_misses',
     NAMESPACE + '.go.info',
     NAMESPACE + '.go.memstats.gc_cpu_fraction',
     NAMESPACE + '.go.memstats.heap_released_bytes',

--- a/coredns/tests/fixtures/metrics.txt
+++ b/coredns/tests/fixtures/metrics.txt
@@ -148,6 +148,12 @@ coredns_health_request_duration_seconds_count 1.32441e+06
 # HELP coredns_panic_count_total A metrics that counts the number of panics.
 # TYPE coredns_panic_count_total counter
 coredns_panic_count_total 0
+# HELP coredns_forward_conn_cache_hits_total Counter of connection cache hits per upstream and protocol.
+# TYPE coredns_forward_conn_cache_hits_total counter
+coredns_forward_conn_cache_hits_total{proto="tcp",to="10.0.0.2:53"} 1204
+# HELP coredns_forward_conn_cache_misses_total Counter of connection cache misses per upstream and protocol.
+# TYPE coredns_forward_conn_cache_misses_total counter
+coredns_forward_conn_cache_misses_total{proto="tcp",to="10.0.0.2:53"} 38
 # HELP coredns_forward_max_concurrent_rejects_total Counter of the number of queries rejected because the concurrent queries were at maximum.
 # TYPE coredns_forward_max_concurrent_rejects_total counter
 coredns_forward_max_concurrent_rejects_total 0


### PR DESCRIPTION
### What does this PR do?
Add new CoreDNS metric `coredns_cache_evictions_total` to list of metrics scraped by DataDog

### Motivation
While using CoreDNS v1.8.4 in production we noticed that the metric `coredns_cache_evictions_total` had been added to the [cache plugin documentation](https://github.com/coredns/coredns/tree/v1.8.4/plugin/cache#metrics) but was not available as a metric in DataDog. 

### Additional Notes

* While reading the DataDog CoreDNS integration documentation I noticed that the metric `coredns.cache_size` was in a different section of the [table](https://docs.datadoghq.com/integrations/coredns/#data-collected) and not colocated with the other cache metrics, so I moved it.
* I am not sure what the `orientation` column of the `metadata.csv` means, and picked `1` for that column for the new entry `coredns.cache_evictions_count`.
* I referred to these two PR's as the basis for this one: [6973](https://github.com/DataDog/integrations-core/pull/6973), [7363](https://github.com/DataDog/integrations-core/pull/7363)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
