### PR TITLE
Update `metrics` param in OpenMetrics's conf.yaml

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy.yaml
@@ -17,8 +17,8 @@
   value:
     type: array
     example:
-      - processor:cpu
-      - memory:mem
+      - processor: cpu
+      - memory: mem
       - io
     items:
       anyOf:

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -60,8 +60,8 @@ instances:
     ## value it'll be renamed. This list should contain at least one metric.
     #
     metrics:
-      - processor:cpu
-      - memory:mem
+      - processor: cpu
+      - memory: mem
       - io
 
     ## @param prometheus_metrics_prefix - string - optional


### PR DESCRIPTION
The example we share for the metrics: parameter is currently configured wrong. There needs to be a space between the original metric name, and the renamed version or the agent will skip collection.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
