### PR TITLE
Add fetching of null row in events_statements_by_digest

### DIFF
--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -121,7 +121,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
 
             # truncate query text to the maximum length supported by metrics tags
             for row in rows:
-                row['digest_text'] = row['digest_text'][0:200]
+                row['digest_text'] = row['digest_text'][0:200] if row['digest_text'] is not None else None
 
             payload = {
                 'host': self._db_hostname,
@@ -166,7 +166,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
                    `sum_no_index_used`,
                    `sum_no_good_index_used`
             FROM performance_schema.events_statements_summary_by_digest
-            WHERE `digest_text` NOT LIKE 'EXPLAIN %'
+            WHERE `digest_text` NOT LIKE 'EXPLAIN %' OR `digest_text` IS NULL
             ORDER BY `count_star` DESC
             LIMIT 10000"""
 
@@ -187,7 +187,11 @@ class MySQLStatementMetrics(DBMAsyncJob):
         for row in rows:
             normalized_row = dict(copy.copy(row))
             try:
-                obfuscated_statement = datadog_agent.obfuscate_sql(row['digest_text'], self._obfuscate_options)
+                obfuscated_statement = (
+                    datadog_agent.obfuscate_sql(row['digest_text'], self._obfuscate_options)
+                    if row['digest_text'] is not None
+                    else None
+                )
             except Exception as e:
                 self.log.warning("Failed to obfuscate query '%s': %s", row['digest_text'], e)
                 continue

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -536,3 +536,57 @@ def test_statement_samples_enable_consumers(dd_run_check, dbm_instance, root_con
         assert enabled_consumers == original_enabled_consumers.union({'events_statements_history_long'})
     else:
         assert enabled_consumers == original_enabled_consumers
+
+
+@pytest.mark.unit
+def test_normalize_queries(dbm_instance):
+    check = MySql(common.CHECK_NAME, {}, [dbm_instance])
+
+    # Test the general case with a valid schema, digest and digest_text
+    assert check._statement_metrics._normalize_queries(
+        [
+            {
+                'schema': 'network',
+                'digest': '44e35cee979ba420eb49a8471f852bbe15b403c89742704817dfbaace0d99dbb',
+                'digest_text': 'SELECT * from table where name = ?',
+                'count': 41,
+                'time': 66721400,
+                'lock_time': 18298000,
+            }
+        ]
+    ) == [
+        {
+            'digest': '44e35cee979ba420eb49a8471f852bbe15b403c89742704817dfbaace0d99dbb',
+            'schema': 'network',
+            'digest_text': 'SELECT * from table where name = ?',
+            'query_signature': u'761498b7d5f04d11',
+            'count': 41,
+            'time': 66721400,
+            'lock_time': 18298000,
+        }
+    ]
+
+    # Test the case of null values for digest, schema and digest_text (which is what the row created when the table
+    # is full returns)
+    assert check._statement_metrics._normalize_queries(
+        [
+            {
+                'digest': None,
+                'schema': None,
+                'digest_text': None,
+                'count': 41,
+                'time': 66721400,
+                'lock_time': 18298000,
+            }
+        ]
+    ) == [
+        {
+            'digest': None,
+            'schema': None,
+            'digest_text': None,
+            'query_signature': None,
+            'count': 41,
+            'time': 66721400,
+            'lock_time': 18298000,
+        }
+    ]


### PR DESCRIPTION
### What does this PR do?
This update adds fetching of the special row in `events_statements_by_digest` that has null `digest_text` (and `digest`, `schema`). This [happens when the table is full](https://dev.mysql.com/doc/refman/5.7/en/performance-schema-statement-summary-tables.html#statement-summary-tables-aggregation) and has reached the limit set in [performance_schema_digests_size](https://dev.mysql.com/doc/refman/5.7/en/performance-schema-system-variables.html#sysvar_performance_schema_digests_size). 

### Motivation
We'd like to provide visibility on when `events_statements_by_digest` and enable users to know that they might be losing queries. 

### Additional Notes
I added unit testing of the normalization that validates that we handle a `None` digest_text correctly. The test that validates we actually fetch the null row was done manually by adding `performance_schema_digests_size = 5` to `mysql.conf` and running the `test_statement_metrics` test with the additional assertion:
```python
none_rows = [r for r in event['mysql_rows'] if r['query_signature'] is None]
assert len(none_rows) == 1
```
Before the change to the query to include `or 'digest_text' is null`, this would assert would fail and, after the change, it would pass. I added adding a log with the number of fetched rows and before the query update, this was:
```
datadog_checks.base.checks.base.mysql:statements.py:180 Found 4 rows in events_statements_by_digest
```

And after:
```
datadog_checks.base.checks.base.mysql:statements.py:180 Found 5 rows in events_statements_by_digest
```

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
