### PR TITLE
Add `timeout` option

### DIFF
--- a/ibm_mq/assets/configuration/spec.yaml
+++ b/ibm_mq/assets/configuration/spec.yaml
@@ -134,6 +134,12 @@ files:
         value:
           example: false
           type: boolean
+      - name: timeout
+        description: |
+          The number of seconds to wait for IBM MQ to respond.
+        value:
+          example: 5
+          type: number
       - name: ssl_auth
         description: Whether or not to use SSL auth while connecting to the channel.
         value:

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -47,7 +47,9 @@ class ChannelMetricCollector(object):
     def get_pcf_channel_metrics(self, queue_manager):
         args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ensure_bytes('*')}
         try:
-            pcf = pymqi.PCFExecute(queue_manager, convert=self.config.convert_endianness)
+            pcf = pymqi.PCFExecute(
+                queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+            )
             response = pcf.MQCMD_INQUIRE_CHANNEL(args)
         except pymqi.MQMIError as e:
             # Don't warn if no messages, see:
@@ -89,7 +91,9 @@ class ChannelMetricCollector(object):
         search_channel_tags = tags + ["channel:{}".format(search_channel_name)]
         try:
             args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ensure_bytes(search_channel_name)}
-            pcf = pymqi.PCFExecute(queue_manager, convert=self.config.convert_endianness)
+            pcf = pymqi.PCFExecute(
+                queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+            )
             response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(args)
             self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.OK, search_channel_tags)
         except pymqi.MQMIError as e:

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/metadata_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/metadata_collector.py
@@ -13,20 +13,23 @@ except ImportError as e:
 
 
 class MetadataCollector(object):
-    def __init__(self, log):
+    def __init__(self, config, log):
+        self.config = config
         self.log = log
 
-    def collect_metadata(self, queue_manager, convert=False):
+    def collect_metadata(self, queue_manager):
         try:
-            raw_version = self._get_version(queue_manager, convert=convert)
+            raw_version = self._get_version(queue_manager)
             self.log.debug('IBM MQ version: %s', raw_version)
             return raw_version
         except Exception as e:
             self.log.debug("Version could not be retreived: %s", e)
             return
 
-    def _get_version(self, queue_manager, convert):
-        pcf = pymqi.PCFExecute(queue_manager, convert=convert)
+    def _get_version(self, queue_manager):
+        pcf = pymqi.PCFExecute(
+            queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+        )
         resp = pcf.MQCMD_INQUIRE_Q_MGR({pymqi.CMQCFC.MQIACF_Q_MGR_ATTRS: [pymqi.CMQC.MQCA_VERSION]})
 
         try:

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
@@ -84,7 +84,9 @@ class QueueMetricCollector(object):
             args = {pymqi.CMQC.MQCA_Q_NAME: pymqi.ensure_bytes(mq_pattern_filter), pymqi.CMQC.MQIA_Q_TYPE: queue_type}
             pcf = None
             try:
-                pcf = pymqi.PCFExecute(queue_manager, convert=self.config.convert_endianness)
+                pcf = pymqi.PCFExecute(
+                    queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                )
                 response = pcf.MQCMD_INQUIRE_Q(args)
             except pymqi.MQMIError as e:
                 # Don't warn if no messages, see:
@@ -127,7 +129,9 @@ class QueueMetricCollector(object):
         pcf = None
         try:
             args = {pymqi.CMQC.MQCA_Q_NAME: pymqi.ensure_bytes(queue_name), pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_ALL}
-            pcf = pymqi.PCFExecute(queue_manager, convert=self.config.convert_endianness)
+            pcf = pymqi.PCFExecute(
+                queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+            )
             response = pcf.MQCMD_INQUIRE_Q(args)
         except pymqi.MQMIError as e:
             # Don't warn if no messages, see:
@@ -168,7 +172,9 @@ class QueueMetricCollector(object):
                 pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_ALL,
                 pymqi.CMQCFC.MQIACF_Q_STATUS_ATTRS: pymqi.CMQCFC.MQIACF_ALL,
             }
-            pcf = pymqi.PCFExecute(queue_manager, convert=self.config.convert_endianness)
+            pcf = pymqi.PCFExecute(
+                queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+            )
             response = pcf.MQCMD_INQUIRE_Q_STATUS(args)
         except pymqi.MQMIError as e:
             # Don't warn if no messages, see:
@@ -200,7 +206,9 @@ class QueueMetricCollector(object):
         pcf = None
         try:
             args = {pymqi.CMQC.MQCA_Q_NAME: pymqi.ensure_bytes(queue_name)}
-            pcf = pymqi.PCFExecute(queue_manager, convert=self.config.convert_endianness)
+            pcf = pymqi.PCFExecute(
+                queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+            )
             response = pcf.MQCMD_RESET_Q_STATS(args)
         except pymqi.MQMIError as e:
             # Don't warn if no messages, see:

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -65,6 +65,7 @@ class IBMMQConfig:
 
         self.username = instance.get('username')  # type: str
         self.password = instance.get('password')  # type: str
+        self.timeout = int(float(instance.get('timeout', 5)) * 1000)  # type: int
 
         self.queues = instance.get('queues', [])  # type: List[str]
         self.queue_patterns = instance.get('queue_patterns', [])  # type: List[str]

--- a/ibm_mq/datadog_checks/ibm_mq/config_models/defaults.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config_models/defaults.py
@@ -96,5 +96,9 @@ def instance_tags(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_timeout(field, value):
+    return 5
+
+
 def instance_username(field, value):
     return get_default_field_value(field, value)

--- a/ibm_mq/datadog_checks/ibm_mq/config_models/instance.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config_models/instance.py
@@ -41,6 +41,7 @@ class InstanceConfig(BaseModel):
     ssl_cipher_spec: Optional[str]
     ssl_key_repository_location: Optional[str]
     tags: Optional[Sequence[str]]
+    timeout: Optional[float]
     username: Optional[str]
 
     @root_validator(pre=True)

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -127,6 +127,11 @@ instances:
     #
     # convert_endianness: false
 
+    ## @param timeout - number - optional - default: 5
+    ## The number of seconds to wait for IBM MQ to respond.
+    #
+    # timeout: 5
+
     ## @param ssl_auth - boolean - optional - default: false
     ## Whether or not to use SSL auth while connecting to the channel.
     #

--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -46,7 +46,7 @@ class IbmMqCheck(AgentCheck):
             self.log,
         )
         self.channel_metric_collector = ChannelMetricCollector(self._config, self.service_check, self.gauge, self.log)
-        self.metadata_collector = MetadataCollector(self.log)
+        self.metadata_collector = MetadataCollector(self._config, self.log)
         self.stats_collector = StatsCollector(self._config, self.send_metrics_from_properties, self.log)
 
     def check(self, _):
@@ -77,7 +77,7 @@ class IbmMqCheck(AgentCheck):
     @AgentCheck.metadata_entrypoint
     def _collect_metadata(self, queue_manager):
         try:
-            version = self.metadata_collector.collect_metadata(queue_manager, self._config.convert_endianness)
+            version = self.metadata_collector.collect_metadata(queue_manager)
             if version:
                 raw_version = '{}.{}.{}.{}'.format(version["major"], version["minor"], version["mod"], version["fix"])
                 self.set_metadata('version', raw_version, scheme='parts', part_map=version)


### PR DESCRIPTION
### Motivation

Some network topologies may require longer waits

- setting https://github.com/dsuch/pymqi/blob/084ab0b2638f9d27303a2844badc76635c4ad6de/code/pymqi/__init__.py#L2799
- another example of adding such an option https://github.com/DataDog/integrations-core/pull/8601/files