### PR TITLE
Add empty password config

### DIFF
--- a/tomcat/tests/compose/docker-compose.yml
+++ b/tomcat/tests/compose/docker-compose.yml
@@ -17,3 +17,4 @@ services:
         -Dtomcat.util.buf.StringCache.byte.enabled=true
         -Dtomcat.util.buf.StringCache.char.enabled=true
         -Dtomcat.util.buf.StringCache.trainThreshold=100
+      ALLOW_EMPTY_PASSWORD: 'yes'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Tomcat is failing because newest version needs to have `ALLOW_EMPTY_PASSWORD: 'yes'` in the docker_compose file. See here: https://github.com/bitnami/bitnami-docker-tomcat/commit/6900407ee296037cc570caf1b72187fb826f6961#diff-4a6cf0275b11b9b99b3237f25b8de4de0da761c089f3c3ffba0a4dd262cfda32R11
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
