### PR TITLE
Pin snowflake-connector and requests

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -70,6 +70,7 @@ pywin32==228; sys_platform == "win32" and python_version < "3.0"
 pywin32==300; sys_platform == "win32" and python_version > "3.0"
 pyyaml==5.4.1
 redis==3.5.3
+requests-kerberos==0.12.0
 requests-unixsocket==0.2.0
 requests==2.23.0; python_version < "3.0"
 requests==2.25.1; python_version > "3.0"

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -70,9 +70,9 @@ pywin32==228; sys_platform == "win32" and python_version < "3.0"
 pywin32==300; sys_platform == "win32" and python_version > "3.0"
 pyyaml==5.4.1
 redis==3.5.3
-requests-kerberos==0.12.0
 requests-unixsocket==0.2.0
-requests==2.25.1
+requests==2.23.0; python_version < "3.0"
+requests==2.25.1; python_version > "3.0"
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1
 rethinkdb==2.4.4
@@ -84,7 +84,8 @@ serpent==1.27; sys_platform == "win32"
 service_identity[idna]==18.1.0
 simplejson==3.6.5
 six==1.16.0
-snowflake-connector-python==2.1.3
+snowflake-connector-python==2.1.3; python_version < "3.0"
+snowflake-connector-python==2.5.1; python_version > "3.0"
 supervisor==4.1.0
 tuf==0.17.0
 typing==3.7.4.1; python_version < "3.0"

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -26,6 +26,7 @@ pywin32==300; sys_platform == 'win32' and python_version > '3.0'
 pyyaml==5.4.1
 requests==2.23.0; python_version < "3.0"
 requests==2.25.1; python_version > "3.0"
+requests-kerberos==0.12.0
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1
 requests-unixsocket==0.2.0

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -24,8 +24,8 @@ python-dateutil==2.8.1
 pywin32==228; sys_platform == 'win32' and python_version < '3.0'
 pywin32==300; sys_platform == 'win32' and python_version > '3.0'
 pyyaml==5.4.1
-requests==2.25.1
-requests-kerberos==0.12.0
+requests==2.23.0; python_version < "3.0"
+requests==2.25.1; python_version > "3.0"
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1
 requests-unixsocket==0.2.0

--- a/snowflake/requirements.in
+++ b/snowflake/requirements.in
@@ -2,4 +2,5 @@
 # Release note: https://pypi.org/project/snowflake-connector-python/2.2.0/
 # Note: Patched in omnibus
 # https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/snowflake-connector-python-py3.rb
-snowflake-connector-python==2.1.3
+snowflake-connector-python==2.1.3; python_version < '3.0'
+snowflake-connector-python==2.5.1; python_version > '3.0'


### PR DESCRIPTION
### What does this PR do?
Pin snowflake connector and requests. `requests==2.25.1` is not compatible with `snowflake==2.1.3,` and `snowflake >2.1.3` is not compatible with Python 2.

### Motivation
https://github.com/snowflakedb/snowflake-connector-python/issues/324
https://github.com/DataDog/datadog-agent/issues/8895

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
