### PR TITLE
Revert request bump

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -72,7 +72,7 @@ pyyaml==5.4.1
 redis==3.5.3
 requests-kerberos==0.12.0
 requests-unixsocket==0.2.0
-requests==2.25.1
+requests==2.23.0
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1
 rethinkdb==2.4.4

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -72,7 +72,7 @@ pyyaml==5.4.1
 redis==3.5.3
 requests-kerberos==0.12.0
 requests-unixsocket==0.2.0
-requests==2.23.0
+requests==2.22.0
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1
 rethinkdb==2.4.4

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -72,8 +72,7 @@ pyyaml==5.4.1
 redis==3.5.3
 requests-kerberos==0.12.0
 requests-unixsocket==0.2.0
-requests==2.23.0; python_version < "3.0"
-requests==2.25.1; python_version > "3.0"
+requests==2.25.1
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1
 rethinkdb==2.4.4
@@ -85,8 +84,7 @@ serpent==1.27; sys_platform == "win32"
 service_identity[idna]==18.1.0
 simplejson==3.6.5
 six==1.16.0
-snowflake-connector-python==2.1.3; python_version < "3.0"
-snowflake-connector-python==2.5.1; python_version > "3.0"
+snowflake-connector-python==2.1.3
 supervisor==4.1.0
 tuf==0.17.0
 typing==3.7.4.1; python_version < "3.0"

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -24,7 +24,7 @@ python-dateutil==2.8.1
 pywin32==228; sys_platform == 'win32' and python_version < '3.0'
 pywin32==300; sys_platform == 'win32' and python_version > '3.0'
 pyyaml==5.4.1
-requests==2.25.1
+requests==2.23.0
 requests-kerberos==0.12.0
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -24,7 +24,7 @@ python-dateutil==2.8.1
 pywin32==228; sys_platform == 'win32' and python_version < '3.0'
 pywin32==300; sys_platform == 'win32' and python_version > '3.0'
 pyyaml==5.4.1
-requests==2.23.0
+requests==2.22.0
 requests-kerberos==0.12.0
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -24,8 +24,7 @@ python-dateutil==2.8.1
 pywin32==228; sys_platform == 'win32' and python_version < '3.0'
 pywin32==300; sys_platform == 'win32' and python_version > '3.0'
 pyyaml==5.4.1
-requests==2.23.0; python_version < "3.0"
-requests==2.25.1; python_version > "3.0"
+requests==2.25.1
 requests-kerberos==0.12.0
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1

--- a/snowflake/requirements.in
+++ b/snowflake/requirements.in
@@ -2,5 +2,4 @@
 # Release note: https://pypi.org/project/snowflake-connector-python/2.2.0/
 # Note: Patched in omnibus
 # https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/snowflake-connector-python-py3.rb
-snowflake-connector-python==2.1.3; python_version < '3.0'
-snowflake-connector-python==2.5.1; python_version > '3.0'
+snowflake-connector-python==2.1.3


### PR DESCRIPTION
The snowflake bump does not build easily on SUSE, it requires additional dependencies for building the library.

For the time being we revert the snowflake bump and we set the requests version back to what it was on 7.29.0