### PR TITLE
Add E2E tests with fixture data

### DIFF
--- a/snowflake/tests/common.py
+++ b/snowflake/tests/common.py
@@ -1,0 +1,35 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+
+from datadog_checks.dev import get_here
+
+HERE = get_here()
+
+CHECK_NAME = 'snowflake'
+INSTANCE = {
+    'user': 'testuser',
+    'password': 'pass',
+    'account': 'test_acct.us-central1.gcp',
+    'database': 'SNOWFLAKE',
+    'schema': 'ACCOUNT_USAGE',
+    'role': 'ACCOUNTADMIN',
+}
+OAUTH_INSTANCE = {
+    'user': 'testuser',
+    'account': 'test_acct.us-central1.gcp',
+    'database': 'SNOWFLAKE',
+    'schema': 'ACCOUNT_USAGE',
+    'role': 'ACCOUNTADMIN',
+    'authenticator': 'oauth',
+    'token': 'testtoken',
+}
+
+EXPECTED_TAGS = ['account:test_acct.us-central1.gcp']
+E2E_METADATA = {
+    'post_install_commands': ['pip install /home/mock_snowflake_connector_python'],
+    'docker_volumes': [
+        '{}:/home/mock_snowflake_connector_python'.format(os.path.join(HERE, 'mock_snowflake_connector_python'))
+    ],
+}

--- a/snowflake/tests/conftest.py
+++ b/snowflake/tests/conftest.py
@@ -1,40 +1,23 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from copy import deepcopy
+
 import pytest
 
-INSTANCE = {
-    "user": "testuser",
-    "password": "pass",
-    "account": "test_acct.us-central1.gcp",
-    "database": "SNOWFLAKE",
-    "schema": "ACCOUNT_USAGE",
-    'role': "ACCOUNTADMIN",
-}
-
-OAUTH_INSTANCE = {
-    "user": "testuser",
-    "account": "test_acct.us-central1.gcp",
-    "database": "SNOWFLAKE",
-    "schema": "ACCOUNT_USAGE",
-    'role': "ACCOUNTADMIN",
-    "authenticator": "oauth",
-    "token": "testtoken",
-}
-
-CHECK_NAME = 'snowflake'
+from . import common
 
 
 @pytest.fixture(scope='session')
-def dd_environment(instance):
-    yield instance
+def dd_environment():
+    yield common.INSTANCE, common.E2E_METADATA
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def instance():
-    return INSTANCE
+    return deepcopy(common.INSTANCE)
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def oauth_instance():
-    return OAUTH_INSTANCE
+    return deepcopy(common.OAUTH_INSTANCE)

--- a/snowflake/tests/mock_snowflake_connector_python/setup.py
+++ b/snowflake/tests/mock_snowflake_connector_python/setup.py
@@ -1,0 +1,6 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from setuptools import setup
+
+setup(name='snowflake-connector-python', version='9000', packages=['snowflake'])

--- a/snowflake/tests/mock_snowflake_connector_python/snowflake/__init__.py
+++ b/snowflake/tests/mock_snowflake_connector_python/snowflake/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/snowflake/tests/mock_snowflake_connector_python/snowflake/connector.py
+++ b/snowflake/tests/mock_snowflake_connector_python/snowflake/connector.py
@@ -1,0 +1,50 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import re
+
+from . import tables
+
+TABLE_PATTERN = re.compile(r'from (\w+)')
+
+
+def connect(*args, **kwargs):
+    return Connection(*args, **kwargs)
+
+
+class Connection(object):
+    def __init__(self, *args, **kwargs):
+        super(Connection, self).__init__()
+
+    def cursor(self, *args, **kwargs):
+        return Cursor(*args, **kwargs)
+
+    def close(self):
+        pass
+
+
+class Cursor(object):
+    def __init__(self, *args, **kwargs):
+        super(Cursor, self).__init__()
+
+        self.__data = []
+
+    @property
+    def rowcount(self):
+        return len(self.__data)
+
+    def execute(self, query):
+        match = TABLE_PATTERN.search(query)
+        if match:
+            table_name = match.group(1)
+            self.__data = getattr(tables, table_name, [])
+        elif query == 'select current_version();':
+            self.__data = [('4.30.2',)]
+        else:
+            self.__data = []
+
+    def fetchall(self):
+        return self.__data
+
+    def close(self):
+        pass

--- a/snowflake/tests/mock_snowflake_connector_python/snowflake/tables.py
+++ b/snowflake/tests/mock_snowflake_connector_python/snowflake/tables.py
@@ -1,0 +1,47 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from decimal import Decimal
+
+STORAGE_USAGE = [(Decimal('0.000000'), Decimal('1206.000000'), Decimal('19.200000'))]
+DATABASE_STORAGE_USAGE_HISTORY = [('SNOWFLAKE_DB', Decimal('133.000000'), Decimal('9.100000'))]
+METERING_HISTORY = [
+    (
+        'WAREHOUSE_METERING',
+        'COMPUTE_WH',
+        Decimal('12.000000000'),
+        Decimal('1.000000000'),
+        Decimal('0.80397000'),
+        Decimal('0.066997500000'),
+        Decimal('12.803970000'),
+        Decimal('1.066997500000'),
+    )
+]
+WAREHOUSE_METERING_HISTORY = [
+    (
+        'COMPUTE_WH',
+        Decimal('13.000000000'),
+        Decimal('1.000000000'),
+        Decimal('0.870148056'),
+        Decimal('0.066934465846'),
+        Decimal('13.870148056'),
+        Decimal('1.066934465846'),
+    )
+]
+LOGIN_HISTORY = [('SNOWFLAKE_UI', 2, 6, 8), ('PYTHON_DRIVER', 0, 148, 148)]
+WAREHOUSE_LOAD_HISTORY = [('COMPUTE_WH', Decimal('0.000446667'), Decimal('0E-9'), Decimal('0E-9'), Decimal('0E-9'))]
+QUERY_HISTORY = [
+    (
+        'USE',
+        'COMPUTE_WH',
+        'SNOWFLAKE',
+        None,
+        Decimal('4.333333'),
+        Decimal('24.555556'),
+        Decimal('0.000000'),
+        Decimal('0.000000'),
+        Decimal('0.000000'),
+        Decimal('0.000000'),
+        Decimal('0.000000'),
+    )
+]

--- a/snowflake/tests/test_e2e.py
+++ b/snowflake/tests/test_e2e.py
@@ -1,0 +1,123 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from .common import EXPECTED_TAGS
+
+pytestmark = pytest.mark.e2e
+
+
+def test_mock_data(dd_agent_check, datadog_agent, instance):
+    instance['metric_groups'] = [
+        'snowflake.billing',
+        'snowflake.logins',
+        'snowflake.query',
+        'snowflake.storage',
+        'snowflake.storage.database',
+    ]
+    aggregator = dd_agent_check(instance, rate=True)
+
+    aggregator.assert_metric('snowflake.storage.storage_bytes.total', value=0.0, tags=EXPECTED_TAGS)
+    aggregator.assert_metric('snowflake.storage.stage_bytes.total', value=1206.0, tags=EXPECTED_TAGS)
+    aggregator.assert_metric('snowflake.storage.failsafe_bytes.total', value=19.2, tags=EXPECTED_TAGS)
+
+    aggregator.assert_metric(
+        'snowflake.storage.database.storage_bytes', value=133.0, tags=EXPECTED_TAGS + ['database:SNOWFLAKE_DB']
+    )
+    aggregator.assert_metric(
+        'snowflake.storage.database.failsafe_bytes', value=9.1, tags=EXPECTED_TAGS + ['database:SNOWFLAKE_DB']
+    )
+
+    aggregator.assert_metric(
+        'snowflake.billing.cloud_service.sum',
+        tags=EXPECTED_TAGS + ['service_type:WAREHOUSE_METERING', 'service:COMPUTE_WH'],
+    )
+    aggregator.assert_metric(
+        'snowflake.billing.cloud_service.avg',
+        tags=EXPECTED_TAGS + ['service_type:WAREHOUSE_METERING', 'service:COMPUTE_WH'],
+    )
+    aggregator.assert_metric('snowflake.billing.total_credit.sum')
+    aggregator.assert_metric('snowflake.billing.total_credit.avg')
+    aggregator.assert_metric('snowflake.billing.virtual_warehouse.sum')
+    aggregator.assert_metric('snowflake.billing.virtual_warehouse.avg')
+
+    aggregator.assert_metric(
+        'snowflake.billing.warehouse.cloud_service.avg', tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH']
+    )
+    aggregator.assert_metric(
+        'snowflake.billing.warehouse.total_credit.avg', tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH']
+    )
+    aggregator.assert_metric(
+        'snowflake.billing.warehouse.virtual_warehouse.avg', tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH']
+    )
+    aggregator.assert_metric(
+        'snowflake.billing.warehouse.cloud_service.sum', tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH']
+    )
+    aggregator.assert_metric(
+        'snowflake.billing.warehouse.total_credit.sum', tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH']
+    )
+    aggregator.assert_metric(
+        'snowflake.billing.warehouse.virtual_warehouse.sum', tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH']
+    )
+
+    aggregator.assert_metric('snowflake.logins.fail.count', tags=EXPECTED_TAGS + ['client_type:SNOWFLAKE_UI'])
+    aggregator.assert_metric('snowflake.logins.success.count', tags=EXPECTED_TAGS + ['client_type:SNOWFLAKE_UI'])
+    aggregator.assert_metric('snowflake.logins.total', tags=EXPECTED_TAGS + ['client_type:SNOWFLAKE_UI'])
+    aggregator.assert_metric('snowflake.logins.fail.count', tags=EXPECTED_TAGS + ['client_type:PYTHON_DRIVER'])
+    aggregator.assert_metric('snowflake.logins.success.count', tags=EXPECTED_TAGS + ['client_type:PYTHON_DRIVER'])
+    aggregator.assert_metric('snowflake.logins.total', tags=EXPECTED_TAGS + ['client_type:PYTHON_DRIVER'])
+
+    aggregator.assert_metric(
+        'snowflake.query.executed', value=0.000446667, tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH']
+    )
+    aggregator.assert_metric('snowflake.query.queued_overload', value=0, tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH'])
+    aggregator.assert_metric('snowflake.query.queued_provision', value=0, tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH'])
+    aggregator.assert_metric('snowflake.query.blocked', value=0, tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH'])
+
+    aggregator.assert_metric(
+        'snowflake.query.execution_time',
+        value=4.333333,
+        tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH', 'database:SNOWFLAKE', 'schema:None', 'query_type:USE'],
+    )
+    aggregator.assert_metric(
+        'snowflake.query.compilation_time',
+        value=24.555556,
+        tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH', 'database:SNOWFLAKE', 'schema:None', 'query_type:USE'],
+    )
+    aggregator.assert_metric(
+        'snowflake.query.bytes_scanned',
+        value=0,
+        tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH', 'database:SNOWFLAKE', 'schema:None', 'query_type:USE'],
+    )
+    aggregator.assert_metric(
+        'snowflake.query.bytes_written',
+        value=0,
+        tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH', 'database:SNOWFLAKE', 'schema:None', 'query_type:USE'],
+    )
+    aggregator.assert_metric(
+        'snowflake.query.bytes_deleted',
+        value=0,
+        tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH', 'database:SNOWFLAKE', 'schema:None', 'query_type:USE'],
+    )
+    aggregator.assert_metric(
+        'snowflake.query.bytes_spilled.local',
+        value=0,
+        tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH', 'database:SNOWFLAKE', 'schema:None', 'query_type:USE'],
+    )
+    aggregator.assert_metric(
+        'snowflake.query.bytes_spilled.remote',
+        value=0,
+        tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH', 'database:SNOWFLAKE', 'schema:None', 'query_type:USE'],
+    )
+
+    datadog_agent.assert_metadata(
+        'snowflake',
+        {
+            'version.major': '4',
+            'version.minor': '30',
+            'version.patch': '2',
+            'version.raw': '4.30.2',
+            'version.scheme': 'semver',
+        },
+    )

--- a/snowflake/tests/test_snowflake.py
+++ b/snowflake/tests/test_snowflake.py
@@ -10,9 +10,7 @@ from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.base.utils.db import Query
 from datadog_checks.snowflake import SnowflakeCheck, queries
 
-from .conftest import CHECK_NAME
-
-EXPECTED_TAGS = ['account:test_acct.us-central1.gcp']
+from .common import CHECK_NAME, EXPECTED_TAGS
 
 
 def test_storage_metrics(dd_run_check, aggregator, instance):

--- a/snowflake/tests/test_unit.py
+++ b/snowflake/tests/test_unit.py
@@ -8,7 +8,7 @@ import pytest
 
 from datadog_checks.snowflake import SnowflakeCheck, queries
 
-from .conftest import CHECK_NAME
+from .common import CHECK_NAME
 
 PROXY_CONFIG = {'http': 'http_host', 'https': 'https_host', 'no_proxy': 'uri1,uri2;uri3,uri4'}
 INVALID_PROXY = {'http': 'unused', 'https': 'unused', 'no_proxy': 'unused'}

--- a/snowflake/tox.ini
+++ b/snowflake/tox.ini
@@ -13,6 +13,8 @@ envdir =
 dd_check_style = true
 dd_check_types = true
 dd_mypy_args = --py2 datadog_checks/ tests/ --exclude '.*/config_models/.*\.py$'
+description =
+    py{27,38}: e2e ready
 usedevelop = true
 platform = linux|darwin|win32
 deps =


### PR DESCRIPTION
### What does this PR do?

Add mocks similar to https://github.com/DataDog/integrations-core/pull/9398

### Additional Notes

This is part 1 of 2, in near future monkeypatch methods of the `snowflake-connector-python` library rather than shadowing the entire library