### PR TITLE
Add agent version to mysql database monitoring payloads

### DIFF
--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -513,6 +513,7 @@ class MySQLStatementSamples(DBMAsyncJob):
             return {
                 "timestamp": row["timer_end_time_s"] * 1000,
                 "host": self._check.resolved_hostname,
+                "ddagentversion": datadog_agent.get_version(),
                 "ddsource": "mysql",
                 "ddtags": self._tags_str,
                 "duration": row['timer_wait_ns'],

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -126,6 +126,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
             payload = {
                 'host': self._check.resolved_hostname,
                 'timestamp': time.time() * 1000,
+                'ddagentversion': datadog_agent.get_version(),
                 'min_collection_interval': self._metric_collection_interval,
                 'tags': self._tags,
                 'mysql_rows': rows,
@@ -212,6 +213,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
             yield {
                 "timestamp": time.time() * 1000,
                 "host": self._check.resolved_hostname,
+                "ddagentversion": datadog_agent.get_version(),
                 "ddsource": "mysql",
                 "ddtags": ",".join(row_tags),
                 "dbm_type": "fqt",

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -278,6 +278,7 @@ def test_statement_samples_collect(
     expected_statement_truncated,
     aurora_replication_role,
     caplog,
+    datadog_agent,
 ):
     caplog.set_level(logging.INFO, logger="datadog_checks.mysql.collection_utils")
     caplog.set_level(logging.DEBUG, logger="datadog_checks")
@@ -321,6 +322,9 @@ def test_statement_samples_collect(
         logger.debug("done second check")
 
     events = aggregator.get_event_platform_events("dbm-samples")
+
+    for event in events:
+        assert event['ddagentversion'] == datadog_agent.get_version()
 
     # Match against the statement itself if it's below the statement length limit or its truncated form which is
     # the first 1024/4096 bytes (depending on the mysql version) with the last 3 replaced by '...'

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -123,6 +123,7 @@ def test_statement_metrics(
     event = events[0]
 
     assert event['host'] == 'stubbed.hostname'
+    assert event['ddagentversion'] == datadog_agent.get_version()
     assert event['timestamp'] > 0
     assert event['min_collection_interval'] == dbm_instance['query_metrics']['collection_interval']
     expected_tags = set(tags.METRIC_TAGS + ['server:{}'.format(common.HOST), 'port:{}'.format(common.PORT)])
@@ -153,6 +154,7 @@ def test_statement_metrics(
     assert event['mysql']['schema'] == default_schema
     assert event['timestamp'] > 0
     assert event['host'] == 'stubbed.hostname'
+    assert event['ddagentversion'] == datadog_agent.get_version()
 
 
 def _obfuscate_sql(query, options=None):


### PR DESCRIPTION
### What does this PR do?
This adds the agent version to mysql database monitoring payloads (query metrics, query samples and full query text events). 

### Motivation
Including the agent version in the database monitoring payloads will be useful information to improve visibility when looking at behavior of database monitoring features related to agent functionality. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
