### PR TITLE
Add agent version to postgres database monitoring payloads

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -409,6 +409,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         if self._seen_samples_ratelimiter.acquire(statement_plan_sig):
             event = {
                 "host": self._db_hostname,
+                "ddagentversion": datadog_agent.get_version(),
                 "ddsource": "postgres",
                 "ddtags": ",".join(self._dbtags(row['datname'])),
                 "timestamp": time.time() * 1000,

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -179,6 +179,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 'tags': self._tags_no_db,
                 'postgres_rows': rows,
                 'postgres_version': self._payload_pg_version(),
+                'ddagentversion': datadog_agent.get_version(),
             }
             self._check.database_monitoring_query_metrics(json.dumps(payload, default=default_json_event_encoding))
         except Exception:
@@ -297,6 +298,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             yield {
                 "timestamp": time.time() * 1000,
                 "host": self._check.resolved_hostname,
+                "ddagentversion": datadog_agent.get_version(),
                 "ddsource": "postgres",
                 "ddtags": ",".join(row_tags),
                 "dbm_type": "fqt",

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -358,6 +358,7 @@ def test_statement_samples_collect(
     expected_error_tag,
     expected_collection_errors,
     expected_statement_truncated,
+    datadog_agent,
 ):
     dbm_instance['pg_stat_activity_view'] = pg_stat_activity_view
     check = integration_check(dbm_instance)
@@ -413,6 +414,7 @@ def test_statement_samples_collect(
 
         # validate the events to ensure we've provided an explanation for not providing an exec plan
         for event in matching:
+            assert event['ddagentversion'] == datadog_agent.get_version()
             if event['db']['plan']['definition'] is None:
                 assert event['db']['plan']['collection_errors'] == expected_collection_errors
             else:

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -99,7 +99,9 @@ def test_statement_metrics_version(integration_check, dbm_instance, version, exp
 
 @pytest.mark.parametrize("dbstrict", [True, False])
 @pytest.mark.parametrize("pg_stat_statements_view", ["pg_stat_statements", "datadog.pg_stat_statements()"])
-def test_statement_metrics(aggregator, integration_check, dbm_instance, dbstrict, pg_stat_statements_view):
+def test_statement_metrics(
+    aggregator, integration_check, dbm_instance, dbstrict, pg_stat_statements_view, datadog_agent
+):
     dbm_instance['dbstrict'] = dbstrict
     dbm_instance['pg_stat_statements_view'] = pg_stat_statements_view
     # don't need samples for this test
@@ -141,6 +143,7 @@ def test_statement_metrics(aggregator, integration_check, dbm_instance, dbstrict
     assert event['host'] == 'stubbed.hostname'
     assert event['timestamp'] > 0
     assert event['postgres_version'] == check.statement_metrics._payload_pg_version()
+    assert event['ddagentversion'] == datadog_agent.get_version()
     assert event['min_collection_interval'] == dbm_instance['query_metrics']['collection_interval']
     expected_dbm_metrics_tags = {'foo:bar', 'server:{}'.format(HOST), 'port:{}'.format(PORT)}
     assert set(event['tags']) == expected_dbm_metrics_tags
@@ -174,6 +177,7 @@ def test_statement_metrics(aggregator, integration_check, dbm_instance, dbstrict
         matching = [e for e in fqt_events if e['db']['query_signature'] == query_signature]
         assert len(matching) == 1
         fqt_event = matching[0]
+        assert fqt_event['ddagentversion'] == datadog_agent.get_version()
         assert fqt_event['ddsource'] == "postgres"
         assert fqt_event['db']['statement'] == expected_query
         assert fqt_event['postgres']['datname'] == dbname


### PR DESCRIPTION
### What does this PR do?
This adds the agent version to postgres database monitoring payloads (query metrics, query samples and full query text events).

### Motivation
Including the agent version in the database monitoring payloads will be useful information to improve visibility when looking at behavior of database monitoring features related to agent functionality.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
