### PR TITLE
[documentation] fixes broken spacing in the conf.yaml example

### DIFF
--- a/process/README.md
+++ b/process/README.md
@@ -27,7 +27,7 @@ Unlike many checks, the Process Check doesn't monitor anything useful by default
     ## @param name - string - required
     ## Used to uniquely identify your metrics as they are tagged with this name in Datadog.
     #
-  - name: ssh
+      - name: ssh
 
     ## @param search_string - list of strings - optional
     ## If one of the elements in the list matches, it returns the count of


### PR DESCRIPTION
This is causing the code example in step 1 to be broken on the docs site: https://docs.datadoghq.com/integrations/process/#configuration

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
