### PR TITLE
Add support for kind config

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/kind.py
+++ b/datadog_checks_dev/datadog_checks/dev/kind.py
@@ -19,7 +19,7 @@ else:
 
 
 @contextmanager
-def kind_run(sleep=None, endpoints=None, conditions=None, env_vars=None, wrappers=None):
+def kind_run(sleep=None, endpoints=None, conditions=None, env_vars=None, wrappers=None, kind_config=None):
     """
     This utility provides a convenient way to safely set up and tear down Kind environments.
 
@@ -33,6 +33,8 @@ def kind_run(sleep=None, endpoints=None, conditions=None, env_vars=None, wrapper
     :param env_vars: A dictionary to update ``os.environ`` with during execution.
     :type env_vars: ``dict``
     :param wrappers: A list of context managers to use during execution.
+    :param kind_config: A path to a yaml file that contains the configuration for creating the kind cluster.
+    :type kind_config: ``str``
     """
     if not which('kind'):
         pytest.skip('Kind not available')
@@ -50,7 +52,7 @@ def kind_run(sleep=None, endpoints=None, conditions=None, env_vars=None, wrapper
             create_file(kubeconfig_path)
 
         with EnvVars({'KUBECONFIG': kubeconfig_path}):
-            set_up = KindUp(cluster_name)
+            set_up = KindUp(cluster_name, kind_config)
             tear_down = KindDown(cluster_name)
 
             with environment_run(
@@ -70,12 +72,13 @@ class KindUp(LazyFunction):
     `kind create cluster --name <integration>-cluster`
     """
 
-    def __init__(self, cluster_name):
+    def __init__(self, cluster_name, kind_config):
         self.cluster_name = cluster_name
+        self.kind_config = kind_config
 
     def __call__(self):
         # Create cluster
-        run_command(['kind', 'create', 'cluster', '--name', self.cluster_name], check=True)
+        run_command(['kind', 'create', 'cluster', '--name', self.cluster_name, '--config', self.kind_config], check=True)
         # Connect to cluster
         run_command(['kind', 'export', 'kubeconfig', '--name', self.cluster_name], check=True)
 

--- a/datadog_checks_dev/datadog_checks/dev/kind.py
+++ b/datadog_checks_dev/datadog_checks/dev/kind.py
@@ -78,7 +78,9 @@ class KindUp(LazyFunction):
 
     def __call__(self):
         # Create cluster
-        run_command(['kind', 'create', 'cluster', '--name', self.cluster_name, '--config', self.kind_config], check=True)
+        run_command(
+            ['kind', 'create', 'cluster', '--name', self.cluster_name, '--config', self.kind_config], check=True
+        )
         # Connect to cluster
         run_command(['kind', 'export', 'kubeconfig', '--name', self.cluster_name], check=True)
 


### PR DESCRIPTION
### What does this PR do?
Adds support for passing in a configuration file when creating a kind cluster in E2E. 

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
