### PR TITLE
Support clusters resource type

### DIFF
--- a/marklogic/datadog_checks/marklogic/constants.py
+++ b/marklogic/datadog_checks/marklogic/constants.py
@@ -11,7 +11,7 @@ BASE_ENDPOINT = '/manage/v2'
 
 RESOURCE_TYPES = {
     'cluster': {'plural': 'clusters', 'singular': 'cluster', 'tag_name': 'cluster_name'},
-    'clusters': {'plural': 'cluster', 'singular': 'cluster', 'tag_name': 'cluster_name'},
+    'clusters': {'plural': 'clusters', 'singular': 'cluster', 'tag_name': 'cluster_name'},
     'forest': {'plural': 'forests', 'singular': 'forest', 'tag_name': 'forest_name'},
     'forests': {'plural': 'forests', 'singular': 'forest', 'tag_name': 'forest_name'},
     'database': {'plural': 'databases', 'singular': 'database', 'tag_name': 'database_name'},

--- a/marklogic/datadog_checks/marklogic/constants.py
+++ b/marklogic/datadog_checks/marklogic/constants.py
@@ -10,7 +10,8 @@ ALLOWED_RESOURCES_FOR_FILTERS = ['database', 'forest', 'host', 'server']
 BASE_ENDPOINT = '/manage/v2'
 
 RESOURCE_TYPES = {
-    'cluster': {'plural': None, 'singular': 'cluster', 'tag_name': 'cluster_name'},
+    'cluster': {'plural': 'clusters', 'singular': 'cluster', 'tag_name': 'cluster_name'},
+    'clusters': {'plural': 'cluster', 'singular': 'cluster', 'tag_name': 'cluster_name'},
     'forest': {'plural': 'forests', 'singular': 'forest', 'tag_name': 'forest_name'},
     'forests': {'plural': 'forests', 'singular': 'forest', 'tag_name': 'forest_name'},
     'database': {'plural': 'databases', 'singular': 'database', 'tag_name': 'database_name'},

--- a/marklogic/tests/fixtures/cluster-query.yaml
+++ b/marklogic/tests/fixtures/cluster-query.yaml
@@ -9,6 +9,14 @@ cluster-query:
     result-count: '28'
   relations:
     relation-group:
+    - typeref: clusters
+      relation-count:
+        units: quantity
+        value: 1
+      relation:
+      - uriref: "/manage/v2/clusters/test-cluster"
+        idref: '123255818103205892753'
+        nameref: test-cluster
     - typeref: databases
       relation-count:
         units: quantity

--- a/marklogic/tests/fixtures/cluster-query.yaml
+++ b/marklogic/tests/fixtures/cluster-query.yaml
@@ -15,6 +15,7 @@ cluster-query:
         value: 1
       relation:
       - uriref: "/manage/v2/clusters/test-cluster"
+        roleref: 'foreign'
         idref: '123255818103205892753'
         nameref: test-cluster
     - typeref: databases

--- a/marklogic/tests/test_parsers.py
+++ b/marklogic/tests/test_parsers.py
@@ -498,6 +498,17 @@ def test_parse_resources():
             'relations': {
                 'relation-group': [
                     {
+                        'typeref': 'clusters',
+                        'relation-count': {'units': 'quantity', 'value': 1},
+                        'relation': [
+                            {
+                                'uriref': "/manage/v2/clusters/test-cluster",
+                                'idref': '123255818103205892753',
+                                'nameref': 'test-cluster',
+                            },
+                        ],
+                    },
+                    {
                         'typeref': 'databases',
                         'relation-count': {'units': 'quantity', 'value': 2},
                         'relation': [
@@ -547,6 +558,7 @@ def test_parse_resources():
     }
 
     EXPECTED_RESULT = [
+        {'id': '123255818103205892753', 'type': 'cluster', 'name': 'test-cluster', 'uri': '/clusters/test-cluster'},
         {'id': '255818103205892753', 'type': 'database', 'name': 'App-Services', 'uri': "/databases/App-Services"},
         {'id': '5004266825873163057', 'type': 'database', 'name': 'Documents', 'uri': "/databases/Documents"},
         {'id': '16024526243775340149', 'type': 'forest', 'name': 'Modules', 'uri': "/forests/Modules"},

--- a/marklogic/tests/test_parsers.py
+++ b/marklogic/tests/test_parsers.py
@@ -502,7 +502,8 @@ def test_parse_resources():
                         'relation-count': {'units': 'quantity', 'value': 1},
                         'relation': [
                             {
-                                'uriref': "/manage/v2/clusters/test-cluster",
+                                'roleref': 'foreign'
+                                'uriref': '/manage/v2/clusters/test-cluster',
                                 'idref': '123255818103205892753',
                                 'nameref': 'test-cluster',
                             },

--- a/marklogic/tests/test_parsers.py
+++ b/marklogic/tests/test_parsers.py
@@ -502,7 +502,7 @@ def test_parse_resources():
                         'relation-count': {'units': 'quantity', 'value': 1},
                         'relation': [
                             {
-                                'roleref': 'foreign'
+                                'roleref': 'foreign',
                                 'uriref': '/manage/v2/clusters/test-cluster',
                                 'idref': '123255818103205892753',
                                 'nameref': 'test-cluster',


### PR DESCRIPTION
### What does this PR do?
Supports parsing the resource type `clusters`

### Motivation
A Marklogic instance can have foreign clusters, and the integration breaks when you have them
https://docs.marklogic.com/REST/GET/manage/v2/clusters

### Additional Notes
We currently don't provide any metrics for clusters, so this is to prevent the parser from breaking, not to enable more metrics.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
