### PR TITLE
Revert "Raise exception during tests for OK service checks sent with messages"

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -10,7 +10,6 @@ from collections import OrderedDict, defaultdict
 
 from six import iteritems
 
-from ..constants import ServiceCheck
 from ..utils.common import ensure_unicode, to_native_string
 from .common import HistogramBucketStub, MetricStub, ServiceCheckStub
 from .similar import build_similar_elements_msg
@@ -124,9 +123,6 @@ class AggregatorStub(object):
             self._metrics[name].append(MetricStub(name, mtype, value, tags, hostname, device))
 
     def submit_service_check(self, check, check_id, name, status, tags, hostname, message):
-        if status == ServiceCheck.OK and message:
-            raise Exception("Expected empty message on OK service check")
-
         check_tag_names(name, tags)
         self._service_checks[name].append(ServiceCheckStub(check_id, name, status, tags, hostname, message))
 


### PR DESCRIPTION
Reverts DataDog/integrations-core#9898 until https://github.com/DataDog/jmxfetch/pull/369 is merged, otherwise CI keeps failing for Hazelcast and Ignite.
