### PR TITLE
Avoid re-explaining queries that cannot be explained

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -128,6 +128,12 @@ class PostgresStatementSamples(DBMAsyncJob):
             ttl=config.statement_samples_config.get('collection_strategy_cache_ttl', 300),
         )
 
+        self._explain_errors_cache = TTLCache(
+            maxsize=config.statement_samples_config.get('explain_errors_cache_maxsize', 5000),
+            # only try to re-explain invalid statements once per day
+            ttl=config.statement_samples_config.get('explain_errors_cache_ttl', 24 * 60 * 60),
+        )
+
         # explained_statements_ratelimiter: limit how often we try to re-explain the same query
         self._explained_statements_ratelimiter = RateLimitingTTLCache(
             maxsize=int(config.statement_samples_config.get('explained_queries_cache_maxsize', 5000)),
@@ -320,8 +326,8 @@ class PostgresStatementSamples(DBMAsyncJob):
                 return None
             return result[0][0]
 
-    def _run_explain_safe(self, dbname, statement, obfuscated_statement):
-        # type: (str, str, str) -> Tuple[Optional[Dict], Optional[DBExplainError], Optional[str]]
+    def _run_explain_safe(self, dbname, statement, obfuscated_statement, query_signature):
+        # type: (str, str, str, str) -> Tuple[Optional[Dict], Optional[DBExplainError], Optional[str]]
         if not self._can_explain_statement(obfuscated_statement):
             return None, DBExplainError.no_plans_possible, None
 
@@ -351,6 +357,10 @@ class PostgresStatementSamples(DBMAsyncJob):
             )
             return None, db_explain_error, '{}'.format(type(err))
 
+        cached_error_response = self._explain_errors_cache.get(query_signature)
+        if cached_error_response:
+            return cached_error_response
+
         try:
             return self._run_explain(dbname, statement, obfuscated_statement), None, None
         except psycopg2.errors.DatabaseError as e:
@@ -361,7 +371,18 @@ class PostgresStatementSamples(DBMAsyncJob):
                 tags=self._dbtags(dbname, "error:explain-{}".format(type(e))) + self._check._get_debug_tags(),
                 hostname=self._check.resolved_hostname,
             )
-            return None, DBExplainError.database_error, '{}'.format(type(e))
+            error_response = None, DBExplainError.database_error, '{}'.format(type(e))
+
+            if isinstance(e, psycopg2.errors.ProgrammingError) and not isinstance(
+                e, psycopg2.errors.InsufficientPrivilege
+            ):
+                # ProgrammingError is things like InvalidName, InvalidSchema, SyntaxError
+                # we don't want to cache things like permission errors for a very long time because they can be fixed
+                # dynamically by the user. the goal here is to cache only those queries which there is no reason to
+                # retry
+                self._explain_errors_cache[query_signature] = error_response
+
+            return error_response
 
     def _collect_plan_for_statement(self, row):
         try:
@@ -388,7 +409,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         # - `resource_hash` - hash computed off the raw sql text to match apm resources
         # - `query_signature` - hash computed from the raw sql text to match query metrics
         plan_dict, explain_err_code, err_msg = self._run_explain_safe(
-            row['datname'], row['query'], obfuscated_statement
+            row['datname'], row['query'], obfuscated_statement, query_signature
         )
         collection_errors = None
         if explain_err_code:

--- a/postgres/tests/compose/resources/02_setup.sh
+++ b/postgres/tests/compose/resources/02_setup.sh
@@ -50,6 +50,19 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" "$DBNAME" <<-'EOSQL'
 
     ALTER FUNCTION datadog.explain_statement(l_query text, out explain json) OWNER TO postgres;
     ALTER FUNCTION datadog.pg_stat_activity() owner to postgres;
+
+    -- datadog.explain_statement_noaccess is not part of the standard setup
+    -- it's added only for the purpose of testing an explain function owned by a user with inadequate permissions
+    CREATE OR REPLACE FUNCTION datadog.explain_statement_noaccess(l_query text, out explain JSON) RETURNS SETOF JSON AS
+    $$
+      BEGIN
+          RETURN QUERY EXECUTE 'EXPLAIN (FORMAT JSON) ' || l_query;
+      END;
+    $$
+    LANGUAGE plpgsql
+    RETURNS NULL ON NULL INPUT
+    SECURITY DEFINER;
+    ALTER FUNCTION datadog.explain_statement_noaccess(l_query text, out explain json) OWNER TO datadog;
 EOSQL
 
 done

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -332,7 +332,7 @@ def test_failed_explain_handling(
     assert err is None
 
     for _ in range(failed_explain_test_repeat_count):
-        check.statement_samples._run_explain_safe(dbname, query, query, "test1")
+        check.statement_samples._run_explain_safe(dbname, query, query, query)
 
     expected_tags = dbm_instance['tags'] + [
         'db:{}'.format(DB_NAME),
@@ -547,7 +547,7 @@ def test_statement_run_explain_errors(
     check._connect()
 
     check.check(dbm_instance)
-    _, explain_err_code, err = check.statement_samples._run_explain_safe("datadog_test", query, query)
+    _, explain_err_code, err = check.statement_samples._run_explain_safe("datadog_test", query, query, query)
 
     assert explain_err_code == expected_explain_err_code
     assert err == expected_err

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -278,6 +278,80 @@ def test_get_db_explain_setup_state(integration_check, dbm_instance, dbname, exp
     assert db_explain_error == expected_db_explain_error
 
 
+failed_explain_test_repeat_count = 5
+
+
+@pytest.mark.parametrize(
+    "query,expected_error_tag,explain_function_override,expected_fail_count",
+    [
+        ("select * from fake_table", "error:explain-<class 'psycopg2.errors.UndefinedTable'>", None, 1),
+        ("select * from fake_schema.fake_table", "error:explain-<class 'psycopg2.errors.UndefinedTable'>", None, 1),
+        (
+            "select * from pg_settings where name = $1",
+            "error:explain-<class 'psycopg2.errors.UndefinedParameter'>",
+            None,
+            1,
+        ),
+        (
+            "select * from pg_settings where name = 'this query is truncated' limi",
+            "error:explain-<class 'psycopg2.errors.SyntaxError'>",
+            None,
+            1,
+        ),
+        (
+            "select * from persons",
+            "error:explain-<class 'psycopg2.errors.InsufficientPrivilege'>",
+            "datadog.explain_statement_noaccess",
+            failed_explain_test_repeat_count,
+        ),
+    ],
+)
+def test_failed_explain_handling(
+    integration_check,
+    dbm_instance,
+    aggregator,
+    query,
+    expected_error_tag,
+    explain_function_override,
+    expected_fail_count,
+):
+    dbname = "datadog_test"
+    if explain_function_override:
+        dbm_instance['query_samples']['explain_function'] = explain_function_override
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    # run check so all internal state is correctly initialized
+    check.check(dbm_instance)
+
+    # clear out contents of aggregator so we measure only the metrics generated during this specific part of the test
+    aggregator.__init__()
+
+    db_explain_error, err = check.statement_samples._get_db_explain_setup_state(dbname)
+    assert db_explain_error is None
+    assert err is None
+
+    for _ in range(failed_explain_test_repeat_count):
+        check.statement_samples._run_explain_safe(dbname, query, query, "test1")
+
+    expected_tags = dbm_instance['tags'] + [
+        'db:{}'.format(DB_NAME),
+        'server:{}'.format(HOST),
+        'port:{}'.format(PORT),
+        'agent_hostname:stubbed.hostname',
+        expected_error_tag,
+    ]
+
+    aggregator.assert_metric(
+        # even though we tried to explain the query multiple times, only a single error was registered, showing
+        # that the cached error response was used
+        'dd.postgres.statement_samples.error',
+        count=expected_fail_count,
+        tags=expected_tags,
+        hostname='stubbed.hostname',
+    )
+
+
 @pytest.mark.parametrize("pg_stat_activity_view", ["pg_stat_activity", "datadog.pg_stat_activity()"])
 @pytest.mark.parametrize(
     "user,password,dbname,query,arg,expected_error_tag,expected_collection_errors,expected_statement_truncated",

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -325,7 +325,7 @@ def test_failed_explain_handling(
     check.check(dbm_instance)
 
     # clear out contents of aggregator so we measure only the metrics generated during this specific part of the test
-    aggregator.__init__()
+    aggregator.reset()
 
     db_explain_error, err = check.statement_samples._get_db_explain_setup_state(dbname)
     assert db_explain_error is None


### PR DESCRIPTION
### What does this PR do?

The following types of queries from `pg_stat_activity` cannot be explained:
* those that are truncated at a point which causes a syntax error
* those that are sent from a client using the extended query protcol, meaning we see `$1, $2, ...` in the query instead of the original query parameters

We will now cache these errors to avoid continuously attempting to re-explain them and in doing so generating unnecessary database error logs.

### Motivation

Avoid continuously attempting to re-explain queries we know will fail.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
