### PR TITLE
Annotating display_queue

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -42,3 +42,7 @@ jobs:
     - name: Run legacy signature validation
       run: |
         ddev validate legacy-signature
+
+    - name: Run service checks validation
+      run: |
+        ddev validate service-checks

--- a/crio/assets/service_checks.json
+++ b/crio/assets/service_checks.json
@@ -10,6 +10,6 @@
             "endpoint"
         ],
         "name": "CRI-O prometheus health",
-        "description": "Returns `CRITICAL` if the check can't access the metrics endpoint."
+        "description": null
     }
 ]

--- a/crio/assets/service_checks.json
+++ b/crio/assets/service_checks.json
@@ -1,6 +1,5 @@
 [
     {
-        "agent_version": "6.0.0",
         "integration": "CRI-O",
         "check": "crio.prometheus.health",
         "statuses": [

--- a/crio/assets/service_checks.json
+++ b/crio/assets/service_checks.json
@@ -1,5 +1,6 @@
 [
     {
+        "agent_version": "6.0.0",
         "integration": "CRI-O",
         "check": "crio.prometheus.health",
         "statuses": [
@@ -10,6 +11,6 @@
             "endpoint"
         ],
         "name": "CRI-O prometheus health",
-        "description": null
+        "description": "Returns `CRITICAL` if the check can't access the metrics endpoint."
     }
 ]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/annotations.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/annotations.py
@@ -16,13 +16,14 @@ GH_ANNOTATION_LEVELS = [ANNOTATE_WARNING, ANNOTATE_ERROR]
 
 def annotate_display_queue(file, display_queue):
     errors = ""
-    warnings = []
+    warnings = ""
     for func, message in display_queue:
         if func == echo_failure:
             errors += message + "\n"
         elif func == echo_warning:
             warnings += message + "\n"
     if errors:
+        errors = "{delimiter}" + errors + "{delimiter}"
         annotate_error(file, errors)
     if warnings:
         annotate_warning(file, warnings)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/annotations.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/annotations.py
@@ -7,10 +7,25 @@ Functions to annotate in Github Actions workflows.
 import os
 
 from datadog_checks.dev.ci import running_on_gh_actions  # noqa: F401
+from datadog_checks.dev.tooling.commands.console import echo_failure, echo_warning
 
 ANNOTATE_WARNING = 'warning'
 ANNOTATE_ERROR = 'error'
 GH_ANNOTATION_LEVELS = [ANNOTATE_WARNING, ANNOTATE_ERROR]
+
+
+def annotate_display_queue(file, display_queue):
+    errors = ""
+    warnings = []
+    for func, message in display_queue:
+        if func == echo_failure:
+            errors += message + "\n"
+        elif func == echo_warning:
+            warnings += message + "\n"
+    if errors:
+        annotate_error(file, errors)
+    if warnings:
+        annotate_warning(file, warnings)
 
 
 def annotate_warning(file, message, line=1):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/annotations.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/annotations.py
@@ -19,11 +19,10 @@ def annotate_display_queue(file, display_queue):
     warnings = ""
     for func, message in display_queue:
         if func == echo_failure:
-            errors += message + "\n"
+            errors += message + "%0A"
         elif func == echo_warning:
-            warnings += message + "\n"
+            warnings += message + "%0A"
     if errors:
-        errors = "{delimiter}" + errors + "{delimiter}"
         annotate_error(file, errors)
     if warnings:
         annotate_warning(file, warnings)


### PR DESCRIPTION
### What does this PR do?
Instead of repeating multiple annotations, annotate messages gathered in display_queue.

### Motivation
Simplify annotations and avoid repetitive code

### Additional Notes
<img width="625" alt="Screen Shot 2021-08-20 at 7 34 37 PM" src="https://user-images.githubusercontent.com/15065007/130302722-305b036d-eb84-4a77-8410-3dbbfb81a4aa.png">


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
