### PR TITLE
Do not to pass kind config if it's None

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/kind.py
+++ b/datadog_checks_dev/datadog_checks/dev/kind.py
@@ -78,8 +78,12 @@ class KindUp(LazyFunction):
 
     def __call__(self):
         # Create cluster
+        create_cmd = ['kind', 'create', 'cluster', '--name', self.cluster_name]
+        if self.kind_config:
+            create_cmd += ['--config', self.kind_config]
+
         run_command(
-            ['kind', 'create', 'cluster', '--name', self.cluster_name, '--config', self.kind_config], check=True
+            create_cmd, check=True
         )
         # Connect to cluster
         run_command(['kind', 'export', 'kubeconfig', '--name', self.cluster_name], check=True)

--- a/datadog_checks_dev/datadog_checks/dev/kind.py
+++ b/datadog_checks_dev/datadog_checks/dev/kind.py
@@ -82,9 +82,7 @@ class KindUp(LazyFunction):
         if self.kind_config:
             create_cmd += ['--config', self.kind_config]
 
-        run_command(
-            create_cmd, check=True
-        )
+        run_command(create_cmd, check=True)
         # Connect to cluster
         run_command(['kind', 'export', 'kubeconfig', '--name', self.cluster_name], check=True)
 


### PR DESCRIPTION
### What does this PR do?
Fix kind_config FR. `--config` should not be included in create command if it's None.

### Motivation
CI failures seem to be related https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=73010&view=logs&j=519bd84d-28fd-598c-db49-0d219af79ef0&t=8d8170c7-f175-5c28-3510-d1de6e6f4791&l=82

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
