### PR TITLE
Fix bug when PR body is empty and include DBM team to selector

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -269,6 +269,7 @@ def testable(
             '4': 'Core',
             '5': 'Platform',
             '6': 'Tools and Libraries',
+            '7': 'Database Monitoring',
             's': 'Skip',
             'q': 'Quit',
         }
@@ -433,7 +434,8 @@ def testable(
                 echo_info(pr_milestone)
 
             # Ensure Unix lines feeds just in case
-            echo_info(pr_body.strip('\r'), indent=indent)
+            if pr_body:
+                echo_info(pr_body.strip('\r'), indent=indent)
 
             echo_info(options_text)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -285,6 +285,7 @@ def testable(
             '8': 'Integrations',
             '9': 'Infra-Integrations',
             '10': 'Tools and Libraries',
+            '11': 'Database Monitoring',
             's': 'Skip',
             'q': 'Quit',
         }


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug where the command fails when the PR body is empty.

The DMB team wasn't included in the team options for assigning cards.
Be sure to 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
