### PR TITLE
Update mib_source_url to our own fork of mibs.snmplabs.com

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_profile.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_profile.py
@@ -10,6 +10,7 @@ import click
 import yaml
 
 from ...console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, set_debug
+from ....constants import MIB_SOURCE_URL
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Generate an SNMP profile from a collection of MIB files')
@@ -22,7 +23,7 @@ from ...console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, set_debug
     '--source',
     '-s',
     help='Source of the MIBs files. Can be a url or a path for a directory',
-    default='http://raw.githubusercontent.com/trevoro/snmp-mibs/master/mibs/@mib@',
+    default=MIB_SOURCE_URL,
 )
 @click.pass_context
 def generate_profile_from_mibs(ctx, mib_files, filters, aliases, debug, interactive, source):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_profile.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_profile.py
@@ -9,8 +9,8 @@ from tempfile import gettempdir
 import click
 import yaml
 
-from ...console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, set_debug
 from ....constants import MIB_SOURCE_URL
+from ...console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, set_debug
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Generate an SNMP profile from a collection of MIB files')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
@@ -37,7 +37,7 @@ def fetch_mib(mib, source_url):
 @click.argument('profile_path')
 @click.option(
     '--mib_source_url',
-    default='https://raw.githubusercontent.com/projx/snmp-mibs/master/@mib@',
+    default='https://raw.githubusercontent.com:443/DataDog/mibs.snmplabs.com/master/asn1/@mib@',
     help='Source url to fetch missing MIBS',
 )
 @click.pass_context

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
@@ -6,6 +6,7 @@ import os
 import click
 import yaml
 
+from ....constants import MIB_SOURCE_URL
 from ...console import CONTEXT_SETTINGS
 
 
@@ -37,7 +38,7 @@ def fetch_mib(mib, source_url):
 @click.argument('profile_path')
 @click.option(
     '--mib_source_url',
-    default='https://raw.githubusercontent.com:443/DataDog/mibs.snmplabs.com/master/asn1/@mib@',
+    default=MIB_SOURCE_URL,
     help='Source url to fetch missing MIBS',
 )
 @click.pass_context

--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -92,6 +92,8 @@ REQUIREMENTS_IN = 'requirements.in'
 
 ROOT = ''
 
+MIB_SOURCE_URL = 'https://raw.githubusercontent.com:443/DataDog/mibs.snmplabs.com/master/asn1/@mib@'
+
 
 def get_root():
     return ROOT


### PR DESCRIPTION
### What does this PR do?

- Updates the `mib_source_url` to https://github.com/DataDog/mibs.snmplabs.com - which is our own fork of https://github.com/cisco-kusanagi/mibs.snmplabs.com


### Motivation
- https://github.com/etingof/pysnmp/issues/376
- https://github.com/inexio/mibs.snmplabs.com aka `http://mibs.thola.io/asn1/` also works but is also a fork of cisco-kusanagi/mibs.snmplabs.com


### Additional Notes
- https://github.com/projx/snmp-mibs (one we used after the down http://mibs.snmplabs.com)  has also been disabled

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
