### PR TITLE
Add try-catch on queue closure

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
@@ -73,7 +73,10 @@ class StatsCollector(object):
             else:
                 raise
         finally:
-            queue.close()
+            try:
+                queue.close()
+            except pymqi.PYIFError:
+                self.log.debug("Could not close queue")
 
     def _collect_channel_stats(self, channel_stats):
         self.log.debug('Collect channel stats. Number of channels: %s', len(channel_stats.channels))

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
@@ -75,8 +75,8 @@ class StatsCollector(object):
         finally:
             try:
                 queue.close()
-            except pymqi.PYIFError:
-                self.log.debug("Could not close queue")
+            except pymqi.PYIFError as e:
+                self.log.debug("Could not close queue: %s", str(e))
 
     def _collect_channel_stats(self, channel_stats):
         self.log.debug('Collect channel stats. Number of channels: %s', len(channel_stats.channels))


### PR DESCRIPTION
Prevents:

```
During handling of the above exception, another exception occurred:
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 996, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/ibm_mq/ibm_mq.py", line 67, in check
          self.stats_collector.collect(queue_manager)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/ibm_mq/collectors/stats_collector.py", line 76, in collect
          queue.close()
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/pymqi/__init__.py", line 2079, in close
          raise PYIFError('not open')
      pymqi.PYIFError: PYMQI Error: not open
```