### PR TITLE
Pin tomcat docker version

### DIFF
--- a/tomcat/tests/compose/docker-compose.yml
+++ b/tomcat/tests/compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   tomcat:
-    image: 'bitnami/tomcat:9.0'
+    image: 'bitnami/tomcat:9.0.50'
     ports:
       - 8080:8080
       - 9012:9012 # JMX


### PR DESCRIPTION
Image for 9.0 has been recently updated to 9.0.52 which breaks e2e due to configuration issues. This PR pins it to the previously passing version