### PR TITLE
Raise exception for OK service checks with messages

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -10,6 +10,7 @@ from collections import OrderedDict, defaultdict
 
 from six import iteritems
 
+from datadog_checks.base.constants import ServiceCheck
 from ..utils.common import ensure_unicode, to_native_string
 from .common import HistogramBucketStub, MetricStub, ServiceCheckStub
 from .similar import build_similar_elements_msg
@@ -123,6 +124,9 @@ class AggregatorStub(object):
             self._metrics[name].append(MetricStub(name, mtype, value, tags, hostname, device))
 
     def submit_service_check(self, check, check_id, name, status, tags, hostname, message):
+        if status == ServiceCheck.OK and message:
+            raise Exception("Expected empty message on OK service check")
+
         check_tag_names(name, tags)
         self._service_checks[name].append(ServiceCheckStub(check_id, name, status, tags, hostname, message))
 

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -10,7 +10,7 @@ from collections import OrderedDict, defaultdict
 
 from six import iteritems
 
-from datadog_checks.base.constants import ServiceCheck
+from ..constants import ServiceCheck
 from ..utils.common import ensure_unicode, to_native_string
 from .common import HistogramBucketStub, MetricStub, ServiceCheckStub
 from .similar import build_similar_elements_msg


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds an exception when service checks output `OK` but also has a message. 

Do not merge this PR until https://github.com/DataDog/jmxfetch/pull/369 is merged.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
