### PR TITLE
Add test for unknown service check status

### DIFF
--- a/ibm_mq/tests/test_ibm_mq_int.py
+++ b/ibm_mq/tests/test_ibm_mq_int.py
@@ -19,7 +19,7 @@ from .common import QUEUE_METRICS, assert_all_metrics
 pytestmark = [pytest.mark.usefixtures("dd_environment"), pytest.mark.integration]
 
 
-def test_no_msg_errors_are_caught(aggregator, get_check, instance, caplog):
+def test_no_msg_errors_are_caught(get_check, instance, caplog):
     # Late import to ignore missing library for e2e
     from pymqi import MQMIError, PCFExecute
     from pymqi.CMQC import MQCC_FAILED, MQRC_NO_MSG_AVAILABLE
@@ -34,8 +34,38 @@ def test_no_msg_errors_are_caught(aggregator, get_check, instance, caplog):
         m.unpack = PCFExecute.unpack
         check = get_check(instance)
         check.check(instance)
-        aggregator.assert_service_check('ibm_mq.channel', check.UNKNOWN, count=1)
+
         assert not caplog.records
+
+
+def test_unknown_service_check(aggregator, get_check, instance, caplog):
+    # Late import to ignore missing library for e2e
+    from pymqi import MQMIError, PCFExecute
+    from pymqi.CMQC import MQCC_FAILED, MQRC_NO_MSG_AVAILABLE
+
+    m = mock.MagicMock()
+    with mock.patch('datadog_checks.ibm_mq.collectors.channel_metric_collector.pymqi.PCFExecute', new=m), mock.patch(
+        'datadog_checks.ibm_mq.collectors.queue_metric_collector.pymqi.PCFExecute', new=m
+    ), mock.patch('datadog_checks.ibm_mq.collectors.stats_collector.pymqi.PCFExecute', new=m):
+        error = MQMIError(MQCC_FAILED, MQRC_NO_MSG_AVAILABLE)
+        m.side_effect = error
+        m.unpack = PCFExecute.unpack
+        check = get_check(instance)
+        check.check(instance)
+
+        tags = [
+            'queue_manager:{}'.format(common.QUEUE_MANAGER),
+            'mq_host:{}'.format(common.HOST),
+            'port:{}'.format(common.PORT),
+            'connection_name:{}({})'.format(common.HOST, common.PORT),
+            'foo:bar',
+        ]
+
+        # assert all channel serive checks are UNKNOWN
+        channels = [common.CHANNEL, common.BAD_CHANNEL, '*']
+        for channel in channels:
+            channel_tags = tags + ['channel:{}'.format(channel)]
+            aggregator.assert_service_check('ibm_mq.channel', check.UNKNOWN, tags=channel_tags, count=1)
 
 
 def test_errors_are_loogged(get_check, instance, caplog):

--- a/ibm_mq/tests/test_ibm_mq_int.py
+++ b/ibm_mq/tests/test_ibm_mq_int.py
@@ -19,7 +19,7 @@ from .common import QUEUE_METRICS, assert_all_metrics
 pytestmark = [pytest.mark.usefixtures("dd_environment"), pytest.mark.integration]
 
 
-def test_no_msg_errors_are_caught(get_check, instance, caplog):
+def test_no_msg_errors_are_caught(aggregator, get_check, instance, caplog):
     # Late import to ignore missing library for e2e
     from pymqi import MQMIError, PCFExecute
     from pymqi.CMQC import MQCC_FAILED, MQRC_NO_MSG_AVAILABLE
@@ -34,7 +34,7 @@ def test_no_msg_errors_are_caught(get_check, instance, caplog):
         m.unpack = PCFExecute.unpack
         check = get_check(instance)
         check.check(instance)
-
+        aggregator.assert_service_check('ibm_mq.channel', check.UNKNOWN, count=1)
         assert not caplog.records
 
 

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -27,7 +27,6 @@ def test_channel_status_service_check_default_mapping(aggregator, get_check, ins
         pymqi.CMQCFC.MQCHS_REQUESTING: AgentCheck.WARNING,
         pymqi.CMQCFC.MQCHS_PAUSED: AgentCheck.WARNING,
         pymqi.CMQCFC.MQCHS_INITIALIZING: AgentCheck.WARNING,
-        pymqi.CMQC.MQRC_NO_MSG_AVAILABLE: AgentCheck.UNKNOWN,
     }
 
     for status in service_check_map:

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -27,6 +27,7 @@ def test_channel_status_service_check_default_mapping(aggregator, get_check, ins
         pymqi.CMQCFC.MQCHS_REQUESTING: AgentCheck.WARNING,
         pymqi.CMQCFC.MQCHS_PAUSED: AgentCheck.WARNING,
         pymqi.CMQCFC.MQCHS_INITIALIZING: AgentCheck.WARNING,
+        pymqi.CMQC.MQRC_NO_MSG_AVAILABLE: AgentCheck.UNKNOWN,
     }
 
     for status in service_check_map:


### PR DESCRIPTION
### What does this PR do?
Adds a service check test for when there are no messages available, see https://www.ibm.com/docs/en/ibm-mq/9.2?topic=codes-2033-07f1-rc2033-mqrc-no-msg-available

### Motivation
QA for https://github.com/DataDog/integrations-core/pull/9703

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
