### PR TITLE
Assert raft metric

### DIFF
--- a/consul/tests/common.py
+++ b/consul/tests/common.py
@@ -39,7 +39,7 @@ PROMETHEUS_METRICS = [
     'consul.serf.member.update',
 ]
 
-PROMETHEUS_METRICS_1_9 = ['consul.client.rpc.failed']
+PROMETHEUS_METRICS_1_9 = ['consul.client.rpc.failed', 'consul.raft.leader.lastContact.count']
 
 PROMETHEUS_HIST_METRICS = [
     'consul.memberlist.gossip.',


### PR DESCRIPTION
### What does this PR do?
adds back assertion for `consul.raft.leader.lastContact.count`
### Motivation
https://github.com/DataDog/integrations-core/pull/9382/files#diff-2518f4bfe13b0ca6ea42e590472f9242a1be5682fb47beb908ad10eecd995785L41 removed it
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
