### PR TITLE
Add empty_default_hostname to dd_environment

### DIFF
--- a/vsphere/tests/common.py
+++ b/vsphere/tests/common.py
@@ -20,6 +20,7 @@ LAB_INSTANCE = {
     'collection_type': 'both',
     'use_legacy_check_version': False,
     'collect_metric_instance_values': True,
+    'empty_default_hostname': True,
     'ssl_verify': False,
     'collect_tags': True,
     'collect_events': True,


### PR DESCRIPTION
### What does this PR do?
Adds the config option `empty_default_hostname: True` to the `dd_environment`

### Motivation
`empty_default_hostname` is a required config option now 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
