### PR TITLE
gitlab-runner bump image for testing

### DIFF
--- a/gitlab_runner/tests/compose/docker-compose.yml
+++ b/gitlab_runner/tests/compose/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     entrypoint:
       - /support/wait_for_master.sh
   gitlab:
-    image: gitlab/gitlab-ce:latest
+    image: gitlab/gitlab-ce:${GITLAB_RUNNER_VERSION}-ce.0
     ports:
       - "${GITLAB_LOCAL_MASTER_PORT}:80"
     environment:

--- a/gitlab_runner/tox.ini
+++ b/gitlab_runner/tox.ini
@@ -1,6 +1,8 @@
 [tox]
 minversion = 2.0
 basepython = py38
+# Gitlab runner support policy is to support one stable release at any given time.
+# https://gitlab.com/gitlab-org/gitlab-foss/-/blob/11661c2a1dfe042f37e3ba1eac69315daa0edb9b/MAINTENANCE.md
 envlist =
     py{27,38}-{13.12.0,14.1.0}
 

--- a/gitlab_runner/tox.ini
+++ b/gitlab_runner/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-10.8.0
+    py{27,38}-{13.12.0,14.1.0}
 
 [testenv]
 ensure_default_envdir = true


### PR DESCRIPTION
Use same version as gitlab runner
Updates testing version as current version is too old
