### PR TITLE
kube_scheduler/kube_controller_manager: pass SSL options for health checks

### DIFF
--- a/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
@@ -11,6 +11,7 @@ from datadog_checks.base import AgentCheck
 from datadog_checks.base.checks.kube_leader import KubeLeaderElectionMixin
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.config import is_affirmative
+from datadog_checks.base.utils.http import RequestsWrapper
 
 
 class KubeControllerManagerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
@@ -224,11 +225,33 @@ class KubeControllerManagerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
 
         tags = instance.get("tags", [])
         service_check_name = 'kube_controller_manager.up'
+        http_handler = self._healthcheck_http_handler(instance, url)
 
         try:
-            response = self.http.get(url)
+            response = http_handler.get(url)
             response.raise_for_status()
             self.service_check(service_check_name, AgentCheck.OK, tags=tags)
         except requests.exceptions.RequestException as e:
             message = str(e)
             self.service_check(service_check_name, AgentCheck.CRITICAL, message=message, tags=tags)
+
+    def _healthcheck_http_handler(self, instance, endpoint):
+        if endpoint in self._http_handlers:
+            return self._http_handlers[endpoint]
+
+        config = {}
+        config['tls_cert'] = instance.get('ssl_cert', None)
+        config['tls_private_key'] = instance.get('ssl_private_key', None)
+        config['tls_verify'] = instance.get('ssl_verify', True)
+        config['tls_ignore_warning'] = instance.get('ssl_ignore_warning', False)
+        config['tls_ca_cert'] = instance.get('ssl_ca_cert', None)
+
+        if config['tls_ca_cert'] is None:
+            config['tls_ignore_warning'] = True
+            config['tls_verify'] = False
+
+        http_handler = self._http_handlers[endpoint] = RequestsWrapper(
+            config, self.init_config, self.HTTP_CONFIG_REMAPPER, self.log
+        )
+
+        return http_handler


### PR DESCRIPTION
### What does this PR do?

Fixes a warning printed out when running the `kube_scheduler` and `kube_controller_manager` checks:

```
2021-08-24 08:34:49 UTC | CORE | WARN | (pkg/collector/python/datadog_agent.go:124 in LogMessage) | kube_scheduler:f99c6bf7f3d8b29b | (http.py:338) | An unverified HTTPS request is being made to https://172.18.0.4:10259/healthz
2021-08-24 08:34:57 UTC | CORE | WARN | (pkg/collector/python/datadog_agent.go:124 in LogMessage) | kube_controller_manager:ec28c854e9635dd6 | (http.py:338) | An unverified HTTPS request is being made to https://172.18.0.4:10257/healthz
```

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
