### PR TITLE
Add tests for version selector

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/legacy_0_10_2.py
@@ -31,7 +31,6 @@ class LegacyKafkaCheck_0_10_2(object):
         # supports that functionality for Zookeeper, not Kafka.
         self.validate_consumer_groups()
 
-        self._kafka_client = self._create_kafka_client()
         self._zk_hosts_ports = self.instance.get('zk_connect_str')
 
         # If we are collecting from Zookeeper, then create a long-lived zk client
@@ -51,6 +50,12 @@ class LegacyKafkaCheck_0_10_2(object):
                 hosts=self._zk_hosts_ports, timeout=int(self.init_config.get('zk_timeout', 5))
             )
             self._zk_client.start()
+
+    @property
+    def kafka_client(self):
+        if self._kafka_client is None:
+            self._kafka_client = self._create_kafka_client()
+        return self._kafka_client
 
     def __getattr__(self, item):
         try:
@@ -84,7 +89,7 @@ class LegacyKafkaCheck_0_10_2(object):
         # Fetch consumer group offsets from Kafka
         # Support for storing offsets in Kafka not available until Kafka 0.8.2. Also, for legacy reasons, this check
         # only fetches consumer offsets from Kafka if Zookeeper is omitted or kafka_consumer_offsets is True.
-        if self._kafka_client.config.get('api_version') >= (0, 8, 2) and is_affirmative(
+        if self.kafka_client.config.get('api_version') >= (0, 8, 2) and is_affirmative(
             self.instance.get('kafka_consumer_offsets', self._zk_hosts_ports is None)
         ):
             try:
@@ -98,7 +103,7 @@ class LegacyKafkaCheck_0_10_2(object):
             self.log.debug(
                 'Identified api_version: %s, kafka_consumer_offsets: %s, zk_connection_string: %s.'
                 ' Skipping consumer offset collection',
-                str(self._kafka_client.config.get('api_version')),
+                str(self.kafka_client.config.get('api_version')),
                 str(self.instance.get('kafka_consumer_offsets')),
                 str(self._zk_hosts_ports),
             )
@@ -139,14 +144,14 @@ class LegacyKafkaCheck_0_10_2(object):
 
     def _make_blocking_req(self, request, node_id=None):
         if node_id is None:
-            node_id = self._kafka_client.least_loaded_node()
+            node_id = self.kafka_client.least_loaded_node()
 
-        while not self._kafka_client.ready(node_id):
+        while not self.kafka_client.ready(node_id):
             # poll until the connection to broker is ready, otherwise send() will fail with NodeNotReadyError
-            self._kafka_client.poll()
+            self.kafka_client.poll()
 
-        future = self._kafka_client.send(node_id, request)
-        self._kafka_client.poll(future=future)  # block until we get response.
+        future = self.kafka_client.send(node_id, request)
+        self.kafka_client.poll(future=future)  # block until we get response.
         if future.failed():
             raise future.exception  # pylint: disable-msg=raising-bad-type
         response = future.value
@@ -174,11 +179,11 @@ class LegacyKafkaCheck_0_10_2(object):
             tps_with_consumer_offset = {(topic, partition) for (_, topic, partition) in self._kafka_consumer_offsets}
             tps_with_consumer_offset.update({(topic, partition) for (_, topic, partition) in self._zk_consumer_offsets})
 
-        for broker in self._kafka_client.cluster.brokers():
+        for broker in self.kafka_client.cluster.brokers():
             if len(self._highwater_offsets) >= contexts_limit:
                 self.warning("Context limit reached. Skipping highwater offsets collection.")
                 return
-            broker_led_partitions = self._kafka_client.cluster.partitions_for_broker(broker.nodeId)
+            broker_led_partitions = self.kafka_client.cluster.partitions_for_broker(broker.nodeId)
             if broker_led_partitions is None:
                 continue
             # Take the partitions for which this broker is the leader and group them by topic in order to construct the
@@ -225,7 +230,7 @@ class LegacyKafkaCheck_0_10_2(object):
                         topic,
                         partition,
                     )
-                    self._kafka_client.cluster.request_update()  # force metadata update on next poll()
+                    self.kafka_client.cluster.request_update()  # force metadata update on next poll()
                 elif error_type is kafka_errors.UnknownTopicOrPartitionError:
                     self.log.warning(
                         "Kafka broker returned %s (error_code %s) for topic: %s, partition: %s. This should only "
@@ -257,7 +262,7 @@ class LegacyKafkaCheck_0_10_2(object):
                 consumer_group_tags.append('source:%s' % kwargs['source'])
             consumer_group_tags.extend(self._custom_tags)
 
-            partitions = self._kafka_client.cluster.partitions_for_topic(topic)
+            partitions = self.kafka_client.cluster.partitions_for_topic(topic)
             if partitions is not None and partition in partitions:
                 # report consumer offset if the partition is valid because even if leaderless the consumer offset will
                 # be valid once the leader failover completes
@@ -299,7 +304,7 @@ class LegacyKafkaCheck_0_10_2(object):
                         "included in the cluster partitions, so skipping reporting these offsets."
                     )
                 self.log.warning(msg, consumer_group, topic, partition)
-                self._kafka_client.cluster.request_update()  # force metadata update on next poll()
+                self.kafka_client.cluster.request_update()  # force metadata update on next poll()
 
     def _get_zk_path_children(self, zk_path, name_for_error):
         """Fetch child nodes for a given Zookeeper path."""
@@ -384,7 +389,7 @@ class LegacyKafkaCheck_0_10_2(object):
                         # If partitions omitted, then we assume the group is consuming all partitions for the topic.
                         # Fetch consumer offsets even for unavailable partitions because those will be valid once the
                         # partition finishes leader failover.
-                        topic_partitions[topic] = self._kafka_client.cluster.partitions_for_topic(topic)
+                        topic_partitions[topic] = self.kafka_client.cluster.partitions_for_topic(topic)
 
                 coordinator_id = self._get_group_coordinator(consumer_group)
                 if coordinator_id is not None:
@@ -400,7 +405,7 @@ class LegacyKafkaCheck_0_10_2(object):
                             # -1, meaning there is no recorded offset for that partition... for example, if the
                             # partition doesn't exist in the cluster. So ignore it.
                             if offset == -1 or error_type is not kafka_errors.NoError:
-                                self._kafka_client.cluster.request_update()  # force metadata update on next poll()
+                                self.kafka_client.cluster.request_update()  # force metadata update on next poll()
                                 continue
                             key = (consumer_group, topic, partition)
                             self._kafka_consumer_offsets[key] = offset

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -6,6 +6,8 @@ import os
 import pytest
 
 from datadog_checks.kafka_consumer import KafkaCheck
+from datadog_checks.kafka_consumer.legacy_0_10_2 import LegacyKafkaCheck_0_10_2
+from datadog_checks.kafka_consumer.new_kafka_consumer import NewKafkaConsumerCheck
 
 from .common import KAFKA_CONNECT_STR, is_legacy_check, is_supported
 
@@ -17,6 +19,24 @@ pytestmark = pytest.mark.skipif(
 BROKER_METRICS = ['kafka.broker_offset']
 
 CONSUMER_METRICS = ['kafka.consumer_offset', 'kafka.consumer_lag']
+
+
+@pytest.mark.unit
+def test_uses_legacy_implementation_when_legacy_version_specified(kafka_instance):
+    kafka_instance['kafka_client_api_version'] = '0.10.1'
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
+    kafka_consumer_check._init_check_based_on_kafka_version()
+
+    assert isinstance(kafka_consumer_check.sub_check, LegacyKafkaCheck_0_10_2)
+
+
+@pytest.mark.unit
+def test_uses_new_implementation_when_new_version_specified(kafka_instance):
+    kafka_instance['kafka_client_api_version'] = '0.10.2'
+    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
+    kafka_consumer_check._init_check_based_on_kafka_version()
+
+    assert isinstance(kafka_consumer_check.sub_check, NewKafkaConsumerCheck)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Add more tests for https://github.com/DataDog/integrations-core/pull/9626

Also changes the legacy check to follow the same property model for `kafka_client` that the new_kafka_consumer has so the test can still be a unit_test (otherwise it tries to actually establish a connnection during `__init__`.
