### PR TITLE
Fix postgres collection_errors error reference

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -361,7 +361,7 @@ class PostgresStatementSamples(DBMAsyncJob):
                 tags=self._dbtags(dbname, "error:explain-{}".format(type(e))) + self._check._get_debug_tags(),
                 hostname=self._check.resolved_hostname,
             )
-            return None, DBExplainError.database_error, '{}'.format(type(err))
+            return None, DBExplainError.database_error, '{}'.format(type(e))
 
     def _collect_plan_for_statement(self, row):
         try:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes a bug where we were referencing the incorrect `error` variable.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
