### PR TITLE
Add 'rabbitmq-server'  to process signature

### DIFF
--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -14,7 +14,8 @@
   "metric_to_check": "rabbitmq.queue.messages",
   "name": "rabbitmq",
   "process_signatures": [
-    "rabbitmq"
+    "rabbitmq",
+    "rabbitmq-server"
   ],
   "public_title": "Datadog-RabbitMQ Integration",
   "short_description": "Track queue size, consumer count, unacknowledged messages, and more.",


### PR DESCRIPTION
### What does this PR do?
Adds a process signature for `rabbitmq-server` to the `rabbitmq` integration per https://www.rabbitmq.com/rabbitmq-server.8.html so we can autodetect this process.

### Motivation
We want to update the integrations signature `rabbitmq` so we'd be able to autodetect them by matching a process command line.

### Additional Notes
@DataDog/processes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
