### PR TITLE
Fix terraform templates

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/terraform/gke_config.tf
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/terraform/gke_config.tf
@@ -25,22 +25,3 @@ resource "random_string" "suffix" {
   special = false
   upper = false
 }
-
-resource "local_file" "kubeconfig" {
-  content = "${data.template_file.kubeconfig.rendered}"
-  filename = "${path.module}/kubeconfig"
-}
-
-data "template_file" "kubeconfig" {
-  template = file("${path.module}/kubeconfig-template.yaml")
-
-  vars = {
-    cluster_name = google_container_cluster.gke_cluster.name
-    user_name = google_container_cluster.gke_cluster.master_auth.0.username
-    user_password = google_container_cluster.gke_cluster.master_auth.0.password
-    endpoint = google_container_cluster.gke_cluster.endpoint
-    cluster_ca = google_container_cluster.gke_cluster.master_auth.0.cluster_ca_certificate
-    client_cert = google_container_cluster.gke_cluster.master_auth.0.client_certificate
-    client_cert_key = google_container_cluster.gke_cluster.master_auth.0.client_key
-  }
-}

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/terraform/providers.tf
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/terraform/providers.tf
@@ -1,5 +1,4 @@
 provider "google" {
-  version = "~> 2.11"
   credentials = var.account_json
   project = "datadog-integrations-lab"
   region = "europe-west4"


### PR DESCRIPTION
### What does this PR do?
Removes unneeded lines from the terraform templates 

### Motivation
- `openstack_controller` is the only check that uses terraform for testing now, and it does not contain the `google_container_cluster.gke_cluster` resource so it breaks with this line
- Version constraints inside provider configuration blocks are deprecated now

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
