### PR TITLE
Fix missing caching of pg_settings

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -423,11 +423,12 @@ class PostgreSql(AgentCheck):
                 db = self._new_connection(dbname)
                 db.set_session(autocommit=True)
                 self._db_pool[dbname] = db
+                if self._config.dbname == dbname:
+                    # reload settings for the main DB only once every time the connection is reestablished
+                    self._load_pg_settings(db)
             if db.status != psycopg2.extensions.STATUS_READY:
                 # Some transaction went wrong and the connection is in an unhealthy state. Let's fix that
                 db.rollback()
-            if self._config.dbname == dbname:
-                self._load_pg_settings(db)
             return db
 
     def _close_db_pool(self):


### PR DESCRIPTION
### What does this PR do?
Reading of `pg_settings` should be done only once after a connection is first established.

### Motivation
Fix missing caching leading to excessive querying of `pg_settings`. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
