### PR TITLE
Fix crash when some permissions are missing

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -33,6 +33,7 @@ from datadog_checks.vsphere.resource_filters import TagFilter
 from datadog_checks.vsphere.types import (
     CounterId,
     InfrastructureData,
+    InfrastructureDataItem,
     InstanceConfig,
     MetricName,
     MorBatch,
@@ -238,7 +239,7 @@ class VSphereCheck(AgentCheck):
                 # Hosts are not considered as parents of the VMs they run, we use the `runtime.host` property
                 # to get the name of the ESXi host
                 runtime_host = properties.get("runtime.host")
-                runtime_host_props = {}
+                runtime_host_props = {}  # type: InfrastructureDataItem
                 if runtime_host:
                     if runtime_host in infrastructure_data:
                         runtime_host_props = infrastructure_data.get(runtime_host, {}) if runtime_host else {}

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -238,7 +238,12 @@ class VSphereCheck(AgentCheck):
                 # Hosts are not considered as parents of the VMs they run, we use the `runtime.host` property
                 # to get the name of the ESXi host
                 runtime_host = properties.get("runtime.host")
-                runtime_host_props = infrastructure_data.get(runtime_host, {}) if runtime_host else {}
+                runtime_host_props = {}
+                if runtime_host:
+                    if runtime_host in infrastructure_data:
+                        runtime_host_props = infrastructure_data.get(runtime_host, {}) if runtime_host else {}
+                    else:
+                        self.log.debug("Missing runtime.host details for VM %s", mor_name)
                 runtime_hostname = to_string(runtime_host_props.get("name", "unknown"))
                 tags.append('vsphere_host:{}'.format(runtime_hostname))
 

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -238,7 +238,7 @@ class VSphereCheck(AgentCheck):
                 # Hosts are not considered as parents of the VMs they run, we use the `runtime.host` property
                 # to get the name of the ESXi host
                 runtime_host = properties.get("runtime.host")
-                runtime_host_props = infrastructure_data[runtime_host] if runtime_host else {}
+                runtime_host_props = infrastructure_data.get(runtime_host, {}) if runtime_host else {}
                 runtime_hostname = to_string(runtime_host_props.get("name", "unknown"))
                 tags.append('vsphere_host:{}'.format(runtime_hostname))
 

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -242,7 +242,7 @@ class VSphereCheck(AgentCheck):
                 runtime_host_props = {}  # type: InfrastructureDataItem
                 if runtime_host:
                     if runtime_host in infrastructure_data:
-                        runtime_host_props = infrastructure_data.get(runtime_host, {}) if runtime_host else {}
+                        runtime_host_props = infrastructure_data.get(runtime_host, {})
                     else:
                         self.log.debug("Missing runtime.host details for VM %s", mor_name)
                 runtime_hostname = to_string(runtime_host_props.get("name", "unknown"))

--- a/vsphere/tests/fixtures/host_tags_values.json
+++ b/vsphere/tests/fixtures/host_tags_values.json
@@ -86,6 +86,20 @@
         }
     ],
     [
+        "VM-on-fake-host",
+        {
+            "vsphere": [
+                "vsphere_host:unknown",
+                "vsphere_folder:Datacenters",
+                "vsphere_datacenter:Datacenter2",
+                "vsphere_folder:vm",
+                "vsphere_folder:Discovered virtual machine",
+                "vsphere_type:vm",
+                "vcenter_server:FAKE"
+            ]
+        }
+    ],
+    [
         "VM3-1",
         {
             "vsphere": [

--- a/vsphere/tests/fixtures/topology.json
+++ b/vsphere/tests/fixtures/topology.json
@@ -153,6 +153,13 @@
                             "children": [
                                 {
                                     "spec": "VirtualMachine",
+                                    "name": "VM-on-fake-host",
+                                    "mo_id": "VM-fake-host",
+                                    "runtime.powerState": "on",
+                                    "runtime.host": "DOES_NOT_EXIST"
+                                },
+                                {
+                                    "spec": "VirtualMachine",
                                     "name": "VM4-2",
                                     "mo_id": "VM4-2-1",
                                     "runtime.powerState": "on",

--- a/vsphere/tests/mocked_api.py
+++ b/vsphere/tests/mocked_api.py
@@ -71,8 +71,7 @@ class MockedAPI(object):
         for _, props in iteritems(self.infrastructure_data):
             if 'runtime.host_moid' in props:
                 hosts = [m for m, p in iteritems(self.infrastructure_data) if p['name'] == props['runtime.host_moid']]
-                assert len(hosts) == 1
-                props['runtime.host'] = hosts[0]
+                props['runtime.host'] = hosts[0] if hosts else object()
                 del props['runtime.host_moid']
 
     def smart_connect(self):


### PR DESCRIPTION
The runtime host on which a VM is running might not be monitorable in some cases, in particular when permissions are missing. This PR gracefully handles such cases.