### PR TITLE
Stop emitting incorrect queue warning

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
@@ -101,6 +101,8 @@ class QueueMetricCollector(object):
                 # https://github.com/dsuch/pymqi/blob/v1.12.0/docs/examples.rst#how-to-wait-for-multiple-messages
                 if e.comp == pymqi.CMQC.MQCC_FAILED and e.reason == pymqi.CMQC.MQRC_NO_MSG_AVAILABLE:
                     self.log.debug("No queue info available")
+                elif e.comp == pymqi.CMQC.MQCC_FAILED and e.reason == pymqi.CMQC.MQRC_UNKNOWN_OBJECT_NAME:
+                    self.log.debug("No matching queue of type %d for pattern %s", queue_type, mq_pattern_filter)
                 else:
                     self.warning("Error discovering queue: %s", e)
             else:
@@ -113,6 +115,9 @@ class QueueMetricCollector(object):
                 # https://dsuch.github.io/pymqi/examples.html#how-to-specify-dynamic-reply-to-queues
                 if pcf is not None:
                     pcf.disconnect()
+
+        if not queues:
+            self.warning("No matching queue of type MQQT_LOCAL or MQQT_REMOTE for pattern %s", mq_pattern_filter)
 
         return queues
 


### PR DESCRIPTION
When discovering queues of types LOCAL and MODEL, the check was emitting a warning if there was no LOCAL queue while it should wait for MODEL queues first and only emit a warning once we're sure that no queue at all matches the given pattern.