### PR TITLE
Fix note widget order for the tomcat dashboard

### DIFF
--- a/tomcat/assets/dashboards/overview.json
+++ b/tomcat/assets/dashboards/overview.json
@@ -217,7 +217,7 @@
               "id": 4016470968177076,
               "definition": {
                 "type": "note",
-                "content": "The sum of request processing times across all requests handled by the request processors (in milliseconds) per second.",
+                "content": "The number of client requests hitting your server. Request counts provide a baseline for understanding the levels of traffic to your server throughout the day.",
                 "background_color": "purple",
                 "font_size": "14",
                 "text_align": "left",
@@ -275,7 +275,7 @@
               "id": 8536291398921956,
               "definition": {
                 "type": "note",
-                "content": "The number of client requests hitting your server. Request counts provide a baseline for understanding the levels of traffic to your server throughout the day.",
+                "content": "The sum of request processing times across all requests handled by the request processors (in milliseconds) per second.",
                 "background_color": "purple",
                 "font_size": "14",
                 "text_align": "left",
@@ -755,4 +755,3 @@
     "reflow_type": "fixed",
     "id": "ge2-uba-mu8"
   }
-  


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Fix note widget order for the tomcat dashboard 

### Motivation
<!-- What inspired you to submit this pull request? -->

![Screenshot 2021-09-01 at 18 24 39](https://user-images.githubusercontent.com/7736434/131708020-33b7e7c2-2fe7-40b1-b11e-63f8a5d45133.png)

![image](https://user-images.githubusercontent.com/7736434/131708075-981cebd0-490d-4b2c-92dd-9f636536b8ef.png)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
