### PR TITLE
Set disable_unsafe_yaml default value

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -21,7 +21,7 @@ class DatadogAgentStub(object):
         self._hostname = 'stubbed.hostname'
 
     def get_default_config(self):
-        return {'enable_metadata_collection': True}
+        return {'enable_metadata_collection': True, 'disable_unsafe_yaml': True}
 
     def reset(self):
         self._metadata.clear()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Set default value of `disable_unsafe_yaml` of the stub datadog agent, so it's the same default value as in the real agent https://github.com/DataDog/datadog-agent/blob/4452508ba1985be3a01320ded1faccb11dc33991/pkg/config/config.go#L296

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
