### PR TITLE
Allow double quote on requirement

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
@@ -61,7 +61,7 @@ def load_base_check(req_file, dependencies, errors, check_name=None):
         if line.startswith('CHECKS_BASE_REQ'):
             try:
                 dep = line.split(' = ')[1]
-                req = Requirement(dep.strip("'"))
+                req = Requirement(dep.strip("'").strip('"'))
             except (IndexError, InvalidRequirement) as e:
                 errors.append(f'File `{req_file}` has an invalid base check dependency: `{line}`\n{e}')
                 return

--- a/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
@@ -61,7 +61,7 @@ def load_base_check(req_file, dependencies, errors, check_name=None):
         if line.startswith('CHECKS_BASE_REQ'):
             try:
                 dep = line.split(' = ')[1]
-                req = Requirement(dep.strip("'").strip('"'))
+                req = Requirement(dep.strip("'\""))
             except (IndexError, InvalidRequirement) as e:
                 errors.append(f'File `{req_file}` has an invalid base check dependency: `{line}`\n{e}')
                 return


### PR DESCRIPTION
Currently this passes validation

```
CHECKS_BASE_REQ = 'datadog-checks-base>=4.2.0'
```

but this doesnt

```
CHECKS_BASE_REQ = "datadog-checks-base>=4.2.0"
```

This PR allows the second case to pass validation