### PR TITLE
Matheus/ndm validator make explicit

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_snmp_profiles.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_snmp_profiles.py
@@ -14,7 +14,7 @@ MESSAGE_METHODS = {'success': echo_success, 'warning': echo_warning, 'failure': 
 
 @click.command("validate-profile", short_help="Validate SNMP profiles", context_settings=CONTEXT_SETTINGS)
 @click.option('-f', '--file', help="Path to a profile file to validate")
-@click.option('-d', '--directory', help="Path to a directory of profiles to validate")
+@click.option('-d', '--directory', multiple=True , help="Path to a directory of profiles to validate")
 @click.option('-v', '--verbose', help="Increase verbosity of error messages", is_flag=True)
 def validate_profile(file, directory, verbose):
     path = initialize_path(directory)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_snmp_profiles.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validate_snmp_profiles.py
@@ -14,7 +14,7 @@ MESSAGE_METHODS = {'success': echo_success, 'warning': echo_warning, 'failure': 
 
 @click.command("validate-profile", short_help="Validate SNMP profiles", context_settings=CONTEXT_SETTINGS)
 @click.option('-f', '--file', help="Path to a profile file to validate")
-@click.option('-d', '--directory', multiple=True , help="Path to a directory of profiles to validate")
+@click.option('-d', '--directory', multiple=True, help="Path to a directory of profiles to validate")
 @click.option('-v', '--verbose', help="Increase verbosity of error messages", is_flag=True)
 def validate_profile(file, directory, verbose):
     path = initialize_path(directory)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/utils.py
@@ -4,6 +4,7 @@ from os.path import join
 import yaml
 from genericpath import isfile
 from yaml.error import YAMLError
+from yaml.events import StreamEndEvent
 from yaml.loader import SafeLoader
 
 from datadog_checks.dev.tooling.commands.console import echo_failure
@@ -14,10 +15,15 @@ def initialize_path(directory):
     path = []
     path.append('./')
 
-    path.append(get_default_snmp_profiles_path())
 
     if directory:
-        path.append(directory)
+        if isinstance(directory, tuple):
+            for dir in directory:
+                path.append(dir)
+        elif isinstance(directory, str):
+            path.append(directory)
+    else:
+        path.append(get_default_snmp_profiles_path())
 
     return path
 
@@ -70,7 +76,13 @@ def get_default_snmp_profiles_path():
 
 
 def get_all_profiles_directory(directory):
-    return glob.glob(join(directory, "*.yaml"))
+    profiles = []
+    if isinstance(directory, tuple):
+        for dir in directory:
+            profiles.extend(glob.glob(join(dir, "*.yaml")))
+    elif isinstance(directory, str):
+        profiles = glob.glob(join(directory, "*.yaml"))
+    return profiles
 
 
 class SafeLineLoader(SafeLoader):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/validators/utils.py
@@ -4,7 +4,6 @@ from os.path import join
 import yaml
 from genericpath import isfile
 from yaml.error import YAMLError
-from yaml.events import StreamEndEvent
 from yaml.loader import SafeLoader
 
 from datadog_checks.dev.tooling.commands.console import echo_failure
@@ -14,7 +13,6 @@ from datadog_checks.dev.tooling.constants import get_root
 def initialize_path(directory):
     path = []
     path.append('./')
-
 
     if directory:
         if isinstance(directory, tuple):


### PR DESCRIPTION
### What does this PR do?
Gives the ability to the user of passing multiple directories to validate-profile, for instance:
` ddev meta snmp validate-profiles -d /path/to/dir1 -d /path/to/dir2`

Also, the directory with the built profiles are only taken into account if no directory is passed or if it is passed explicitly.

### Motivation
To allow user to validate custom profiles in different directories.

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
