### PR TITLE
kubelet: don't call the tagger for pods not running

### DIFF
--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -105,6 +105,7 @@ class PodListUtils(object):
 
     def __init__(self, podlist):
         self.containers = {}
+        self.pods = {}
         self.static_pod_uids = set()
         self.cache = {}
         self.pod_uid_by_name_tuple = {}
@@ -119,6 +120,7 @@ class PodListUtils(object):
             namespace = metadata.get("namespace")
             pod_name = metadata.get("name")
             self.pod_uid_by_name_tuple[(namespace, pod_name)] = uid
+            self.pods[uid] = pod
 
             # FIXME we are forced to do that because the Kubelet PodList isn't updated
             # for static pods, see https://github.com/kubernetes/kubernetes/pull/59948

--- a/kubelet/datadog_checks/kubelet/summary.py
+++ b/kubelet/datadog_checks/kubelet/summary.py
@@ -32,12 +32,22 @@ class SummaryScraperMixin(object):
                 self.log.warning("Got incomplete results from '/stats/summary', missing data for POD: %s", pod)
                 continue
 
-            self._report_pod_stats(pod_namespace, pod_name, pod_uid, pod, instance_tags, main_stats_source)
+            self._report_pod_stats(
+                pod_namespace, pod_name, pod_uid, pod, pod_list_utils, instance_tags, main_stats_source
+            )
             self._report_container_stats(
                 pod_namespace, pod_name, pod.get('containers', []), pod_list_utils, instance_tags, main_stats_source
             )
 
-    def _report_pod_stats(self, pod_namespace, pod_name, pod_uid, pod, instance_tags, main_stats_source):
+    def _report_pod_stats(
+        self, pod_namespace, pod_name, pod_uid, pod, pod_list_utils, instance_tags, main_stats_source
+    ):
+        # avoid calling the tagger for pods that aren't running, as these are
+        # never stored
+        pod_phase = pod_list_utils.pods.get(pod_uid, {}).get('status', {}).get('phase', None)
+        if pod_phase != 'Running':
+            return
+
         pod_tags = tags_for_pod(pod_uid, tagger.ORCHESTRATOR)
         if not pod_tags:
             self.log.debug("Tags not found for pod: %s/%s - no metrics will be sent", pod_namespace, pod_name)

--- a/kubelet/tests/fixtures/pods_list_1.2.json
+++ b/kubelet/tests/fixtures/pods_list_1.2.json
@@ -448,7 +448,7 @@
         "generateName": "dd-agent-",
         "namespace": "default",
         "selfLink": "/api/v1/namespaces/default/pods/dd-agent-ntepl",
-        "uid": "12ceeaa9-33ca-11e6-ac8f-42010af00003",
+        "uid": "c2319815-10d0-11e8-bd5a-42010af00137",
         "resourceVersion": "456746",
         "creationTimestamp": "2016-06-16T13:56:07Z",
         "labels": {

--- a/kubelet/tests/fixtures/stats_summary.json
+++ b/kubelet/tests/fixtures/stats_summary.json
@@ -126,9 +126,9 @@
   "pods": [
    {
     "podRef": {
-     "name": "dd-agent-ntepl",
-     "namespace": "datadog",
-     "uid": "12ceeaa9-33ca-11e6-ac8f-42010af00003"
+     "name": "fluentd-gcp-v2.0.10-9q9t4",
+     "namespace": "kube-system",
+     "uid": "2edfd4d9-10ce-11e8-bd5a-42010af00137"
     },
     "startTime": "2019-11-19T10:43:16Z",
     "containers": [
@@ -1333,9 +1333,9 @@
    },
    {
     "podRef": {
-     "name": "demo-app-success-c485bc67b-klj45",
-     "namespace": "lenaic",
-     "uid": "24d6daa3-10d8-11e8-bd5a-42010af00137"
+     "name": "datadog-agent-ntepl",
+     "namespace": "default",
+     "uid": "c2319815-10d0-11e8-bd5a-42010af00137"
     },
     "startTime": "2019-11-20T13:10:17Z",
     "containers": [

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -129,6 +129,7 @@ EXPECTED_METRICS_PROMETHEUS_PRE_1_14 = EXPECTED_METRICS_PROMETHEUS + [
 ]
 
 COMMON_TAGS = {
+    "kubernetes_pod_uid://c2319815-10d0-11e8-bd5a-42010af00137": ["pod_name:datadog-agent-jbm2k"],
     "kubernetes_pod_uid://2edfd4d9-10ce-11e8-bd5a-42010af00137": ["pod_name:fluentd-gcp-v2.0.10-9q9t4"],
     "kubernetes_pod_uid://2fdfd4d9-10ce-11e8-bd5a-42010af00137": ["pod_name:fluentd-gcp-v2.0.10-p13r3"],
     'container_id://5741ed2471c0e458b6b95db40ba05d1a5ee168256638a0264f08703e48d76561': [
@@ -943,10 +944,10 @@ def test_process_stats_summary_not_source_linux(monkeypatch, aggregator, tagger)
     # As we did not activate `use_stats_summary_as_source`,
     # we only have ephemeral storage metrics and kubelet stats
     aggregator.assert_metric(
-        'kubernetes.ephemeral_storage.usage', 69406720.0, ['instance:tag', 'pod_name:dd-agent-ntepl']
+        'kubernetes.ephemeral_storage.usage', 69406720.0, ['instance:tag', 'pod_name:fluentd-gcp-v2.0.10-9q9t4']
     )
     aggregator.assert_metric(
-        'kubernetes.ephemeral_storage.usage', 49152.0, ['instance:tag', 'pod_name:demo-app-success-c485bc67b-klj45']
+        'kubernetes.ephemeral_storage.usage', 49152.0, ['instance:tag', 'pod_name:datadog-agent-jbm2k']
     )
     aggregator.assert_metric('kubernetes.runtime.cpu.usage', 19442853.0, ['instance:tag'])
     aggregator.assert_metric('kubernetes.kubelet.cpu.usage', 36755862.0, ['instance:tag'])


### PR DESCRIPTION
### What does this PR do?

Calling the tagger when an entity does not exist in its store is an
expensive operation, since it'll cause all of its collectors to perform
a remote fetch. Since we know that the tagger does not store pods that
aren't running, calling it for pods that we know not to be running
yet/anymore is waste.

This change stores all pods in PodListUtils, and the summary (that
otherwise has no way of knowing a pod's status) checks to see if the pod
is present and its phase is "Running".

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached