### PR TITLE
Allow non-default yaml loader and dumper

### DIFF
--- a/datadog_checks_base/datadog_checks/base/ddyaml.py
+++ b/datadog_checks_base/datadog_checks/base/ddyaml.py
@@ -2,10 +2,8 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import logging
-from os.path import realpath
 
 import yaml
-from six import string_types
 
 try:
     from yaml import CSafeDumper as yDumper
@@ -40,14 +38,13 @@ def safe_yaml_dump_all(
     tags=None,
 ):
     if Dumper != yDumper:
-        stream_name = get_stream_name(stream)
-        log.debug("Unsafe dumping of YAML has been disabled - using safe dumper instead in %s", stream_name)
+        log.debug("`%s` YAML dumper is used instead of the default one, please make sure it is safe to do so", Dumper.__name__)
 
     if pyyaml_dump_all:
         return pyyaml_dump_all(
             documents,
             stream,
-            yDumper,
+            Dumper,
             default_style,
             default_flow_style,
             canonical,
@@ -65,7 +62,7 @@ def safe_yaml_dump_all(
     return yaml.dump_all(
         documents,
         stream,
-        yDumper,
+        Dumper,
         default_style,
         default_flow_style,
         canonical,
@@ -83,35 +80,22 @@ def safe_yaml_dump_all(
 
 def safe_yaml_load(stream, Loader=yLoader):
     if Loader != yLoader:
-        stream_name = get_stream_name(stream)
-        log.debug("Unsafe loading of YAML has been disabled - using safe loader instead in %s", stream_name)
+        log.debug("`%s` YAML loader is used instead of the default one, please make sure it is safe to do so", Loader.__name__)
 
     if pyyaml_load:
-        return pyyaml_load(stream, Loader=yLoader)
+        return pyyaml_load(stream, Loader=Loader)
 
-    return yaml.load(stream, Loader=yLoader)
+    return yaml.load(stream, Loader=Loader)
 
 
 def safe_yaml_load_all(stream, Loader=yLoader):
     if Loader != yLoader:
-        stream_name = get_stream_name(stream)
-        log.debug("Unsafe loading of YAML has been disabled - using safe loader instead in %s", stream_name)
+        log.debug("`%s` YAML loader is used instead of the default one, please make sure it is safe to do so", Loader.__name__)
 
     if pyyaml_load_all:
-        return pyyaml_load_all(stream, Loader=yLoader)
+        return pyyaml_load_all(stream, Loader=Loader)
 
-    return yaml.load_all(stream, Loader=yLoader)
-
-
-def get_stream_name(stream):
-    """Using the same logic as pyyaml to handle both string types and file types. All file objects do not necessarily
-    have a `name` attribute, in that case we can only say the stream is a file."""
-    if isinstance(stream, string_types):
-        return "<string>"
-    elif hasattr(stream, 'name'):
-        return realpath(stream.name)
-    else:
-        return "<file>"
+    return yaml.load_all(stream, Loader=Loader)
 
 
 def monkey_patch_pyyaml():

--- a/datadog_checks_base/datadog_checks/base/ddyaml.py
+++ b/datadog_checks_base/datadog_checks/base/ddyaml.py
@@ -38,7 +38,9 @@ def safe_yaml_dump_all(
     tags=None,
 ):
     if Dumper != yDumper:
-        log.debug("`%s` YAML dumper is used instead of the default one, please make sure it is safe to do so", Dumper.__name__)
+        log.debug(
+            "`%s` YAML dumper is used instead of the default one, please make sure it is safe to do so", Dumper.__name__
+        )
 
     if pyyaml_dump_all:
         return pyyaml_dump_all(
@@ -80,7 +82,9 @@ def safe_yaml_dump_all(
 
 def safe_yaml_load(stream, Loader=yLoader):
     if Loader != yLoader:
-        log.debug("`%s` YAML loader is used instead of the default one, please make sure it is safe to do so", Loader.__name__)
+        log.debug(
+            "`%s` YAML loader is used instead of the default one, please make sure it is safe to do so", Loader.__name__
+        )
 
     if pyyaml_load:
         return pyyaml_load(stream, Loader=Loader)
@@ -90,7 +94,9 @@ def safe_yaml_load(stream, Loader=yLoader):
 
 def safe_yaml_load_all(stream, Loader=yLoader):
     if Loader != yLoader:
-        log.debug("`%s` YAML loader is used instead of the default one, please make sure it is safe to do so", Loader.__name__)
+        log.debug(
+            "`%s` YAML loader is used instead of the default one, please make sure it is safe to do so", Loader.__name__
+        )
 
     if pyyaml_load_all:
         return pyyaml_load_all(stream, Loader=Loader)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Allow integrations to use a non-default YAML loader and dumper

#### How to use it
Inside an integration
```python
import yaml
...

class CustomCheck(AgentCheck):
   ...
   def func(self):
       yaml.load(mystring, Loader=yaml.SafeLoader)
```

### Motivation
<!-- What inspired you to submit this pull request? -->

Needed for #9815 to use the python safe loader instead of the C one.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This is changing the behaviour of the undocumented `disable_unsafe_yaml` agent option (which is true by default).

Before:
* If true, monkey patching, change default loader to CSafeLoader or SafeLoader (same with dumper)  and forbid non-default loader/dumper use
* If false, no monkey patch

After:
* If true, monkey patching, change default loader to CSafeLoader or SafeLoader (same with dumper) and print a debug log line if using a different loader/dumper
* If false no monkey patch

