### PR TITLE
Add max_client_conn metric

### DIFF
--- a/pgbouncer/datadog_checks/pgbouncer/metrics.py
+++ b/pgbouncer/datadog_checks/pgbouncer/metrics.py
@@ -6,6 +6,13 @@ from datadog_checks.base import AgentCheck
 RATE = AgentCheck.rate
 GAUGE = AgentCheck.gauge
 
+CONFIG_METRICS = {
+    'descriptors': [],
+    'metrics': [
+        ('max_client_conn', ('pgbouncer.max_client_conn', GAUGE)),
+    ],
+    'query': """SHOW CONFIG""",
+}
 
 STATS_METRICS = {
     'descriptors': [('database', 'db')],

--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -77,6 +77,9 @@ class PgBouncer(AgentCheck):
                             self.log.debug("Processing row: %r", row)
 
                             if 'key' in row:  # We are processing "config metrics"
+                                # Make a copy of the row to allow mutation
+                                # (a `psycopg2.lib.extras.DictRow` object doesn't accept a new key)
+                                row = row.copy()
                                 # We flip/rotate the row: row value becomes the column name
                                 row[row['key']] = row['value']
                             else:

--- a/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
+++ b/pgbouncer/datadog_checks/pgbouncer/pgbouncer.py
@@ -82,10 +82,9 @@ class PgBouncer(AgentCheck):
                                 row = row.copy()
                                 # We flip/rotate the row: row value becomes the column name
                                 row[row['key']] = row['value']
-                            else:
-                                # Skip the "pgbouncer" database
-                                if row['database'] == self.DB_NAME:
-                                    continue
+                            # Skip the "pgbouncer" database
+                            elif row.get('database') == self.DB_NAME:
+                                continue
 
                             tags = list(self.tags)
                             tags += ["%s:%s" % (tag, row[column]) for (column, tag) in descriptors if column in row]

--- a/pgbouncer/metadata.csv
+++ b/pgbouncer/metadata.csv
@@ -1,5 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-pgbouncer.max_client_conn,gauge,connection,,The maximum number of client connections allowed.,0,pgbouncer,max client conns
+pgbouncer.max_client_conn,gauge,,connection,,The maximum number of client connections allowed.,0,pgbouncer,max client conns
 pgbouncer.stats.requests_per_second,rate,,request,second,The request rate,0,pgbouncer,requests
 pgbouncer.stats.queries_per_second,rate,,query,second,The query rate,0,pgbouncer,queries
 pgbouncer.stats.transactions_per_second,rate,,transaction,second,The transaction rate,0,pgbouncer,transactions

--- a/pgbouncer/metadata.csv
+++ b/pgbouncer/metadata.csv
@@ -1,4 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+pgbouncer.max_client_conn,gauge,connection,,The maximum number of client connections allowed.,0,pgbouncer,max client conns
 pgbouncer.stats.requests_per_second,rate,,request,second,The request rate,0,pgbouncer,requests
 pgbouncer.stats.queries_per_second,rate,,query,second,The query rate,0,pgbouncer,queries
 pgbouncer.stats.transactions_per_second,rate,,transaction,second,The transaction rate,0,pgbouncer,transactions

--- a/pgbouncer/tests/test_pgbouncer_integration_e2e.py
+++ b/pgbouncer/tests/test_pgbouncer_integration_e2e.py
@@ -110,6 +110,8 @@ def assert_metric_coverage(env_version, aggregator):
     aggregator.assert_metric('pgbouncer.databases.max_connections')
     aggregator.assert_metric('pgbouncer.databases.current_connections')
 
+    aggregator.assert_metric('pgbouncer.max_client_conn')
+
     # Service checks
     sc_tags = ['host:{}'.format(common.HOST), 'port:{}'.format(common.PORT), 'db:pgbouncer', 'optional:tag1']
     aggregator.assert_service_check(PgBouncer.SERVICE_CHECK_NAME, status=PgBouncer.OK, tags=sc_tags)


### PR DESCRIPTION
### What does this PR do?
Add a new PGBouncer metric: max_client_conn

### Motivation
So we can compute a percent of client conn used:
(cl_active + cl_waiting) / max_client_conn

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
