### PR TITLE
Add base tags to `zookeeper.instances.*`

### DIFF
--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -222,7 +222,7 @@ class ZookeeperCheck(AgentCheck):
         gauges[mode] = 1
         for k, v in iteritems(gauges):
             gauge_name = 'zookeeper.instances.%s' % k
-            self.gauge(gauge_name, v)
+            self.gauge(gauge_name, v, tags=self.base_tags)
 
     @staticmethod
     def _get_data(sock, command):

--- a/zk/tests/conftest.py
+++ b/zk/tests/conftest.py
@@ -89,7 +89,7 @@ def get_conn_failure_config():
         conn_failure_config = deepcopy(VALID_TLS_CONFIG_FOR_TEST)
     conn_failure_config['port'] = 2182
     conn_failure_config['expected_mode'] = 'down'
-    conn_failure_config['tags'] = []
+    conn_failure_config['tags'] = ["mytag"]
     return conn_failure_config
 
 

--- a/zk/tests/test_zk.py
+++ b/zk/tests/test_zk.py
@@ -45,7 +45,7 @@ def test_check(aggregator, dd_environment, get_test_instance, caplog):
 
     expected_mode = get_test_instance['expected_mode']
     mname = "zookeeper.instances.{}".format(expected_mode)
-    aggregator.assert_metric(mname, value=1)
+    aggregator.assert_metric(mname, value=1, tags=["mytag"])
     aggregator.assert_all_metrics_covered()
 
 
@@ -71,11 +71,11 @@ def test_error_state(aggregator, dd_environment, get_conn_failure_config):
 
     aggregator.assert_service_check("zookeeper.ruok", status=zk_check.CRITICAL)
 
-    aggregator.assert_metric("zookeeper.instances", tags=["mode:down"], count=1)
+    aggregator.assert_metric("zookeeper.instances", tags=["mode:down", "mytag"], count=1)
 
     expected_mode = get_conn_failure_config['expected_mode']
     mname = "zookeeper.instances.{}".format(expected_mode)
-    aggregator.assert_metric(mname, value=1, count=1)
+    aggregator.assert_metric(mname, value=1, count=1, tags=["mytag"])
 
 
 def test_metadata(datadog_agent, get_test_instance):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fixes an issue: https://github.com/DataDog/integrations-core/issues/9998 where base tags are not included with `zookeeper.instances.*` metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
