### PR TITLE
Add `datadog_checks_dependency_provider` check

### DIFF
--- a/datadog_checks_dependency_provider/CHANGELOG.md
+++ b/datadog_checks_dependency_provider/CHANGELOG.md
@@ -1,0 +1,2 @@
+# CHANGELOG - datadog_checks_dependency_provider
+

--- a/datadog_checks_dependency_provider/MANIFEST.in
+++ b/datadog_checks_dependency_provider/MANIFEST.in
@@ -1,0 +1,7 @@
+graft datadog_checks
+
+include MANIFEST.in
+include README.md
+include requirements.in
+
+global-exclude *.py[cod] __pycache__

--- a/datadog_checks_dependency_provider/README.md
+++ b/datadog_checks_dependency_provider/README.md
@@ -1,0 +1,3 @@
+# datadog_checks_dependency_provider
+
+This check exists solely to provide a place to define dependencies for integrations that do not reside in `integrations-core`.

--- a/datadog_checks_dependency_provider/datadog_checks/__init__.py
+++ b/datadog_checks_dependency_provider/datadog_checks/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/datadog_checks_dependency_provider/datadog_checks/datadog_checks_dependency_provider/__about__.py
+++ b/datadog_checks_dependency_provider/datadog_checks/datadog_checks_dependency_provider/__about__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+__version__ = '0.0.1'

--- a/datadog_checks_dependency_provider/datadog_checks/datadog_checks_dependency_provider/__init__.py
+++ b/datadog_checks_dependency_provider/datadog_checks/datadog_checks_dependency_provider/__init__.py
@@ -1,0 +1,6 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from .__about__ import __version__
+
+__all__ = ['__version__']

--- a/datadog_checks_dependency_provider/datadog_checks/datadog_checks_dependency_provider/data/conf.yaml.example
+++ b/datadog_checks_dependency_provider/datadog_checks/datadog_checks_dependency_provider/data/conf.yaml.example
@@ -1,0 +1,6 @@
+init_config: {}
+instances:
+    ## @param required - boolean - required
+    ## required
+    #
+  - required: false

--- a/datadog_checks_dependency_provider/setup.py
+++ b/datadog_checks_dependency_provider/setup.py
@@ -1,0 +1,64 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from codecs import open  # To use a consistent encoding
+from os import path
+
+from setuptools import setup
+
+HERE = path.dirname(path.abspath(__file__))
+
+# Get version info
+ABOUT = {}
+with open(path.join(HERE, 'datadog_checks', 'datadog_checks_dependency_provider', '__about__.py')) as f:
+    exec(f.read(), ABOUT)
+
+# Get the long description from the README file
+with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+
+def get_dependencies():
+    dep_file = path.join(HERE, 'requirements.in')
+    if not path.isfile(dep_file):
+        return []
+
+    with open(dep_file, encoding='utf-8') as f:
+        return f.readlines()
+
+
+CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+
+
+setup(
+    name='datadog-datadog_checks_dependency_provider',
+    version=ABOUT['__version__'],
+    description='The datadog_checks_dependency_provider check',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    keywords='datadog agent datadog_checks_dependency_provider check',
+    # The project's main homepage.
+    url='https://github.com/DataDog/integrations-core',
+    # Author details
+    author='Datadog',
+    author_email='packages@datadoghq.com',
+    # License
+    license='BSD-3-Clause',
+    # See https://pypi.org/classifiers
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'Intended Audience :: System Administrators',
+        'Topic :: System :: Monitoring',
+        'License :: OSI Approved :: BSD License',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.8',
+    ],
+    # The package we're going to ship
+    packages=['datadog_checks.datadog_checks_dependency_provider'],
+    # Run-time dependencies
+    install_requires=[CHECKS_BASE_REQ],
+    extras_require={'deps': get_dependencies()},
+    # Extra files to ship with the wheel package
+    include_package_data=True,
+)


### PR DESCRIPTION
### What does this PR do?

Adds a check that exists solely to provide a place to define dependencies for integrations that do not reside in `integrations-core`.

### Motivation

We have need to ship dependencies for select third party integrations, starting with [foundationdb](https://github.com/DataDog/integrations-extras/pull/950).

### Downsides of alternatives compared to this

#### Omnibus

We could add dependencies within our builds like we do for [snowflake-connector-python](https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/snowflake-connector-python-py3.rb).

Cons:

- Another instance where we have to specially handle transient dependencies
- If another integration starts depending on it there is no CI validation for version mismatches
- Ruby code is generally more difficult to work with for contributors

#### Add to `agent_requirements.in`

We could add dependencies directly to the [frozen dependency file](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/data/agent_requirements.in).

Cons:

- Noisy Git history
- No central source that lists all such external dependency definitions
- Requires modification of our dependency validation tooling

#### Add to standalone file

We could add dependencies to a new requirements file at the root of this repo.

Cons:

- No versioning
- Inability to release/sign modifications
- Requires modification of our dependency validation tooling