### PR TITLE
[SNMP][tests] open files in 'wb' mode when serialising yaml

### DIFF
--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -131,7 +131,7 @@ def create_datadog_conf_file(tmp_dir):
         'listeners': [{'name': 'snmp'}],
     }
     datadog_conf_file = os.path.join(tmp_dir, 'datadog.yaml')
-    with open(datadog_conf_file, 'w') as file:
+    with open(datadog_conf_file, 'wb') as file:
         file.write(yaml.dump(datadog_conf))
     return datadog_conf_file
 

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -717,7 +717,7 @@ def test_profile_by_file(aggregator):
     instance['profile'] = 'profile1'
     with temp_dir() as tmp:
         profile_file = os.path.join(tmp, 'profile1.yaml')
-        with open(profile_file, 'w') as f:
+        with open(profile_file, 'wb') as f:
             f.write(yaml.safe_dump({'metrics': common.SUPPORTED_METRIC_TYPES}))
         init_config = {'profiles': {'profile1': {'definition_file': profile_file}}}
         check = SnmpCheck('snmp', init_config, [instance])

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -448,10 +448,10 @@ def test_profile_extends():
 
     with temp_dir() as tmp:
         with mock_profiles_confd_root(tmp):
-            with open(os.path.join(tmp, 'base.yaml'), 'w') as f:
+            with open(os.path.join(tmp, 'base.yaml'), 'wb') as f:
                 f.write(yaml.safe_dump(base))
 
-            with open(os.path.join(tmp, 'profile1.yaml'), 'w') as f:
+            with open(os.path.join(tmp, 'profile1.yaml'), 'wb') as f:
                 f.write(yaml.safe_dump(profile1))
 
             definition = {'extends': ['profile1.yaml']}
@@ -477,7 +477,7 @@ def test_default_profiles():
     with temp_dir() as tmp:
         with mock_profiles_confd_root(tmp):
             profile_file = os.path.join(tmp, 'profile.yaml')
-            with open(profile_file, 'w') as f:
+            with open(profile_file, 'wb') as f:
                 f.write(yaml.safe_dump(profile))
 
             profiles = _load_default_profiles()
@@ -492,7 +492,7 @@ def test_profile_override():
     with temp_dir() as tmp:
         with mock_profiles_confd_root(tmp):
             profile_file = os.path.join(tmp, 'generic-router.yaml')
-            with open(profile_file, 'w') as f:
+            with open(profile_file, 'wb') as f:
                 f.write(yaml.safe_dump(profile))
 
             profiles = _load_default_profiles()


### PR DESCRIPTION
### What does this PR do?
Fix unit tests that are failing since this commit: https://github.com/DataDog/integrations-core/commit/b1b9ace9099569a5217e6d509152965b052ab723

This PR will make sure to open files in "wb" mode so that the yaml lib can serialize Yaml even if we use the C safeloader in tests.

### Motivation

Repair failing tests.

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
