### PR TITLE
Update release tooling to support `datadog_checks_dependency_provider`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/release.py
@@ -47,6 +47,8 @@ def get_package_name(folder_name):
         return 'datadog-checks-base'
     elif folder_name == 'datadog_checks_downloader':
         return 'datadog-checks-downloader'
+    elif folder_name == 'datadog_checks_dependency_provider':
+        return 'datadog-checks-dependency-provider'
 
     return f"{DATADOG_PACKAGE_PREFIX}{folder_name.replace('_', '-')}"
 
@@ -60,6 +62,8 @@ def get_folder_name(package_name):
         return 'datadog_checks_base'
     elif package_name == 'datadog-checks-downloader':
         return 'datadog_checks_downloader'
+    elif package_name == 'datadog-checks-dependency-provider':
+        return 'datadog_checks_dependency_provider'
 
     return package_name.replace('-', '_')[len(DATADOG_PACKAGE_PREFIX) :]
 
@@ -72,7 +76,7 @@ def get_agent_requirement_line(check, version):
     package_name = get_package_name(check)
 
     # no manifest
-    if check in ('datadog_checks_base', 'datadog_checks_downloader'):
+    if check in ('datadog_checks_base', 'datadog_checks_downloader', 'datadog_checks_dependency_provider'):
         return f'{package_name}=={version}'
 
     m = load_manifest(check)


### PR DESCRIPTION
### Motivation

```
Updating the Agent requirements file... Traceback (most recent call last):
  File "C:\Users\ofek\AppData\Local\Programs\Python\Python38\Scripts\ddev-script.py", line 30, in <module>
    sys.exit(load_entry_point('datadog-checks-dev', 'console_scripts', 'ddev')())
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "c:\users\ofek\appdata\local\programs\python\python38\lib\site-packages\click\decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "c:\users\ofek\desktop\code\integrations-core\datadog_checks_dev\datadog_checks\dev\tooling\commands\release\make.py", line 157, in make
    update_agent_requirements(req_file, check, get_agent_requirement_line(check, version))
  File "c:\users\ofek\desktop\code\integrations-core\datadog_checks_dev\datadog_checks\dev\tooling\release.py", line 95, in get_agent_requirement_line
    raise ManifestError(f"Can't parse the `supported_os` list for the check {check}: {platforms}")
datadog_checks.dev.errors.ManifestError: Can't parse the `supported_os` list for the check datadog_checks_dependency_provider: []
```