### PR TITLE
Echo warning for unnecessary params used

### DIFF
--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/cloud_foundry_api.py
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/cloud_foundry_api.py
@@ -111,7 +111,7 @@ class CloudFoundryApiCheck(AgentCheck):
         try:
             res = self.http.get(
                 join_url(self._uaa_url, "oauth/token"),
-                auth=(self._client_id, self._client_secret),
+                auth=(self._client_id, self._client_secret),  # SKIP_HTTP_VALIDATION`
                 params={"grant_type": "client_credentials"},
             )
         except RequestException:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -121,7 +121,7 @@ def validate_use_http_wrapper(check):
             if check_uses_http_wrapper and has_arg_warning:
                 # Check for headers= or auth=
                 echo_warning(f"{check}: \n"
-                             f"    The HTTP wrapper contains parameter `{has_arg_warning.group()}`, "
+                             f"    The HTTP wrapper contains parameter `{has_arg_warning.group().replace('=', '')}`, "
                              f"this configuration is handled by the wrapper automatically.\n"
                              f"    If this a genuine usage of the parameters, "
                              f"please inline comment `# SKIP_HTTP_VALIDATION`")

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 import re
+
 import click
 
 from datadog_checks.dev.tooling.annotations import annotate_error
@@ -120,11 +121,13 @@ def validate_use_http_wrapper(check):
             check_uses_http_wrapper = check_uses_http_wrapper or file_uses_http_wrapper
             if check_uses_http_wrapper and has_arg_warning:
                 # Check for headers= or auth=
-                echo_warning(f"{check}: \n"
-                             f"    The HTTP wrapper contains parameter `{has_arg_warning.group().replace('=', '')}`, "
-                             f"this configuration is handled by the wrapper automatically.\n"
-                             f"    If this a genuine usage of the parameters, "
-                             f"please inline comment `# SKIP_HTTP_VALIDATION`")
+                echo_warning(
+                    f"{check}: \n"
+                    f"    The HTTP wrapper contains parameter `{has_arg_warning.group().replace('=', '')}`, "
+                    f"this configuration is handled by the wrapper automatically.\n"
+                    f"    If this a genuine usage of the parameters, "
+                    f"please inline comment `# SKIP_HTTP_VALIDATION`"
+                )
                 pass
 
     if has_failed:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/http.py
@@ -120,7 +120,8 @@ def validate_use_http_wrapper(check):
             check_uses_http_wrapper = check_uses_http_wrapper or file_uses_http_wrapper
             if check_uses_http_wrapper and has_arg_warning:
                 # Check for headers= or auth=
-                echo_warning(f"{check}: the HTTP wrapper contains parameter `{has_arg_warning.group()}`, "
+                echo_warning(f"{check}: \n"
+                             f"    The HTTP wrapper contains parameter `{has_arg_warning.group()}`, "
                              f"this configuration is handled by the wrapper automatically.\n"
                              f"    If this a genuine usage of the parameters, "
                              f"please inline comment `# SKIP_HTTP_VALIDATION`")

--- a/voltdb/datadog_checks/voltdb/client.py
+++ b/voltdb/datadog_checks/voltdb/client.py
@@ -32,7 +32,7 @@ class Client(object):
                 parameters = json.dumps(parameters)
             params['Parameters'] = parameters
 
-        return self._http_get(url, auth=auth, params=params)
+        return self._http_get(url, auth=auth, params=params)  # SKIP_HTTP_VALIDATION
 
 
 class VoltDBAuth(requests.auth.AuthBase):


### PR DESCRIPTION
### What does this PR do?
This PR warns on usage of `auth` or `header` in http wrapper. These are already handled and is redundant
### Motivation
<img width="770" alt="Screen Shot 2021-09-03 at 4 02 52 PM" src="https://user-images.githubusercontent.com/15065007/132060036-11108bf4-da94-42bd-bd06-c1d56fdc6178.png">

### Additional Notes
Instead of iterating each line of a python file, perhaps we can just regex search?
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
