### PR TITLE
Bump snowflake and requests for Py3

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -73,7 +73,6 @@ pyyaml==5.4.1
 redis==3.5.3
 requests-kerberos==0.12.0
 requests-unixsocket==0.2.0
-# Newer requests versions are incomopatible with latest py2 supported snowflake-connector
 requests==2.22.0; python_version < '3.0'
 requests==2.25.0; python_version > '3.0'
 requests_ntlm==1.1.0

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -74,8 +74,8 @@ redis==3.5.3
 requests-kerberos==0.12.0
 requests-unixsocket==0.2.0
 # Newer requests versions are incomopatible with latest py2 supported snowflake-connector
-requests==2.22.0; ; python_version < '3.0'
-requests==2.25.0; ; python_version > '3.0'
+requests==2.22.0; python_version < '3.0'
+requests==2.25.0; python_version > '3.0'
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1
 rethinkdb==2.4.4

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -73,7 +73,9 @@ pyyaml==5.4.1
 redis==3.5.3
 requests-kerberos==0.12.0
 requests-unixsocket==0.2.0
-requests==2.22.0
+# Newer requests versions are incomopatible with latest py2 supported snowflake-connector
+requests==2.22.0; ; python_version < '3.0'
+requests==2.25.0; ; python_version > '3.0'
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1
 rethinkdb==2.4.4
@@ -85,7 +87,8 @@ serpent==1.27; sys_platform == "win32"
 service_identity[idna]==18.1.0
 simplejson==3.6.5
 six==1.16.0
-snowflake-connector-python==2.1.3
+snowflake-connector-python==2.1.3; python_version < '3.0'
+snowflake-connector-python==2.6.0; python_version > '3.0'
 supervisor==4.1.0
 tuf==0.17.0
 typing==3.7.4.1; python_version < "3.0"

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -24,7 +24,9 @@ python-dateutil==2.8.1
 pywin32==228; sys_platform == 'win32' and python_version < '3.0'
 pywin32==300; sys_platform == 'win32' and python_version > '3.0'
 pyyaml==5.4.1
-requests==2.22.0
+# Newer requests versions are incomopatible with latest py2 supported snowflake-connector
+requests==2.22.0; ; python_version < '3.0'
+requests==2.25.0; ; python_version > '3.0'
 requests-kerberos==0.12.0
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -25,8 +25,8 @@ pywin32==228; sys_platform == 'win32' and python_version < '3.0'
 pywin32==300; sys_platform == 'win32' and python_version > '3.0'
 pyyaml==5.4.1
 # Newer requests versions are incomopatible with latest py2 supported snowflake-connector
-requests==2.22.0; ; python_version < '3.0'
-requests==2.25.0; ; python_version > '3.0'
+requests==2.22.0; python_version < '3.0'
+requests==2.25.0; python_version > '3.0'
 requests-kerberos==0.12.0
 requests_ntlm==1.1.0
 requests_toolbelt==0.9.1

--- a/snowflake/requirements.in
+++ b/snowflake/requirements.in
@@ -2,4 +2,5 @@
 # Release note: https://pypi.org/project/snowflake-connector-python/2.2.0/
 # Note: Patched in omnibus
 # https://github.com/DataDog/datadog-agent/blob/main/omnibus/config/software/snowflake-connector-python-py3.rb
-snowflake-connector-python==2.1.3
+snowflake-connector-python==2.1.3; python_version < '3.0'
+snowflake-connector-python==2.6.0; python_version > '3.0'


### PR DESCRIPTION
We are on the latest supported version for py2 so we can only bump on py3