### PR TITLE
Add test for critical service check and fix namespace

### DIFF
--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -32,7 +32,7 @@ class SnowflakeCheck(AgentCheck):
 
     __NAMESPACE__ = 'snowflake'
 
-    SERVICE_CHECK_CONNECT = 'snowflake.can_connect'
+    SERVICE_CHECK_CONNECT = 'can_connect'
 
     def __init__(self, *args, **kwargs):
         super(SnowflakeCheck, self).__init__(*args, **kwargs)

--- a/snowflake/tests/test_snowflake.py
+++ b/snowflake/tests/test_snowflake.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import copy
 from decimal import Decimal
 from typing import Any, Callable, Dict
 
@@ -11,6 +12,14 @@ from datadog_checks.base.utils.db import Query
 from datadog_checks.snowflake import SnowflakeCheck, queries
 
 from .common import CHECK_NAME, EXPECTED_TAGS
+
+
+def test_emits_critical_service_check_when_service_is_down(dd_run_check, aggregator, instance):
+    config = copy.deepcopy(instance)
+    config['login_timeout'] = 5
+    check = SnowflakeCheck(CHECK_NAME, {}, [config])
+    dd_run_check(check)
+    aggregator.assert_service_check('snowflake.can_connect', SnowflakeCheck.CRITICAL)
 
 
 def test_storage_metrics(dd_run_check, aggregator, instance):


### PR DESCRIPTION
Added a test for critical service check when the service is down
Found we were appending snowflake prefix twice