### PR TITLE
Update fluent image tag recommendation to stable

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -96,7 +96,7 @@ Resources:
               apikey: <API_KEY>
           MemoryReservation: 500
         - Name: log_router
-          Image: 'amazon/aws-for-fluent-bit:latest'
+          Image: 'amazon/aws-for-fluent-bit:stable'
           Essential: true
           FirelensConfiguration:
             Type: fluentbit
@@ -234,7 +234,7 @@ Configure the AWS FireLens integration built on Datadog's Fluent Bit output plug
    ```json
    {
      "essential": true,
-     "image": "amazon/aws-for-fluent-bit:latest",
+     "image": "amazon/aws-for-fluent-bit:stable",
      "name": "log_router",
      "firelensConfiguration": {
        "type": "fluentbit",
@@ -248,7 +248,7 @@ Configure the AWS FireLens integration built on Datadog's Fluent Bit output plug
    ```json
    {
      "essential": true,
-     "image": "amazon/aws-for-fluent-bit:latest",
+     "image": "amazon/aws-for-fluent-bit:stable",
      "name": "log_router",
      "firelensConfiguration": {
        "type": "fluentbit",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update our recommended container image tag for `amazon/aws-for-fluent-bit` from `latest` to `stable`. 

### Motivation
<!-- What inspired you to submit this pull request? -->
Issue with the `latest` release

https://datadoghq.atlassian.net/browse/CONS-4175

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
