### PR TITLE
[proc] add 'php-fpm:' to process signature

### DIFF
--- a/php_fpm/manifest.json
+++ b/php_fpm/manifest.json
@@ -17,6 +17,7 @@
   "name": "php_fpm",
   "process_signatures": [
     "php-fpm",
+    "php-fpm:",
     "php7.0-fpm",
     "php7.0-fpm start",
     "service php-fpm",


### PR DESCRIPTION
### What does this PR do?
Adds a process signature for `php-fpm:` to the php-fpm integration per so we can autodetect this process.

Motivation
We want to update the integrations signature for php-fpm so we'd be able to autodetect them by matching a process command line.


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
