### PR TITLE
Add `latest` to the list of known environments to skip for default E2E

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -100,7 +100,12 @@ def get_tox_envs(
 
                 envs_selected[:] = selected
             else:
-                envs_selected[:] = [e for e in envs_available if 'bench' not in e and 'format_style' not in e]
+                envs_selected[:] = [
+                    e for e in envs_available
+                    if 'bench' not in e
+                    and 'format_style' not in e
+                    and e != 'latest'
+                ]
 
         if tox_env_filter_re:
             envs_selected[:] = [e for e in envs_selected if not tox_env_filter_re.match(e)]


### PR DESCRIPTION
### Motivation

Fix https://github.com/DataDog/integrations-core/pull/9945 causing CI failures https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=74263&view=logs&j=b9b61b1e-e7ad-5a75-8bb3-f1445ef55317&t=f78518e6-9c2d-541b-f94c-8183303ec0e1