### PR TITLE
Better naming for snmp envs

### DIFF
--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -19,7 +19,7 @@ HOST = get_docker_hostname()
 PORT = 1161
 HERE = os.path.dirname(os.path.abspath(__file__))
 COMPOSE_DIR = os.path.join(HERE, 'compose')
-AUTODISCOVERY_TYPE = os.environ['AUTODISCOVERY_TYPE']
+SNMP_LISTENER_ENV = os.environ['SNMP_LISTENER_ENV']
 TOX_ENV_NAME = os.environ['TOX_ENV_NAME']
 
 AUTH_PROTOCOLS = {'MD5': 'usmHMACMD5AuthProtocol', 'SHA': 'usmHMACSHAAuthProtocol'}
@@ -189,8 +189,8 @@ RESOLVED_TABULAR_OBJECTS = [
     }
 ]
 
-agent_autodiscovery_only = pytest.mark.skipif(AUTODISCOVERY_TYPE != 'agent', reason='Agent discovery only')
-python_autodiscovery_only = pytest.mark.skipif(AUTODISCOVERY_TYPE != 'python', reason='Python discovery only')
+snmp_listener_only = pytest.mark.skipif(SNMP_LISTENER_ENV != 'true', reason='Agent snmp lister tests only')
+snmp_integration_only = pytest.mark.skipif(SNMP_LISTENER_ENV != 'false', reason='Normal tests')
 
 
 def generate_instance_config(metrics, template=None):

--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -14,7 +14,7 @@ from datadog_checks.dev import TempDir, WaitFor, docker_run, run_command
 from datadog_checks.dev.docker import get_container_ip
 
 from .common import (
-    AUTODISCOVERY_TYPE,
+    SNMP_LISTENER_ENV,
     COMPOSE_DIR,
     PORT,
     SCALAR_OBJECTS,
@@ -51,7 +51,7 @@ def dd_environment():
                     output.write(response.content)
 
         with docker_run(os.path.join(COMPOSE_DIR, 'docker-compose.yaml'), env_vars=env, log_patterns="Listening at"):
-            if AUTODISCOVERY_TYPE == 'agent':
+            if SNMP_LISTENER_ENV == 'true':
                 instance_config = {}
                 new_e2e_metadata['docker_volumes'] = [
                     '{}:/etc/datadog-agent/datadog.yaml'.format(create_datadog_conf_file(tmp_dir))

--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -14,12 +14,12 @@ from datadog_checks.dev import TempDir, WaitFor, docker_run, run_command
 from datadog_checks.dev.docker import get_container_ip
 
 from .common import (
-    SNMP_LISTENER_ENV,
     COMPOSE_DIR,
     PORT,
     SCALAR_OBJECTS,
     SCALAR_OBJECTS_WITH_TAGS,
     SNMP_CONTAINER_NAME,
+    SNMP_LISTENER_ENV,
     TABULAR_OBJECTS,
     TOX_ENV_NAME,
     generate_container_instance_config,

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -19,7 +19,7 @@ from datadog_checks.snmp import SnmpCheck
 
 from . import common
 
-pytestmark = [pytest.mark.usefixtures("dd_environment"), common.python_autodiscovery_only]
+pytestmark = [pytest.mark.usefixtures("dd_environment"), common.snmp_integration_only]
 
 
 def test_command_generator():

--- a/snmp/tests/test_e2e_agent_ad.py
+++ b/snmp/tests/test_e2e_agent_ad.py
@@ -30,7 +30,7 @@ def _build_device_ip(container_ip, last_digit='1'):
     return snmp_device
 
 
-@common.agent_autodiscovery_only
+@common.snmp_listener_only
 def test_e2e_agent_autodiscovery(dd_agent_check, container_ip, autodiscovery_ready):
     """
     Test Agent Autodiscovery

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -5,7 +5,7 @@ import pytest
 
 from . import common
 
-pytestmark = [pytest.mark.e2e, common.python_autodiscovery_only]
+pytestmark = [pytest.mark.e2e, common.snmp_integration_only]
 
 
 def test_e2e_v1_with_apc_ups_profile(dd_agent_check):

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -10,7 +10,7 @@ from datadog_checks.base.stubs.common import MetricStub
 
 from . import common
 
-pytestmark = [pytest.mark.e2e, common.python_autodiscovery_only]
+pytestmark = [pytest.mark.e2e, common.snmp_integration_only]
 
 SUPPORTED_METRIC_TYPES = [
     {'MIB': 'ABC', 'symbol': {'OID': "1.3.6.1.2.1.7.1.0", 'name': "IAmACounter32"}},  # Counter32

--- a/snmp/tests/test_e2e_python.py
+++ b/snmp/tests/test_e2e_python.py
@@ -11,7 +11,7 @@ from . import common
 pytestmark = pytest.mark.e2e
 
 
-@common.python_autodiscovery_only
+@common.snmp_integration_only
 def test_e2e_python(dd_agent_check):
     metrics = common.SUPPORTED_METRIC_TYPES
     config = common.generate_container_instance_config(metrics)

--- a/snmp/tests/test_e2e_snmp_listener.py
+++ b/snmp/tests/test_e2e_snmp_listener.py
@@ -31,7 +31,7 @@ def _build_device_ip(container_ip, last_digit='1'):
 
 
 @common.snmp_listener_only
-def test_e2e_agent_autodiscovery(dd_agent_check, container_ip, autodiscovery_ready):
+def test_e2e_snmp_listener(dd_agent_check, container_ip, autodiscovery_ready):
     """
     Test Agent Autodiscovery
 

--- a/snmp/tests/test_parsing.py
+++ b/snmp/tests/test_parsing.py
@@ -9,7 +9,7 @@ from datadog_checks.snmp.parsing import parse_metrics
 
 from . import common
 
-pytestmark = common.python_autodiscovery_only
+pytestmark = common.snmp_integration_only
 
 logger = logging.getLogger(__name__)
 

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -66,7 +66,7 @@ from .metrics import (
     VOLTAGE_GAUGES,
 )
 
-pytestmark = common.python_autodiscovery_only
+pytestmark = common.snmp_integration_only
 
 
 def test_load_profiles(caplog):

--- a/snmp/tests/test_unit.py
+++ b/snmp/tests/test_unit.py
@@ -31,7 +31,7 @@ from datadog_checks.snmp.utils import (
 from . import common
 from .utils import mock_profiles_confd_root
 
-pytestmark = [pytest.mark.unit, common.python_autodiscovery_only]
+pytestmark = [pytest.mark.unit, common.snmp_integration_only]
 
 
 @mock.patch("datadog_checks.snmp.pysnmp_types.lcd")

--- a/snmp/tests/test_utils.py
+++ b/snmp/tests/test_utils.py
@@ -17,7 +17,7 @@ from datadog_checks.snmp.utils import transform_index
 
 from . import common
 
-pytestmark = common.python_autodiscovery_only
+pytestmark = common.snmp_integration_only
 
 
 @pytest.mark.unit

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 basepython = py38
 envlist =
     py{27,38}
-    py{27,38}-snmp_listener
+    py{27,38}-snmplistener
     bench
 
 [testenv]
@@ -31,7 +31,7 @@ passenv =
 setenv =
     DDEV_SKIP_GENERIC_TAGS_CHECK=true
     SNMP_LISTENER_ENV=false
-    snmp_listener: SNMP_LISTENER_ENV=true
+    snmplistener: SNMP_LISTENER_ENV=true
 commands =
     pip install -r requirements.in
     pytest -v {posargs}

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -2,7 +2,8 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{python_ad,agent_ad}
+    py{27,38}
+    py{27,38}-snmp_listener
     bench
 
 [testenv]
@@ -29,8 +30,8 @@ passenv =
     COMPOSE*
 setenv =
     DDEV_SKIP_GENERIC_TAGS_CHECK=true
-    AUTODISCOVERY_TYPE=python
-    agent_ad: AUTODISCOVERY_TYPE=agent
+    SNMP_LISTENER_ENV=false
+    snmp_listener: SNMP_LISTENER_ENV=true
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?

Better naming for snmp envs

### Motivation

Previously called agent_ad env is related to snmp_listener, which is not suitable anymore since the previously called `python_ad` env is now also running SNMP corecheck e2e tests.


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
