### PR TITLE
Add autodiscovery_subnet tag to discovered_devices_count metric

### DIFF
--- a/snmp/datadog_checks/snmp/snmp.py
+++ b/snmp/datadog_checks/snmp/snmp.py
@@ -391,7 +391,7 @@ class SnmpCheck(AgentCheck):
                 future.add_done_callback(functools.partial(self._on_check_device_done, host))
             futures.wait(sent)
 
-            tags = ['network:{}'.format(config.ip_network)]
+            tags = ['network:{}'.format(config.ip_network), 'autodiscovery_subnet:{}'.format(config.ip_network)]
             tags.extend(config.tags)
             self.gauge('snmp.discovered_devices_count', len(config.discovered_instances), tags=tags)
         else:

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -904,7 +904,7 @@ def test_discovery(aggregator):
         'snmp_profile:profile1',
         'autodiscovery_subnet:{}'.format(to_native_string(network)),
     ]
-    network_tags = ['network:{}'.format(network)]
+    network_tags = ['network:{}'.format(network), 'autodiscovery_subnet:{}'.format(network)]
 
     instance = {
         'name': 'snmp_conf',
@@ -953,7 +953,7 @@ def test_discovery_devices_monitored_count(read_mock, aggregator):
     check_tags = [
         'autodiscovery_subnet:{}'.format(to_native_string(network)),
     ]
-    network_tags = ['network:{}'.format(network)]
+    network_tags = ['network:{}'.format(network), 'autodiscovery_subnet:{}'.format(network)]
     instance = {
         'name': 'snmp_conf',
         # Make sure the check handles bytes


### PR DESCRIPTION
### What does this PR do?

Add autodiscovery_subnet tag to discovered_devices_count metric

### Motivation

- It's preferred to use autodiscovery_subnet instead of network tag since the later is used in some profiles
- Align with SNMP Corecheck autodiscovery impl (https://github.com/DataDog/datadog-agent/pull/8996)

### Additional Notes

Use autodiscovery config and check that the new tags is present.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
