### PR TITLE
Add borrower and pysmi logs to MIB compiler

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/constants.py
@@ -1,0 +1,1 @@
+MIB_SOURCE_URL = 'https://raw.githubusercontent.com:443/DataDog/mibs.snmplabs.com/master/asn1/@mib@'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/constants.py
@@ -1,1 +1,3 @@
 MIB_SOURCE_URL = 'https://raw.githubusercontent.com:443/DataDog/mibs.snmplabs.com/master/asn1/@mib@'
+
+MIB_COMPILED_URL = "https://raw.githubusercontent.com/DataDog/mibs.snmplabs.com/master/json/@mib@"

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_profile.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_profile.py
@@ -7,9 +7,10 @@ from collections import namedtuple
 from tempfile import gettempdir
 
 import click
+from datadog_checks.dev.tooling.commands.meta.snmp.constants import MIB_SOURCE_URL
 import yaml
 
-from ....constants import MIB_SOURCE_URL
+
 from ...console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, set_debug
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_profile.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_profile.py
@@ -109,6 +109,9 @@ def generate_profile_from_mibs(ctx, mib_files, filters, aliases, debug, interact
     """
     if debug:
         set_debug()
+        from pysmi import debug
+
+        debug.setLogger(debug.Debug('all'))
 
     # ensure at least one mib file is provided
     if len(mib_files) == 0:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_profile.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_profile.py
@@ -7,9 +7,9 @@ from collections import namedtuple
 from tempfile import gettempdir
 
 import click
-from datadog_checks.dev.tooling.commands.meta.snmp.constants import MIB_SOURCE_URL
 import yaml
 
+from datadog_checks.dev.tooling.commands.meta.snmp.constants import MIB_COMPILED_URL, MIB_SOURCE_URL
 
 from ...console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, set_debug
 
@@ -26,8 +26,14 @@ from ...console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, set_debug
     help='Source of the MIBs files. Can be a url or a path for a directory',
     default=MIB_SOURCE_URL,
 )
+@click.option(
+    '--compiled_mib_path',
+    '-c',
+    help='Source of compiled MIBs files. Can be a url or a path for a directory',
+    default=MIB_COMPILED_URL,
+)
 @click.pass_context
-def generate_profile_from_mibs(ctx, mib_files, filters, aliases, debug, interactive, source):
+def generate_profile_from_mibs(ctx, mib_files, filters, aliases, debug, interactive, source, borrower):
     """
     Generate an SNMP profile from MIBs. Accepts a directory path containing mib files
     to be used as source to generate the profile, along with a filter if a device or
@@ -103,7 +109,6 @@ def generate_profile_from_mibs(ctx, mib_files, filters, aliases, debug, interact
     human readable information - we might prefer to see the interface name vs its numerical table index. This can be
     achieved using metric_tag_aliases
 
-
     Return a list of SNMP metrics and copy its yaml dump to the clipboard
     Metric tags need to be added manually
     """
@@ -125,13 +130,14 @@ def generate_profile_from_mibs(ctx, mib_files, filters, aliases, debug, interact
         mibs.add(os.path.splitext(os.path.basename(file))[0])
     # create a tmp dir for compiled json mibs
     json_destination_directory = os.path.join(gettempdir(), 'mibs')
+
     if not os.path.exists(json_destination_directory):
         os.mkdir(json_destination_directory)
 
     profile_oid_collection = {}
     # build profile
     for oid_node in _extract_oids_from_mibs(
-        list(mibs), list(source_directories), json_destination_directory, source, filters
+        list(mibs), list(source_directories), json_destination_directory, source, [borrower], filters
     ):
         if oid_node.node_type == 'table':
             _add_profile_table_node(profile_oid_collection, oid_node)
@@ -144,6 +150,7 @@ def generate_profile_from_mibs(ctx, mib_files, filters, aliases, debug, interact
                 metric_tag_aliases_path=aliases,
                 json_mib_directory=json_destination_directory,
                 source=source,
+                borrowers=[borrower],
             )
         elif oid_node.node_type == 'column':
             _add_profile_column_node(profile_oid_collection, oid_node)
@@ -258,7 +265,7 @@ class OidNode:
         return self.mib_class == 'objecttype'
 
 
-def _compile_mib_to_json(mib, source_mib_directories, destination_directory, source):
+def _compile_mib_to_json(mib, source_mib_directories, destination_directory, source, borrowers):
     from pysmi.codegen import JsonCodeGen
     from pysmi.compiler import MibCompiler
     from pysmi.parser import SmiV1CompatParser
@@ -287,6 +294,8 @@ def _compile_mib_to_json(mib, source_mib_directories, destination_directory, sou
     mib_compiler.addSources(reader)
 
     mib_compiler.addSearchers(*searchers)
+
+    mib_compiler.addBorrowers(*borrowers)
 
     processed = mib_compiler.compile(
         mib,
@@ -337,7 +346,7 @@ def _load_json_module(source_directory, mib):
         return None
 
 
-def _load_module_or_compile(mib, source_directories, json_mib_directory, source):
+def _load_module_or_compile(mib, source_directories, json_mib_directory, source, borrowers):
     # try loading the json mib, if already compiled
     echo_debug('⏳ Loading mib {}'.format(mib))
     mib_json = _load_json_module(json_mib_directory, mib)
@@ -347,7 +356,7 @@ def _load_module_or_compile(mib, source_directories, json_mib_directory, source)
 
     # compile and reload
     echo_debug('⏳ Compile mib {}'.format(mib))
-    processed = _compile_mib_to_json(mib, source_directories, json_mib_directory, source)
+    processed = _compile_mib_to_json(mib, source_directories, json_mib_directory, source, borrowers)
     echo_debug('✅ Mib {} compiled: {}'.format(mib, processed[mib]))
     if processed[mib] != 'missing':
         mib_json = _load_json_module(json_mib_directory, mib)
@@ -356,8 +365,8 @@ def _load_module_or_compile(mib, source_directories, json_mib_directory, source)
     return None
 
 
-def _find_oid_by_name(mib, oid_name, source_directories, json_mib_directory, source):
-    mib_json = _load_module_or_compile(mib, source_directories, json_mib_directory, source)
+def _find_oid_by_name(mib, oid_name, source_directories, json_mib_directory, source, borrowers):
+    mib_json = _load_module_or_compile(mib, source_directories, json_mib_directory, source, borrowers)
     if mib_json is None:
         return None
 
@@ -367,8 +376,8 @@ def _find_oid_by_name(mib, oid_name, source_directories, json_mib_directory, sou
     return mib_json[oid_name]['oid']
 
 
-def _find_name_by_oid(mib, oid, source_directories, json_mib_directory, source):
-    mib_json = _load_module_or_compile(mib, source_directories, json_mib_directory, source)
+def _find_name_by_oid(mib, oid, source_directories, json_mib_directory, source, borrowers):
+    mib_json = _load_module_or_compile(mib, source_directories, json_mib_directory, source, borrowers)
     if mib_json is None:
         return None
 
@@ -409,7 +418,7 @@ def _filter_mib_oids(mib, json_mib, filter_data):
     return filtered_json_oids
 
 
-def _extract_oids_from_mibs(mibs, source_directories, json_destination_directory, source, filter_path=None):
+def _extract_oids_from_mibs(mibs, source_directories, json_destination_directory, source, borrower, filter_path=None):
     filter_data = None
     if filter_path is not None and os.path.isfile(filter_path):
         with open(filter_path) as f:
@@ -417,7 +426,9 @@ def _extract_oids_from_mibs(mibs, source_directories, json_destination_directory
 
     json_mibs = {}
     for mib in mibs:
-        json_mib = _load_module_or_compile(mib, source_directories, json_destination_directory, source)
+        json_mib = _load_module_or_compile(
+            mib, source_directories, json_destination_directory, source, borrowers=[borrower]
+        )
         if json_mib is None:
             continue
 
@@ -575,7 +586,7 @@ def _load_aliases_from_yaml(aliases_path):
 
 
 def _add_profile_row_node(
-    profile_oid_collection, oid_node, mibs_directories, json_mib_directory, metric_tag_aliases_path, source
+    profile_oid_collection, oid_node, mibs_directories, json_mib_directory, metric_tag_aliases_path, source, borrowers
 ):
     """
     Updates a collection of profile nodes, indexed by oid, adding indexes if found in oid_node
@@ -617,11 +628,13 @@ def _add_profile_row_node(
 
         index = {'MIB': mib, 'tag': oid_name}
         column = {'name': oid_name}
-        index_oid = _find_oid_by_name(mib, oid_name, mibs_directories, json_mib_directory, source)
+        index_oid = _find_oid_by_name(mib, oid_name, mibs_directories, json_mib_directory, source, borrowers)
         if index_oid is not None:
             column['OID'] = index_oid
             index_table_oid = '.'.join(index_oid.split('.')[:-2])
-            index_table_name = _find_name_by_oid(mib, index_table_oid, mibs_directories, json_mib_directory, source)
+            index_table_name = _find_name_by_oid(
+                mib, index_table_oid, mibs_directories, json_mib_directory, source, borrowers
+            )
             if index_table_name is not None:
                 index['table'] = index_table_name
         index['column'] = column

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
@@ -6,7 +6,8 @@ import os
 import click
 import yaml
 
-from ....constants import MIB_SOURCE_URL
+from datadog_checks.dev.tooling.commands.meta.snmp.constants import MIB_SOURCE_URL
+
 from ...console import CONTEXT_SETTINGS
 
 


### PR DESCRIPTION
### What does this PR do?
* Enable pysmi debug logs when debug logs are enabled
* Add `borrowers` to pysmi compiler, to let it fetch already compiled mibs when available in our repo 🎉 

This PR is based on https://github.com/DataDog/integrations-core/pull/9952

### Motivation

Some MIBs fail compilation because of bad formatting / values duplication. Already compiled MIBs are a safe way to let any customer create their profile from them

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
