### PR TITLE
[ddev] instantiate borrowers in snmp profile generator

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_profile.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_profile.py
@@ -27,13 +27,13 @@ from ...console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, set_debug
     default=MIB_SOURCE_URL,
 )
 @click.option(
-    '--compiled_mib_path',
+    '--compiled_mibs_path',
     '-c',
     help='Source of compiled MIBs files. Can be a url or a path for a directory',
     default=MIB_COMPILED_URL,
 )
 @click.pass_context
-def generate_profile_from_mibs(ctx, mib_files, filters, aliases, debug, interactive, source, borrower):
+def generate_profile_from_mibs(ctx, mib_files, filters, aliases, debug, interactive, source, compiled_mibs_path):
     """
     Generate an SNMP profile from MIBs. Accepts a directory path containing mib files
     to be used as source to generate the profile, along with a filter if a device or
@@ -137,7 +137,7 @@ def generate_profile_from_mibs(ctx, mib_files, filters, aliases, debug, interact
     profile_oid_collection = {}
     # build profile
     for oid_node in _extract_oids_from_mibs(
-        list(mibs), list(source_directories), json_destination_directory, source, [borrower], filters
+        list(mibs), list(source_directories), json_destination_directory, source, compiled_mibs_path, filters
     ):
         if oid_node.node_type == 'table':
             _add_profile_table_node(profile_oid_collection, oid_node)
@@ -150,7 +150,7 @@ def generate_profile_from_mibs(ctx, mib_files, filters, aliases, debug, interact
                 metric_tag_aliases_path=aliases,
                 json_mib_directory=json_destination_directory,
                 source=source,
-                borrowers=[borrower],
+                compiled_mibs_path=compiled_mibs_path,
             )
         elif oid_node.node_type == 'column':
             _add_profile_column_node(profile_oid_collection, oid_node)
@@ -265,11 +265,12 @@ class OidNode:
         return self.mib_class == 'objecttype'
 
 
-def _compile_mib_to_json(mib, source_mib_directories, destination_directory, source, borrowers):
+def _compile_mib_to_json(mib, source_mib_directories, destination_directory, source, compiled_mibs_path):
+    from pysmi.borrower import AnyFileBorrower
     from pysmi.codegen import JsonCodeGen
     from pysmi.compiler import MibCompiler
     from pysmi.parser import SmiV1CompatParser
-    from pysmi.reader import FileReader
+    from pysmi.reader import getReadersFromUrls
     from pysmi.searcher import AnyFileSearcher, StubSearcher
     from pysmi.writer import FileWriter
 
@@ -278,7 +279,6 @@ def _compile_mib_to_json(mib, source_mib_directories, destination_directory, sou
     compile_documentation = True
 
     # Compiler infrastructure
-    searchers = [AnyFileSearcher(destination_directory).setOptions(exts=['.json']), StubSearcher(*mib_stubs)]
 
     code_generator = JsonCodeGen()
 
@@ -287,15 +287,19 @@ def _compile_mib_to_json(mib, source_mib_directories, destination_directory, sou
     mib_compiler = MibCompiler(SmiV1CompatParser(tempdir=''), code_generator, file_writer)
 
     # use source_mib_directories as mibs source
-    for source_directory in source_mib_directories:
-        mib_compiler.addSources(FileReader(source_directory))
-    # use snmp mibs repo as mibs source
-    reader = _get_reader_from_source(source)
-    mib_compiler.addSources(reader)
+    sources = [source]
+    sources.extend(source_mib_directories)
+    mib_compiler.addSources(*getReadersFromUrls(*sources, **dict(fuzzyMatching=True)))
 
+    searchers = [AnyFileSearcher(destination_directory).setOptions(exts=['.json']), StubSearcher(*mib_stubs)]
     mib_compiler.addSearchers(*searchers)
 
-    mib_compiler.addBorrowers(*borrowers)
+    # borrowers, aka compiled mibs source
+    borrowers = [
+        AnyFileBorrower(borrower_reader, genTexts=True).setOptions(exts=['.json'])
+        for borrower_reader in getReadersFromUrls(*[compiled_mibs_path], **dict(lowcaseMatching=False))
+    ]
+    mib_compiler.addBorrowers(borrowers)
 
     processed = mib_compiler.compile(
         mib,
@@ -346,7 +350,7 @@ def _load_json_module(source_directory, mib):
         return None
 
 
-def _load_module_or_compile(mib, source_directories, json_mib_directory, source, borrowers):
+def _load_module_or_compile(mib, source_directories, json_mib_directory, source, compiled_mibs_path):
     # try loading the json mib, if already compiled
     echo_debug('⏳ Loading mib {}'.format(mib))
     mib_json = _load_json_module(json_mib_directory, mib)
@@ -356,7 +360,7 @@ def _load_module_or_compile(mib, source_directories, json_mib_directory, source,
 
     # compile and reload
     echo_debug('⏳ Compile mib {}'.format(mib))
-    processed = _compile_mib_to_json(mib, source_directories, json_mib_directory, source, borrowers)
+    processed = _compile_mib_to_json(mib, source_directories, json_mib_directory, source, compiled_mibs_path)
     echo_debug('✅ Mib {} compiled: {}'.format(mib, processed[mib]))
     if processed[mib] != 'missing':
         mib_json = _load_json_module(json_mib_directory, mib)
@@ -365,8 +369,8 @@ def _load_module_or_compile(mib, source_directories, json_mib_directory, source,
     return None
 
 
-def _find_oid_by_name(mib, oid_name, source_directories, json_mib_directory, source, borrowers):
-    mib_json = _load_module_or_compile(mib, source_directories, json_mib_directory, source, borrowers)
+def _find_oid_by_name(mib, oid_name, source_directories, json_mib_directory, source, compiled_mibs_path):
+    mib_json = _load_module_or_compile(mib, source_directories, json_mib_directory, source, compiled_mibs_path)
     if mib_json is None:
         return None
 
@@ -376,8 +380,8 @@ def _find_oid_by_name(mib, oid_name, source_directories, json_mib_directory, sou
     return mib_json[oid_name]['oid']
 
 
-def _find_name_by_oid(mib, oid, source_directories, json_mib_directory, source, borrowers):
-    mib_json = _load_module_or_compile(mib, source_directories, json_mib_directory, source, borrowers)
+def _find_name_by_oid(mib, oid, source_directories, json_mib_directory, source, compiled_mibs_path):
+    mib_json = _load_module_or_compile(mib, source_directories, json_mib_directory, source, compiled_mibs_path)
     if mib_json is None:
         return None
 
@@ -418,7 +422,9 @@ def _filter_mib_oids(mib, json_mib, filter_data):
     return filtered_json_oids
 
 
-def _extract_oids_from_mibs(mibs, source_directories, json_destination_directory, source, borrower, filter_path=None):
+def _extract_oids_from_mibs(
+    mibs, source_directories, json_destination_directory, source, compiled_mibs_path, filter_path=None
+):
     filter_data = None
     if filter_path is not None and os.path.isfile(filter_path):
         with open(filter_path) as f:
@@ -427,7 +433,7 @@ def _extract_oids_from_mibs(mibs, source_directories, json_destination_directory
     json_mibs = {}
     for mib in mibs:
         json_mib = _load_module_or_compile(
-            mib, source_directories, json_destination_directory, source, borrowers=[borrower]
+            mib, source_directories, json_destination_directory, source, compiled_mibs_path
         )
         if json_mib is None:
             continue
@@ -586,7 +592,13 @@ def _load_aliases_from_yaml(aliases_path):
 
 
 def _add_profile_row_node(
-    profile_oid_collection, oid_node, mibs_directories, json_mib_directory, metric_tag_aliases_path, source, borrowers
+    profile_oid_collection,
+    oid_node,
+    mibs_directories,
+    json_mib_directory,
+    metric_tag_aliases_path,
+    source,
+    compiled_mibs_path,
 ):
     """
     Updates a collection of profile nodes, indexed by oid, adding indexes if found in oid_node
@@ -628,12 +640,12 @@ def _add_profile_row_node(
 
         index = {'MIB': mib, 'tag': oid_name}
         column = {'name': oid_name}
-        index_oid = _find_oid_by_name(mib, oid_name, mibs_directories, json_mib_directory, source, borrowers)
+        index_oid = _find_oid_by_name(mib, oid_name, mibs_directories, json_mib_directory, source, compiled_mibs_path)
         if index_oid is not None:
             column['OID'] = index_oid
             index_table_oid = '.'.join(index_oid.split('.')[:-2])
             index_table_name = _find_name_by_oid(
-                mib, index_table_oid, mibs_directories, json_mib_directory, source, borrowers
+                mib, index_table_oid, mibs_directories, json_mib_directory, source, compiled_mibs_path
             )
             if index_table_name is not None:
                 index['table'] = index_table_name


### PR DESCRIPTION
### What does this PR do?
Fixing snmp profile generator, broken by my previous PR

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Validation

#### Test default borrowers work

* Download https://github.com/DataDog/mibs.snmplabs.com/blob/master/asn1/CISCO-UNIFIED-COMPUTING-TC-MIB
* Launch the generator on this file using 
   ```sh
   ddev meta snmp generate-profile-from-mibs -i <path/to/CISCO-UNIFIED-COMPUTING-TC-MIB>
   ```

#### Test `pysmi` logs work

* Verify metrics are detected
* Launch the generator on this file using 
   ```sh
   ddev meta snmp generate-profile-from-mibs -i -d <path/to/CISCO-UNIFIED-COMPUTING-TC-MIB>
   ```
* Verify logs from `pysmi` are in output

#### Test local borrowers and sources work

* Locally clone https://github.com/DataDog/mibs.snmplabs.com
* Launch the generator on this file using 
   ```sh
   ddev meta snmp generate-profile-from-mibs -i <path/to/CISCO-UNIFIED-COMPUTING-TC-MIB> -s <path/to/mibs.snmplabs.com repo/asn1> -c <path/to/mibs.snmplabs.com repo/json>
   ```
* Verify metrics are detected

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
