### PR TITLE
Add more descriptive warning message 

### DIFF
--- a/go_expvar/datadog_checks/go_expvar/go_expvar.py
+++ b/go_expvar/datadog_checks/go_expvar/go_expvar.py
@@ -170,7 +170,14 @@ class GoExpvar(AgentCheck):
                 try:
                     float(value)
                 except (TypeError, ValueError):
-                    self.log.warning("Unreportable value for path %s: %s", actual_path, value)
+                    if isinstance(value, dict):
+                        self.log.warning(
+                            "Path %s is a mapping; specify a more specific path to report a value: %s",
+                            actual_path,
+                            value,
+                        )
+                    else:
+                        self.log.warning("Unreportable value for path %s: %s", actual_path, value)
                     continue
 
                 if count >= max_metrics:

--- a/go_expvar/tests/test_unit.py
+++ b/go_expvar/tests/test_unit.py
@@ -213,3 +213,14 @@ def test_alias_tag_path(go_expvar_mock, check, aggregator):
     shared_tags = ['expvar_url:{0}'.format(common.URL_WITH_PATH)]
     aggregator.assert_metric("array.dict.key", count=1, tags=shared_tags + ["path:array.0.key"])
     aggregator.assert_metric("array.dict.key", count=1, tags=shared_tags + ["path:array.1.key"])
+
+
+@pytest.mark.unit
+def test_warn_with_bad_path(go_expvar_mock, caplog, check, aggregator):
+    mock_config = {
+        "expvar_url": common.URL_WITH_PATH,
+        "metrics": [{"path": "memstats"}],
+    }
+    check.check(mock_config)
+
+    assert 'Path memstats is a mapping; specify a more specific path to report a value' in caplog.text


### PR DESCRIPTION
### What does this PR do?
Adds a more descriptive warning message when a path that is a dictionary such as memstats is provided

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
