### PR TITLE
Fix TLSContextWrapper to not override tls_verify

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -88,11 +88,6 @@ class TlsContextWrapper(object):
 
             config[field] = value
 
-        if any(
-            (config['tls_ca_cert'], config['tls_cert'], config['tls_private_key'], config['tls_private_key_password'])
-        ):
-            config['tls_verify'] = True
-
         # Populate with the higher-priority configuration options if set
         for field in default_fields:
             unique_name = UNIQUE_FIELD_PREFIX + field

--- a/datadog_checks_base/datadog_checks/base/utils/tls.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tls.py
@@ -88,6 +88,9 @@ class TlsContextWrapper(object):
 
             config[field] = value
 
+        if config['tls_ca_cert']:
+            config['tls_verify'] = True
+
         # Populate with the higher-priority configuration options if set
         for field in default_fields:
             unique_name = UNIQUE_FIELD_PREFIX + field

--- a/datadog_checks_base/tests/base/utils/test_tls.py
+++ b/datadog_checks_base/tests/base/utils/test_tls.py
@@ -43,6 +43,13 @@ class TestVerify:
         tls = TlsContextWrapper({'tls_verify': False})
         assert tls.config['tls_verify'] is False
 
+    @pytest.mark.parametrize('param', ('tls_ca_cert', 'tls_cert', 'tls_private_key', 'tls_private_key_password'))
+    def test_config_overwrite(self, param):
+        config = {param: param}
+        with patch('ssl.SSLContext'):
+            tls = TlsContextWrapper(config)
+        assert tls.config['tls_verify'] is True
+
     @pytest.mark.parametrize('param', ('tls_cert', 'tls_private_key'))
     def test_config_no_overwrite_tls_verify(self, param):
         config = {'tls_verify': False, param: param}

--- a/datadog_checks_base/tests/base/utils/test_tls.py
+++ b/datadog_checks_base/tests/base/utils/test_tls.py
@@ -43,16 +43,16 @@ class TestVerify:
         tls = TlsContextWrapper({'tls_verify': False})
         assert tls.config['tls_verify'] is False
 
-    @pytest.mark.parametrize('param', ('tls_ca_cert', 'tls_cert', 'tls_private_key', 'tls_private_key_password'))
+    @pytest.mark.parametrize('param', ['tls_ca_cert'])
     def test_config_overwrite(self, param):
-        config = {param: param}
+        config = {'tls_verify': False, param: 'foo'}
         with patch('ssl.SSLContext'):
             tls = TlsContextWrapper(config)
         assert tls.config['tls_verify'] is True
 
     @pytest.mark.parametrize('param', ('tls_cert', 'tls_private_key'))
     def test_config_no_overwrite_tls_verify(self, param):
-        config = {'tls_verify': False, param: param}
+        config = {'tls_verify': False, param: 'foo'}
         with patch('ssl.SSLContext'):
             tls = TlsContextWrapper(config)
         assert tls.config['tls_verify'] is False

--- a/datadog_checks_base/tests/base/utils/test_tls.py
+++ b/datadog_checks_base/tests/base/utils/test_tls.py
@@ -43,12 +43,12 @@ class TestVerify:
         tls = TlsContextWrapper({'tls_verify': False})
         assert tls.config['tls_verify'] is False
 
-    @pytest.mark.parametrize('param', ('tls_ca_cert', 'tls_cert', 'tls_private_key', 'tls_private_key_password'))
-    def test_config_overwrite(self, param):
-        config = {'tls_verify': False, param: 'foo'}
+    @pytest.mark.parametrize('param', ('tls_cert', 'tls_private_key'))
+    def test_config_no_overwrite_tls_verify(self, param):
+        config = {'tls_verify': False, param: param}
         with patch('ssl.SSLContext'):
             tls = TlsContextWrapper(config)
-        assert tls.config['tls_verify'] is True
+        assert tls.config['tls_verify'] is False
 
 
 @pytest.mark.parametrize(
@@ -90,6 +90,12 @@ class TestRemapper:
         remapper = {'disable_tls_validation': {'name': 'tls_verify', 'invert': True}}
         tls = TlsContextWrapper(instance, remapper)
         assert tls.config['tls_verify'] is True
+
+    def test_remap_validate_cert(self):
+        instance = {'validate_cert': False}
+        remapper = {'validate_cert': {'name': 'tls_verify', 'default': True}}
+        tls = TlsContextWrapper(instance, remapper)
+        assert tls.config['tls_verify'] is False
 
 
 class TestHigherPriorityRemapper:


### PR DESCRIPTION
### What does this PR do?
Previously, the `TLSContextWrapper` was overriding the configured `tls_verify` value and forcing it to `True` if any of these configs were present, `tls_ca_cert`, `tls_cert`, `tls_private_key`, `tls_private_key_password` even if `tls_verify: false` is configured. This PR updates the override to only force `tls_verify: true` if `tls_ca_cert` is configured.

### Motivation
Customer support case

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
