### PR TITLE
Try to reconnect when vcenter connection lost

### DIFF
--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -612,9 +612,8 @@ class VSphereCheck(AgentCheck):
                 self.set_metadata('version', version_info.version_str)
         except Exception:
             # Explicitly do not attach any host to the service checks.
-            self.log.exception("The vCenter API is not responding. The check will not run.")
-            self.service_check(SERVICE_CHECK_NAME, AgentCheck.CRITICAL, tags=self._config.base_tags, hostname=None)
-            raise
+            self.log.warning('The vCenter API is not responding. Trying to reconnect.')
+            self.initiate_api_connection()
         else:
             self.service_check(SERVICE_CHECK_NAME, AgentCheck.OK, tags=self._config.base_tags, hostname=None)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Try to reconnect when the connection is lost, to avoid an agent restart

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Could not really reproduce the issue

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
