### PR TITLE
Allow exclusion of specific branch for changelog generation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -36,7 +36,8 @@ ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, autho
 )
 @click.pass_context
 def changelog(
-    ctx, check, version, old_version, initial, quiet, dry_run, output_file, tag_prefix, no_semver, organization, exclude_branch,
+    ctx, check, version, old_version, initial, quiet, dry_run, output_file, tag_prefix, no_semver, organization,
+    exclude_branch,
 ):
     """Perform the operations needed to update the changelog.
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -31,12 +31,20 @@ ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, autho
 @click.option('--output-file', '-o', default='CHANGELOG.md', show_default=True)
 @click.option('--tag-prefix', '-tp', default='v', show_default=True)
 @click.option('--no-semver', '-ns', default=False, is_flag=True)
-@click.option(
-    '--exclude-branch', default=None, help="Exclude changes comming from a specific branch"
-)
+@click.option('--exclude-branch', default=None, help="Exclude changes comming from a specific branch")
 @click.pass_context
 def changelog(
-    ctx, check, version, old_version, initial, quiet, dry_run, output_file, tag_prefix, no_semver, organization,
+    ctx,
+    check,
+    version,
+    old_version,
+    initial,
+    quiet,
+    dry_run,
+    output_file,
+    tag_prefix,
+    no_semver,
+    organization,
     exclude_branch,
 ):
     """Perform the operations needed to update the changelog.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -31,9 +31,12 @@ ChangelogEntry = namedtuple('ChangelogEntry', 'number, title, url, author, autho
 @click.option('--output-file', '-o', default='CHANGELOG.md', show_default=True)
 @click.option('--tag-prefix', '-tp', default='v', show_default=True)
 @click.option('--no-semver', '-ns', default=False, is_flag=True)
+@click.option(
+    '--exclude-branch', default=None, help="Exclude changes comming from a specific branch"
+)
 @click.pass_context
 def changelog(
-    ctx, check, version, old_version, initial, quiet, dry_run, output_file, tag_prefix, no_semver, organization
+    ctx, check, version, old_version, initial, quiet, dry_run, output_file, tag_prefix, no_semver, organization, exclude_branch,
 ):
     """Perform the operations needed to update the changelog.
 
@@ -62,7 +65,7 @@ def changelog(
     target_tag = get_release_tag_string(check, cur_version)
 
     # get the diff from HEAD
-    diff_lines = get_commits_since(check, None if initial else target_tag)
+    diff_lines = get_commits_since(check, None if initial else target_tag, exclude_branch=exclude_branch)
 
     # for each PR get the title, we'll use it to populate the changelog
     pr_numbers = parse_pr_numbers(diff_lines)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
@@ -25,8 +25,11 @@ from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_su
 @click.option(
     '--since', default=None, help="The git ref to use instead of auto-detecting the tag to view changes since"
 )
+@click.option(
+    '--exclude-branch', default=None, help="Exclude changes comming from a specific branch"
+)
 @click.pass_context
-def changes(ctx, check, tag_pattern, tag_prefix, dry_run, organization, since):
+def changes(ctx, check, tag_pattern, tag_prefix, dry_run, organization, since, exclude_branch):
     """Show all the pending PRs for a given check."""
     if not dry_run and check and check not in get_valid_checks():
         abort(f'Check `{check}` is not an Agent-based Integration')
@@ -41,7 +44,7 @@ def changes(ctx, check, tag_pattern, tag_prefix, dry_run, organization, since):
     target_tag = get_release_tag_string(check, cur_version)
 
     # get the diff from HEAD
-    diff_lines = get_commits_since(check, target_tag)
+    diff_lines = get_commits_since(check, target_tag, exclude_branch=exclude_branch)
 
     # for each PR get the title, we'll use it to populate the changelog
     pr_numbers = parse_pr_numbers(diff_lines)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
@@ -25,9 +25,7 @@ from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_su
 @click.option(
     '--since', default=None, help="The git ref to use instead of auto-detecting the tag to view changes since"
 )
-@click.option(
-    '--exclude-branch', default=None, help="Exclude changes comming from a specific branch"
-)
+@click.option('--exclude-branch', default=None, help="Exclude changes comming from a specific branch")
 @click.pass_context
 def changes(ctx, check, tag_pattern, tag_prefix, dry_run, organization, since, exclude_branch):
     """Show all the pending PRs for a given check."""

--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -68,7 +68,7 @@ def files_changed(include_uncommitted=True):
     return sorted([f for f in set(changed_files) if f])
 
 
-def get_commits_since(check_name, target_tag=None):
+def get_commits_since(check_name, target_tag=None, exclude_branch=None):
     """
     Get the list of commits from `target_tag` to `HEAD` for the given check
     """
@@ -77,7 +77,13 @@ def get_commits_since(check_name, target_tag=None):
         target_path = os.path.join(root, check_name)
     else:
         target_path = root
-    command = f"git log --pretty=%s {'' if target_tag is None else f'{target_tag}... '}{target_path}"
+
+    if exclude_branch is not None and check_name not in {".", None}:
+        raise ValueError(f"Cannot exclude a branch from a non-root check {check_name}")
+    elif exclude_branch is not None:
+        command = f"git cherry -v {exclude_branch} HEAD {'' if target_tag is None else f'{target_tag} '}"
+    else:
+        command = f"git log --pretty=%s {'' if target_tag is None else f'{target_tag}... '}{target_path}"
 
     with chdir(root):
         return run_command(command, capture=True).stdout.splitlines()


### PR DESCRIPTION
### What does this PR do?

Adds `--exclude-branch` option for generating changelogs.

### Motivation

Generated API clients contain subtree from openapi-generator with full history.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
