### PR TITLE
Annotate codeowners

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -31,6 +31,10 @@ jobs:
         ddev config set repos.core .
         ddev config set repo core
 
+    - name: Run codeowners validation
+      run: |
+        ddev validate codeowners
+
     - name: Run configuration validation
       run: |
         ddev validate config

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
@@ -5,7 +5,8 @@ import re
 
 import click
 
-from ...utils import get_codeowners, get_valid_integrations
+from ...annotations import annotate_error
+from ...utils import get_codeowners, get_codeowners_file, get_valid_integrations
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_success
 
 DIRECTORY_REGEX = re.compile(r"\/(.*)\/$")
@@ -57,19 +58,24 @@ def codeowners():
 
     has_failed = False
     codeowner_map = create_codeowners_map()
-
+    codeowners_file = get_codeowners_file()
     for integration, codeowner in codeowner_map.items():
         if not codeowner:
             has_failed = True
-            echo_failure(f"Integration {integration} does not have a valid `CODEOWNERS` entry.")
+            raise Exception(integration, codeowner)
+            message = f"Integration {integration} does not have a valid `CODEOWNERS` entry."
+            echo_failure(message)
+            annotate_error(codeowners_file, message)
         elif codeowner == "empty":
             has_failed = True
-            echo_failure(f"Integration {integration} has a `CODEOWNERS` entry, but the codeowner is empty.")
+            message = f"Integration {integration} has a `CODEOWNERS` entry, but the codeowner is empty."
+            echo_failure(message)
+            annotate_error(codeowners_file, message)
         elif not codeowner.startswith("@") and integration not in IGNORE_TILES:
             has_failed = True
-            echo_failure(
-                f"Integration {integration} has a `CODEOWNERS` entry, but the codeowner is not a username or team."
-            )
+            message = f"Integration {integration} has a `CODEOWNERS` entry, but the codeowner is not a username or team."
+            echo_failure(message)
+            annotate_error(codeowners_file, message)
 
     if not has_failed:
         echo_success("All integrations have valid codeowners.")

--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -311,8 +311,12 @@ def get_test_directory(check_name):
     return os.path.join(get_root(), check_name, 'tests')
 
 
+def get_codeowners_file():
+    return os.path.join(get_root(), '.github', 'CODEOWNERS')
+
+
 def get_codeowners():
-    codeowners_file = os.path.join(get_root(), '.github', 'CODEOWNERS')
+    codeowners_file = get_codeowners_file()
     contents = read_file_lines(codeowners_file)
     return contents
 


### PR DESCRIPTION
### What does this PR do?
This PR introduces codeowners annotation and refactors the utils to return codeowner file location.

### Motivation
Part of automatic review workflow

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
