### PR TITLE
Kafka check - add listeners metric

### DIFF
--- a/kafka/datadog_checks/kafka/data/metrics.yaml
+++ b/kafka/datadog_checks/kafka/data/metrics.yaml
@@ -346,7 +346,7 @@ jmx_metrics:
           Count:
             metric_type: rate
             alias: kafka.net.bytes_rejected.rate
-    
+
     #
     # Per Topic Broker Stats (only v0.8.x)
     #
@@ -682,3 +682,15 @@ jmx_metrics:
           Count:
             alias: kafka.session.fetch.eviction
             metric_type: rate
+    #
+    # Listeners stats
+    #
+    - include:
+        domain: 'kafka.server'
+        bean_regex: 'kafka\.server:type=socket-server-metrics,listener=(.*?),networkProcessor=.*'
+        attribute:
+          connection-count:
+            metric_type: gauge
+            alias: kafka.server.socket_server_metrics.connection_count
+        tags:
+          listener: $1

--- a/kafka/datadog_checks/kafka/data/metrics.yaml
+++ b/kafka/datadog_checks/kafka/data/metrics.yaml
@@ -691,6 +691,6 @@ jmx_metrics:
         attribute:
           connection-count:
             metric_type: gauge
-            alias: kafka.server.socket_server_metrics.connection_count
+            alias: kafka.server.socket.connection_count
         tags:
           listener: $1

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -87,3 +87,4 @@ kafka.topic.net.bytes_in.rate,gauge,10,byte,second,Incoming byte rate by topic.,
 kafka.topic.net.bytes_rejected.rate,gauge,10,byte,second,Rejected byte rate by topic.,-1,kafka,topic bytes rejected
 kafka.session.fetch.count,gauge,10,,,Number of fetch sessions.,0,kafka,fetch sessions
 kafka.session.fetch.eviction,gauge,10,event,second,Eviction rate of fetch session.,0,kafka,eviction session rate
+kafka.server.socket_server_metrics.connection_count,gauge,10,connection,second,Number of currently open connections to the broker.,0,kafka,open connections number

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -87,4 +87,4 @@ kafka.topic.net.bytes_in.rate,gauge,10,byte,second,Incoming byte rate by topic.,
 kafka.topic.net.bytes_rejected.rate,gauge,10,byte,second,Rejected byte rate by topic.,-1,kafka,topic bytes rejected
 kafka.session.fetch.count,gauge,10,,,Number of fetch sessions.,0,kafka,fetch sessions
 kafka.session.fetch.eviction,gauge,10,event,second,Eviction rate of fetch session.,0,kafka,eviction session rate
-kafka.server.socket_server_metrics.connection_count,gauge,10,connection,,Number of currently open connections to the broker.,0,kafka,open connections number
+kafka.server.socket.connection_count,gauge,10,connection,,Number of currently open connections to the broker.,0,kafka,open connections number

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -87,4 +87,4 @@ kafka.topic.net.bytes_in.rate,gauge,10,byte,second,Incoming byte rate by topic.,
 kafka.topic.net.bytes_rejected.rate,gauge,10,byte,second,Rejected byte rate by topic.,-1,kafka,topic bytes rejected
 kafka.session.fetch.count,gauge,10,,,Number of fetch sessions.,0,kafka,fetch sessions
 kafka.session.fetch.eviction,gauge,10,event,second,Eviction rate of fetch session.,0,kafka,eviction session rate
-kafka.server.socket_server_metrics.connection_count,gauge,10,connection,second,Number of currently open connections to the broker.,0,kafka,open connections number
+kafka.server.socket_server_metrics.connection_count,gauge,10,connection,,Number of currently open connections to the broker.,0,kafka,open connections number

--- a/kafka/tests/common.py
+++ b/kafka/tests/common.py
@@ -62,4 +62,6 @@ KAFKA_E2E_METRICS = [
     # Session
     "kafka.session.fetch.count",
     "kafka.session.fetch.eviction",
+    # Listeners
+    "kafka.server.socket_server_metrics.connection_count",
 ]

--- a/kafka/tests/common.py
+++ b/kafka/tests/common.py
@@ -63,5 +63,5 @@ KAFKA_E2E_METRICS = [
     "kafka.session.fetch.count",
     "kafka.session.fetch.eviction",
     # Listeners
-    "kafka.server.socket_server_metrics.connection_count",
+    "kafka.server.socket.connection_count",
 ]


### PR DESCRIPTION
### What does this PR do?
Add a metric about the number of currently open connections to the broker, per listener. 

### Motivation
We'd need to monitor the number of clients connected per listener, for instance in order to disable the plain text listener we need to ensure that no client is connected.

### Additional Notes
Since the cardinality is very low, it shouldn't be a problem regarding the number of metrics collected by the check.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached