### PR TITLE
Refactor `process` integration

### DIFF
--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -254,7 +254,7 @@ class ProcessCheck(AgentCheck):
                         try:
                             result[acc] = getattr(res, acc)
                         except AttributeError:
-                            self.log.exception("psutil.%s().%s attribute does not exist", method, acc)
+                            self.log.debug("psutil.%s().%s attribute does not exist", method, acc)
             except (NotImplementedError, AttributeError):
                 self.log.debug("psutil method %s not implemented", method)
             except psutil.AccessDenied:

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -242,7 +242,7 @@ class ProcessCheck(AgentCheck):
                 process_ls = subprocess.check_output(ls_args)
                 result = len(process_ls.splitlines())
             except Exception as e:
-                self.log.debug("Trying to retrieve %s with sudo failed with error: %s", method, e)
+                self.log.exception("Trying to retrieve %s with sudo failed with error: %s", method, e)
 
         else:
             try:
@@ -285,7 +285,7 @@ class ProcessCheck(AgentCheck):
                     self.log.debug('New process in cache: %s', pid)
                 # Skip processes dead in the meantime
                 except psutil.NoSuchProcess:
-                    self.log.warning('Process %s disappeared while scanning', pid)
+                    self.warning('Process %s disappeared while scanning', pid)
                     # reset the process caches now, something changed
                     self.last_pid_cache_ts[name] = 0
                     self.process_list_cache.reset()
@@ -389,14 +389,14 @@ class ProcessCheck(AgentCheck):
         tags = list(self.tags)
 
         if self._conflicting_procfs:
-            self.log.warning(
+            self.warning(
                 'The `procfs_path` defined in `process.yaml is different from the one defined in '
                 '`datadog.conf` This is currently not supported by the Agent. Defaulting to the '
                 'value defined in `datadog.conf`: %s',
                 psutil.PROCFS_PATH,
             )
         elif self._deprecated_init_procfs:
-            self.log.warning(
+            self.warning(
                 'DEPRECATION NOTICE: Specifying `procfs_path` in process.yaml` is deprecated. '
                 'Please specify it in `datadog.conf` instead'
             )
@@ -407,7 +407,7 @@ class ProcessCheck(AgentCheck):
         # FIXME 8.x remove me
         if self.search_string is not None:
             if "All" in self.search_string:
-                self.log.warning(
+                self.warning(
                     'Deprecated: Having "All" in your search_string will greatly reduce the '
                     'performance of the check and will be removed in a future version of the agent.'
                 )
@@ -448,7 +448,7 @@ class ProcessCheck(AgentCheck):
         self.gauge('system.processes.number', len(pids), tags=tags)
 
         if len(pids) == 0:
-            self.log.warning("No matching process '%s' was found", self.name)
+            self.warning("No matching process '%s' was found", self.name)
             # reset the process caches now, something changed
             self.last_pid_cache_ts[self.name] = 0
             self.process_list_cache.reset()

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -180,7 +180,7 @@ class ProcessCheck(AgentCheck):
                         # As the process list isn't necessarily scanned right after it's created
                         # (since we're using a shared cache), there can be cases where processes
                         # in the list are dead when an instance of the check tries to scan them.
-                        self.log.warning('Process disappeared while scanning')
+                        self.log.debug('Process disappeared while scanning')
                     except psutil.AccessDenied as e:
                         ad_error_logger('Access denied to process with PID {}'.format(proc.pid))
                         ad_error_logger('Error: {}'.format(e))
@@ -285,7 +285,7 @@ class ProcessCheck(AgentCheck):
                     self.log.debug('New process in cache: %s', pid)
                 # Skip processes dead in the meantime
                 except psutil.NoSuchProcess:
-                    self.log.debug('Process %s disappeared while scanning', pid)
+                    self.log.warning('Process %s disappeared while scanning', pid)
                     # reset the process caches now, something changed
                     self.last_pid_cache_ts[name] = 0
                     self.process_list_cache.reset()

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -256,9 +256,9 @@ class ProcessCheck(AgentCheck):
                         except AttributeError:
                             self.log.debug("psutil.%s().%s attribute does not exist", method, acc)
             except (NotImplementedError, AttributeError):
-                self.log.debug("psutil method %s not implemented", method)
+                self.log.exception("psutil method %s not implemented", method)
             except psutil.AccessDenied:
-                self.log.debug("psutil was denied access for method %s", method)
+                self.log.exception("psutil was denied access for method %s", method)
             except psutil.NoSuchProcess:
                 self.warning("Process %s disappeared while scanning", process.pid)
 

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -180,7 +180,7 @@ class ProcessCheck(AgentCheck):
                         # As the process list isn't necessarily scanned right after it's created
                         # (since we're using a shared cache), there can be cases where processes
                         # in the list are dead when an instance of the check tries to scan them.
-                        self.log.debug('Process disappeared while scanning')
+                        self.log.exception('Process disappeared while scanning')
                     except psutil.AccessDenied as e:
                         ad_error_logger('Access denied to process with PID {}'.format(proc.pid))
                         ad_error_logger('Error: {}'.format(e))
@@ -203,7 +203,7 @@ class ProcessCheck(AgentCheck):
                 except (psutil.NoSuchProcess, psutil.AccessDenied):
                     pass
                 else:
-                    self.log.debug(
+                    self.log.exception(
                         "Unable to find process named %s among processes: %s", search_string, ', '.join(processes)
                     )
 
@@ -213,7 +213,7 @@ class ProcessCheck(AgentCheck):
             self.last_ad_cache_ts[name] = time.time()
         return matching_pids
 
-    def psutil_wrapper(self, process, method, accessors, try_sudo, *args, **kwargs):
+    def psutil_wrapper(self, process, method, accessors=None, *args, **kwargs):
         """
         A psutil wrapper that is calling
         * psutil.method(*args, **kwargs) and returns the result
@@ -264,7 +264,7 @@ class ProcessCheck(AgentCheck):
 
         return result
 
-    def get_process_state(self, name, pids, try_sudo):
+    def get_process_state(self, name, pids):
         st = defaultdict(list)
 
         # Remove from cache the processes that are not in `pids`
@@ -285,7 +285,7 @@ class ProcessCheck(AgentCheck):
                     self.log.debug('New process in cache: %s', pid)
                 # Skip processes dead in the meantime
                 except psutil.NoSuchProcess:
-                    self.warning('Process %s disappeared while scanning', pid)
+                    self.log.exception('Process %s disappeared while scanning', pid)
                     # reset the process caches now, something changed
                     self.last_pid_cache_ts[name] = 0
                     self.process_list_cache.reset()
@@ -293,27 +293,27 @@ class ProcessCheck(AgentCheck):
 
             p = self.process_cache[name][pid]
 
-            meminfo = self.psutil_wrapper(p, 'memory_info', ['rss', 'vms'], try_sudo)
+            meminfo = self.psutil_wrapper(p, 'memory_info', ['rss', 'vms'])
             st['rss'].append(meminfo.get('rss'))
             st['vms'].append(meminfo.get('vms'))
 
-            mem_percent = self.psutil_wrapper(p, 'memory_percent', None, try_sudo)
+            mem_percent = self.psutil_wrapper(p, 'memory_percent')
             st['mem_pct'].append(mem_percent)
 
             # will fail on win32 and solaris
-            shared_mem = self.psutil_wrapper(p, 'memory_info', ['shared'], try_sudo).get('shared')
+            shared_mem = self.psutil_wrapper(p, 'memory_info', ['shared']).get('shared')
             if shared_mem is not None and meminfo.get('rss') is not None:
                 st['real'].append(meminfo['rss'] - shared_mem)
             else:
                 st['real'].append(None)
 
-            ctxinfo = self.psutil_wrapper(p, 'num_ctx_switches', ['voluntary', 'involuntary'], try_sudo)
+            ctxinfo = self.psutil_wrapper(p, 'num_ctx_switches', ['voluntary', 'involuntary'])
             st['ctx_swtch_vol'].append(ctxinfo.get('voluntary'))
             st['ctx_swtch_invol'].append(ctxinfo.get('involuntary'))
 
-            st['thr'].append(self.psutil_wrapper(p, 'num_threads', None, try_sudo))
+            st['thr'].append(self.psutil_wrapper(p, 'num_threads'))
 
-            cpu_percent = self.psutil_wrapper(p, 'cpu_percent', None, try_sudo)
+            cpu_percent = self.psutil_wrapper(p, 'cpu_percent')
             cpu_count = psutil.cpu_count()
             if not new_process:
                 # psutil returns `0.` for `cpu_percent` the
@@ -324,12 +324,10 @@ class ProcessCheck(AgentCheck):
                     st['cpu_norm'].append(cpu_percent / cpu_count)
                 else:
                     self.log.debug('could not calculate the normalized cpu pct, cpu_count: %s', cpu_count)
-            st['open_fd'].append(self.psutil_wrapper(p, 'num_fds', None, try_sudo))
-            st['open_handle'].append(self.psutil_wrapper(p, 'num_handles', None, try_sudo))
+            st['open_fd'].append(self.psutil_wrapper(p, 'num_fds'))
+            st['open_handle'].append(self.psutil_wrapper(p, 'num_handles'))
 
-            ioinfo = self.psutil_wrapper(
-                p, 'io_counters', ['read_count', 'write_count', 'read_bytes', 'write_bytes'], try_sudo
-            )
+            ioinfo = self.psutil_wrapper(p, 'io_counters', ['read_count', 'write_count', 'read_bytes', 'write_bytes'])
             st['r_count'].append(ioinfo.get('read_count'))
             st['w_count'].append(ioinfo.get('write_count'))
             st['r_bytes'].append(ioinfo.get('read_bytes'))
@@ -349,7 +347,7 @@ class ProcessCheck(AgentCheck):
                 st['cmajflt'].append(None)
 
             # calculate process run time
-            create_time = self.psutil_wrapper(p, 'create_time', None, try_sudo)
+            create_time = self.psutil_wrapper(p, 'create_time')
             if create_time is not None:
                 now = time.time()
                 run_time = now - create_time
@@ -370,7 +368,9 @@ class ProcessCheck(AgentCheck):
         try:
             data = file_to_string('/{}/{}/stat'.format(psutil.PROCFS_PATH, pid))
         except Exception:
-            self.log.debug('error getting proc stats: file_to_string failed for /%s/%s/stat', psutil.PROCFS_PATH, pid)
+            self.log.exception(
+                'error getting proc stats: file_to_string failed for /%s/%s/stat', psutil.PROCFS_PATH, pid
+            )
             return None
         return (int(i) for i in data.split()[9:13])
 
@@ -383,7 +383,7 @@ class ProcessCheck(AgentCheck):
                 for child in children:
                     children_pids.add(child.pid)
             except psutil.NoSuchProcess:
-                pass
+                self.log.exception("Unable to get children for process because process %s does not exist", pid)
 
         return children_pids
 
@@ -391,14 +391,14 @@ class ProcessCheck(AgentCheck):
         tags = list(self.tags)
 
         if self._conflicting_procfs:
-            self.warning(
+            self.log.warning(
                 'The `procfs_path` defined in `process.yaml is different from the one defined in '
                 '`datadog.conf` This is currently not supported by the Agent. Defaulting to the '
                 'value defined in `datadog.conf`: %s',
                 psutil.PROCFS_PATH,
             )
         elif self._deprecated_init_procfs:
-            self.warning(
+            self.log.warning(
                 'DEPRECATION NOTICE: Specifying `procfs_path` in process.yaml` is deprecated. '
                 'Please specify it in `datadog.conf` instead'
             )
@@ -430,7 +430,7 @@ class ProcessCheck(AgentCheck):
                     pids = self._get_pid_set(int(pid_line))
             except IOError as e:
                 # pid file doesn't exist, assuming the process is not running
-                self.log.debug('Unable to find pid file: %s', e)
+                self.log.exception('Unable to find pid file: %s', e)
                 pids = set()
         else:
             raise ValueError('The "search_string" or "pid" options are required for process identification')
@@ -441,7 +441,7 @@ class ProcessCheck(AgentCheck):
         if self.user:
             pids = self._filter_by_user(self.user, pids)
 
-        proc_state = self.get_process_state(self.name, pids, self.try_sudo)
+        proc_state = self.get_process_state(self.name, pids)
 
         # FIXME 8.x remove the `name` tag
         tags.extend(['process_name:{}'.format(self.name), self.name])
@@ -450,7 +450,7 @@ class ProcessCheck(AgentCheck):
         self.gauge('system.processes.number', len(pids), tags=tags)
 
         if len(pids) == 0:
-            self.warning("No matching process '%s' was found", self.name)
+            self.log.warning("No matching process '%s' was found", self.name)
             # reset the process caches now, something changed
             self.last_pid_cache_ts[self.name] = 0
             self.process_list_cache.reset()
@@ -482,6 +482,7 @@ class ProcessCheck(AgentCheck):
         try:
             return {psutil.Process(pid).pid}
         except psutil.NoSuchProcess:
+            self.log.exception("Unable to get pid set, process %s does not exist", pid)
             return set()
 
     def _process_service_check(self, name, nb_procs, bounds, tags):
@@ -533,6 +534,7 @@ class ProcessCheck(AgentCheck):
                 else:
                     self.log.debug("Discarding pid %s not belonging to %s", pid, user)
             except psutil.NoSuchProcess:
+                self.log.exception("Unable to filter pids by username, process %s does not exist", pid)
                 pass
 
         return filtered_pids

--- a/process/datadog_checks/process/process.py
+++ b/process/datadog_checks/process/process.py
@@ -254,7 +254,7 @@ class ProcessCheck(AgentCheck):
                         try:
                             result[acc] = getattr(res, acc)
                         except AttributeError:
-                            self.log.debug("psutil.%s().%s attribute does not exist", method, acc)
+                            self.log.exception("psutil.%s().%s attribute does not exist", method, acc)
             except (NotImplementedError, AttributeError):
                 self.log.debug("psutil method %s not implemented", method)
             except psutil.AccessDenied:

--- a/process/tests/test_integration.py
+++ b/process/tests/test_integration.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixtures("dd_environment")
-def test_check(aggregator, check, dd_run_check):
+def test_integration(aggregator, check, dd_run_check):
     dd_run_check(check)
     for metric in common.EXPECTED_METRICS:
         aggregator.assert_metric(metric, tags=common.EXPECTED_TAGS)

--- a/process/tests/test_process.py
+++ b/process/tests/test_process.py
@@ -69,21 +69,21 @@ def noop_get_pagefault_stats(pid):
 def test_psutil_wrapper_simple(aggregator):
     # Load check with empty config
     process = ProcessCheck(common.CHECK_NAME, {}, [{}])
-    name = process.psutil_wrapper(get_psutil_proc(), 'name', None, False)
+    name = process.psutil_wrapper(get_psutil_proc(), 'name')
     assert name is not None
 
 
 def test_psutil_wrapper_simple_fail(aggregator):
     # Load check with empty config
     process = ProcessCheck(common.CHECK_NAME, {}, [{}])
-    name = process.psutil_wrapper(get_psutil_proc(), 'blah', None, False)
+    name = process.psutil_wrapper(get_psutil_proc(), 'blah')
     assert name is None
 
 
 def test_psutil_wrapper_accessors(aggregator):
     # Load check with empty config
     process = ProcessCheck(common.CHECK_NAME, {}, [{}])
-    meminfo = process.psutil_wrapper(get_psutil_proc(), 'memory_info', ['rss', 'vms', 'foo'], False)
+    meminfo = process.psutil_wrapper(get_psutil_proc(), 'memory_info', ['rss', 'vms', 'foo'])
     assert 'rss' in meminfo
     assert 'vms' in meminfo
     assert 'foo' not in meminfo
@@ -92,7 +92,7 @@ def test_psutil_wrapper_accessors(aggregator):
 def test_psutil_wrapper_accessors_fail(aggregator):
     # Load check with empty config
     process = ProcessCheck(common.CHECK_NAME, {}, [{}])
-    meminfo = process.psutil_wrapper(get_psutil_proc(), 'memory_infoo', ['rss', 'vms'], False)
+    meminfo = process.psutil_wrapper(get_psutil_proc(), 'memory_infoo', ['rss', 'vms'])
     assert 'rss' not in meminfo
     assert 'vms' not in meminfo
 
@@ -149,7 +149,7 @@ def mock_find_pid(name, search_string, exact_match=True, ignore_ad=True, refresh
     return config_stubs[int(idx)]['mocked_processes']
 
 
-def mock_psutil_wrapper(process, method, accessors, try_sudo, *args, **kwargs):
+def mock_psutil_wrapper(method, accessors):
     if method == 'num_handles':  # win32 only
         return None
     if accessors is None:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR updates the `process` integration code by removing `try_sudo` as a parameter, since it is already an instance variable. This also sets a default value for  `accessors` as most uses of it are `None`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
