### PR TITLE
[kubernetes] Fix OOTB dashboards

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_dashboard.json
+++ b/kubernetes/assets/dashboards/kubernetes_dashboard.json
@@ -132,7 +132,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.deployment.replicas_available{$scope,$deployment,$daemonset,$service,$label,$cluster,$namespace,$node} by {deployment}",
+                        "q": "sum:kubernetes_state.deployment.replicas_available{$scope,$deployment,$daemonset,$service,$label,$cluster,$namespace,$node} by {kube_deployment}",
                         "display_type": "area",
                         "style": {
                             "palette": "green",
@@ -199,7 +199,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$deployment,$daemonset,$cluster,$label,$namespace,$service,$node} by {deployment}",
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$deployment,$daemonset,$cluster,$label,$namespace,$service,$node} by {kube_deployment}",
                         "display_type": "area",
                         "style": {
                             "palette": "purple",
@@ -270,7 +270,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.deployment.replicas_unavailable{$scope,$deployment,$daemonset,$service,$label,$cluster,$namespace,$node} by {deployment}",
+                        "q": "sum:kubernetes_state.deployment.replicas_unavailable{$scope,$deployment,$daemonset,$service,$label,$cluster,$namespace,$node} by {kube_deployment}",
                         "display_type": "area",
                         "style": {
                             "palette": "orange",
@@ -739,7 +739,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.daemonset.desired{$scope,$deployment,$daemonset,$service,$namespace,$label,$cluster,$node} by {daemonset}",
+                        "q": "sum:kubernetes_state.daemonset.desired{$scope,$deployment,$daemonset,$service,$namespace,$label,$cluster,$node} by {kube_daemon_set}",
                         "display_type": "area",
                         "style": {
                             "palette": "purple",
@@ -1172,7 +1172,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.daemonset.ready{$scope,$deployment,$daemonset,$service,$namespace,$label,$cluster,$node} by {daemonset}",
+                        "q": "sum:kubernetes_state.daemonset.ready{$scope,$deployment,$daemonset,$service,$namespace,$label,$cluster,$node} by {kube_daemon_set}",
                         "display_type": "area",
                         "style": {
                             "palette": "green",

--- a/kubernetes/assets/dashboards/kubernetes_deployments.json
+++ b/kubernetes/assets/dashboards/kubernetes_deployments.json
@@ -39,7 +39,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.deployment.replicas_available{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "q": "sum:kubernetes_state.deployment.replicas_available{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {kube_deployment}",
                         "display_type": "area",
                         "style": {
                             "palette": "green",
@@ -107,7 +107,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace} by {deployment}",
+                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_deployment,$kube_cluster_name,$kube_namespace} by {kube_deployment}",
                         "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
@@ -252,7 +252,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {kube_deployment}",
                         "display_type": "area",
                         "style": {
                             "palette": "cool",
@@ -319,7 +319,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "q": "sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {kube_deployment}",
                         "display_type": "area",
                         "style": {
                             "palette": "dog_classic",
@@ -361,7 +361,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.deployment.rollingupdate.max_unavailable{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "q": "sum:kubernetes_state.deployment.rollingupdate.max_unavailable{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {kube_deployment}",
                         "display_type": "area",
                         "style": {
                             "palette": "warm",
@@ -397,7 +397,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment,kube_cluster_name,kube_namespace}-sum:kubernetes_state.deployment.replicas_available{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment,kube_cluster_name,kube_namespace}",
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {kube_deployment,kube_cluster_name,kube_namespace}-sum:kubernetes_state.deployment.replicas_available{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {kube_deployment,kube_cluster_name,kube_namespace}",
                         "display_type": "area",
                         "style": {
                             "palette": "warm",
@@ -439,7 +439,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}-sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "q": "sum:kubernetes_state.deployment.replicas{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {kube_deployment}-sum:kubernetes_state.deployment.replicas_updated{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {kube_deployment}",
                         "display_type": "area",
                         "style": {
                             "palette": "orange",
@@ -678,7 +678,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}-sum:kubernetes_state.deployment.replicas_available{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {deployment}",
+                        "q": "sum:kubernetes_state.deployment.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {kube_deployment}-sum:kubernetes_state.deployment.replicas_available{$scope,$kube_cluster_name,$kube_namespace,$kube_deployment} by {kube_deployment}",
                         "display_type": "area",
                         "style": {
                             "palette": "dog_classic",

--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -61,7 +61,7 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes.pods.running{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job}",
+                        "query": "sum:kubernetes.pods.running{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob}",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -131,7 +131,7 @@
                     "response_format": "scalar",
                     "queries": [
                       {
-                        "query": "sum:kubernetes_state.pod.status_phase{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,!phase:running,!phase:succeeded} by {phase,kube_namespace}",
+                        "query": "sum:kubernetes_state.pod.status_phase{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob,!phase:running,!phase:succeeded} by {phase,kube_namespace}",
                         "data_source": "metrics",
                         "name": "query1",
                         "aggregator": "last"
@@ -892,7 +892,8 @@
       { "name": "deployment", "default": "*", "prefix": "kube_deployment" },
       { "name": "statefulset", "default": "*", "prefix": "kube_stateful_set" },
       { "name": "daemonset", "default": "*", "prefix": "kube_daemon_set" },
-      { "name": "job", "default": "*", "prefix": "kube_job" }
+      { "name": "job", "default": "*", "prefix": "kube_job" },
+      { "name": "cronjob", "default": "*", "prefix": "kube_cronjob" }
     ],
     "layout_type": "ordered",
     "is_read_only": false,

--- a/kubernetes/assets/dashboards/kubernetes_statefulsets.json
+++ b/kubernetes/assets/dashboards/kubernetes_statefulsets.json
@@ -21,7 +21,7 @@
       {
           "default": "*",
           "name": "kube_stateful_set",
-          "prefix": "statefulset"
+          "prefix": "kube_stateful_set"
       }
   ],
   "title": "Kubernetes StatefulSets Overview",
@@ -91,7 +91,7 @@
                           {
                               "data_source": "metrics",
                               "name": "query1",
-                              "query": "sum:kubernetes_state.statefulset.replicas_ready{$scope,$kube_cluster_name,$kube_namespace,$kube_stateful_set} by {statefulset}"
+                              "query": "sum:kubernetes_state.statefulset.replicas_ready{$scope,$kube_cluster_name,$kube_namespace,$kube_stateful_set} by {kube_stateful_set}"
                           }
                       ],
                       "response_format": "timeseries",
@@ -188,7 +188,7 @@
                           {
                               "data_source": "metrics",
                               "name": "query1",
-                              "query": "sum:kubernetes_state.statefulset.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_stateful_set} by {statefulset}"
+                              "query": "sum:kubernetes_state.statefulset.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_stateful_set} by {kube_stateful_set}"
                           }
                       ],
                       "response_format": "timeseries",
@@ -262,7 +262,7 @@
                           {
                               "data_source": "metrics",
                               "name": "query1",
-                              "query": "sum:kubernetes_state.statefulset.replicas_ready{$scope,$kube_namespace,$kube_cluster_name,$kube_stateful_set} by {kube_cluster_name,kube_namespace,statefulset}"
+                              "query": "sum:kubernetes_state.statefulset.replicas_ready{$scope,$kube_namespace,$kube_cluster_name,$kube_stateful_set} by {kube_cluster_name,kube_namespace,kube_stateful_set}"
                           }
                       ],
                       "response_format": "timeseries",
@@ -1149,12 +1149,12 @@
                           {
                               "data_source": "metrics",
                               "name": "query1",
-                              "query": "sum:kubernetes_state.statefulset.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_stateful_set} by {kube_cluster_name,kube_namespace,statefulset}"
+                              "query": "sum:kubernetes_state.statefulset.replicas_desired{$scope,$kube_cluster_name,$kube_namespace,$kube_stateful_set} by {kube_cluster_name,kube_namespace,kube_stateful_set}"
                           },
                           {
                               "data_source": "metrics",
                               "name": "query2",
-                              "query": "sum:kubernetes_state.statefulset.replicas_ready{$scope,$kube_cluster_name,$kube_namespace,$kube_stateful_set} by {kube_cluster_name,kube_namespace,statefulset}"
+                              "query": "sum:kubernetes_state.statefulset.replicas_ready{$scope,$kube_cluster_name,$kube_namespace,$kube_stateful_set} by {kube_cluster_name,kube_namespace,kube_stateful_set}"
                           }
                       ],
                       "response_format": "timeseries",

--- a/kubernetes/assets/monitors/monitor_deployments_replicas.json
+++ b/kubernetes/assets/monitors/monitor_deployments_replicas.json
@@ -1,8 +1,8 @@
 {
 	"name": "[kubernetes] Monitor Kubernetes Deployments Replica Pods",
 	"type": "query alert",
-	"query": "avg(last_15m):avg:kubernetes_state.deployment.replicas_desired{*} by {kube_deployment} - avg:kubernetes_state.deployment.replicas_available{*} by {kube_deployment} >= 2",
-	"message": "More than one Deployments Replica's pods are down.",
+	"query": "avg(last_15m):avg:kubernetes_state.deployment.replicas_desired{*} by {kube_namespace,kube_deployment} - avg:kubernetes_state.deployment.replicas_available{*} by {kube_namespace,kube_deployment} >= 2",
+	"message": "More than one Deployments Replica's pods are down in Deployment {{kube_namespace.name}}/{{kube_deployment.name}}.",
 	"tags": [
 		"integration:kubernetes"
 	],

--- a/kubernetes/assets/monitors/monitor_statefulset_replicas.json
+++ b/kubernetes/assets/monitors/monitor_statefulset_replicas.json
@@ -1,8 +1,8 @@
 {
 	"name": "[kubernetes] Monitor Kubernetes Statefulset Replicas",
 	"type": "query alert",
-	"query": "max(last_15m):sum:kubernetes_state.statefulset.replicas_desired{*} by {statefulset} - sum:kubernetes_state.statefulset.replicas_ready{*} by {statefulset} >= 2",
-	"message": "More than one Statefulset Replica's pods are down. This might present an unsafe situation for any further manual operations, such as killing other pods.",
+	"query": "max(last_15m):sum:kubernetes_state.statefulset.replicas_desired{*} by {kube_namespace,kube_stateful_set} - sum:kubernetes_state.statefulset.replicas_ready{*} by {kube_namespace,kube_stateful_set} >= 2",
+	"message": "More than one Statefulset Replica's pods are down in Statefulset {{kube_namespace.name}}/{{kube_stateful_set.name}}. This might present an unsafe situation for any further manual operations, such as killing other pods.",
 	"tags": [
 		"integration:kubernetes"
 	],


### PR DESCRIPTION
### What does this PR do?

* use `kube_deployment` tag instead of `deployment`
* use `kube_stateful_set` tag instead of `statefulset`
* use `kube_daemon_set` tag instead of `daemonset`
* use `kube_replica_set` tag instead of `replicaset`

### Motivation

Remove the usage of depreacted tags in our official dashboards.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
