### PR TITLE
Remove annotation for unnecessary warning

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_reqs.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_reqs.py
@@ -4,7 +4,7 @@
 import click
 
 from ....utils import read_file
-from ...annotations import annotate_error, annotate_warning
+from ...annotations import annotate_error
 from ...constants import AGENT_V5_ONLY, NOT_CHECKS, get_agent_release_requirements
 from ...release import get_package_name
 from ...testing import process_checks_option

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_reqs.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/agent_reqs.py
@@ -43,7 +43,6 @@ def agent_reqs(check):
                 unreleased_checks.append(check_name)
                 message = f'{check_name} has not yet been released'
                 echo_warning(message)
-                annotate_warning(release_requirements_file, message)
             elif check_version != pinned_version:
                 failed_checks += 1
                 message = f"{check_name} has version {check_version} but is pinned to {pinned_version}"


### PR DESCRIPTION
### What does this PR do?
The unreleased checks warning annotation is loud and unneeded. The integrations should be released as part of the release process and doesn't need to be warned.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
