### PR TITLE
Recommend PDH check for mount point metrics

### DIFF
--- a/disk/README.md
+++ b/disk/README.md
@@ -14,7 +14,7 @@ The disk check is included in the [Datadog Agent][1] package, so you don't need 
 
 The Disk check is enabled by default, and the Agent collects metrics on all local partitions. To configure the check with custom options, edit the `disk.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample disk.d/conf.yaml][3] for all available configuration options.
 
-#### Note for Windows Hosts
+#### Note for Windows hosts
 The Agent requires Administrator permissions to collect mount point metrics on hosts running Windows. To collect these metrics without granting Administrator permissions, use the [PDH check][4] to collect mount point metrics from the corresponding perf counters. 
 
 ### Validation

--- a/disk/README.md
+++ b/disk/README.md
@@ -14,15 +14,18 @@ The disk check is included in the [Datadog Agent][1] package, so you don't need 
 
 The Disk check is enabled by default, and the Agent collects metrics on all local partitions. To configure the check with custom options, edit the `disk.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample disk.d/conf.yaml][3] for all available configuration options.
 
+#### Note for Windows Hosts
+The Agent requires Administrator permissions to collect mount point metrics on hosts running Windows. To collect these metrics without granting Administrator permissions, use the [PDH check][4] to collect mount point metrics from the corresponding perf counters. 
+
 ### Validation
 
-[Run the Agent's `status` subcommand][4] and look for `disk` under the Checks section.
+[Run the Agent's `status` subcommand][5] and look for `disk` under the Checks section.
 
 ## Data Collected
 
 ### Metrics
 
-See [metadata.csv][5] for a list of metrics provided by this integration.
+See [metadata.csv][6] for a list of metrics provided by this integration.
 
 ### Events
 
@@ -34,13 +37,14 @@ See [service_checks.json][7] for a list of service checks provided by this integ
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][6].
+Need help? Contact [Datadog support][8].
 
 
 [1]: https://app.datadoghq.com/account/settings#agent
 [2]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
 [3]: https://github.com/DataDog/integrations-core/blob/master/disk/datadog_checks/disk/data/conf.yaml.default
-[4]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[5]: https://github.com/DataDog/integrations-core/blob/master/disk/metadata.csv
-[6]: https://docs.datadoghq.com/help/
+[4]: https://docs.datadoghq.com/integrations/pdh_check/#pagetitle
+[5]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[6]: https://github.com/DataDog/integrations-core/blob/master/disk/metadata.csv
 [7]: https://github.com/DataDog/integrations-core/blob/master/disk/assets/service_checks.json
+[8]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?
The agent user requires Administrator permissions to collect mount point metrics on Windows hosts. Many customers will not want to give the Agent user these permissions, so as a workaround they can use the PDH check.

### Motivation
Customer request -

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
