### PR TITLE
Allow kube port forwarding to support any resource

### DIFF
--- a/cilium/tests/conftest.py
+++ b/cilium/tests/conftest.py
@@ -54,7 +54,8 @@ def dd_environment():
     with kind_run(conditions=[setup_cilium]) as kubeconfig:
         with ExitStack() as stack:
             ip_ports = [
-                stack.enter_context(port_forward(kubeconfig, 'cilium', 'cilium-operator', port)) for port in PORTS
+                stack.enter_context(port_forward(kubeconfig, 'cilium', port, deployment='cilium-operator'))
+                for port in PORTS
             ]
         instances = {
             'instances': [

--- a/cilium/tests/conftest.py
+++ b/cilium/tests/conftest.py
@@ -54,7 +54,7 @@ def dd_environment():
     with kind_run(conditions=[setup_cilium]) as kubeconfig:
         with ExitStack() as stack:
             ip_ports = [
-                stack.enter_context(port_forward(kubeconfig, 'cilium', port, deployment='cilium-operator'))
+                stack.enter_context(port_forward(kubeconfig, 'cilium', port, 'deployment', 'cilium-operator'))
                 for port in PORTS
             ]
         instances = {

--- a/datadog_checks_dev/datadog_checks/dev/kube_port_forward.py
+++ b/datadog_checks_dev/datadog_checks/dev/kube_port_forward.py
@@ -20,18 +20,11 @@ def _build_temp_key(namespace, deployment, remote_port):
 
 
 @contextmanager
-def port_forward(kubeconfig, namespace, remote_port, deployment=None, service=None):
+def port_forward(kubeconfig, namespace, remote_port, resource, resource_name):
     """Use `kubectl` to forward a remote port locally."""
-    if not deployment and not service:
-        raise Exception("You must specify a deployment or service")
-    if deployment:
-        set_up = PortForwardUp(kubeconfig, namespace, remote_port, deployment=deployment)
-        key = _build_temp_key(namespace, deployment, remote_port)
-        tear_down = KillProcess(key, PID_FILE)
-    else:
-        set_up = PortForwardUp(kubeconfig, namespace, remote_port, service=service)
-        key = _build_temp_key(namespace, service, remote_port)
-        tear_down = KillProcess(key, PID_FILE)
+    set_up = PortForwardUp(kubeconfig, namespace, remote_port, resource, resource_name)
+    key = _build_temp_key(namespace, resource_name, remote_port)
+    tear_down = KillProcess(key, PID_FILE)
 
     with environment_run(up=set_up, down=tear_down) as result:
         yield result
@@ -40,21 +33,15 @@ def port_forward(kubeconfig, namespace, remote_port, deployment=None, service=No
 class PortForwardUp(LazyFunction):
     """Setup `kubectl port-forward`."""
 
-    def __init__(self, kubeconfig, namespace, remote_port, deployment=None, service=None):
+    def __init__(self, kubeconfig, namespace, remote_port, resource, resource_name):
         self.kubeconfig = kubeconfig
         self.namespace = namespace
         self.remote_port = remote_port
-        self.deployment = deployment
-        self.service = service
+        self.resource = resource
+        self.resource_name = resource_name
 
     def __call__(self):
-        if self.deployment:
-            key = _build_temp_key(self.namespace, self.deployment, self.remote_port)
-            subject = 'deployment/{}'.format(self.deployment)
-        else:
-            key = _build_temp_key(self.namespace, self.service, self.remote_port)
-            subject = 'service/{}'.format(self.service)
-
+        key = _build_temp_key(self.namespace, self.resource_name, self.remote_port)
         with TempDir(key) as temp_dir:
             # Run in the temp dir to put kube cache files there
             with chdir(temp_dir):
@@ -67,7 +54,7 @@ class PortForwardUp(LazyFunction):
                     ip,
                     '--namespace',
                     self.namespace,
-                    subject,
+                    "{}/{}".format(self.resource, self.resource_name),
                     '{}:{}'.format(local_port, self.remote_port),
                 ]
                 env = os.environ.copy()

--- a/istio/tests/conftest.py
+++ b/istio/tests/conftest.py
@@ -59,7 +59,7 @@ def dd_environment():
         with ExitStack() as stack:
             if VERSION == '1.5.1':
                 istiod_host, istiod_port = stack.enter_context(
-                    port_forward(kubeconfig, 'istio-system', 8080, deployment='istiod')
+                    port_forward(kubeconfig, 'istio-system', 8080, 'deployment', 'istiod')
                 )
                 instance = {'istiod_endpoint': 'http://{}:{}/metrics'.format(istiod_host, istiod_port)}
 

--- a/istio/tests/conftest.py
+++ b/istio/tests/conftest.py
@@ -58,7 +58,9 @@ def dd_environment():
     with kind_run(conditions=[setup_istio]) as kubeconfig:
         with ExitStack() as stack:
             if VERSION == '1.5.1':
-                istiod_host, istiod_port = stack.enter_context(port_forward(kubeconfig, 'istio-system', 'istiod', 8080))
+                istiod_host, istiod_port = stack.enter_context(
+                    port_forward(kubeconfig, 'istio-system', 8080, deployment='istiod')
+                )
                 instance = {'istiod_endpoint': 'http://{}:{}/metrics'.format(istiod_host, istiod_port)}
 
                 yield instance

--- a/linkerd/tests/conftest.py
+++ b/linkerd/tests/conftest.py
@@ -38,7 +38,7 @@ def dd_environment():
         ):
             with ExitStack() as stack:
                 ip, port = stack.enter_context(
-                    port_forward(kubeconfig, 'linkerd', 4191, deployment='linkerd-controller')
+                    port_forward(kubeconfig, 'linkerd', 4191, 'deployment', 'linkerd-controller')
                 )
 
             instance = {

--- a/linkerd/tests/conftest.py
+++ b/linkerd/tests/conftest.py
@@ -37,7 +37,9 @@ def dd_environment():
             conditions=[CheckDockerLogs(compose_file, 'LINKERD DEPLOY COMPLETE', wait=5, attempts=120)],
         ):
             with ExitStack() as stack:
-                ip, port = stack.enter_context(port_forward(kubeconfig, 'linkerd', 'linkerd-controller', 4191))
+                ip, port = stack.enter_context(
+                    port_forward(kubeconfig, 'linkerd', 4191, deployment='linkerd-controller')
+                )
 
             instance = {
                 'prometheus_url': 'http://{ip}:{port}/metrics'.format(ip=ip, port=port),


### PR DESCRIPTION
### What does this PR do?
Previously the port_forward by default support deployment only. This PR allows users to set a resource and resource name (e.g support service/pod/replicaset)
 
### Motivation
Supports collecting metrics from services (contributor use case)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
