### PR TITLE
Fix mypy tests

### DIFF
--- a/aerospike/tox.ini
+++ b/aerospike/tox.ini
@@ -17,6 +17,8 @@ dd_check_types = true
 dd_mypy_args =
     --py2
     --follow-imports silent
+    --install-types
+    --non-interactive
     datadog_checks/aerospike
 usedevelop = true
 platform = linux|darwin|win32

--- a/azure_iot_edge/tox.ini
+++ b/azure_iot_edge/tox.ini
@@ -13,7 +13,14 @@ envdir =
     py38: {toxworkdir}/py38
 dd_check_style = true
 dd_check_types = true
-dd_mypy_args = --check-untyped-defs --py2 datadog_checks/ tests/
+dd_mypy_args =
+    --check-untyped-defs
+    --py2
+    --install-types
+    --non-interactive
+    --follow-imports skip
+    datadog_checks/
+    tests/
 description =
     py{27,38}: e2e ready if IOT_EDGE_CONNSTR
 usedevelop = true

--- a/cloud_foundry_api/tox.ini
+++ b/cloud_foundry_api/tox.ini
@@ -8,7 +8,14 @@ envlist =
 [testenv]
 dd_check_style = true
 dd_check_types = true
-dd_mypy_args = --py2 datadog_checks/ tests/
+dd_mypy_args =
+    --py2
+    --install-types
+    --non-interactive
+    datadog_checks/
+    tests/
+dd_mypy_deps =
+    types-mock==0.1.5
 usedevelop = true
 platform = linux|darwin|win32
 deps =

--- a/datadog_checks_base/tox.ini
+++ b/datadog_checks_base/tox.ini
@@ -16,6 +16,8 @@ dd_mypy_args =
     --py2
     --check-untyped-defs
     --follow-imports silent
+    --install-types
+    --non-interactive
     datadog_checks/base/checks/base.py
     datadog_checks/base/checks/win/wmi/__init__.py
     datadog_checks/base/checks/win/winpdh_base.py

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -13,6 +13,7 @@ STYLE_FORMATTER_ENV_NAME = 'format_style'
 STYLE_FLAG = 'dd_check_style'
 TYPES_FLAG = 'dd_check_types'
 MYPY_ARGS_OPTION = 'dd_mypy_args'
+MYPY_ADDITIONAL_DEPS = 'dd_mypy_deps'
 E2E_READY_CONDITION = 'e2e ready if'
 FIX_DEFAULT_ENVDIR_FLAG = 'ensure_default_envdir'
 
@@ -142,11 +143,15 @@ def add_style_checker(config, sections, make_envconfig, reader):
         # Each integration should explicitly specify its options and which files it'd like to type check, which is
         # why we're defaulting to 'no arguments' by default.
         mypy_args = sections['testenv'].get(MYPY_ARGS_OPTION, '')
+        mypy_deps = sections['testenv'].get(MYPY_ADDITIONAL_DEPS, "").splitlines()
 
         # Allow using multiple lines for enhanced readability in case of large amount of options/files to check.
         mypy_args = mypy_args.replace('\n', ' ')
 
         dependencies.append(MYPY_DEP)
+        for mypy_dep in mypy_deps:
+            dependencies.append(mypy_dep)
+
         commands.append('mypy --config-file=../mypy.ini {}'.format(mypy_args))
 
     sections[section] = {

--- a/glusterfs/tox.ini
+++ b/glusterfs/tox.ini
@@ -14,7 +14,14 @@ envdir =
     py38: {toxworkdir}/py38
 dd_check_style = true
 dd_check_types = true
-dd_mypy_args = --py2 datadog_checks/ tests/ --exclude '.*/config_models/.*\.py$'
+dd_mypy_args =
+    --py2
+    datadog_checks/
+    tests/
+    --exclude
+    '.*/config_models/.*\.py$'
+dd_mypy_deps =
+    types-mock==0.1.5
 usedevelop = true
 platform = linux|darwin|win32
 deps =

--- a/ibm_mq/tox.ini
+++ b/ibm_mq/tox.ini
@@ -14,7 +14,16 @@ description=
     py{27,38}: e2e ready
 dd_check_style = true
 dd_check_types = true
-dd_mypy_args = --py2 datadog_checks/ tests/ --exclude '.*/config_models/.*\.py$'
+dd_mypy_args =
+    --py2
+    --install-types
+    --non-interactive
+    datadog_checks/
+    tests/
+    --exclude
+    '.*/config_models/.*\.py$'
+dd_mypy_deps =
+    types-mock==0.1.5
 platform = linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]

--- a/marklogic/tox.ini
+++ b/marklogic/tox.ini
@@ -7,7 +7,15 @@ envlist =
 
 [testenv]
 dd_check_types = true
-dd_mypy_args = --disallow-untyped-defs --py2 datadog_checks/ tests/
+dd_mypy_args =
+    --disallow-untyped-defs
+    --py2
+    --install-types
+    --non-interactive
+    datadog_checks/
+    tests/
+dd_mypy_deps =
+    types-mock==0.1.5
 description =
     py{27,38}: e2e ready
 dd_check_style = true

--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -17,7 +17,11 @@ dd_mypy_args =
     --py2
     --check-untyped-defs
     --follow-imports silent
+    --install-types
+    --non-interactive
     datadog_checks/mysql/statements.py
+dd_mypy_deps =
+    types-cachetools==0.1.10
 usedevelop = true
 platform = linux|darwin|win32
 passenv =

--- a/postgres/tox.ini
+++ b/postgres/tox.ini
@@ -13,7 +13,16 @@ description =
     py{27,38}: e2e ready
 dd_check_style = true
 dd_check_types = true
-dd_mypy_args = --py2 datadog_checks/ tests/ --exclude '.*/config_models/.*\.py$'
+dd_mypy_args =
+    --py2
+    --install-types
+    --non-interactive
+    datadog_checks/
+    tests/
+    --exclude '.*/config_models/.*\.py$'
+dd_mypy_deps =
+    types-mock==0.1.5
+    types-cachetools==0.1.10
 usedevelop = true
 platform = linux|darwin|win32
 passenv =

--- a/rethinkdb/tox.ini
+++ b/rethinkdb/tox.ini
@@ -12,7 +12,15 @@ envdir =
     py38: {toxworkdir}/py38
 dd_check_style = true
 dd_check_types = true
-dd_mypy_args = --py2 --disallow-untyped-defs datadog_checks/ tests/
+dd_mypy_args =
+    --py2
+    --disallow-untyped-defs
+    --install-types
+    --non-interactive
+    datadog_checks/
+    tests/
+dd_mypy_deps =
+    types-mock==0.1.5
 description =
     py{27,38}: e2e ready
 usedevelop = true

--- a/snmp/tox.ini
+++ b/snmp/tox.ini
@@ -18,6 +18,8 @@ dd_mypy_args =
     --py2
     --disallow-untyped-defs
     --follow-imports silent
+    --install-types
+    --non-interactive
     datadog_checks/snmp
 usedevelop = true
 platform = linux|darwin|win32

--- a/snowflake/tox.ini
+++ b/snowflake/tox.ini
@@ -12,7 +12,16 @@ envdir =
     py38: {toxworkdir}/py38
 dd_check_style = true
 dd_check_types = true
-dd_mypy_args = --py2 datadog_checks/ tests/ --exclude '.*/config_models/.*\.py$'
+dd_mypy_args =
+    --py2
+    --install-types
+    --non-interactive
+    datadog_checks/
+    tests/
+    --exclude
+    '.*/config_models/.*\.py$'
+dd_mypy_deps =
+    types-mock==0.1.5
 description =
     py38: e2e ready
 usedevelop = true

--- a/voltdb/tox.ini
+++ b/voltdb/tox.ini
@@ -12,7 +12,16 @@ envdir =
     py38: {toxworkdir}/py38
 dd_check_style = true
 dd_check_types = true
-dd_mypy_args = datadog_checks/ tests/
+dd_mypy_args =
+    --py2
+    --install-types
+    --non-interactive
+    datadog_checks/
+    tests/
+    --exclude
+    '.*/config_models/.*\.py$'
+dd_mypy_deps =
+    types-mock==0.1.5
 description =
     py{27,38}: e2e ready
 usedevelop = true

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -15,6 +15,8 @@ dd_mypy_args =
     --py2
     --disallow-untyped-defs
     --follow-imports silent
+    --install-types
+    --non-interactive
     datadog_checks/vsphere/api.py
     datadog_checks/vsphere/api_rest.py
     datadog_checks/vsphere/cache.py


### PR DESCRIPTION
With mypy's bump, stubs for third-party libraries are not included anymore. They can be installed automatically by using `--install-types` and `--non-interactive` flags but unfortunately some stubs are now py3 only while we use mypy in `--py2` mode.

To workaround the issue, this PR gives check the ability to pass additional style dependencies in each check tox.ini file.