### PR TITLE
[cri] Add cri uptime metric to metadata

### DIFF
--- a/cri/metadata.csv
+++ b/cri/metadata.csv
@@ -3,3 +3,4 @@ cri.mem.rss,gauge,,byte,,The amount of working set memory in bytes ,0,cri,mem rs
 cri.cpu.usage,rate,,nanocore,,Cumulative CPU usage (sum across all cores) since object creation,0,cri,cpu
 cri.disk.used,gauge,,byte,,Represents the bytes used for images on the filesystem,0,cri,disk used
 cri.disk.inodes,gauge,,inode,,Represents the inodes used by the images,0,cri,disk inodes
+cri.uptime,gauge,,second,,Time since the container was started,0,cri,uptime


### PR DESCRIPTION
### What does this PR do?
Adds cri.uptime metric (added several months ago) to the metadata.csv

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have `changelog/` and `integration/` labels attached
