### PR TITLE
Fix metric used in "Ready" query value widget

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_daemonsets.json
+++ b/kubernetes/assets/dashboards/kubernetes_daemonsets.json
@@ -18,7 +18,7 @@
         "type": "query_value",
         "requests": [
           {
-            "q": "sum:kubernetes_state.daemonset.desired{$scope,$kube_cluster_name,$kube_namespace,$kube_daemon_set}",
+            "q": "sum:kubernetes_state.daemonset.ready{$scope,$kube_cluster_name,$kube_namespace,$kube_daemon_set}",
             "aggregator": "last",
             "conditional_formats": [
               {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
In the Dashboard "Kubernetes DaemonSets Overview" the "Ready" query value widget was querying for the metric `kubernetes_state.daemonset.desired` rather than `kubernetes_state.daemonset.ready`. For reference too there is a "Desired" query value widget right next to it that is correctly querying for `kubernetes_state.daemonset.desired`.

This just fixes that metric in the query.

### Motivation
<!-- What inspired you to submit this pull request? -->
Wrong metric used in widget CONS-4201

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
