### PR TITLE
Remove unused ssl_context documentation

### DIFF
--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -150,13 +150,6 @@ files:
           type: string
           example: localhost
           display_default: null
-      - name: ssl_context
-        description: |
-          Pre-configured SSLContext for wrapping socket connections.
-          If provided, all other ssl_* configurations are ignored.
-        value:
-          type: string
-          example: <SSL_CONTEXT>
       - name: ssl_check_hostname
         description: |
           Flag to configure whether SSL handshake should verify that the

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
@@ -92,10 +92,6 @@ def instance_ssl_check_hostname(field, value):
     return True
 
 
-def instance_ssl_context(field, value):
-    return get_default_field_value(field, value)
-
-
 def instance_ssl_crlfile(field, value):
     return get_default_field_value(field, value)
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
@@ -37,7 +37,6 @@ class InstanceConfig(BaseModel):
     ssl_cafile: Optional[str]
     ssl_certfile: Optional[str]
     ssl_check_hostname: Optional[bool]
-    ssl_context: Optional[str]
     ssl_crlfile: Optional[str]
     ssl_keyfile: Optional[str]
     ssl_password: Optional[str]

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -167,12 +167,6 @@ instances:
     #
     # sasl_kerberos_domain_name: localhost
 
-    ## @param ssl_context - string - optional
-    ## Pre-configured SSLContext for wrapping socket connections.
-    ## If provided, all other ssl_* configurations are ignored.
-    #
-    # ssl_context: <SSL_CONTEXT>
-
     ## @param ssl_check_hostname - boolean - optional - default: true
     ## Flag to configure whether SSL handshake should verify that the
     ## certificate matches the broker’s hostname.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`ssl_context` is not used in the `kafka_consumer` integration.
According to the doc https://kafka-python.readthedocs.io/en/master/apidoc/KafkaClient.html it's a wrapper around options we already support, so we should remove it.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This option does not exist in `TlsContextWrapper` too, we have a card in the backlog to switch to this wrapper

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
