### PR TITLE
Fix ibm db2 tests

### DIFF
--- a/ibm_db2/requirements-dev.txt
+++ b/ibm_db2/requirements-dev.txt
@@ -1,2 +1,3 @@
 -e ../datadog_checks_dev
+2to3; python_version > '3.0'
 ibm_db==3.0.1

--- a/ibm_db2/requirements-dev.txt
+++ b/ibm_db2/requirements-dev.txt
@@ -1,3 +1,3 @@
 -e ../datadog_checks_dev
-2to3; python_version > '3.0'
+setuptools<58; python_version > '3.0'  # https://setuptools.readthedocs.io/en/latest/history.html#breaking-changes
 ibm_db==3.0.1


### PR DESCRIPTION
To fix  `error in ibm_db setup command: use_2to3 is invalid.`
 Also opened https://github.com/ibmdb/python-ibmdb/issues/660