### PR TITLE
Create tests for new V2 manifest validators

### DIFF
--- a/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
@@ -1,0 +1,231 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.dev.tooling.datastructures import JSONDict
+
+# This file contains the constants used for V2 manifest validator testing
+
+ORACLE_METADATA_CSV_EXAMPLE = [(0, {"metric_name": "oracle.session_count"})]
+
+V2_MANIFEST_ALL_PASS = JSONDict(
+    {
+        "app_id": "datadog-oracle",
+        "assets": {
+            "dashboards": {"oracle": "https://app.datadoghq.com/screen/integration/240/oracle-database---overview"},
+            "integration": {
+                "configuration": {"spec": "assets/configuration/spec.yaml"},
+                "events": {"creates_events": True},
+                "id": "oracle",
+                "metrics": {
+                    "auto_install": True,
+                    "check": "oracle.session_count",
+                    "metadata_path": "metrics_metadata.csv",
+                    "prefix": "oracle.",
+                },
+                "service_checks": {"metadata_path": "assets/service_checks.json"},
+                "source_type_name": "Oracle Database",
+            },
+        },
+        "author": {
+            "homepage": "https://www.datadoghq.com",
+            "name": "Datadog",
+            "sales_email": "help@datadoghq.com",
+            "support_email": "help@datadoghq.com",
+        },
+        "display_on_public_website": True,
+        "legal_terms": {},
+        "manifest_version": "2.0.0",
+        "oauth": {},
+        "pricing": [{"billing_type": "free"}],
+        "tile": {
+            "changelog": "CHANGELOG.md",
+            "classifier_tags": [
+                "Category::Marketplace",
+                "Category::Cloud",
+                "Category::Log Collection",
+                "Supported OS::Windows",
+                "Supported OS::Mac OS",
+                "Offering::Integration",
+                "Offering::UI Extension",
+            ],
+            "configuration": "README.md#Setup",
+            "description": "Oracle relational database system designed for enterprise grid computing",
+            "media": [],
+            "overview": "README.md#Overview",
+            "title": "Oracle",
+        },
+    }
+)
+
+INCORRECT_MAINTAINER_MANIFEST = JSONDict(
+    {
+        "author": {
+            "homepage": "https://www.datadoghq.com",
+            "name": "Datadog",
+            "sales_email": "help@datadoghq.com",
+            "support_email": "stupidemail@fake.com",
+        },
+    }
+)
+
+INVALID_MAINTAINER_MANIFEST = JSONDict(
+    {
+        "author": {
+            "homepage": "https://www.datadoghq.com",
+            "name": "Datadog",
+            "sales_email": "help@datadoghq.com",
+            "support_email": "ǨĽŇŘŠŤŽ@invalid.com",
+        },
+    }
+)
+
+CORRECT_MAINTAINER_MANIFEST = JSONDict(
+    {
+        "author": {
+            "homepage": "https://www.datadoghq.com",
+            "name": "Datadog",
+            "sales_email": "help@datadoghq.com",
+            "support_email": "help@datadoghq.com",
+        }
+    }
+)
+
+FILE_EXISTS_NOT_IN_MANIFEST = JSONDict(
+    {
+        "assets": {
+            "integration": {
+                "metrics": {
+                    "auto_install": True,
+                    "check": "oracle.session_count",
+                    "metadata_path": "",
+                    "prefix": "oracle.",
+                },
+            },
+        },
+    }
+)
+
+FILE_IN_MANIFEST_DOES_NOT_EXIST = JSONDict(
+    {
+        "assets": {
+            "integration": {
+                "metrics": {
+                    "auto_install": True,
+                    "check": "oracle.session_count",
+                    "metadata_path": "fake_metadata_file.csv",
+                    "prefix": "oracle.",
+                },
+            },
+        },
+    }
+)
+
+CORRECT_METADATA_FILE_MANIFEST = JSONDict(
+    {
+        "assets": {
+            "integration": {
+                "metrics": {
+                    "auto_install": True,
+                    "check": "oracle.session_count",
+                    "metadata_path": "metrics_metadata.csv",
+                    "prefix": "oracle.",
+                },
+            },
+        },
+    }
+)
+
+CHECK_NOT_IN_METADATA_MANIFEST = JSONDict(
+    {
+        "assets": {
+            "integration": {
+                "metrics": {
+                    "auto_install": True,
+                    "check": "oracle.session_count",
+                    "metadata_path": "metrics_metadata.csv",
+                    "prefix": "oracle.",
+                },
+            },
+        },
+    }
+)
+
+CHECK_NOT_IN_MANIFEST = JSONDict(
+    {
+        "assets": {
+            "integration": {
+                "metrics": {
+                    "auto_install": True,
+                    "check": "",
+                    "metadata_path": "metrics_metadata.csv",
+                    "prefix": "oracle.",
+                },
+            },
+        },
+    }
+)
+
+CORRECT_CHECK_IN_METADATA_MANIFEST = JSONDict(
+    {
+        "assets": {
+            "integration": {
+                "metrics": {
+                    "auto_install": True,
+                    "check": "oracle.session_count",
+                    "metadata_path": "metrics_metadata.csv",
+                    "prefix": "oracle.",
+                },
+            },
+        },
+    }
+)
+
+HAS_LOGS_NO_TAG_MANIFEST = JSONDict(
+    {
+        "tile": {
+            "classifier_tags": [
+                "Category::Marketplace",
+                "Offering::Integration",
+                "Offering::UI Extension",
+            ],
+        },
+    }
+)
+
+DISPLAY_ON_PUBLIC_INVALID_MANIFEST = JSONDict({"app_id": "datadog-oracle"})
+
+DISPLAY_ON_PUBLIC_VALID_MANIFEST = JSONDict({"display_on_public_website": True})
+
+INVALID_DIFF = ['app_id', 'id']
+
+VALID_DIFF = ['new file', 'other_val']
+
+
+class MockedResponseInvalid:
+    status_code = 400
+
+    def raise_for_status(self):
+        raise AssertionError()
+
+    def json(self):
+        return "Invalid response for test!"
+
+
+class MockedResponseValid:
+    status_code = 200
+
+    def raise_for_status(self):
+        return
+
+
+class MockedContextObj:
+    obj = {
+        'org': 'my-org',
+        'orgs': {
+            'my-org': {
+                'api_key': '123abc',
+                'app_key': 'app123',
+                'dd_url': 'foo.com',
+            }
+        },
+    }

--- a/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
@@ -1,0 +1,235 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+from pathlib import Path
+
+import mock
+import pytest
+import tests.tooling.manifest_validator.input_constants as input_constants
+
+import datadog_checks.dev.tooling.manifest_validator.common.validator as common
+import datadog_checks.dev.tooling.manifest_validator.v2.validator as v2_validators
+from datadog_checks.dev.tooling.constants import get_root, set_root
+from datadog_checks.dev.tooling.manifest_validator import get_all_validators
+from datadog_checks.dev.tooling.manifest_validator.constants import V2
+
+
+@pytest.fixture
+def setup_route():
+    # We want to change the path before and after running each individual test
+    root = Path(os.path.realpath(__file__)).parent.parent.parent.parent.parent.absolute()
+    current_root = get_root()
+    set_root(str(root))
+    yield root
+    set_root(current_root)
+
+
+@mock.patch(
+    'datadog_checks.dev.tooling.utils.read_metadata_rows', return_value=input_constants.ORACLE_METADATA_CSV_EXAMPLE
+)
+def test_manifest_v2_all_pass(_, setup_route):
+    validators = get_all_validators(False, "2.0.0")
+    for validator in validators:
+        # Currently skipping SchemaValidator because of no context object and config
+        if isinstance(validator, v2_validators.SchemaValidator):
+            continue
+
+        validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+        assert not validator.result.failed, validator.result
+        assert not validator.result.fixed
+
+
+def test_manifest_v2_maintainer_validator_incorrect_maintainer(setup_route):
+    # Use specific validator
+    validator = common.MaintainerValidator(
+        is_extras=False, is_marketplace=False, check_in_extras=False, check_in_marketplace=False, version=V2
+    )
+    validator.validate('active_directory', input_constants.INCORRECT_MAINTAINER_MANIFEST, False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+def test_manifest_v2_maintainer_validator_invalid_maintainer(setup_route):
+    # Use specific validator
+    validator = common.MaintainerValidator(
+        is_extras=False, is_marketplace=False, check_in_extras=False, check_in_marketplace=False, version=V2
+    )
+    validator.validate('active_directory', input_constants.INVALID_MAINTAINER_MANIFEST, False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+def test_manifest_v2_maintainer_validator_correct_maintainer(setup_route):
+    # Use specific validator
+    validator = common.MaintainerValidator(
+        is_extras=False, is_marketplace=False, check_in_extras=False, check_in_marketplace=False, version=V2
+    )
+    validator.validate('active_directory', input_constants.CORRECT_MAINTAINER_MANIFEST, False)
+
+    # Assert test case
+    assert not validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+def test_manifest_v2_metrics_metadata_validator_file_exists_not_in_manifest(setup_route):
+    # Use specific validator
+    validator = common.MetricsMetadataValidator(version=V2)
+    validator.validate('active_directory', input_constants.FILE_EXISTS_NOT_IN_MANIFEST, False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+@mock.patch('os.path.isfile', return_value=False)
+def test_manifest_v2_metrics_metadata_validator_file_in_manifest_not_exist(_, setup_route):
+    # Use specific validator
+    validator = common.MetricsMetadataValidator(version=V2)
+    validator.validate('active_directory', input_constants.FILE_IN_MANIFEST_DOES_NOT_EXIST, False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+@mock.patch(
+    'datadog_checks.dev.tooling.utils.read_metadata_rows', return_value=input_constants.ORACLE_METADATA_CSV_EXAMPLE
+)
+def test_manifest_v2_metrics_metadata_validator_correct_metadata(_, setup_route):
+    # Use specific validator
+    validator = common.MetricsMetadataValidator(version=V2)
+    validator.validate('active_directory', input_constants.CORRECT_METADATA_FILE_MANIFEST, False)
+
+    # Assert test case
+    assert not validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+def test_manifest_v2_metrics_to_check_validator_check_not_in_metadata(setup_route):
+    # Use specific validator
+    validator = common.MetricToCheckValidator(version=V2)
+    validator.validate('active_directory', input_constants.CHECK_NOT_IN_METADATA_MANIFEST, False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+def test_manifest_v2_metrics_to_check_validator_check_not_in_manifest(setup_route):
+    # Use specific validator
+    validator = common.MetricToCheckValidator(version=V2)
+    validator.validate('active_directory', input_constants.CHECK_NOT_IN_MANIFEST, False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+@mock.patch(
+    'datadog_checks.dev.tooling.utils.read_metadata_rows', return_value=input_constants.ORACLE_METADATA_CSV_EXAMPLE
+)
+def test_manifest_v2_metrics_metadata_validator_correct_check_in_metadata(_, setup_route):
+    # Use specific validator
+    validator = common.MetricToCheckValidator(version=V2)
+    validator.validate('active_directory', input_constants.CORRECT_CHECK_IN_METADATA_MANIFEST, False)
+
+    # Assert test case
+    assert not validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+@mock.patch('datadog_checks.dev.tooling.utils.has_logs', return_value=True)
+def test_manifest_v2_logs_category_validator_has_logs_no_tag(_, setup_route):
+    # Use specific validator
+    validator = common.LogsCategoryValidator(version=V2)
+    validator.validate('active_directory', input_constants.HAS_LOGS_NO_TAG_MANIFEST, False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+@mock.patch('datadog_checks.dev.tooling.utils.has_logs', return_value=True)
+def test_manifest_v2_logs_category_validator_correct_has_logs_correct_tag(_, setup_route):
+    # Use specific validator
+    validator = common.LogsCategoryValidator(version=V2)
+    validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+
+    # Assert test case
+    assert not validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+def test_manifest_v2_display_on_public_validator_invalid(setup_route):
+    # Use specific validator
+    validator = v2_validators.DisplayOnPublicValidator(version=V2)
+    validator.validate('active_directory', input_constants.DISPLAY_ON_PUBLIC_INVALID_MANIFEST, False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+def test_manifest_v2_display_on_public_validator_valid(setup_route):
+    # Use specific validator
+    validator = v2_validators.DisplayOnPublicValidator(version=V2)
+    validator.validate('active_directory', input_constants.DISPLAY_ON_PUBLIC_VALID_MANIFEST, False)
+
+    # Assert test case
+    assert not validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+@mock.patch('requests.post', return_value=input_constants.MockedResponseInvalid())
+def test_manifest_v2_schema_validator_manifest_invalid(_, setup_route):
+    # Use specific validator
+    validator = v2_validators.SchemaValidator(ctx=input_constants.MockedContextObj(), version=V2, skip_if_errors=False)
+    validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+@mock.patch('requests.post', return_value=input_constants.MockedResponseValid())
+def test_manifest_v2_schema_validator_manifest_valid(_, setup_route):
+    # Use specific validator
+    validator = v2_validators.SchemaValidator(ctx=input_constants.MockedContextObj(), version=V2, skip_if_errors=False)
+    validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+
+    # Assert test case
+    assert not validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+@mock.patch(
+    'datadog_checks.dev.tooling.manifest_validator.common.validator.content_changed',
+    return_value=input_constants.INVALID_DIFF,
+)
+def test_manifest_v2_immutable_attributes_validator_invalid_change(_, setup_route):
+    # Use specific validator
+    validator = common.ImmutableAttributesValidator(version=V2)
+    validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+@mock.patch(
+    'datadog_checks.dev.tooling.manifest_validator.common.validator.content_changed',
+    return_value=input_constants.VALID_DIFF,
+)
+def test_manifest_v2_immutable_attributes_validator_valid_change(_, setup_route):
+    # Use specific validator
+    validator = common.ImmutableAttributesValidator(version=V2)
+    validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+
+    # Assert test case
+    assert not validator.result.failed, validator.result
+    assert not validator.result.fixed


### PR DESCRIPTION
### What does this PR do?
This PR adds various tests to test the new manifest V2 validators. 

### Motivation
We need tests to support the new manifest V2 validators especially as we are about to be migrating manifests from V1 to V2 before Dash.

### Additional Notes
N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
