### PR TITLE
Refactor dep validation to support annotations

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -43,6 +43,10 @@ jobs:
       run: |
         ddev validate dashboards
 
+    - name: Run dependencies validation
+      run: |
+        ddev validate dep
+
     - name: Run HTTP wrapper validation
       run: |
         ddev validate http


### PR DESCRIPTION
### What does this PR do?
Refactor how the dep validation validates checks by passing looping through checks in order to keep track of file path.

Add annotations
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
