### PR TITLE
Add disable_generic tag to AVI

### DIFF
--- a/avi_vantage/assets/configuration/spec.yaml
+++ b/avi_vantage/assets/configuration/spec.yaml
@@ -37,3 +37,8 @@ files:
         persist_connections.default: true
         openmetrics_endpoint.hidden: true
         openmetrics_endpoint.required: false
+        disable_generic_tags.hidden: false
+        disable_generic_tags.value.display_default: true
+        disable_generic_tags.description: |
+          Replaces generic tag such as `server` with `avi_vantage_server` to avoid getting it mixed with
+          other integratons tags.

--- a/avi_vantage/datadog_checks/avi_vantage/check.py
+++ b/avi_vantage/datadog_checks/avi_vantage/check.py
@@ -93,6 +93,7 @@ class AviVantageCheck(OpenMetricsBaseCheckV2, ConfigMixin):
         return scraper
 
     def check(self, _):
+        self.disable_generic_tags = self.config.disable_generic_tags
         with self.login():
             try:
                 self.collect_avi_version()

--- a/avi_vantage/datadog_checks/avi_vantage/config_models/defaults.py
+++ b/avi_vantage/datadog_checks/avi_vantage/config_models/defaults.py
@@ -61,7 +61,7 @@ def instance_connect_timeout(field, value):
 
 
 def instance_disable_generic_tags(field, value):
-    return False
+    return True
 
 
 def instance_empty_default_hostname(field, value):

--- a/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
+++ b/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
@@ -562,3 +562,9 @@ instances:
     ## This is useful for cluster-level checks.
     #
     # empty_default_hostname: false
+
+    ## @param disable_generic_tags - boolean - optional - default: true
+    ## Replaces generic tag such as `server` with `avi_vantage_server` to avoid getting it mixed with
+    ## other integratons tags.
+    #
+    # disable_generic_tags: true

--- a/avi_vantage/setup.py
+++ b/avi_vantage/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=16.9.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=21.2.1'
 
 
 setup(

--- a/avi_vantage/tests/conftest.py
+++ b/avi_vantage/tests/conftest.py
@@ -33,12 +33,16 @@ def get_expected_metrics():
     def _get_metrics(endpoint=None):
         with open(os.path.join(HERE, 'compose', 'fixtures', "metrics.json")) as f:
             expected_metrics = json.load(f)
+
         if endpoint is None:
-            return expected_metrics
+            endpoint = 'https://34.123.32.255/'
 
         transformed_expected_metrics = []
         for metric in expected_metrics:
-            tags = [t.replace('https://34.123.32.255/', endpoint) for t in metric['tags']]
+            tags = [
+                t.replace('https://34.123.32.255/', endpoint).replace('server:', 'avi_vantage_server:')
+                for t in metric['tags']
+            ]
             transformed_expected_metrics.append(
                 {"name": metric['name'], "type": metric['type'], "value": metric['value'], "tags": tags}
             )

--- a/avi_vantage/tox.ini
+++ b/avi_vantage/tox.ini
@@ -23,5 +23,3 @@ passenv =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
-setenv =
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1103,7 +1103,7 @@ class AgentCheck(object):
         return normalized_tags
 
     def degeneralise_tag(self, tag):
-        tag_name, value = tag.split(':')
+        tag_name, value = tag.split(':', 1)
         if tag_name in GENERIC_TAGS:
             new_name = '{}_{}'.format(self.name, tag_name)
             return '{}:{}'.format(new_name, value)


### PR DESCRIPTION
This is a breaking change but since AVI is so new I think it's ok
Depends on https://github.com/DataDog/integrations-core/pull/10165