### PR TITLE
Add limit to tag split

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1103,7 +1103,7 @@ class AgentCheck(object):
         return normalized_tags
 
     def degeneralise_tag(self, tag):
-        tag_name, value = tag.split(':')
+        tag_name, value = tag.split(':', 1)
         if tag_name in GENERIC_TAGS:
             new_name = '{}_{}'.format(self.name, tag_name)
             return '{}:{}'.format(new_name, value)


### PR DESCRIPTION
If a tag value such as a hostname includes ':' it will crash