### PR TITLE
Owen/update immutable attributes validator for manifest upgrades v2

### DIFF
--- a/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
@@ -196,9 +196,11 @@ DISPLAY_ON_PUBLIC_INVALID_MANIFEST = JSONDict({"app_id": "datadog-oracle"})
 
 DISPLAY_ON_PUBLIC_VALID_MANIFEST = JSONDict({"display_on_public_website": True})
 
-INVALID_DIFF = ['app_id', 'id']
+INVALID_DIFF = 'app_id id'
 
-VALID_DIFF = ['new file', 'other_val']
+VERSION_UPGRADE_DIFF = '+ "manifest_version": "2.0.0",'
+
+VALID_DIFF = 'new file'
 
 
 class MockedResponseInvalid:

--- a/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
@@ -223,6 +223,20 @@ def test_manifest_v2_immutable_attributes_validator_invalid_change(_, setup_rout
 
 @mock.patch(
     'datadog_checks.dev.tooling.manifest_validator.common.validator.content_changed',
+    return_value=input_constants.VERSION_UPGRADE_DIFF,
+)
+def test_manifest_v2_immutable_attributes_validator_version_upgrade(_, setup_route):
+    # Use specific validator
+    validator = common.ImmutableAttributesValidator(version=V2)
+    validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+
+    # Assert test case
+    assert not validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+@mock.patch(
+    'datadog_checks.dev.tooling.manifest_validator.common.validator.content_changed',
     return_value=input_constants.VALID_DIFF,
 )
 def test_manifest_v2_immutable_attributes_validator_valid_change(_, setup_route):


### PR DESCRIPTION
### What does this PR do?
This PR updates the ImmutableAttributesValidator to skip if the manifest was upgraded to version 2. Also, the tests for this validator were updated to work with the new changes. Now, this validation will not run if the manifest is a new file or if it was upgraded from 1.0 to 2.0.

### Motivation
This would originally fail for manifest upgrades because some immutable attributes are changed to fit the new schema.

### Additional Notes
N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
