### PR TITLE
Fixed Agent Platform checks documentation codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -86,12 +86,23 @@ assets/               @DataDog/agent-integrations
 
 # Agent Platform
 /disk/                                    @DataDog/agent-integrations @DataDog/agent-platform
+/disk/*.md                                @DataDog/agent-integrations @DataDog/agent-platform @DataDog/documentation
+/disk/manifest.json                       @DataDog/agent-integrations @DataDog/agent-platform @DataDog/documentation
 /network/                                 @DataDog/agent-integrations @DataDog/agent-platform
+/network/*.md                             @DataDog/agent-integrations @DataDog/agent-platform @DataDog/documentation
+/network/manifest.json                    @DataDog/agent-integrations @DataDog/agent-platform @DataDog/documentation
 /process/                                 @DataDog/agent-integrations @DataDog/agent-platform
+/process/*.md                             @DataDog/agent-integrations @DataDog/agent-platform @DataDog/documentation
+/process/manifest.json                    @DataDog/agent-integrations @DataDog/agent-platform @DataDog/documentation
 /otel/                                    @DataDog/agent-integrations @DataDog/agent-platform
+/otel/*.md                                @DataDog/agent-integrations @DataDog/agent-platform @DataDog/documentation
+/otel/manifest.json                       @DataDog/agent-integrations @DataDog/agent-platform @DataDog/documentation
 /nvidia_jetson/                           @DataDog/agent-integrations @DataDog/agent-platform
+/nvidia_jetson/*.md                       @DataDog/agent-integrations @DataDog/agent-platform @DataDog/documentation
+/nvidia_jetson/manifest.json              @DataDog/agent-integrations @DataDog/agent-platform @DataDog/documentation
 /ibm_i/                                   @DataDog/agent-integrations @DataDog/agent-platform
-/ibm_i/*.md                           @DataDog/agent-integrations @DataDog/agent-platform @DataDog/documentation
+/ibm_i/*.md                               @DataDog/agent-integrations @DataDog/agent-platform @DataDog/documentation
+/ibm_i/manifest.json                      @DataDog/agent-integrations @DataDog/agent-platform @DataDog/documentation
 
 
 # Database monitoring


### PR DESCRIPTION
### What does this PR do?

Adds the Documentation team as codeowners of the `md` and `manifest.json` files in the Agent Platform check folders.

### Motivation

Have the same codeowners structure as other checks.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
