### PR TITLE
Update coredns check with v1.8.5 metrics

### DIFF
--- a/coredns/CHANGELOG.md
+++ b/coredns/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - CoreDNS
 
+## 1.9.0 / 2021-09-21 / Agent 7.32.0
+
+* [Changed] Replace cache_misses_count with cache_requests_count for coredns 1.8.5.
+
 ## 1.8.0 / 2021-05-28 / Agent 7.29.0
 
 * [Added] Support "ignore_tags" configuration. See [#9392](https://github.com/DataDog/integrations-core/pull/9392).

--- a/coredns/assets/dashboards/coredns.json
+++ b/coredns/assets/dashboards/coredns.json
@@ -78,7 +78,7 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "avg:coredns.cache_misses_count{$cluster,$deployment,$service,$namespace,$node,$label}.as_count()",
+                        "query": "avg:coredns.cache_requests_count{$cluster,$deployment,$service,$namespace,$node,$label}.as_count()-avg:coredns.cache_hits_count{$cluster,$deployment,$service,$namespace,$node,$label} by {type}.as_count()",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -152,7 +152,7 @@
                 "type": "heatmap",
                 "requests": [
                   {
-                    "q": "avg:coredns.cache_hits_count{$cluster,$deployment,$service,$namespace,$node,$label} by {host}.as_count()*100/(avg:coredns.cache_hits_count{$cluster,$deployment,$service,$namespace,$node,$label} by {host}.as_count()+avg:coredns.cache_misses_count{$cluster,$deployment,$service,$namespace,$node,$label} by {host}.as_count())",
+                    "q": "avg:coredns.cache_hits_count{$cluster,$deployment,$service,$namespace,$node,$label} by {host}.as_count()*100/(avg:coredns.cache_requests_count{$cluster,$deployment,$service,$namespace,$node,$label} by {host}.as_count())",
                     "style": { "palette": "purple" }
                   }
                 ]

--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -13,7 +13,7 @@ DEFAULT_METRICS = {
     # cache: https://github.com/coredns/coredns/tree/v1.6.9/plugin/cache
     'coredns_cache_size': 'cache_size.count',
     'coredns_cache_hits_total': 'cache_hits_count',
-    'coredns_cache_misses_total': 'cache_misses_count',
+    'coredns_cache_requests_total': 'cache_requests_count',
     'coredns_cache_drops_total': 'cache_drops_count',
     'coredns_cache_prefetch_total': 'cache_prefetch_count',
     'coredns_cache_served_stale_total': 'cache_stale_count',

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -7,7 +7,7 @@ coredns.response_code_count,count,,,,number of responses per zone and rcode,1,co
 coredns.proxy_request_count,count,,request,,query count per upstream.,1,coredns,proxy request count
 coredns.cache_drops_count,count,,response,,"Counter of responses excluded from the cache due to request/response question name mismatch.",0,coredns,cache drop
 coredns.cache_hits_count,count,,hit,,Counter of cache hits by cache type,1,coredns,cache hit
-coredns.cache_misses_count,count,,miss,,Counter of cache misses.,1,coredns,cache miss
+coredns.cache_requests_count,count,,request,,Counter of cache requests.,1,coredns,cache request count
 coredns.cache_prefetch_count,count,,,,"The number of time the cache has prefetched a cached item.",1,coredns,cache prefetch
 coredns.cache_stale_count,count,,request,,"Counter of requests served from stale cache entries.",0,coredns,cache stale
 coredns.dnssec.cache_size,gauge,,,,"Total elements in the cache, type is signature.",0,coredns,dnssec cache size

--- a/coredns/tests/common.py
+++ b/coredns/tests/common.py
@@ -54,7 +54,7 @@ COMMON_METRICS = [
     NAMESPACE + '.process.virtual_memory_bytes',
     NAMESPACE + '.request_count',
     NAMESPACE + '.cache_size.count',
-    NAMESPACE + '.cache_misses_count',
+    NAMESPACE + '.cache_requests_count',
     NAMESPACE + '.response_code_count',
     NAMESPACE + '.response_size.bytes.sum',
     NAMESPACE + '.response_size.bytes.count',


### PR DESCRIPTION
### What does this PR do?
Update coredns check with v1.8.5 metrics as coredns deprecated cache_misses_count metric in [1.8.5 release notes 
](https://coredns.io/2021/09/10/coredns-1.8.5-release/)

### Motivation
cache_misses_count was deprecated in coredns v1.8.5

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
