### PR TITLE
Add proxy support in client initialization

### DIFF
--- a/amazon_msk/assets/configuration/spec.yaml
+++ b/amazon_msk/assets/configuration/spec.yaml
@@ -51,6 +51,19 @@ files:
       value:
         type: string
         example: /metrics
+    - name: boto_config
+      description: |
+        Specify additional configuration options for botocore clients.
+
+        https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
+      value:
+        example:
+          proxies_config:
+            proxy_client_cert: '/path/of/certificate'
+            proxy_ca_bundle: 'path/to/ca/bundle'
+            proxy_use_forwarding_for_https: false
+          signature_version: s3v4
+        type: object
     - template: instances/openmetrics
       overrides:
         openmetrics_endpoint.hidden: true

--- a/amazon_msk/assets/configuration/spec.yaml
+++ b/amazon_msk/assets/configuration/spec.yaml
@@ -53,8 +53,10 @@ files:
         example: /metrics
     - name: boto_config
       description: |
-        Specify additional configuration options for botocore clients.
+        Specify additional configuration options for the botocore Config object.
 
+        Note: Configuration values set in your AWS config file can be singularly overwritten
+        through the use of a Config object.
         https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
       value:
         example:

--- a/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
+++ b/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
@@ -62,8 +62,8 @@ class AmazonMskCheck(OpenMetricsBaseCheck):
         try:
             self._boto_config = construct_boto_config(self.instance.get('boto_config', {}), proxies=proxies)
         except TypeError as e:
-            self.log.debug("Got error when constructing Config object: {}".format(str(e)))
-            self.log.debug("Boto Config parameters: {}".format(self.instance.get('boto_config')))
+            self.log.debug("Got error when constructing Config object: %s", str(e))
+            self.log.debug("Boto Config parameters: %s", self.instance.get('boto_config'))
             self._boto_config = None
 
         instance = self.instance.copy()

--- a/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
+++ b/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
@@ -59,7 +59,12 @@ class AmazonMskCheck(OpenMetricsBaseCheck):
         )
         self._prometheus_metrics_path = self.instance.get('prometheus_metrics_path', '/metrics')
         proxies = self.instance.get('proxy', init_config.get('proxy', datadog_agent.get_config('proxy')))
-        self._boto_config = construct_boto_config(self.instance.get('boto_config', {}), proxies=proxies)
+        try:
+            self._boto_config = construct_boto_config(self.instance.get('boto_config', {}), proxies=proxies)
+        except TypeError as e:
+            self.log.debug("Got error when constructing Config object: {}".format(str(e)))
+            self.log.debug("Boto Config parameters: {}".format(self.instance.get('boto_config')))
+            self._boto_config = None
 
         instance = self.instance.copy()
         instance['prometheus_url'] = 'necessary for scraper creation'

--- a/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
+++ b/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
@@ -15,6 +15,7 @@ try:
 except ImportError:
     from datadog_checks.base.stubs import datadog_agent
 
+
 class AmazonMskCheck(OpenMetricsBaseCheck):
     """
     This is a legacy implementation that will be removed at some point, refer to check.py for the new implementation.
@@ -56,7 +57,7 @@ class AmazonMskCheck(OpenMetricsBaseCheck):
             (int(self.instance.get('node_exporter_port', 11002)), NODE_METRICS_MAP, NODE_METRICS_OVERRIDES),
         )
         self._prometheus_metrics_path = self.instance.get('prometheus_metrics_path', '/metrics')
-        self._proxies = self.instance.get('proxy', init_config.get('proxy'), datadog_agent.get_config('proxy'))
+        self._proxies = self.instance.get('proxy', init_config.get('proxy', datadog_agent.get_config('proxy')))
 
         instance = self.instance.copy()
         instance['prometheus_url'] = 'necessary for scraper creation'

--- a/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
+++ b/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
@@ -4,6 +4,7 @@
 import json
 
 import boto3
+from botocore.config import Config
 from six import PY2
 
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck, is_affirmative
@@ -68,6 +69,10 @@ class AmazonMskCheck(OpenMetricsBaseCheck):
         self.check_initializations.append(self.parse_config)
 
     def check(self, _):
+        # Configure boto config
+        boto_config = Config(
+            proxies=self._proxies,
+        )
         # Create assume_role credentials if assume_role ARN is specified in config
         if self._assume_role:
             self.log.info('Assume role %s found. Creating temporary credentials using role...', self._assume_role)
@@ -83,14 +88,14 @@ class AmazonMskCheck(OpenMetricsBaseCheck):
                 aws_access_key_id=access_key_id,
                 aws_secret_access_key=secret_access_key,
                 aws_session_token=session_token,
-                proxies=self._proxies,
+                config=boto_config,
                 region_name=self._region_name,
             )
         else:
             # Always create a new client to account for changes in auth
             client = boto3.client(
                 'kafka',
-                proxies=self._proxies,
+                config=boto_config,
                 region_name=self._region_name,
             )
 

--- a/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
+++ b/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
@@ -8,8 +8,8 @@ from six import PY2
 
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck, is_affirmative
 
-from .utils import construct_boto_config
 from .metrics import JMX_METRICS_MAP, JMX_METRICS_OVERRIDES, NODE_METRICS_MAP, NODE_METRICS_OVERRIDES
+from .utils import construct_boto_config
 
 try:
     import datadog_agent

--- a/amazon_msk/datadog_checks/amazon_msk/check.py
+++ b/amazon_msk/datadog_checks/amazon_msk/check.py
@@ -9,9 +9,9 @@ from datadog_checks.base import OpenMetricsBaseCheckV2
 from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
 from datadog_checks.base.utils.serialization import json
 
-from .utils import construct_boto_config
 from .config_models import ConfigMixin
 from .metrics import METRICS_WITH_NAME_AS_LABEL, construct_jmx_metrics_config, construct_node_metrics_config
+from .utils import construct_boto_config
 
 try:
     import datadog_agent

--- a/amazon_msk/datadog_checks/amazon_msk/check.py
+++ b/amazon_msk/datadog_checks/amazon_msk/check.py
@@ -37,7 +37,12 @@ class AmazonMskCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
         self._static_tags = None
         self._service_check_tags = None
         proxies = self.instance.get('proxy', init_config.get('proxy', datadog_agent.get_config('proxy')))
-        self._boto_config = construct_boto_config(self.instance.get('boto_config', {}), proxies=proxies)
+        try:
+            self._boto_config = construct_boto_config(self.instance.get('boto_config', {}), proxies=proxies)
+        except TypeError as e:
+            self.log.debug("Got error when constructing Config object: %s", str(e))
+            self.log.debug("Boto Config parameters: %s", self.instance.get('boto_config'))
+            self._boto_config = None
         self.check_initializations.append(self.parse_config)
 
     def refresh_scrapers(self):

--- a/amazon_msk/datadog_checks/amazon_msk/check.py
+++ b/amazon_msk/datadog_checks/amazon_msk/check.py
@@ -4,6 +4,7 @@
 from collections import ChainMap
 
 import boto3
+from botocore.config import Config
 
 from datadog_checks.base import OpenMetricsBaseCheckV2
 from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
@@ -40,6 +41,10 @@ class AmazonMskCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
         self.check_initializations.append(self.parse_config)
 
     def refresh_scrapers(self):
+        # Configure boto config
+        boto_config = Config(
+            proxies=self._proxies,
+        )
         # Create assume_role credentials if assume_role ARN is specified in config
         assume_role = self.config.assume_role
         if assume_role:
@@ -56,14 +61,14 @@ class AmazonMskCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
                 aws_access_key_id=access_key_id,
                 aws_secret_access_key=secret_access_key,
                 aws_session_token=session_token,
-                proxies=self._proxies,
+                config=boto_config,
                 region_name=self._region_name,
             )
         else:
             # Always create a new client to account for changes in auth
             client = boto3.client(
                 'kafka',
-                proxies=self._proxies,
+                config=boto_config,
                 region_name=self._region_name,
             )
 

--- a/amazon_msk/datadog_checks/amazon_msk/check.py
+++ b/amazon_msk/datadog_checks/amazon_msk/check.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     from datadog_checks.base.stubs import datadog_agent
 
+
 class AmazonMskCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
     __NAMESPACE__ = 'aws.msk'
 
@@ -34,7 +35,7 @@ class AmazonMskCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
         self._endpoint_prefix = None
         self._static_tags = None
         self._service_check_tags = None
-        self._proxies = self.instance.get('proxy', init_config.get('proxy'), datadog_agent.get_config('proxy'))
+        self._proxies = self.instance.get('proxy', init_config.get('proxy', datadog_agent.get_config('proxy')))
 
         self.check_initializations.append(self.parse_config)
 
@@ -55,14 +56,14 @@ class AmazonMskCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
                 aws_access_key_id=access_key_id,
                 aws_secret_access_key=secret_access_key,
                 aws_session_token=session_token,
-                proxies = self._proxies,
+                proxies=self._proxies,
                 region_name=self._region_name,
             )
         else:
             # Always create a new client to account for changes in auth
             client = boto3.client(
                 'kafka',
-                proxies = self._proxies,
+                proxies=self._proxies,
                 region_name=self._region_name,
             )
 

--- a/amazon_msk/datadog_checks/amazon_msk/config_models/defaults.py
+++ b/amazon_msk/datadog_checks/amazon_msk/config_models/defaults.py
@@ -48,6 +48,10 @@ def instance_aws_service(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_boto_config(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_cache_metric_wildcards(field, value):
     return True
 

--- a/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
+++ b/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
@@ -67,6 +67,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
+    boto_config: Optional[Mapping[str, Any]]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]
     cluster_arn: str

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -86,8 +86,10 @@ instances:
     # prometheus_metrics_path: /metrics
 
     ## @param boto_config - mapping - optional
-    ## Specify additional configuration options for botocore clients.
+    ## Specify additional configuration options for the botocore Config object.
     ##
+    ## Note: Configuration values set in your AWS config file can be singularly overwritten
+    ## through the use of a Config object.
     ## https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
     #
     # boto_config:

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -85,6 +85,18 @@ instances:
     #
     # prometheus_metrics_path: /metrics
 
+    ## @param boto_config - mapping - optional
+    ## Specify additional configuration options for botocore clients.
+    ##
+    ## https://botocore.amazonaws.com/v1/documentation/api/latest/reference/config.html
+    #
+    # boto_config:
+    #   proxies_config:
+    #     proxy_client_cert: /path/of/certificate
+    #     proxy_ca_bundle: path/to/ca/bundle
+    #     proxy_use_forwarding_for_https: false
+    #   signature_version: s3v4
+
     ## @param raw_metric_prefix - string - optional
     ## A prefix that will be removed from all exposed metric names, if present.
     ## All configuration options will use the prefix-less name.

--- a/amazon_msk/datadog_checks/amazon_msk/utils.py
+++ b/amazon_msk/datadog_checks/amazon_msk/utils.py
@@ -8,7 +8,8 @@ def construct_boto_config(boto_config, proxies=None):
     if boto_config.get('proxies'):
         # Proxy settings configured in the boto_config config option takes precedence
         return Config(**boto_config)
-
-    if proxies:
+    elif proxies:
         boto_config["proxies"] = proxies
         return Config(**boto_config)
+
+    return Config(**boto_config)

--- a/amazon_msk/datadog_checks/amazon_msk/utils.py
+++ b/amazon_msk/datadog_checks/amazon_msk/utils.py
@@ -1,14 +1,14 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import boto3
 from botocore.config import Config
+
 
 def construct_boto_config(boto_config, proxies=None):
     if boto_config.get('proxies'):
         # Proxy settings configured in the boto_config config option takes precedence
-        return Config(boto_config)
+        return Config(**boto_config)
 
     if proxies:
         boto_config["proxies"] = proxies
-        return Config(boto_config)
+        return Config(**boto_config)

--- a/amazon_msk/datadog_checks/amazon_msk/utils.py
+++ b/amazon_msk/datadog_checks/amazon_msk/utils.py
@@ -1,0 +1,14 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import boto3
+from botocore.config import Config
+
+def construct_boto_config(boto_config, proxies=None):
+    if boto_config.get('proxies'):
+        # Proxy settings configured in the boto_config config option takes precedence
+        return Config(boto_config)
+
+    if proxies:
+        boto_config["proxies"] = proxies
+        return Config(boto_config)

--- a/amazon_msk/tests/test_unit.py
+++ b/amazon_msk/tests/test_unit.py
@@ -25,7 +25,7 @@ def test_node_check_legacy(aggregator, instance_legacy, mock_client):
     cluster_arn = instance_legacy['cluster_arn']
     region_name = cluster_arn.split(':')[3]
 
-    caller.assert_called_once_with('kafka', region_name=region_name)
+    caller.assert_called_once_with('kafka', region_name=region_name, config=None)
     client.list_nodes.assert_called_once_with(ClusterArn=cluster_arn)
 
     global_tags = ['cluster_arn:{}'.format(cluster_arn), 'region_name:{}'.format(region_name)]
@@ -60,7 +60,7 @@ def test_node_check(aggregator, dd_run_check, instance, mock_client):
     cluster_arn = instance['cluster_arn']
     region_name = cluster_arn.split(':')[3]
 
-    caller.assert_called_once_with('kafka', region_name=region_name)
+    caller.assert_called_once_with('kafka', config=None, region_name=region_name)
     client.list_nodes.assert_called_once_with(ClusterArn=cluster_arn)
 
     global_tags = ['cluster_arn:{}'.format(cluster_arn), 'region_name:{}'.format(region_name)]
@@ -156,7 +156,7 @@ def test_custom_metric_path(aggregator, instance_legacy, mock_client):
     cluster_arn = instance_legacy['cluster_arn']
     region_name = cluster_arn.split(':')[3]
 
-    caller.assert_called_once_with('kafka', region_name=region_name)
+    caller.assert_called_once_with('kafka', region_name=region_name, config=None)
     client.list_nodes.assert_called_once_with(ClusterArn=cluster_arn)
 
     global_tags = ['cluster_arn:{}'.format(cluster_arn), 'region_name:{}'.format(region_name)]

--- a/amazon_msk/tests/test_unit.py
+++ b/amazon_msk/tests/test_unit.py
@@ -184,8 +184,10 @@ def test_custom_metric_path(aggregator, instance_legacy, mock_client):
 @pytest.mark.parametrize(
     'instance',
     [
-        pytest.param(INSTANCE_LEGACY, id='legacy config proxy'),
-        pytest.param(INSTANCE, id='new config proxy'),
+        pytest.param(INSTANCE_LEGACY, None, id='legacy config proxy'),
+        pytest.param(
+            INSTANCE, id='new config proxy', marks=pytest.mark.skipif(PY2, reason='Test only available on Python 3')
+        ),
     ],
 )
 def test_proxy_config(instance):

--- a/amazon_msk/tests/test_unit.py
+++ b/amazon_msk/tests/test_unit.py
@@ -180,12 +180,13 @@ def test_custom_metric_path(aggregator, instance_legacy, mock_client):
 
     aggregator.assert_all_metrics_covered()
 
+
 @pytest.mark.parametrize(
     'instance',
     [
         pytest.param(INSTANCE_LEGACY, id='legacy config proxy'),
         pytest.param(INSTANCE, id='new config proxy'),
-    ]
+    ],
 )
 def test_proxy_config(instance):
     HTTP_PROXY = {"http": "example.com"}

--- a/amazon_msk/tests/test_unit.py
+++ b/amazon_msk/tests/test_unit.py
@@ -184,7 +184,7 @@ def test_custom_metric_path(aggregator, instance_legacy, mock_client):
 @pytest.mark.parametrize(
     'instance',
     [
-        pytest.param(INSTANCE_LEGACY, None, id='legacy config proxy'),
+        pytest.param(INSTANCE_LEGACY, id='legacy config proxy'),
         pytest.param(
             INSTANCE, id='new config proxy', marks=pytest.mark.skipif(PY2, reason='Test only available on Python 3')
         ),

--- a/amazon_msk/tests/test_unit.py
+++ b/amazon_msk/tests/test_unit.py
@@ -13,7 +13,7 @@ from datadog_checks.amazon_msk.metrics import (
     NODE_METRICS_OVERRIDES,
 )
 
-from .common import METRICS_FROM_LABELS
+from .common import INSTANCE, INSTANCE_LEGACY, METRICS_FROM_LABELS
 
 
 @pytest.mark.usefixtures('mock_data')
@@ -179,3 +179,16 @@ def test_custom_metric_path(aggregator, instance_legacy, mock_client):
                 aggregator.assert_service_check('aws.msk.prometheus.health', c.OK, tags=service_check_tags)
 
     aggregator.assert_all_metrics_covered()
+
+@pytest.mark.parametrize(
+    'instance',
+    [
+        pytest.param(INSTANCE_LEGACY, id='legacy config proxy'),
+        pytest.param(INSTANCE, id='new config proxy'),
+    ]
+)
+def test_proxy_config(instance):
+    HTTP_PROXY = {"http": "example.com"}
+    init_config = {"proxy": HTTP_PROXY}
+    c = AmazonMskCheck('amazon_msk', init_config, [instance])
+    assert c._boto_config.proxies == HTTP_PROXY

--- a/amazon_msk/tests/test_unit.py
+++ b/amazon_msk/tests/test_unit.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
+from mock import ANY
 from six import PY2
 
 from datadog_checks.amazon_msk import AmazonMskCheck
@@ -25,7 +26,7 @@ def test_node_check_legacy(aggregator, instance_legacy, mock_client):
     cluster_arn = instance_legacy['cluster_arn']
     region_name = cluster_arn.split(':')[3]
 
-    caller.assert_called_once_with('kafka', region_name=region_name, config=None)
+    caller.assert_called_once_with('kafka', region_name=region_name, config=ANY)
     client.list_nodes.assert_called_once_with(ClusterArn=cluster_arn)
 
     global_tags = ['cluster_arn:{}'.format(cluster_arn), 'region_name:{}'.format(region_name)]
@@ -60,7 +61,7 @@ def test_node_check(aggregator, dd_run_check, instance, mock_client):
     cluster_arn = instance['cluster_arn']
     region_name = cluster_arn.split(':')[3]
 
-    caller.assert_called_once_with('kafka', config=None, region_name=region_name)
+    caller.assert_called_once_with('kafka', config=ANY, region_name=region_name)
     client.list_nodes.assert_called_once_with(ClusterArn=cluster_arn)
 
     global_tags = ['cluster_arn:{}'.format(cluster_arn), 'region_name:{}'.format(region_name)]
@@ -153,10 +154,10 @@ def test_custom_metric_path(aggregator, instance_legacy, mock_client):
     assert not c.run()
 
     caller, client = mock_client
-    cluster_arn = instance_legacy['cluster_arn']
+    cluster_arn = instance_legacy['cluster_arn']test_node_check_legacy
     region_name = cluster_arn.split(':')[3]
 
-    caller.assert_called_once_with('kafka', region_name=region_name, config=None)
+    caller.assert_called_once_with('kafka', region_name=region_name, config=ANY)
     client.list_nodes.assert_called_once_with(ClusterArn=cluster_arn)
 
     global_tags = ['cluster_arn:{}'.format(cluster_arn), 'region_name:{}'.format(region_name)]

--- a/amazon_msk/tests/test_unit.py
+++ b/amazon_msk/tests/test_unit.py
@@ -154,7 +154,7 @@ def test_custom_metric_path(aggregator, instance_legacy, mock_client):
     assert not c.run()
 
     caller, client = mock_client
-    cluster_arn = instance_legacy['cluster_arn']test_node_check_legacy
+    cluster_arn = instance_legacy['cluster_arn']
     region_name = cluster_arn.split(':')[3]
 
     caller.assert_called_once_with('kafka', region_name=region_name, config=ANY)


### PR DESCRIPTION
### What does this PR do?
This PR adds proxy support.

Currently, users can only configure proxy settings by using environment variables.

The source states that proxy support via configuration files is not yet available
https://github.com/boto/botocore/blob/6a0f13261b3ecaf4e2cebbf134c3b3c7005a3c78/botocore/endpoint.py#L311-L314

### Motivation
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
