### PR TITLE
Catch exception for malformed requirement syntax

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -55,7 +55,7 @@ jobs:
       run: |
         ddev validate jmx-metrics
 
-    - name: Run legacy metadata validation
+    - name: Run metadata validation
       run: |
         ddev validate metadata
 

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -3,7 +3,7 @@ aerospike==4.0.0; sys_platform != "win32" and sys_platform != "darwin" and pytho
 aerospike==6.0.0; sys_platform != "win32" and sys_platform != "darwin" and python_version > "3.0"
 aws-requests-auth==0.4.2
 beautifulsoup4==4.5.1
-binary==1.0.0;
+binary==1.0.0
 boto3==1.17.91
 boto==2.46.1
 botocore==1.20.91

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -3,7 +3,7 @@ aerospike==4.0.0; sys_platform != "win32" and sys_platform != "darwin" and pytho
 aerospike==6.0.0; sys_platform != "win32" and sys_platform != "darwin" and python_version > "3.0"
 aws-requests-auth==0.4.2
 beautifulsoup4==4.5.1
-binary==1.0.0
+binary==1.0.0;
 boto3==1.17.91
 boto==2.46.1
 botocore==1.20.91

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -245,9 +245,8 @@ def licenses(ctx, sync):
         except Exception as e:
             rel_file = os.path.basename(agent_requirements_file)
             line = i + 1
-            message = f"Detected error in {rel_file}:{line} {e}"
-            annotate_error(agent_requirements_file, message, line=line)
-            echo_failure(message)
+            annotate_error(agent_requirements_file, str(e), line=line)
+            echo_failure(f"Detected error in {rel_file}:{line} {e}")
 
     api_urls = []
     for package, versions in packages.items():

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -245,7 +245,7 @@ def licenses(ctx, sync):
         except Exception as e:
             rel_file = os.path.basename(agent_requirements_file)
             line = i + 1
-            annotate_error(agent_requirements_file, str(e).strip('"'), line=line)
+            annotate_error(agent_requirements_file, str(e).replace('\"', ''), line=line)
             echo_failure(f"Detected error in {rel_file}:{line} {e}")
 
     api_urls = []

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -245,7 +245,7 @@ def licenses(ctx, sync):
         except Exception as e:
             rel_file = os.path.basename(agent_requirements_file)
             line = i + 1
-            annotate_error(agent_requirements_file, str(e), line=line)
+            annotate_error(agent_requirements_file, str(e).strip('"'), line=line)
             echo_failure(f"Detected error in {rel_file}:{line} {e}")
 
     api_urls = []

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -2,11 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import asyncio
+import os
 from collections import defaultdict
 
 import click
 import orjson
-import os
 import requests
 from aiohttp import request
 from aiomultiprocess import Pool

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -245,7 +245,7 @@ def licenses(ctx, sync):
         except Exception as e:
             rel_file = os.path.basename(agent_requirements_file)
             line = i + 1
-            annotate_error(agent_requirements_file, str(e).replace(':', ''), line=line)
+            annotate_error(agent_requirements_file, str(e).split(":")[1], line=line)
             echo_failure(f"Detected error in {rel_file}:{line} {e}")
 
     api_urls = []

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -245,7 +245,7 @@ def licenses(ctx, sync):
         except Exception as e:
             rel_file = os.path.basename(agent_requirements_file)
             line = i + 1
-            annotate_error(agent_requirements_file, str(e).replace('\"', ''), line=line)
+            annotate_error(agent_requirements_file, str(e).replace(':', ''), line=line)
             echo_failure(f"Detected error in {rel_file}:{line} {e}")
 
     api_urls = []


### PR DESCRIPTION
### What does this PR do?
This PR catches the exception when the requirements file syntax is wrong. It previously crashed the licenses validation, this PR catches and prints fail message/annotate.

### Motivation
![image](https://user-images.githubusercontent.com/15065007/134280759-b61e0d38-be9a-456f-88fa-f72b86883609.png)
### Additional Notes

<img width="679" alt="Screen Shot 2021-09-22 at 10 18 47 AM" src="https://user-images.githubusercontent.com/15065007/134361267-d5bc0933-6042-4610-9f16-931f8960d9ac.png">
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
