### PR TITLE
Add exception for IBM i logs collection

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/catalog_const.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/catalog_const.py
@@ -51,6 +51,7 @@ INTEGRATION_LOGS_NOT_POSSIBLE = {
     'go-metro',  # for agent 5 only
     'go_expvar',  # its a go package
     'http_check',  # Its not a service
+    'ibm_i',  # remote connection
     'linux_proc_extras',
     'ntp',  # the integration is for a remote ntp server
     'openmetrics',  # base class


### PR DESCRIPTION
### What does this PR do?
Add an exception for logs support on IBM i, which can't collect logs because it's a remote check.

