### PR TITLE
Strengthen ImmutableAttributesValidator to check for manifest changes in asset short names

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/common/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/common/validator.py
@@ -3,13 +3,14 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import abc
+import json
 import os
-import re
 from typing import Dict
 
 import six
 
-from datadog_checks.dev.tooling.git import content_changed
+from datadog_checks.dev.tooling.datastructures import JSONDict
+from datadog_checks.dev.tooling.git import git_show_file
 from datadog_checks.dev.tooling.utils import get_metadata_file, has_logs, is_metric_in_metadata_file, read_metadata_rows
 
 from ..constants import V1, V2
@@ -177,36 +178,86 @@ class MetricToCheckValidator(BaseManifestValidator):
 
 
 class ImmutableAttributesValidator(BaseManifestValidator):
-    """Ensure attributes haven't changed
-    Skip if the manifest is a new file (i.e. new integration)
+    """
+    Ensure that immutable attributes haven't changed
+    Skip if the manifest is a new file (i.e. new integration) or if the manifest was upgraded to V2
     """
 
-    FIELDS_NOT_ALLOWED_TO_CHANGE = {
+    MANIFEST_VERSION_PATH = "manifest_version"
+
+    IMMUTABLE_FIELD_PATHS = {
         V1: ("integration_id", "display_name", "guid"),
-        V2: ("id", "source_type_name", "app_id"),
+        V2: (
+            "app_id",
+            "assets/integration/id",
+            "assets/integration/source_type_name",
+        ),
+    }
+
+    SHORT_NAME_PATHS = {
+        V1: (
+            "assets/dashboards",
+            "assets/monitors",
+            "assets/saved_views",
+        ),
+        V2: (
+            "assets/dashboards",
+            "assets/monitors",
+            "assets/saved_views",
+        ),
     }
 
     def validate(self, check_name, decoded, fix):
-        manifest_fields_changed = content_changed(file_glob=f"{check_name}/manifest.json")
+        # Check if previous version of manifest exists
+        # If not, this is a new file so this validation is skipped
+        try:
+            previous = git_show_file(path=f"{check_name}/manifest.json", ref="master")
+            previous_manifest = JSONDict(json.loads(previous))
+        except Exception:
+            self.result.messages['info'].append(
+                "  skipping check for changed fields: integration not on default branch"
+            )
+            return
 
         # Skip this validation if the manifest was updated from 1.0.0 -> 2.0.0
-        manifest_upgrade_regex = re.compile(r'\+\s+"manifest_version": "2.0.0",')
-        version_upgraded = manifest_upgrade_regex.findall(manifest_fields_changed)
+        current_manifest = decoded
+        if (
+            previous_manifest[self.MANIFEST_VERSION_PATH] == "1.0.0"
+            and current_manifest[self.MANIFEST_VERSION_PATH] == "2.0.0"
+        ):
+            self.result.messages['info'].append("  skipping check for changed fields: manifest version was upgraded")
+            return
 
-        if 'new file' not in manifest_fields_changed and not version_upgraded:
-            for field in self.FIELDS_NOT_ALLOWED_TO_CHANGE[self.version]:
-                if field in manifest_fields_changed:
-                    output = f'Attribute `{field}` is not allowed to be modified. Please revert to original value'
+        # Check for differences in immutable attributes
+        immutable_attribute_changed = False
+        for key_path in self.IMMUTABLE_FIELD_PATHS[self.version]:
+            previous_value = previous_manifest.get_path(key_path)
+            current_value = current_manifest.get_path(key_path)
+
+            if previous_value != current_value:
+                output = f'Attribute `{current_value}` at `{key_path}` is not allowed to be modified. Please revert it \
+to the original value `{previous_value}`.'
+                immutable_attribute_changed = True
+                self.fail(output)
+
+        # If already failed, stop validations with failure messages gathered above
+        if immutable_attribute_changed:
+            return
+
+        # Check for differences in `short_name` keys
+        for key_path in self.SHORT_NAME_PATHS[self.version]:
+            previous_short_name_dict = previous_manifest.get_path(key_path) or {}
+            current_short_name_dict = current_manifest.get_path(key_path) or {}
+
+            # Every `short_name` in the prior manifest must be in the current manifest
+            # The key cannot change and it cannot be removed
+            previous_short_names = previous_short_name_dict.keys()
+            current_short_names = set(current_short_name_dict.keys())
+            for short_name in previous_short_names:
+                if short_name not in current_short_names:
+                    output = f'Short name `{short_name}` at `{key_path}` is not allowed to be modified. \
+Please revert to original value.'
                     self.fail(output)
-        else:
-            if 'new file' in manifest_fields_changed:
-                self.result.messages['info'].append(
-                    "  skipping check for changed fields: integration not on default branch"
-                )
-            elif version_upgraded:
-                self.result.messages['info'].append(
-                    "  skipping check for changed fields: manifest version was upgraded"
-                )
 
 
 class LogsCategoryValidator(BaseManifestValidator):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/common/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/common/validator.py
@@ -180,7 +180,7 @@ class MetricToCheckValidator(BaseManifestValidator):
 class ImmutableAttributesValidator(BaseManifestValidator):
     """
     Ensure that immutable attributes haven't changed
-    Skip if the manifest is a new file (i.e. new integration) or if the manifest was upgraded to V2
+    Skip if the manifest is a new file (i.e. new integration) or if the manifest is being upgraded to V2
     """
 
     MANIFEST_VERSION_PATH = "manifest_version"

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/common/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/common/validator.py
@@ -189,6 +189,7 @@ class ImmutableAttributesValidator(BaseManifestValidator):
         V1: ("integration_id", "display_name", "guid"),
         V2: (
             "app_id",
+            "app_uuid",
             "assets/integration/id",
             "assets/integration/source_type_name",
         ),
@@ -219,7 +220,7 @@ class ImmutableAttributesValidator(BaseManifestValidator):
             )
             return
 
-        # Skip this validation if the manifest was updated from 1.0.0 -> 2.0.0
+        # Skip this validation if the manifest is being updated from 1.0.0 -> 2.0.0
         current_manifest = decoded
         if (
             previous_manifest[self.MANIFEST_VERSION_PATH] == "1.0.0"
@@ -229,7 +230,6 @@ class ImmutableAttributesValidator(BaseManifestValidator):
             return
 
         # Check for differences in immutable attributes
-        immutable_attribute_changed = False
         for key_path in self.IMMUTABLE_FIELD_PATHS[self.version]:
             previous_value = previous_manifest.get_path(key_path)
             current_value = current_manifest.get_path(key_path)
@@ -237,12 +237,7 @@ class ImmutableAttributesValidator(BaseManifestValidator):
             if previous_value != current_value:
                 output = f'Attribute `{current_value}` at `{key_path}` is not allowed to be modified. Please revert it \
 to the original value `{previous_value}`.'
-                immutable_attribute_changed = True
                 self.fail(output)
-
-        # If already failed, stop validations with failure messages gathered above
-        if immutable_attribute_changed:
-            return
 
         # Check for differences in `short_name` keys
         for key_path in self.SHORT_NAME_PATHS[self.version]:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/common/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/common/validator.py
@@ -212,7 +212,7 @@ class ImmutableAttributesValidator(BaseManifestValidator):
         # Check if previous version of manifest exists
         # If not, this is a new file so this validation is skipped
         try:
-            previous = git_show_file(path=f"{check_name}/manifest.json", ref="master")
+            previous = git_show_file(path=f"{check_name}/manifest.json", ref="origin/master")
             previous_manifest = JSONDict(json.loads(previous))
         except Exception:
             self.result.messages['info'].append(

--- a/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
@@ -13,7 +13,7 @@ V2_MANIFEST_ALL_PASS = JSONDict(
     {
         "app_id": "datadog-oracle",
         "assets": {
-            "dashboards": {"oracle": "https://app.datadoghq.com/screen/integration/240/oracle-database---overview"},
+            "dashboards": {"oracle": "assets/dashboards/example.json"},
             "integration": {
                 "configuration": {"spec": "assets/configuration/spec.yaml"},
                 "events": {"creates_events": True},
@@ -202,12 +202,12 @@ IMMUTABLE_ATTRIBUTES_V1_MANIFEST = {"manifest_version": "1.0.0"}
 
 IMMUTABLE_ATTRIBUTES_V2_MANIFEST = JSONDict({"manifest_version": "2.0.0"})
 
-IMMUTABLE_ATTRIBUTES_PREV_MANIFEST_INVALID = json.dumps(
+IMMUTABLE_ATTRIBUTES_VALID_MANIFEST = json.dumps(
     {
         "app_id": "datadog-oracle",
         "assets": {
-            "dashboards": {"oracle": "https://app.datadoghq.com/screen/integration/240/oracle-database---overview"},
-            "monitors": {"cool-monitor": "link"},
+            "dashboards": {"oracle": "assets/dashboards/example.json"},
+            "monitors": {"cool-monitor": "assets/monitors/example.json"},
             "integration": {
                 "configuration": {"spec": "assets/configuration/spec.yaml"},
                 "events": {"creates_events": True},
@@ -252,12 +252,12 @@ IMMUTABLE_ATTRIBUTES_PREV_MANIFEST_INVALID = json.dumps(
     }
 )
 
-IMMUTABLE_ATTRIBUTES_CUR_MANIFEST_INVALID_SHORT_NAME = JSONDict(
+IMMUTABLE_ATTRIBUTES_INVALID_CHANGED_SHORT_NAME = JSONDict(
     {
         "app_id": "datadog-oracle",
         "assets": {
-            "dashboards": {"oracle": "https://app.datadoghq.com/screen/integration/240/oracle-dash"},
-            "monitors": {"cool-monitor-dog": "link"},
+            "dashboards": {"oracle": "assets/dashboards/example.json"},
+            "monitors": {"cool-monitor-dog": "assets/monitors/example.json"},
             "integration": {
                 "configuration": {"spec": "assets/configuration/spec.yaml"},
                 "events": {"creates_events": True},
@@ -304,9 +304,9 @@ IMMUTABLE_ATTRIBUTES_CUR_MANIFEST_INVALID_SHORT_NAME = JSONDict(
 
 IMMUTABLE_ATTRIBUTES_CURRENT_MANIFEST_INVALID = JSONDict(
     {
-        "app_id": "datadog-oracle-failure",
+        "app_id": "datadog-oracle-changed-name",
         "assets": {
-            "dashboards": {"oracle": "https://app.datadoghq.com/screen/integration/240/oracle-database---overview"},
+            "dashboards": {"oracle": "assets/dashboards/example.json"},
             "integration": {
                 "configuration": {"spec": "assets/configuration/spec.yaml"},
                 "events": {"creates_events": True},
@@ -355,8 +355,8 @@ IMMUTABLE_ATTRIBUTES_CURRENT_MANIFEST_VALID = JSONDict(
     {
         "app_id": "datadog-oracle",
         "assets": {
-            "dashboards": {"oracle": "https://app.datadoghq.com/screen/integration/240/oracle-database---overview"},
-            "monitors": {"cool-monitor": "link"},
+            "dashboards": {"oracle": "assets/dashboards/example.json"},
+            "monitors": {"cool-monitor": "assets/monitors/example.json"},
             "integration": {
                 "configuration": {"spec": "assets/configuration/spec.yaml"},
                 "events": {"creates_events": True},

--- a/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
@@ -1,405 +1,64 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import json
-
 from datadog_checks.dev.tooling.datastructures import JSONDict
 
 # This file contains the constants used for V2 manifest validator testing
 
 ORACLE_METADATA_CSV_EXAMPLE = [(0, {"metric_name": "oracle.session_count"})]
 
-V2_MANIFEST_ALL_PASS = JSONDict(
-    {
-        "app_id": "datadog-oracle",
-        "assets": {
-            "dashboards": {"oracle": "assets/dashboards/example.json"},
-            "integration": {
-                "configuration": {"spec": "assets/configuration/spec.yaml"},
-                "events": {"creates_events": True},
-                "id": "oracle",
-                "metrics": {
-                    "auto_install": True,
-                    "check": "oracle.session_count",
-                    "metadata_path": "metrics_metadata.csv",
-                    "prefix": "oracle.",
-                },
-                "service_checks": {"metadata_path": "assets/service_checks.json"},
-                "source_type_name": "Oracle Database",
+V2_VALID_MANIFEST = {
+    "app_id": "datadog-oracle",
+    "assets": {
+        "dashboards": {"oracle": "assets/dashboards/example.json"},
+        "integration": {
+            "configuration": {"spec": "assets/configuration/spec.yaml"},
+            "events": {"creates_events": True},
+            "id": "oracle",
+            "metrics": {
+                "auto_install": True,
+                "check": "oracle.session_count",
+                "metadata_path": "metrics_metadata.csv",
+                "prefix": "oracle.",
             },
+            "service_checks": {"metadata_path": "assets/service_checks.json"},
+            "source_type_name": "Oracle Database",
         },
-        "author": {
-            "homepage": "https://www.datadoghq.com",
-            "name": "Datadog",
-            "sales_email": "help@datadoghq.com",
-            "support_email": "help@datadoghq.com",
-        },
-        "display_on_public_website": True,
-        "legal_terms": {},
-        "manifest_version": "2.0.0",
-        "oauth": {},
-        "pricing": [{"billing_type": "free"}],
-        "tile": {
-            "changelog": "CHANGELOG.md",
-            "classifier_tags": [
-                "Category::Marketplace",
-                "Category::Cloud",
-                "Category::Log Collection",
-                "Supported OS::Windows",
-                "Supported OS::Mac OS",
-                "Offering::Integration",
-                "Offering::UI Extension",
-            ],
-            "configuration": "README.md#Setup",
-            "description": "Oracle relational database system designed for enterprise grid computing",
-            "media": [],
-            "overview": "README.md#Overview",
-            "title": "Oracle",
-        },
-    }
-)
+    },
+    "author": {
+        "homepage": "https://www.datadoghq.com",
+        "name": "Datadog",
+        "sales_email": "help@datadoghq.com",
+        "support_email": "help@datadoghq.com",
+    },
+    "display_on_public_website": True,
+    "legal_terms": {},
+    "manifest_version": "2.0.0",
+    "oauth": {},
+    "pricing": [{"billing_type": "free"}],
+    "tile": {
+        "changelog": "CHANGELOG.md",
+        "classifier_tags": [
+            "Category::Marketplace",
+            "Category::Cloud",
+            "Category::Log Collection",
+            "Supported OS::Windows",
+            "Supported OS::Mac OS",
+            "Offering::Integration",
+            "Offering::UI Extension",
+        ],
+        "configuration": "README.md#Setup",
+        "description": "Oracle relational database system designed for enterprise grid computing",
+        "media": [],
+        "overview": "README.md#Overview",
+        "title": "Oracle",
+    },
+}
 
-INCORRECT_MAINTAINER_MANIFEST = JSONDict(
-    {
-        "author": {
-            "homepage": "https://www.datadoghq.com",
-            "name": "Datadog",
-            "sales_email": "help@datadoghq.com",
-            "support_email": "stupidemail@fake.com",
-        },
-    }
-)
-
-INVALID_MAINTAINER_MANIFEST = JSONDict(
-    {
-        "author": {
-            "homepage": "https://www.datadoghq.com",
-            "name": "Datadog",
-            "sales_email": "help@datadoghq.com",
-            "support_email": "ǨĽŇŘŠŤŽ@invalid.com",
-        },
-    }
-)
-
-CORRECT_MAINTAINER_MANIFEST = JSONDict(
-    {
-        "author": {
-            "homepage": "https://www.datadoghq.com",
-            "name": "Datadog",
-            "sales_email": "help@datadoghq.com",
-            "support_email": "help@datadoghq.com",
-        }
-    }
-)
-
-FILE_EXISTS_NOT_IN_MANIFEST = JSONDict(
-    {
-        "assets": {
-            "integration": {
-                "metrics": {
-                    "auto_install": True,
-                    "check": "oracle.session_count",
-                    "metadata_path": "",
-                    "prefix": "oracle.",
-                },
-            },
-        },
-    }
-)
-
-FILE_IN_MANIFEST_DOES_NOT_EXIST = JSONDict(
-    {
-        "assets": {
-            "integration": {
-                "metrics": {
-                    "auto_install": True,
-                    "check": "oracle.session_count",
-                    "metadata_path": "fake_metadata_file.csv",
-                    "prefix": "oracle.",
-                },
-            },
-        },
-    }
-)
-
-CORRECT_METADATA_FILE_MANIFEST = JSONDict(
-    {
-        "assets": {
-            "integration": {
-                "metrics": {
-                    "auto_install": True,
-                    "check": "oracle.session_count",
-                    "metadata_path": "metrics_metadata.csv",
-                    "prefix": "oracle.",
-                },
-            },
-        },
-    }
-)
-
-CHECK_NOT_IN_METADATA_MANIFEST = JSONDict(
-    {
-        "assets": {
-            "integration": {
-                "metrics": {
-                    "auto_install": True,
-                    "check": "oracle.session_count",
-                    "metadata_path": "metrics_metadata.csv",
-                    "prefix": "oracle.",
-                },
-            },
-        },
-    }
-)
-
-CHECK_NOT_IN_MANIFEST = JSONDict(
-    {
-        "assets": {
-            "integration": {
-                "metrics": {
-                    "auto_install": True,
-                    "check": "",
-                    "metadata_path": "metrics_metadata.csv",
-                    "prefix": "oracle.",
-                },
-            },
-        },
-    }
-)
-
-CORRECT_CHECK_IN_METADATA_MANIFEST = JSONDict(
-    {
-        "assets": {
-            "integration": {
-                "metrics": {
-                    "auto_install": True,
-                    "check": "oracle.session_count",
-                    "metadata_path": "metrics_metadata.csv",
-                    "prefix": "oracle.",
-                },
-            },
-        },
-    }
-)
-
-HAS_LOGS_NO_TAG_MANIFEST = JSONDict(
-    {
-        "tile": {
-            "classifier_tags": [
-                "Category::Marketplace",
-                "Offering::Integration",
-                "Offering::UI Extension",
-            ],
-        },
-    }
-)
-
-DISPLAY_ON_PUBLIC_INVALID_MANIFEST = JSONDict({"app_id": "datadog-oracle"})
-
-DISPLAY_ON_PUBLIC_VALID_MANIFEST = JSONDict({"display_on_public_website": True})
 
 IMMUTABLE_ATTRIBUTES_V1_MANIFEST = {"manifest_version": "1.0.0"}
 
 IMMUTABLE_ATTRIBUTES_V2_MANIFEST = JSONDict({"manifest_version": "2.0.0"})
-
-IMMUTABLE_ATTRIBUTES_VALID_MANIFEST = json.dumps(
-    {
-        "app_id": "datadog-oracle",
-        "assets": {
-            "dashboards": {"oracle": "assets/dashboards/example.json"},
-            "monitors": {"cool-monitor": "assets/monitors/example.json"},
-            "integration": {
-                "configuration": {"spec": "assets/configuration/spec.yaml"},
-                "events": {"creates_events": True},
-                "id": "oracle",
-                "metrics": {
-                    "auto_install": True,
-                    "check": "oracle.session_count",
-                    "metadata_path": "metrics_metadata.csv",
-                    "prefix": "oracle.",
-                },
-                "service_checks": {"metadata_path": "assets/service_checks.json"},
-                "source_type_name": "Oracle Database",
-            },
-        },
-        "author": {
-            "homepage": "https://www.datadoghq.com",
-            "name": "Datadog",
-            "sales_email": "help@datadoghq.com",
-            "support_email": "help@datadoghq.com",
-        },
-        "display_on_public_website": True,
-        "legal_terms": {},
-        "manifest_version": "2.0.0",
-        "oauth": {},
-        "pricing": [{"billing_type": "free"}],
-        "tile": {
-            "changelog": "CHANGELOG.md",
-            "classifier_tags": [
-                "Category::Marketplace",
-                "Category::Cloud",
-                "Supported OS::Windows",
-                "Supported OS::Mac OS",
-                "Offering::Integration",
-                "Offering::UI Extension",
-            ],
-            "configuration": "README.md#Setup",
-            "description": "Oracle relational database system designed for enterprise grid computing",
-            "media": [],
-            "overview": "README.md#Overview",
-            "title": "Oracle",
-        },
-    }
-)
-
-IMMUTABLE_ATTRIBUTES_INVALID_CHANGED_SHORT_NAME = JSONDict(
-    {
-        "app_id": "datadog-oracle",
-        "assets": {
-            "dashboards": {"oracle": "assets/dashboards/example.json"},
-            "monitors": {"cool-monitor-dog": "assets/monitors/example.json"},
-            "integration": {
-                "configuration": {"spec": "assets/configuration/spec.yaml"},
-                "events": {"creates_events": True},
-                "id": "oracle",
-                "metrics": {
-                    "auto_install": True,
-                    "check": "oracle.session_count",
-                    "metadata_path": "metrics_metadata.csv",
-                    "prefix": "oracle.",
-                },
-                "service_checks": {"metadata_path": "assets/service_checks.json"},
-                "source_type_name": "Oracle Database",
-            },
-        },
-        "author": {
-            "homepage": "https://www.datadoghq.com",
-            "name": "Datadog",
-            "sales_email": "help@datadoghq.com",
-            "support_email": "help@datadoghq.com",
-        },
-        "display_on_public_website": True,
-        "legal_terms": {},
-        "manifest_version": "2.0.0",
-        "oauth": {},
-        "pricing": [{"billing_type": "free"}],
-        "tile": {
-            "changelog": "CHANGELOG.md",
-            "classifier_tags": [
-                "Category::Marketplace",
-                "Category::Cloud",
-                "Supported OS::Windows",
-                "Supported OS::Mac OS",
-                "Offering::Integration",
-                "Offering::UI Extension",
-            ],
-            "configuration": "README.md#Setup",
-            "description": "Oracle relational database system designed for enterprise grid computing",
-            "media": [],
-            "overview": "README.md#Overview",
-            "title": "Oracle",
-        },
-    }
-)
-
-IMMUTABLE_ATTRIBUTES_CURRENT_MANIFEST_INVALID = JSONDict(
-    {
-        "app_id": "datadog-oracle-changed-name",
-        "assets": {
-            "dashboards": {"oracle": "assets/dashboards/example.json"},
-            "integration": {
-                "configuration": {"spec": "assets/configuration/spec.yaml"},
-                "events": {"creates_events": True},
-                "id": "oracle",
-                "metrics": {
-                    "auto_install": True,
-                    "check": "oracle.session_count",
-                    "metadata_path": "metrics_metadata.csv",
-                    "prefix": "oracle.",
-                },
-                "service_checks": {"metadata_path": "assets/service_checks.json"},
-                "source_type_name": "Oracle Database",
-            },
-        },
-        "author": {
-            "homepage": "https://www.datadoghq.com",
-            "name": "Datadog",
-            "sales_email": "help@datadoghq.com",
-            "support_email": "help@datadoghq.com",
-        },
-        "display_on_public_website": True,
-        "legal_terms": {},
-        "manifest_version": "2.0.0",
-        "oauth": {},
-        "pricing": [{"billing_type": "free"}],
-        "tile": {
-            "changelog": "CHANGELOG.md",
-            "classifier_tags": [
-                "Category::Marketplace",
-                "Category::Cloud",
-                "Supported OS::Windows",
-                "Supported OS::Mac OS",
-                "Offering::Integration",
-                "Offering::UI Extension",
-            ],
-            "configuration": "README.md#Setup",
-            "description": "Oracle relational database system designed for enterprise grid computing",
-            "media": [],
-            "overview": "README.md#Overview",
-            "title": "Oracle",
-        },
-    }
-)
-
-IMMUTABLE_ATTRIBUTES_CURRENT_MANIFEST_VALID = JSONDict(
-    {
-        "app_id": "datadog-oracle",
-        "assets": {
-            "dashboards": {"oracle": "assets/dashboards/example.json"},
-            "monitors": {"cool-monitor": "assets/monitors/example.json"},
-            "integration": {
-                "configuration": {"spec": "assets/configuration/spec.yaml"},
-                "events": {"creates_events": True},
-                "id": "oracle",
-                "metrics": {
-                    "auto_install": True,
-                    "check": "oracle.session_count",
-                    "metadata_path": "metrics_metadata.csv",
-                    "prefix": "oracle.",
-                },
-                "service_checks": {"metadata_path": "assets/service_checks.json"},
-                "source_type_name": "Oracle Database",
-            },
-        },
-        "author": {
-            "homepage": "https://www.datadoghq.com",
-            "name": "Datadog",
-            "sales_email": "help@datadoghq.com",
-            "support_email": "help@datadoghq.com",
-        },
-        "display_on_public_website": True,
-        "legal_terms": {},
-        "manifest_version": "2.0.0",
-        "oauth": {},
-        "pricing": [{"billing_type": "free"}],
-        "tile": {
-            "changelog": "CHANGELOG.md",
-            "classifier_tags": [
-                "Category::Marketplace",
-                "Category::Cloud",
-                "Supported OS::Windows",
-                "Supported OS::Mac OS",
-                "Offering::Integration",
-                "Offering::UI Extension",
-            ],
-            "configuration": "README.md#Setup",
-            "description": "Oracle relational database system designed for enterprise grid computing",
-            "media": [],
-            "overview": "README.md#Overview",
-            "title": "Oracle",
-        },
-    }
-)
 
 
 class MockedResponseInvalid:

--- a/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+
 from datadog_checks.dev.tooling.datastructures import JSONDict
 
 # This file contains the constants used for V2 manifest validator testing
@@ -196,11 +198,208 @@ DISPLAY_ON_PUBLIC_INVALID_MANIFEST = JSONDict({"app_id": "datadog-oracle"})
 
 DISPLAY_ON_PUBLIC_VALID_MANIFEST = JSONDict({"display_on_public_website": True})
 
-INVALID_DIFF = 'app_id id'
+IMMUTABLE_ATTRIBUTES_V1_MANIFEST = {"manifest_version": "1.0.0"}
 
-VERSION_UPGRADE_DIFF = '+ "manifest_version": "2.0.0",'
+IMMUTABLE_ATTRIBUTES_V2_MANIFEST = JSONDict({"manifest_version": "2.0.0"})
 
-VALID_DIFF = 'new file'
+IMMUTABLE_ATTRIBUTES_PREV_MANIFEST_INVALID = json.dumps(
+    {
+        "app_id": "datadog-oracle",
+        "assets": {
+            "dashboards": {"oracle": "https://app.datadoghq.com/screen/integration/240/oracle-database---overview"},
+            "monitors": {"cool-monitor": "link"},
+            "integration": {
+                "configuration": {"spec": "assets/configuration/spec.yaml"},
+                "events": {"creates_events": True},
+                "id": "oracle",
+                "metrics": {
+                    "auto_install": True,
+                    "check": "oracle.session_count",
+                    "metadata_path": "metrics_metadata.csv",
+                    "prefix": "oracle.",
+                },
+                "service_checks": {"metadata_path": "assets/service_checks.json"},
+                "source_type_name": "Oracle Database",
+            },
+        },
+        "author": {
+            "homepage": "https://www.datadoghq.com",
+            "name": "Datadog",
+            "sales_email": "help@datadoghq.com",
+            "support_email": "help@datadoghq.com",
+        },
+        "display_on_public_website": True,
+        "legal_terms": {},
+        "manifest_version": "2.0.0",
+        "oauth": {},
+        "pricing": [{"billing_type": "free"}],
+        "tile": {
+            "changelog": "CHANGELOG.md",
+            "classifier_tags": [
+                "Category::Marketplace",
+                "Category::Cloud",
+                "Supported OS::Windows",
+                "Supported OS::Mac OS",
+                "Offering::Integration",
+                "Offering::UI Extension",
+            ],
+            "configuration": "README.md#Setup",
+            "description": "Oracle relational database system designed for enterprise grid computing",
+            "media": [],
+            "overview": "README.md#Overview",
+            "title": "Oracle",
+        },
+    }
+)
+
+IMMUTABLE_ATTRIBUTES_CUR_MANIFEST_INVALID_SHORT_NAME = JSONDict(
+    {
+        "app_id": "datadog-oracle",
+        "assets": {
+            "dashboards": {"oracle": "https://app.datadoghq.com/screen/integration/240/oracle-dash"},
+            "monitors": {"cool-monitor-dog": "link"},
+            "integration": {
+                "configuration": {"spec": "assets/configuration/spec.yaml"},
+                "events": {"creates_events": True},
+                "id": "oracle",
+                "metrics": {
+                    "auto_install": True,
+                    "check": "oracle.session_count",
+                    "metadata_path": "metrics_metadata.csv",
+                    "prefix": "oracle.",
+                },
+                "service_checks": {"metadata_path": "assets/service_checks.json"},
+                "source_type_name": "Oracle Database",
+            },
+        },
+        "author": {
+            "homepage": "https://www.datadoghq.com",
+            "name": "Datadog",
+            "sales_email": "help@datadoghq.com",
+            "support_email": "help@datadoghq.com",
+        },
+        "display_on_public_website": True,
+        "legal_terms": {},
+        "manifest_version": "2.0.0",
+        "oauth": {},
+        "pricing": [{"billing_type": "free"}],
+        "tile": {
+            "changelog": "CHANGELOG.md",
+            "classifier_tags": [
+                "Category::Marketplace",
+                "Category::Cloud",
+                "Supported OS::Windows",
+                "Supported OS::Mac OS",
+                "Offering::Integration",
+                "Offering::UI Extension",
+            ],
+            "configuration": "README.md#Setup",
+            "description": "Oracle relational database system designed for enterprise grid computing",
+            "media": [],
+            "overview": "README.md#Overview",
+            "title": "Oracle",
+        },
+    }
+)
+
+IMMUTABLE_ATTRIBUTES_CURRENT_MANIFEST_INVALID = JSONDict(
+    {
+        "app_id": "datadog-oracle-failure",
+        "assets": {
+            "dashboards": {"oracle": "https://app.datadoghq.com/screen/integration/240/oracle-database---overview"},
+            "integration": {
+                "configuration": {"spec": "assets/configuration/spec.yaml"},
+                "events": {"creates_events": True},
+                "id": "oracle",
+                "metrics": {
+                    "auto_install": True,
+                    "check": "oracle.session_count",
+                    "metadata_path": "metrics_metadata.csv",
+                    "prefix": "oracle.",
+                },
+                "service_checks": {"metadata_path": "assets/service_checks.json"},
+                "source_type_name": "Oracle Database",
+            },
+        },
+        "author": {
+            "homepage": "https://www.datadoghq.com",
+            "name": "Datadog",
+            "sales_email": "help@datadoghq.com",
+            "support_email": "help@datadoghq.com",
+        },
+        "display_on_public_website": True,
+        "legal_terms": {},
+        "manifest_version": "2.0.0",
+        "oauth": {},
+        "pricing": [{"billing_type": "free"}],
+        "tile": {
+            "changelog": "CHANGELOG.md",
+            "classifier_tags": [
+                "Category::Marketplace",
+                "Category::Cloud",
+                "Supported OS::Windows",
+                "Supported OS::Mac OS",
+                "Offering::Integration",
+                "Offering::UI Extension",
+            ],
+            "configuration": "README.md#Setup",
+            "description": "Oracle relational database system designed for enterprise grid computing",
+            "media": [],
+            "overview": "README.md#Overview",
+            "title": "Oracle",
+        },
+    }
+)
+
+IMMUTABLE_ATTRIBUTES_CURRENT_MANIFEST_VALID = JSONDict(
+    {
+        "app_id": "datadog-oracle",
+        "assets": {
+            "dashboards": {"oracle": "https://app.datadoghq.com/screen/integration/240/oracle-database---overview"},
+            "monitors": {"cool-monitor": "link"},
+            "integration": {
+                "configuration": {"spec": "assets/configuration/spec.yaml"},
+                "events": {"creates_events": True},
+                "id": "oracle",
+                "metrics": {
+                    "auto_install": True,
+                    "check": "oracle.session_count",
+                    "metadata_path": "metrics_metadata.csv",
+                    "prefix": "oracle.",
+                },
+                "service_checks": {"metadata_path": "assets/service_checks.json"},
+                "source_type_name": "Oracle Database",
+            },
+        },
+        "author": {
+            "homepage": "https://www.datadoghq.com",
+            "name": "Datadog",
+            "sales_email": "help@datadoghq.com",
+            "support_email": "help@datadoghq.com",
+        },
+        "display_on_public_website": True,
+        "legal_terms": {},
+        "manifest_version": "2.0.0",
+        "oauth": {},
+        "pricing": [{"billing_type": "free"}],
+        "tile": {
+            "changelog": "CHANGELOG.md",
+            "classifier_tags": [
+                "Category::Marketplace",
+                "Category::Cloud",
+                "Supported OS::Windows",
+                "Supported OS::Mac OS",
+                "Offering::Integration",
+                "Offering::UI Extension",
+            ],
+            "configuration": "README.md#Setup",
+            "description": "Oracle relational database system designed for enterprise grid computing",
+            "media": [],
+            "overview": "README.md#Overview",
+            "title": "Oracle",
+        },
+    }
+)
 
 
 class MockedResponseInvalid:

--- a/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
@@ -1,7 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
 import os
+from copy import deepcopy
 from pathlib import Path
 
 import mock
@@ -11,8 +13,30 @@ import tests.tooling.manifest_validator.input_constants as input_constants
 import datadog_checks.dev.tooling.manifest_validator.common.validator as common
 import datadog_checks.dev.tooling.manifest_validator.v2.validator as v2_validators
 from datadog_checks.dev.tooling.constants import get_root, set_root
+from datadog_checks.dev.tooling.datastructures import JSONDict
 from datadog_checks.dev.tooling.manifest_validator import get_all_validators
 from datadog_checks.dev.tooling.manifest_validator.constants import V2
+
+
+# Helpers
+def get_changed_immutable_short_name_manifest():
+    """
+    Helper function to change immutable short names in a manifest
+    """
+    immutable_attributes_changed_short_name = JSONDict(deepcopy(input_constants.V2_VALID_MANIFEST))
+    immutable_attributes_changed_short_name['assets']['dashboards'] = {
+        "oracle-changed": "assets/dashboards/example.json"
+    }
+    return immutable_attributes_changed_short_name
+
+
+def get_changed_immutable_attribute_manifest():
+    """
+    Helper function to change other immutable attributes in a manifest
+    """
+    immutable_attributes_changed_attribute = JSONDict(deepcopy(input_constants.V2_VALID_MANIFEST))
+    immutable_attributes_changed_attribute['app_id'] = 'datadog-oracle-changed'
+    return immutable_attributes_changed_attribute
 
 
 @pytest.fixture
@@ -29,23 +53,40 @@ def setup_route():
     'datadog_checks.dev.tooling.utils.read_metadata_rows', return_value=input_constants.ORACLE_METADATA_CSV_EXAMPLE
 )
 def test_manifest_v2_all_pass(_, setup_route):
+    """
+    Run a valid manifest through all V2 validators
+    """
     validators = get_all_validators(False, "2.0.0")
     for validator in validators:
         # Currently skipping SchemaValidator because of no context object and config
         if isinstance(validator, v2_validators.SchemaValidator):
             continue
 
-        validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+        validator.validate('active_directory', JSONDict(input_constants.V2_VALID_MANIFEST), False)
         assert not validator.result.failed, validator.result
         assert not validator.result.fixed
 
 
 def test_manifest_v2_maintainer_validator_incorrect_maintainer(setup_route):
+    """
+    Ensure MaintainerValidator fails if supplied an incorrect support_email
+    """
+    incorrect_maintainer_manifest = JSONDict(
+        {
+            "author": {
+                "homepage": "https://www.datadoghq.com",
+                "name": "Datadog",
+                "sales_email": "help@datadoghq.com",
+                "support_email": "fake_email@datadoghq.com",
+            },
+        }
+    )
+
     # Use specific validator
     validator = common.MaintainerValidator(
         is_extras=False, is_marketplace=False, check_in_extras=False, check_in_marketplace=False, version=V2
     )
-    validator.validate('active_directory', input_constants.INCORRECT_MAINTAINER_MANIFEST, False)
+    validator.validate('active_directory', incorrect_maintainer_manifest, False)
 
     # Assert test case
     assert validator.result.failed, validator.result
@@ -53,11 +94,25 @@ def test_manifest_v2_maintainer_validator_incorrect_maintainer(setup_route):
 
 
 def test_manifest_v2_maintainer_validator_invalid_maintainer(setup_route):
+    """
+    Ensure MaintainerValidator fails if supplied a support_email with non-ASCII characters
+    """
+    invalid_maintainer_manifest = JSONDict(
+        {
+            "author": {
+                "homepage": "https://www.datadoghq.com",
+                "name": "Datadog",
+                "sales_email": "help@datadoghq.com",
+                "support_email": "Ǩ_help@datadoghq.com",
+            },
+        }
+    )
+
     # Use specific validator
     validator = common.MaintainerValidator(
         is_extras=False, is_marketplace=False, check_in_extras=False, check_in_marketplace=False, version=V2
     )
-    validator.validate('active_directory', input_constants.INVALID_MAINTAINER_MANIFEST, False)
+    validator.validate('active_directory', invalid_maintainer_manifest, False)
 
     # Assert test case
     assert validator.result.failed, validator.result
@@ -69,7 +124,7 @@ def test_manifest_v2_maintainer_validator_correct_maintainer(setup_route):
     validator = common.MaintainerValidator(
         is_extras=False, is_marketplace=False, check_in_extras=False, check_in_marketplace=False, version=V2
     )
-    validator.validate('active_directory', input_constants.CORRECT_MAINTAINER_MANIFEST, False)
+    validator.validate('active_directory', JSONDict(input_constants.V2_VALID_MANIFEST), False)
 
     # Assert test case
     assert not validator.result.failed, validator.result
@@ -77,9 +132,26 @@ def test_manifest_v2_maintainer_validator_correct_maintainer(setup_route):
 
 
 def test_manifest_v2_metrics_metadata_validator_file_exists_not_in_manifest(setup_route):
+    """
+    Ensure MetricsMetadataValidator fails if supplied an empty metadata_path value
+    """
+    file_exists_not_in_manifest = JSONDict(
+        {
+            "assets": {
+                "integration": {
+                    "metrics": {
+                        "auto_install": True,
+                        "check": "oracle.session_count",
+                        "metadata_path": "",
+                        "prefix": "oracle.",
+                    },
+                },
+            },
+        }
+    )
     # Use specific validator
     validator = common.MetricsMetadataValidator(version=V2)
-    validator.validate('active_directory', input_constants.FILE_EXISTS_NOT_IN_MANIFEST, False)
+    validator.validate('active_directory', file_exists_not_in_manifest, False)
 
     # Assert test case
     assert validator.result.failed, validator.result
@@ -88,9 +160,26 @@ def test_manifest_v2_metrics_metadata_validator_file_exists_not_in_manifest(setu
 
 @mock.patch('os.path.isfile', return_value=False)
 def test_manifest_v2_metrics_metadata_validator_file_in_manifest_not_exist(_, setup_route):
+    """
+    Ensure MetricsMetadataValidator fails if supplied a path to a non-existant metadata.csv
+    """
+    file_in_manifest_does_not_exist = JSONDict(
+        {
+            "assets": {
+                "integration": {
+                    "metrics": {
+                        "auto_install": True,
+                        "check": "oracle.session_count",
+                        "metadata_path": "metrics_metadata1.csv",
+                        "prefix": "oracle.",
+                    },
+                },
+            },
+        }
+    )
     # Use specific validator
     validator = common.MetricsMetadataValidator(version=V2)
-    validator.validate('active_directory', input_constants.FILE_IN_MANIFEST_DOES_NOT_EXIST, False)
+    validator.validate('active_directory', file_in_manifest_does_not_exist, False)
 
     # Assert test case
     assert validator.result.failed, validator.result
@@ -103,7 +192,7 @@ def test_manifest_v2_metrics_metadata_validator_file_in_manifest_not_exist(_, se
 def test_manifest_v2_metrics_metadata_validator_correct_metadata(_, setup_route):
     # Use specific validator
     validator = common.MetricsMetadataValidator(version=V2)
-    validator.validate('active_directory', input_constants.CORRECT_METADATA_FILE_MANIFEST, False)
+    validator.validate('active_directory', JSONDict(input_constants.V2_VALID_MANIFEST), False)
 
     # Assert test case
     assert not validator.result.failed, validator.result
@@ -111,9 +200,27 @@ def test_manifest_v2_metrics_metadata_validator_correct_metadata(_, setup_route)
 
 
 def test_manifest_v2_metrics_to_check_validator_check_not_in_metadata(setup_route):
+    """
+    Ensure MetricToCheckValidator fails if the check value is not present in
+    the metadata.csv
+    """
+    check_not_in_metadata_csv = JSONDict(
+        {
+            "assets": {
+                "integration": {
+                    "metrics": {
+                        "auto_install": True,
+                        "check": "oracle.session_count",
+                        "metadata_path": "metrics_metadata.csv",
+                        "prefix": "oracle.",
+                    },
+                },
+            },
+        }
+    )
     # Use specific validator
     validator = common.MetricToCheckValidator(version=V2)
-    validator.validate('active_directory', input_constants.CHECK_NOT_IN_METADATA_MANIFEST, False)
+    validator.validate('active_directory', check_not_in_metadata_csv, False)
 
     # Assert test case
     assert validator.result.failed, validator.result
@@ -121,9 +228,27 @@ def test_manifest_v2_metrics_to_check_validator_check_not_in_metadata(setup_rout
 
 
 def test_manifest_v2_metrics_to_check_validator_check_not_in_manifest(setup_route):
+    """
+    Ensure MetricToCheckValidator fails if supplied an empty check value
+    """
+    check_not_in_manifest = JSONDict(
+        {
+            "assets": {
+                "integration": {
+                    "metrics": {
+                        "auto_install": True,
+                        "check": "",
+                        "metadata_path": "metrics_metadata.csv",
+                        "prefix": "oracle.",
+                    },
+                },
+            },
+        }
+    )
+
     # Use specific validator
     validator = common.MetricToCheckValidator(version=V2)
-    validator.validate('active_directory', input_constants.CHECK_NOT_IN_MANIFEST, False)
+    validator.validate('active_directory', check_not_in_manifest, False)
 
     # Assert test case
     assert validator.result.failed, validator.result
@@ -136,7 +261,7 @@ def test_manifest_v2_metrics_to_check_validator_check_not_in_manifest(setup_rout
 def test_manifest_v2_metrics_metadata_validator_correct_check_in_metadata(_, setup_route):
     # Use specific validator
     validator = common.MetricToCheckValidator(version=V2)
-    validator.validate('active_directory', input_constants.CORRECT_CHECK_IN_METADATA_MANIFEST, False)
+    validator.validate('active_directory', JSONDict(input_constants.V2_VALID_MANIFEST), False)
 
     # Assert test case
     assert not validator.result.failed, validator.result
@@ -145,9 +270,24 @@ def test_manifest_v2_metrics_metadata_validator_correct_check_in_metadata(_, set
 
 @mock.patch('datadog_checks.dev.tooling.utils.has_logs', return_value=True)
 def test_manifest_v2_logs_category_validator_has_logs_no_tag(_, setup_route):
+    """
+    Ensure LogsCategoryValidator fails if the integration has logs but no Log Collection tag
+    """
+    has_logs_no_tag_manifest = JSONDict(
+        {
+            "tile": {
+                "classifier_tags": [
+                    "Category::Marketplace",
+                    "Offering::Integration",
+                    "Offering::UI Extension",
+                ],
+            },
+        }
+    )
+
     # Use specific validator
     validator = common.LogsCategoryValidator(version=V2)
-    validator.validate('active_directory', input_constants.HAS_LOGS_NO_TAG_MANIFEST, False)
+    validator.validate('active_directory', has_logs_no_tag_manifest, False)
 
     # Assert test case
     assert validator.result.failed, validator.result
@@ -158,7 +298,7 @@ def test_manifest_v2_logs_category_validator_has_logs_no_tag(_, setup_route):
 def test_manifest_v2_logs_category_validator_correct_has_logs_correct_tag(_, setup_route):
     # Use specific validator
     validator = common.LogsCategoryValidator(version=V2)
-    validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+    validator.validate('active_directory', JSONDict(input_constants.V2_VALID_MANIFEST), False)
 
     # Assert test case
     assert not validator.result.failed, validator.result
@@ -166,9 +306,14 @@ def test_manifest_v2_logs_category_validator_correct_has_logs_correct_tag(_, set
 
 
 def test_manifest_v2_display_on_public_validator_invalid(setup_route):
+    """
+    Ensure DisplayOnPublicValidator fails if the display_on_public_website attribute is not True
+    """
+    display_on_public_invalid_manifest = JSONDict({"app_id": "datadog-oracle"})
+
     # Use specific validator
     validator = v2_validators.DisplayOnPublicValidator(version=V2)
-    validator.validate('active_directory', input_constants.DISPLAY_ON_PUBLIC_INVALID_MANIFEST, False)
+    validator.validate('active_directory', display_on_public_invalid_manifest, False)
 
     # Assert test case
     assert validator.result.failed, validator.result
@@ -176,9 +321,11 @@ def test_manifest_v2_display_on_public_validator_invalid(setup_route):
 
 
 def test_manifest_v2_display_on_public_validator_valid(setup_route):
+    display_on_public_valid_manifest = JSONDict({"display_on_public_website": True})
+
     # Use specific validator
     validator = v2_validators.DisplayOnPublicValidator(version=V2)
-    validator.validate('active_directory', input_constants.DISPLAY_ON_PUBLIC_VALID_MANIFEST, False)
+    validator.validate('active_directory', display_on_public_valid_manifest, False)
 
     # Assert test case
     assert not validator.result.failed, validator.result
@@ -187,9 +334,12 @@ def test_manifest_v2_display_on_public_validator_valid(setup_route):
 
 @mock.patch('requests.post', return_value=input_constants.MockedResponseInvalid())
 def test_manifest_v2_schema_validator_manifest_invalid(_, setup_route):
+    """
+    Ensure SchemaValidator fails if a 400 status_code is received from request
+    """
     # Use specific validator
     validator = v2_validators.SchemaValidator(ctx=input_constants.MockedContextObj(), version=V2, skip_if_errors=False)
-    validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+    validator.validate('active_directory', JSONDict(input_constants.V2_VALID_MANIFEST), False)
 
     # Assert test case
     assert validator.result.failed, validator.result
@@ -200,7 +350,7 @@ def test_manifest_v2_schema_validator_manifest_invalid(_, setup_route):
 def test_manifest_v2_schema_validator_manifest_valid(_, setup_route):
     # Use specific validator
     validator = v2_validators.SchemaValidator(ctx=input_constants.MockedContextObj(), version=V2, skip_if_errors=False)
-    validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+    validator.validate('active_directory', JSONDict(input_constants.V2_VALID_MANIFEST), False)
 
     # Assert test case
     assert not validator.result.failed, validator.result
@@ -209,12 +359,15 @@ def test_manifest_v2_schema_validator_manifest_valid(_, setup_route):
 
 @mock.patch(
     'datadog_checks.dev.tooling.manifest_validator.common.validator.git_show_file',
-    return_value=input_constants.IMMUTABLE_ATTRIBUTES_VALID_MANIFEST,
+    return_value=json.dumps(input_constants.V2_VALID_MANIFEST),
 )
 def test_manifest_v2_immutable_attributes_validator_invalid_attribute_change(_, setup_route):
+    """
+    Ensure ImmutableAttributesValidator fails if an immutable attribute is changed
+    """
     # Use specific validator
     validator = common.ImmutableAttributesValidator(version=V2)
-    validator.validate('active_directory', input_constants.IMMUTABLE_ATTRIBUTES_CURRENT_MANIFEST_INVALID, False)
+    validator.validate('active_directory', JSONDict(get_changed_immutable_attribute_manifest()), False)
 
     # Assert test case
     assert validator.result.failed, validator.result
@@ -223,12 +376,15 @@ def test_manifest_v2_immutable_attributes_validator_invalid_attribute_change(_, 
 
 @mock.patch(
     'datadog_checks.dev.tooling.manifest_validator.common.validator.git_show_file',
-    return_value=input_constants.IMMUTABLE_ATTRIBUTES_VALID_MANIFEST,
+    return_value=json.dumps(input_constants.V2_VALID_MANIFEST),
 )
 def test_manifest_v2_immutable_attributes_validator_invalid_short_name_change(_, setup_route):
+    """
+    Ensure ImmutableAttributesValidator fails if the short name of an asset is changed
+    """
     # Use specific validator
     validator = common.ImmutableAttributesValidator(version=V2)
-    validator.validate('active_directory', input_constants.IMMUTABLE_ATTRIBUTES_INVALID_CHANGED_SHORT_NAME, False)
+    validator.validate('active_directory', JSONDict(get_changed_immutable_short_name_manifest()), False)
 
     # Assert test case
     assert validator.result.failed, validator.result
@@ -240,6 +396,9 @@ def test_manifest_v2_immutable_attributes_validator_invalid_short_name_change(_,
     return_value=input_constants.IMMUTABLE_ATTRIBUTES_V1_MANIFEST,
 )
 def test_manifest_v2_immutable_attributes_validator_version_upgrade(_, setup_route):
+    """
+    Ensure ImmutableAttributesValidator skips validations if the manifest is being upgraded from v1 to v2
+    """
     # Use specific validator
     validator = common.ImmutableAttributesValidator(version=V2)
     validator.validate('active_directory', input_constants.IMMUTABLE_ATTRIBUTES_V2_MANIFEST, False)
@@ -251,12 +410,12 @@ def test_manifest_v2_immutable_attributes_validator_version_upgrade(_, setup_rou
 
 @mock.patch(
     'datadog_checks.dev.tooling.manifest_validator.common.validator.git_show_file',
-    return_value=input_constants.IMMUTABLE_ATTRIBUTES_VALID_MANIFEST,
+    return_value=json.dumps(input_constants.V2_VALID_MANIFEST),
 )
 def test_manifest_v2_immutable_attributes_validator_valid_change(_, setup_route):
     # Use specific validator
     validator = common.ImmutableAttributesValidator(version=V2)
-    validator.validate('active_directory', input_constants.IMMUTABLE_ATTRIBUTES_CURRENT_MANIFEST_VALID, False)
+    validator.validate('active_directory', JSONDict(input_constants.V2_VALID_MANIFEST), False)
 
     # Assert test case
     assert not validator.result.failed, validator.result

--- a/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
@@ -209,7 +209,7 @@ def test_manifest_v2_schema_validator_manifest_valid(_, setup_route):
 
 @mock.patch(
     'datadog_checks.dev.tooling.manifest_validator.common.validator.git_show_file',
-    return_value=input_constants.IMMUTABLE_ATTRIBUTES_PREV_MANIFEST_INVALID,
+    return_value=input_constants.IMMUTABLE_ATTRIBUTES_VALID_MANIFEST,
 )
 def test_manifest_v2_immutable_attributes_validator_invalid_attribute_change(_, setup_route):
     # Use specific validator
@@ -223,12 +223,12 @@ def test_manifest_v2_immutable_attributes_validator_invalid_attribute_change(_, 
 
 @mock.patch(
     'datadog_checks.dev.tooling.manifest_validator.common.validator.git_show_file',
-    return_value=input_constants.IMMUTABLE_ATTRIBUTES_PREV_MANIFEST_INVALID,
+    return_value=input_constants.IMMUTABLE_ATTRIBUTES_VALID_MANIFEST,
 )
 def test_manifest_v2_immutable_attributes_validator_invalid_short_name_change(_, setup_route):
     # Use specific validator
     validator = common.ImmutableAttributesValidator(version=V2)
-    validator.validate('active_directory', input_constants.IMMUTABLE_ATTRIBUTES_CUR_MANIFEST_INVALID_SHORT_NAME, False)
+    validator.validate('active_directory', input_constants.IMMUTABLE_ATTRIBUTES_INVALID_CHANGED_SHORT_NAME, False)
 
     # Assert test case
     assert validator.result.failed, validator.result
@@ -251,7 +251,7 @@ def test_manifest_v2_immutable_attributes_validator_version_upgrade(_, setup_rou
 
 @mock.patch(
     'datadog_checks.dev.tooling.manifest_validator.common.validator.git_show_file',
-    return_value=input_constants.IMMUTABLE_ATTRIBUTES_PREV_MANIFEST_INVALID,
+    return_value=input_constants.IMMUTABLE_ATTRIBUTES_VALID_MANIFEST,
 )
 def test_manifest_v2_immutable_attributes_validator_valid_change(_, setup_route):
     # Use specific validator

--- a/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
@@ -208,13 +208,13 @@ def test_manifest_v2_schema_validator_manifest_valid(_, setup_route):
 
 
 @mock.patch(
-    'datadog_checks.dev.tooling.manifest_validator.common.validator.content_changed',
-    return_value=input_constants.INVALID_DIFF,
+    'datadog_checks.dev.tooling.manifest_validator.common.validator.git_show_file',
+    return_value=input_constants.IMMUTABLE_ATTRIBUTES_PREV_MANIFEST_INVALID,
 )
-def test_manifest_v2_immutable_attributes_validator_invalid_change(_, setup_route):
+def test_manifest_v2_immutable_attributes_validator_invalid_attribute_change(_, setup_route):
     # Use specific validator
     validator = common.ImmutableAttributesValidator(version=V2)
-    validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+    validator.validate('active_directory', input_constants.IMMUTABLE_ATTRIBUTES_CURRENT_MANIFEST_INVALID, False)
 
     # Assert test case
     assert validator.result.failed, validator.result
@@ -222,13 +222,27 @@ def test_manifest_v2_immutable_attributes_validator_invalid_change(_, setup_rout
 
 
 @mock.patch(
-    'datadog_checks.dev.tooling.manifest_validator.common.validator.content_changed',
-    return_value=input_constants.VERSION_UPGRADE_DIFF,
+    'datadog_checks.dev.tooling.manifest_validator.common.validator.git_show_file',
+    return_value=input_constants.IMMUTABLE_ATTRIBUTES_PREV_MANIFEST_INVALID,
+)
+def test_manifest_v2_immutable_attributes_validator_invalid_short_name_change(_, setup_route):
+    # Use specific validator
+    validator = common.ImmutableAttributesValidator(version=V2)
+    validator.validate('active_directory', input_constants.IMMUTABLE_ATTRIBUTES_CUR_MANIFEST_INVALID_SHORT_NAME, False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+@mock.patch(
+    'datadog_checks.dev.tooling.manifest_validator.common.validator.git_show_file',
+    return_value=input_constants.IMMUTABLE_ATTRIBUTES_V1_MANIFEST,
 )
 def test_manifest_v2_immutable_attributes_validator_version_upgrade(_, setup_route):
     # Use specific validator
     validator = common.ImmutableAttributesValidator(version=V2)
-    validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+    validator.validate('active_directory', input_constants.IMMUTABLE_ATTRIBUTES_V2_MANIFEST, False)
 
     # Assert test case
     assert not validator.result.failed, validator.result
@@ -236,13 +250,13 @@ def test_manifest_v2_immutable_attributes_validator_version_upgrade(_, setup_rou
 
 
 @mock.patch(
-    'datadog_checks.dev.tooling.manifest_validator.common.validator.content_changed',
-    return_value=input_constants.VALID_DIFF,
+    'datadog_checks.dev.tooling.manifest_validator.common.validator.git_show_file',
+    return_value=input_constants.IMMUTABLE_ATTRIBUTES_PREV_MANIFEST_INVALID,
 )
 def test_manifest_v2_immutable_attributes_validator_valid_change(_, setup_route):
     # Use specific validator
     validator = common.ImmutableAttributesValidator(version=V2)
-    validator.validate('active_directory', input_constants.V2_MANIFEST_ALL_PASS, False)
+    validator.validate('active_directory', input_constants.IMMUTABLE_ATTRIBUTES_CURRENT_MANIFEST_VALID, False)
 
     # Assert test case
     assert not validator.result.failed, validator.result

--- a/datadog_checks_dev/tests/tooling/manifest_validator/test_validator.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/test_validator.py
@@ -10,6 +10,7 @@ from datadog_checks.dev.tooling.manifest_validator import get_all_validators
 
 
 def test_manifest_ok():
+    # fmt: off
     manifest = JSONDict(
         {
             "categories": ["os & system", "log collection"],
@@ -31,7 +32,11 @@ def test_manifest_ok():
             "integration_id": "active-directory",
             "assets": {
                 "configuration": {"spec": "assets/configuration/spec.yaml"},
-                "monitors": {},
+                "monitors": {
+                    "[Active Directory] Elevated LDAP binding duration for host {{host.name}}": "assets/monitors/ldap_binding.json",  # noqa: E501
+                    "[Active Directory] Anomalous number of sessions for connected LDAP clients for host: {{host.name}}": "assets/monitors/ldap_client_sessions.json",  # noqa: E501
+                    "[Active Directory] Anomalous number of successful LDAP bindings for host: {{host.name}}": "assets/monitors/ldap_binding_successful.json",  # noqa: E501
+                },
                 "dashboards": {"Active Directory": "assets/dashboards/active_directory.json"},
                 "service_checks": "assets/service_checks.json",
                 "logs": {"source": "ruby"},
@@ -39,6 +44,8 @@ def test_manifest_ok():
             },
         }
     )
+
+    # fmt: on
     root = Path(os.path.realpath(__file__)).parent.parent.parent.parent.parent.absolute()
     current_root = get_root()
     set_root(str(root))


### PR DESCRIPTION
### What does this PR do?
This PR refactors the manifest ImmutableAttributesValidator to do a more extensive check of immutable attributes. Specifically, this strengthens the validation to check if asset short names were changed. Also, the validator's tests were expanded to more extensively test the strengthened functionality.

### Motivation
When the short_name of integration assets change (like the short_name of a dashboard) it gets propagated to the integration_dashboard table as a new row. This causes some different types of issues like 5xx on dashboard list pages. It would then take a considerable amount of manual dev work to resolve the issue. This PR eliminates that issue.

### Additional Notes
In datadog_checks_dev/tests/tooling/manifest_validator/test_validator.py, I had to add comments for the flake8 and black style validators to ignore the test input. The changes I made to the test input were necessary to pass the stronger validations introduced in this PR.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
