### PR TITLE
Add app_uuid to manifest migrator

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import json
+import uuid
 
 import click
 
@@ -153,6 +154,10 @@ def migrate(ctx, integration, to_version):
 
     # Explicitly set the manifest_version first so it appears at the top of the manifest
     migrated_manifest.set_path("/manifest_version", "2.0.0")
+
+    # Generate and introduce a uuid
+    app_uuid = str(uuid.uuid4())
+    migrated_manifest.set_path("/app_uuid", app_uuid)
 
     for key, val in V2_TO_V1_MAP.items():
         if val == SKIP_IF_FOUND:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a new `app_uuid` field to the migrated manifest when going from v1 -> v2

### Motivation
<!-- What inspired you to submit this pull request? -->
The architecture of the backend now requires a UUID to be tied to the App. This is a new field that we can generate for users, but must be part of the V2 manifest. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
