### PR TITLE
Use GCR for accessing Agent Docker images

### DIFF
--- a/.azure-pipelines/all_master.yml
+++ b/.azure-pipelines/all_master.yml
@@ -13,7 +13,7 @@ variables:
 resources:
   containers:
     - container: dd_agent
-      image: datadog/agent:latest
+      image: gcr.io/datadoghq/agent:latest
       ports:
         - 8127:8126
       env:

--- a/.azure-pipelines/latest.yml
+++ b/.azure-pipelines/latest.yml
@@ -18,7 +18,7 @@ variables:
 resources:
   containers:
     - container: dd_agent
-      image: datadog/agent:latest
+      image: gcr.io/datadoghq/agent:latest
       ports:
         - 8127:8126
       env:


### PR DESCRIPTION
### Motivation

Decrease dependence on Docker Hub