### PR TITLE
Add agent pipeline

### DIFF
--- a/.azure-pipelines/agent.yml
+++ b/.azure-pipelines/agent.yml
@@ -1,0 +1,37 @@
+parameters:
+- name: agent_image
+  displayName: Agent Docker Image
+  type: string
+  default: gcr.io/datadoghq/agent:latest
+
+trigger: none
+
+variables:
+  DDEV_E2E_AGENT: ${{ parameters.agent_image }}
+  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
+  DDEV_COLOR: 1
+  DD_TRACE_AGENT_PORT: 8127
+
+resources:
+  containers:
+    - container: dd_agent
+      image: gcr.io/datadoghq/agent:latest
+      ports:
+        - 8127:8126
+      env:
+        DD_API_KEY: $(DD_CI_API_KEY)
+        DD_HOSTNAME: "none"
+        DD_INSIDE_CI: "true"
+
+jobs:
+- template: './templates/test-all-checks.yml'
+  parameters:
+    run_py2_tests: true
+    test_e2e: true
+    ddtrace_flag: '--ddtrace'
+    pip_cache_config:
+      key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
+      restoreKeys: |
+        pip | $(Agent.OS)
+      path: $(PIP_CACHE_DIR)
+      ispr: false

--- a/.azure-pipelines/agent.yml
+++ b/.azure-pipelines/agent.yml
@@ -26,6 +26,7 @@ resources:
 jobs:
 - template: './templates/test-all-checks.yml'
   parameters:
+    job_name: Agent
     run_py2_tests: true
     test_e2e: true
     ddtrace_flag: '--ddtrace'

--- a/.azure-pipelines/agent.yml
+++ b/.azure-pipelines/agent.yml
@@ -2,12 +2,17 @@ parameters:
 - name: agent_image
   displayName: Agent Docker Image
   type: string
-  default: gcr.io/datadoghq/agent:latest
+  default: datadog/agent-dev:latest
+- name: agent_windows_image
+  displayName: Windows Agent Docker Image
+  type: string
+  default: datadog/agent-dev:master-py2-win-servercore
 
 trigger: none
 
 variables:
   DDEV_E2E_AGENT: ${{ parameters.agent_image }}
+  DDEV_E2E_AGENT_WIN: ${{ parameters.agent_windows_image }}
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
   DDEV_COLOR: 1
   DD_TRACE_AGENT_PORT: 8127

--- a/.azure-pipelines/agent.yml
+++ b/.azure-pipelines/agent.yml
@@ -1,3 +1,10 @@
+trigger: none
+
+pr:
+  branches:
+    include:
+    - master
+
 parameters:
 - name: agent_image
   displayName: Agent Docker Image
@@ -8,7 +15,6 @@ parameters:
   type: string
   default: datadog/agent-dev:master-py2-win-servercore
 
-trigger: none
 
 variables:
   DDEV_E2E_AGENT: ${{ parameters.agent_image }}

--- a/.azure-pipelines/agent.yml
+++ b/.azure-pipelines/agent.yml
@@ -1,9 +1,6 @@
 trigger: none
 
-pr:
-  branches:
-    include:
-    - master
+pr: none
 
 parameters:
 - name: agent_image

--- a/.azure-pipelines/agent.yml
+++ b/.azure-pipelines/agent.yml
@@ -11,6 +11,10 @@ parameters:
   displayName: Windows Agent Docker Image
   type: string
   default: datadog/agent-dev:master-py2-win-servercore
+- name: run_py2
+  displayName: Run Python 2 tests
+  type: boolean
+  default: true
 
 
 variables:
@@ -35,7 +39,7 @@ jobs:
 - template: './templates/test-all-checks.yml'
   parameters:
     job_name: Agent
-    run_py2_tests: true
+    run_py2_tests: ${{ parameters.run_py2 }}
     test_e2e: true
     ddtrace_flag: '--ddtrace'
     pip_cache_config:

--- a/.azure-pipelines/agent.yml
+++ b/.azure-pipelines/agent.yml
@@ -3,6 +3,10 @@ trigger: none
 pr: none
 
 parameters:
+- name: run_py3_tests
+  displayName: Run Python 3 tests
+  type: boolean
+  default: true
 - name: run_py2_tests
   displayName: Run Python 2 tests
   type: boolean
@@ -39,6 +43,7 @@ jobs:
   parameters:
     job_name: Agent
     run_py2_tests: ${{ parameters.run_py2_tests }}
+    run_py3_tests: ${{ parameters.run_py3_tests }}
     test_e2e: true
     ddtrace_flag: '--ddtrace'
     pip_cache_config:

--- a/.azure-pipelines/agent.yml
+++ b/.azure-pipelines/agent.yml
@@ -7,30 +7,22 @@ parameters:
   displayName: Run Python 3 tests
   type: boolean
   default: true
-- name: agent_image_py3
-  displayName: Agent Docker Image for Python 3
-  type: string
-  default: datadog/agent-dev:latest
-- name: agent_windows_image_py3
-  displayName: Windows Agent Docker Image for Python 3
-  type: string
-  default: datadog/agent-dev:master-py2-win-servercore
 - name: run_py2_tests
   displayName: Run Python 2 tests
   type: boolean
   default: true
-- name: agent_image_py2
-  displayName: Agent Docker Image for Python 2
+- name: agent_image
+  displayName: Agent Docker Image
   type: string
   default: datadog/agent-dev:latest
-- name: agent_windows_image_py2
-  displayName: Windows Agent Docker Image for Python 2
+- name: agent_windows_image
+  displayName: Windows Agent Docker Image
   type: string
   default: datadog/agent-dev:master-py2-win-servercore
 
 variables:
-  DDEV_E2E_AGENT: ${{ parameters.agent_image_py3 }}
-  DDEV_E2E_AGENT_WIN: ${{ parameters.agent_windows_image_py3 }}
+  DDEV_E2E_AGENT: ${{ parameters.agent_image }}
+  DDEV_E2E_AGENT_WIN: ${{ parameters.agent_windows_image }}
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
   DDEV_COLOR: 1
   DD_TRACE_AGENT_PORT: 8127

--- a/.azure-pipelines/agent.yml
+++ b/.azure-pipelines/agent.yml
@@ -3,10 +3,6 @@ trigger: none
 pr: none
 
 parameters:
-- name: run_py3_tests
-  displayName: Run Python 3 tests
-  type: boolean
-  default: true
 - name: run_py2_tests
   displayName: Run Python 2 tests
   type: boolean
@@ -43,7 +39,6 @@ jobs:
   parameters:
     job_name: Agent
     run_py2_tests: ${{ parameters.run_py2_tests }}
-    run_py3_tests: ${{ parameters.run_py3_tests }}
     test_e2e: true
     ddtrace_flag: '--ddtrace'
     pip_cache_config:

--- a/.azure-pipelines/agent.yml
+++ b/.azure-pipelines/agent.yml
@@ -7,22 +7,32 @@ parameters:
   displayName: Run Python 3 tests
   type: boolean
   default: true
+- name: agent_image
+  displayName: Agent Docker Image
+  type: string
+  default: datadog/agent:7-rc
+- name: agent_windows_image
+  displayName: Windows Agent Docker Image
+  type: string
+  default: datadog/agent:7-rc-servercore
 - name: run_py2_tests
   displayName: Run Python 2 tests
   type: boolean
   default: true
-- name: agent_image
-  displayName: Agent Docker Image
+- name: agent_image_py2
+  displayName: Agent Docker Image for Python 2
   type: string
-  default: datadog/agent-dev:latest
-- name: agent_windows_image
-  displayName: Windows Agent Docker Image
+  default: datadog/agent:6-rc
+- name: agent_windows_image_py2
+  displayName: Windows Agent Docker Image for Python 2
   type: string
   default: datadog/agent-dev:master-py2-win-servercore
 
 variables:
   DDEV_E2E_AGENT: ${{ parameters.agent_image }}
+  DDEV_E2E_AGENT_PY2: ${{ parameters.agent_image_py2 }}
   DDEV_E2E_AGENT_WIN: ${{ parameters.agent_windows_image }}
+  DDEV_E2E_AGENT_WIN_PY2: ${{ parameters.agent_windows_image_py2 }}
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
   DDEV_COLOR: 1
   DD_TRACE_AGENT_PORT: 8127

--- a/.azure-pipelines/agent.yml
+++ b/.azure-pipelines/agent.yml
@@ -3,23 +3,34 @@ trigger: none
 pr: none
 
 parameters:
-- name: agent_image
-  displayName: Agent Docker Image
+- name: run_py3_tests
+  displayName: Run Python 3 tests
+  type: boolean
+  default: true
+- name: agent_image_py3
+  displayName: Agent Docker Image for Python 3
   type: string
   default: datadog/agent-dev:latest
-- name: agent_windows_image
-  displayName: Windows Agent Docker Image
+- name: agent_windows_image_py3
+  displayName: Windows Agent Docker Image for Python 3
   type: string
   default: datadog/agent-dev:master-py2-win-servercore
-- name: run_py2
+- name: run_py2_tests
   displayName: Run Python 2 tests
   type: boolean
   default: true
-
+- name: agent_image_py2
+  displayName: Agent Docker Image for Python 2
+  type: string
+  default: datadog/agent-dev:latest
+- name: agent_windows_image_py2
+  displayName: Windows Agent Docker Image for Python 2
+  type: string
+  default: datadog/agent-dev:master-py2-win-servercore
 
 variables:
-  DDEV_E2E_AGENT: ${{ parameters.agent_image }}
-  DDEV_E2E_AGENT_WIN: ${{ parameters.agent_windows_image }}
+  DDEV_E2E_AGENT: ${{ parameters.agent_image_py3 }}
+  DDEV_E2E_AGENT_WIN: ${{ parameters.agent_windows_image_py3 }}
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
   DDEV_COLOR: 1
   DD_TRACE_AGENT_PORT: 8127
@@ -39,7 +50,8 @@ jobs:
 - template: './templates/test-all-checks.yml'
   parameters:
     job_name: Agent
-    run_py2_tests: ${{ parameters.run_py2 }}
+    run_py2_tests: ${{ parameters.run_py2_tests }}
+    run_py3_tests: ${{ parameters.run_py3_tests }}
     test_e2e: true
     ddtrace_flag: '--ddtrace'
     pip_cache_config:

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -9,7 +9,6 @@ parameters:
   repo: ''
   coverage: true
   force_base_package: false
-  tox_skip_env: ''
 
 steps:
 - ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.force_base_package, 'false')) }}:
@@ -17,52 +16,40 @@ steps:
     displayName: 'Run Unit/Integration tests'
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
-      TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 - ${{ if and(eq(parameters.test, 'true'), not(eq(parameters.coverage, 'true'))) }}:
     - script: ddev test --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}
       displayName: 'Run Unit/Integration tests (no coverage)'
-      env:
-        TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 # Nightly base package check
 - ${{ if and(eq(parameters.test, 'true'), eq(parameters.force_base_package, 'true')) }}:
     - script: ddev test --force-base-min --force-env-rebuild --junit ${{ parameters.check }}
       displayName: 'Run Unit/Integration tests (forced install of minimum datadog_checks_base package)'
-      env:
-        TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 - ${{ if and(eq(parameters.test_e2e, 'true'), eq(parameters.repo, 'core'))}}:
   - script: ddev env test --base --new-env --junit ${{ parameters.check }}
     displayName: 'Run E2E tests against latest base package'
     env:
       DD_API_KEY: $(DD_API_KEY)
-      TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 - ${{ if and(eq(parameters.test_e2e, 'true'), ne(parameters.repo, 'core'))}}:
   - script: ddev env test --new-env --junit ${{ parameters.check }}
     displayName: 'Run E2E tests'
     env:
       DD_API_KEY: $(DD_API_KEY)
-      TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 - ${{ if eq(parameters.benchmark, 'true') }}:
   - script: ddev test --bench --junit ${{ parameters.check }}
     displayName: 'Run benchmarks'
-    env:
-      TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 - ${{ if eq(parameters.latest, 'true') }}:
     - script: ddev test --latest --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}
       displayName: 'Run tests and verify support for the latest version'
-      env:
-        TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
     - script: ddev env test --base --new-env --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}:latest
       displayName: 'Run E2E tests for the latest version'
       env:
         DD_API_KEY: $(DD_API_KEY)
-        TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 - task: PublishTestResults@2 # Task info: https://docs.microsoft.com/en-gb/azure/devops/pipelines/tasks/test/publish-test-results
   condition: succeededOrFailed()

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -9,6 +9,7 @@ parameters:
   repo: ''
   coverage: true
   force_base_package: false
+  tox_skip_env: ''
 
 steps:
 - ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.force_base_package, 'false')) }}:
@@ -16,40 +17,52 @@ steps:
     displayName: 'Run Unit/Integration tests'
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
+      TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 - ${{ if and(eq(parameters.test, 'true'), not(eq(parameters.coverage, 'true'))) }}:
     - script: ddev test --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}
       displayName: 'Run Unit/Integration tests (no coverage)'
+      env:
+        TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 # Nightly base package check
 - ${{ if and(eq(parameters.test, 'true'), eq(parameters.force_base_package, 'true')) }}:
     - script: ddev test --force-base-min --force-env-rebuild --junit ${{ parameters.check }}
       displayName: 'Run Unit/Integration tests (forced install of minimum datadog_checks_base package)'
+      env:
+        TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 - ${{ if and(eq(parameters.test_e2e, 'true'), eq(parameters.repo, 'core'))}}:
   - script: ddev env test --base --new-env --junit ${{ parameters.check }}
     displayName: 'Run E2E tests against latest base package'
     env:
       DD_API_KEY: $(DD_API_KEY)
+      TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 - ${{ if and(eq(parameters.test_e2e, 'true'), ne(parameters.repo, 'core'))}}:
   - script: ddev env test --new-env --junit ${{ parameters.check }}
     displayName: 'Run E2E tests'
     env:
       DD_API_KEY: $(DD_API_KEY)
+      TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 - ${{ if eq(parameters.benchmark, 'true') }}:
   - script: ddev test --bench --junit ${{ parameters.check }}
     displayName: 'Run benchmarks'
+    env:
+      TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 - ${{ if eq(parameters.latest, 'true') }}:
     - script: ddev test --latest --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}
       displayName: 'Run tests and verify support for the latest version'
+      env:
+        TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
     - script: ddev env test --base --new-env --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}:latest
       displayName: 'Run E2E tests for the latest version'
       env:
         DD_API_KEY: $(DD_API_KEY)
+        TOX_SKIP_ENV: ${{ parameters.tox_skip_env }}
 
 - task: PublishTestResults@2 # Task info: https://docs.microsoft.com/en-gb/azure/devops/pipelines/tasks/test/publish-test-results
   condition: succeededOrFailed()

--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -2,6 +2,7 @@ parameters:
   ispr: false
   pip_cache_config: null
   run_py2_tests: true
+  run_py3_tests: true
   force_base_package: false
   test: true
   test_e2e: true
@@ -14,6 +15,7 @@ jobs:
     ispr: ${{ parameters.ispr }}
     pip_cache_config: ${{ parameters.pip_cache_config }}
     run_py2_tests: ${{ parameters.run_py2_tests }}
+    run_py2_tests: ${{ parameters.run_py3_tests }}
     force_base_package: ${{ parameters.force_base_package }}
     test: ${{ parameters.test }}
     test_e2e: ${{ parameters.test_e2e }}

--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -2,7 +2,6 @@ parameters:
   ispr: false
   pip_cache_config: null
   run_py2_tests: true
-  run_py3_tests: true
   force_base_package: false
   test: true
   test_e2e: true
@@ -15,7 +14,6 @@ jobs:
     ispr: ${{ parameters.ispr }}
     pip_cache_config: ${{ parameters.pip_cache_config }}
     run_py2_tests: ${{ parameters.run_py2_tests }}
-    run_py3_tests: ${{ parameters.run_py3_tests }}
     force_base_package: ${{ parameters.force_base_package }}
     test: ${{ parameters.test }}
     test_e2e: ${{ parameters.test_e2e }}

--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -2,6 +2,7 @@ parameters:
   ispr: false
   pip_cache_config: null
   run_py2_tests: true
+  run_py3_tests: true
   force_base_package: false
   test: true
   test_e2e: true
@@ -14,6 +15,7 @@ jobs:
     ispr: ${{ parameters.ispr }}
     pip_cache_config: ${{ parameters.pip_cache_config }}
     run_py2_tests: ${{ parameters.run_py2_tests }}
+    run_py3_tests: ${{ parameters.run_py3_tests }}
     force_base_package: ${{ parameters.force_base_package }}
     test: ${{ parameters.test }}
     test_e2e: ${{ parameters.test_e2e }}

--- a/.azure-pipelines/templates/test-all-checks.yml
+++ b/.azure-pipelines/templates/test-all-checks.yml
@@ -15,7 +15,7 @@ jobs:
     ispr: ${{ parameters.ispr }}
     pip_cache_config: ${{ parameters.pip_cache_config }}
     run_py2_tests: ${{ parameters.run_py2_tests }}
-    run_py2_tests: ${{ parameters.run_py3_tests }}
+    run_py3_tests: ${{ parameters.run_py3_tests }}
     force_base_package: ${{ parameters.force_base_package }}
     test: ${{ parameters.test }}
     test_e2e: ${{ parameters.test_e2e }}

--- a/.azure-pipelines/templates/test-all.yml
+++ b/.azure-pipelines/templates/test-all.yml
@@ -24,7 +24,7 @@ jobs:
       ispr: ${{ parameters.ispr }}
       pip_cache_config: ${{ parameters.pip_cache_config }}
       run_py2_tests: ${{ parameters.run_py2_tests }}
-      run_py2_tests: ${{ parameters.run_py3_tests }}
+      run_py3_tests: ${{ parameters.run_py3_tests }}
       force_base_package: ${{ parameters.force_base_package }}
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}

--- a/.azure-pipelines/templates/test-all.yml
+++ b/.azure-pipelines/templates/test-all.yml
@@ -4,6 +4,7 @@ parameters:
   ispr: false
   pip_cache_config: null
   run_py2_tests: true
+  run_py3_tests: true
   force_base_package: false
   coverage: true
   test: true
@@ -23,6 +24,7 @@ jobs:
       ispr: ${{ parameters.ispr }}
       pip_cache_config: ${{ parameters.pip_cache_config }}
       run_py2_tests: ${{ parameters.run_py2_tests }}
+      run_py2_tests: ${{ parameters.run_py3_tests }}
       force_base_package: ${{ parameters.force_base_package }}
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}

--- a/.azure-pipelines/templates/test-all.yml
+++ b/.azure-pipelines/templates/test-all.yml
@@ -4,6 +4,7 @@ parameters:
   ispr: false
   pip_cache_config: null
   run_py2_tests: true
+  run_py3_tests: true
   force_base_package: false
   coverage: true
   test: true
@@ -23,6 +24,7 @@ jobs:
       ispr: ${{ parameters.ispr }}
       pip_cache_config: ${{ parameters.pip_cache_config }}
       run_py2_tests: ${{ parameters.run_py2_tests }}
+      run_py3_tests: ${{ parameters.run_py3_tests }}
       force_base_package: ${{ parameters.force_base_package }}
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}

--- a/.azure-pipelines/templates/test-all.yml
+++ b/.azure-pipelines/templates/test-all.yml
@@ -4,7 +4,6 @@ parameters:
   ispr: false
   pip_cache_config: null
   run_py2_tests: true
-  run_py3_tests: true
   force_base_package: false
   coverage: true
   test: true
@@ -24,7 +23,6 @@ jobs:
       ispr: ${{ parameters.ispr }}
       pip_cache_config: ${{ parameters.pip_cache_config }}
       run_py2_tests: ${{ parameters.run_py2_tests }}
-      run_py3_tests: ${{ parameters.run_py3_tests }}
       force_base_package: ${{ parameters.force_base_package }}
       test: ${{ parameters.test }}
       test_e2e: ${{ parameters.test_e2e }}

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -30,10 +30,6 @@ jobs:
     vmImage: 'ubuntu-18.04'
 
   variables:
-    ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:
-      TOX_SKIP_ENV: py27.*  # Don't run py2 tests
-    ${{ if not(eq(parameters.run_py3_tests, 'true')) }}:
-      TOX_SKIP_ENV: py3.*  # Don't run py2 tests
     ${{ if eq(parameters.ddtrace_flag, '--ddtrace') }}:
       DD_ENV: ci
       DD_SERVICE: ddev-integrations-${{ parameters.repo }}
@@ -62,15 +58,31 @@ jobs:
         ispr: ${{ parameters.ispr }}
         validate_codeowners: ${{ parameters.validate_codeowners }}
 
-  - template: './run-tests.yml'
-    parameters:
-      test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.linux'
-      check: ${{ parameters.check }}
-      test: ${{ parameters.test }}
-      test_e2e: ${{ parameters.test_e2e }}
-      ddtrace_flag: ${{ parameters.ddtrace_flag }}
-      benchmark: ${{ parameters.benchmark }}
-      latest: ${{ parameters.latest }}
-      repo: ${{ parameters.repo }}
-      coverage: ${{ parameters.coverage }}
-      force_base_package: ${{ parameters.force_base_package }}
+  - ${{ if eq(parameters.run_py2_tests, 'true') }}:  
+    - template: './run-tests.yml'
+      parameters:
+        test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.linux'
+        check: ${{ parameters.check }}
+        test: ${{ parameters.test }}
+        test_e2e: ${{ parameters.test_e2e }}
+        ddtrace_flag: ${{ parameters.ddtrace_flag }}
+        benchmark: ${{ parameters.benchmark }}
+        latest: ${{ parameters.latest }}
+        repo: ${{ parameters.repo }}
+        coverage: ${{ parameters.coverage }}
+        force_base_package: ${{ parameters.force_base_package }}
+        tox_skip_env: py3.* # Don't run py3 tests
+  - ${{ if eq(parameters.run_py3_tests, 'true') }}:
+    - template: './run-tests.yml'
+      parameters:
+        test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.linux'
+        check: ${{ parameters.check }}
+        test: ${{ parameters.test }}
+        test_e2e: ${{ parameters.test_e2e }}
+        ddtrace_flag: ${{ parameters.ddtrace_flag }}
+        benchmark: ${{ parameters.benchmark }}
+        latest: ${{ parameters.latest }}
+        repo: ${{ parameters.repo }}
+        coverage: ${{ parameters.coverage }}
+        force_base_package: ${{ parameters.force_base_package }}
+        tox_skip_env: py27.* # Don't run py2 tests

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -30,6 +30,10 @@ jobs:
     vmImage: 'ubuntu-18.04'
 
   variables:
+    ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:
+      TOX_SKIP_ENV: py27.*  # Don't run py2 tests
+    ${{ if not(eq(parameters.run_py3_tests, 'true')) }}:
+      TOX_SKIP_ENV: py3.*  # Don't run py2 tests
     ${{ if eq(parameters.ddtrace_flag, '--ddtrace') }}:
       DD_ENV: ci
       DD_SERVICE: ddev-integrations-${{ parameters.repo }}
@@ -58,31 +62,15 @@ jobs:
         ispr: ${{ parameters.ispr }}
         validate_codeowners: ${{ parameters.validate_codeowners }}
 
-  - ${{ if eq(parameters.run_py2_tests, 'true') }}:  
-    - template: './run-tests.yml'
-      parameters:
-        test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.linux'
-        check: ${{ parameters.check }}
-        test: ${{ parameters.test }}
-        test_e2e: ${{ parameters.test_e2e }}
-        ddtrace_flag: ${{ parameters.ddtrace_flag }}
-        benchmark: ${{ parameters.benchmark }}
-        latest: ${{ parameters.latest }}
-        repo: ${{ parameters.repo }}
-        coverage: ${{ parameters.coverage }}
-        force_base_package: ${{ parameters.force_base_package }}
-        tox_skip_env: py3.* # Don't run py3 tests
-  - ${{ if eq(parameters.run_py3_tests, 'true') }}:
-    - template: './run-tests.yml'
-      parameters:
-        test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.linux'
-        check: ${{ parameters.check }}
-        test: ${{ parameters.test }}
-        test_e2e: ${{ parameters.test_e2e }}
-        ddtrace_flag: ${{ parameters.ddtrace_flag }}
-        benchmark: ${{ parameters.benchmark }}
-        latest: ${{ parameters.latest }}
-        repo: ${{ parameters.repo }}
-        coverage: ${{ parameters.coverage }}
-        force_base_package: ${{ parameters.force_base_package }}
-        tox_skip_env: py27.* # Don't run py2 tests
+  - template: './run-tests.yml'
+    parameters:
+      test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.linux'
+      check: ${{ parameters.check }}
+      test: ${{ parameters.test }}
+      test_e2e: ${{ parameters.test_e2e }}
+      ddtrace_flag: ${{ parameters.ddtrace_flag }}
+      benchmark: ${{ parameters.benchmark }}
+      latest: ${{ parameters.latest }}
+      repo: ${{ parameters.repo }}
+      coverage: ${{ parameters.coverage }}
+      force_base_package: ${{ parameters.force_base_package }}

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -13,7 +13,6 @@ parameters:
   repo: 'core'
   ispr: false
   run_py2_tests: true  # Whether or not to run python2 tests.
-  run_py3_tests: true  # Whether or not to run python3 tests.
   force_base_package: false
   pip_cache_config: null
   coverage: true
@@ -32,8 +31,6 @@ jobs:
   variables:
     ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:
       TOX_SKIP_ENV: py27.*  # Don't run py2 tests
-    ${{ if not(eq(parameters.run_py3_tests, 'true')) }}:
-      TOX_SKIP_ENV: py3.*  # Don't run py2 tests
     ${{ if eq(parameters.ddtrace_flag, '--ddtrace') }}:
       DD_ENV: ci
       DD_SERVICE: ddev-integrations-${{ parameters.repo }}

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -13,6 +13,7 @@ parameters:
   repo: 'core'
   ispr: false
   run_py2_tests: true  # Whether or not to run python2 tests.
+  run_py3_tests: true  # Whether or not to run python3 tests.
   force_base_package: false
   pip_cache_config: null
   coverage: true
@@ -31,6 +32,8 @@ jobs:
   variables:
     ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:
       TOX_SKIP_ENV: py27.*  # Don't run py2 tests
+    ${{ if not(eq(parameters.run_py3_tests, 'true')) }}:
+      TOX_SKIP_ENV: py3.*  # Don't run py2 tests
     ${{ if eq(parameters.ddtrace_flag, '--ddtrace') }}:
       DD_ENV: ci
       DD_SERVICE: ddev-integrations-${{ parameters.repo }}

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -29,7 +29,11 @@ jobs:
     vmImage: 'windows-2019'
 
   variables:
-    DDEV_E2E_AGENT: datadog/agent-dev:master-py2-win-servercore
+    ${{ if eq($DDEV_E2E_AGENT_WIN, "") }}:
+      DDEV_E2E_AGENT: datadog/agent-dev:master-py2-win-servercore
+    ${{ if ne($DDEV_E2E_AGENT_WIN, "") }}:
+      DDEV_E2E_AGENT: $DDEV_E2E_AGENT_WIN
+    
     # Generic tag check disabled on non-core repo
     ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:
       TOX_SKIP_ENV: py27.*  # Don't run py2 tests

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -29,9 +29,9 @@ jobs:
     vmImage: 'windows-2019'
 
   variables:
-    ${{ if eq($(DDEV_E2E_AGENT_WIN), "") }}:
+    ${{ if eq($(DDEV_E2E_AGENT_WIN), '') }}:
       DDEV_E2E_AGENT: datadog/agent-dev:master-py2-win-servercore
-    ${{ if ne($(DDEV_E2E_AGENT_WIN), "") }}:
+    ${{ if ne($(DDEV_E2E_AGENT_WIN), '') }}:
       DDEV_E2E_AGENT: $(DDEV_E2E_AGENT_WIN)
     
     # Generic tag check disabled on non-core repo

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -29,10 +29,10 @@ jobs:
     vmImage: 'windows-2019'
 
   variables:
-    ${{ if eq($DDEV_E2E_AGENT_WIN, "") }}:
+    ${{ if eq($(DDEV_E2E_AGENT_WIN), "") }}:
       DDEV_E2E_AGENT: datadog/agent-dev:master-py2-win-servercore
-    ${{ if ne($DDEV_E2E_AGENT_WIN, "") }}:
-      DDEV_E2E_AGENT: $DDEV_E2E_AGENT_WIN
+    ${{ if ne($(DDEV_E2E_AGENT_WIN), "") }}:
+      DDEV_E2E_AGENT: $(DDEV_E2E_AGENT_WIN)
     
     # Generic tag check disabled on non-core repo
     ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -1,4 +1,5 @@
 parameters:
+  agent_image_win: $(DDEV_E2E_AGENT_WIN)
   job_name: ''
   check: ''
   display: ''
@@ -29,10 +30,10 @@ jobs:
     vmImage: 'windows-2019'
 
   variables:
-    ${{ if eq($(DDEV_E2E_AGENT_WIN), '') }}:
+    ${{ if eq(parameters.agent_image_win, '') }}:
       DDEV_E2E_AGENT: datadog/agent-dev:master-py2-win-servercore
-    ${{ if ne($(DDEV_E2E_AGENT_WIN), '') }}:
-      DDEV_E2E_AGENT: $(DDEV_E2E_AGENT_WIN)
+    ${{ if ne(parameters.agent_image_win, '') }}:
+      DDEV_E2E_AGENT: ${{ parameters.agent_image_win }}
     
     # Generic tag check disabled on non-core repo
     ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -14,6 +14,7 @@ parameters:
   repo: 'core'
   ispr: false
   run_py2_tests: true  # Whether or not to run python2 tests
+  run_py3_tests: true  # Whether or not to run python3 tests.
   force_base_package: false
   pip_cache_config: null
   coverage: true
@@ -38,6 +39,8 @@ jobs:
     # Generic tag check disabled on non-core repo
     ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:
       TOX_SKIP_ENV: py27.*  # Don't run py2 tests
+    ${{ if not(eq(parameters.run_py3_tests, 'true')) }}:
+      TOX_SKIP_ENV: py3.*  # Don't run py2 tests
     ${{ if eq(parameters.ddtrace_flag, '--ddtrace') }}:
       DD_ENV: ci
       DD_SERVICE: ddev-integrations-${{ parameters.repo }}

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -14,7 +14,6 @@ parameters:
   repo: 'core'
   ispr: false
   run_py2_tests: true  # Whether or not to run python2 tests
-  run_py3_tests: true  # Whether or not to run python3 tests.
   force_base_package: false
   pip_cache_config: null
   coverage: true
@@ -39,8 +38,6 @@ jobs:
     # Generic tag check disabled on non-core repo
     ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:
       TOX_SKIP_ENV: py27.*  # Don't run py2 tests
-    ${{ if not(eq(parameters.run_py3_tests, 'true')) }}:
-      TOX_SKIP_ENV: py3.*  # Don't run py2 tests
     ${{ if eq(parameters.ddtrace_flag, '--ddtrace') }}:
       DD_ENV: ci
       DD_SERVICE: ddev-integrations-${{ parameters.repo }}

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -1,5 +1,6 @@
 parameters:
   agent_image_win: $(DDEV_E2E_AGENT_WIN)
+  agent_image_win_py2: $(DDEV_E2E_AGENT_WIN_PY2)
   job_name: ''
   check: ''
   display: ''
@@ -35,6 +36,8 @@ jobs:
       DDEV_E2E_AGENT: datadog/agent-dev:master-py2-win-servercore
     ${{ if ne(parameters.agent_image_win, '') }}:
       DDEV_E2E_AGENT: ${{ parameters.agent_image_win }}
+    ${{ if ne(parameters.agent_image_win_py2, '') }}:
+      DDEV_E2E_AGENT_PY2: ${{ parameters.agent_image_win_py2 }}
     
     # Generic tag check disabled on non-core repo
     ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -37,10 +37,6 @@ jobs:
       DDEV_E2E_AGENT: ${{ parameters.agent_image_win }}
     
     # Generic tag check disabled on non-core repo
-    ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:
-      TOX_SKIP_ENV: py27.*  # Don't run py2 tests
-    ${{ if not(eq(parameters.run_py3_tests, 'true')) }}:
-      TOX_SKIP_ENV: py3.*  # Don't run py2 tests
     ${{ if eq(parameters.ddtrace_flag, '--ddtrace') }}:
       DD_ENV: ci
       DD_SERVICE: ddev-integrations-${{ parameters.repo }}
@@ -71,15 +67,31 @@ jobs:
         ispr: ${{ parameters.ispr }}
         validate_codeowners: ${{ parameters.validate_codeowners }}
 
-  - template: './run-tests.yml'
-    parameters:
-      test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.windows'
-      check: ${{ parameters.check }}
-      test: ${{ parameters.test }}
-      test_e2e: ${{ parameters.test_e2e }}
-      dd_flag: ${{ parameters.ddtrace_flag }}
-      benchmark: ${{ parameters.benchmark }}
-      latest: ${{ parameters.latest }}
-      repo: ${{ parameters.repo }}
-      coverage: ${{ parameters.coverage }}
-      force_base_package: ${{ parameters.force_base_package }}
+  - ${{ if eq(parameters.run_py2_tests, 'true') }}:  
+    - template: './run-tests.yml'
+      parameters:
+        test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.windows'
+        check: ${{ parameters.check }}
+        test: ${{ parameters.test }}
+        test_e2e: ${{ parameters.test_e2e }}
+        dd_flag: ${{ parameters.ddtrace_flag }}
+        benchmark: ${{ parameters.benchmark }}
+        latest: ${{ parameters.latest }}
+        repo: ${{ parameters.repo }}
+        coverage: ${{ parameters.coverage }}
+        force_base_package: ${{ parameters.force_base_package }}
+        tox_skip_env: py3.* # Don't run py3 tests
+  - ${{ if eq(parameters.run_py3_tests, 'true') }}:
+    - template: './run-tests.yml'
+      parameters:
+        test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.windows'
+        check: ${{ parameters.check }}
+        test: ${{ parameters.test }}
+        test_e2e: ${{ parameters.test_e2e }}
+        dd_flag: ${{ parameters.ddtrace_flag }}
+        benchmark: ${{ parameters.benchmark }}
+        latest: ${{ parameters.latest }}
+        repo: ${{ parameters.repo }}
+        coverage: ${{ parameters.coverage }}
+        force_base_package: ${{ parameters.force_base_package }}
+        tox_skip_env: py27.* # Don't run py2 tests

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -37,6 +37,10 @@ jobs:
       DDEV_E2E_AGENT: ${{ parameters.agent_image_win }}
     
     # Generic tag check disabled on non-core repo
+    ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:
+      TOX_SKIP_ENV: py27.*  # Don't run py2 tests
+    ${{ if not(eq(parameters.run_py3_tests, 'true')) }}:
+      TOX_SKIP_ENV: py3.*  # Don't run py2 tests
     ${{ if eq(parameters.ddtrace_flag, '--ddtrace') }}:
       DD_ENV: ci
       DD_SERVICE: ddev-integrations-${{ parameters.repo }}
@@ -67,31 +71,15 @@ jobs:
         ispr: ${{ parameters.ispr }}
         validate_codeowners: ${{ parameters.validate_codeowners }}
 
-  - ${{ if eq(parameters.run_py2_tests, 'true') }}:  
-    - template: './run-tests.yml'
-      parameters:
-        test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.windows'
-        check: ${{ parameters.check }}
-        test: ${{ parameters.test }}
-        test_e2e: ${{ parameters.test_e2e }}
-        dd_flag: ${{ parameters.ddtrace_flag }}
-        benchmark: ${{ parameters.benchmark }}
-        latest: ${{ parameters.latest }}
-        repo: ${{ parameters.repo }}
-        coverage: ${{ parameters.coverage }}
-        force_base_package: ${{ parameters.force_base_package }}
-        tox_skip_env: py3.* # Don't run py3 tests
-  - ${{ if eq(parameters.run_py3_tests, 'true') }}:
-    - template: './run-tests.yml'
-      parameters:
-        test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.windows'
-        check: ${{ parameters.check }}
-        test: ${{ parameters.test }}
-        test_e2e: ${{ parameters.test_e2e }}
-        dd_flag: ${{ parameters.ddtrace_flag }}
-        benchmark: ${{ parameters.benchmark }}
-        latest: ${{ parameters.latest }}
-        repo: ${{ parameters.repo }}
-        coverage: ${{ parameters.coverage }}
-        force_base_package: ${{ parameters.force_base_package }}
-        tox_skip_env: py27.* # Don't run py2 tests
+  - template: './run-tests.yml'
+    parameters:
+      test_run: '${{ coalesce(parameters.job_name, parameters.check) }}.windows'
+      check: ${{ parameters.check }}
+      test: ${{ parameters.test }}
+      test_e2e: ${{ parameters.test_e2e }}
+      dd_flag: ${{ parameters.ddtrace_flag }}
+      benchmark: ${{ parameters.benchmark }}
+      latest: ${{ parameters.latest }}
+      repo: ${{ parameters.repo }}
+      coverage: ${{ parameters.coverage }}
+      force_base_package: ${{ parameters.force_base_package }}


### PR DESCRIPTION
Add a pipeline that can be manually triggered against a specific datadog agent image.
The goal is to run that at least against all RC during QA

Example of parameters for a pipeline run:

<img width="449" alt="Capture d’écran 2021-09-27 à 09 58 06" src="https://user-images.githubusercontent.com/26168335/134867854-6b564045-b8e5-4e53-8231-3ac63aad798d.png">

Check/uncheck a `Python 2 tests` and `Python 3 tests` boxes to enable/disable Python2 or Python3 testing.

`Agent Docker Image`: docker image for python3-linux e2e tests (if `Python 3 tests` is checked)
`Windows Agent Docker Image`: docker image for python3-windows e2e (if `Python 3 tests` is checked)
`Agent Docker Image for Python 2`: docker image for python2-linux e2e tests (if `Python 2 tests` is checked)
`Windows Agent Docker Image for Python 2`: docker image for python2-windows e2e (if `Python 2 tests` is checked)
