### PR TITLE
Upgrade python-dateutil to 2.8.2

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -64,7 +64,7 @@ pysnmp==4.4.9
 pysocks==1.7.0
 python-binary-memcached==0.26.1; sys_platform != "win32" and python_version < "3.0"
 python-binary-memcached==0.30.1; sys_platform != "win32" and python_version > "3.0"
-python-dateutil==2.8.1
+python-dateutil==2.8.2
 python3-gearman==0.1.0; sys_platform != "win32" and python_version > "3.0"
 pyvmomi==v7.0.2
 pywin32==228; sys_platform == "win32" and python_version < "3.0"
@@ -85,7 +85,7 @@ serpent==1.27; sys_platform == "win32"
 service_identity[idna]==18.1.0
 simplejson==3.6.5
 six==1.16.0
-snowflake-connector-python==2.6.0; python_version > '3.0'
+snowflake-connector-python==2.6.0; python_version > "3.0"
 supervisor==4.1.0
 tuf==0.17.0
 typing==3.7.4.1; python_version < "3.0"

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -20,7 +20,7 @@ pydantic==1.8.2; python_version > '3.0'
 pyjwt==1.7.1; python_version < '3.0'
 pyjwt==2.0.1; python_version > '3.0'
 pysocks==1.7.0
-python-dateutil==2.8.1
+python-dateutil==2.8.2
 pywin32==228; sys_platform == 'win32' and python_version < '3.0'
 pywin32==300; sys_platform == 'win32' and python_version > '3.0'
 pyyaml==5.4.1

--- a/twistlock/requirements.in
+++ b/twistlock/requirements.in
@@ -1,1 +1,1 @@
-python-dateutil==2.8.1
+python-dateutil==2.8.2


### PR DESCRIPTION
### Motivation

Stay up-to-date, esp. for latest tz database https://github.com/dateutil/dateutil/blob/master/NEWS