### PR TITLE
Remove factors from `latest` env vars definition

### DIFF
--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -38,4 +38,4 @@ commands =
 [testenv:latest]
 setenv =
     HAPROXY_LEGACY=false
-    latest: HAPROXY_VERSION=latest
+    HAPROXY_VERSION=latest

--- a/nginx/tox.ini
+++ b/nginx/tox.ini
@@ -31,4 +31,4 @@ setenv =
 
 [testenv:latest]
 setenv =
-    latest: NGINX_IMAGE=nginx:latest
+    NGINX_IMAGE=nginx:latest


### PR DESCRIPTION
### What does this PR do?

Example without use of factors: https://github.com/DataDog/integrations-core/blob/2f7a618e826da1babccf4ed49695b86c785ed361/redisdb/tox.ini#L34-L37

### Motivation

Simplify config