### PR TITLE
fix latest haproxy version handling

### DIFF
--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -5,6 +5,7 @@ import os
 
 import pytest
 from packaging import version
+from sys import maxsize
 
 from datadog_checks.dev import get_docker_hostname, get_here
 
@@ -15,7 +16,7 @@ HAPROXY_VERSION_RAW = os.getenv('HAPROXY_VERSION', 'latest')
 
 HAPROXY_VERSION_IS_LATEST = HAPROXY_VERSION_RAW.endswith('latest')
 if HAPROXY_VERSION_IS_LATEST:
-    HAPROXY_VERSION = version.parse('latest')
+    HAPROXY_VERSION = version.parse(str(maxsize))
 else:
     HAPROXY_VERSION = version.parse(HAPROXY_VERSION_RAW)
 ENDPOINT_PROMETHEUS = 'http://{}:8404/metrics'.format(HOST)

--- a/haproxy/tests/common.py
+++ b/haproxy/tests/common.py
@@ -2,10 +2,10 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+from sys import maxsize
 
 import pytest
 from packaging import version
-from sys import maxsize
 
 from datadog_checks.dev import get_docker_hostname, get_here
 


### PR DESCRIPTION
### What does this PR do?
Make sure the version is always the same type, for the **latest** version it would be the max integer available

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
