### PR TITLE
Add DDEV_E2E_AGENT_PY2 env option

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -140,7 +140,12 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, org_name, profile
     if os.path.isdir(legacy_fallback):
         legacy_fallback = ''
 
-    agent_ver = agent or os.getenv('DDEV_E2E_AGENT', legacy_fallback)
+    fallback = os.getenv('DDEV_E2E_AGENT', legacy_fallback)
+    # DDEV_E2E_AGENT_PY2 overrides DDEV_E2E_AGENT when starting a Python 2 environment
+    if python == 2 and os.getenv('DDEV_E2E_AGENT_PY2'):
+        fallback = os.getenv('DDEV_E2E_AGENT_PY2')
+
+    agent_ver = agent or fallback
     agent_build = ctx.obj.get('agents', {}).get(
         agent_ver,
         # TODO: remove this legacy fallback lookup in any future major version bump


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Consider `DDEV_E2E_AGENT_PY2` environment variable when starting python 2 environment with `ddev env start` or `ddev env test`

### Motivation
<!-- What inspired you to submit this pull request? -->
Pre-requisite to add a new pipeline to tests integration against specific agent builds #10204 

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Test example: `DDEV_E2E_AGENT=datadog/agent:7.31.0-rc.10 DDEV_E2E_AGENT_PY2=datadog/agent:6.31.0-rc.11 ddev env test --base -ne --junit citrix_hypervisor`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
