### PR TITLE
Update AZP templates to take in a dd_url and small fixes to validator

### DIFF
--- a/.azure-pipelines/templates/install-deps.yml
+++ b/.azure-pipelines/templates/install-deps.yml
@@ -55,9 +55,9 @@ steps:
   - script: pip install datadog-checks-dev[cli]
     displayName: 'Install ddev from PyPI'
 
-- script:
-    - ddev config set repos.${{ parameters.repo }} .
-    - ddev config set repo ${{ parameters.repo }}
-    - ddev config set orgs.ci.dd_url ${{ parameters.dd_url}}
-    - ddev config set org ci
+- script: |
+    ddev config set repos.${{ parameters.repo }} .
+    ddev config set repo ${{ parameters.repo }}
+    ddev config set orgs.ci.dd_url ${{ parameters.dd_url}}
+    ddev config set org ci
   displayName: 'Configure ddev'

--- a/.azure-pipelines/templates/install-deps.yml
+++ b/.azure-pipelines/templates/install-deps.yml
@@ -7,6 +7,8 @@ parameters:
     default: null
   - name: run_py2_tests
     default: true
+  - name: dd_url
+    default: https://app.datadoghq.com
 
 steps:
 # Install the Python version with which to use globally last as
@@ -53,5 +55,9 @@ steps:
   - script: pip install datadog-checks-dev[cli]
     displayName: 'Install ddev from PyPI'
 
-- script: ddev config set repos.${{ parameters.repo }} . && ddev config set repo ${{ parameters.repo }}
+- script:
+    - ddev config set repos.${{ parameters.repo }} .
+    - ddev config set repo ${{ parameters.repo }}
+    - ddev config set orgs.ci.dd_url ${{ parameters.dd_url}}
+    - ddev config set org ci
   displayName: 'Configure ddev'

--- a/.azure-pipelines/templates/test-all.yml
+++ b/.azure-pipelines/templates/test-all.yml
@@ -11,6 +11,7 @@ parameters:
   benchmark: true
   latest: false
   ddtrace_flag: ''
+  dd_url: https://app.datadoghq.com
 
 jobs:
 - ${{ each check in parameters.checks }}:
@@ -30,6 +31,7 @@ jobs:
       latest: ${{ parameters.latest }}
       ddtrace_flag: ${{ parameters.ddtrace_flag }}
       validate_codeowners: ${{ parameters.validate_codeowners }}
+      dd_url: ${{ parameters.dd_url }}
 
       # Avoid max step limits
       ${{ if eq(check.checkName, 'datadog_checks_base') }}:

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -45,6 +45,7 @@ jobs:
       repo: ${{ parameters.repo }}
       pip_cache_config: ${{ parameters.pip_cache_config }}
       run_py2_tests: ${{ parameters.run_py2_tests }}
+      dd_url: ${{ parameters.dd_url }}
 
   - template: './set-up-integrations.yml'
     parameters:

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -16,6 +16,7 @@ parameters:
   force_base_package: false
   pip_cache_config: null
   coverage: true
+  dd_url: https://app.datadoghq.com
 
 jobs:
 - job: '${{ coalesce(parameters.job_name, parameters.check) }}_Linux'

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -49,6 +49,7 @@ jobs:
       repo: ${{ parameters.repo }}
       pip_cache_config: ${{ parameters.pip_cache_config }}
       run_py2_tests: ${{ parameters.run_py2_tests }}
+      dd_url: ${{ parameters.dd_url }}
 
   - template: './set-up-integrations.yml'
     parameters:

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -16,6 +16,7 @@ parameters:
   force_base_package: false
   pip_cache_config: null
   coverage: true
+  dd_url: https://app.datadoghq.com
 
 jobs:
 - job: '${{ coalesce(parameters.job_name, parameters.check) }}_Windows'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
@@ -37,26 +37,21 @@ class SchemaValidator(BaseManifestValidator):
             return
 
         # Get API and APP keys which are needed to call Datadog API
-        org_name = self.ctx.obj['org']
+        org_name = self.ctx.obj.get('org')
         if not org_name:
             self.fail('No `org` has been set')
+            return
 
-        if org_name not in self.ctx.obj['orgs']:
+        if org_name not in self.ctx.obj.get('orgs'):
             self.fail(f'Selected org {org_name} is not in `orgs`')
+            return
 
         org = self.ctx.obj['orgs'][org_name]
-
-        api_key = org.get('api_key')
-        if not api_key:
-            self.fail(f'No `api_key` has been set for org `{org_name}`')
-
-        app_key = org.get('app_key')
-        if not app_key:
-            self.fail(f'No `app_key` has been set for org `{org_name}`')
 
         dd_url = org.get('dd_url')
         if not dd_url:
             self.fail(f'No `dd_url` has been set for org `{org_name}`')
+            return
 
         url = f"{dd_url}/api/beta/apps/manifest/validate"
 
@@ -65,7 +60,7 @@ class SchemaValidator(BaseManifestValidator):
 
         try:
             payload_json = json.dumps(payload)
-            r = requests.post(url, data=payload_json, headers={'DD-API-KEY': api_key, 'DD-APPLICATION-KEY': app_key})
+            r = requests.post(url, data=payload_json)
 
             if r.status_code == 400:
                 # parse the errors
@@ -75,7 +70,7 @@ class SchemaValidator(BaseManifestValidator):
             else:
                 r.raise_for_status()
         except Exception as e:
-            self.fail(str(e).replace(api_key, '*' * len(api_key)).replace(app_key, '*' * len(app_key)))
+            self.fail(str(e))
 
 
 def get_v2_validators(ctx, is_extras, is_marketplace):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Fail fast and return if we don't have the proper config to run the v2 validation. (Each check requires the previous to be true, so we should return quick if there are issues)
* Remove API/APP key from being required 
* Add dd_url to the Azure templates so that we can pass in a URL to use to run the validation against

### Motivation
<!-- What inspired you to submit this pull request? -->
We're working on fixing the Marketplace CI and beginning to validate V2 manifests

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
