### PR TITLE
Don't set empty asset values on migration

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
@@ -168,6 +168,10 @@ def migrate(ctx, integration, to_version):
         else:
             final_value = val
 
+        # We need to remove any of the underlying "assets" that are just an empty dictionary
+        if key in ["/assets/dashboards", "/assets/monitors", "/assets/saved_views"] and not final_value:
+            continue
+
         if final_value is not None:
             migrated_manifest.set_path(key, final_value)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Don't set the empty underlying asset fields on migration

### Motivation
<!-- What inspired you to submit this pull request? -->
These fields should be non existant, not empty

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
