### PR TITLE
Forbid time_unit/time_unit metric metadata type

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -45,6 +45,17 @@ EXCLUDE_INTEGRATIONS = [
     'tcp',
 ]
 
+VALID_TIME_UNIT_NAMES = {
+    'nanosecond',
+    'microsecond',
+    'millisecond',
+    'second',
+    'minute',
+    'hour',
+    'day',
+    'week',
+}
+
 # To easily derive these again in future, copy the contents of `integration/system/units_catalog.csv` then run:
 #
 # pyperclip.copy('\n'.join("    '{}',".format(line.split(',')[2]) for line in pyperclip.paste().splitlines()))
@@ -371,6 +382,18 @@ def metadata(check, check_duplicates, show_warnings):
                 errors = True
                 display_queue.append(
                     (echo_failure, f"{current_check}:{line} `{row['per_unit_name']}` is an invalid per_unit_name.")
+                )
+
+            # Check if unit/per_unit is valid
+            if row['unit_name'] in VALID_TIME_UNIT_NAMES and row['per_unit_name'] in VALID_TIME_UNIT_NAMES:
+                errors = True
+                display_queue.append(
+                    (
+                        echo_failure,
+                        f"{current_check}:{line} `{row['unit_name']}/{row['per_unit_name']}` unit is invalid, "
+                        f"use the fraction unit instead. If `{row['unit_name']}` and `{row['per_unit_name']}` "
+                        "are not the same unit, eg ms/s, note that in the description.",
+                    )
                 )
 
             # integration header


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`time_unit/time_unit` (e.g. `ms/s`) is forbidden in the backend, let's raise an error with `ddev validate metadata`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
