### PR TITLE
Apply namespace exclusion rules before reporting network metrics

### DIFF
--- a/kubelet/README.md
+++ b/kubelet/README.md
@@ -63,12 +63,13 @@ deployed by setting the [`DD_CONTAINER_EXCLUDE` environment
 variable][7]. This integration does not report metrics from the containers
 specified in that environment variable.
 
-This integration reports network metrics that apply to a pod instead of a
-single container. So, if `DD_CONTAINER_EXCLUDE` applies to a
-namespace, the pod-level metrics will not be reported if the pod is in that
-namespace. However, if `DD_CONTAINER_EXCLUDE` refers to a container name or an
-image name, the pod-level metrics will be reported even if the exclusion rules
-defined apply to some containers included in the pod.
+For network metrics reported at the pod level, excluding containers based on
+"name" or "image name" will not work since other containers can be part of the
+same pod. So, if `DD_CONTAINER_EXCLUDE` applies to a namespace, the pod-level
+metrics will not be reported if the pod is in that namespace. However, if
+`DD_CONTAINER_EXCLUDE` refers to a container name or an image name, the
+pod-level metrics will be reported even if the exclusion rules defined apply to
+some containers included in the pod.
 
 
 ## Troubleshooting

--- a/kubelet/README.md
+++ b/kubelet/README.md
@@ -58,13 +58,13 @@ See [service_checks.json][6] for a list of service checks provided by this integ
 
 ### Excluded containers
 
-It is possible to restrict the data collected to a subset of the containers
-deployed. This is done setting the [`DD_CONTAINER_EXCLUDE` environment
+You can restrict the data collected to a subset of the containers
+deployed by setting the [`DD_CONTAINER_EXCLUDE` environment
 variable][7]. This integration does not report metrics from the containers
 specified in that environment variable.
 
-This integration also reports network metrics that apply to a pod instead of a
-single container. In that case, if `DD_CONTAINER_EXCLUDE` applies to a
+This integration reports network metrics that apply to a pod instead of a
+single container. So, if `DD_CONTAINER_EXCLUDE` applies to a
 namespace, the pod-level metrics will not be reported if the pod is in that
 namespace. However, if `DD_CONTAINER_EXCLUDE` refers to a container name or an
 image name, the pod-level metrics will be reported even if the exclusion rules

--- a/kubelet/README.md
+++ b/kubelet/README.md
@@ -56,6 +56,21 @@ The check will still be able to collect:
 
 See [service_checks.json][6] for a list of service checks provided by this integration.
 
+### Excluded containers
+
+It is possible to restrict the data collected to a subset of the containers
+deployed. This is done setting the [`DD_CONTAINER_EXCLUDE` environment
+variable][7]. This integration does not report metrics from the containers
+specified in that environment variable.
+
+This integration also reports network metrics that apply to a pod instead of a
+single container. In that case, if `DD_CONTAINER_EXCLUDE` applies to a
+namespace, the pod-level metrics will not be reported if the pod is in that
+namespace. However, if `DD_CONTAINER_EXCLUDE` refers to a container name or an
+image name, the pod-level metrics will be reported even if the exclusion rules
+defined apply to some containers included in the pod.
+
+
 ## Troubleshooting
 
 Need help? Contact [Datadog support][5].
@@ -67,3 +82,4 @@ Need help? Contact [Datadog support][5].
 [4]: https://docs.openshift.org/3.7/install_config/master_node_configuration.html#node-configuration-files
 [5]: https://docs.datadoghq.com/help/
 [6]: https://github.com/DataDog/integrations-core/blob/master/kubelet/assets/service_checks.json
+[7]: https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent

--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -108,6 +108,7 @@ class PodListUtils(object):
         self.pods = {}
         self.static_pod_uids = set()
         self.cache = {}
+        self.cache_namespace_exclusion = {}
         self.pod_uid_by_name_tuple = {}
         self.container_id_by_name_tuple = {}
         self.container_id_to_namespace = {}
@@ -187,4 +188,23 @@ class PodListUtils(object):
 
         excluded = c_is_excluded(ctr.get("name"), ctr.get("image"), self.container_id_to_namespace.get(cid, ""))
         self.cache[cid] = excluded
+        return excluded
+
+    def is_namespace_excluded(self, namespace):
+        """
+        Queries the agent container filter interface to check whether a
+        Kubernetes namespace should be excluded.
+
+        The result is cached between calls to avoid the python-go switching
+        cost.
+        :param namespace: namespace
+        :return: bool
+        """
+        if not namespace:
+            return False
+
+        # Sent empty container name and image because we are interested in
+        # applying only the namespace exclusion rules.
+        excluded = c_is_excluded('', '', namespace)
+        self.cache_namespace_exclusion[namespace] = excluded
         return excluded

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -344,6 +344,11 @@ class CadvisorPrometheusScraperMixin(object):
 
         samples = self._sum_values_by_context(metric, self._get_pod_uid_if_pod_metric)
         for pod_uid, sample in iteritems(samples):
+            pod = get_pod_by_uid(pod_uid, self.pod_list)
+            namespace = pod.get('metadata', {}).get('namespace', None)
+            if self.pod_list_utils.is_namespace_excluded(namespace):
+                continue
+
             if '.network.' in metric_name and self._is_pod_host_networked(pod_uid):
                 continue
             tags = tagger.tag('kubernetes_pod_uid://%s' % pod_uid, tagger.HIGH)

--- a/kubelet/tests/test_common.py
+++ b/kubelet/tests/test_common.py
@@ -91,6 +91,33 @@ def test_filter_staticpods(monkeypatch):
     )
 
 
+def test_is_namespace_excluded(monkeypatch):
+    c_is_excluded = mock.Mock(return_value=False)
+    monkeypatch.setattr('datadog_checks.kubelet.common.c_is_excluded', c_is_excluded)
+
+    pods = json.loads(mock_from_file('pods.json'))
+    pod_list_utils = PodListUtils(pods)
+
+    # Test namespace=None
+    c_is_excluded.reset_mock()
+    assert pod_list_utils.is_namespace_excluded(None) is False
+    c_is_excluded.assert_not_called()
+
+    # Test excluded namespace
+    c_is_excluded.reset_mock()
+    c_is_excluded.return_value = True
+    assert pod_list_utils.is_namespace_excluded('an_excluded_namespace') is True
+    c_is_excluded.assert_called_once()
+    c_is_excluded.assert_called_with('', '', 'an_excluded_namespace')
+
+    # Test non-excluded namespace
+    c_is_excluded.reset_mock()
+    c_is_excluded.return_value = False
+    assert pod_list_utils.is_namespace_excluded('a_non_excluded_namespace') is False
+    c_is_excluded.assert_called_once()
+    c_is_excluded.assert_called_with('', '', 'a_non_excluded_namespace')
+
+
 def test_pod_by_uid():
     podlist = json.loads(mock_from_file('pods.json'))
 


### PR DESCRIPTION
### What does this PR do?
Fixes a bug in the Kubelet check. Now the check verifies if a Kubernetes namespace should be excluded before reporting `network.*` metrics.

 Users can exclude metrics from certain containers using the `DD_CONTAINER_EXCLUDE` env ([docs](https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent)). The Kubelet check applied those exclusion rules in most cases, but not for the network metrics at the pod level. So, when a user specified something like: `kube_namespace:my_namespace`, the Kubelet check still reported network metrics of pods deployed in `my_namespace`. This PR fixes the issue.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
