### PR TITLE
[snmp] update e2e test default metadata namespace

### DIFF
--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -159,3 +159,81 @@ def test_e2e_core_discovery(dd_agent_check):
         'snmp.devices_monitored', metric_type=aggregator.GAUGE, tags=tags_with_loader, at_least=4, value=1
     )
     aggregator.assert_metric('snmp.upsAdvBatteryTemperature', metric_type=aggregator.GAUGE, tags=tags, at_least=4)
+
+
+def test_e2e_regex_match(dd_agent_check):
+    metrics = [
+        {
+            'MIB': "IF-MIB",
+            'table': {
+                "name": "ifTable",
+                "OID": "1.3.6.1.2.1.2.2",
+            },
+            'symbols': [
+                {
+                    "name": "ifInOctets",
+                    "OID": "1.3.6.1.2.1.2.2.1.10",
+                },
+                {
+                    "name": "ifOutOctets",
+                    "OID": "1.3.6.1.2.1.2.2.1.16",
+                },
+            ],
+            'metric_tags': [
+                {
+                    'tag': "interface",
+                    'column': {
+                        "name": "ifDescr",
+                        "OID": "1.3.6.1.2.1.2.2.1.2",
+                    },
+                },
+                {
+                    'column': {
+                        "name": "ifDescr",
+                        "OID": "1.3.6.1.2.1.2.2.1.2",
+                    },
+                    'match': '(\\w)(\\w+)',
+                    'tags': {'prefix': '\\1', 'suffix': '\\2'},
+                },
+            ],
+        }
+    ]
+    config = common.generate_container_instance_config(metrics)
+    instance = config['instances'][0]
+    instance['metric_tags'] = [
+        {
+            "OID": "1.3.6.1.2.1.1.5.0",
+            "symbol": "sysName",
+            "match": "(\\d+)(\\w+)",
+            "tags": {
+                "digits": "\\1",
+                "remainder": "\\2",
+            },
+        },
+        {
+            "OID": "1.3.6.1.2.1.1.5.0",
+            "symbol": "sysName",
+            "match": "(\\w)(\\w)",
+            "tags": {
+                "letter1": "\\1",
+                "letter2": "\\2",
+            },
+        },
+    ]
+    aggregator = dd_agent_check(config, rate=True)
+    config['init_config']['loader'] = 'core'
+    aggregator = dd_agent_check(config, rate=True)
+
+    # raw sysName: 41ba948911b9
+    aggregator.assert_metric(
+        'snmp.devices_monitored',
+        tags=[
+            'digits:41',
+            'remainder:ba948911b9',
+            'letter1:4',
+            'letter2:1',
+            'loader:core',
+            'snmp_device:' + instance['ip_address'],
+            'device_namespace:default',
+        ],
+    )

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -79,6 +79,7 @@ def assert_apc_ups_metrics(dd_agent_check, config):
         'serial_num:test_serial',
         'ups_name:testIdentName',
         'device_vendor:apc',
+        'device_namespace:default',
     ]
     tags = profile_tags + ["snmp_device:{}".format(instance['ip_address'])]
 
@@ -144,6 +145,7 @@ def test_e2e_core_discovery(dd_agent_check):
         'serial_num:test_serial',
         'ups_name:testIdentName',
         'device_vendor:apc',
+        'device_namespace:default',
         # autodiscovery
         'autodiscovery_subnet:' + network,
         'snmp_device:' + ip_address,

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -24,6 +24,10 @@ ASSERT_VALUE_METRICS = [
     'datadog.snmp.submitted_metrics',
 ]
 
+SKIPPED_TAGS = ['loader']
+
+CORE_ONLY_TAGS = ['device_namespace:default']
+
 
 def test_e2e_metric_types(dd_agent_check):
     instance = common.generate_container_instance_config(SUPPORTED_METRIC_TYPES)
@@ -358,6 +362,7 @@ def assert_python_vs_core(
     python_config['init_config']['loader'] = 'python'
     core_config = deepcopy(config)
     core_config['init_config']['loader'] = 'core'
+    core_config['init_config']['collect_device_metadata'] = 'false'
     metrics_to_skip = metrics_to_skip or []
 
     # building expected metrics (python)
@@ -368,12 +373,14 @@ def assert_python_vs_core(
             if stub.name in metrics_to_skip:
                 continue
             stub = normalize_stub_metric(stub)
-            python_metrics[(stub.name, stub.type, tuple(sorted(stub.tags)))].append(stub)
+            python_metrics[(stub.name, stub.type, tuple(sorted(list(stub.tags) + CORE_ONLY_TAGS)))].append(stub)
 
     python_service_checks = defaultdict(list)
     for _, service_checks in aggregator._service_checks.items():
         for stub in service_checks:
-            python_service_checks[(stub.name, stub.status, tuple(sorted(stub.tags)), stub.message)].append(stub)
+            python_service_checks[
+                (stub.name, stub.status, tuple(sorted(list(stub.tags) + CORE_ONLY_TAGS)), stub.message)
+            ].append(stub)
 
     total_count_python = sum(len(stubs) for stubs in python_metrics.values())
 
@@ -426,7 +433,7 @@ def assert_python_vs_core(
 
 
 def normalize_stub_metric(stub):
-    tags = [t for t in stub.tags if not t.startswith('loader:')]  # Remove `loader` tag
+    tags = [t for t in stub.tags if not is_skipped_tag(t)]  # Remove skipped tag
     return MetricStub(
         stub.name,
         stub.type,
@@ -435,3 +442,10 @@ def normalize_stub_metric(stub):
         stub.hostname,
         stub.device,
     )
+
+
+def is_skipped_tag(tag):
+    for skipped_tag in SKIPPED_TAGS:
+        if tag.startswith('{}:'.format(skipped_tag)):
+            return True
+    return False

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -67,7 +67,7 @@ def test_e2e_v3_explicit_version(dd_agent_check):
     assert_python_vs_core(dd_agent_check, config, expected_total_count=511 + 5)
 
 
-def test_e2e_regex_match(dd_agent_check, aggregator):
+def test_e2e_regex_match(dd_agent_check):
     metrics = [
         {
             'MIB': "IF-MIB",
@@ -127,23 +127,6 @@ def test_e2e_regex_match(dd_agent_check, aggregator):
         },
     ]
     assert_python_vs_core(dd_agent_check, config)
-
-    config['init_config']['loader'] = 'core'
-    aggregator.reset()
-    aggregator = dd_agent_check(config, rate=True)
-
-    # raw sysName: 41ba948911b9
-    aggregator.assert_metric(
-        'snmp.devices_monitored',
-        tags=[
-            'digits:41',
-            'remainder:ba948911b9',
-            'letter1:4',
-            'letter2:1',
-            'loader:core',
-            'snmp_device:' + instance['ip_address'],
-        ],
-    )
 
 
 def test_e2e_scalar_oid_retry(dd_agent_check):

--- a/snmp/tests/test_e2e_snmp_listener.py
+++ b/snmp/tests/test_e2e_snmp_listener.py
@@ -49,6 +49,7 @@ def test_e2e_snmp_listener(dd_agent_check, container_ip, autodiscovery_ready):
         'autodiscovery_subnet:{}.0/29'.format(subnet_prefix),
         'tag1:val1',
         'tag2:val2',
+        'device_namespace:default',
     ]
 
     common.assert_common_metrics(aggregator, common_tags, is_e2e=True, loader='core')


### PR DESCRIPTION
### What does this PR do?

Update e2e tests to support changes in core configuration 
* collecting metadata by default
* namespace tag


### Motivation

https://github.com/DataDog/datadog-agent/pull/9225
https://github.com/DataDog/datadog-agent/pull/9231

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
