### PR TITLE
Account for possible nonetype

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -435,6 +435,8 @@ class SqlMasterDatabaseFileStats(BaseSqlServerMetric):
 
         for row in rows:
             column_val = row[value_column_index]
+            if column_val is None:
+                continue
             if self.column in ('size', 'max_size'):
                 column_val *= 8  # size reported in 8 KB pages
 


### PR DESCRIPTION
### What does this PR do?
In the scenario that the size/max_size value is None/Null, the attempt to compute the file size results in a TypeError

```
2021-08-30 16:38:06 EDT | CORE | ERROR | (pkg/collector/runner/runner.go:301 in work) | Error running check sqlserver: [{"message": "unsupported operand type(s) for *=: 'NoneType' and 'int'", "traceback": "Traceback (most recent call last):\n File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\datadog_checks\\base\\checks\\base.py\", line 996, in run\n self.check(instance)\n File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\datadog_checks\\sqlserver\\sqlserver.py\", line 445, in check\n self.collect_metrics()\n File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\datadog_checks\\sqlserver\\sqlserver.py\", line 486, in collect_metrics\n metric.fetch_metric(rows, cols)\n File \"C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\datadog_checks\\sqlserver\\metrics.py\", line 439, in fetch_metric\n column_val *= 8 # size reported in 8 KB pages\nTypeError: unsupported operand type(s) for *=: 'NoneType' and 'int'\n"}]

```
### Motivation
Support case
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
