### PR TITLE
Set repo name after we process the `--here` flag

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -135,7 +135,6 @@ def initialize_root(config, agent=False, core=False, extras=False, marketplace=F
         else config.get('repo', 'core')
     )
     config['repo_choice'] = repo_choice
-    config['repo_name'] = REPO_CHOICES.get(repo_choice, repo_choice)
     message = None
     # TODO: remove this legacy fallback lookup in any future major version bump
     legacy_option = None if repo_choice == 'agent' else config.get(repo_choice)
@@ -156,6 +155,7 @@ def initialize_root(config, agent=False, core=False, extras=False, marketplace=F
             # Repo choices use the integration repo name without the `integrations-` prefix
             config['repo_choice'] = os.path.basename(root).replace('integrations-', '')
 
+    config['repo_name'] = REPO_CHOICES.get(config['repo_choice'], config['repo_choice'])
     set_root(root)
     return message
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes the processing of the context's `repo_name` when using the `--here\-x` flag

### Motivation
<!-- What inspired you to submit this pull request? -->
There's a lot of ddev tooling that checks the context objects `repo_name` to know to perform certain actions. 
However previously, we were only updating the `repo_choice` setting. This caused some weird inconsistencies when running the tooling. 

For example, the `get_root` method lets the `--here` flag take precedence, so when you pass a check_name, it can find it in that folder. However, any logic checking for `repo_name` would take the config value directly. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
