### PR TITLE
[NDM] Add config for enabling NDM metadata collection

### DIFF
--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -111,6 +111,13 @@ files:
         value:
           type: boolean
           example: false
+      - name: collect_device_metadata
+        description: |
+          Enable device metadata collection for all instances.
+          Only available using corecheck SNMP integration with `loader: core` config.
+        value:
+          type: boolean
+          example: true
       - template: init_config/default
     - template: instances
       options:
@@ -355,4 +362,11 @@ files:
           type: integer
           example: 3600
           display_default: 0
+      - name: collect_device_metadata
+        description: |
+          Enable device metadata collection.
+          Only available using corecheck SNMP integration with `loader: core` config.
+        value:
+          type: boolean
+          example: true
       - template: instances/default

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -98,6 +98,12 @@ init_config:
     #
     # service: <SERVICE>
 
+    ## @param collect_device_metadata - boolean - optional - default: true
+    ## Enable device metadata collection for all
+    ## Only available using corecheck SNMP integration with `loader: core` config.
+    #
+    # collect_device_metadata: true
+
 ## Every instance is scheduled independent of the others.
 #
 instances:
@@ -338,3 +344,9 @@ instances:
     ## This is useful for cluster-level checks.
     #
     # empty_default_hostname: false
+
+    ## @param collect_device_metadata - boolean - optional - default: true
+    ## Enable device metadata collection
+    ## Only available using corecheck SNMP integration with `loader: core` config.
+    #
+    # collect_device_metadata: true

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -91,18 +91,18 @@ init_config:
     #
     # ignore_nonincreasing_oid: false
 
+    ## @param collect_device_metadata - boolean - optional - default: true
+    ## Enable device metadata collection for all instances.
+    ## Only available using corecheck SNMP integration with `loader: core` config.
+    #
+    # collect_device_metadata: true
+
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
     ##
     ## Additionally, this sets the default `service` for every log source.
     #
     # service: <SERVICE>
-
-    ## @param collect_device_metadata - boolean - optional - default: true
-    ## Enable device metadata collection for all instances.
-    ## Only available using corecheck SNMP integration with `loader: core` config.
-    #
-    # collect_device_metadata: true
 
 ## Every instance is scheduled independent of the others.
 #
@@ -316,6 +316,12 @@ instances:
     #
     # refresh_oids_cache_interval: 3600
 
+    ## @param collect_device_metadata - boolean - optional - default: true
+    ## Enable device metadata collection.
+    ## Only available using corecheck SNMP integration with `loader: core` config.
+    #
+    # collect_device_metadata: true
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##
@@ -344,9 +350,3 @@ instances:
     ## This is useful for cluster-level checks.
     #
     # empty_default_hostname: false
-
-    ## @param collect_device_metadata - boolean - optional - default: true
-    ## Enable device metadata collection.
-    ## Only available using corecheck SNMP integration with `loader: core` config.
-    #
-    # collect_device_metadata: true

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -99,7 +99,7 @@ init_config:
     # service: <SERVICE>
 
     ## @param collect_device_metadata - boolean - optional - default: true
-    ## Enable device metadata collection for all
+    ## Enable device metadata collection for all instances.
     ## Only available using corecheck SNMP integration with `loader: core` config.
     #
     # collect_device_metadata: true
@@ -346,7 +346,7 @@ instances:
     # empty_default_hostname: false
 
     ## @param collect_device_metadata - boolean - optional - default: true
-    ## Enable device metadata collection
+    ## Enable device metadata collection.
     ## Only available using corecheck SNMP integration with `loader: core` config.
     #
     # collect_device_metadata: true


### PR DESCRIPTION
### What does this PR do?

Add config for enabling NDM metadata collection.

### Motivation

We have added this option to enable/disable device metadata collection. It needs to be documented.

### Review checklist (to be filled by reviewers)

* Check the file `datadog.yaml` does contain the lines describing the configuration.

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
