### PR TITLE
Fix the manifest version for the kubelet check

### DIFF
--- a/kubelet/manifest.json
+++ b/kubelet/manifest.json
@@ -7,7 +7,7 @@
   "guid": "55039e21-7e89-41fb-968c-ab8bf8f25da0",
   "is_public": true,
   "maintainer": "help@datadoghq.com",
-  "manifest_version": "1.2.0",
+  "manifest_version": "1.0.0",
   "metric_prefix": "kubernetes.",
   "metric_to_check": "kubernetes.cpu.usage.total",
   "name": "kubelet",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fix the manifest version for the kubelet check to properly be 1.0.0

### Motivation
<!-- What inspired you to submit this pull request? -->
The only valid value of the manifest version at this time is 1.0.0 (We didn't strictly validate against non 1.0.0 values, but as we're looking to support more, we need to have these properly set)

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This should have 0 impact on any running part of this integration and only impact the validations and readers of the manifest file.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
