### PR TITLE
DBMAsyncJob send internal metrics as raw

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -230,11 +230,13 @@ class DBMAsyncJob(object):
             while True:
                 if self._cancel_event.isSet():
                     self._log.info("[%s] Job loop cancelled", self._job_tags_str)
-                    self._check.count("dd.{}.async_job.cancel".format(self._dbms), 1, tags=self._job_tags)
+                    self._check.count("dd.{}.async_job.cancel".format(self._dbms), 1, tags=self._job_tags, raw=True)
                     break
                 if time.time() - self._last_check_run > self._min_collection_interval * 2:
                     self._log.info("[%s] Job loop stopping due to check inactivity", self._job_tags_str)
-                    self._check.count("dd.{}.async_job.inactive_stop".format(self._dbms), 1, tags=self._job_tags)
+                    self._check.count(
+                        "dd.{}.async_job.inactive_stop".format(self._dbms), 1, tags=self._job_tags, raw=True
+                    )
                     break
                 self._run_job_rate_limited()
         except self._expected_db_exceptions as e:
@@ -248,6 +250,7 @@ class DBMAsyncJob(object):
                 "dd.{}.async_job.error".format(self._dbms),
                 1,
                 tags=self._job_tags + ["error:database-{}".format(type(e))],
+                raw=True,
             )
         except Exception as e:
             self._log.exception("[%s] Job loop crash", self._job_tags_str)
@@ -255,6 +258,7 @@ class DBMAsyncJob(object):
                 "dd.{}.async_job.error".format(self._dbms),
                 1,
                 tags=self._job_tags + ["error:crash-{}".format(type(e))],
+                raw=True,
             )
         finally:
             self._log.info("[%s] Shutting down job loop", self._job_tags_str)


### PR DESCRIPTION
### What does this PR do?

Send internal debug metrics with `raw=True` to ensure the check's standard namespace is not added as a prefix.

### Motivation

The upcoming SQL Server DBM integration uses the `__NAMESPACE__` setting so these metrics must be "raw" to ensure they're not prefixed the same way. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
