### PR TITLE
[snmp] add namespace doc

### DIFF
--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -122,6 +122,7 @@ files:
         description: |
             Namespace can be used to disambiguate devices with same IPs.
             Changing namespace will cause devices being recreated in NDM app.
+            Only available using corecheck SNMP integration with `loader: core` config.
         value:
           example: default
           type: string
@@ -381,6 +382,7 @@ files:
         description: |
           Namespace can be used to disambiguate devices with same IPs.
           Changing namespace will cause devices being recreated in NDM app.
+          Only available using corecheck SNMP integration with `loader: core` config.
         value:
           example: default
           type: string

--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -118,6 +118,14 @@ files:
         value:
           type: boolean
           example: true
+      - name: namespace
+        description: |
+            Namespace can be used to disambiguate devices with same IPs.
+            Changing namespace will cause devices being recreated in NDM app.
+        value:
+          example: default
+          type: string
+          display_default: default
       - template: init_config/default
     - template: instances
       options:
@@ -369,4 +377,12 @@ files:
         value:
           type: boolean
           example: true
+      - name: namespace
+        description: |
+          Namespace can be used to disambiguate devices with same IPs.
+          Changing namespace will cause devices being recreated in NDM app.
+        value:
+          example: default
+          type: string
+          display_default: default
       - template: instances/default

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -100,6 +100,7 @@ init_config:
     ## @param namespace - string - optional - default: default
     ## Namespace can be used to disambiguate devices with same IPs.
     ## Changing namespace will cause devices being recreated in NDM app.
+    ## Only available using corecheck SNMP integration with `loader: core` config.
     #
     # namespace: default
 
@@ -331,6 +332,7 @@ instances:
     ## @param namespace - string - optional - default: default
     ## Namespace can be used to disambiguate devices with same IPs.
     ## Changing namespace will cause devices being recreated in NDM app.
+    ## Only available using corecheck SNMP integration with `loader: core` config.
     #
     # namespace: default
 

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -97,6 +97,12 @@ init_config:
     #
     # collect_device_metadata: true
 
+    ## @param namespace - string - optional - default: default
+    ## Namespace can be used to disambiguate devices with same IPs.
+    ## Changing namespace will cause devices being recreated in NDM app.
+    #
+    # namespace: default
+
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
     ##
@@ -321,6 +327,12 @@ instances:
     ## Only available using corecheck SNMP integration with `loader: core` config.
     #
     # collect_device_metadata: true
+
+    ## @param namespace - string - optional - default: default
+    ## Namespace can be used to disambiguate devices with same IPs.
+    ## Changing namespace will cause devices being recreated in NDM app.
+    #
+    # namespace: default
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.


### PR DESCRIPTION
### What does this PR do?

Add documentation in snmp spec for `namespace` option. Related to https://github.com/DataDog/datadog-agent/pull/9303

### Motivation

Avoid ambiguity between devices with the same IP address within the same organisation 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
