### PR TITLE
Don't add null values to classifier tags

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
@@ -186,7 +186,7 @@ def migrate(ctx, integration, to_version):
     for os in supported_os:
         os_tag = OS_TO_CLASSIFIER_TAGS.get(os.lower())
         if os_tag:
-            classifier_tags.append(OS_TO_CLASSIFIER_TAGS.get(os.lower()))
+            classifier_tags.append(os_tag)
 
     categories = loaded_manifest.get_path("/categories")
     for category in categories:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
@@ -184,11 +184,15 @@ def migrate(ctx, integration, to_version):
     classifier_tags = []
     supported_os = loaded_manifest.get_path("/supported_os")
     for os in supported_os:
-        classifier_tags.append(OS_TO_CLASSIFIER_TAGS.get(os.lower()))
+        os_tag = OS_TO_CLASSIFIER_TAGS.get(os.lower())
+        if os_tag:
+            classifier_tags.append(OS_TO_CLASSIFIER_TAGS.get(os.lower()))
 
     categories = loaded_manifest.get_path("/categories")
     for category in categories:
-        classifier_tags.append(CATEGORIES_TO_CLASSIFIER_TAGS.get(category.lower()))
+        category_tag = CATEGORIES_TO_CLASSIFIER_TAGS.get(category.lower())
+        if category_tag:
+            classifier_tags.append(category_tag)
 
     # Write the manifest back to disk
     migrated_manifest.set_path("/classifier_tags", classifier_tags)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Avoid having null values be added to the classifier tags list when migrating a manifest to v2

### Motivation
<!-- What inspired you to submit this pull request? -->
The migrator does a lookup of each category to see what the coresponding enum value is. There are some cases where categories is `[""]`, which causes a `null` value to be added to the final migrated manifest. This avoids that scenario and skips any classifier_tags we can't use. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
