### PR TITLE
Add Windows metrics in containerd integration

### DIFF
--- a/containerd/README.md
+++ b/containerd/README.md
@@ -106,7 +106,7 @@ CPU, memory, block I/O, or huge page table metrics are collected out of the box.
 See [metadata.csv][5] for a list of metrics provided by this integration.
 
 This integration works on Linux and Windows, but some metrics are OS dependent.
-- Linux-specific: `containerd.hugetlb.*`, `containerd.blkio.*`, `containerd.cpu.throttled.periods`, and all the `containerd.mem.*` ones except these 3: `containerd.mem.commit`, `containerd.mem.commit_peak`, and `containerd.mem.private_working_set`.
+- Linux-specific: `containerd.hugetlb.*`, `containerd.blkio.*`, `containerd.cpu.throttled.periods`, and all the `containerd.mem.*` metrics except: `containerd.mem.commit`, `containerd.mem.commit_peak`, and `containerd.mem.private_working_set`.
 - Windows-specific: `containerd.mem.commit`, `containerd.mem.commit_peak`, `containerd.mem.private_working_set`, and `containerd.storage.*`.
  
 ### Events

--- a/containerd/README.md
+++ b/containerd/README.md
@@ -105,9 +105,7 @@ CPU, memory, block I/O, or huge page table metrics are collected out of the box.
 
 See [metadata.csv][5] for a list of metrics provided by this integration.
 
-This integration works on Linux and Windows, but some metrics are OS dependent.
-- Linux-specific: `containerd.hugetlb.*`, `containerd.blkio.*`, `containerd.cpu.throttled.periods`, and all the `containerd.mem.*` metrics except: `containerd.mem.commit`, `containerd.mem.commit_peak`, and `containerd.mem.private_working_set`.
-- Windows-specific: `containerd.mem.commit`, `containerd.mem.commit_peak`, `containerd.mem.private_working_set`, and `containerd.storage.*`.
+This integration works on Linux and Windows, but some metrics are OS dependent. Look at `metadata.csv` for the list of OS dependent metrics. 
  
 ### Events
 

--- a/containerd/README.md
+++ b/containerd/README.md
@@ -105,6 +105,10 @@ CPU, memory, block I/O, or huge page table metrics are collected out of the box.
 
 See [metadata.csv][5] for a list of metrics provided by this integration.
 
+This integration works on Linux and Windows, but some metrics are OS dependent.
+- Linux-specific: `containerd.hugetlb.*`, `containerd.blkio.*`, `containerd.cpu.throttled.periods`, and all the `containerd.mem.*` ones except these 3: `containerd.mem.commit`, `containerd.mem.commit_peak`, and `containerd.mem.private_working_set`.
+- Windows-specific: `containerd.mem.commit`, `containerd.mem.commit_peak`, `containerd.mem.private_working_set`, and `containerd.storage.*`.
+ 
 ### Events
 
 The Containerd check can collect events. Use `filters` to select the relevant events. Refer to the [sample containerd.d/conf.yaml][2] to have more details.

--- a/containerd/metadata.csv
+++ b/containerd/metadata.csv
@@ -22,6 +22,9 @@ containerd.mem.cache,gauge,,byte,,The cache amount used,0,containerd, cache_amou
 containerd.mem.rss,gauge,,byte,,The rss amount used,0,containerd, mem_rss
 containerd.mem.rsshuge,gauge,,byte,,The rss_huge amount used,0,containerd, mem_rss_huge
 containerd.mem.dirty,gauge,,byte,,The dirty amount,0,containerd, mem_dirty
+containerd.mem.commit,gauge,,byte,,The committed memory,0,containerd,mem_commit
+containerd.mem.commit_peak,gauge,,byte,,The peak committed memory,0,containerd,mem_commit_peak
+containerd.mem.private_working_set,gauge,,byte,,The private working set usage,0,containerd,mem_private_working_set
 containerd.cpu.throttled.periods,rate,,nanosecond,,The total cpu throttled time,0,containerd,cpu_throttled_time
 containerd.cpu.system,rate,,nanosecond,,The total cpu time,0,containerd,cpu_system
 containerd.cpu.total,rate,,nanosecond,,The total cpu time,0,containerd,cpu_total
@@ -34,6 +37,8 @@ containerd.blkio.time_recursive,rate,,nanosecond,,The disk time allocated to cgr
 containerd.blkio.serviced_recursive,rate,,,,The number of IOs (bio) issued to the disk by the group,0,containerd,io_serviced_recursive
 containerd.blkio.wait_time_recursive,rate,,nanosecond,,The total amount of time the IOs for this cgroup spent waiting in the scheduler queues for service,0,containerd,io_wait_time_recursive
 containerd.blkio.service_time_recursive,rate,,,,The total amount of time between request dispatch and request completion for the IOs done by this cgroup,0,containerd,io service time recursive
+containerd.storage.read,rate,,byte,,Read bytes,0,containerd,storage_read
+containerd.storage.write,rate,,byte,,Write bytes,0,containerd,storage_write
 containerd.image.size,gauge,,byte,,The size of the container image,0,containerd,image size
 containerd.proc.open_fds,gauge,,file,,The number of open file descriptors,0,containerd,open_fds
 containerd.uptime,gauge,,second,,Time since the container was started,0,containerd,uptime

--- a/containerd/metadata.csv
+++ b/containerd/metadata.csv
@@ -1,44 +1,44 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-containerd.hugetlb.failcnt,gauge,,,,The hugetlb failcnt,0,containerd, hugetbl_failcount
-containerd.hugetlb.max,gauge,,byte,,The hugetlb maximum usage,0,containerd, hugetlb_maximum_usage
-containerd.hugetlb.usage,gauge,,byte,,The hugetlb usage,0,containerd, hugetlb_usage
-containerd.mem.current.usage,gauge,,byte,,The memory usage,0,containerd,mem_usage
-containerd.mem.current.failcnt,gauge,,,,The usage failcnt,0,containerd,mem_usage_failcnt_total
-containerd.mem.current.limit,gauge,,byte,,The memory limit,0,containerd,mem_usage_limit
-containerd.mem.current.max,gauge,,byte,,The memory maximum usage,0,containerd,mem_usage_max
-containerd.mem.kernel_tcp.usage,gauge,,byte,,The kerneltcp usage,0,containerd, mem_kerneltcp_usage
-containerd.mem.kernel_tcp.failcnt,gauge,,,,The kerneltcp failcnt,0,containerd, mem_kerneltcp_failcnt_total
-containerd.mem.kernel_tcp.limit,gauge,,byte,,The kerneltcp limit,0,containerd, mem_kerneltcp_limit
-containerd.mem.kernel_tcp.max,gauge,,byte,,The kerneltcp maximum usage,0,containerd, mem_kerneltcp_max
-containerd.mem.kernel.usage,gauge,,byte,,The kernel usage,0,containerd, mem_kernel_usage
-containerd.mem.kernel.failcnt,gauge,,,,The kernel failcnt,0,containerd, mem_kernel_failcnt_total
-containerd.mem.kernel.limit,gauge,,byte,,The kernel limit,0,containerd, mem_kernel_limit
-containerd.mem.kernel.max,gauge,,byte,,The kernel maximum usage,0,containerd, mem_kernel_max
-containerd.mem.swap.usage,gauge,,byte,,The swap usage,0,containerd,mem_swap_usage
-containerd.mem.swap.failcnt,gauge,,,,The swap failcnt,0,containerd, mem_swap_failcnt_total
-containerd.mem.swap.limit,gauge,,byte,,The swap limit,0,containerd,mem_swap_limit
-containerd.mem.swap.max,gauge,,byte,,The swap maximum usage,0,containerd,mem_swap_max
-containerd.mem.cache,gauge,,byte,,The cache amount used,0,containerd, cache_amount
-containerd.mem.rss,gauge,,byte,,The rss amount used,0,containerd, mem_rss
-containerd.mem.rsshuge,gauge,,byte,,The rss_huge amount used,0,containerd, mem_rss_huge
-containerd.mem.dirty,gauge,,byte,,The dirty amount,0,containerd, mem_dirty
-containerd.mem.commit,gauge,,byte,,The committed memory,0,containerd,mem_commit
-containerd.mem.commit_peak,gauge,,byte,,The peak committed memory,0,containerd,mem_commit_peak
-containerd.mem.private_working_set,gauge,,byte,,The private working set usage,0,containerd,mem_private_working_set
-containerd.cpu.throttled.periods,rate,,nanosecond,,The total cpu throttled time,0,containerd,cpu_throttled_time
-containerd.cpu.system,rate,,nanosecond,,The total cpu time,0,containerd,cpu_system
-containerd.cpu.total,rate,,nanosecond,,The total cpu time,0,containerd,cpu_total
-containerd.cpu.user,rate,,nanosecond,,The total user cpu time,0,containerd,cpu_user
-containerd.blkio.merged_recursive,rate,,,,The total number of bios/requests merged into requests belonging to this cgroup,0,containerd,io_merged_recursive
-containerd.blkio.queued_recursive,rate,,,,The total number of requests queued up at any given instant for this cgroup,0,containerd,io_queued_recursive
-containerd.blkio.sectors_recursive,rate,,,,The number of sectors transferred to/from disk by the group,0,containerd,io_sectors_recursive
-containerd.blkio.service_recursive_byte,rate,,byte,,The number of bytes transferred to/from the disk by the group.,0,containerd, blkio_service_byte_recursive
-containerd.blkio.time_recursive,rate,,nanosecond,,The disk time allocated to cgroup per device in milliseconds,0,containerd,io_sectors_recursive
-containerd.blkio.serviced_recursive,rate,,,,The number of IOs (bio) issued to the disk by the group,0,containerd,io_serviced_recursive
-containerd.blkio.wait_time_recursive,rate,,nanosecond,,The total amount of time the IOs for this cgroup spent waiting in the scheduler queues for service,0,containerd,io_wait_time_recursive
-containerd.blkio.service_time_recursive,rate,,,,The total amount of time between request dispatch and request completion for the IOs done by this cgroup,0,containerd,io service time recursive
-containerd.storage.read,rate,,byte,,Read bytes,0,containerd,storage_read
-containerd.storage.write,rate,,byte,,Write bytes,0,containerd,storage_write
+containerd.hugetlb.failcnt,gauge,,,,The hugetlb failcnt (Linux only),0,containerd, hugetbl_failcount
+containerd.hugetlb.max,gauge,,byte,,The hugetlb maximum usage (Linux only),0,containerd, hugetlb_maximum_usage
+containerd.hugetlb.usage,gauge,,byte,,The hugetlb usage (Linux only),0,containerd, hugetlb_usage
+containerd.mem.current.usage,gauge,,byte,,The memory usage (Linux only),0,containerd,mem_usage
+containerd.mem.current.failcnt,gauge,,,,The usage failcnt (Linux only),0,containerd,mem_usage_failcnt_total
+containerd.mem.current.limit,gauge,,byte,,The memory limit (Linux only),0,containerd,mem_usage_limit
+containerd.mem.current.max,gauge,,byte,,The memory maximum usage (Linux only),0,containerd,mem_usage_max
+containerd.mem.kernel_tcp.usage,gauge,,byte,,The kerneltcp usage (Linux only),0,containerd, mem_kerneltcp_usage
+containerd.mem.kernel_tcp.failcnt,gauge,,,,The kerneltcp failcnt (Linux only),0,containerd, mem_kerneltcp_failcnt_total
+containerd.mem.kernel_tcp.limit,gauge,,byte,,The kerneltcp limit (Linux only),0,containerd, mem_kerneltcp_limit
+containerd.mem.kernel_tcp.max,gauge,,byte,,The kerneltcp maximum usage (Linux only),0,containerd, mem_kerneltcp_max
+containerd.mem.kernel.usage,gauge,,byte,,The kernel usage (Linux only),0,containerd, mem_kernel_usage
+containerd.mem.kernel.failcnt,gauge,,,,The kernel failcnt (Linux only),0,containerd, mem_kernel_failcnt_total
+containerd.mem.kernel.limit,gauge,,byte,,The kernel limit (Linux only),0,containerd, mem_kernel_limit
+containerd.mem.kernel.max,gauge,,byte,,The kernel maximum usage (Linux only),0,containerd, mem_kernel_max
+containerd.mem.swap.usage,gauge,,byte,,The swap usage (Linux only),0,containerd,mem_swap_usage
+containerd.mem.swap.failcnt,gauge,,,,The swap failcnt (Linux only),0,containerd, mem_swap_failcnt_total
+containerd.mem.swap.limit,gauge,,byte,,The swap limit (Linux only),0,containerd,mem_swap_limit
+containerd.mem.swap.max,gauge,,byte,,The swap maximum usage (Linux only),0,containerd,mem_swap_max
+containerd.mem.cache,gauge,,byte,,The cache amount used (Linux only),0,containerd, cache_amount
+containerd.mem.rss,gauge,,byte,,The rss amount used (Linux only),0,containerd, mem_rss
+containerd.mem.rsshuge,gauge,,byte,,The rss_huge amount used (Linux only),0,containerd, mem_rss_huge
+containerd.mem.dirty,gauge,,byte,,The dirty amount (Linux only),0,containerd, mem_dirty
+containerd.mem.commit,gauge,,byte,,The committed memory (Windows only),0,containerd,mem_commit
+containerd.mem.commit_peak,gauge,,byte,,The peak committed memory (Windows only),0,containerd,mem_commit_peak
+containerd.mem.private_working_set,gauge,,byte,,The private working set usage (Windows only),0,containerd,mem_private_working_set
+containerd.cpu.throttled.periods,rate,,nanosecond,,The total CPU throttled time (Linux only),0,containerd,cpu_throttled_time
+containerd.cpu.system,rate,,nanosecond,,The total CPU time,0,containerd,cpu_system
+containerd.cpu.total,rate,,nanosecond,,The total CPU time,0,containerd,cpu_total
+containerd.cpu.user,rate,,nanosecond,,The total user CPU time,0,containerd,cpu_user
+containerd.blkio.merged_recursive,rate,,,,The total number of bios/requests merged into requests belonging to this cgroup (Linux only),0,containerd,io_merged_recursive
+containerd.blkio.queued_recursive,rate,,,,The total number of requests queued up at any given instant for this cgroup (Linux only),0,containerd,io_queued_recursive
+containerd.blkio.sectors_recursive,rate,,,,The number of sectors transferred to/from disk by the group (Linux only),0,containerd,io_sectors_recursive
+containerd.blkio.service_recursive_byte,rate,,byte,,The number of bytes transferred to/from the disk by the group (Linux only),0,containerd, blkio_service_byte_recursive
+containerd.blkio.time_recursive,rate,,nanosecond,,The disk time allocated to cgroup per device in milliseconds (Linux only),0,containerd,io_sectors_recursive
+containerd.blkio.serviced_recursive,rate,,,,The number of IOs (bio) issued to the disk by the group (Linux only),0,containerd,io_serviced_recursive
+containerd.blkio.wait_time_recursive,rate,,nanosecond,,The total amount of time the IOs for this cgroup spent waiting in the scheduler queues for service (Linux only),0,containerd,io_wait_time_recursive
+containerd.blkio.service_time_recursive,rate,,,,The total amount of time between request dispatch and request completion for the IOs done by this cgroup (Linux only),0,containerd,io service time recursive
+containerd.storage.read,rate,,byte,,Read bytes (Windows only),0,containerd,storage_read
+containerd.storage.write,rate,,byte,,Write bytes (Windows only),0,containerd,storage_write
 containerd.image.size,gauge,,byte,,The size of the container image,0,containerd,image size
 containerd.proc.open_fds,gauge,,file,,The number of open file descriptors,0,containerd,open_fds
 containerd.uptime,gauge,,second,,Time since the container was started,0,containerd,uptime


### PR DESCRIPTION
### What does this PR do?
Adds the Windows metrics in the containerd check.
The new metrics were added in https://github.com/DataDog/datadog-agent/pull/9296


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
