### PR TITLE
Enable E2E logs agent by default if environments mount logs

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -176,6 +176,11 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, org_name, profile
     for key, value in metadata.get('env_vars', {}).items():
         env_vars.setdefault(key, value)
 
+        # Enable logs agent by default if the environment is mounting logs, see:
+        # https://github.com/DataDog/integrations-core/pull/5346
+        if key.startswith('DDEV_E2E_ENV_TEMP_DIR_DD_LOG_'):
+            env_vars.setdefault('DD_LOGS_ENABLED', 'true')
+
     if dogstatsd:
         env_vars['DD_DOGSTATSD_NON_LOCAL_TRAFFIC'] = 'true'
         env_vars['DD_DOGSTATSD_METRICS_STATS_ENABLE'] = 'true'

--- a/docs/developer/ddev/test.md
+++ b/docs/developer/ddev/test.md
@@ -151,9 +151,7 @@ We provide an easy way to utilize [log collection][integration-log-collection] w
      - ${DD_LOG_2}:/usr/local/apache2/logs/error_log
      ```
 
-1. When [starting](cli.md#ddev-env-start) the environment, pass `-e DD_LOGS_ENABLED=true` to activate the Logs Agent.
-
-1. To send logs to a custom url, pass `-e DD_LOGS_CONFIG_LOGS_DD_URL=[CUSTOM_URL]:[CUSTOM_PORT]` when [starting](cli.md#ddev-env-start) the environment
+1. To send logs to a custom URL, set `log_url` for the configured [organization](configuration.md#organization).
 
 ## Reference
 


### PR DESCRIPTION
### Motivation

Easier testing experience