### PR TITLE
Update release docs

### DIFF
--- a/docs/developer/process/agent-release/pre-release.md
+++ b/docs/developer/process/agent-release/pre-release.md
@@ -17,7 +17,6 @@ Ensure that you have configured the following:
 
 - [GitHub](../../ddev/configuration.md#github) credentials
 - [Trello](../../ddev/configuration.md#trello) credentials
-- [Trello team mappings](../../ddev/configuration.md#card-assignment)
 
 ## Before Freeze
 

--- a/docs/developer/process/agent-release/pre-release.md
+++ b/docs/developer/process/agent-release/pre-release.md
@@ -87,7 +87,7 @@ would select all commits that were merged between the Git references.
 
 The command will display each change and prompt you to assign a team or skip. Purely documentation changes are automatically skipped.
 
-Cards are automatically assigned if `$trello_users_$team` table is [configured](../../ddev/configuration.md#card-assignment).
+Cards are automatically assigned to members of [the team](../../ddev/configuration.md#card-assignment).
 
 ### Release candidates
 


### PR DESCRIPTION
### What does this PR do?
Updates release docs to remove mention of trello/github users map

### Motivation
The trello script no longer needs this map

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
