### PR TITLE
Document troubleshooting missing default metrics

### DIFF
--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -223,6 +223,9 @@ See [service_checks.json][16] for a list of service checks provided by this inte
 
 ## Troubleshooting
 
+### Missing `tomcat.*` metrics
+The integration collects default Tomcat metrics from the `Catalina` bean domain name. If exposed Tomcat metrics are prefixed with a different bean domain name, such as `Tomcat`, modify the `domain` filter to use the applicable domain name in the `metrics.yaml`. See the [JMX Check documentation][8] for more detailed information.
+
 ### Commands to view the available metrics
 
 The `datadog-agent jmx` command was added in version 4.1.0.


### PR DESCRIPTION
### What does this PR do?
Document troubleshooting missing default tomcat metrics reporting with bean domain name other than `Catalina`. 

### Motivation
https://github.com/DataDog/integrations-core/issues/10233

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
