### PR TITLE
Add v2 marketplace manifest media validations

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
@@ -9,8 +9,8 @@ import requests
 import datadog_checks.dev.tooling.manifest_validator.common.validator as common
 from datadog_checks.dev.tooling.manifest_validator.common.validator import BaseManifestValidator
 
-from ..constants import V2
 from ...constants import get_root
+from ..constants import V2
 
 METRIC_TO_CHECK_EXCLUDE_LIST = {
     'openstack.controller',  # "Artificial" metric, shouldn't be listed in metadata file.

--- a/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
@@ -55,6 +55,48 @@ V2_VALID_MANIFEST = {
     },
 }
 
+VALID_MEDIA_MANIFEST = JSONDict(
+    {
+        "tile": {
+            "media": [
+                {
+                    "media_type": "video",
+                    "caption": "This is an example image caption!",
+                    "image_url": "images/video.png",
+                },
+                {
+                    "media_type": "image",
+                    "caption": "This is an example image caption!",
+                    "image_url": "images/bigpanda_dd_before.png",
+                },
+                {
+                    "media_type": "image",
+                    "caption": "This is an example image caption!",
+                    "image_url": "images/bigpanda_dd_after.png",
+                },
+            ]
+        }
+    }
+)
+
+INVALID_MEDIA_MANIFEST_TOO_MANY_VIDEOS = JSONDict(
+    {
+        "tile": {
+            "media": [
+                {
+                    "media_type": "video",
+                    "caption": "This is an example image caption!",
+                    "image_url": "images/video.png",
+                },
+                {
+                    "media_type": "video",
+                    "caption": "This is an example image caption!",
+                    "image_url": "images/bigpanda_dd_before.png",
+                },
+            ]
+        }
+    }
+)
 
 IMMUTABLE_ATTRIBUTES_V1_MANIFEST = {"manifest_version": "1.0.0"}
 

--- a/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
@@ -420,3 +420,36 @@ def test_manifest_v2_immutable_attributes_validator_valid_change(_, setup_route)
     # Assert test case
     assert not validator.result.failed, validator.result
     assert not validator.result.fixed
+
+
+@mock.patch('os.path.getsize', return_value=300000)
+def test_manifest_v2_media_gallery_validator_pass(_, setup_route):
+    # Use specific validator
+    validator = v2_validators.MediaGalleryValidator(is_marketplace=True, version=V2, check_in_extras=False)
+    validator.validate('active_directory', JSONDict(input_constants.VALID_MEDIA_MANIFEST), False)
+
+    # Assert test case
+    assert not validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+@mock.patch('os.path.getsize', return_value=1300000)
+def test_manifest_v2_media_gallery_validator_image_size_too_large(_, setup_route):
+    # Use specific validator
+    validator = v2_validators.MediaGalleryValidator(is_marketplace=True, version=V2, check_in_extras=False)
+    validator.validate('active_directory', JSONDict(input_constants.VALID_MEDIA_MANIFEST), False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+@mock.patch('os.path.getsize', return_value=300000)
+def test_manifest_v2_media_gallery_validator_too_many_videos(_, setup_route):
+    # Use specific validator
+    validator = v2_validators.MediaGalleryValidator(is_marketplace=True, version=V2, check_in_extras=False)
+    validator.validate('active_directory', JSONDict(input_constants.INVALID_MEDIA_MANIFEST_TOO_MANY_VIDEOS), False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed


### PR DESCRIPTION
### What does this PR do?
This PR adds validations to check the media section of marketplace integration manifests.

### Motivation
Need to validate this section of v2 marketplace integration manifests.

### Additional Notes
N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
