### PR TITLE
Add only_custom_queries option to database utils

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -66,7 +66,7 @@ class QueryManager(object):
         self.hostname = hostname  # type: str
         self.logger = self.check.log
 
-        only_custom_queries = is_affirmative(self.check.instance.get('only_custom_queries', False))  # type: str
+        only_custom_queries = is_affirmative(self.check.instance.get('only_custom_queries', False))  # type: bool
         custom_queries = list(self.check.instance.get('custom_queries', []))  # type: List[str]
         use_global_custom_queries = self.check.instance.get('use_global_custom_queries', True)  # type: str
 

--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -66,6 +66,7 @@ class QueryManager(object):
         self.hostname = hostname  # type: str
         self.logger = self.check.log
 
+        only_custom_queries = is_affirmative(self.check.instance.get('only_custom_queries', False))  # type: str
         custom_queries = list(self.check.instance.get('custom_queries', []))  # type: List[str]
         use_global_custom_queries = self.check.instance.get('use_global_custom_queries', True)  # type: str
 
@@ -78,6 +79,10 @@ class QueryManager(object):
             and is_affirmative(use_global_custom_queries)
         ):
             custom_queries = self.check.init_config.get('global_custom_queries', [])
+
+        # Override statement queries if only running custom queries
+        if only_custom_queries:
+            self.queries = []
 
         # Deduplicate
         for i, custom_query in enumerate(iter_unique(custom_queries), 1):

--- a/datadog_checks_base/tests/base/utils/db/test_custom_queries.py
+++ b/datadog_checks_base/tests/base/utils/db/test_custom_queries.py
@@ -35,11 +35,24 @@ class TestCustomQueries:
 
     def test_init_config(self, aggregator):
         query_manager = create_query_manager(
+            {
+                'name': 'test query',
+                'query': 'foo',
+                'columns': [
+                    {'name': 'test.statement.foo', 'type': 'gauge', 'tags': ['override:ok']},
+                    {'name': 'test.statement.baz', 'type': 'gauge', 'raw': True},
+                ],
+                'tags': ['test:bar'],
+            },
             check=AgentCheck(
                 'test',
                 {
                     'global_custom_queries': [
-                        {'query': 'foo', 'columns': [{'name': 'test.foo', 'type': 'gauge'}], 'tags': ['test:bar']},
+                        {
+                            'query': 'foo',
+                            'columns': [{'name': 'test.custom', 'type': 'gauge'}],
+                            'tags': ['test:custom'],
+                        },
                     ],
                 },
                 [{}],
@@ -50,7 +63,12 @@ class TestCustomQueries:
         query_manager.compile_queries()
         query_manager.execute()
 
-        aggregator.assert_metric('test.foo', 1, metric_type=aggregator.GAUGE, tags=['test:foo', 'test:bar'])
+        aggregator.assert_metric('test.custom', 1, metric_type=aggregator.GAUGE, tags=['test:foo', 'test:custom'])
+        aggregator.assert_metric(
+            'test.statement.foo', count=0, metric_type=aggregator.GAUGE, tags=['override:ok', 'test:bar']
+        )
+        aggregator.assert_metric('test.statement.baz', count=0, metric_type=aggregator.GAUGE, tags=['test:bar'])
+
         aggregator.assert_all_metrics_covered()
 
     def test_instance_override(self, aggregator):
@@ -183,3 +201,30 @@ class TestCustomQueries:
 
         with pytest.raises(ValueError, match='^field `query` for custom query #1 is required$'):
             query_manager.compile_queries()
+
+    def test_only_custom_queries(self, aggregator):
+        query_manager = create_query_manager(
+            check=AgentCheck(
+                'test',
+                {
+                    'global_custom_queries': [
+                        {'query': 'foo', 'columns': [{'name': 'test.foo', 'type': 'gauge'}], 'tags': ['test:bar']},
+                    ],
+                },
+                [
+                    {
+                        'only_custom_queries': True,
+                        'custom_queries': [
+                            {'query': 'foo', 'columns': [{'name': 'test.bar', 'type': 'gauge'}], 'tags': ['test:bar']},
+                        ],
+                    },
+                ],
+            ),
+            executor=mock_executor([[1]]),
+            tags=['test:foo'],
+        )
+        query_manager.compile_queries()
+        query_manager.execute()
+
+        aggregator.assert_metric('test.bar', 1, metric_type=aggregator.GAUGE, tags=['test:foo', 'test:bar'])
+        aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
This PR introduces `only_custom_queries` option (Oracle had a version of this), which allows users to confgure instances to only collect custom queries. 

### Motivation
Support case, if a customer wants to specify a db-level connection (Snowflake), they don't want multiple instances attempting to run default queries. This is especially erroneous if the custom queries use a different set of credentials (results in error logs).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
