### PR TITLE
Don't use latest maven version in tests

### DIFF
--- a/hudi/tests/docker/Dockerfile
+++ b/hudi/tests/docker/Dockerfile
@@ -15,10 +15,10 @@ RUN wget -O - https://github.com/sbt/sbt/releases/download/v1.4.1/sbt-1.4.1.tgz 
 ENV PATH /usr/local/sbt/bin:${PATH}
 
 # we have to build hudi from source because the JMX fix has not been released yet
-RUN wget -P /opt https://dlcdn.apache.org/maven/maven-3/3.8.2/binaries/apache-maven-3.8.2-bin.tar.gz \
-    && tar -xzf /opt/apache-maven-3.8.2-bin.tar.gz 
+RUN wget -P /opt https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
+    && tar -xzf /opt/apache-maven-3.6.3-bin.tar.gz 
 
-RUN apk add git && git clone https://github.com/apache/hudi.git && cd hudi/ && /apache-maven-3.8.2/bin/mvn clean package -DskipTests -Dspark3 -Dscala-2.12 
+RUN apk add git && git clone https://github.com/apache/hudi.git && cd hudi/ && /apache-maven-3.6.3/bin/mvn clean package -DskipTests -Dspark3 -Dscala-2.12 
 
 COPY . /usr/src/app/
 RUN cd /usr/src/app && sbt update && sbt clean assembly && sbt package


### PR DESCRIPTION
### What does this PR do?
Rely on a stable version of maven that won't be replaced by new versions

### Motivation
Tests failing due to removal of hosted 3.8.2

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
