### PR TITLE
Skip generic tag check on latest env

### DIFF
--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -37,5 +37,6 @@ commands =
 
 [testenv:latest]
 setenv =
+    DDEV_SKIP_GENERIC_TAGS_CHECK=true
     HAPROXY_LEGACY=false
     HAPROXY_VERSION=latest


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
HAproxy is still sending generic tags
This PR fixes `latest` environment before fixing this

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
