### PR TITLE
[Fixed] Remove duplicate names from the list of metrics to collect (#10332)

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -78,7 +78,7 @@ class SQLServer(AgentCheck):
         self.connection = None
         self.failed_connections = {}
         self.instance_metrics = []
-        self.instance_per_type_metrics = defaultdict(list)
+        self.instance_per_type_metrics = defaultdict(set)
         self.do_check = True
 
         self.autodiscovery = is_affirmative(self.instance.get('database_autodiscovery'))
@@ -411,9 +411,9 @@ class SQLServer(AgentCheck):
             name = m.sql_name or m.column
             self.log.debug("Adding metric class %s named %s", cls, name)
 
-            self.instance_per_type_metrics[cls].append(name)
+            self.instance_per_type_metrics[cls].add(name)
             if m.base_name:
-                self.instance_per_type_metrics[cls].append(m.base_name)
+                self.instance_per_type_metrics[cls].add(m.base_name)
 
     def _add_performance_counters(self, metrics, metrics_to_collect, tags, db=None):
         if db is not None:
@@ -535,7 +535,7 @@ class SQLServer(AgentCheck):
                         instance_results[cls] = None, None
                     else:
                         try:
-                            rows, cols = getattr(metrics, cls).fetch_all_values(cursor, metric_names, self.log)
+                            rows, cols = getattr(metrics, cls).fetch_all_values(cursor, list(metric_names), self.log)
                         except Exception as e:
                             self.log.error("Error running `fetch_all` for metrics %s - skipping.  Error: %s", cls, e)
                             rows, cols = None, None

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -241,6 +241,18 @@ def test_autodiscovery_perf_counters(aggregator, dd_run_check, instance_autodisc
         aggregator.assert_metric(metric, tags=msdb_tags)
         aggregator.assert_metric(metric, tags=base_tags)
 
+@not_windows_ci
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_autodiscovery_perf_counters_doesnt_duplicate_names_of_metrics_to_collect(dd_run_check, instance_autodiscovery):
+    instance_autodiscovery['autodiscovery_include'] = ['master', 'msdb']
+    check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
+    dd_run_check(check)
+
+    for _cls,metric_names in check.instance_per_type_metrics.items():
+        expected = list(set(metric_names))
+        assert sorted(metric_names) == sorted(expected)
+
 
 @not_windows_ci
 @pytest.mark.integration


### PR DESCRIPTION
with AutoDiscovery enabled the list of metric names per check type was getting duplicated values
(one per different db instance), and while in most scenarios this won't affect the behavior of the check,
there are edge cases when the same SQL Server has a large number of databases that this duplication could lead to
exceptions like:

```
Error running `fetch_all` for metrics SqlSimpleMetric - skipping.  Error: (-2147352567, 'Exception occurred.', (0, 'Microsoft OLE DB Provider for SQL Server', 'The incoming request has too many parameters. The server supports a maximum of 2100 parameters. Reduce the number of parameters and resend the request.', None, 0, -2147217900), None)
```

### What does this PR do?
Fix issue #10332 by removing the duplicated metric names used by SqlSimpleMetric

### Motivation
The existing issue is currently causing all the sqlserver builtin checks to be skipped in our larger SQL Server hosts

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
