### PR TITLE
Fix config example

### DIFF
--- a/postfix/assets/configuration/spec.yaml
+++ b/postfix/assets/configuration/spec.yaml
@@ -39,13 +39,16 @@ files:
       description: |
         Path to the postfix directory. The directory option is required if `postqueue: false` is set. For more 
         information see https://docs.datadoghq.com/integrations/postfix/#using-sudo.
+      enabled: true
       value:
+        display_default: null
         example: /var/spool/postfix
         type: string
     - name: queues
-      required: true
       description: List of queues to monitor.
+      enabled: true
       value:
+        display_default: null
         type: array
         items:
           type: string

--- a/postfix/datadog_checks/postfix/config_models/defaults.py
+++ b/postfix/datadog_checks/postfix/config_models/defaults.py
@@ -21,7 +21,7 @@ def instance_config_directory(field, value):
 
 
 def instance_directory(field, value):
-    return '/var/spool/postfix'
+    return get_default_field_value(field, value)
 
 
 def instance_disable_generic_tags(field, value):
@@ -34,6 +34,10 @@ def instance_empty_default_hostname(field, value):
 
 def instance_min_collection_interval(field, value):
     return 15
+
+
+def instance_queues(field, value):
+    return get_default_field_value(field, value)
 
 
 def instance_service(field, value):

--- a/postfix/datadog_checks/postfix/config_models/instance.py
+++ b/postfix/datadog_checks/postfix/config_models/instance.py
@@ -22,7 +22,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]
     min_collection_interval: Optional[float]
-    queues: Sequence[str]
+    queues: Optional[Sequence[str]]
     service: Optional[str]
     tags: Optional[Sequence[str]]
 

--- a/postfix/datadog_checks/postfix/data/conf.yaml.example
+++ b/postfix/datadog_checks/postfix/data/conf.yaml.example
@@ -39,14 +39,13 @@ init_config:
 #
 instances:
 
-  -
-    ## @param directory - string - optional - default: /var/spool/postfix
+    ## @param directory - string - optional
     ## Path to the postfix directory. The directory option is required if `postqueue: false` is set. For more 
     ## information see https://docs.datadoghq.com/integrations/postfix/#using-sudo.
     #
-    # directory: /var/spool/postfix
+  - directory: /var/spool/postfix
 
-    ## @param queues - list of strings - required
+    ## @param queues - list of strings - optional
     ## List of queues to monitor.
     #
     queues:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`queues` and `directory` are optional if `postqueue: true` in the init_config, but they don't have a default value.

https://github.com/DataDog/integrations-core/blob/3e7f81b20a2c4d93afea43019ff92aa253bc3242/postfix/datadog_checks/postfix/postfix.py#L95-L108

### Motivation
<!-- What inspired you to submit this pull request? -->
QA #10051 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
