### PR TITLE
Remove `server` from the list of generic tags

### DIFF
--- a/avi_vantage/assets/configuration/spec.yaml
+++ b/avi_vantage/assets/configuration/spec.yaml
@@ -37,8 +37,3 @@ files:
         persist_connections.default: true
         openmetrics_endpoint.hidden: true
         openmetrics_endpoint.required: false
-        disable_generic_tags.hidden: false
-        disable_generic_tags.value.display_default: true
-        disable_generic_tags.description: |
-          Replaces generic tag such as `server` with `avi_vantage_server` to avoid getting it mixed with
-          other integratons tags.

--- a/avi_vantage/datadog_checks/avi_vantage/check.py
+++ b/avi_vantage/datadog_checks/avi_vantage/check.py
@@ -93,7 +93,6 @@ class AviVantageCheck(OpenMetricsBaseCheckV2, ConfigMixin):
         return scraper
 
     def check(self, _):
-        self.disable_generic_tags = self.config.disable_generic_tags
         with self.login():
             try:
                 self.collect_avi_version()

--- a/avi_vantage/datadog_checks/avi_vantage/config_models/defaults.py
+++ b/avi_vantage/datadog_checks/avi_vantage/config_models/defaults.py
@@ -65,7 +65,7 @@ def instance_connect_timeout(field, value):
 
 
 def instance_disable_generic_tags(field, value):
-    return True
+    return False
 
 
 def instance_empty_default_hostname(field, value):

--- a/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
+++ b/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
@@ -567,9 +567,3 @@ instances:
     ## This is useful for cluster-level checks.
     #
     # empty_default_hostname: false
-
-    ## @param disable_generic_tags - boolean - optional - default: true
-    ## Replaces generic tag such as `server` with `avi_vantage_server` to avoid getting it mixed with
-    ## other integratons tags.
-    #
-    # disable_generic_tags: true

--- a/avi_vantage/tests/conftest.py
+++ b/avi_vantage/tests/conftest.py
@@ -36,14 +36,11 @@ def get_expected_metrics():
             expected_metrics = json.load(f)
 
         if endpoint is None:
-            endpoint = 'https://34.123.32.255/'
+            return expected_metrics
 
         transformed_expected_metrics = []
         for metric in expected_metrics:
-            tags = [
-                t.replace('https://34.123.32.255/', endpoint).replace('server:', 'avi_vantage_server:')
-                for t in metric['tags']
-            ]
+            tags = [t.replace('https://34.123.32.255/', endpoint) for t in metric['tags']]
             transformed_expected_metrics.append(
                 {"name": metric['name'], "type": metric['type'], "value": metric['value'], "tags": tags}
             )

--- a/clickhouse/tox.ini
+++ b/clickhouse/tox.ini
@@ -27,7 +27,6 @@ setenv =
     19: CLICKHOUSE_VERSION=19
     20: CLICKHOUSE_VERSION=20
     21: CLICKHOUSE_VERSION=21
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true
 commands =
     pip install -r requirements.in
     pytest -v {posargs}

--- a/datadog_checks_base/datadog_checks/base/utils/tagging.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tagging.py
@@ -18,7 +18,6 @@ GENERIC_TAGS = {
     'host_name',
     'hostname',
     'host',
-    'server',
     'service',
     'version',
 }

--- a/gearmand/tox.ini
+++ b/gearmand/tox.ini
@@ -30,4 +30,4 @@ setenv =
     1.0.6: DOCKER_IMAGE=kendu/gearman
     1.0.6: DOCKER_TAG=latest
     1.0.6: GEARMAND_VERSION=1.0.6
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true
+

--- a/ibm_was/tox.ini
+++ b/ibm_was/tox.ini
@@ -29,4 +29,3 @@ setenv =
     ## Waiting upstream update, see issue: https://github.com/WASdev/ci.docker.websphere-traditional/issues/198
     # 8.5: IBM_WAS_VERSION=8.5.5.14-profile
     9: IBM_WAS_VERSION=9.0.5.5
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/jboss_wildfly/tox.ini
+++ b/jboss_wildfly/tox.ini
@@ -20,7 +20,5 @@ deps =
 passenv =
     DOCKER*
     COMPOSE*
-setenv=
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true
 commands =
     pytest -v {posargs}

--- a/openstack/tox.ini
+++ b/openstack/tox.ini
@@ -18,5 +18,3 @@ deps =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
-setenv =
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true

--- a/oracle/tox.ini
+++ b/oracle/tox.ini
@@ -24,7 +24,6 @@ setenv =
     jdbc: CLIENT_LIB=jdbc
     oracle: CLIENT_LIB=oracle
     12.2: ORACLE_DATABASE_VERSION=12.2.0.1
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true
 commands =
     pip install -r requirements.in
     oracle: pip uninstall -y jpype1 # Should work even if jpype is not installed.

--- a/sap_hana/tox.ini
+++ b/sap_hana/tox.ini
@@ -23,7 +23,6 @@ passenv =
     COMPOSE*
 setenv =
     2: SAP_HANA_VERSION=2.00.036.00.20190223.1
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true
 commands =
     pip install -r requirements.in
     pytest -v {posargs}

--- a/tls/tox.ini
+++ b/tls/tox.ini
@@ -25,5 +25,3 @@ passenv =
 commands =
     pip install -r requirements.in
     pytest -v {posargs}
-setenv =
-    DDEV_SKIP_GENERIC_TAGS_CHECK=true


### PR DESCRIPTION
### What does this PR do?

This reverts commit f03660cb45487242e5aa399d33b8cc75ffe580c1, so only reserved tags are considered generic.

### Motivation

We have an RFC to decide how to handle such tagging in the future so we should avoid any premature implementation of such enforcement.

### Additional Notes

The 2 integrations where we didn't want a `server` tag are unaffected by this change:

- https://github.com/DataDog/integrations-core/blob/7.32.x/mysql/datadog_checks/mysql/mysql.py#L223-L224
- https://github.com/DataDog/integrations-core/blob/7.32.x/postgres/datadog_checks/postgres/config.py#L103-L104