### PR TITLE
Hide collect_device_metadata by default

### DIFF
--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -115,6 +115,7 @@ files:
         description: |
           Enable device metadata collection for all instances.
           Only available using corecheck SNMP integration with `loader: core` config.
+        hidden: true
         value:
           type: boolean
           example: true
@@ -375,6 +376,7 @@ files:
         description: |
           Enable device metadata collection.
           Only available using corecheck SNMP integration with `loader: core` config.
+        hidden: true
         value:
           type: boolean
           example: true

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -91,12 +91,6 @@ init_config:
     #
     # ignore_nonincreasing_oid: false
 
-    ## @param collect_device_metadata - boolean - optional - default: true
-    ## Enable device metadata collection for all instances.
-    ## Only available using corecheck SNMP integration with `loader: core` config.
-    #
-    # collect_device_metadata: true
-
     ## @param namespace - string - optional - default: default
     ## Namespace can be used to disambiguate devices with same IPs.
     ## Changing namespace will cause devices being recreated in NDM app.
@@ -322,12 +316,6 @@ instances:
     ##         the OIDs are refreshed only according to the refresh interval.
     #
     # refresh_oids_cache_interval: 3600
-
-    ## @param collect_device_metadata - boolean - optional - default: true
-    ## Enable device metadata collection.
-    ## Only available using corecheck SNMP integration with `loader: core` config.
-    #
-    # collect_device_metadata: true
 
     ## @param namespace - string - optional - default: default
     ## Namespace can be used to disambiguate devices with same IPs.


### PR DESCRIPTION
This config is true by default and doesn't need to be visible to the user.