### PR TITLE
Adds postgres vacuumed and autoanalyzed metrics

### DIFF
--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -56,8 +56,10 @@ REL_METRICS = {
         'n_tup_hot_upd': ('postgresql.rows_hot_updated', AgentCheck.rate),
         'n_live_tup': ('postgresql.live_rows', AgentCheck.gauge),
         'n_dead_tup': ('postgresql.dead_rows', AgentCheck.gauge),
+        'vacuum_count': ('postgresql.vacuumed', AgentCheck.monotonic_count),
         'autovacuum_count': ('postgresql.autovacuumed', AgentCheck.monotonic_count),
         'analyze_count': ('postgresql.analyzed', AgentCheck.monotonic_count),
+        'autoanalyze_count': ('postgresql.autoanalyzed', AgentCheck.monotonic_count),
     },
     'query': """
 SELECT relname,schemaname,{metrics_columns}

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -34,8 +34,10 @@ postgresql.index_rel_rows_fetched,gauge,,row,second,The number of live rows fetc
 postgresql.rows_hot_updated,gauge,,row,second,"The number of rows HOT updated, meaning no separate index update was needed.",0,postgres,rows hot updated
 postgresql.live_rows,gauge,,row,,The estimated number of live rows.,0,postgres,live rows
 postgresql.dead_rows,gauge,,row,,The estimated number of dead rows.,0,postgres,dead rows
+postgresql.vacuumed,count,,,,The number of times this table has been manually vacuumed.,0,postgres,vac
 postgresql.autovacuumed,count,,,,The number of times this table has been vacuumed by the autovacuum daemon.,0,postgres,auto vac
 postgresql.analyzed,count,,,,The number of times this table has been manually analyzed.,0,postgres,analyze
+postgresql.autoanalyzed,count,,,,The number of times this table has been analyzed by the autovacuum daemon.,0,postgres,auto analyze
 postgresql.index_rows_read,gauge,,row,second,The number of index entries returned by scans on this index.,0,postgres,idx rows read
 postgresql.table_size,gauge,,byte,,"The total disk space used by the specified table. Includes TOAST, free space map, and visibility map. Excludes indexes.",0,postgres,tbl size
 postgresql.index_size,gauge,,byte,,The total disk space used by indexes attached to the specified table.,0,postgres,idx size

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -24,8 +24,10 @@ RELATION_METRICS = [
     'postgresql.toast_blocks_hit',
     'postgresql.toast_index_blocks_read',
     'postgresql.toast_index_blocks_hit',
+    'postgresql.vacuumed',
     'postgresql.autovacuumed',
     'postgresql.analyzed',
+    'postgresql.autoanalyzed',
 ]
 
 RELATION_SIZE_METRICS = ['postgresql.table_size', 'postgresql.total_size', 'postgresql.index_size']


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Follow-up for https://github.com/DataDog/integrations-core/pull/9758 where some other related metrics are added.

It adds the `vacuum_count` (`vacuumed`) and `autoanalyze_count` (`autoanalyzed`) metrics in the postgres check.

### Motivation
<!-- What inspired you to submit this pull request? -->
We actually want to monitor `autoanalyze_count`. At this point it makes sense to just add `vacuum_count` too.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached