### PR TITLE
Remove python only mention from check discovery props

### DIFF
--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -297,13 +297,11 @@ files:
       - name: network_address
         description: |
           The network address of the devices to scan for monitor.
-          Only available using python SNMP integration.
         value:
           type: string
       - name: ignored_ip_addresses
         description: |
           A list of IP addresses to ignore when scanning the network.
-          Only available using python SNMP integration.
         value:
           type: array
           items:

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -260,13 +260,11 @@ instances:
 
     ## @param network_address - string - optional
     ## The network address of the devices to scan for monitor.
-    ## Only available using python SNMP integration.
     #
     # network_address: <NETWORK_ADDRESS>
 
     ## @param ignored_ip_addresses - list of strings - optional
     ## A list of IP addresses to ignore when scanning the network.
-    ## Only available using python SNMP integration.
     #
     # ignored_ip_addresses:
     #   - <IP_ADDRESS_1>


### PR DESCRIPTION
Fixes bug II-557

### What does this PR do?

As network discovery is available in 7.32 with core check, remove `python only` mention from related props

### Motivation
II-557

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
