### PR TITLE
Remove unused MIB_SOURCE_URL

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -92,8 +92,6 @@ REQUIREMENTS_IN = 'requirements.in'
 
 ROOT = ''
 
-MIB_SOURCE_URL = 'https://raw.githubusercontent.com:443/DataDog/mibs.snmplabs.com/master/asn1/@mib@'
-
 
 def get_root():
     return ROOT


### PR DESCRIPTION
### What does this PR do?

Remove unused MIB_SOURCE_URL

### Motivation

MIB_SOURCE_URL has been moved to a new location in https://github.com/DataDog/integrations-core/pull/10074
but the old one hasn't been deleted

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
