### PR TITLE
Load CA certs if SSL is enabled and CA certs are not passed in the configurations

### DIFF
--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -13,8 +13,8 @@ class MongoConfig(object):
         # x.509 authentication
 
         cacert_cert_dir = instance.get('ssl_ca_certs')
-        if (cacert_cert_dir is None and (is_affirmative(instance.get('options', {}).get("ssl")))) or is_affirmative(
-            instance.get('ssl')
+        if cacert_cert_dir is None and (
+            is_affirmative(instance.get('options', {}).get("ssl")) or is_affirmative(instance.get('ssl'))
         ):
             cacert_cert_dir = certifi.where()
 


### PR DESCRIPTION
### What does this PR do?
A recent change in pymongo(3.11.0+) is causing the mongo check to fail if SSL is enabled and no `ssl_ca_certs` is passed in the config when running the container agent. When tested against Mongodb Atlas, this has been observed to throw an ssl_validation error.  This change is aimed at trying to load CA certs from certifi if SSL is enabled and `ssl_ca_certs` is not configured in the config. 

### Motivation
From support ticket

### Additional Notes
I'm suspecting that with the inclusion of pyopenssl in pymongo(3.11.0), the default location in which pymongo loads these CA certs are no longer the same or it's not being loaded at all. 


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
