### PR TITLE
Add option to override default IBM i hostname

### DIFF
--- a/ibm_i/assets/configuration/spec.yaml
+++ b/ibm_i/assets/configuration/spec.yaml
@@ -12,6 +12,13 @@ files:
         The name of the IBM i system.
       value:
         type: string
+    - name: hostname
+      description: |
+        Hostname used for this instance's metrics. If unset, HOST_NAME from SYSIBMADM.ENV_SYS_INFO will be used.
+      value:
+        type: string
+        minLength: 1
+        maxLength: 255
     - name: username
       description: |
         The user profile name used to authenticate to the system.

--- a/ibm_i/datadog_checks/ibm_i/check.py
+++ b/ibm_i/datadog_checks/ibm_i/check.py
@@ -229,12 +229,17 @@ class IbmICheck(AgentCheck, ConfigMixin):
             else:
                 query_list.append(queries.get_base_disk_usage_72(self.config.query_timeout))
 
+            hostname = system_info.hostname
+            # Override hostname with configuration
+            if self.config.hostname:
+                hostname = self.config.hostname
+
             self._query_manager = QueryManager(
                 self,
                 self.execute_query,
                 tags=self.config.tags,
                 queries=query_list,
-                hostname=system_info.hostname,
+                hostname=hostname,
                 error_handler=self.handle_query_error,
             )
             self._query_manager.compile_queries()

--- a/ibm_i/datadog_checks/ibm_i/config_models/defaults.py
+++ b/ibm_i/datadog_checks/ibm_i/config_models/defaults.py
@@ -24,6 +24,10 @@ def instance_empty_default_hostname(field, value):
     return False
 
 
+def instance_hostname(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_job_query_timeout(field, value):
     return 240
 

--- a/ibm_i/datadog_checks/ibm_i/config_models/instance.py
+++ b/ibm_i/datadog_checks/ibm_i/config_models/instance.py
@@ -21,6 +21,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool]
     driver: Optional[str]
     empty_default_hostname: Optional[bool]
+    hostname: Optional[str] = Field(None, max_length=255, min_length=1)
     job_query_timeout: Optional[int] = Field(None, gt=0.0)
     min_collection_interval: Optional[float]
     password: Optional[str]

--- a/ibm_i/datadog_checks/ibm_i/data/conf.yaml.example
+++ b/ibm_i/datadog_checks/ibm_i/data/conf.yaml.example
@@ -19,6 +19,11 @@ instances:
     #
     # system: <SYSTEM>
 
+    ## @param hostname - string - optional
+    ## Hostname used for this instance's metrics. If unset, HOST_NAME from SYSIBMADM.ENV_SYS_INFO will be used.
+    #
+    # hostname: <HOSTNAME>
+
     ## @param username - string - optional
     ## The user profile name used to authenticate to the system.
     #

--- a/ibm_i/tests/test_ibm_i.py
+++ b/ibm_i/tests/test_ibm_i.py
@@ -206,6 +206,7 @@ def test_set_up_query_manager_7_2(instance):
     with mock.patch('datadog_checks.ibm_i.IbmICheck.fetch_system_info', return_value=SystemInfo("host", 7, 2)):
         check.set_up_query_manager()
     assert check._query_manager is not None
+    assert check._query_manager.hostname == "host"
     assert len(check._query_manager.queries) == 8
 
 
@@ -216,6 +217,22 @@ def test_set_up_query_manager_7_4(instance):
     with mock.patch('datadog_checks.ibm_i.IbmICheck.fetch_system_info', return_value=SystemInfo("host", 7, 4)):
         check.set_up_query_manager()
     assert check._query_manager is not None
+    assert check._query_manager.hostname == "host"
+    assert len(check._query_manager.queries) == 10
+
+
+def test_set_up_query_manager_7_4_hostname(instance):
+    instance = {
+        **instance,
+        **{'hostname': 'overridden-hostname'},
+    }
+    check = IbmICheck('ibm_i', {}, [instance])
+    check.log = mock.MagicMock()
+    check.load_configuration_models()
+    with mock.patch('datadog_checks.ibm_i.IbmICheck.fetch_system_info', return_value=SystemInfo("host", 7, 4)):
+        check.set_up_query_manager()
+    assert check._query_manager is not None
+    assert check._query_manager.hostname == "overridden-hostname"
     assert len(check._query_manager.queries) == 10
 
 
@@ -241,6 +258,7 @@ def test_check_query_error(aggregator, instance):
         assert check._query_manager is None
         check.check(instance)
         assert check._query_manager is not None
+        assert check._query_manager.hostname == "host"
         check.check(instance)
     aggregator.assert_service_check("ibm_i.can_connect", count=2, status=AgentCheck.CRITICAL)
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

Add `hostname` field to instance configuration; it allows users to override the default IBM i hostname for a given machine.

### Motivation

Customer request.

### Additional Notes

OpenAPI supports the `hostname` format, but
- when validation fails the message just prints a terribly long regex and
- the generated type annotation causes samuelcolvin/pydantic#2872,

so I decided to go with a simple length check.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
