### PR TITLE
[disk] Fix `tag_by_label` when used together with `use_mount`

### DIFF
--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -159,8 +159,10 @@ class Disk(AgentCheck):
                 if regex.match(device_name):
                     tags.extend(device_tags)
 
-            if self.devices_label.get(device_name):
-                tags.extend(self.devices_label.get(device_name))
+            # apply device labels as tags (from blkid or lsblk).
+            # we want to use the real device name and not the device_name (which can be the mountpoint)
+            if self.devices_label.get(part.device):
+                tags.extend(self.devices_label.get(part.device))
 
             # legacy check names c: vs psutil name C:\\
             if Platform.is_win32():


### PR DESCRIPTION
### What does this PR do?
- Fixes accessing `devices_label` using the wrong key (ie: the mountpoint instead of the device name)
- Removes an unused dictionary in the same code path

### Motivation
If `tag_by_label` and `use_mount` were both set, we would end up accessing
the `devices_label` array by mountpoint instead of the actual device path.