### PR TITLE
[OpenMetricsV2] Allow empty namespaces

### DIFF
--- a/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
+++ b/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
@@ -98,7 +98,7 @@ class InstanceConfig(BaseModel):
     log_requests: Optional[bool]
     metrics: Optional[Sequence[Union[str, Mapping[str, Union[str, Metric]]]]]
     min_collection_interval: Optional[float]
-    namespace: Optional[str] = Field(None, regex='\\w+')
+    namespace: Optional[str] = Field(None, regex='\\w*')
     node_exporter_port: Optional[int]
     non_cumulative_histogram_buckets: Optional[bool]
     ntlm_domain: Optional[str]

--- a/avi_vantage/datadog_checks/avi_vantage/config_models/instance.py
+++ b/avi_vantage/datadog_checks/avi_vantage/config_models/instance.py
@@ -96,7 +96,7 @@ class InstanceConfig(BaseModel):
     log_requests: Optional[bool]
     metrics: Optional[Sequence[Union[str, Mapping[str, Union[str, Metric]]]]]
     min_collection_interval: Optional[float]
-    namespace: Optional[str] = Field(None, regex='\\w+')
+    namespace: Optional[str] = Field(None, regex='\\w*')
     non_cumulative_histogram_buckets: Optional[bool]
     ntlm_domain: Optional[str]
     openmetrics_endpoint: Optional[str]

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -46,8 +46,6 @@ class OpenMetricsScraper:
         self.namespace = check.__NAMESPACE__ or config.get('namespace', '')
         if not isinstance(self.namespace, str):
             raise ConfigurationError('Setting `namespace` must be a string')
-        elif not self.namespace:
-            raise ConfigurationError('Setting `namespace` is required')
 
         self.raw_metric_prefix = config.get('raw_metric_prefix', '')
         if not isinstance(self.raw_metric_prefix, str):

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_config.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_config.py
@@ -39,13 +39,6 @@ class TestNamespace:
         with pytest.raises(Exception, match='^Setting `namespace` must be a string$'):
             dd_run_check(check, extract_message=True)
 
-    def test_missing(self, dd_run_check):
-        check = get_check({'openmetrics_endpoint': 'test'})
-        check.__NAMESPACE__ = ''
-
-        with pytest.raises(Exception, match='^Setting `namespace` is required$'):
-            dd_run_check(check, extract_message=True)
-
 
 class TestRawMetricPrefix:
     def test_not_string(self, dd_run_check):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics.yaml
@@ -10,7 +10,7 @@
     The namespace to be prepended to all metrics.
   value:
     type: string
-    pattern: '\w+'
+    pattern: '\w*'
 - name: raw_metric_prefix
   description: |
     A prefix that will be removed from all exposed metric names, if present.

--- a/openmetrics/assets/configuration/spec.yaml
+++ b/openmetrics/assets/configuration/spec.yaml
@@ -9,7 +9,6 @@ files:
       options:
         - template: instances/openmetrics
           overrides:
-            namespace.required: true
             namespace.hidden: false
             metrics.required: true
             metrics.hidden: false

--- a/openmetrics/datadog_checks/openmetrics/config_models/defaults.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/defaults.py
@@ -184,6 +184,10 @@ def instance_min_collection_interval(field, value):
     return 15
 
 
+def instance_namespace(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_non_cumulative_histogram_buckets(field, value):
     return False
 

--- a/openmetrics/datadog_checks/openmetrics/config_models/instance.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/instance.py
@@ -125,7 +125,7 @@ class InstanceConfig(BaseModel):
     log_requests: Optional[bool]
     metrics: Sequence[Union[str, Mapping[str, Union[str, Metric]]]]
     min_collection_interval: Optional[float]
-    namespace: str = Field(..., regex='\\w+')
+    namespace: Optional[str] = Field(None, regex='\\w*')
     non_cumulative_histogram_buckets: Optional[bool]
     ntlm_domain: Optional[str]
     openmetrics_endpoint: Optional[str]

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -51,10 +51,10 @@ instances:
     #
     # openmetrics_endpoint: <OPENMETRICS_ENDPOINT>
 
-    ## @param namespace - string - required
+    ## @param namespace - string - optional
     ## The namespace to be prepended to all metrics.
     #
-    namespace: <NAMESPACE>
+    # namespace: <NAMESPACE>
 
     ## @param raw_metric_prefix - string - optional
     ## A prefix that will be removed from all exposed metric names, if present.


### PR DESCRIPTION
### Motivation

Ease migration to v2, and it was overly strict anyway