### PR TITLE
Add controller last sync timestamp metric to external dns

### DIFF
--- a/external_dns/datadog_checks/external_dns/metrics.py
+++ b/external_dns/datadog_checks/external_dns/metrics.py
@@ -6,4 +6,5 @@ DEFAULT_METRICS = {
     'external_dns_source_endpoints_total': 'source.endpoints.total',
     'source_errors_total': 'source.errors.total',
     'registry_errors_total': 'registry.errors.total',
+    'external_dns_controller_last_sync_timestamp_seconds': 'controller.last_sync',
 }

--- a/external_dns/metadata.csv
+++ b/external_dns/metadata.csv
@@ -3,3 +3,4 @@ external_dns.registry.errors.total,gauge,,error,,Number of registry errors,-1,ex
 external_dns.registry.endpoints.total,gauge,,resource,,Number of registry endpoints,0,external_dns,registry endpoints
 external_dns.source.errors.total,gauge,,error,,Number of source errors,-1,external_dns,source errors
 external_dns.source.endpoints.total,gauge,,resource,,Number of source endpoints,0,external_dns,source endpoints
+external_dns.controller.last_sync,gauge,,second,,Timestamp of last successful sync with the DNS provider,0,external_dns,controller last sync timestamp

--- a/external_dns/tests/fixtures/metrics.txt
+++ b/external_dns/tests/fixtures/metrics.txt
@@ -10,3 +10,6 @@ registry_errors_total 0
 # HELP source_errors_total Number of Source errors.
 # TYPE source_errors_total counter
 source_errors_total 0
+# HELP external_dns_controller_last_sync_timestamp_seconds Timestamp of last successful sync with the DNS provider
+# TYPE external_dns_controller_last_sync_timestamp_seconds gauge
+external_dns_controller_last_sync_timestamp_seconds 1.6343090342347014e+09


### PR DESCRIPTION
### What does this PR do?

External DNS exposes several custom prometheus metrics. The current DataDog External DNS integration was missing the `external_dns_controller_last_sync_timestamp_seconds` metric. This change adds the metric to the integration.

### Motivation

We were implementing dashboards for our External DNS deployments and wanted the `external_dns_controller_last_sync_timestamp_seconds` to verify the timestamp of the last sync with the DNS provider. It also keeps the integration in line with the metrics listed by External DNS on their FAQ. See https://github.com/kubernetes-sigs/external-dns/blob/master/docs/faq.md#what-metrics-can-i-get-from-externaldns-and-what-do-they-mean  and https://github.com/kubernetes-sigs/external-dns/blob/master/controller/controller.go#L67

### Additional Notes

I know in DataDog epoch timestamps have limited use without a built in current time function. But I still think it's important for the integration to match the metrics listed by External DNS's documentation.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
