### PR TITLE
Detect and warn on unknown config options

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -386,6 +386,14 @@ class AgentCheck(object):
         self._log_deprecation('in_developer_mode')
         return False
 
+    def validate_unknown_options(self, user_config, models_config, level):
+        unknown_options = sorted(list(dict(user_config).keys() - dict(models_config).keys()))
+        if unknown_options:
+            message = "Detected undocumented or unknown configuration options in {}/{} section: {}".format(
+                self.name, level, ", ".join(unknown_options)
+            )
+            self.log.warning(message)
+
     def load_configuration_models(self, package_path=None):
         if package_path is None:
             # 'datadog_checks.<PACKAGE>.<MODULE>...'
@@ -398,12 +406,7 @@ class AgentCheck(object):
             raw_shared_config.update(intg_shared_config)
 
             shared_config = self.load_configuration_model(package_path, 'SharedConfig', raw_shared_config)
-            unknown_shared_options = list(set(intg_shared_config) - set(shared_config))
-            if unknown_shared_options:
-                message = "Detected undocumented or unknown configuration options in {}: {}".format(
-                    self.name, unknown_shared_options
-                )
-                self.log.warning(message)
+            self.validate_unknown_options(intg_shared_config, shared_config, 'init_config')
             if shared_config is not None:
                 self._config_model_shared = shared_config
 
@@ -413,12 +416,8 @@ class AgentCheck(object):
             raw_instance_config.update(intg_instance_config)
 
             instance_config = self.load_configuration_model(package_path, 'InstanceConfig', raw_instance_config)
-            unknown_instance_options = list(set(intg_instance_config) - set(instance_config))
-            if unknown_instance_options:
-                message = "Detected undocumented or unknown configuration options in {}: {}".format(
-                    self.name, unknown_instance_options
-                )
-                self.log.warning(message)
+            self.validate_unknown_options(intg_instance_config, instance_config, 'instances')
+
             if instance_config is not None:
                 self._config_model_instance = instance_config
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -387,11 +387,8 @@ class AgentCheck(object):
         return False
 
     def validate_unknown_options(self, user_config, models_config, level):
-        if not user_config:
-            user_config = {}
-
-        if not models_config:
-            models_config = {}
+        user_config = user_config or {}
+        models_config = models_config or {}
         unknown_options = sorted(list(dict(user_config).keys() - dict(models_config).keys()))
         if unknown_options:
             message = "Detected undocumented or unknown configuration options in {}/{} section: {}".format(

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -394,17 +394,27 @@ class AgentCheck(object):
 
         if self._config_model_shared is None:
             raw_shared_config = self._get_config_model_initialization_data()
-            raw_shared_config.update(self._get_shared_config())
+            intg_shared_config = self._get_shared_config()
+            raw_shared_config.update(intg_shared_config)
 
             shared_config = self.load_configuration_model(package_path, 'SharedConfig', raw_shared_config)
+            unknown_shared_options = list(set(intg_shared_config) - set(shared_config))
+            if unknown_shared_options:
+                message = "Detected unknown configuration options in {}: {}".format(self.name, unknown_shared_options)
+                self.log.warning(message)
             if shared_config is not None:
                 self._config_model_shared = shared_config
 
         if self._config_model_instance is None:
             raw_instance_config = self._get_config_model_initialization_data()
-            raw_instance_config.update(self._get_instance_config())
+            intg_instance_config = self._get_instance_config()
+            raw_instance_config.update(intg_instance_config)
 
             instance_config = self.load_configuration_model(package_path, 'InstanceConfig', raw_instance_config)
+            unknown_instance_options = list(set(intg_instance_config) - set(instance_config))
+            if unknown_instance_options:
+                message = "Detected unknown configuration options in {}: {}".format(self.name, unknown_instance_options)
+                self.log.warning(message)
             if instance_config is not None:
                 self._config_model_instance = instance_config
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -400,7 +400,9 @@ class AgentCheck(object):
             shared_config = self.load_configuration_model(package_path, 'SharedConfig', raw_shared_config)
             unknown_shared_options = list(set(intg_shared_config) - set(shared_config))
             if unknown_shared_options:
-                message = "Detected unknown configuration options in {}: {}".format(self.name, unknown_shared_options)
+                message = "Detected undocumented or unknown configuration options in {}: {}".format(
+                    self.name, unknown_shared_options
+                )
                 self.log.warning(message)
             if shared_config is not None:
                 self._config_model_shared = shared_config
@@ -413,7 +415,9 @@ class AgentCheck(object):
             instance_config = self.load_configuration_model(package_path, 'InstanceConfig', raw_instance_config)
             unknown_instance_options = list(set(intg_instance_config) - set(instance_config))
             if unknown_instance_options:
-                message = "Detected unknown configuration options in {}: {}".format(self.name, unknown_instance_options)
+                message = "Detected undocumented or unknown configuration options in {}: {}".format(
+                    self.name, unknown_instance_options
+                )
                 self.log.warning(message)
             if instance_config is not None:
                 self._config_model_instance = instance_config

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -389,7 +389,7 @@ class AgentCheck(object):
     def validate_unknown_options(self, user_config, models_config, level):
         user_config = user_config or {}
         models_config = models_config or {}
-        unknown_options = sorted(list(dict(user_config).keys() - dict(models_config).keys()))
+        unknown_options = sorted(list(user_config.keys() - dict(models_config).keys()))
         if unknown_options:
             message = "Detected undocumented or unknown configuration options in {}/{} section: {}".format(
                 self.name, level, ", ".join(unknown_options)

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -387,6 +387,11 @@ class AgentCheck(object):
         return False
 
     def validate_unknown_options(self, user_config, models_config, level):
+        if not user_config:
+            user_config = {}
+
+        if not models_config:
+            models_config = {}
         unknown_options = sorted(list(dict(user_config).keys() - dict(models_config).keys()))
         if unknown_options:
             message = "Detected undocumented or unknown configuration options in {}/{} section: {}".format(

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -865,8 +865,8 @@ def test_load_configuration_models(dd_run_check, mocker):
     assert check._config_model_instance is None
     assert check._config_model_shared is None
 
-    instance_config = object()
-    shared_config = object()
+    instance_config = {}
+    shared_config = {}
     package = mocker.MagicMock()
     package.InstanceConfig = mocker.MagicMock(return_value=instance_config)
     package.SharedConfig = mocker.MagicMock(return_value=shared_config)


### PR DESCRIPTION
### What does this PR do?
This PR detects unknown configuration options (using the templates in config models).
### Motivation
Sometimes users misconfigure options with typos or wrong name, so logging a warning will allow customers to be aware of them.

### Additional Notes
tested with `fake_config` in init_config and `tag` in instances.
```
2021-10-20 20:02:44 UTC | CORE | WARN | (pkg/collector/python/datadog_agent.go:124 in LogMessage) | openmetrics:openmetrics:3d40b0d2ff51583e | (base.py:395) | Detected undocumented or unknown configuration options in openmetrics/init_config section: fake_config
2021-10-20 20:02:44 UTC | CORE | WARN | (pkg/collector/python/datadog_agent.go:124 in LogMessage) | openmetrics:openmetrics:3d40b0d2ff51583e | (base.py:395) | Detected undocumented or unknown configuration options in openmetrics/instances section: tag

```
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
