### PR TITLE
Add default datadog_cluster_agent dashboard

### DIFF
--- a/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
+++ b/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
@@ -1,0 +1,1667 @@
+{
+    "title": "Datadog Cluster Agent Overview",
+    "description": "",
+    "widgets": [
+        {
+            "id": 1430425362261404,
+            "definition": {
+                "type": "note",
+                "content": "Overview",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "vertical_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "left",
+                "has_padding": true
+            },
+            "layout": {
+                "x": 0,
+                "y": 0,
+                "width": 12,
+                "height": 1
+            }
+        },
+        {
+            "id": 70989027784664,
+            "definition": {
+                "title": "Running DCA by version",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "horizontal",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "time": {},
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
+                        "queries": [
+                            {
+                                "query": "sum:datadog.cluster_agent.running{$cluster,$namespace} by {version}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "bars"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "label": "",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 0,
+                "y": 1,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 6450041508181648,
+            "definition": {
+                "title": "CPU usage by pod",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "time": {},
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            },
+                            {
+                                "formula": "query2"
+                            }
+                        ],
+                        "queries": [
+                            {
+                                "query": "avg:kubernetes.cpu.usage.total{$cluster,$namespace,kube_app_component:cluster-agent} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            },
+                            {
+                                "query": "avg:kubernetes.cpu.limits{$cluster,$namespace,kube_app_component:cluster-agent} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query2"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "label": "",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 4,
+                "y": 1,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 3314099977769190,
+            "definition": {
+                "title": "Network in/out",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:kubernetes.network.tx_bytes{$cluster,$namespace,kube_app_component:cluster-agent} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "area"
+                    },
+                    {
+                        "formulas": [
+                            {
+                                "formula": "-query1"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:kubernetes.network.rx_bytes{$cluster,$namespace,kube_app_component:cluster-agent} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 8,
+                "y": 1,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 8683956689530306,
+            "definition": {
+                "title": "Pods running",
+                "title_size": "16",
+                "title_align": "left",
+                "type": "query_value",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "default_zero(query1)"
+                            }
+                        ],
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "green_on_white",
+                                "value": 0
+                            },
+                            {
+                                "comparator": "<=",
+                                "palette": "red_on_white",
+                                "value": 0
+                            }
+                        ],
+                        "response_format": "scalar",
+                        "queries": [
+                            {
+                                "query": "sum:kubernetes_state.pod.status_phase{kube_deployment:*cluster-agent,pod_phase:running,$cluster,$namespace}",
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "aggregator": "last"
+                            }
+                        ]
+                    }
+                ],
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 0,
+                "y": 3,
+                "width": 2,
+                "height": 2
+            }
+        },
+        {
+            "id": 6920596960361872,
+            "definition": {
+                "title": "Pods in bad phase",
+                "title_size": "16",
+                "title_align": "left",
+                "type": "query_value",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "default_zero(query1)"
+                            }
+                        ],
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "red_on_white",
+                                "value": 0
+                            },
+                            {
+                                "comparator": "<=",
+                                "palette": "green_on_white",
+                                "value": 0
+                            }
+                        ],
+                        "response_format": "scalar",
+                        "queries": [
+                            {
+                                "query": "sum:kubernetes_state.pod.status_phase{kube_deployment:*cluster-agent,!pod_phase:running,$cluster,$namespace}",
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "aggregator": "last"
+                            }
+                        ]
+                    }
+                ],
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 2,
+                "y": 3,
+                "width": 2,
+                "height": 2
+            }
+        },
+        {
+            "id": 7075904209994732,
+            "definition": {
+                "title": "Memory usage by pod",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            },
+                            {
+                                "formula": "query2"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "queries": [
+                            {
+                                "query": "avg:kubernetes.memory.usage{kube_app_component:cluster-agent,$cluster,$namespace} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            },
+                            {
+                                "query": "avg:kubernetes.memory.limits{kube_app_component:cluster-agent,$cluster,$namespace} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query2"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "label": "",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 4,
+                "y": 3,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 1526364967727124,
+            "definition": {
+                "title": "Container restarts",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:kubernetes.containers.restarts{kube_app_component:cluster-agent,$cluster,$namespace} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 8,
+                "y": 3,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 8272634505281274,
+            "definition": {
+                "type": "note",
+                "content": "Cluster Checks",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "vertical_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "left",
+                "has_padding": true
+            },
+            "layout": {
+                "x": 0,
+                "y": 5,
+                "width": 12,
+                "height": 1
+            }
+        },
+        {
+            "id": 5247319193061510,
+            "definition": {
+                "title": "Nodes reporting",
+                "title_size": "16",
+                "title_align": "left",
+                "type": "query_value",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "default_zero(query1)"
+                            }
+                        ],
+                        "response_format": "scalar",
+                        "queries": [
+                            {
+                                "query": "sum:datadog.cluster_agent.cluster_checks.nodes_reporting{$cluster,$namespace}",
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "aggregator": "last"
+                            }
+                        ]
+                    }
+                ],
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 0,
+                "y": 6,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 2986570066088046,
+            "definition": {
+                "type": "note",
+                "content": "Cluster Check Workers",
+                "background_color": "gray",
+                "font_size": "18",
+                "text_align": "center",
+                "vertical_align": "center",
+                "show_tick": true,
+                "tick_pos": "50%",
+                "tick_edge": "bottom",
+                "has_padding": true
+            },
+            "layout": {
+                "x": 4,
+                "y": 6,
+                "width": 8,
+                "height": 1
+            }
+        },
+        {
+            "id": 7447656200743962,
+            "definition": {
+                "title": "CPU usage by pod",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            },
+                            {
+                                "formula": "query2"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "queries": [
+                            {
+                                "query": "avg:kubernetes.cpu.usage.total{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            },
+                            {
+                                "query": "avg:kubernetes.cpu.limits{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query2"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "label": "",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 4,
+                "y": 7,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 2070905222445640,
+            "definition": {
+                "title": "Network in/out",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:kubernetes.network.tx_bytes{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "area"
+                    },
+                    {
+                        "formulas": [
+                            {
+                                "formula": "-query1"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:kubernetes.network.rx_bytes{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 8,
+                "y": 7,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 5912889026039722,
+            "definition": {
+                "title": "Dispatched configs",
+                "title_size": "16",
+                "title_align": "left",
+                "type": "query_value",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "green_on_white",
+                                "value": 0
+                            }
+                        ],
+                        "response_format": "scalar",
+                        "queries": [
+                            {
+                                "query": "sum:datadog.cluster_agent.cluster_checks.configs_dispatched{$cluster,$namespace}",
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "aggregator": "last"
+                            }
+                        ]
+                    }
+                ],
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 0,
+                "y": 8,
+                "width": 2,
+                "height": 1
+            }
+        },
+        {
+            "id": 7239462763754610,
+            "definition": {
+                "title": "Dangling configs",
+                "title_size": "16",
+                "title_align": "left",
+                "type": "query_value",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "default_zero(query1)"
+                            }
+                        ],
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "red_on_white",
+                                "value": 1
+                            }
+                        ],
+                        "response_format": "scalar",
+                        "queries": [
+                            {
+                                "query": "sum:datadog.cluster_agent.cluster_checks.configs_dangling{$cluster,$namespace}",
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "aggregator": "last"
+                            }
+                        ]
+                    }
+                ],
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 2,
+                "y": 8,
+                "width": 2,
+                "height": 1
+            }
+        },
+        {
+            "id": 435427916739656,
+            "definition": {
+                "title": "Dispatched configs by node",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:datadog.cluster_agent.cluster_checks.configs_dispatched{$cluster,$namespace} by {node}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "bars"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "label": "",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 0,
+                "y": 9,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 4375001843481402,
+            "definition": {
+                "title": "Memory usage by pod",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            },
+                            {
+                                "formula": "query2"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "queries": [
+                            {
+                                "query": "avg:kubernetes.memory.usage{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            },
+                            {
+                                "query": "avg:kubernetes.memory.limits{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query2"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "label": "",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 4,
+                "y": 9,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 5207589473122188,
+            "definition": {
+                "title": "Container restarts",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:kubernetes.containers.restarts{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 8,
+                "y": 9,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 6162266504604468,
+            "definition": {
+                "title": "Dangling configs",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "time": {},
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query0"
+                            }
+                        ],
+                        "queries": [
+                            {
+                                "query": "avg:datadog.cluster_agent.cluster_checks.configs_dangling{$cluster,$namespace}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query0"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "bars"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "label": "",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 0,
+                "y": 11,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 4975221172828252,
+            "definition": {
+                "type": "note",
+                "content": "Admission Controller",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "vertical_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "left",
+                "has_padding": true
+            },
+            "layout": {
+                "x": 4,
+                "y": 11,
+                "width": 8,
+                "height": 1
+            }
+        },
+        {
+            "id": 6663819055752588,
+            "definition": {
+                "title": "Webhooks controller reconcile successes per minute by pod name",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "per_minute(query1)"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.reconcile_success{controller:webhooks,$cluster,$namespace} by {pod_name}",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "bars"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 4,
+                "y": 12,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 6447540349438448,
+            "definition": {
+                "title": "Secrets controller reconcile successes per minute by pod name",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "per_minute(query1)"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.reconcile_success{controller:secrets,$cluster,$namespace} by {pod_name}",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "bars"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 8,
+                "y": 12,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 2251680059559436,
+            "definition": {
+                "type": "note",
+                "content": "Autoscaling",
+                "background_color": "gray",
+                "font_size": "24",
+                "text_align": "center",
+                "vertical_align": "center",
+                "show_tick": false,
+                "tick_pos": "50%",
+                "tick_edge": "left",
+                "has_padding": true
+            },
+            "layout": {
+                "x": 0,
+                "y": 13,
+                "width": 4,
+                "height": 1
+            }
+        },
+        {
+            "id": 648237577478650,
+            "definition": {
+                "title": "Valid external metrics",
+                "title_size": "16",
+                "title_align": "left",
+                "type": "query_value",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "default_zero(query1)"
+                            }
+                        ],
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "green_on_white",
+                                "value": 0
+                            }
+                        ],
+                        "response_format": "scalar",
+                        "queries": [
+                            {
+                                "query": "sum:datadog.cluster_agent.external_metrics{valid:true,$cluster,$namespace}",
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "aggregator": "last"
+                            }
+                        ]
+                    }
+                ],
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 0,
+                "y": 14,
+                "width": 2,
+                "height": 2
+            }
+        },
+        {
+            "id": 7845597748336138,
+            "definition": {
+                "title": "Invalid external metrics",
+                "title_size": "16",
+                "title_align": "left",
+                "type": "query_value",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "default_zero(query1)"
+                            }
+                        ],
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "red_on_white",
+                                "value": 0
+                            }
+                        ],
+                        "response_format": "scalar",
+                        "queries": [
+                            {
+                                "query": "sum:datadog.cluster_agent.external_metrics{valid:false,$cluster,$namespace}",
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "aggregator": "last"
+                            }
+                        ]
+                    }
+                ],
+                "autoscale": true,
+                "precision": 2
+            },
+            "layout": {
+                "x": 2,
+                "y": 14,
+                "width": 2,
+                "height": 2
+            }
+        },
+        {
+            "id": 2115429908145864,
+            "definition": {
+                "title": "Webhooks controller reconcile errors per minute by pod name",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "per_minute(query0)"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.reconcile_errors{controller:webhooks,$cluster,$namespace} by {pod_name}",
+                                "data_source": "metrics",
+                                "name": "query0"
+                            }
+                        ],
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 4,
+                "y": 14,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 6193726040061968,
+            "definition": {
+                "title": "Secrets controller reconcile successes per minute by pod name",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "per_minute(query0)"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.reconcile_errors{controller:secrets,$cluster,$namespace} by {pod_name}",
+                                "data_source": "metrics",
+                                "name": "query0"
+                            }
+                        ],
+                        "style": {
+                            "palette": "warm",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 8,
+                "y": 14,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 8846979597038894,
+            "definition": {
+                "title": "External metrics by namespace",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "queries": [
+                            {
+                                "query": "avg:datadog.cluster_agent.external_metrics{$namespace,$cluster} by {valid,kube_namespace}",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "label": "",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 0,
+                "y": 16,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 7537528746656452,
+            "definition": {
+                "title": "Successful mutation attempts per minute by type",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "per_minute(query1)"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_attempts{injected:true,$cluster,$namespace} by {mutation_type}",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "bars"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 4,
+                "y": 16,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 4551516642114976,
+            "definition": {
+                "title": "Mutation errors by type and reason",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_errors{$cluster,$namespace} by {mutation_type,reason}",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "area"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 8,
+                "y": 16,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 1453748622802082,
+            "definition": {
+                "title": "API queries made per period",
+                "title_size": "16",
+                "title_align": "left",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "alias": "Queries",
+                                "formula": "query1 - query4"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "queries": [
+                            {
+                                "query": "avg:datadog.cluster_agent.datadog.rate_limit_queries.limit{endpoint:/api/v1/query,$cluster,$namespace}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            },
+                            {
+                                "query": "avg:datadog.cluster_agent.datadog.rate_limit_queries.remaining{endpoint:/api/v1/query,$cluster,$namespace}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query4"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "line"
+                    },
+                    {
+                        "formulas": [
+                            {
+                                "alias": "Rate Limit",
+                                "formula": "query0"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:datadog.cluster_agent.datadog.rate_limit_queries.limit{endpoint:/api/v1/query,$cluster,$namespace}.fill(null)",
+                                "data_source": "metrics",
+                                "name": "query0"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "dashed",
+                            "line_width": "normal"
+                        },
+                        "display_type": "line"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "label": "",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 0,
+                "y": 18,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 3587666939487434,
+            "definition": {
+                "title": "Failed mutation attempts by type per minute",
+                "show_legend": true,
+                "legend_layout": "auto",
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "type": "timeseries",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "per_minute(query1)"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_attempts{injected:false,$cluster,$namespace} by {mutation_type}",
+                                "data_source": "metrics",
+                                "name": "query1"
+                            }
+                        ],
+                        "style": {
+                            "palette": "dog_classic",
+                            "line_type": "solid",
+                            "line_width": "normal"
+                        },
+                        "display_type": "bars"
+                    }
+                ],
+                "yaxis": {
+                    "include_zero": true,
+                    "scale": "linear",
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "markers": []
+            },
+            "layout": {
+                "x": 4,
+                "y": 18,
+                "width": 4,
+                "height": 2
+            }
+        },
+        {
+            "id": 4404687275565510,
+            "definition": {
+                "title": "Certificate validity - hours left",
+                "type": "query_value",
+                "requests": [
+                    {
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
+                        "conditional_formats": [
+                            {
+                                "hide_value": false,
+                                "comparator": "<",
+                                "palette": "red_on_white",
+                                "value": 72
+                            },
+                            {
+                                "comparator": "<",
+                                "palette": "yellow_on_white",
+                                "value": 720
+                            },
+                            {
+                                "comparator": ">=",
+                                "palette": "green_on_white",
+                                "value": 720
+                            }
+                        ],
+                        "response_format": "scalar",
+                        "queries": [
+                            {
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.certificate_expiry{$cluster,$namespace}",
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "aggregator": "last"
+                            }
+                        ]
+                    }
+                ],
+                "autoscale": true,
+                "precision": 0
+            },
+            "layout": {
+                "x": 8,
+                "y": 18,
+                "width": 4,
+                "height": 2
+            }
+        }
+    ],
+    "template_variables": [
+        {
+            "name": "cluster",
+            "default": "*",
+            "prefix": "kube_cluster_name",
+            "available_values": []
+        },
+        {
+            "name": "namespace",
+            "default": "*",
+            "prefix": "kube_namespace",
+            "available_values": []
+        }
+    ],
+    "layout_type": "ordered",
+    "is_read_only": false,
+    "notify_list": [],
+    "reflow_type": "fixed",
+    "id": "t2y-mkn-4rs"
+}

--- a/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
+++ b/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
@@ -1,5 +1,5 @@
 {
-    "title": "Datadog Cluster Agent Overview",
+    "title": "Datadog Cluster Agent - Overview",
     "description": "",
     "widgets": [
         {

--- a/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
+++ b/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
@@ -1,36 +1,108 @@
 {
-    "title": "Datadog Cluster Agent - Overview",
+    "author_name": "Datadog",
     "description": "",
+    "layout_type": "ordered",
+    "template_variables": [
+        {
+            "available_values": [],
+            "default": "*",
+            "name": "cluster",
+            "prefix": "kube_cluster_name"
+        },
+        {
+            "available_values": [],
+            "default": "*",
+            "name": "namespace",
+            "prefix": "kube_namespace"
+        },
+        {
+            "available_values": [],
+            "default": "true",
+            "name": "leader",
+            "prefix": "is_leader"
+        }
+    ],
+    "title": "Datadog Cluster Agent - Overview",
     "widgets": [
         {
-            "id": 1430425362261404,
             "definition": {
-                "type": "note",
+                "background_color": "gray",
                 "content": "Overview",
-                "background_color": "gray",
                 "font_size": "24",
-                "text_align": "center",
-                "vertical_align": "center",
+                "has_padding": true,
                 "show_tick": false,
-                "tick_pos": "50%",
+                "text_align": "center",
                 "tick_edge": "left",
-                "has_padding": true
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "center"
             },
+            "id": 1430425362261404,
             "layout": {
-                "x": 0,
-                "y": 0,
+                "height": 1,
                 "width": 12,
-                "height": 1
+                "x": 0,
+                "y": 0
             }
         },
         {
-            "id": 70989027784664,
             "definition": {
-                "title": "Running DCA by version",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": true,
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
                 "legend_layout": "horizontal",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "bars",
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "query": "sum:datadog.cluster_agent.running{$cluster,$namespace} by {version}.fill(null)"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "show_legend": true,
+                "title": "Running DCA by version",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 70989027784664,
+            "layout": {
+                "height": 2,
+                "width": 4,
+                "x": 0,
+                "y": 1
+            }
+        },
+        {
+            "definition": {
                 "legend_columns": [
                     "avg",
                     "min",
@@ -38,56 +110,62 @@
                     "value",
                     "sum"
                 ],
-                "time": {},
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "line",
                         "formulas": [
                             {
                                 "formula": "query1"
+                            },
+                            {
+                                "formula": "query2"
                             }
                         ],
                         "queries": [
                             {
-                                "query": "sum:datadog.cluster_agent.running{$cluster,$namespace} by {version}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:kubernetes.cpu.usage.total{($cluster AND $namespace AND kube_app_component:cluster-agent OR kube_app_instance:cluster-agent)} by {pod_name}.fill(null)"
+                            },
+                            {
+                                "data_source": "metrics",
+                                "name": "query2",
+                                "query": "avg:kubernetes.cpu.limits{($cluster AND $namespace AND kube_app_component:cluster-agent OR kube_app_instance:cluster-agent)} by {pod_name}.fill(null)"
                             }
                         ],
                         "response_format": "timeseries",
-                        "on_right_yaxis": false,
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "bars"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "title": "CPU usage by pod",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
                     "label": "",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
-            "layout": {
-                "x": 0,
-                "y": 1,
-                "width": 4,
-                "height": 2
-            }
-        },
-        {
             "id": 6450041508181648,
+            "layout": {
+                "height": 2,
+                "width": 4,
+                "x": 4,
+                "y": 1
+            }
+        },
+        {
             "definition": {
-                "title": "CPU usage by pod",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": true,
-                "legend_layout": "auto",
                 "legend_columns": [
                     "avg",
                     "min",
@@ -95,232 +173,168 @@
                     "value",
                     "sum"
                 ],
-                "time": {},
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "area",
                         "formulas": [
                             {
                                 "formula": "query1"
-                            },
-                            {
-                                "formula": "query2"
                             }
                         ],
+                        "on_right_yaxis": false,
                         "queries": [
                             {
-                                "query": "avg:kubernetes.cpu.usage.total{$cluster,$namespace,kube_app_component:cluster-agent} by {pod_name}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query1"
-                            },
-                            {
-                                "query": "avg:kubernetes.cpu.limits{$cluster,$namespace,kube_app_component:cluster-agent} by {pod_name}.fill(null)",
-                                "data_source": "metrics",
-                                "name": "query2"
+                                "name": "query1",
+                                "query": "avg:kubernetes.network.tx_bytes{($cluster AND $namespace AND kube_app_component:cluster-agent OR kube_app_instance:cluster-agent)} by {pod_name}.fill(null)"
                             }
                         ],
                         "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "line"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    },
+                    {
+                        "display_type": "line",
+                        "formulas": [
+                            {
+                                "formula": "-query1"
+                            }
+                        ],
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "query": "avg:kubernetes.network.rx_bytes{($cluster AND $namespace AND kube_app_component:cluster-agent OR kube_app_instance:cluster-agent)} by {pod_name}.fill(null)"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "title": "Network in/out",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
-                    "label": "",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
-            "layout": {
-                "x": 4,
-                "y": 1,
-                "width": 4,
-                "height": 2
-            }
-        },
-        {
             "id": 3314099977769190,
-            "definition": {
-                "title": "Network in/out",
-                "show_legend": true,
-                "legend_layout": "auto",
-                "legend_columns": [
-                    "avg",
-                    "min",
-                    "max",
-                    "value",
-                    "sum"
-                ],
-                "type": "timeseries",
-                "requests": [
-                    {
-                        "formulas": [
-                            {
-                                "formula": "query1"
-                            }
-                        ],
-                        "response_format": "timeseries",
-                        "on_right_yaxis": false,
-                        "queries": [
-                            {
-                                "query": "avg:kubernetes.network.tx_bytes{$cluster,$namespace,kube_app_component:cluster-agent} by {pod_name}.fill(null)",
-                                "data_source": "metrics",
-                                "name": "query1"
-                            }
-                        ],
-                        "style": {
-                            "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "area"
-                    },
-                    {
-                        "formulas": [
-                            {
-                                "formula": "-query1"
-                            }
-                        ],
-                        "response_format": "timeseries",
-                        "on_right_yaxis": false,
-                        "queries": [
-                            {
-                                "query": "avg:kubernetes.network.rx_bytes{$cluster,$namespace,kube_app_component:cluster-agent} by {pod_name}.fill(null)",
-                                "data_source": "metrics",
-                                "name": "query1"
-                            }
-                        ],
-                        "style": {
-                            "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "line"
-                    }
-                ],
-                "yaxis": {
-                    "include_zero": true,
-                    "scale": "linear",
-                    "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
-            },
             "layout": {
-                "x": 8,
-                "y": 1,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 8,
+                "y": 1
             }
         },
         {
-            "id": 8683956689530306,
             "definition": {
+                "autoscale": true,
+                "precision": 2,
+                "requests": [
+                    {
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "green_on_white",
+                                "value": 0
+                            },
+                            {
+                                "comparator": "<=",
+                                "palette": "red_on_white",
+                                "value": 0
+                            }
+                        ],
+                        "formulas": [
+                            {
+                                "formula": "default_zero(query1)"
+                            }
+                        ],
+                        "queries": [
+                            {
+                                "aggregator": "last",
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "query": "sum:kubernetes_state.pod.status_phase{kube_deployment:*cluster-agent,pod_phase:running,$cluster,$namespace}"
+                            }
+                        ],
+                        "response_format": "scalar"
+                    }
+                ],
                 "title": "Pods running",
-                "title_size": "16",
                 "title_align": "left",
-                "type": "query_value",
+                "title_size": "16",
+                "type": "query_value"
+            },
+            "id": 8683956689530306,
+            "layout": {
+                "height": 2,
+                "width": 2,
+                "x": 0,
+                "y": 3
+            }
+        },
+        {
+            "definition": {
+                "autoscale": true,
+                "precision": 2,
                 "requests": [
                     {
+                        "conditional_formats": [
+                            {
+                                "comparator": ">",
+                                "palette": "red_on_white",
+                                "value": 0
+                            },
+                            {
+                                "comparator": "<=",
+                                "palette": "green_on_white",
+                                "value": 0
+                            }
+                        ],
                         "formulas": [
                             {
                                 "formula": "default_zero(query1)"
                             }
                         ],
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "green_on_white",
-                                "value": 0
-                            },
-                            {
-                                "comparator": "<=",
-                                "palette": "red_on_white",
-                                "value": 0
-                            }
-                        ],
-                        "response_format": "scalar",
                         "queries": [
                             {
-                                "query": "sum:kubernetes_state.pod.status_phase{kube_deployment:*cluster-agent,pod_phase:running,$cluster,$namespace}",
+                                "aggregator": "last",
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "aggregator": "last"
+                                "query": "sum:kubernetes_state.pod.status_phase{kube_deployment:*cluster-agent,!pod_phase:running,$cluster,$namespace}"
                             }
-                        ]
+                        ],
+                        "response_format": "scalar"
                     }
                 ],
-                "autoscale": true,
-                "precision": 2
-            },
-            "layout": {
-                "x": 0,
-                "y": 3,
-                "width": 2,
-                "height": 2
-            }
-        },
-        {
-            "id": 6920596960361872,
-            "definition": {
                 "title": "Pods in bad phase",
-                "title_size": "16",
                 "title_align": "left",
-                "type": "query_value",
-                "requests": [
-                    {
-                        "formulas": [
-                            {
-                                "formula": "default_zero(query1)"
-                            }
-                        ],
-                        "conditional_formats": [
-                            {
-                                "comparator": ">",
-                                "palette": "red_on_white",
-                                "value": 0
-                            },
-                            {
-                                "comparator": "<=",
-                                "palette": "green_on_white",
-                                "value": 0
-                            }
-                        ],
-                        "response_format": "scalar",
-                        "queries": [
-                            {
-                                "query": "sum:kubernetes_state.pod.status_phase{kube_deployment:*cluster-agent,!pod_phase:running,$cluster,$namespace}",
-                                "data_source": "metrics",
-                                "name": "query1",
-                                "aggregator": "last"
-                            }
-                        ]
-                    }
-                ],
-                "autoscale": true,
-                "precision": 2
+                "title_size": "16",
+                "type": "query_value"
             },
+            "id": 6920596960361872,
             "layout": {
-                "x": 2,
-                "y": 3,
+                "height": 2,
                 "width": 2,
-                "height": 2
+                "x": 2,
+                "y": 3
             }
         },
         {
-            "id": 7075904209994732,
             "definition": {
-                "title": "Memory usage by pod",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": true,
-                "legend_layout": "auto",
                 "legend_columns": [
                     "avg",
                     "min",
@@ -328,9 +342,11 @@
                     "value",
                     "sum"
                 ],
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "line",
                         "formulas": [
                             {
                                 "formula": "query1"
@@ -339,49 +355,49 @@
                                 "formula": "query2"
                             }
                         ],
-                        "response_format": "timeseries",
                         "queries": [
                             {
-                                "query": "avg:kubernetes.memory.usage{kube_app_component:cluster-agent,$cluster,$namespace} by {pod_name}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:kubernetes.memory.usage{($cluster AND $namespace AND kube_app_component:cluster-agent OR kube_app_instance:cluster-agent)} by {pod_name}.fill(null)"
                             },
                             {
-                                "query": "avg:kubernetes.memory.limits{kube_app_component:cluster-agent,$cluster,$namespace} by {pod_name}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query2"
+                                "name": "query2",
+                                "query": "avg:kubernetes.memory.limits{($cluster AND $namespace AND kube_app_component:cluster-agent OR kube_app_instance:cluster-agent)} by {pod_name}.fill(null)"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "line"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "title": "Memory usage by pod",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
                     "label": "",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
+            "id": 7075904209994732,
             "layout": {
-                "x": 4,
-                "y": 3,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 4,
+                "y": 3
             }
         },
         {
-            "id": 1526364967727124,
             "definition": {
-                "title": "Container restarts",
-                "show_legend": true,
-                "legend_layout": "auto",
                 "legend_columns": [
                     "avg",
                     "min",
@@ -389,74 +405,75 @@
                     "value",
                     "sum"
                 ],
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "line",
                         "formulas": [
                             {
                                 "formula": "query1"
                             }
                         ],
-                        "response_format": "timeseries",
                         "on_right_yaxis": false,
                         "queries": [
                             {
-                                "query": "avg:kubernetes.containers.restarts{kube_app_component:cluster-agent,$cluster,$namespace} by {pod_name}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:kubernetes.containers.restarts{($cluster AND $namespace AND kube_app_component:cluster-agent OR kube_app_instance:cluster-agent)} by {pod_name}.fill(null)"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "line"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "title": "Container restarts",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
+            "id": 1526364967727124,
             "layout": {
-                "x": 8,
-                "y": 3,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 8,
+                "y": 3
             }
         },
         {
-            "id": 8272634505281274,
             "definition": {
-                "type": "note",
-                "content": "Cluster Checks",
                 "background_color": "gray",
+                "content": "Cluster Checks",
                 "font_size": "24",
-                "text_align": "center",
-                "vertical_align": "center",
+                "has_padding": true,
                 "show_tick": false,
-                "tick_pos": "50%",
+                "text_align": "center",
                 "tick_edge": "left",
-                "has_padding": true
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "center"
             },
+            "id": 8272634505281274,
             "layout": {
-                "x": 0,
-                "y": 5,
+                "height": 1,
                 "width": 12,
-                "height": 1
+                "x": 0,
+                "y": 5
             }
         },
         {
-            "id": 5247319193061510,
             "definition": {
-                "title": "Nodes reporting",
-                "title_size": "16",
-                "title_align": "left",
-                "type": "query_value",
+                "autoscale": true,
+                "precision": 2,
                 "requests": [
                     {
                         "formulas": [
@@ -464,56 +481,53 @@
                                 "formula": "default_zero(query1)"
                             }
                         ],
-                        "response_format": "scalar",
                         "queries": [
                             {
-                                "query": "sum:datadog.cluster_agent.cluster_checks.nodes_reporting{$cluster,$namespace}",
+                                "aggregator": "last",
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "aggregator": "last"
+                                "query": "sum:datadog.cluster_agent.cluster_checks.nodes_reporting{$cluster,$namespace,$leader}"
                             }
-                        ]
+                        ],
+                        "response_format": "scalar"
                     }
                 ],
-                "autoscale": true,
-                "precision": 2
-            },
-            "layout": {
-                "x": 0,
-                "y": 6,
-                "width": 4,
-                "height": 2
-            }
-        },
-        {
-            "id": 2986570066088046,
-            "definition": {
-                "type": "note",
-                "content": "Cluster Check Workers",
-                "background_color": "gray",
-                "font_size": "18",
-                "text_align": "center",
-                "vertical_align": "center",
-                "show_tick": true,
-                "tick_pos": "50%",
-                "tick_edge": "bottom",
-                "has_padding": true
-            },
-            "layout": {
-                "x": 4,
-                "y": 6,
-                "width": 8,
-                "height": 1
-            }
-        },
-        {
-            "id": 7447656200743962,
-            "definition": {
-                "title": "CPU usage by pod",
-                "title_size": "16",
+                "title": "Agents reporting",
                 "title_align": "left",
-                "show_legend": true,
-                "legend_layout": "auto",
+                "title_size": "16",
+                "type": "query_value"
+            },
+            "id": 5247319193061510,
+            "layout": {
+                "height": 2,
+                "width": 4,
+                "x": 0,
+                "y": 6
+            }
+        },
+        {
+            "definition": {
+                "background_color": "gray",
+                "content": "Cluster Check Runners",
+                "font_size": "18",
+                "has_padding": true,
+                "show_tick": true,
+                "text_align": "center",
+                "tick_edge": "bottom",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "center"
+            },
+            "id": 2986570066088046,
+            "layout": {
+                "height": 1,
+                "width": 8,
+                "x": 4,
+                "y": 6
+            }
+        },
+        {
+            "definition": {
                 "legend_columns": [
                     "avg",
                     "min",
@@ -521,9 +535,11 @@
                     "value",
                     "sum"
                 ],
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "line",
                         "formulas": [
                             {
                                 "formula": "query1"
@@ -532,49 +548,49 @@
                                 "formula": "query2"
                             }
                         ],
-                        "response_format": "timeseries",
                         "queries": [
                             {
-                                "query": "avg:kubernetes.cpu.usage.total{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:kubernetes.cpu.usage.total{(kube_app_component:clusterchecks-agent OR kube_app_instance:cluster-checks-runner AND $cluster AND $namespace)} by {pod_name}.fill(null)"
                             },
                             {
-                                "query": "avg:kubernetes.cpu.limits{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query2"
+                                "name": "query2",
+                                "query": "avg:kubernetes.cpu.limits{(kube_app_component:clusterchecks-agent OR kube_app_instance:cluster-checks-runner AND $cluster AND $namespace)} by {pod_name}.fill(null)"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "line"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "title": "CPU usage by pod",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
                     "label": "",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
+            "id": 7447656200743962,
             "layout": {
-                "x": 4,
-                "y": 7,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 4,
+                "y": 7
             }
         },
         {
-            "id": 2070905222445640,
             "definition": {
-                "title": "Network in/out",
-                "show_legend": true,
-                "legend_layout": "auto",
                 "legend_columns": [
                     "avg",
                     "min",
@@ -582,82 +598,78 @@
                     "value",
                     "sum"
                 ],
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "area",
                         "formulas": [
                             {
                                 "formula": "query1"
                             }
                         ],
-                        "response_format": "timeseries",
                         "on_right_yaxis": false,
                         "queries": [
                             {
-                                "query": "avg:kubernetes.network.tx_bytes{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:kubernetes.network.tx_bytes{(kube_app_component:clusterchecks-agent OR kube_app_instance:cluster-checks-runner AND $cluster AND $namespace)} by {pod_name}.fill(null)"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "area"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     },
                     {
+                        "display_type": "line",
                         "formulas": [
                             {
                                 "formula": "-query1"
                             }
                         ],
-                        "response_format": "timeseries",
                         "on_right_yaxis": false,
                         "queries": [
                             {
-                                "query": "avg:kubernetes.network.rx_bytes{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:kubernetes.network.rx_bytes{(kube_app_component:clusterchecks-agent OR kube_app_instance:cluster-checks-runner AND $cluster AND $namespace)} by {pod_name}.fill(null)"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "line"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "title": "Network in/out",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
+            "id": 2070905222445640,
             "layout": {
-                "x": 8,
-                "y": 7,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 8,
+                "y": 7
             }
         },
         {
-            "id": 5912889026039722,
             "definition": {
-                "title": "Dispatched configs",
-                "title_size": "16",
-                "title_align": "left",
-                "type": "query_value",
+                "autoscale": true,
+                "precision": 2,
                 "requests": [
                     {
-                        "formulas": [
-                            {
-                                "formula": "query1"
-                            }
-                        ],
                         "conditional_formats": [
                             {
                                 "comparator": ">",
@@ -665,41 +677,41 @@
                                 "value": 0
                             }
                         ],
-                        "response_format": "scalar",
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
                         "queries": [
                             {
-                                "query": "sum:datadog.cluster_agent.cluster_checks.configs_dispatched{$cluster,$namespace}",
+                                "aggregator": "last",
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "aggregator": "last"
+                                "query": "sum:datadog.cluster_agent.cluster_checks.configs_dispatched{$cluster,$namespace,$leader}"
                             }
-                        ]
+                        ],
+                        "response_format": "scalar"
                     }
                 ],
-                "autoscale": true,
-                "precision": 2
+                "title": "Dispatched configs",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "query_value"
             },
+            "id": 5912889026039722,
             "layout": {
-                "x": 0,
-                "y": 8,
+                "height": 1,
                 "width": 2,
-                "height": 1
+                "x": 0,
+                "y": 8
             }
         },
         {
-            "id": 7239462763754610,
             "definition": {
-                "title": "Dangling configs",
-                "title_size": "16",
-                "title_align": "left",
-                "type": "query_value",
+                "autoscale": true,
+                "precision": 2,
                 "requests": [
                     {
-                        "formulas": [
-                            {
-                                "formula": "default_zero(query1)"
-                            }
-                        ],
                         "conditional_formats": [
                             {
                                 "comparator": ">",
@@ -707,35 +719,37 @@
                                 "value": 1
                             }
                         ],
-                        "response_format": "scalar",
+                        "formulas": [
+                            {
+                                "formula": "default_zero(query1)"
+                            }
+                        ],
                         "queries": [
                             {
-                                "query": "sum:datadog.cluster_agent.cluster_checks.configs_dangling{$cluster,$namespace}",
+                                "aggregator": "last",
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "aggregator": "last"
+                                "query": "sum:datadog.cluster_agent.cluster_checks.configs_dangling{$cluster,$namespace,$leader}"
                             }
-                        ]
+                        ],
+                        "response_format": "scalar"
                     }
                 ],
-                "autoscale": true,
-                "precision": 2
+                "title": "Dangling configs",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "query_value"
             },
+            "id": 7239462763754610,
             "layout": {
-                "x": 2,
-                "y": 8,
+                "height": 1,
                 "width": 2,
-                "height": 1
+                "x": 2,
+                "y": 8
             }
         },
         {
-            "id": 435427916739656,
             "definition": {
-                "title": "Dispatched configs by node",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": true,
-                "legend_layout": "auto",
                 "legend_columns": [
                     "avg",
                     "min",
@@ -743,55 +757,55 @@
                     "value",
                     "sum"
                 ],
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "bars",
                         "formulas": [
                             {
                                 "formula": "query1"
                             }
                         ],
-                        "response_format": "timeseries",
                         "on_right_yaxis": false,
                         "queries": [
                             {
-                                "query": "avg:datadog.cluster_agent.cluster_checks.configs_dispatched{$cluster,$namespace} by {node}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:datadog.cluster_agent.cluster_checks.configs_dispatched{$cluster,$namespace,$leader} by {node}.fill(null)"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "bars"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "title": "Dispatched configs by node",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
                     "label": "",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
+            "id": 435427916739656,
             "layout": {
-                "x": 0,
-                "y": 9,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 0,
+                "y": 9
             }
         },
         {
-            "id": 4375001843481402,
             "definition": {
-                "title": "Memory usage by pod",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": true,
-                "legend_layout": "auto",
                 "legend_columns": [
                     "avg",
                     "min",
@@ -799,9 +813,11 @@
                     "value",
                     "sum"
                 ],
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "line",
                         "formulas": [
                             {
                                 "formula": "query1"
@@ -810,49 +826,49 @@
                                 "formula": "query2"
                             }
                         ],
-                        "response_format": "timeseries",
                         "queries": [
                             {
-                                "query": "avg:kubernetes.memory.usage{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:kubernetes.memory.usage{(kube_app_component:clusterchecks-agent OR kube_app_instance:cluster-checks-runner AND $cluster AND $namespace)} by {pod_name}.fill(null)"
                             },
                             {
-                                "query": "avg:kubernetes.memory.limits{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query2"
+                                "name": "query2",
+                                "query": "avg:kubernetes.memory.limits{(kube_app_component:clusterchecks-agent OR kube_app_instance:cluster-checks-runner AND $cluster AND $namespace)} by {pod_name}.fill(null)"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "line"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "title": "Memory usage by pod",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
                     "label": "",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
+            "id": 4375001843481402,
             "layout": {
-                "x": 4,
-                "y": 9,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 4,
+                "y": 9
             }
         },
         {
-            "id": 5207589473122188,
             "definition": {
-                "title": "Container restarts",
-                "show_legend": true,
-                "legend_layout": "auto",
                 "legend_columns": [
                     "avg",
                     "min",
@@ -860,54 +876,52 @@
                     "value",
                     "sum"
                 ],
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "line",
                         "formulas": [
                             {
                                 "formula": "query1"
                             }
                         ],
-                        "response_format": "timeseries",
                         "on_right_yaxis": false,
                         "queries": [
                             {
-                                "query": "avg:kubernetes.containers.restarts{kube_app_component:clusterchecks-agent,$cluster,$namespace} by {pod_name}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:kubernetes.containers.restarts{(kube_app_component:clusterchecks-agent OR kube_app_instance:cluster-checks-runner AND $cluster AND $namespace)} by {pod_name}.fill(null)"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "line"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "title": "Container restarts",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
+            "id": 5207589473122188,
             "layout": {
-                "x": 8,
-                "y": 9,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 8,
+                "y": 9
             }
         },
         {
-            "id": 6162266504604468,
             "definition": {
-                "title": "Dangling configs",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": true,
-                "legend_layout": "auto",
                 "legend_columns": [
                     "avg",
                     "min",
@@ -915,210 +929,209 @@
                     "value",
                     "sum"
                 ],
-                "time": {},
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "bars",
                         "formulas": [
                             {
                                 "formula": "query0"
                             }
                         ],
+                        "on_right_yaxis": false,
                         "queries": [
                             {
-                                "query": "avg:datadog.cluster_agent.cluster_checks.configs_dangling{$cluster,$namespace}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query0"
+                                "name": "query0",
+                                "query": "avg:datadog.cluster_agent.cluster_checks.configs_dangling{$cluster,$namespace,$leader}.fill(null)"
                             }
                         ],
                         "response_format": "timeseries",
-                        "on_right_yaxis": false,
                         "style": {
-                            "palette": "warm",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "bars"
+                            "line_width": "normal",
+                            "palette": "warm"
+                        }
                     }
                 ],
-                "yaxis": {
-                    "include_zero": true,
-                    "scale": "linear",
-                    "label": "",
-                    "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
-            },
-            "layout": {
-                "x": 0,
-                "y": 11,
-                "width": 4,
-                "height": 2
-            }
-        },
-        {
-            "id": 4975221172828252,
-            "definition": {
-                "type": "note",
-                "content": "Admission Controller",
-                "background_color": "gray",
-                "font_size": "24",
-                "text_align": "center",
-                "vertical_align": "center",
-                "show_tick": false,
-                "tick_pos": "50%",
-                "tick_edge": "left",
-                "has_padding": true
-            },
-            "layout": {
-                "x": 4,
-                "y": 11,
-                "width": 8,
-                "height": 1
-            }
-        },
-        {
-            "id": 6663819055752588,
-            "definition": {
-                "title": "Webhooks controller reconcile successes per minute by pod name",
                 "show_legend": true,
-                "legend_layout": "auto",
-                "legend_columns": [
-                    "avg",
-                    "min",
-                    "max",
-                    "value",
-                    "sum"
-                ],
-                "type": "timeseries",
-                "requests": [
-                    {
-                        "formulas": [
-                            {
-                                "formula": "per_minute(query1)"
-                            }
-                        ],
-                        "response_format": "timeseries",
-                        "on_right_yaxis": false,
-                        "queries": [
-                            {
-                                "query": "avg:datadog.cluster_agent.admission_webhooks.reconcile_success{controller:webhooks,$cluster,$namespace} by {pod_name}",
-                                "data_source": "metrics",
-                                "name": "query1"
-                            }
-                        ],
-                        "style": {
-                            "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "bars"
-                    }
-                ],
-                "yaxis": {
-                    "include_zero": true,
-                    "scale": "linear",
-                    "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
-            },
-            "layout": {
-                "x": 4,
-                "y": 12,
-                "width": 4,
-                "height": 2
-            }
-        },
-        {
-            "id": 6447540349438448,
-            "definition": {
-                "title": "Secrets controller reconcile successes per minute by pod name",
-                "show_legend": true,
-                "legend_layout": "auto",
-                "legend_columns": [
-                    "avg",
-                    "min",
-                    "max",
-                    "value",
-                    "sum"
-                ],
-                "type": "timeseries",
-                "requests": [
-                    {
-                        "formulas": [
-                            {
-                                "formula": "per_minute(query1)"
-                            }
-                        ],
-                        "response_format": "timeseries",
-                        "on_right_yaxis": false,
-                        "queries": [
-                            {
-                                "query": "avg:datadog.cluster_agent.admission_webhooks.reconcile_success{controller:secrets,$cluster,$namespace} by {pod_name}",
-                                "data_source": "metrics",
-                                "name": "query1"
-                            }
-                        ],
-                        "style": {
-                            "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "bars"
-                    }
-                ],
-                "yaxis": {
-                    "include_zero": true,
-                    "scale": "linear",
-                    "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
-            },
-            "layout": {
-                "x": 8,
-                "y": 12,
-                "width": 4,
-                "height": 2
-            }
-        },
-        {
-            "id": 2251680059559436,
-            "definition": {
-                "type": "note",
-                "content": "Autoscaling",
-                "background_color": "gray",
-                "font_size": "24",
-                "text_align": "center",
-                "vertical_align": "center",
-                "show_tick": false,
-                "tick_pos": "50%",
-                "tick_edge": "left",
-                "has_padding": true
-            },
-            "layout": {
-                "x": 0,
-                "y": 13,
-                "width": 4,
-                "height": 1
-            }
-        },
-        {
-            "id": 648237577478650,
-            "definition": {
-                "title": "Valid external metrics",
-                "title_size": "16",
+                "title": "Dangling configs",
                 "title_align": "left",
-                "type": "query_value",
+                "title_size": "16",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "label": "",
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 6162266504604468,
+            "layout": {
+                "height": 2,
+                "width": 4,
+                "x": 0,
+                "y": 11
+            }
+        },
+        {
+            "definition": {
+                "background_color": "gray",
+                "content": "Admission Controller",
+                "font_size": "24",
+                "has_padding": true,
+                "show_tick": false,
+                "text_align": "center",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "center"
+            },
+            "id": 4975221172828252,
+            "layout": {
+                "height": 1,
+                "width": 8,
+                "x": 4,
+                "y": 11
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "bars",
                         "formulas": [
                             {
-                                "formula": "default_zero(query1)"
+                                "formula": "per_minute(query1)"
                             }
                         ],
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.reconcile_success{controller:webhooks,$cluster,$namespace} by {pod_name}"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "show_legend": true,
+                "time": {},
+                "title": "Webhooks controller reconcile successes per minute by pod name",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 6663819055752588,
+            "layout": {
+                "height": 2,
+                "width": 4,
+                "x": 4,
+                "y": 12
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "bars",
+                        "formulas": [
+                            {
+                                "formula": "per_minute(query1)"
+                            }
+                        ],
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.reconcile_success{controller:secrets,$cluster,$namespace} by {pod_name}"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "show_legend": true,
+                "time": {},
+                "title": "Secrets controller reconcile successes per minute by pod name",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 6447540349438448,
+            "layout": {
+                "height": 2,
+                "width": 4,
+                "x": 8,
+                "y": 12
+            }
+        },
+        {
+            "definition": {
+                "background_color": "gray",
+                "content": "Autoscaling",
+                "font_size": "24",
+                "has_padding": true,
+                "show_tick": false,
+                "text_align": "center",
+                "tick_edge": "left",
+                "tick_pos": "50%",
+                "type": "note",
+                "vertical_align": "center"
+            },
+            "id": 2251680059559436,
+            "layout": {
+                "height": 1,
+                "width": 4,
+                "x": 0,
+                "y": 13
+            }
+        },
+        {
+            "definition": {
+                "autoscale": true,
+                "precision": 2,
+                "requests": [
+                    {
                         "conditional_formats": [
                             {
                                 "comparator": ">",
@@ -1126,41 +1139,41 @@
                                 "value": 0
                             }
                         ],
-                        "response_format": "scalar",
-                        "queries": [
-                            {
-                                "query": "sum:datadog.cluster_agent.external_metrics{valid:true,$cluster,$namespace}",
-                                "data_source": "metrics",
-                                "name": "query1",
-                                "aggregator": "last"
-                            }
-                        ]
-                    }
-                ],
-                "autoscale": true,
-                "precision": 2
-            },
-            "layout": {
-                "x": 0,
-                "y": 14,
-                "width": 2,
-                "height": 2
-            }
-        },
-        {
-            "id": 7845597748336138,
-            "definition": {
-                "title": "Invalid external metrics",
-                "title_size": "16",
-                "title_align": "left",
-                "type": "query_value",
-                "requests": [
-                    {
                         "formulas": [
                             {
                                 "formula": "default_zero(query1)"
                             }
                         ],
+                        "queries": [
+                            {
+                                "aggregator": "last",
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "query": "sum:datadog.cluster_agent.external_metrics{valid:true,$cluster,$namespace,$leader}"
+                            }
+                        ],
+                        "response_format": "scalar"
+                    }
+                ],
+                "title": "Valid external metrics",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "query_value"
+            },
+            "id": 648237577478650,
+            "layout": {
+                "height": 2,
+                "width": 2,
+                "x": 0,
+                "y": 14
+            }
+        },
+        {
+            "definition": {
+                "autoscale": true,
+                "precision": 2,
+                "requests": [
+                    {
                         "conditional_formats": [
                             {
                                 "comparator": ">",
@@ -1168,141 +1181,37 @@
                                 "value": 0
                             }
                         ],
-                        "response_format": "scalar",
+                        "formulas": [
+                            {
+                                "formula": "default_zero(query1)"
+                            }
+                        ],
                         "queries": [
                             {
-                                "query": "sum:datadog.cluster_agent.external_metrics{valid:false,$cluster,$namespace}",
+                                "aggregator": "last",
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "aggregator": "last"
+                                "query": "sum:datadog.cluster_agent.external_metrics{valid:false,$cluster,$namespace,$leader}"
                             }
-                        ]
+                        ],
+                        "response_format": "scalar"
                     }
                 ],
-                "autoscale": true,
-                "precision": 2
-            },
-            "layout": {
-                "x": 2,
-                "y": 14,
-                "width": 2,
-                "height": 2
-            }
-        },
-        {
-            "id": 2115429908145864,
-            "definition": {
-                "title": "Webhooks controller reconcile errors per minute by pod name",
-                "show_legend": true,
-                "legend_layout": "auto",
-                "legend_columns": [
-                    "avg",
-                    "min",
-                    "max",
-                    "value",
-                    "sum"
-                ],
-                "type": "timeseries",
-                "requests": [
-                    {
-                        "formulas": [
-                            {
-                                "formula": "per_minute(query0)"
-                            }
-                        ],
-                        "response_format": "timeseries",
-                        "on_right_yaxis": false,
-                        "queries": [
-                            {
-                                "query": "avg:datadog.cluster_agent.admission_webhooks.reconcile_errors{controller:webhooks,$cluster,$namespace} by {pod_name}",
-                                "data_source": "metrics",
-                                "name": "query0"
-                            }
-                        ],
-                        "style": {
-                            "palette": "warm",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "line"
-                    }
-                ],
-                "yaxis": {
-                    "include_zero": true,
-                    "scale": "linear",
-                    "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
-            },
-            "layout": {
-                "x": 4,
-                "y": 14,
-                "width": 4,
-                "height": 2
-            }
-        },
-        {
-            "id": 6193726040061968,
-            "definition": {
-                "title": "Secrets controller reconcile successes per minute by pod name",
-                "show_legend": true,
-                "legend_layout": "auto",
-                "legend_columns": [
-                    "avg",
-                    "min",
-                    "max",
-                    "value",
-                    "sum"
-                ],
-                "type": "timeseries",
-                "requests": [
-                    {
-                        "formulas": [
-                            {
-                                "formula": "per_minute(query0)"
-                            }
-                        ],
-                        "response_format": "timeseries",
-                        "on_right_yaxis": false,
-                        "queries": [
-                            {
-                                "query": "avg:datadog.cluster_agent.admission_webhooks.reconcile_errors{controller:secrets,$cluster,$namespace} by {pod_name}",
-                                "data_source": "metrics",
-                                "name": "query0"
-                            }
-                        ],
-                        "style": {
-                            "palette": "warm",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "line"
-                    }
-                ],
-                "yaxis": {
-                    "include_zero": true,
-                    "scale": "linear",
-                    "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
-            },
-            "layout": {
-                "x": 8,
-                "y": 14,
-                "width": 4,
-                "height": 2
-            }
-        },
-        {
-            "id": 8846979597038894,
-            "definition": {
-                "title": "External metrics by namespace",
-                "title_size": "16",
+                "title": "Invalid external metrics",
                 "title_align": "left",
-                "show_legend": true,
-                "legend_layout": "auto",
+                "title_size": "16",
+                "type": "query_value"
+            },
+            "id": 7845597748336138,
+            "layout": {
+                "height": 2,
+                "width": 2,
+                "x": 2,
+                "y": 14
+            }
+        },
+        {
+            "definition": {
                 "legend_columns": [
                     "avg",
                     "min",
@@ -1310,52 +1219,162 @@
                     "value",
                     "sum"
                 ],
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "line",
+                        "formulas": [
+                            {
+                                "formula": "per_minute(query0)"
+                            }
+                        ],
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "data_source": "metrics",
+                                "name": "query0",
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.reconcile_errors{controller:webhooks,$cluster,$namespace} by {pod_name}"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "warm"
+                        }
+                    }
+                ],
+                "show_legend": true,
+                "time": {},
+                "title": "Webhooks controller reconcile errors per minute by pod name",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 2115429908145864,
+            "layout": {
+                "height": 2,
+                "width": 4,
+                "x": 4,
+                "y": 14
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "line",
+                        "formulas": [
+                            {
+                                "formula": "per_minute(query0)"
+                            }
+                        ],
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "data_source": "metrics",
+                                "name": "query0",
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.reconcile_errors{controller:secrets,$cluster,$namespace} by {pod_name}"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "warm"
+                        }
+                    }
+                ],
+                "show_legend": true,
+                "time": {},
+                "title": "Secrets controller reconcile errors per minute by pod name",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 6193726040061968,
+            "layout": {
+                "height": 2,
+                "width": 4,
+                "x": 8,
+                "y": 14
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "line",
                         "formulas": [
                             {
                                 "formula": "query1"
                             }
                         ],
-                        "response_format": "timeseries",
                         "queries": [
                             {
-                                "query": "avg:datadog.cluster_agent.external_metrics{$namespace,$cluster} by {valid,kube_namespace}",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:datadog.cluster_agent.external_metrics{$namespace,$cluster,$leader} by {valid,kube_namespace}"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "line"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "title": "External metrics by namespace",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
                     "label": "",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
+            "id": 8846979597038894,
             "layout": {
-                "x": 0,
-                "y": 16,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 0,
+                "y": 16
             }
         },
         {
-            "id": 7537528746656452,
             "definition": {
-                "title": "Successful mutation attempts per minute by type",
-                "show_legend": true,
-                "legend_layout": "auto",
                 "legend_columns": [
                     "avg",
                     "min",
@@ -1363,52 +1382,53 @@
                     "value",
                     "sum"
                 ],
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "bars",
                         "formulas": [
                             {
                                 "formula": "per_minute(query1)"
                             }
                         ],
-                        "response_format": "timeseries",
                         "on_right_yaxis": false,
                         "queries": [
                             {
-                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_attempts{injected:true,$cluster,$namespace} by {mutation_type}",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_attempts{injected:true,$cluster,$namespace} by {mutation_type}"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "bars"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "time": {},
+                "title": "Successful mutation attempts per minute by type",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
+            "id": 7537528746656452,
             "layout": {
-                "x": 4,
-                "y": 16,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 4,
+                "y": 16
             }
         },
         {
-            "id": 4551516642114976,
             "definition": {
-                "title": "Mutation errors by type and reason",
-                "show_legend": true,
-                "legend_layout": "auto",
                 "legend_columns": [
                     "avg",
                     "min",
@@ -1416,54 +1436,53 @@
                     "value",
                     "sum"
                 ],
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "area",
                         "formulas": [
                             {
                                 "formula": "query1"
                             }
                         ],
-                        "response_format": "timeseries",
                         "on_right_yaxis": false,
                         "queries": [
                             {
-                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_errors{$cluster,$namespace} by {mutation_type,reason}",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_errors{$cluster,$namespace} by {mutation_type,reason}"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "area"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "time": {},
+                "title": "Mutation errors by type and reason",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
+            "id": 4551516642114976,
             "layout": {
-                "x": 8,
-                "y": 16,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 8,
+                "y": 16
             }
         },
         {
-            "id": 1453748622802082,
             "definition": {
-                "title": "API queries made per period",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": true,
-                "legend_layout": "auto",
                 "legend_columns": [
                     "avg",
                     "min",
@@ -1471,81 +1490,83 @@
                     "value",
                     "sum"
                 ],
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "line",
                         "formulas": [
                             {
                                 "alias": "Queries",
                                 "formula": "query1 - query4"
                             }
                         ],
-                        "response_format": "timeseries",
                         "queries": [
                             {
-                                "query": "avg:datadog.cluster_agent.datadog.rate_limit_queries.limit{endpoint:/api/v1/query,$cluster,$namespace}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:datadog.cluster_agent.datadog.rate_limit_queries.limit{endpoint:/api/v1/query,$cluster,$namespace,$leader}.fill(null)"
                             },
                             {
-                                "query": "avg:datadog.cluster_agent.datadog.rate_limit_queries.remaining{endpoint:/api/v1/query,$cluster,$namespace}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query4"
+                                "name": "query4",
+                                "query": "avg:datadog.cluster_agent.datadog.rate_limit_queries.remaining{endpoint:/api/v1/query,$cluster,$namespace,$leader}.fill(null)"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "line"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     },
                     {
+                        "display_type": "line",
                         "formulas": [
                             {
                                 "alias": "Rate Limit",
                                 "formula": "query0"
                             }
                         ],
-                        "response_format": "timeseries",
                         "on_right_yaxis": false,
                         "queries": [
                             {
-                                "query": "avg:datadog.cluster_agent.datadog.rate_limit_queries.limit{endpoint:/api/v1/query,$cluster,$namespace}.fill(null)",
                                 "data_source": "metrics",
-                                "name": "query0"
+                                "name": "query0",
+                                "query": "avg:datadog.cluster_agent.datadog.rate_limit_queries.limit{endpoint:/api/v1/query,$cluster,$namespace,$leader}.fill(null)"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "dashed",
-                            "line_width": "normal"
-                        },
-                        "display_type": "line"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "title": "API queries made per period",
+                "title_align": "left",
+                "title_size": "16",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
                     "label": "",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
+            "id": 1453748622802082,
             "layout": {
-                "x": 0,
-                "y": 18,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 0,
+                "y": 18
             }
         },
         {
-            "id": 3587666939487434,
             "definition": {
-                "title": "Failed mutation attempts by type per minute",
-                "show_legend": true,
-                "legend_layout": "auto",
                 "legend_columns": [
                     "avg",
                     "min",
@@ -1553,62 +1574,61 @@
                     "value",
                     "sum"
                 ],
-                "type": "timeseries",
+                "legend_layout": "auto",
+                "markers": [],
                 "requests": [
                     {
+                        "display_type": "bars",
                         "formulas": [
                             {
                                 "formula": "per_minute(query1)"
                             }
                         ],
-                        "response_format": "timeseries",
                         "on_right_yaxis": false,
                         "queries": [
                             {
-                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_attempts{injected:false,$cluster,$namespace} by {mutation_type}",
                                 "data_source": "metrics",
-                                "name": "query1"
+                                "name": "query1",
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.mutation_attempts{injected:false,$cluster,$namespace} by {mutation_type}"
                             }
                         ],
+                        "response_format": "timeseries",
                         "style": {
-                            "palette": "dog_classic",
                             "line_type": "solid",
-                            "line_width": "normal"
-                        },
-                        "display_type": "bars"
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
                     }
                 ],
+                "show_legend": true,
+                "time": {},
+                "title": "Failed mutation attempts by type per minute",
+                "type": "timeseries",
                 "yaxis": {
                     "include_zero": true,
-                    "scale": "linear",
+                    "max": "auto",
                     "min": "auto",
-                    "max": "auto"
-                },
-                "markers": []
+                    "scale": "linear"
+                }
             },
+            "id": 3587666939487434,
             "layout": {
-                "x": 4,
-                "y": 18,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 4,
+                "y": 18
             }
         },
         {
-            "id": 4404687275565510,
             "definition": {
-                "title": "Certificate validity - hours left",
-                "type": "query_value",
+                "autoscale": true,
+                "precision": 0,
                 "requests": [
                     {
-                        "formulas": [
-                            {
-                                "formula": "query1"
-                            }
-                        ],
                         "conditional_formats": [
                             {
-                                "hide_value": false,
                                 "comparator": "<",
+                                "hide_value": false,
                                 "palette": "red_on_white",
                                 "value": 72
                             },
@@ -1623,45 +1643,33 @@
                                 "value": 720
                             }
                         ],
-                        "response_format": "scalar",
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
                         "queries": [
                             {
-                                "query": "avg:datadog.cluster_agent.admission_webhooks.certificate_expiry{$cluster,$namespace}",
+                                "aggregator": "last",
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "aggregator": "last"
+                                "query": "avg:datadog.cluster_agent.admission_webhooks.certificate_expiry{$cluster,$namespace}"
                             }
-                        ]
+                        ],
+                        "response_format": "scalar"
                     }
                 ],
-                "autoscale": true,
-                "precision": 0
+                "time": {},
+                "title": "Certificate validity - hours left",
+                "type": "query_value"
             },
+            "id": 4404687275565510,
             "layout": {
-                "x": 8,
-                "y": 18,
+                "height": 2,
                 "width": 4,
-                "height": 2
+                "x": 8,
+                "y": 18
             }
         }
-    ],
-    "template_variables": [
-        {
-            "name": "cluster",
-            "default": "*",
-            "prefix": "kube_cluster_name",
-            "available_values": []
-        },
-        {
-            "name": "namespace",
-            "default": "*",
-            "prefix": "kube_namespace",
-            "available_values": []
-        }
-    ],
-    "layout_type": "ordered",
-    "is_read_only": false,
-    "notify_list": [],
-    "reflow_type": "fixed",
-    "id": "t2y-mkn-4rs"
+    ]
 }

--- a/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
+++ b/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
@@ -1033,7 +1033,6 @@
                     }
                 ],
                 "show_legend": true,
-                "time": {},
                 "title": "Webhooks controller reconcile successes per minute by pod name",
                 "type": "timeseries",
                 "yaxis": {
@@ -1087,7 +1086,6 @@
                     }
                 ],
                 "show_legend": true,
-                "time": {},
                 "title": "Secrets controller reconcile successes per minute by pod name",
                 "type": "timeseries",
                 "yaxis": {
@@ -1141,7 +1139,7 @@
                         ],
                         "formulas": [
                             {
-                                "formula": "default_zero(query1)"
+                                "formula": "default_zero(query1) + default_zero(query2)"
                             }
                         ],
                         "queries": [
@@ -1150,11 +1148,18 @@
                                 "data_source": "metrics",
                                 "name": "query1",
                                 "query": "sum:datadog.cluster_agent.external_metrics{valid:true,$cluster,$namespace,$leader}"
+                            },
+                            {
+                                "aggregator": "last",
+                                "data_source": "metrics",
+                                "name": "query2",
+                                "query": "sum:datadog.cluster_agent.external_metrics.datadog_metrics{valid:true,$cluster,$namespace,$leader}"
                             }
                         ],
                         "response_format": "scalar"
                     }
                 ],
+                "time": {},
                 "title": "Valid external metrics",
                 "title_align": "left",
                 "title_size": "16",
@@ -1183,7 +1188,7 @@
                         ],
                         "formulas": [
                             {
-                                "formula": "default_zero(query1)"
+                                "formula": "default_zero(query1) + default_zero(query2)"
                             }
                         ],
                         "queries": [
@@ -1192,11 +1197,18 @@
                                 "data_source": "metrics",
                                 "name": "query1",
                                 "query": "sum:datadog.cluster_agent.external_metrics{valid:false,$cluster,$namespace,$leader}"
+                            },
+                            {
+                                "aggregator": "last",
+                                "data_source": "metrics",
+                                "name": "query2",
+                                "query": "sum:datadog.cluster_agent.external_metrics.datadog_metrics{valid:false,$cluster,$namespace,$leader}"
                             }
                         ],
                         "response_format": "scalar"
                     }
                 ],
+                "time": {},
                 "title": "Invalid external metrics",
                 "title_align": "left",
                 "title_size": "16",
@@ -1246,7 +1258,6 @@
                     }
                 ],
                 "show_legend": true,
-                "time": {},
                 "title": "Webhooks controller reconcile errors per minute by pod name",
                 "type": "timeseries",
                 "yaxis": {
@@ -1300,7 +1311,6 @@
                     }
                 ],
                 "show_legend": true,
-                "time": {},
                 "title": "Secrets controller reconcile errors per minute by pod name",
                 "type": "timeseries",
                 "yaxis": {
@@ -1335,6 +1345,9 @@
                         "formulas": [
                             {
                                 "formula": "query1"
+                            },
+                            {
+                                "formula": "query2"
                             }
                         ],
                         "queries": [
@@ -1342,6 +1355,11 @@
                                 "data_source": "metrics",
                                 "name": "query1",
                                 "query": "avg:datadog.cluster_agent.external_metrics{$namespace,$cluster,$leader} by {valid,kube_namespace}"
+                            },
+                            {
+                                "data_source": "metrics",
+                                "name": "query2",
+                                "query": "avg:datadog.cluster_agent.external_metrics.datadog_metrics{$namespace,$cluster,$leader} by {valid,kube_namespace}"
                             }
                         ],
                         "response_format": "timeseries",
@@ -1353,6 +1371,7 @@
                     }
                 ],
                 "show_legend": true,
+                "time": {},
                 "title": "External metrics by namespace",
                 "title_align": "left",
                 "title_size": "16",
@@ -1409,7 +1428,6 @@
                     }
                 ],
                 "show_legend": true,
-                "time": {},
                 "title": "Successful mutation attempts per minute by type",
                 "type": "timeseries",
                 "yaxis": {
@@ -1463,7 +1481,6 @@
                     }
                 ],
                 "show_legend": true,
-                "time": {},
                 "title": "Mutation errors by type and reason",
                 "type": "timeseries",
                 "yaxis": {
@@ -1601,7 +1618,6 @@
                     }
                 ],
                 "show_legend": true,
-                "time": {},
                 "title": "Failed mutation attempts by type per minute",
                 "type": "timeseries",
                 "yaxis": {
@@ -1659,7 +1675,6 @@
                         "response_format": "scalar"
                     }
                 ],
-                "time": {},
                 "title": "Certificate validity - hours left",
                 "type": "query_value"
             },

--- a/datadog_cluster_agent/manifest.json
+++ b/datadog_cluster_agent/manifest.json
@@ -26,7 +26,7 @@
       "spec": "assets/configuration/spec.yaml"
     },
     "dashboards": {
-      "Datadog Cluster Agent Overview": "assets/dashboards/datadog_cluster_agent_overview.json"
+      "Datadog Cluster Agent - Overview": "assets/dashboards/datadog_cluster_agent_overview.json"
     },
     "monitors": {},
     "saved_views": {},

--- a/datadog_cluster_agent/manifest.json
+++ b/datadog_cluster_agent/manifest.json
@@ -25,7 +25,9 @@
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
-    "dashboards": {},
+    "dashboards": {
+      "Datadog Cluster Agent Overview": "assets/dashboards/datadog_cluster_agent_overview.json"
+    },
     "monitors": {},
     "saved_views": {},
     "service_checks": "assets/service_checks.json",


### PR DESCRIPTION
### What does this PR do?
Adds a default dashboard for the `datadog_cluster_agent` check

### Additional Notes
Staging Link: https://dd.datad0g.com/dash/integration/30706/datadog-cluster-agent---overview

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
