### PR TITLE
Update tuf to 0.19.0 for python 3

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -91,7 +91,8 @@ simplejson==3.6.5
 six==1.16.0
 snowflake-connector-python==2.6.0; python_version > "3.0"
 supervisor==4.1.0
-tuf==0.17.0
+tuf==0.17.0; python_version < "3.0"
+tuf==0.19.0; python_version > "3.0"
 typing==3.7.4.1; python_version < "3.0"
 uptime==3.0.1
 vertica-python==0.10.1

--- a/datadog_checks_downloader/requirements.in
+++ b/datadog_checks_downloader/requirements.in
@@ -2,7 +2,8 @@
 # At the time of writing (Jan 30 2020), this was the latest version of these
 # libraries.
 #
-tuf==0.17.0
+tuf==0.17.0; python_version < "3.0"
+tuf==0.19.0; python_version > "3.0"
 in-toto==1.0.1
 #
 # Make sure TUF and in-toto use the same version of this library, which they


### PR DESCRIPTION
### What does this PR do?
Updates the version of tuf used for python 3

### Motivation
A new version was released that includes a security fix: https://github.com/theupdateframework/python-tuf/pull/1625 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
