### PR TITLE
Fix description of jmx options

### DIFF
--- a/activemq/datadog_checks/activemq/data/conf.yaml.example
+++ b/activemq/datadog_checks/activemq/data/conf.yaml.example
@@ -79,16 +79,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 

--- a/cassandra/datadog_checks/cassandra/data/conf.yaml.example
+++ b/cassandra/datadog_checks/cassandra/data/conf.yaml.example
@@ -85,16 +85,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 

--- a/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
+++ b/confluent_platform/datadog_checks/confluent_platform/data/conf.yaml.example
@@ -90,16 +90,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/jmx.yaml
@@ -42,17 +42,18 @@
     Note: It needs to be set when process_name_regex parameter is set
     e.g. .*process_name.*
 
-    Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    so this option will only work on Java 8 and below.
+    Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    This option is supported in Java 8 and below.
   value:
     type: string
 
 - name: tools_jar_path
   description: |
-    The tool.jar path to be used with the `process_name_regex` parameter,
+    The tools.jar path to be used with the `process_name_regex` parameter,
     for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    so this option will only work on Java 8 and below.
+
+    Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    This option is supported in Java 8 and below.
   value:
     type: string
 

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -127,16 +127,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 

--- a/hive/datadog_checks/hive/data/conf.yaml.example
+++ b/hive/datadog_checks/hive/data/conf.yaml.example
@@ -79,16 +79,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 

--- a/hivemq/datadog_checks/hivemq/data/conf.yaml.example
+++ b/hivemq/datadog_checks/hivemq/data/conf.yaml.example
@@ -79,16 +79,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 

--- a/hudi/datadog_checks/hudi/data/conf.yaml.example
+++ b/hudi/datadog_checks/hudi/data/conf.yaml.example
@@ -79,16 +79,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 

--- a/ignite/datadog_checks/ignite/data/conf.yaml.example
+++ b/ignite/datadog_checks/ignite/data/conf.yaml.example
@@ -79,16 +79,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/data/conf.yaml.example
@@ -92,16 +92,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 

--- a/kafka/datadog_checks/kafka/data/conf.yaml.example
+++ b/kafka/datadog_checks/kafka/data/conf.yaml.example
@@ -79,16 +79,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 

--- a/presto/datadog_checks/presto/data/conf.yaml.example
+++ b/presto/datadog_checks/presto/data/conf.yaml.example
@@ -79,16 +79,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 

--- a/solr/datadog_checks/solr/data/conf.yaml.example
+++ b/solr/datadog_checks/solr/data/conf.yaml.example
@@ -79,16 +79,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -464,16 +464,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 

--- a/tomcat/datadog_checks/tomcat/data/conf.yaml.example
+++ b/tomcat/datadog_checks/tomcat/data/conf.yaml.example
@@ -79,16 +79,17 @@ instances:
     ## Note: It needs to be set when process_name_regex parameter is set
     ## e.g. .*process_name.*
     ##
-    ## Note2: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # process_name_regex: <PROCESS_NAME_REGEX>
 
     ## @param tools_jar_path - string - optional
-    ## The tool.jar path to be used with the `process_name_regex` parameter,
+    ## The tools.jar path to be used with the `process_name_regex` parameter,
     ## for example: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar
-    ## Note: tool.jar was removed in Java 9: https://openjdk.java.net/jeps/220,
-    ## so this option will only work on Java 8 and below.
+    ##
+    ## Note: tools.jar was removed in Java 9: https://openjdk.java.net/jeps/220.
+    ## This option is supported in Java 8 and below.
     #
     # tools_jar_path: <TOOLS_JAR_PATH>
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`tools_jar_path` and `process_name_regex` require the `tools.jar` file, which was removed in Java 9: https://openjdk.java.net/jeps/220. This PR updates the descriptions to note this change.
### Motivation
<!-- What inspired you to submit this pull request? -->
Support case
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
