### PR TITLE
Upgrade datadog checks base to 23.1.5

### DIFF
--- a/postgres/setup.py
+++ b/postgres/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.1.5'
 
 setup(
     name='datadog-postgres',


### PR DESCRIPTION
### What does this PR do?
Upgrade the datadog checks base version to 23.1.5 to get https://github.com/DataDog/integrations-core/pull/10460 which fixes the unintentional limit on the number of instances that could use database monitoring. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
