### PR TITLE
Fix possible KeyError when collecting metrics 

### DIFF
--- a/mcache/datadog_checks/mcache/mcache.py
+++ b/mcache/datadog_checks/mcache/mcache.py
@@ -148,7 +148,7 @@ class Memcache(AgentCheck):
             limit_maxbytes = stats.get("limit_maxbytes")
             curr_items = stats.get("curr_items")
 
-            if get_hits and cmd_get and cmd_get != 0:
+            if get_hits and cmd_get and float(cmd_get) != 0:
                 self.gauge("memcache.get_hit_percent", 100.0 * float(get_hits) / float(cmd_get), tags=tags)
             else:
                 self.log.warning(
@@ -156,7 +156,7 @@ class Memcache(AgentCheck):
                     "missing, or `cmd_get` is 0"
                 )
 
-            if bytes and limit_maxbytes and limit_maxbytes != 0:
+            if bytes and limit_maxbytes and float(limit_maxbytes) != 0:
                 self.gauge("memcache.fill_percent", 100.0 * float(bytes) / float(limit_maxbytes), tags=tags)
             else:
                 self.log.warning(
@@ -164,7 +164,7 @@ class Memcache(AgentCheck):
                     "missing, or `limit_maxbytes` is 0"
                 )
 
-            if bytes and curr_items and curr_items != 0:
+            if bytes and curr_items and float(curr_items) != 0:
                 self.gauge("memcache.avg_item_size", float(bytes) / float(curr_items), tags=tags)
             else:
                 self.log.warning(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Some `mcache` metrics rely on other metrics that may be missing. This PR updates the metric collection to be safer and log a warning when metrics are not collected.

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case.
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
