### PR TITLE
Fix style on datadog-checks-dev

### DIFF
--- a/datadog_checks_dev/tox.ini
+++ b/datadog_checks_dev/tox.ini
@@ -9,6 +9,8 @@ envlist =
 dd_check_style = true
 dd_check_types = true
 dd_mypy_args =
+    --install-types
+    --non-interactive
     --follow-imports=silent
     datadog_checks/dev/tooling/commands/release/trello/testable.py
     datadog_checks/dev/tooling/commands/release/trello/status.py


### PR DESCRIPTION
Currently broken on master https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=79061&view=logs&j=2c9050e0-5be6-5014-27c6-a7b39b941d76&t=10d6e3ab-b4f8-529d-730f-63a4ea08f9e0

Checks base is also broken, this PR does not fix that