### PR TITLE
Only build the hudi spark bundle in tests

### DIFF
--- a/hudi/tests/docker/Dockerfile
+++ b/hudi/tests/docker/Dockerfile
@@ -18,7 +18,7 @@ ENV PATH /usr/local/sbt/bin:${PATH}
 RUN wget -P /opt https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
     && tar -xzf /opt/apache-maven-3.6.3-bin.tar.gz 
 
-RUN apk add git && git clone https://github.com/apache/hudi.git && cd hudi/ && /apache-maven-3.6.3/bin/mvn clean package -DskipTests -Dspark3 -Dscala-2.12 
+RUN apk add git && git clone https://github.com/apache/hudi.git && cd hudi/ && /apache-maven-3.6.3/bin/mvn --projects packaging/hudi-spark-bundle --also-make clean package -DskipTests -Dspark3 -Dscala-2.12 
 
 COPY . /usr/src/app/
 RUN cd /usr/src/app && sbt update && sbt clean assembly && sbt package


### PR DESCRIPTION
### What does this PR do?
Only build the hudi spark bundle in tests. This will fix the tests and also speed up testing time since we only have to build the required packages now.

### Motivation
Tests were failing due to an unrelated module failing to build.  

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
