### PR TITLE
Pin google-auth dependency

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -22,6 +22,7 @@ flup-py3==1.0.3; python_version > "3.0"
 flup==1.0.3.dev-20110405; python_version < "3.0"
 futures==3.3.0; python_version < "3.0"
 gearman==2.0.2; sys_platform != "win32" and python_version < "3.0"
+google-auth==1.34.0; python_version < "3.0"
 immutables==0.15; python_version > "3.0"
 in-toto==1.0.1
 ipaddress==1.0.22; python_version < "3.0"

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -8,6 +8,7 @@ cryptography==3.4.6; python_version > '3.0'
 ddtrace==0.32.2; sys_platform == 'win32' and python_version < '3.0'
 ddtrace==0.48.0; sys_platform != 'win32' or python_version > '3.0'
 enum34==1.1.6; python_version < '3.0'
+google-auth==1.34.0; python_version < '3.0'
 immutables==0.15; python_version > '3.0'
 ipaddress==1.0.22; python_version < '3.0'
 kubernetes==12.0.1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Pin google-auth dependency.
Nightly build was breaking on python 2 because the latest version of `google-auth` added python2 support back, and pinned `enum34` to a different version.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Gitlab pipeline based on 7.31.x https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/5857084

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
