### PR TITLE
fix used memory grant metric description typo

### DIFF
--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -63,7 +63,7 @@ sqlserver.queries.logical_writes,count,,write,,Total number of logical writes pe
 sqlserver.queries.columnstore_segment_reads,count,,segment,,Total columnstore segments read by executed queries per query (DBM only),0,sql_server,query columnstore segment reads
 sqlserver.queries.columnstore_segment_skips,count,,segment,,Total columnstore segments skipped by executed queries per query (DBM only),0,sql_server,query columnstore segment skips
 sqlserver.queries.memory_grant,count,,byte,,The total amount of reserved memory received by executions of this query per query. It will always be 0 for querying a memory-optimized table (DBM only).,0,sql_server,query grant kb
-sqlserver.queries.used_memory_grant,count,,byte,,The total amount of reserved memory received by executions of this query per query. It will always be 0 for querying a memory-optimized table (DBM only).,0,sql_server,query used grant kb
+sqlserver.queries.used_memory_grant,count,,byte,,The total amount of reserved memory used by executions of this query per query. It will always be 0 for querying a memory-optimized table (DBM only).,0,sql_server,query used grant kb
 sqlserver.queries.ideal_memory_grant,count,,byte,,The total amount of ideal memory grant estimated by executions of this query per query (DBM only),0,sql_server,query ideal grant kb
 sqlserver.queries.reserved_threads,count,,thread,,The total sum of reserved parallel threads used by executions of this query per query (DBM only),0,sql_server,query reserved threads
 sqlserver.queries.used_threads,count,,thread,,The total sum of used parallel threads used by executions of this query per query (DBM only),0,sql_server,query used threads


### PR DESCRIPTION
### What does this PR do?

`used_memory_grant` is "memory used" not "memory received".

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
