### PR TITLE
Allow trigger-agent-build step to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -123,6 +123,7 @@ validate-agent-build:
       else
         echo "A pipeline was not triggered, skipping this job."
       fi
+
   tags: [ "runner:main" ]
 
 notify-slack:


### PR DESCRIPTION
### What does this PR do?
Currently, the `trigger_agent_build` step will run on all PRs to all branches that have a different `agent_requirements.txt` than master. This makes it so that if the agent build is flakey, it will block release. This allows failure for `validate_agent_build`. No release PR makes changes in the requirements file, so this should not allow erroneous releases. see docs about `allow_failure` here: https://docs.gitlab.com/ee/ci/yaml/#allow_failure

### Motivation
Before, this ran unnecessary pipelines that "blocked" PRs and releases.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
