### PR TITLE
Fix airflow log paths

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -220,7 +220,7 @@ _Available for Agent versions >6.0_
               name: new_log_start_with_date
               pattern: \[\d{4}\-\d{2}\-\d{2}
         - type: file
-          path: "<PATH_TO_AIRFLOW>/logs/scheduler/latest/**/*.log"
+          path: "<PATH_TO_AIRFLOW>/logs/scheduler/latest/*.log"
           source: airflow
           log_processing_rules:
             - type: multi_line
@@ -235,7 +235,7 @@ _Available for Agent versions >6.0_
       ```yaml
       logs:
         - type: file
-          path: "<PATH_TO_AIRFLOW>/logs/!(scheduler)/**/*.log"
+          path: "<PATH_TO_AIRFLOW>/logs/!(scheduler)/*/*.log"
           source: airflow
           log_processing_rules:
             - type: multi_line

--- a/airflow/assets/configuration/spec.yaml
+++ b/airflow/assets/configuration/spec.yaml
@@ -25,7 +25,7 @@ files:
           name: new_log_start_with_date
           pattern: \[\d{4}\-\d{2}\-\d{2}
     - type: file
-      path: <PATH_TO_AIRFLOW>/logs/scheduler/latest/**/*.log
+      path: <PATH_TO_AIRFLOW>/logs/scheduler/latest/*.log
       source: airflow
       log_processing_rules:
         - type: multi_line

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -391,7 +391,7 @@ instances:
 #       name: new_log_start_with_date
 #       pattern: \[\d{4}\-\d{2}\-\d{2}
 #   - type: file
-#     path: <PATH_TO_AIRFLOW>/logs/scheduler/latest/**/*.log
+#     path: <PATH_TO_AIRFLOW>/logs/scheduler/latest/*.log
 #     source: airflow
 #     log_processing_rules:
 #     - type: multi_line


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The go agent is using `filepath.Glob`, `/**/` is not supported: https://pkg.go.dev/path/filepath#Match

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
