### PR TITLE
Make warning log verbose

### DIFF
--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -395,8 +395,8 @@ class ZookeeperCheck(AgentCheck):
 
                 metrics.append(ZKMetric(metric_name, metric_value, metric_type, tags))
 
-            except ValueError:
-                self.log.warning("Cannot format `mntr` value. key=%s, value=%s", key, value)
+            except ValueError as e:
+                self.log.warning("Cannot format `mntr` value - key=%s, value=%s: %s", key, value, str(e))
 
             except Exception:
                 self.log.exception("Unexpected exception occurred while parsing `mntr` command content:\n%s", buf)


### PR DESCRIPTION
### What does this PR do?
Make warning log more verbose when parsing mntr output.

### Motivation
The following message is not helpful to debugging when it's unclear what the ValueError is
```Cannot format `mntr` value. key=zk_server_state, value=leader"```
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
