### PR TITLE
Update tag name to be consistent with others

### DIFF
--- a/hudi/datadog_checks/hudi/data/metrics.yaml
+++ b/hudi/datadog_checks/hudi/data/metrics.yaml
@@ -266,7 +266,7 @@ jmx_metrics:
         - name
       tags:
         table_name: $1
-        action_name: $2
+        action: $2
       attribute:
         50thPercentile:
           alias: hudi.action.time.50th_percentile


### PR DESCRIPTION
### What does this PR do?
Update `hudi.action.time.*` metrics to be tagged with `action`

### Motivation
All other action metrics are tagged by `action`, not `action_name`
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
