### PR TITLE
Add attempts for opensearch

### DIFF
--- a/elastic/tests/conftest.py
+++ b/elastic/tests/conftest.py
@@ -74,7 +74,7 @@ def dd_environment(instance):
         compose_file=compose_file,
         conditions=[WaitFor(ping_elastic, attempts=100), WaitFor(create_slm, attempts=5)],
         attempts=2,
-        attempt_wait=10,
+        attempts_wait=10,
     ):
         yield instance
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Opensearch can have trouble to start, adding `attempts` to reduce flakiness
Ex: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=79440&view=logs&j=87b3f66b-df09-5dcb-cf32-1cf5d8d1b569&t=aaa21cbe-eb89-5bb8-86b1-fdb0584a07a2&l=142
```
1.0.0: Pulling from opensearchproject/opensearch
Digest: sha256:405edc708d0f019a3e1224c34029edb9633b79b496bf04e7da4fc3e8b003bcda
Status: Downloaded newer image for opensearchproject/opensearch:1.0.0
Attaching to compose_elastic_1
elastic_1  | Killing opensearch process 10
elastic_1  | Killing performance analyzer process 11

```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
