### PR TITLE
Fixes E2E instance config

### DIFF
--- a/pgbouncer/tests/test_pgbouncer_integration_e2e.py
+++ b/pgbouncer/tests/test_pgbouncer_integration_e2e.py
@@ -67,9 +67,9 @@ def test_check_with_url(instance_with_url, aggregator, datadog_agent):
 
 
 @pytest.mark.e2e
-def test_check_e2e(dd_agent_check, instance):
+def test_check_e2e(dd_agent_check, instance_with_url):
     # run the check
-    aggregator = dd_agent_check(instance, rate=True)
+    aggregator = dd_agent_check(instance_with_url, rate=True)
     version = common.get_version_from_env()
     assert_metric_coverage(version, aggregator)
 


### PR DESCRIPTION
### What does this PR do?
Fixes instance config that would break e2e tests when config data models are added.

https://github.com/DataDog/integrations-core/pull/8968/files#diff-b4e6b821e84d8dd40a7442830595917c30222eb347b5a4af300f54ebba6d031eR20

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
