### PR TITLE
Fixes E2E instance config

### DIFF
--- a/fluentd/tests/common.py
+++ b/fluentd/tests/common.py
@@ -23,7 +23,7 @@ BAD_URL = "http://{}:{}/api/plugins.json".format(HOST, BAD_PORT)
 CHECK_NAME = 'fluentd'
 
 DEFAULT_INSTANCE = {"monitor_agent_url": URL}
-INSTANCE_WITH_PLUGIN = {"monitor_agent_url": URL, "plugin_ids": "plg1"}
+INSTANCE_WITH_PLUGIN = {"monitor_agent_url": URL, "plugin_ids": ["plg1"]}
 
 EXPECTED_GAUGES = [
     'retry_count',


### PR DESCRIPTION
### What does this PR do?
Fixes instance config that would break e2e tests when config data models are added.

https://github.com/DataDog/integrations-core/pull/8916/files#diff-d04c9500dcc5b27ec362bccdb15f216b30d3c386b2342ddd497ef0860d0f6cbcR62

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
