### PR TITLE
Add option to include security deps in dep command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -247,12 +247,12 @@ def is_version_compatible(marker, supported_versions):
     help="""Only flag a dependency as needing an update if the newest version has python classifiers matching the marker.
     NOTE: Some packages may not have proper classifiers.""",
 )
-@click.option('--ignore-security-deps', '-d', is_flag=True, help="Don't attempt to update security dependencies")
+@click.option('--include-security-deps', '-i', is_flag=True, help="Attempt to update security dependencies")
 @click.option('--batch-size', '-b', type=int, help='The maximum number of dependencies to upgrade if syncing')
-def updates(sync, check_python_classifiers, ignore_security_deps, batch_size):
+def updates(sync, check_python_classifiers, include_security_deps, batch_size):
 
     dont_update_deps = copy.deepcopy(IGNORED_DEPS)
-    if ignore_security_deps:
+    if not include_security_deps:
         sec_deps = copy.deepcopy(SECURITY_DEPS)
         dont_update_deps = dont_update_deps.union(sec_deps)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -251,10 +251,10 @@ def is_version_compatible(marker, supported_versions):
 @click.option('--batch-size', '-b', type=int, help='The maximum number of dependencies to upgrade if syncing')
 def updates(sync, check_python_classifiers, include_security_deps, batch_size):
 
-    dont_update_deps = copy.deepcopy(IGNORED_DEPS)
+    ignore_deps = copy.deepcopy(IGNORED_DEPS)
     if not include_security_deps:
         sec_deps = copy.deepcopy(SECURITY_DEPS)
-        dont_update_deps = dont_update_deps.union(sec_deps)
+        ignore_deps = ignore_deps.union(sec_deps)
 
     all_agent_dependencies, errors = read_agent_dependencies()
 
@@ -270,7 +270,7 @@ def updates(sync, check_python_classifiers, include_security_deps, batch_size):
     deps_to_update = {
         agent_dependency_definition: package_data[package]['version']
         for package, package_dependency_definitions in all_agent_dependencies.items()
-        if package not in dont_update_deps
+        if package not in ignore_deps
         for agent_dep_version, agent_dependency_definitions in package_dependency_definitions.items()
         for agent_dependency_definition in agent_dependency_definitions
         if str(agent_dep_version)[2:] != package_data[package]['version']

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -27,7 +27,7 @@ IGNORED_DEPS = {
 }
 
 # Dependencies for the downloader that are security-related and should be updated separately from the others
-SECURITY_DEPS = {'in-toto', 'tuf', 'securesystemslib[crypto,pynacl]'}
+SECURITY_DEPS = {'in-toto', 'tuf', 'securesystemslib'}
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Manage dependencies')
@@ -242,7 +242,7 @@ def is_version_compatible(marker, supported_versions):
 @click.option('--sync', '-s', is_flag=True, help='Update the `agent_requirements.in` file')
 @click.option(
     '--check-python-classifiers',
-    '-s',
+    '-c',
     is_flag=True,
     help="""Only flag a dependency as needing an update if the newest version has python classifiers matching the marker.
     NOTE: Some packages may not have proper classifiers.""",
@@ -254,7 +254,7 @@ def updates(sync, check_python_classifiers, ignore_security_deps, batch_size):
     dont_update_deps = copy.deepcopy(IGNORED_DEPS)
     if ignore_security_deps:
         sec_deps = copy.deepcopy(SECURITY_DEPS)
-        dont_update_deps.union(sec_deps)
+        dont_update_deps = dont_update_deps.union(sec_deps)
 
     all_agent_dependencies, errors = read_agent_dependencies()
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -254,7 +254,7 @@ def updates(sync, check_python_classifiers, ignore_security_deps, batch_size):
     dont_update_deps = copy.deepcopy(IGNORED_DEPS)
     if ignore_security_deps:
         sec_deps = copy.deepcopy(SECURITY_DEPS)
-        dont_update_deps.add(sec_deps)
+        dont_update_deps.union(sec_deps)
 
     all_agent_dependencies, errors = read_agent_dependencies()
 


### PR DESCRIPTION
### What does this PR do?
Add option to include security dependencies when updating dependencies, and ignore by default.

Additionally changes the short name of `check-python-classifiers` so it does not clash with `sync`

### Motivation
Reduce number of dependencies updated at once, and encourage more testing for those dependencies in particular

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
