### PR TITLE
Support newer versions of Hadoop

### DIFF
--- a/hdfs_datanode/README.md
+++ b/hdfs_datanode/README.md
@@ -18,19 +18,6 @@ The HDFS DataNode check is included in the [Datadog Agent][3] package, so you do
 
 ### Configuration
 
-#### Prepare the node
-
-1. The Agent collects metrics from the DataNode's JMX remote interface. The interface is disabled by default, enable it by setting the following option in `hadoop-env.sh` (usually found in $HADOOP_HOME/conf):
-
-   ```conf
-   export HADOOP_DATANODE_OPTS="-Dcom.sun.management.jmxremote
-     -Dcom.sun.management.jmxremote.authenticate=false
-     -Dcom.sun.management.jmxremote.ssl=false
-     -Dcom.sun.management.jmxremote.port=50075 $HADOOP_DATANODE_OPTS"
-   ```
-
-2. Restart the DataNode process to enable the JMX interface.
-
 #### Connect the Agent
 
 <!-- xxx tabs xxx -->
@@ -53,9 +40,9 @@ To configure this check for an Agent running on a host:
      ##
      ## The hostname and port can be found in the hdfs-site.xml conf file under
      ## the property dfs.datanode.http.address
-     ## https://hadoop.apache.org/docs/r2.7.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
+     ## https://hadoop.apache.org/docs/r3.1.3/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
      #
-     - hdfs_datanode_jmx_uri: http://localhost:50075
+     - hdfs_datanode_jmx_uri: http://localhost:9864
    ```
 
 2. [Restart the Agent][6].
@@ -67,11 +54,11 @@ To configure this check for an Agent running on a host:
 
 For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.
 
-| Parameter            | Value                                                |
-| -------------------- | ---------------------------------------------------- |
-| `<INTEGRATION_NAME>` | `hdfs_datanode`                                      |
-| `<INIT_CONFIG>`      | blank or `{}`                                        |
-| `<INSTANCE_CONFIG>`  | `{"hdfs_datanode_jmx_uri": "http://%%host%%:50075"}` |
+| Parameter            | Value                                               |
+| -------------------- | --------------------------------------------------- |
+| `<INTEGRATION_NAME>` | `hdfs_datanode`                                     |
+| `<INIT_CONFIG>`      | blank or `{}`                                       |
+| `<INSTANCE_CONFIG>`  | `{"hdfs_datanode_jmx_uri": "http://%%host%%:9864"}` |
 
 #### Log collection
 

--- a/hdfs_datanode/assets/configuration/spec.yaml
+++ b/hdfs_datanode/assets/configuration/spec.yaml
@@ -13,13 +13,13 @@ files:
               The HDFS DataNode check retrieves metrics from the HDFS DataNode's JMX
               interface via HTTP(S) (not a JMX remote connection). This check must be installed on a HDFS DataNode. The HDFS
               DataNode JMX URI is composed of the DataNode's hostname and port.
-              
+
               The hostname and port can be found in the hdfs-site.xml conf file under
               the property dfs.datanode.http.address
-              https://hadoop.apache.org/docs/r2.7.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
+              https://hadoop.apache.org/docs/r3.1.3/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
             required: true
             value:
-              example: http://localhost:50075
+              example: http://localhost:9864
               type: string
           - template: instances/http
           - template: instances/default

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
@@ -52,9 +52,9 @@ instances:
     ##
     ## The hostname and port can be found in the hdfs-site.xml conf file under
     ## the property dfs.datanode.http.address
-    ## https://hadoop.apache.org/docs/r2.7.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
+    ## https://hadoop.apache.org/docs/r3.1.3/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
     #
-  - hdfs_datanode_jmx_uri: http://localhost:50075
+  - hdfs_datanode_jmx_uri: http://localhost:9864
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/hdfs_datanode.py
@@ -167,7 +167,10 @@ class HDFSDataNode(AgentCheck):
         version = data.get('Version', None)
 
         if version is not None:
-            self.set_metadata('version', version)
             self.log.debug('found hadoop version %s', version)
+            # account for possible build data e.g.:
+            # 3.1.3, rba631c436b806728f8ec2f54ab1e289526c90579
+            version = version.replace(', ', '+')
+            self.set_metadata('version', version)
         else:
             self.log.warning('could not retrieve hadoop version information, this was data retrieved: %s', data)

--- a/hdfs_datanode/tests/common.py
+++ b/hdfs_datanode/tests/common.py
@@ -10,14 +10,14 @@ HERE = get_here()
 HOST = get_docker_hostname()
 FIXTURE_DIR = os.path.join(HERE, 'fixtures')
 
-DATANODE_URI = 'http://{}:50070/'.format(HOST)
+DATANODE_URI = 'http://{}:9870/'.format(HOST)
 
 CUSTOM_TAGS = ['optional:tag1']
 
 TEST_USERNAME = 'AzureDiamond'
 TEST_PASSWORD = 'hunter2'
 
-INSTANCE_INTEGRATION = {"hdfs_datanode_jmx_uri": "http://{}:50075".format(HOST)}
+INSTANCE_INTEGRATION = {"hdfs_datanode_jmx_uri": "http://{}:9864".format(HOST)}
 
 HDFS_RAW_VERSION = os.environ.get('HDFS_RAW_VERSION')
 HDFS_IMAGE_TAG = os.environ.get('HDFS_IMAGE_TAG')
@@ -33,6 +33,7 @@ EXPECTED_METRICS = [
     'hdfs.datanode.num_blocks_cached',
     'hdfs.datanode.num_failed_volumes',
     'hdfs.datanode.num_blocks_failed_to_cache',
+    'hdfs.datanode.num_blocks_failed_to_uncache',
 ]
 
 HDFS_DATANODE_CONFIG = {'instances': [{'hdfs_datanode_jmx_uri': DATANODE_URI, 'tags': list(CUSTOM_TAGS)}]}

--- a/hdfs_datanode/tests/compose/docker-compose.yaml
+++ b/hdfs_datanode/tests/compose/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - HDFS_CONF_dfs_webhdfs_enabled=true
       - HDFS_CONF_dfs_permissions_enabled=false
     ports:
-      - "50070:50070"
+      - "9870:9870"
 
   datanode:
     image: bde2020/hadoop-datanode:${HDFS_IMAGE_TAG}
@@ -29,7 +29,7 @@ services:
       - HDFS_CONF_dfs_webhdfs_enabled=true
       - HDFS_CONF_dfs_permissions_enabled=false
     ports:
-      - "50075:50075"
+      - "9864:9864"
 
 volumes:
   hadoop_namenode:

--- a/hdfs_datanode/tests/conftest.py
+++ b/hdfs_datanode/tests/conftest.py
@@ -20,6 +20,7 @@ def dd_environment():
     with docker_run(
         compose_file=os.path.join(HERE, "compose", "docker-compose.yaml"),
         log_patterns='Got finalize command for block pool',
+        sleep=30,
     ):
         yield INSTANCE_INTEGRATION
 

--- a/hdfs_datanode/tests/fixtures/hdfs_datanode_info_jmx.json
+++ b/hdfs_datanode/tests/fixtures/hdfs_datanode_info_jmx.json
@@ -4,7 +4,7 @@
     "modelerType" : "org.apache.hadoop.hdfs.server.datanode.DataNode",
     "XceiverCount" : 1,
     "DatanodeNetworkCounts" : [ ],
-    "Version" : "2.7.1",
+    "Version" : "3.1.3, rba631c436b806728f8ec2f54ab1e289526c90579",
     "RpcPort" : "50020",
     "HttpPort" : null,
     "NamenodeAddresses" : "{\"namenode\":\"BP-2057692275-172.27.0.2-1574696115415\"}",

--- a/hdfs_datanode/tests/test_hdfs_datanode.py
+++ b/hdfs_datanode/tests/test_hdfs_datanode.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
 import pytest
 from six import iteritems
 
@@ -62,15 +63,16 @@ def test_metadata(aggregator, mocked_request, mocked_metadata_request, datadog_a
     major, minor, patch = HDFS_RAW_VERSION.split('.')
 
     version_metadata = {
-        'version.raw': HDFS_RAW_VERSION,
+        'version.raw': mock.ANY,
         'version.scheme': 'semver',
         'version.major': major,
         'version.minor': minor,
         'version.patch': patch,
+        'version.build': mock.ANY,
     }
 
     datadog_agent.assert_metadata(CHECK_ID, version_metadata)
-    datadog_agent.assert_metadata_count(5)
+    datadog_agent.assert_metadata_count(6)
 
 
 def test_auth(aggregator, mocked_auth_request):

--- a/hdfs_datanode/tests/test_integration.py
+++ b/hdfs_datanode/tests/test_integration.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
+import mock
 import pytest
 
 from . import common
@@ -29,12 +29,13 @@ def test_metadata(aggregator, check, dd_run_check, instance, datadog_agent):
     major, minor, patch = common.HDFS_RAW_VERSION.split('.')
 
     version_metadata = {
-        'version.raw': common.HDFS_RAW_VERSION,
+        'version.raw': mock.ANY,
         'version.scheme': 'semver',
         'version.major': major,
         'version.minor': minor,
         'version.patch': patch,
+        'version.build': mock.ANY,
     }
 
     datadog_agent.assert_metadata(CHECK_ID, version_metadata)
-    datadog_agent.assert_metadata_count(5)
+    datadog_agent.assert_metadata_count(6)

--- a/hdfs_datanode/tox.ini
+++ b/hdfs_datanode/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-2.7.1
+    py{27,38}-3.1.3
 
 [testenv]
 ensure_default_envdir = true
@@ -21,8 +21,8 @@ passenv =
     DOCKER*
     COMPOSE*
 setenv =
-    2.7.1: HDFS_RAW_VERSION=2.7.1
-    2.7.1: HDFS_IMAGE_TAG=1.1.0-hadoop2.7.1-java8
+    3.1.3: HDFS_RAW_VERSION=3.1.3
+    3.1.3: HDFS_IMAGE_TAG=2.0.0-hadoop3.1.3-java8
 commands =
     pip install -r requirements.in
     pytest -v {posargs}

--- a/hdfs_namenode/README.md
+++ b/hdfs_namenode/README.md
@@ -18,19 +18,6 @@ The HDFS NameNode check is included in the [Datadog Agent][3] package, so you do
 
 ### Configuration
 
-#### Prepare the node
-
-1. The Agent collects metrics from the NameNode's JMX remote interface. The interface is disabled by default, so enable it by setting the following option in `hadoop-env.sh` (usually found in \$HADOOP_HOME/conf):
-
-    ```conf
-    export HADOOP_NAMENODE_OPTS="-Dcom.sun.management.jmxremote
-      -Dcom.sun.management.jmxremote.authenticate=false
-      -Dcom.sun.management.jmxremote.ssl=false
-      -Dcom.sun.management.jmxremote.port=50070 $HADOOP_NAMENODE_OPTS"
-    ```
-
-2. Restart the NameNode process to enable the JMX interface.
-
 #### Connect the Agent
 
 <!-- xxx tabs xxx -->
@@ -53,9 +40,9 @@ To configure this check for an Agent running on a host:
      ##
      ## The hostname and port can be found in the hdfs-site.xml conf file under
      ## the property dfs.namenode.http-address
-     ## https://hadoop.apache.org/docs/r2.7.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
+     ## https://hadoop.apache.org/docs/r3.1.3/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
      #
-     - hdfs_namenode_jmx_uri: http://localhost:50070
+     - hdfs_namenode_jmx_uri: http://localhost:9870
    ```
 
 2. [Restart the Agent][6].
@@ -67,11 +54,11 @@ To configure this check for an Agent running on a host:
 
 For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.
 
-| Parameter            | Value                                                 |
-| -------------------- | ----------------------------------------------------- |
-| `<INTEGRATION_NAME>` | `hdfs_namenode`                                       |
-| `<INIT_CONFIG>`      | blank or `{}`                                         |
-| `<INSTANCE_CONFIG>`  | `{"hdfs_namenode_jmx_uri": "https://%%host%%:50070"}` |
+| Parameter            | Value                                                |
+| -------------------- | ---------------------------------------------------- |
+| `<INTEGRATION_NAME>` | `hdfs_namenode`                                      |
+| `<INIT_CONFIG>`      | blank or `{}`                                        |
+| `<INSTANCE_CONFIG>`  | `{"hdfs_namenode_jmx_uri": "https://%%host%%:9870"}` |
 
 #### Log collection
 

--- a/hdfs_namenode/assets/configuration/spec.yaml
+++ b/hdfs_namenode/assets/configuration/spec.yaml
@@ -13,13 +13,13 @@ files:
                 The HDFS NameNode check retrieves metrics from the HDFS NameNode's JMX
                 interface via HTTP(S) (not a JMX remote connection). This check must be installed on
                 a HDFS NameNode. The HDFS NameNode JMX URI is composed of the NameNode's hostname and port.
-                
+
                 The hostname and port can be found in the hdfs-site.xml conf file under
                 the property dfs.namenode.http-address.
-                https://hadoop.apache.org/docs/r2.7.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
+                https://hadoop.apache.org/docs/r3.1.3/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
               required: true
               value:
-                example: http://localhost:50070
+                example: http://localhost:9870
                 type: string
             - template: instances/http
             - template: instances/default

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
@@ -52,9 +52,9 @@ instances:
     ##
     ## The hostname and port can be found in the hdfs-site.xml conf file under
     ## the property dfs.namenode.http-address.
-    ## https://hadoop.apache.org/docs/r2.7.1/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
+    ## https://hadoop.apache.org/docs/r3.1.3/hadoop-project-dist/hadoop-hdfs/hdfs-default.xml
     #
-  - hdfs_namenode_jmx_uri: http://localhost:50070
+  - hdfs_namenode_jmx_uri: http://localhost:9870
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/hdfs_namenode.py
@@ -200,10 +200,13 @@ class HDFSNameNode(AgentCheck):
         # only get first info block
         data = next(iter(value), {})
 
-        version = data.get('SoftwareVersion', None)
+        version = data.get('Version', None)
 
         if version is not None:
-            self.set_metadata('version', version)
             self.log.debug('found hadoop version %s', version)
+            # account for possible build data e.g.:
+            # 3.1.3, rba631c436b806728f8ec2f54ab1e289526c90579
+            version = version.replace(', ', '+')
+            self.set_metadata('version', version)
         else:
             self.log.warning('could not retrieve hadoop version information, this was data retrieved: %s', data)

--- a/hdfs_namenode/tests/common.py
+++ b/hdfs_namenode/tests/common.py
@@ -12,7 +12,7 @@ HOST = get_docker_hostname()
 FIXTURE_DIR = os.path.join(HERE, 'fixtures')
 
 # Namenode URI
-NAMENODE_URI = 'http://{}:50070/'.format(HOST)
+NAMENODE_URI = 'http://{}:9870/'.format(HOST)
 NAMENODE_JMX_URI = NAMENODE_URI + 'jmx'
 
 # Namesystem state URL
@@ -61,6 +61,7 @@ EXPECTED_METRICS = [
     'hdfs.namenode.num_stale_storages',
     'hdfs.namenode.missing_blocks',
     'hdfs.namenode.corrupt_blocks',
+    'hdfs.namenode.fs_lock_queue_length',
 ]
 
 HDFS_NAMENODE_AUTH_CONFIG = {

--- a/hdfs_namenode/tests/compose/docker-compose.yaml
+++ b/hdfs_namenode/tests/compose/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - HDFS_CONF_dfs_webhdfs_enabled=true
       - HDFS_CONF_dfs_permissions_enabled=false
     ports:
-      - "50070:50070"
+      - "9870:9870"
 
   datanode:
     image: bde2020/hadoop-datanode:${HDFS_IMAGE_TAG}
@@ -29,7 +29,7 @@ services:
       - HDFS_CONF_dfs_webhdfs_enabled=true
       - HDFS_CONF_dfs_permissions_enabled=false
     ports:
-      - "50075:50075"
+      - "9864:9864"
 
 volumes:
   hadoop_namenode:

--- a/hdfs_namenode/tests/conftest.py
+++ b/hdfs_namenode/tests/conftest.py
@@ -27,6 +27,7 @@ def dd_environment():
     with docker_run(
         compose_file=os.path.join(HERE, "compose", "docker-compose.yaml"),
         log_patterns='Got finalize command for block pool',
+        sleep=30,
     ):
         yield INSTANCE_INTEGRATION
 

--- a/hdfs_namenode/tests/fixtures/hdfs_namesystem_info.json
+++ b/hdfs_namenode/tests/fixtures/hdfs_namesystem_info.json
@@ -5,7 +5,7 @@
     "Total" : 62725623808,
     "UpgradeFinalized" : true,
     "ClusterId" : "CID-44e20313-500c-4587-ad7d-4bf751a4a652",
-    "Version" : "2.7.1, r15ecc87ccf4a0228f35af08fc56de536e6ce657a",
+    "Version" : "3.1.3, rba631c436b806728f8ec2f54ab1e289526c90579",
     "Used" : 24576,
     "Free" : 55830482944,
     "Safemode" : "",
@@ -33,10 +33,10 @@
     "CorruptFiles" : "[]",
     "DistinctVersionCount" : 1,
     "DistinctVersions" : [ {
-      "key" : "2.7.1",
+      "key" : "3.1.3",
       "value" : 1
     } ],
-    "SoftwareVersion" : "2.7.1",
+    "SoftwareVersion" : "3.1.3",
     "RollingUpgradeStatus" : null,
     "Threads" : 33
   } ]

--- a/hdfs_namenode/tests/test_hdfs_namenode.py
+++ b/hdfs_namenode/tests/test_hdfs_namenode.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
 import pytest
 from six import iteritems
 
@@ -60,15 +61,16 @@ def test_metadata(aggregator, dd_run_check, mocked_request, datadog_agent):
     major, minor, patch = HDFS_RAW_VERSION.split('.')
 
     version_metadata = {
-        'version.raw': HDFS_RAW_VERSION,
+        'version.raw': mock.ANY,
         'version.scheme': 'semver',
         'version.major': major,
         'version.minor': minor,
         'version.patch': patch,
+        'version.build': mock.ANY,
     }
 
     datadog_agent.assert_metadata(CHECK_ID, version_metadata)
-    datadog_agent.assert_metadata_count(5)
+    datadog_agent.assert_metadata_count(6)
 
 
 def test_auth(aggregator, dd_run_check, mocked_auth_request):

--- a/hdfs_namenode/tests/test_integration.py
+++ b/hdfs_namenode/tests/test_integration.py
@@ -1,7 +1,7 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
+import mock
 import pytest
 
 from . import common
@@ -31,12 +31,13 @@ def test_metadata(aggregator, dd_run_check, check, instance, datadog_agent):
     major, minor, patch = common.HDFS_RAW_VERSION.split('.')
 
     version_metadata = {
-        'version.raw': common.HDFS_RAW_VERSION,
+        'version.raw': mock.ANY,
         'version.scheme': 'semver',
         'version.major': major,
         'version.minor': minor,
         'version.patch': patch,
+        'version.build': mock.ANY,
     }
 
     datadog_agent.assert_metadata(CHECK_ID, version_metadata)
-    datadog_agent.assert_metadata_count(5)
+    datadog_agent.assert_metadata_count(6)

--- a/hdfs_namenode/tox.ini
+++ b/hdfs_namenode/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-2.7.1
+    py{27,38}-3.1.3
 
 [testenv]
 ensure_default_envdir = true
@@ -21,8 +21,8 @@ passenv =
     DOCKER*
     COMPOSE*
 setenv =
-    2.7.1: HDFS_RAW_VERSION=2.7.1
-    2.7.1: HDFS_IMAGE_TAG=1.1.0-hadoop2.7.1-java8
+    3.1.3: HDFS_RAW_VERSION=3.1.3
+    3.1.3: HDFS_IMAGE_TAG=2.0.0-hadoop3.1.3-java8
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?

1. Updated default port numbers, e.g. see https://github.com/big-data-europe/docker-hadoop/pull/26
2. Fixed version metadata submission for `hdfs_datanode` so it handles build data
3. Changed version metadata for `hdfs_namenode` so it submits build data

### Motivation

Customer inquiry