### PR TITLE
Enable `extra_status_metrics` and `replication` metrics by default when DBM is enabled

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -288,7 +288,7 @@ class MySql(AgentCheck):
         metrics.update(INNODB_VARS)
         metrics.update(BINLOG_VARS)
 
-        if is_affirmative(self._config.options.get('extra_status_metrics', False)):
+        if is_affirmative(self._config.options.get('extra_status_metrics', self._config.dbm_enabled)):
             self.log.debug("Collecting Extra Status Metrics")
             metrics.update(OPTIONAL_STATUS_VARS)
 
@@ -317,7 +317,7 @@ class MySql(AgentCheck):
             results['information_schema_size'] = self._query_size_per_schema(db)
             metrics.update(SCHEMA_VARS)
 
-        if is_affirmative(self._config.options.get('replication', False)):
+        if is_affirmative(self._config.options.get('replication', self._config.dbm_enabled)):
             replication_metrics = self._collect_replication_metrics(db, results, above_560)
             metrics.update(replication_metrics)
             self._check_replication_status(results)


### PR DESCRIPTION
### What does this PR do?

Changes the default behavior when DBM is enabled so that the innodb status metrics and replication metrics are automatically collected.

### Motivation

These extra settings provide richer data so we should be sure to collect them for DBM insights.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
