### PR TITLE
Add troubleshooting note for high custom metric billings when enabling openmetrics

### DIFF
--- a/istio/README.md
+++ b/istio/README.md
@@ -152,7 +152,7 @@ To ensure that your Openmetrics configuration is not redundantly collecting metr
 
 #### Openmetrics V2 configuration
 
-```text
+```yaml
 ## Every instance is scheduled independent of the others.
 #
 instances:

--- a/istio/README.md
+++ b/istio/README.md
@@ -147,7 +147,7 @@ If Istio proxy sidecar injection is enabled, monitoring other Prometheus metrics
 
 To ensure that your Openmetrics configuration is not redundantly collecting metrics, either:
 
-1. Use specific metric matching in the `metrics` configuration option
+1. Use specific metric matching in the `metrics` configuration option, or
 2. If you use `*` value for `metrics`, consider using the following options to exclude metrics already collected by the Istio and Envoy integrations.
 
 #### Openmetrics V2 configuration

--- a/istio/README.md
+++ b/istio/README.md
@@ -145,7 +145,7 @@ Note: you must upgrade to at minimum Agent `7.31.0` and Python 3. See the [Confi
 
 If Istio proxy sidecar injection is enabled, monitoring other Prometheus metrics via the [Openmetrics integration][20] with the same metrics endpoint as `istio_mesh_endpoint` can result in high custom metrics usage and duplicated metric collection.
 
-To ensure that your Openmetrics configuration is not redundantly collecting metrics, either:
+To ensure that your Openmetrics configuration does not redundantly collect metrics, either:
 
 1. Use specific metric matching in the `metrics` configuration option, or
 2. If you use `*` value for `metrics`, consider using the following options to exclude metrics already collected by the Istio and Envoy integrations.

--- a/istio/README.md
+++ b/istio/README.md
@@ -143,79 +143,32 @@ Note: you must upgrade to at minimum Agent `7.31.0` and Python 3. See the [Confi
 
 ### Using the generic Openmetrics Integration in an Istio deployment
 
-If Istio proxy sidecar injection is enabled, monitoring other Prometheus metrics via the [Openmetrics integration][20] with the same metrics endpoint as `istio_mesh_endpoint` can result in high custom metrics usage and duplicated metric collection.
+If Istio proxy sidecar injection is enabled, monitoring other Prometheus metrics via the [Openmetrics integration][21] with the same metrics endpoint as `istio_mesh_endpoint` can result in high custom metrics usage and duplicated metric collection.
 
 To ensure that your Openmetrics configuration does not redundantly collect metrics, either:
 
 1. Use specific metric matching in the `metrics` configuration option, or
 2. If you use `*` value for `metrics`, consider using the following options to exclude metrics already collected by the Istio and Envoy integrations.
 
-#### Openmetrics V2 configuration
+#### Openmetrics V2 configuration with generic metric collection
 
+Be sure to exclude Istio and Envoy metrics from your configuration to avoid high custom metrics billing. Use `exclude_metrics` if configuring the Openmetrics V2 (`openmetrics_endpoint` enabled).
+ 
 ```yaml
 ## Every instance is scheduled independent of the others.
 #
 instances:
-  -
-    ## @param openmetrics_endpoint - string - optional
-    ## The URL exposing metrics in the OpenMetrics format.
-    #
-    openmetrics_endpoint: <OPENMETRICS_ENDPOINT>
-
-    ## @param metrics - (list of string or mapping) - required
-    ## This list defines which metrics to collect from the `openmetrics_endpoint`.
-    ## Metrics may be defined in 3 ways:
-    ##
-    ## 1. If the item is a string, then it represents the exposed metric name, and
-    ##    the sent metric name will be identical. For example:
-    ##
-    ##      metrics:
-    ##      - <METRIC_1>
-    ##      - <METRIC_2>
-    ## 2. If the item is a mapping, then the keys represent the exposed metric names.
-    ##
-    ##      a. If a value is a string, then it represents the sent metric name. For example:
-    ##
-    ##           metrics:
-    ##           - <EXPOSED_METRIC_1>: <SENT_METRIC_1>
-    ##           - <EXPOSED_METRIC_2>: <SENT_METRIC_2>
-    ##      b. If a value is a mapping, then it must have a `name` and/or `type` key.
-    ##         The `name` represents the sent metric name, and the `type` represents how
-    ##         the metric should be handled, overriding any type information the endpoint
-    ##         may provide. For example:
-    ##
-    ##           metrics:
-    ##           - <EXPOSED_METRIC_1>:
-    ##               name: <SENT_METRIC_1>
-    ##               type: <METRIC_TYPE_1>
-    ##           - <EXPOSED_METRIC_2>:
-    ##               name: <SENT_METRIC_2>
-    ##               type: <METRIC_TYPE_2>
-    ##
-    ##         The supported native types are `gauge`, `counter`, `histogram`, and `summary`.
-    ##
-    ## Regular expressions may be used to match the exposed metric names, for example:
-    ##
-    ##   metrics:
-    ##   - ^network_(ingress|egress)_.+
-    ##   - .+:
-    ##       type: gauge
-    #
+  - openmetrics_endpoint: <OPENMETRICS_ENDPOINT>
     metrics: [*]
-    ## @param exclude_metrics - list of strings - optional
-    ## A list of metrics to exclude, with each entry being either
-    ## the exact metric name or a regular expression.
-    ## In order to exclude all metrics but the ones matching a specific filter,
-    ## you can use a negative lookahead regex like:
-    ##   - ^(?!foo).*$
-    #
     exclude_metrics:
       - istio_*
       - envoy_*
 
 ```
 
-#### Openmetrics V1 configuration (Legacy)
+#### Openmetrics V1 configuration (Legacy) with generic metric collection
+
+Be sure to exclude Istio and Envoy metrics from your configuration to avoid high custom metrics billing. Use `ignore_metrics` if configuring the Openmetrics V2 (`openmetrics_endpoint` enabled).
 
 ```yaml
 instances:

--- a/istio/README.md
+++ b/istio/README.md
@@ -168,7 +168,7 @@ instances:
 
 #### Openmetrics V1 configuration (Legacy) with generic metric collection
 
-Be sure to exclude Istio and Envoy metrics from your configuration to avoid high custom metrics billing. Use `ignore_metrics` if configuring the Openmetrics V2 (`openmetrics_endpoint` enabled).
+Be sure to exclude Istio and Envoy metrics from your configuration to avoid high custom metrics billing. Use `ignore_metrics` if using the Openmetrics V1 configuration (`prometheus_url` enabled).
 
 ```yaml
 instances:

--- a/istio/README.md
+++ b/istio/README.md
@@ -152,7 +152,7 @@ To ensure that your Openmetrics configuration does not redundantly collect metri
 
 #### Openmetrics V2 configuration with generic metric collection
 
-Be sure to exclude Istio and Envoy metrics from your configuration to avoid high custom metrics billing. Use `exclude_metrics` if configuring the Openmetrics V2 (`openmetrics_endpoint` enabled).
+Be sure to exclude Istio and Envoy metrics from your configuration to avoid high custom metrics billing. Use `exclude_metrics` if using the Openmetrics V2 configuration (`openmetrics_endpoint` enabled).
  
 ```yaml
 ## Every instance is scheduled independent of the others.

--- a/istio/README.md
+++ b/istio/README.md
@@ -156,8 +156,51 @@ To ensure that your Openmetrics configuration is not redundantly collecting metr
 ## Every instance is scheduled independent of the others.
 #
 instances:
+  -
+    ## @param openmetrics_endpoint - string - optional
+    ## The URL exposing metrics in the OpenMetrics format.
+    #
+    openmetrics_endpoint: <OPENMETRICS_ENDPOINT>
 
-  - openmetrics_endpoint: <OPENMETRICS_ENDPOINT>
+    ## @param metrics - (list of string or mapping) - required
+    ## This list defines which metrics to collect from the `openmetrics_endpoint`.
+    ## Metrics may be defined in 3 ways:
+    ##
+    ## 1. If the item is a string, then it represents the exposed metric name, and
+    ##    the sent metric name will be identical. For example:
+    ##
+    ##      metrics:
+    ##      - <METRIC_1>
+    ##      - <METRIC_2>
+    ## 2. If the item is a mapping, then the keys represent the exposed metric names.
+    ##
+    ##      a. If a value is a string, then it represents the sent metric name. For example:
+    ##
+    ##           metrics:
+    ##           - <EXPOSED_METRIC_1>: <SENT_METRIC_1>
+    ##           - <EXPOSED_METRIC_2>: <SENT_METRIC_2>
+    ##      b. If a value is a mapping, then it must have a `name` and/or `type` key.
+    ##         The `name` represents the sent metric name, and the `type` represents how
+    ##         the metric should be handled, overriding any type information the endpoint
+    ##         may provide. For example:
+    ##
+    ##           metrics:
+    ##           - <EXPOSED_METRIC_1>:
+    ##               name: <SENT_METRIC_1>
+    ##               type: <METRIC_TYPE_1>
+    ##           - <EXPOSED_METRIC_2>:
+    ##               name: <SENT_METRIC_2>
+    ##               type: <METRIC_TYPE_2>
+    ##
+    ##         The supported native types are `gauge`, `counter`, `histogram`, and `summary`.
+    ##
+    ## Regular expressions may be used to match the exposed metric names, for example:
+    ##
+    ##   metrics:
+    ##   - ^network_(ingress|egress)_.+
+    ##   - .+:
+    ##       type: gauge
+    #
     metrics: [*]
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either

--- a/istio/README.md
+++ b/istio/README.md
@@ -141,6 +141,49 @@ You can use the Openmetrics V2 implementation of the Istio integration to resolv
 Note: you must upgrade to at minimum Agent `7.31.0` and Python 3. See the [Configuration](#configuration) section on enabling Openmetrics V2.
 
 
+### Using the generic Openmetrics Integration in an Istio deployment
+
+If Istio proxy sidecar injection is enabled, monitoring other Prometheus metrics via the [Openmetrics integration][20] with the same metrics endpoint as `istio_mesh_endpoint` can result in high custom metrics usage and duplicated metric collection.
+
+To ensure that your Openmetrics configuration is not redundantly collecting metrics, either:
+
+1. Use specific metric matching in the `metrics` configuration option
+2. If you use `*` value for `metrics`, then at minimum, consider including the following optional options to exclude metrics already collected by istio and Envoy inegrations.
+
+#### Openmetrics V2 configuration
+
+```text
+## Every instance is scheduled independent of the others.
+#
+instances:
+
+  - openmetrics_endpoint: <OPENMETRICS_ENDPOINT>
+    metrics: [*]
+    ## @param exclude_metrics - list of strings - optional
+    ## A list of metrics to exclude, with each entry being either
+    ## the exact metric name or a regular expression.
+    ## In order to exclude all metrics but the ones matching a specific filter,
+    ## you can use a negative lookahead regex like:
+    ##   - ^(?!foo).*$
+    #
+    exclude_metrics:
+      - istio_*
+      - envoy_*
+
+```
+
+#### Openmetrics V1 configuration (Legacy)
+
+```yaml
+instances:
+  - prometheus_url: <PROMETHEUS_URL>
+    metrics:
+      - *
+    ignore_metrics:
+      - istio_*
+      - envoy_*
+```
+
 Need help? Contact [Datadog support][17].
 
 ## Further Reading
@@ -170,4 +213,5 @@ Additional helpful documentation, links, and articles:
 [17]: https://docs.datadoghq.com/help/
 [18]: https://www.datadoghq.com/blog/monitor-istio-with-datadog
 [19]: https://www.datadoghq.com/blog/istio-metrics/
-[20]: https://github.com/DataDog/integrations-core/blob/7.32.x/istio/datadog_checks/istio/data/conf.yaml.example
+[20]: https://docs.datadoghq.com/integrations/openmetrics/
+[21]: https://github.com/DataDog/integrations-core/blob/7.32.x/istio/datadog_checks/istio/data/conf.yaml.example

--- a/istio/README.md
+++ b/istio/README.md
@@ -148,7 +148,7 @@ If Istio proxy sidecar injection is enabled, monitoring other Prometheus metrics
 To ensure that your Openmetrics configuration is not redundantly collecting metrics, either:
 
 1. Use specific metric matching in the `metrics` configuration option
-2. If you use `*` value for `metrics`, then at minimum, consider including the following optional options to exclude metrics already collected by the Istio and Envoy integrations.
+2. If you use `*` value for `metrics`, consider using the following options to exclude metrics already collected by the Istio and Envoy integrations.
 
 #### Openmetrics V2 configuration
 

--- a/istio/README.md
+++ b/istio/README.md
@@ -148,7 +148,7 @@ If Istio proxy sidecar injection is enabled, monitoring other Prometheus metrics
 To ensure that your Openmetrics configuration does not redundantly collect metrics, either:
 
 1. Use specific metric matching in the `metrics` configuration option, or
-2. If you use `*` value for `metrics`, consider using the following options to exclude metrics already collected by the Istio and Envoy integrations.
+2. If using the wildcard `*` value for `metrics`, consider using the following Openmetrics integration options to exclude metrics already supported by the Istio and Envoy integrations.
 
 #### Openmetrics V2 configuration with generic metric collection
 

--- a/istio/README.md
+++ b/istio/README.md
@@ -148,7 +148,7 @@ If Istio proxy sidecar injection is enabled, monitoring other Prometheus metrics
 To ensure that your Openmetrics configuration is not redundantly collecting metrics, either:
 
 1. Use specific metric matching in the `metrics` configuration option
-2. If you use `*` value for `metrics`, then at minimum, consider including the following optional options to exclude metrics already collected by istio and Envoy inegrations.
+2. If you use `*` value for `metrics`, then at minimum, consider including the following optional options to exclude metrics already collected by the Istio and Envoy integrations.
 
 #### Openmetrics V2 configuration
 


### PR DESCRIPTION
### What does this PR do?
This PR adds a note to the troubleshooting section. Sometimes users configure generic metric collection with the Openmetrics integration which results in duplicate metrics from the istio-proxy sidecars. This PR includes examples to exclude metrics in their openmetrics configuration to prevent this.

### Motivation
Troubleshooting note

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
