### PR TITLE
Add support for monitoring Redis stream keys

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -374,6 +374,10 @@ class Redis(AgentCheck):
                         # Send 1 if the key exists as a string
                         lengths[text_key]["length"] += 1
                         lengths_overall[text_key] += 1
+                    elif key_type == 'stream':
+                        keylen = db_conn.xlen(key)
+                        lengths[text_key]["length"] += 1
+                        lengths_overall[text_key] += 1
                     else:
                         # If the type is unknown, it might be because the key doesn't exist,
                         # which can be because the list is empty. So always send 0 in that case.


### PR DESCRIPTION
This uses XLEN to get the length of a stream.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
