### PR TITLE
Add saturation metrics for network

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -700,10 +700,8 @@ class Network(AgentCheck):
                         'bytes_rcvd': self._parse_value(x[-5]),
                         'bytes_sent': self._parse_value(x[-2]),
                         'packets_in.count': self._parse_value(x[-7]),
-                        'packets_in.drop': 0,
                         'packets_in.error': self._parse_value(x[-6]),
                         'packets_out.count': self._parse_value(x[-4]),
-                        'packets_out.drop': 0,
                         'packets_out.error': self._parse_value(x[-3]),
                     }
                     self._submit_devicemetrics(iface, metrics, custom_tags)
@@ -877,7 +875,7 @@ class Network(AgentCheck):
                 continue
 
             # Add it to this interface's list of metrics.
-            metrics = metrics_by_interface.get(iface, {'packets_in.drop': 0, 'packets_out.drop': 0})
+            metrics = metrics_by_interface.get(iface, {})
             metrics[ddname] = self._parse_value(cols[1])
             metrics_by_interface[iface] = metrics
 

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -266,8 +266,10 @@ class Network(AgentCheck):
             'bytes_rcvd',
             'bytes_sent',
             'packets_in.count',
+            'packets_in.drop',
             'packets_in.error',
             'packets_out.count',
+            'packets_out.drop',
             'packets_out.error',
         ]
         for m in expected_metrics:
@@ -450,8 +452,10 @@ class Network(AgentCheck):
                     'bytes_rcvd': self._parse_value(x[0]),
                     'bytes_sent': self._parse_value(x[8]),
                     'packets_in.count': self._parse_value(x[1]),
+                    'packets_in.drop': self._parse_value(x[3]),
                     'packets_in.error': self._parse_value(x[2]) + self._parse_value(x[3]),
                     'packets_out.count': self._parse_value(x[9]),
+                    'packets_out.drop': self._parse_value(x[11]),
                     'packets_out.error': self._parse_value(x[10]) + self._parse_value(x[11]),
                 }
                 self._submit_devicemetrics(iface, metrics, custom_tags)
@@ -696,8 +700,10 @@ class Network(AgentCheck):
                         'bytes_rcvd': self._parse_value(x[-5]),
                         'bytes_sent': self._parse_value(x[-2]),
                         'packets_in.count': self._parse_value(x[-7]),
+                        'packets_in.drop': 0,
                         'packets_in.error': self._parse_value(x[-6]),
                         'packets_out.count': self._parse_value(x[-4]),
+                        'packets_out.drop': 0,
                         'packets_out.error': self._parse_value(x[-3]),
                     }
                     self._submit_devicemetrics(iface, metrics, custom_tags)
@@ -871,7 +877,7 @@ class Network(AgentCheck):
                 continue
 
             # Add it to this interface's list of metrics.
-            metrics = metrics_by_interface.get(iface, {})
+            metrics = metrics_by_interface.get(iface, {'packets_in.drop': 0, 'packets_out.drop': 0})
             metrics[ddname] = self._parse_value(cols[1])
             metrics_by_interface[iface] = metrics
 
@@ -916,8 +922,10 @@ class Network(AgentCheck):
                 'bytes_rcvd': counters.bytes_recv,
                 'bytes_sent': counters.bytes_sent,
                 'packets_in.count': counters.packets_recv,
+                'packets_in.drop': counters.dropin,
                 'packets_in.error': counters.errin,
                 'packets_out.count': counters.packets_sent,
+                'packets_out.drop': counters.dropout,
                 'packets_out.error': counters.errout,
             }
             self._submit_devicemetrics(iface, metrics, tags)

--- a/network/metadata.csv
+++ b/network/metadata.csv
@@ -44,10 +44,10 @@ system.net.conntrack.tcp_timeout,gauge,,second,,,0,system,timeout
 system.net.conntrack.tcp_timeout_stream,gauge,,second,,,0,system,timeout stream
 system.net.conntrack.timestamp,gauge,,unit,,Boolean to enable connection tracking flow timestamping.,0,system,timestamp
 system.net.packets_in.count,gauge,,packet,second,The number of packets of data received by the interface.,0,system,packets in
-system.net.packets_in.drop,gauge,,packet,second,The number of packet receive drop detected by the device driver.,-1,system,pkts in drop
+system.net.packets_in.drop,gauge,,packet,second,The number of packet receive drops detected by the device driver.,-1,system,pkts in drop
 system.net.packets_in.error,gauge,,error,second,The number of packet receive errors detected by the device driver.,-1,system,pkts in err
 system.net.packets_out.count,gauge,,packet,second,The number of packets of data transmitted by the interface.,0,system,packets out
-system.net.packets_out.drop,gauge,,packet,second,The number of packet transmit drop detected by the device driver.,-1,system,pkts out drop
+system.net.packets_out.drop,gauge,,packet,second,The number of packet transmit drops detected by the device driver.,-1,system,pkts out drop
 system.net.packets_out.error,gauge,,error,second,The number of packet transmit errors detected by the device driver.,-1,system,pkts out err
 system.net.tcp.in_segs,gauge,,segment,second,The number of TCP segments received (Linux or Solaris only).,0,system,segs in
 system.net.tcp.in_segs.count,count,,segment,,Total number of received TCP segments (Linux or Solaris only).,0,system,segs in

--- a/network/metadata.csv
+++ b/network/metadata.csv
@@ -44,8 +44,10 @@ system.net.conntrack.tcp_timeout,gauge,,second,,,0,system,timeout
 system.net.conntrack.tcp_timeout_stream,gauge,,second,,,0,system,timeout stream
 system.net.conntrack.timestamp,gauge,,unit,,Boolean to enable connection tracking flow timestamping.,0,system,timestamp
 system.net.packets_in.count,gauge,,packet,second,The number of packets of data received by the interface.,0,system,packets in
+system.net.packets_in.drop,gauge,,packet,second,The number of packet receive drop detected by the device driver.,-1,system,pkts in drop
 system.net.packets_in.error,gauge,,error,second,The number of packet receive errors detected by the device driver.,-1,system,pkts in err
 system.net.packets_out.count,gauge,,packet,second,The number of packets of data transmitted by the interface.,0,system,packets out
+system.net.packets_out.drop,gauge,,packet,second,The number of packet transmit drop detected by the device driver.,-1,system,pkts out drop
 system.net.packets_out.error,gauge,,error,second,The number of packet transmit errors detected by the device driver.,-1,system,pkts out err
 system.net.tcp.in_segs,gauge,,segment,second,The number of TCP segments received (Linux or Solaris only).,0,system,segs in
 system.net.tcp.in_segs.count,count,,segment,,Total number of received TCP segments (Linux or Solaris only).,0,system,segs in

--- a/network/tests/common.py
+++ b/network/tests/common.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+from datadog_checks.base.utils.platform import Platform
 from datadog_checks.dev import get_here
 
 HERE = get_here()
@@ -18,12 +19,18 @@ EXPECTED_METRICS = [
     'system.net.bytes_rcvd',
     'system.net.bytes_sent',
     'system.net.packets_in.count',
-    'system.net.packets_in.drop',
     'system.net.packets_in.error',
     'system.net.packets_out.count',
-    'system.net.packets_out.drop',
     'system.net.packets_out.error',
 ]
+
+if Platform.is_linux() or Platform.is_windows():
+    EXPECTED_METRICS.extend(
+        [
+            'system.net.packets_in.drop',
+            'system.net.packets_out.drop',
+        ]
+    )
 
 E2E_EXPECTED_METRICS = EXPECTED_METRICS + [
     "system.net.tcp4.closing",

--- a/network/tests/common.py
+++ b/network/tests/common.py
@@ -18,8 +18,10 @@ EXPECTED_METRICS = [
     'system.net.bytes_rcvd',
     'system.net.bytes_sent',
     'system.net.packets_in.count',
+    'system.net.packets_in.drop',
     'system.net.packets_in.error',
     'system.net.packets_out.count',
+    'system.net.packets_out.drop',
     'system.net.packets_out.error',
 ]
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add saturation metrics for network.

### Motivation
<!-- What inspired you to submit this pull request? -->

We currently gather utilization and error metrics of network (bytes received and sent, number of packets) but not the saturation metrics (number of dropped packets).

Having this additional data is needed to apply the USE Method [1] for system performance analysis.

[1] https://www.brendangregg.com/usemethod.html

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
