### PR TITLE
Add TileDescriptionValidator for V2 manifests

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
@@ -34,6 +34,19 @@ class DisplayOnPublicValidator(BaseManifestValidator):
                 self.fail(output)
 
 
+class TileDescriptionValidator(BaseManifestValidator):
+    DESCRIPTION_PATH = '/tile/description'
+    MAX_DESCRIPTION_LENGTH = 70
+
+    def validate(self, check_name, decoded, fix):
+        # The description for V2 manifests should not be longer than 70 characters to avoid being
+        # cut off or shortened on the UI
+        tile_description = decoded.get_path(self.DESCRIPTION_PATH)
+        if len(tile_description) > self.MAX_DESCRIPTION_LENGTH:
+            output = f'  The tile description should be no longer than {self.MAX_DESCRIPTION_LENGTH} characters.'
+            self.fail(output)
+
+
 class SchemaValidator(BaseManifestValidator):
     def validate(self, check_name, decoded, fix):
         if not self.should_validate():
@@ -219,6 +232,7 @@ def get_v2_validators(ctx, is_extras, is_marketplace):
         common.ImmutableAttributesValidator(version=V2),
         common.LogsCategoryValidator(version=V2),
         DisplayOnPublicValidator(version=V2),
+        TileDescriptionValidator(is_marketplace, is_extras, version=V2),
         MediaGalleryValidator(is_marketplace, is_extras, version=V2),
         # keep SchemaValidator last, and avoid running this validation if errors already found
         SchemaValidator(ctx=ctx, version=V2, skip_if_errors=True),

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
@@ -42,8 +42,10 @@ class TileDescriptionValidator(BaseManifestValidator):
         # The description for V2 manifests should not be longer than 70 characters to avoid being
         # cut off or shortened on the UI
         tile_description = decoded.get_path(self.DESCRIPTION_PATH)
-        if len(tile_description) > self.MAX_DESCRIPTION_LENGTH:
-            output = f'  The tile description should be no longer than {self.MAX_DESCRIPTION_LENGTH} characters.'
+        current_length = len(tile_description)
+        if current_length > self.MAX_DESCRIPTION_LENGTH:
+            output = f'  The tile description is {current_length} characters long. It should be no longer than \
+{self.MAX_DESCRIPTION_LENGTH} characters.'
             self.fail(output)
 
 

--- a/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
@@ -48,7 +48,7 @@ V2_VALID_MANIFEST = {
     "tile": {
         "changelog": "CHANGELOG.md",
         "configuration": "README.md#Setup",
-        "description": "Oracle relational database system designed for enterprise grid computing",
+        "description": "Oracle relational database system designed for enterprise grid",
         "media": [],
         "overview": "README.md#Overview",
         "title": "Oracle",
@@ -144,6 +144,16 @@ INVALID_MEDIA_MANIFEST_INCORRECT_VIMEO_ID_TYPE = JSONDict(
 IMMUTABLE_ATTRIBUTES_V1_MANIFEST = {"manifest_version": "1.0.0"}
 
 IMMUTABLE_ATTRIBUTES_V2_MANIFEST = JSONDict({"manifest_version": "2.0.0"})
+
+VALID_TILE_DESCRIPTION_V2_MANIFEST = JSONDict({"tile": {"description": "This is a valid length tile description!"}})
+
+INVALID_TILE_DESCRIPTION_V2_MANIFEST = JSONDict(
+    {
+        "tile": {
+            "description": "This description is way too long to be valid! It will be cut off when displayed in the UI."
+        }
+    }
+)
 
 
 class MockedResponseInvalid:

--- a/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
@@ -475,3 +475,23 @@ def test_manifest_v2_media_gallery_validator_incorrect_vimeo_id_type(_, setup_ro
     # Assert test case
     assert validator.result.failed, validator.result
     assert not validator.result.fixed
+
+
+def test_manifest_v2_tile_description_validator_pass(setup_route):
+    # Use specific validator
+    validator = v2_validators.TileDescriptionValidator(is_marketplace=True, version=V2, check_in_extras=True)
+    validator.validate('active_directory', input_constants.VALID_TILE_DESCRIPTION_V2_MANIFEST, False)
+
+    # Assert test case
+    assert not validator.result.failed, validator.result
+    assert not validator.result.fixed
+
+
+def test_manifest_v2_tile_description_validator_invalid(setup_route):
+    # Use specific validator
+    validator = v2_validators.TileDescriptionValidator(is_marketplace=True, version=V2, check_in_extras=True)
+    validator.validate('active_directory', input_constants.INVALID_TILE_DESCRIPTION_V2_MANIFEST, False)
+
+    # Assert test case
+    assert validator.result.failed, validator.result
+    assert not validator.result.fixed


### PR DESCRIPTION
### What does this PR do?
This PR adds a validator to ensure tile descriptions are a maximum 70 characters for V2 manifests.

### Motivation
Descriptions over 70 characters are cut off in the UI.

### Additional Notes
No

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
