### PR TITLE
Add documentation for new DBM only postgres metrics

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -366,7 +366,7 @@ Some of the metrics listed below require additional configuration, see the [samp
 
 See [metadata.csv][20] for a list of metrics provided by this integration.
 
-For Agent version `7.32.0` and later, if you have Database Monitoring enabled, the `postgresql.connections` metric is tagged with `state`, `app`, and `user`.
+For Agent version `7.32.0` and later, if you have Database Monitoring enabled, the `postgresql.connections` metric is tagged with `state`, `app`, `db` and `user`.
 
 ### Events
 

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -1,5 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-postgresql.connections,gauge,,connection,,"The number of active connections to this database. If you have Database Monitoring enabled, this metric is tagged with state, app, db and user",0,postgres,conns
+postgresql.connections,gauge,,connection,,"The number of active connections to this database. If you have DBM enabled, this metric is tagged with state, app, db and user",0,postgres,conns
 postgresql.commits,gauge,,transaction,second,The number of transactions that have been committed in this database.,0,postgres,commits
 postgresql.rollbacks,gauge,,transaction,second,The number of transactions that have been rolled back in this database.,-1,postgres,rollbacks
 postgresql.disk_read,gauge,,block,second,The number of disk blocks read in this database.,0,postgres,disk read
@@ -65,22 +65,22 @@ postgresql.transactions.idle_in_transaction,gauge,,transaction,,The number of 'i
 postgresql.before_xid_wraparound,gauge,,transaction,,The number of transactions that can occur until a transaction wraparound.,0,postgres,tx before xid wraparound
 postgresql.active_queries,gauge,,,,The number of active queries in this database.,0,postgres,active queries
 postgresql.waiting_queries,gauge,,,,The number of waiting queries in this database.,0,postgres,transactions waiting queries
-postgresql.queries.count,count,,query,,"The total query execution count per normalized query, database, and user. (DBM only)",0,postgres,postgres queries count
-postgresql.queries.time,count,,nanosecond,,"The total query execution time per normalized query, database, and user. (DBM only)",0,postgres,postgres queries time
-postgresql.queries.rows,count,,row,,"The total number of rows retrieved or affected per normalized query, database, and user. (DBM only)",0,postgres,postgres queries rows
-postgresql.queries.shared_blks_hit,count,,block,,"Total number of shared block cache hits per normalized query, database, and user. (DBM only)",0,postgres,postgres queries shared blocks hit
-postgresql.queries.shared_blks_read,count,,block,,"Total number of shared blocks read per normalized query, database, and user. (DBM only)",0,postgres,postgres queries shared blocks read
-postgresql.queries.shared_blks_dirtied,count,,block,,"Total number of shared blocks dirtied per normalized query, database, and user. (DBM only)",0,postgres,postgres queries shared blocks dirtied
-postgresql.queries.shared_blks_written,count,,block,,"Total number of shared blocks written per normalized query, database, and user. (DBM only)",0,postgres,postgres queries shared blocks written
-postgresql.queries.local_blks_hit,count,,block,,"Total number of local block cache hits per normalized query, database, and user. (DBM only)",0,postgres,postgres queries local blocks hit
-postgresql.queries.local_blks_read,count,,block,,"Total number of local blocks read per normalized query, database, and user. (DBM only)",0,postgres,postgres queries local blocks read
-postgresql.queries.local_blks_dirtied,count,,block,,"Total number of local blocks dirtied per normalized query, database, and user. (DBM only)",0,postgres,postgres queries local blocks dirtied
-postgresql.queries.local_blks_written,count,,block,,"Total number of local blocks written per normalized query, database, and user. (DBM only)",0,postgres,postgres queries local blocks written
-postgresql.queries.temp_blks_read,count,,block,,"Total number of temp blocks read per normalized query, database, and user. (DBM only)",0,postgres,postgres queries temp blocks read
-postgresql.queries.temp_blks_written,count,,block,,"Total number of temp blocks written per normalized query, database, and user. (DBM only)",0,postgres,postgres queries temp blocks written
-postgresql.queries.duration.max,gauge,,nanosecond,,"The age of the longest running query per user, db, app and host. (DBM only)",0,postgres,postgres queries duration max
-postgresql.queries.duration.sum,gauge,,nanosecond,,"The sum of the age of all running queries per user, db, app and host. (DBM only)",0,postgres,postgres queries duration sum
-postgresql.transactions.duration.max,gauge,,nanosecond,,"The age of the longest running transaction per user, db, app and host. (DBM only)",0,postgres,postgres transactions duration max
-postgresql.transactions.duration.sum,gauge,,nanosecond,,"The sum of the age of all running transactions per user, db, app and host. (DBM only)",0,postgres,postgres transactions duration sum
+postgresql.queries.count,count,,query,,"The total query execution count per query_signature, db, and user. (DBM only)",0,postgres,postgres queries count
+postgresql.queries.time,count,,nanosecond,,"The total query execution time per query_signature, db, and user. (DBM only)",0,postgres,postgres queries time
+postgresql.queries.rows,count,,row,,"The total number of rows retrieved or affected per query_signature, db, and user. (DBM only)",0,postgres,postgres queries rows
+postgresql.queries.shared_blks_hit,count,,block,,"Total number of shared block cache hits per query_signature, db, and user. (DBM only)",0,postgres,postgres queries shared blocks hit
+postgresql.queries.shared_blks_read,count,,block,,"Total number of shared blocks read per query_signature, db, and user. (DBM only)",0,postgres,postgres queries shared blocks read
+postgresql.queries.shared_blks_dirtied,count,,block,,"Total number of shared blocks dirtied per query_signature, db, and user. (DBM only)",0,postgres,postgres queries shared blocks dirtied
+postgresql.queries.shared_blks_written,count,,block,,"Total number of shared blocks written per query_signature, db, and user. (DBM only)",0,postgres,postgres queries shared blocks written
+postgresql.queries.local_blks_hit,count,,block,,"Total number of local block cache hits per query_signature, db, and user. (DBM only)",0,postgres,postgres queries local blocks hit
+postgresql.queries.local_blks_read,count,,block,,"Total number of local blocks read per query_signature, db, and user. (DBM only)",0,postgres,postgres queries local blocks read
+postgresql.queries.local_blks_dirtied,count,,block,,"Total number of local blocks dirtied per query_signature, db, and user. (DBM only)",0,postgres,postgres queries local blocks dirtied
+postgresql.queries.local_blks_written,count,,block,,"Total number of local blocks written per query_signature, db, and user. (DBM only)",0,postgres,postgres queries local blocks written
+postgresql.queries.temp_blks_read,count,,block,,"Total number of temp blocks read per query_signature, db, and user. (DBM only)",0,postgres,postgres queries temp blocks read
+postgresql.queries.temp_blks_written,count,,block,,"Total number of temp blocks written per query_signature, db, and user. (DBM only)",0,postgres,postgres queries temp blocks written
+postgresql.queries.duration.max,gauge,,nanosecond,,"The age of the longest running query per user, db and app. (DBM only)",0,postgres,postgres queries duration max
+postgresql.queries.duration.sum,gauge,,nanosecond,,"The sum of the age of all running queries per user, db and app. (DBM only)",0,postgres,postgres queries duration sum
+postgresql.transactions.duration.max,gauge,,nanosecond,,"The age of the longest running transaction per user, db and app. (DBM only)",0,postgres,postgres transactions duration max
+postgresql.transactions.duration.sum,gauge,,nanosecond,,"The sum of the age of all running transactions per user, db and app. (DBM only)",0,postgres,postgres transactions duration sum
 postgresql.wal_age,gauge,,second,,The age in seconds of the oldest WAL file.,0,postgres,wal age
 postgresql.function.calls,rate,,,,The number of calls made to a function.,0,postgres,postgres_function_calls

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -1,5 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-postgresql.connections,gauge,,connection,,The number of active connections to this database.,0,postgres,conns
+postgresql.connections,gauge,,connection,,"The number of active connections to this database. If you have Database Monitoring enabled, this metric is tagged with state, app, db and user",0,postgres,conns
 postgresql.commits,gauge,,transaction,second,The number of transactions that have been committed in this database.,0,postgres,commits
 postgresql.rollbacks,gauge,,transaction,second,The number of transactions that have been rolled back in this database.,-1,postgres,rollbacks
 postgresql.disk_read,gauge,,block,second,The number of disk blocks read in this database.,0,postgres,disk read
@@ -78,9 +78,9 @@ postgresql.queries.local_blks_dirtied,count,,block,,"Total number of local block
 postgresql.queries.local_blks_written,count,,block,,"Total number of local blocks written per normalized query, database, and user. (DBM only)",0,postgres,postgres queries local blocks written
 postgresql.queries.temp_blks_read,count,,block,,"Total number of temp blocks read per normalized query, database, and user. (DBM only)",0,postgres,postgres queries temp blocks read
 postgresql.queries.temp_blks_written,count,,block,,"Total number of temp blocks written per normalized query, database, and user. (DBM only)",0,postgres,postgres queries temp blocks written
-postgresql.queries.duration.max,gauge,,,,The age of the longest running query per user, db, app and host (DBM only).,0,postgres,postgres queries duration max
-postgresql.queries.duration.sum,gauge,,,,The sum of the age of all running queries per user, db, app and host (DBM only).,0,postgres,postgres queries duration sum
-postgresql.transactions.duration.max,gauge,,,,The age of the longest running transaction per user, db, app and host (DBM only).,0,postgres,postgres transactions duration max
-postgresql.transactions.duration.sum,gauge,,,,The sum of the age of all running transactions per user, db, app and host (DBM only),0,postgres,postgres transactions duration sum
+postgresql.queries.duration.max,gauge,,nanosecond,,"The age of the longest running query per user, db, app and host. (DBM only)",0,postgres,postgres queries duration max
+postgresql.queries.duration.sum,gauge,,nanosecond,,"The sum of the age of all running queries per user, db, app and host. (DBM only)",0,postgres,postgres queries duration sum
+postgresql.transactions.duration.max,gauge,,nanosecond,,"The age of the longest running transaction per user, db, app and host. (DBM only)",0,postgres,postgres transactions duration max
+postgresql.transactions.duration.sum,gauge,,nanosecond,,"The sum of the age of all running transactions per user, db, app and host. (DBM only)",0,postgres,postgres transactions duration sum
 postgresql.wal_age,gauge,,second,,The age in seconds of the oldest WAL file.,0,postgres,wal age
 postgresql.function.calls,rate,,,,The number of calls made to a function.,0,postgres,postgres_function_calls

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -78,5 +78,9 @@ postgresql.queries.local_blks_dirtied,count,,block,,"Total number of local block
 postgresql.queries.local_blks_written,count,,block,,"Total number of local blocks written per normalized query, database, and user. (DBM only)",0,postgres,postgres queries local blocks written
 postgresql.queries.temp_blks_read,count,,block,,"Total number of temp blocks read per normalized query, database, and user. (DBM only)",0,postgres,postgres queries temp blocks read
 postgresql.queries.temp_blks_written,count,,block,,"Total number of temp blocks written per normalized query, database, and user. (DBM only)",0,postgres,postgres queries temp blocks written
+postgresql.queries.duration.max,gauge,,,,The age of the longest running query (DBM only).,0,postgres,postgres queries duration max
+postgresql.queries.duration.sum,gauge,,,,The sum of the age of all running queries (DBM only).,0,postgres,postgres queries duration sum
+postgresql.transactions.duration.max,gauge,,,,The age of the longest running transaction (DBM only).,0,postgres,postgres transactions duration max
+postgresql.transactions.duration.sum,gauge,,,,The sum of the age of all running transactions (DBM only),0,postgres,postgres transactions duration sum
 postgresql.wal_age,gauge,,second,,The age in seconds of the oldest WAL file.,0,postgres,wal age
 postgresql.function.calls,rate,,,,The number of calls made to a function.,0,postgres,postgres_function_calls

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -78,9 +78,9 @@ postgresql.queries.local_blks_dirtied,count,,block,,"Total number of local block
 postgresql.queries.local_blks_written,count,,block,,"Total number of local blocks written per normalized query, database, and user. (DBM only)",0,postgres,postgres queries local blocks written
 postgresql.queries.temp_blks_read,count,,block,,"Total number of temp blocks read per normalized query, database, and user. (DBM only)",0,postgres,postgres queries temp blocks read
 postgresql.queries.temp_blks_written,count,,block,,"Total number of temp blocks written per normalized query, database, and user. (DBM only)",0,postgres,postgres queries temp blocks written
-postgresql.queries.duration.max,gauge,,,,The age of the longest running query (DBM only).,0,postgres,postgres queries duration max
-postgresql.queries.duration.sum,gauge,,,,The sum of the age of all running queries (DBM only).,0,postgres,postgres queries duration sum
-postgresql.transactions.duration.max,gauge,,,,The age of the longest running transaction (DBM only).,0,postgres,postgres transactions duration max
-postgresql.transactions.duration.sum,gauge,,,,The sum of the age of all running transactions (DBM only),0,postgres,postgres transactions duration sum
+postgresql.queries.duration.max,gauge,,,,The age of the longest running query per user, db, app and host (DBM only).,0,postgres,postgres queries duration max
+postgresql.queries.duration.sum,gauge,,,,The sum of the age of all running queries per user, db, app and host (DBM only).,0,postgres,postgres queries duration sum
+postgresql.transactions.duration.max,gauge,,,,The age of the longest running transaction per user, db, app and host (DBM only).,0,postgres,postgres transactions duration max
+postgresql.transactions.duration.sum,gauge,,,,The sum of the age of all running transactions per user, db, app and host (DBM only),0,postgres,postgres transactions duration sum
 postgresql.wal_age,gauge,,second,,The age in seconds of the oldest WAL file.,0,postgres,wal age
 postgresql.function.calls,rate,,,,The number of calls made to a function.,0,postgres,postgres_function_calls

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -1,5 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-postgresql.connections,gauge,,connection,,"The number of active connections to this database. If you have DBM enabled, this metric is tagged with state, app, db and user",0,postgres,conns
+postgresql.connections,gauge,,connection,,"The number of active connections to this database. If DBM is enabled, this metric is tagged with state, app, db and user",0,postgres,conns
 postgresql.commits,gauge,,transaction,second,The number of transactions that have been committed in this database.,0,postgres,commits
 postgresql.rollbacks,gauge,,transaction,second,The number of transactions that have been rolled back in this database.,-1,postgres,rollbacks
 postgresql.disk_read,gauge,,block,second,The number of disk blocks read in this database.,0,postgres,disk read


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds documentation for 4 new postgres metrics that DBM customers will get in the next agent release 
```
postgresql.transactions.duration.max
postgresql.transactions.duration.sum
postgresql.queries.duration.max
postgresql.queries.duration.sum
```
Collection for these metrics were added as part of this change https://github.com/DataDog/integrations-core/pull/9866 and the metrics are being reported in our backend now 

In addition to this, I also updated documentation for the other DBM only related metrics to include the actual tag names and not the full "english translation" for what they are. This should make it easier for customers to figure out what these metrics are tagged by. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
