### PR TITLE
Change order of gitlab pipeline stages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,8 +21,8 @@ variables:
 stages:
   - build
   - trigger
-  - validate
   - release
+  - validate
   - notify
 
 cache: &slack-cache


### PR DESCRIPTION
### What does this PR do?
Changes order of gitlab stages so releases off of the release branch are not blocked by agent build and logs validation

### Motivation
Release PRs never change log assets or the agent requirements file so this should have no effect besides not blocking releases off of the release branch when the agent pipeline runs when it shouldn't
 
### Additional Notes
Alternative ideas: 
- Create a new stage and put jobs that are independent of each other all in one stage so they run at once
- Keep the same ordering of stages but set `allow_failure` to true on validate-agent-build so it still runs before release but doesn't block it
- add a `needs: []` clause to release_manual so that it is not blocked by other stages

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
