### PR TITLE
Move config fetching to init and add types

### DIFF
--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -4,7 +4,7 @@
 
 from __future__ import unicode_literals
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
 import dns.resolver
 
@@ -44,7 +44,7 @@ class DNSCheck(AgentCheck):
             self.base_tags.append('resolved_as:{}'.format(resolved_as))
 
     def _get_resolver(self):
-        # type: () -> (dns.resolver.Resolver, str)
+        # type: () -> dns.resolver.Resolver
         # Fetches the conf and creates a resolver accordingly
         resolver = dns.resolver.Resolver()  # type: dns.resolver.Resolver
 
@@ -75,9 +75,9 @@ class DNSCheck(AgentCheck):
                 else:
                     raise AssertionError("Expected an NXDOMAIN, got a result.")
             else:
-                answer = resolver.query(self.hostname, rdtype=self.record_type)
+                answer = resolver.query(self.hostname, rdtype=self.record_type)  # dns.resolver.Answer
                 assert answer.rrset.items[0].to_text()
-                if self.resolves_as:
+                if self.resolves_as_ips:
                     self._check_answer(answer)
 
             response_time = get_precise_time() - t0
@@ -98,7 +98,7 @@ class DNSCheck(AgentCheck):
             self.report_as_service_check(AgentCheck.OK)
 
     def _check_answer(self, answer):
-        # type: (Any, str) -> None
+        # type: (dns.resolver.Answer) -> None
         number_of_results = len(answer.rrset.items)
 
         assert len(self.resolves_as_ips) == number_of_results

--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -4,6 +4,8 @@
 
 from __future__ import unicode_literals
 
+from typing import Any, List, Optional
+
 import dns.resolver
 
 from datadog_checks.base import AgentCheck, ConfigurationError
@@ -19,77 +21,87 @@ class DNSCheck(AgentCheck):
         inst.setdefault("name", "dns-check-0")
 
         super(DNSCheck, self).__init__(name, init_config, instances)
-
-        self.default_timeout = init_config.get('default_timeout', self.DEFAULT_TIMEOUT)
-
-    def _load_conf(self):
-        # Fetches the conf
-        hostname = self.instance.get('hostname')
-        if not hostname:
+        self.hostname = self.instance.get('hostname')  # type: str
+        if not self.hostname:
             raise ConfigurationError('A valid "hostname" must be specified')
+        self.nameserver = self.instance.get('nameserver')  # type: Optional[str]
+        self.timeout = float(
+            self.instance.get('timeout', init_config.get('default_timeout', self.DEFAULT_TIMEOUT))
+        )  # type: float
 
-        resolver = dns.resolver.Resolver()
+        self.record_type = self.instance.get('record_type', 'A')  # type: str
+        resolved_as = self.instance.get('resolves_as', '')
+        if resolved_as and self.record_type not in ['A', 'CNAME', 'MX']:
+            raise ConfigurationError('"resolves_as" can currently only support A, CNAME and MX records')
+        self.resolves_as_ips = [x.strip().lower() for x in resolved_as.split(',')]  # type: List[str]
+
+        self.base_tags = self.instance.get('tags', []) + [
+            'resolved_hostname:{}'.format(self.hostname),
+            'instance:{}'.format(self.instance.get('name', self.hostname)),
+            'record_type:{}'.format(self.record_type),
+        ]
+        if resolved_as:
+            self.base_tags.append('resolved_as:{}'.format(resolved_as))
+
+    def _get_resolver(self):
+        # type: () -> (dns.resolver.Resolver, str)
+        # Fetches the conf and creates a resolver accordingly
+        resolver = dns.resolver.Resolver()  # type: dns.resolver.Resolver
 
         # If a specific DNS server was defined use it, else use the system default
-        nameserver = self.instance.get('nameserver')
-        nameserver_port = self.instance.get('nameserver_port')
-        if nameserver is not None:
-            resolver.nameservers = [nameserver]
+        nameserver_port = self.instance.get('nameserver_port')  # type: Optional[int]
+        if self.nameserver is not None:
+            resolver.nameservers = [self.nameserver]
         if nameserver_port is not None:
             resolver.port = nameserver_port
 
-        timeout = float(self.instance.get('timeout', self.default_timeout))
-        resolver.lifetime = timeout
-        record_type = self.instance.get('record_type', 'A')
-        resolves_as = self.instance.get('resolves_as', None)
-        if resolves_as and record_type not in ['A', 'CNAME', 'MX']:
-            raise ConfigurationError('"resolves_as" can currently only support A, CNAME and MX records')
+        resolver.lifetime = self.timeout
 
-        return hostname, timeout, nameserver, record_type, resolver, resolves_as
+        return resolver
 
     def check(self, _):
-        hostname, timeout, nameserver, record_type, resolver, resolves_as = self._load_conf()
+        resolver = self._get_resolver()
 
         # Perform the DNS query, and report its duration as a gauge
         t0 = get_precise_time()
 
         try:
-            self.log.debug('Querying "%s" record for hostname "%s"...', record_type, hostname)
-            if record_type == "NXDOMAIN":
+            self.log.debug('Querying "%s" record for hostname "%s"...', self.record_type, self.hostname)
+            if self.record_type == "NXDOMAIN":
                 try:
-                    resolver.query(hostname)
+                    resolver.query(self.hostname)
                 except dns.resolver.NXDOMAIN:
                     pass
                 else:
                     raise AssertionError("Expected an NXDOMAIN, got a result.")
             else:
-                answer = resolver.query(hostname, rdtype=record_type)
+                answer = resolver.query(self.hostname, rdtype=self.record_type)
                 assert answer.rrset.items[0].to_text()
-                if resolves_as:
-                    self._check_answer(answer, resolves_as)
+                if self.resolves_as:
+                    self._check_answer(answer)
 
             response_time = get_precise_time() - t0
 
         except dns.exception.Timeout:
-            self.log.error('DNS resolution of %s timed out', hostname)
-            self.report_as_service_check(AgentCheck.CRITICAL, 'DNS resolution of {} timed out'.format(hostname))
+            self.log.error('DNS resolution of %s timed out', self.hostname)
+            self.report_as_service_check(AgentCheck.CRITICAL, 'DNS resolution of {} timed out'.format(self.hostname))
 
         except Exception:
-            self.log.exception('DNS resolution of %s has failed.', hostname)
-            self.report_as_service_check(AgentCheck.CRITICAL, 'DNS resolution of {} has failed'.format(hostname))
+            self.log.exception('DNS resolution of %s has failed.', self.hostname)
+            self.report_as_service_check(AgentCheck.CRITICAL, 'DNS resolution of {} has failed'.format(self.hostname))
 
         else:
             tags = self._get_tags()
             if response_time > 0:
                 self.gauge('dns.response_time', response_time, tags=tags)
-            self.log.debug('Resolved hostname: %s', hostname)
+            self.log.debug('Resolved hostname: %s', self.hostname)
             self.report_as_service_check(AgentCheck.OK)
 
-    def _check_answer(self, answer, resolves_as):
-        ips = [x.strip().lower() for x in resolves_as.split(',')]
+    def _check_answer(self, answer):
+        # type: (Any, str) -> None
         number_of_results = len(answer.rrset.items)
 
-        assert len(ips) == number_of_results
+        assert len(self.resolves_as_ips) == number_of_results
         result_ips = []
         for rip in answer.rrset.items:
             result = rip.to_text().lower()
@@ -97,32 +109,17 @@ class DNSCheck(AgentCheck):
                 result = result[:-1]
             result_ips.append(result)
 
-        for ip in ips:
+        for ip in self.resolves_as_ips:
             assert ip in result_ips
 
     def _get_tags(self):
-        hostname = self.instance.get('hostname')
-        instance_name = self.instance.get('name', hostname)
-        record_type = self.instance.get('record_type', 'A')
-        custom_tags = self.instance.get('tags', [])
-        resolved_as = self.instance.get('resolves_as')
-
         nameserver = ''
         try:
-            nameserver = self.instance.get('nameserver') or dns.resolver.Resolver().nameservers[0]
+            nameserver = self.nameserver or dns.resolver.Resolver().nameservers[0]
         except IndexError:
             self.log.error('No DNS server was found on this host.')
 
-        tags = custom_tags + [
-            'nameserver:{}'.format(nameserver),
-            'resolved_hostname:{}'.format(hostname),
-            'instance:{}'.format(instance_name),
-            'record_type:{}'.format(record_type),
-        ]
-        if resolved_as:
-            tags.append('resolved_as:{}'.format(resolved_as))
-
-        return tags
+        return self.base_tags + ['nameserver:{}'.format(nameserver)]
 
     def report_as_service_check(self, status, msg=None):
         tags = self._get_tags()

--- a/dns_check/datadog_checks/dns_check/dns_check.py
+++ b/dns_check/datadog_checks/dns_check/dns_check.py
@@ -33,7 +33,9 @@ class DNSCheck(AgentCheck):
         resolved_as = self.instance.get('resolves_as', '')
         if resolved_as and self.record_type not in ['A', 'CNAME', 'MX']:
             raise ConfigurationError('"resolves_as" can currently only support A, CNAME and MX records')
-        self.resolves_as_ips = [x.strip().lower() for x in resolved_as.split(',')]  # type: List[str]
+        self.resolves_as_ips = (
+            [x.strip().lower() for x in resolved_as.split(',')] if resolved_as else []
+        )  # type: List[str]
 
         self.base_tags = self.instance.get('tags', []) + [
             'resolved_hostname:{}'.format(self.hostname),

--- a/dns_check/tox.ini
+++ b/dns_check/tox.ini
@@ -12,6 +12,12 @@ envdir =
 description=
     py{27,38}: e2e ready
 dd_check_style = true
+dd_check_types = true
+dd_mypy_args =
+    --py2
+    --follow-imports silent
+    datadog_checks/dns_check
+    --exclude '.*/config_models/.*\.py$'
 usedevelop = true
 platform = linux|darwin|win32
 deps =


### PR DESCRIPTION
* Config is fetched and stored in init rather than on each check run
* All non dynamic tags are calculated on init rather than on each check run
* _load_conf has been replaced with _get_resolver, it still runs on each check run
* Added some types