### PR TITLE
Remove expected metric

### DIFF
--- a/hdfs_datanode/tests/common.py
+++ b/hdfs_datanode/tests/common.py
@@ -33,7 +33,7 @@ EXPECTED_METRICS = [
     'hdfs.datanode.num_blocks_cached',
     'hdfs.datanode.num_failed_volumes',
     'hdfs.datanode.num_blocks_failed_to_cache',
-    'hdfs.datanode.num_blocks_failed_to_uncache',
+    # 'hdfs.datanode.num_blocks_failed_to_uncache', metric is flakey in 3.1.3
 ]
 
 HDFS_DATANODE_CONFIG = {'instances': [{'hdfs_datanode_jmx_uri': DATANODE_URI, 'tags': list(CUSTOM_TAGS)}]}


### PR DESCRIPTION
### What does this PR do?
It appears that `hdfs.datanode.num_blocks_failed_to_uncache` is flakey in version 3.1.3, ignoring it for now 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
