### PR TITLE
Fix a race in a test for running async jobs

### DIFF
--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -140,7 +140,7 @@ def test_dbm_async_job_run_sync(aggregator):
 def test_dbm_async_job_rate_limit(aggregator):
     # test the main collection loop rate limit
     rate_limit = 10
-    sleep_time = 1
+    sleep_time = 0.9  # just below what the rate limit should hit to buffer before cancelling the loop
 
     job = TestJob(AgentCheck(), rate_limit=rate_limit)
     job.run_job_loop([])


### PR DESCRIPTION
### What does this PR do?

Fixes a rare race condition in running the async job loop rate limiter. I believe what's happening is that because there is no wait in the run_job function, there is one extra execution of the job slipping in after the 1s wait period before the call to cancel the job.

As long as the test job continues to have no waits, this should still be a valid test with deterministic results.

```
________________________ test_dbm_async_job_rate_limit _________________________
tests/base/utils/db/test_util.py:153: in test_dbm_async_job_rate_limit
    assert max_collections / 2.0 <= len(metrics) <= max_collections
E   AssertionError: assert 12 <= 11
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
