### PR TITLE
feat: add kube_apiserver.etcd.db.total_size metric

### DIFF
--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -17,6 +17,7 @@ METRICS = {
     'APIServiceRegistrationController_depth': 'APIServiceRegistrationController_depth',
     'etcd_object_counts': 'etcd_object_counts',
     'etcd_request_duration_seconds': 'etcd_request_duration_seconds',
+    'etcd_db_total_size_in_bytes': 'etcd.db.total_size',
     'apiserver_registered_watchers': 'registered_watchers',
     'apiserver_request_duration_seconds': 'request_duration_seconds',
     'apiserver_request_latencies': 'request_latencies',

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -95,7 +95,7 @@ class KubeAPIServerMetricsCheck(OpenMetricsBaseCheck):
 
     def check(self, instance):
         if self.kube_apiserver_config is None:
-            self.kube_apiserver_config = self.get_scraper_config(instance)
+            self.kube_apiserver_config = self.get_scraper_config(self.instance)
 
         if not self.kube_apiserver_config['metrics_mapper']:
             url = self.kube_apiserver_config['prometheus_url']

--- a/kube_apiserver_metrics/metadata.csv
+++ b/kube_apiserver_metrics/metadata.csv
@@ -6,6 +6,7 @@ kube_apiserver.go_threads,gauge,,thread,,Number of OS threads created,0, kube_ap
 kube_apiserver.go_goroutines,gauge,,,,Number of goroutines that currently exist,0, kube_apiserver, go routines
 kube_apiserver.APIServiceRegistrationController_depth,gauge,,,,Current depth of workqueue: APIServiceRegistrationController,0, kube_apiserver, service registration controller depth
 kube_apiserver.etcd_object_counts,gauge,,object,,Number of stored objects at the time of last check split by kind,0, kube_apiserver, etcd object counts
+kube_apiserver.etcd.db.total_size,gauge,,byte,,The total size of the etcd database file physically allocated in bytes (Only present from Kubernetes 1.19; this metric can be removed in a future Kubernetes version since it is still in alpha),0, kube_apiserver, etcd db total size
 kube_apiserver.rest_client_requests_total,gauge,,request,,Accumulated number of HTTP requests partitioned by status code method and host,1, kube_apiserver, accumulated rest client requests
 kube_apiserver.apiserver_request_count,gauge,,request,,Accumulated number of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (deprecated since kubernetes 1.15),1, kube_apiserver, accumulated number of requests
 kube_apiserver.apiserver_dropped_requests_total,gauge,,request,,Accumulated number of requests dropped with 'Try again later' response,1, kube_apiserver, accumulated number of dropped requests

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_19.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_19.py
@@ -47,6 +47,7 @@ class TestKubeAPIServerMetrics:
         NAMESPACE + '.go_threads',
         NAMESPACE + '.go_goroutines',
         NAMESPACE + '.etcd_object_counts',
+        NAMESPACE + '.etcd.db.total_size',
         NAMESPACE + '.rest_client_requests_total',
         NAMESPACE + '.authenticated_user_requests',
         NAMESPACE + '.apiserver_request_total',


### PR DESCRIPTION
### What does this PR do?

the `kube_apiserver.etcd.db.total_size` metric is a gauge representing
the total size of the etcd database file physically allocated in bytes.

Refs: #10472

### Motivation

Implement the feature request: #10472

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
