### PR TITLE
Add to Mysql additional vars about status and variables

### DIFF
--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -25,6 +25,8 @@ class MySQLConfig(object):
             self.tags.append("channel:{0}".format(replication_channel))
         self.queries = instance.get('queries', [])
         self.ssl = instance.get('ssl', {})
+        self.additional_status = instance.get('additional_status', {})
+        self.additional_variable = instance.get('additional_variable', {})
         self.connect_timeout = instance.get('connect_timeout', 10)
         self.max_custom_queries = instance.get('max_custom_queries', DEFAULT_MAX_CUSTOM_QUERIES)
         self.charset = instance.get('charset')

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -96,6 +96,14 @@ def instance_ssl(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_additional_status(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_additional_variable(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tags(field, value):
     return get_default_field_value(field, value)
 

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -81,6 +81,24 @@ class Ssl(BaseModel):
     key: Optional[str]
 
 
+class AdditionalStatus(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    name: Optional[str]
+    metric_name: Optional[str]
+    type: Optional[str]
+
+
+class AdditionalVariable(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    name: Optional[str]
+    metric_name: Optional[str]
+    type: Optional[str]
+
+
 class InstanceConfig(BaseModel):
     class Config:
         allow_mutation = False
@@ -106,6 +124,8 @@ class InstanceConfig(BaseModel):
     service: Optional[str]
     sock: Optional[str]
     ssl: Optional[Ssl]
+    additional_status: Optional[Sequence[AdditionalStatus]]
+    additional_variable: Optional[Sequence[AdditionalVariable]]
     tags: Optional[Sequence[str]]
     use_global_custom_queries: Optional[str]
     username: Optional[str]

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -83,6 +83,30 @@ instances:
     #   cert: <CERT_FILE_PATH>
     #   ca: <CA_PATH_FILE>
 
+    ## @param additional_status - list of mappings
+    ## Set this parameter to collect mysql status exclude STATUS_VARS and OPTIONAL_STATUS_VARS of const
+    ##
+    ## name : mysql status name on "SHOW GLOBAL STATUS"
+    ## metric : datadog metric name
+    ## type : gauge | rate | count | ...
+    #
+    # additional_status:
+    #   - name: innodb_rows_read
+    #     metric_name: mysql.innodb.rows_read
+    #     type: rate
+
+    ## @param additional_variable - list of mappings
+    ## Set this parameter to collect mysql variable exclude VARIABLES_VARS and another VARS of const
+    ##
+    ## name : mysql variable name on "SHOW GLOBAL VARIABLES"
+    ## metric : datadog metric name
+    ## type : gauge | rate | count | ...
+    #
+    # additional_variable:
+    #   - name: long_query_time
+    #     metric_name: mysql.performance.long_query_time
+    #     type: gauge
+
     ## @param only_custom_queries - boolean - optional - default: false
     ## Set this parameter to `true` if you want to skip the integration's default metrics collection.
     ## Only metrics specified in `custom_queries` will be collected.

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -322,6 +322,18 @@ class MySql(AgentCheck):
             metrics.update(replication_metrics)
             self._check_replication_status(results)
 
+        if len(self._config.additional_status) > 0:
+            additional_status_dict = {}
+            for status_dict in self._config.additional_status:
+                additional_status_dict[status_dict["name"]] = (status_dict["metric_name"], status_dict["type"])
+            metrics.update(additional_status_dict)
+
+        if len(self._config.additional_variable) > 0:
+            additional_variable_dict = {}
+            for variable_dict in self._config.additional_variable:
+                additional_variable_dict[variable_dict["name"]] = (variable_dict["metric_name"], variable_dict["type"])
+            metrics.update(additional_variable_dict)
+
         # "synthetic" metrics
         metrics.update(SYNTHETIC_VARS)
         self._compute_synthetic_results(results)

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -118,6 +118,54 @@ def instance_complex():
 
 
 @pytest.fixture
+def instance_additional_status():
+    return {
+        'host': common.HOST,
+        'user': common.USER,
+        'pass': common.PASS,
+        'port': common.PORT,
+        'tags': tags.METRIC_TAGS,
+        'disable_generic_tags': 'true',
+        'additional_status': [
+            {
+                'name': "innodb_rows_read",
+                'metric_name': "mysql.innodb.rows_read",
+                'type': "rate",
+            },
+            {
+                'name': "row_lock_time",
+                'metric_name': "mysql.innodb.row_lock_time",
+                'type': "rate",
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def instance_additional_variable():
+    return {
+        'host': common.HOST,
+        'user': common.USER,
+        'pass': common.PASS,
+        'port': common.PORT,
+        'tags': tags.METRIC_TAGS,
+        'disable_generic_tags': 'true',
+        'additional_status': [
+            {
+                'name': "long_query_time",
+                'metric_name': "mysql.performance.long_query_time",
+                'type': "gauge",
+            },
+            {
+                'name': "innodb_flush_log_at_trx_commit",
+                'metric_name': "mysql.performance.innodb_flush_log_at_trx_commit",
+                'type': "gauge",
+            },
+        ],
+    }
+
+
+@pytest.fixture
 def instance_custom_queries():
     return {
         'host': common.HOST,

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -294,3 +294,23 @@ def test_custom_queries(aggregator, instance_custom_queries, dd_run_check):
 
     aggregator.assert_metric('alice.age', value=25, tags=tags.METRIC_TAGS)
     aggregator.assert_metric('bob.age', value=20, tags=tags.METRIC_TAGS)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_additional_status(aggregator, dd_run_check, instance_additional_status):
+    mysql_check = MySql(common.CHECK_NAME, {}, [instance_additional_status])
+    dd_run_check(mysql_check)
+
+    aggregator.assert_metric('mysql.innodb.rows_read', metric_type=1, tags=tags.METRIC_TAGS)
+    aggregator.assert_metric('mysql.innodb.row_lock_time', metric_type=1, tags=tags.METRIC_TAGS)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_additional_variable(aggregator, dd_run_check, instance_additional_variable):
+    mysql_check = MySql(common.CHECK_NAME, {}, [instance_additional_variable])
+    dd_run_check(mysql_check)
+
+    aggregator.assert_metric('mysql.performance.long_query_time', metric_type=0, tags=tags.METRIC_TAGS)
+    aggregator.assert_metric('mysql.performance.innodb_flush_log_at_trx_commit', metric_type=0, tags=tags.METRIC_TAGS)


### PR DESCRIPTION
### What does this PR do?
Sometimes the result of "SHOW VARIABLE" or "SHOW STATUS" is not in const. 
Since using a custom query is considered an unnecessary process, we are going to send the result value using yaml as needed.

### Motivation
As i am monitoring, i need to collect more parameters.

### Review checklist (to be filled by reviewers)

- [v] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [v] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [v] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [v] PR must have `changelog/` and `integration/` labels attached
