### PR TITLE
Add optional assertion and assert all metrics

### DIFF
--- a/hdfs_datanode/tests/common.py
+++ b/hdfs_datanode/tests/common.py
@@ -22,6 +22,8 @@ INSTANCE_INTEGRATION = {"hdfs_datanode_jmx_uri": "http://{}:9864".format(HOST)}
 HDFS_RAW_VERSION = os.environ.get('HDFS_RAW_VERSION')
 HDFS_IMAGE_TAG = os.environ.get('HDFS_IMAGE_TAG')
 
+OPTIONAL_METRICS = ['hdfs.datanode.num_blocks_failed_to_uncache']
+
 EXPECTED_METRICS = [
     'hdfs.datanode.dfs_remaining',
     'hdfs.datanode.dfs_capacity',
@@ -33,7 +35,6 @@ EXPECTED_METRICS = [
     'hdfs.datanode.num_blocks_cached',
     'hdfs.datanode.num_failed_volumes',
     'hdfs.datanode.num_blocks_failed_to_cache',
-    # 'hdfs.datanode.num_blocks_failed_to_uncache', metric is flakey in 3.1.3
 ]
 
 HDFS_DATANODE_CONFIG = {'instances': [{'hdfs_datanode_jmx_uri': DATANODE_URI, 'tags': list(CUSTOM_TAGS)}]}

--- a/hdfs_datanode/tests/test_integration.py
+++ b/hdfs_datanode/tests/test_integration.py
@@ -4,6 +4,8 @@
 import mock
 import pytest
 
+from datadog_checks.dev.utils import get_metadata_metrics
+
 from . import common
 
 pytestmark = pytest.mark.integration
@@ -18,6 +20,10 @@ def test_check(aggregator, check, dd_run_check, instance):
 
     for metric in common.EXPECTED_METRICS:
         aggregator.assert_metric(metric)
+    for metric in common.OPTIONAL_METRICS:
+        aggregator.assert_metric(metric, at_least=0)
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 @pytest.mark.usefixtures("dd_environment")


### PR DESCRIPTION
It is better to optionally assert than to ignore because that way when the metric is present we can ensure it has the right type and it let us assert that all metrics are present in metadata