### PR TITLE
fix autodiscovery typos

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -270,9 +270,9 @@ kind: Pod
 metadata:
   name: mysql
   annotations:
-    ad.datadoghq.com/nginx.check_names: '["mysql"]'
-    ad.datadoghq.com/nginx.init_configs: '[{}]'
-    ad.datadoghq.com/nginx.instances: |
+    ad.datadoghq.com/mysql.check_names: '["mysql"]'
+    ad.datadoghq.com/mysql.init_configs: '[{}]'
+    ad.datadoghq.com/mysql.instances: |
       [
         {
           "server": "%%host%%", 


### PR DESCRIPTION
### What does this PR do?
Autodiscovery example included "nginx" instead of "mysql" in the annotations. This is a quick fix to those typos.  

### Motivation
Annotations as they currently exist will not allow someone to enable the integration successfully. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
