### PR TITLE
Set is_public to true in the IBM i check metadata

### DIFF
--- a/ibm_i/manifest.json
+++ b/ibm_i/manifest.json
@@ -19,7 +19,7 @@
     "os & system"
   ],
   "type": "check",
-  "is_public": false,
+  "is_public": true,
   "integration_id": "ibm-i",
   "assets": {
     "configuration": {


### PR DESCRIPTION
### What does this PR do?
Updates the ibm_i check metadata so documentation is made public.

### Motivation
Doing this ahead of the 7.32 release, which is the first one to include this check.
