### PR TITLE
Add attempts to SQLServer docker run

### DIFF
--- a/harbor/tests/conftest.py
+++ b/harbor/tests/conftest.py
@@ -58,7 +58,7 @@ def dd_environment(e2e_instance):
         lambda: time.sleep(4),
         CreateSimpleUser(),
     ]
-    with docker_run(compose_file, conditions=conditions):
+    with docker_run(compose_file, conditions=conditions, attempts=2):
         yield e2e_instance
 
 

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -166,5 +166,5 @@ def dd_environment():
             )
         ]
 
-    with docker_run(compose_file=compose_file, conditions=conditions, mount_logs=True, build=True):
+    with docker_run(compose_file=compose_file, conditions=conditions, mount_logs=True, build=True, attempts=2):
         yield FULL_E2E_CONFIG


### PR DESCRIPTION
SQL Server failed on docker-compose
```
________________ ERROR at setup of test_async_job_cancel_cancel ________________
tests/conftest.py:169: in dd_environment
    with docker_run(compose_file=compose_file, conditions=conditions, mount_logs=True, build=True):
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/contextlib.py:113: in __enter__
    return next(self.gen)
../datadog_checks_dev/datadog_checks/dev/docker.py:217: in docker_run
    with environment_run(
/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/contextlib.py:113: in __enter__
    return next(self.gen)
../datadog_checks_dev/datadog_checks/dev/env.py:73: in environment_run
    condition()
../datadog_checks_dev/datadog_checks/dev/conditions.py:159: in __call__
    raise RetryError(
E   datadog_checks.dev.errors.RetryError: Command: ['docker-compose', '-f', '/home/vsts/work/1/s/sqlserver/tests/compose-ha/docker-compose.yaml', 'logs']
E   Failed to match `1` of following patterns:
E   	- re.compile('Always On Availability Groups connection with primary database established for secondary database', re.MULTILINE)
E   Exit code: 0
```
There are errors on the docker log
```
E   aoag_secondary | 
2021-11-09 10:09:59.84 spid41s     Error: 1205, Severity: 13, State: 55.

E   aoag_secondary | 
2021-11-09 10:09:59.84 spid41s     Transaction (Process ID 41) was deadlocked on lock resources with another process and has been chosen as the deadlock victim. Rerun the transaction.

E   aoag_secondary | 
2021-11-09 10:09:59.85 spid41s     The default language (LCID 0) failed to be set for engine and full-text services.

E   aoag_secondary | 
2021-11-09 10:09:59.85 spid41s     An error occurred during server setup. See previous errors for more information.

E   aoag_secondary | 
2021-11-09 10:09:59.86 spid41s     SQL Trace was stopped due to server shutdown. Trace ID = '1'. This is an informational message only; no user action is required.
```


Harbor failed with:
```
ERROR: for harbor-db  UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)

ERROR: for redis  UnixHTTPConnectionPool(host='localhost', port=None): Read timed out. (read timeout=60)
An HTTP request took too long to complete. Retry with --verbose to obtain debug information.
If you encounter this issue regularly because of slow network conditions, consider setting COMPOSE_HTTP_TIMEOUT to a higher value (current value: 60).
```