### PR TITLE
Pin tested clickhouse 21 version

### DIFF
--- a/clickhouse/tests/test_clickhouse.py
+++ b/clickhouse/tests/test_clickhouse.py
@@ -104,4 +104,6 @@ def test_version_metadata(instance, datadog_agent, dd_run_check):
     check.check_id = 'test:123'
     dd_run_check(check)
 
-    datadog_agent.assert_metadata('test:123', {'version.scheme': 'calver', 'version.year': CLICKHOUSE_VERSION})
+    datadog_agent.assert_metadata(
+        'test:123', {'version.scheme': 'calver', 'version.year': CLICKHOUSE_VERSION.split(".")[0]}
+    )

--- a/clickhouse/tox.ini
+++ b/clickhouse/tox.ini
@@ -26,7 +26,7 @@ setenv =
     18: CLICKHOUSE_VERSION=18
     19: CLICKHOUSE_VERSION=19
     20: CLICKHOUSE_VERSION=20
-    21: CLICKHOUSE_VERSION=21.8
+    21.8: CLICKHOUSE_VERSION=21.8
 commands =
     pip install -r requirements.in
     pytest -v {posargs}

--- a/clickhouse/tox.ini
+++ b/clickhouse/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py{27,38}-{18,19,20,21}
+    py{27,38}-{18,19,20,21.8}
 
 [testenv]
 ensure_default_envdir = true

--- a/clickhouse/tox.ini
+++ b/clickhouse/tox.ini
@@ -26,7 +26,7 @@ setenv =
     18: CLICKHOUSE_VERSION=18
     19: CLICKHOUSE_VERSION=19
     20: CLICKHOUSE_VERSION=20
-    21: CLICKHOUSE_VERSION=21
+    21: CLICKHOUSE_VERSION=21.8
 commands =
     pip install -r requirements.in
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?
A new version of clickhouse was released that introduced a flakey metric: https://github.com/ClickHouse/ClickHouse/releases/tag/v21.11.2.2-stable

The `latest` image is also currently the same as `21`, so testing the `21` is unnecessary.

### Motivation
We want to test a stable version for now, and investigate the differences of the new version later.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
