### PR TITLE
Fix location of config

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/config.py
@@ -11,7 +11,7 @@ from platformdirs import user_data_dir
 
 from ..fs import ensure_parent_dir_exists, file_exists, read_file
 
-APP_DIR = user_data_dir('dd-checks-dev', '')
+APP_DIR = user_data_dir('dd-checks-dev', False)
 CONFIG_FILE = os.path.join(APP_DIR, 'config.toml')
 
 SECRET_KEYS = {


### PR DESCRIPTION
### Motivation

Newer versions require explicit `False` https://github.com/platformdirs/platformdirs/blob/7b7852128dd6f07511b618d6edea35046bd0c6ff/src/platformdirs/windows.py#L33

```pycon
>>> from platformdirs import user_data_dir
>>>
>>> user_data_dir('dd-checks-dev', '')
'C:\\Users\\ofek\\AppData\\Local\\dd-checks-dev\\dd-checks-dev'
>>> user_data_dir('dd-checks-dev', False)
'C:\\Users\\ofek\\AppData\\Local\\dd-checks-dev'
```