### PR TITLE
fix sqlserver resolved_hostname by handling comma correctly

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -133,7 +133,7 @@ class SQLServer(AgentCheck):
         """
         if not host:
             return host, None
-        host_split = host.split(',')
+        host_split = [s.strip() for s in host.split(',')]
         if len(host_split) == 1:
             return host_split[0], None
         if len(host_split) == 2:

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -323,6 +323,7 @@ def test_check_windows_defaults(aggregator, dd_run_check, init_config, instance_
     "instance_host,split_host,split_port",
     [
         ("localhost,1433,some-typo", "localhost", "1433"),
+        ("localhost, 1433,some-typo", "localhost", "1433"),
         ("localhost,1433", "localhost", "1433"),
         ("localhost", "localhost", None),
     ],

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -314,3 +314,46 @@ def test_check_windows_defaults(aggregator, dd_run_check, init_config, instance_
 
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK)
     aggregator.assert_all_metrics_covered()
+
+
+@not_windows_ci
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize(
+    "instance_host,split_host,split_port",
+    [
+        ("localhost,1433,some-typo", "localhost", "1433"),
+        ("localhost,1433", "localhost", "1433"),
+        ("localhost", "localhost", None),
+    ],
+)
+def test_split_sqlserver_host(instance_docker, instance_host, split_host, split_port):
+    sqlserver_check = SQLServer(CHECK_NAME, {}, [instance_docker])
+    s_host, s_port = sqlserver_check.split_sqlserver_host_port(instance_host)
+    assert (s_host, s_port) == (split_host, split_port)
+
+
+@not_windows_ci
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize("dbm_enabled,", [True, False])
+@pytest.mark.parametrize(
+    "instance_host,resolved_hostname",
+    [
+        ("localhost,1433,some-typo", "stubbed.hostname"),
+        ("localhost,1433", "stubbed.hostname"),
+        ("localhost", "stubbed.hostname"),
+        ("datadoghq.com,1433", "datadoghq.com"),
+        ("datadoghq.com", "datadoghq.com"),
+        ("8.8.8.8,1433", "8.8.8.8"),
+        ("8.8.8.8", "8.8.8.8"),
+    ],
+)
+def test_resolved_hostname(instance_docker, dbm_enabled, instance_host, resolved_hostname):
+    instance_docker['dbm'] = dbm_enabled
+    instance_docker['host'] = instance_host
+    sqlserver_check = SQLServer(CHECK_NAME, {}, [instance_docker])
+    if dbm_enabled:
+        assert sqlserver_check.resolved_hostname == resolved_hostname
+    else:
+        assert sqlserver_check.resolved_hostname == "stubbed.hostname"


### PR DESCRIPTION
### What does this PR do?

Fixes the incorrect `resolved_hostname` which was falling back to the agent hostname due to failed DNS resolution when using SQL Server DBM. Now it correctly parses out the host when the host connection has the `{host},{port}` connection format.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
