### PR TITLE
Pin mypy types-PyMySQL to 1.0.4

### DIFF
--- a/mysql/tox.ini
+++ b/mysql/tox.ini
@@ -22,6 +22,7 @@ dd_mypy_args =
     datadog_checks/mysql/statements.py
 dd_mypy_deps =
     types-cachetools==0.1.10
+    types-PyMySQL==1.0.4
 usedevelop = true
 platform = linux|darwin|win32
 passenv =

--- a/singlestore/tox.ini
+++ b/singlestore/tox.ini
@@ -22,6 +22,8 @@ dd_mypy_args =
     --install-types
     --non-interactive
     datadog_checks/singlestore
+dd_mypy_deps =
+    types-PyMySQL==1.0.4
 usedevelop = true
 platform = linux|darwin|win32
 deps =


### PR DESCRIPTION
### What does this PR do?
Pin mypy `types-PyMySQL` to 1.0.4 because the latest v1.0.5 release was breaking py27 style checks for singlestore and mysql

### Motivation
Broken CI

### Additional Notes
`types-PyMySQL` v1.0.5 dropped support for python 2: https://github.com/python/typeshed/pull/6267/files#diff-8c6a665db0a06e7c5108bc93201f557aeb15ea7ef0819569bf445e4ed36cf803L2

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
