### PR TITLE
Set log level to debug for memstats

### DIFF
--- a/go_expvar/datadog_checks/go_expvar/go_expvar.py
+++ b/go_expvar/datadog_checks/go_expvar/go_expvar.py
@@ -171,13 +171,11 @@ class GoExpvar(AgentCheck):
                     float(value)
                 except (TypeError, ValueError):
                     if isinstance(value, dict):
-                        self.log.warning(
-                            "Path %s is a mapping; specify a more specific path to report a value: %s",
-                            actual_path,
-                            value,
+                        self.log.debug(
+                            "Path %s is a mapping; specify a more specific path to report a value", actual_path
                         )
                     else:
-                        self.log.warning("Unreportable value for path %s: %s", actual_path, value)
+                        self.log.debug("Unreportable value for path %s: %s", actual_path, value)
                     continue
 
                 if count >= max_metrics:

--- a/go_expvar/datadog_checks/go_expvar/go_expvar.py
+++ b/go_expvar/datadog_checks/go_expvar/go_expvar.py
@@ -179,7 +179,7 @@ class GoExpvar(AgentCheck):
                             )
                         else:
                             self.log.warning(
-                                "Path %s is a mapping; specify a more specific path to report a value", actual_path
+                                "Path cannot be a mapping or array ; specify a more specific path to report a value", actual_path
                             )
                     else:
                         self.log.warning("Unreportable value for path %s: %s", actual_path, value)

--- a/go_expvar/datadog_checks/go_expvar/go_expvar.py
+++ b/go_expvar/datadog_checks/go_expvar/go_expvar.py
@@ -23,7 +23,7 @@ COUNT = "count"
 COUNTER = "counter"  # Deprecated
 MONOTONIC_COUNTER = "monotonic_counter"
 DEFAULT_TYPE = GAUGE
-
+DEFAULT_MAPPING = "memstats"
 
 SUPPORTED_TYPES = {
     GAUGE: AgentCheck.gauge,
@@ -170,12 +170,19 @@ class GoExpvar(AgentCheck):
                 try:
                     float(value)
                 except (TypeError, ValueError):
-                    if isinstance(value, dict):
-                        self.log.debug(
-                            "Path %s is a mapping; specify a more specific path to report a value", actual_path
-                        )
+                    if isinstance(value, dict) or isinstance(value, list):
+                        if actual_path == DEFAULT_MAPPING:
+                            self.log.debug(
+                                "Skipping configured path %s; most memstats metrics are collected by default."
+                                "Specify a more specific path to report a new value",
+                                actual_path,
+                            )
+                        else:
+                            self.log.warning(
+                                "Path %s is a mapping; specify a more specific path to report a value", actual_path
+                            )
                     else:
-                        self.log.debug("Unreportable value for path %s: %s", actual_path, value)
+                        self.log.warning("Unreportable value for path %s: %s", actual_path, value)
                     continue
 
                 if count >= max_metrics:

--- a/go_expvar/datadog_checks/go_expvar/go_expvar.py
+++ b/go_expvar/datadog_checks/go_expvar/go_expvar.py
@@ -179,7 +179,7 @@ class GoExpvar(AgentCheck):
                             )
                         else:
                             self.log.warning(
-                                "Path cannot be a mapping or array; specify a more specific path to report a value",
+                                "Path %s cannot be a mapping or array; specify a more specific path to report a value",
                                 actual_path,
                             )
                     else:

--- a/go_expvar/datadog_checks/go_expvar/go_expvar.py
+++ b/go_expvar/datadog_checks/go_expvar/go_expvar.py
@@ -179,7 +179,8 @@ class GoExpvar(AgentCheck):
                             )
                         else:
                             self.log.warning(
-                                "Path cannot be a mapping or array ; specify a more specific path to report a value", actual_path
+                                "Path cannot be a mapping or array; specify a more specific path to report a value",
+                                actual_path,
                             )
                     else:
                         self.log.warning("Unreportable value for path %s: %s", actual_path, value)

--- a/go_expvar/tests/test_unit.py
+++ b/go_expvar/tests/test_unit.py
@@ -239,4 +239,4 @@ def test_warn_path_mapping(go_expvar_mock, caplog, check, aggregator):
     }
     check.check(mock_config)
 
-    assert 'Path cannot be a mapping or array; specify a more specific path to report a value' in caplog.text
+    assert 'Path array cannot be a mapping or array; specify a more specific path to report a value' in caplog.text

--- a/go_expvar/tests/test_unit.py
+++ b/go_expvar/tests/test_unit.py
@@ -217,6 +217,7 @@ def test_alias_tag_path(go_expvar_mock, check, aggregator):
 
 @pytest.mark.unit
 def test_warn_with_bad_path(go_expvar_mock, caplog, check, aggregator):
+    caplog.set_level(logging.DEBUG)
     mock_config = {
         "expvar_url": common.URL_WITH_PATH,
         "metrics": [{"path": "memstats"}],

--- a/go_expvar/tests/test_unit.py
+++ b/go_expvar/tests/test_unit.py
@@ -239,4 +239,4 @@ def test_warn_path_mapping(go_expvar_mock, caplog, check, aggregator):
     }
     check.check(mock_config)
 
-    assert 'Path array is a mapping; specify a more specific path to report a value' in caplog.text
+    assert 'Path cannot be a mapping or array; specify a more specific path to report a value' in caplog.text

--- a/go_expvar/tests/test_unit.py
+++ b/go_expvar/tests/test_unit.py
@@ -216,7 +216,7 @@ def test_alias_tag_path(go_expvar_mock, check, aggregator):
 
 
 @pytest.mark.unit
-def test_warn_with_bad_path(go_expvar_mock, caplog, check, aggregator):
+def test_debug_memstats(go_expvar_mock, caplog, check, aggregator):
     caplog.set_level(logging.DEBUG)
     mock_config = {
         "expvar_url": common.URL_WITH_PATH,
@@ -224,4 +224,19 @@ def test_warn_with_bad_path(go_expvar_mock, caplog, check, aggregator):
     }
     check.check(mock_config)
 
-    assert 'Path memstats is a mapping; specify a more specific path to report a value' in caplog.text
+    assert (
+        "Skipping configured path memstats; most memstats metrics are collected by default."
+        "Specify a more specific path to report a new value"
+    ) in caplog.text
+
+
+@pytest.mark.unit
+def test_warn_path_mapping(go_expvar_mock, caplog, check, aggregator):
+    caplog.set_level(logging.WARNING)
+    mock_config = {
+        "expvar_url": common.URL_WITH_PATH,
+        "metrics": [{"path": r"array"}],
+    }
+    check.check(mock_config)
+
+    assert 'Path array is a mapping; specify a more specific path to report a value' in caplog.text


### PR DESCRIPTION
### What does this PR do?
follow up to https://github.com/DataDog/integrations-core/pull/10089/s, sets log level to debug on mappings (`"memstats"`) that are collected by default. Also sends more descriptive warning message for arrays. Future work can include refactoring the check to send debug messages when default paths are specified such as `"memstats/TotalAlloc"`

### Motivation
Lower log level for unnecessary config
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
