### PR TITLE
fix: Add missing metric to datadog_cluster_agent

### DIFF
--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -35,6 +35,7 @@ DEFAULT_METRICS = {
     'rate_limit_queries_period': 'datadog.rate_limit_queries.period',
     'rate_limit_queries_remaining': 'datadog.rate_limit_queries.remaining',
     'rate_limit_queries_reset': 'datadog.rate_limit_queries.reset',
+    'secret_backend__elapsed_ms': 'secret_backend.elapsed',
 }
 
 

--- a/datadog_cluster_agent/metadata.csv
+++ b/datadog_cluster_agent/metadata.csv
@@ -26,6 +26,7 @@ datadog.cluster_agent.external_metrics,gauge,,,,Number of external metrics tagge
 datadog.cluster_agent.external_metrics.datadog_metrics,gauge,,,,"The label valid is true if the DatadogMetric CR is valid, false otherwise",0,datadog_cluster_agent,external metrics datadog metrics
 datadog.cluster_agent.external_metrics.delay_seconds,gauge,,second,,Freshness of the metric evaluated from querying Datadog,0,datadog_cluster_agent,external metrics delay
 datadog.cluster_agent.external_metrics.processed_value,gauge,,,,Value processed from querying Datadog by metric,0,datadog_cluster_agent,external metrics processed
+datadog.cluster_agent.secret_backend.elapsed,gauge,,millisecond,,The elapsed time of secret backend invocation,0,datadog_cluster_agent,secret backend elapsed time duration
 datadog.cluster_agent.go.goroutines,gauge,,,,Number of goroutines that currently exist,0,datadog_cluster_agent,go goroutines
 datadog.cluster_agent.go.memstats.alloc_bytes,gauge,,byte,,Number of bytes allocated and still in use,0,datadog_cluster_agent,go memstats alloc bytes
 datadog.cluster_agent.go.threads,gauge,,thread,,Number of OS threads created,0,datadog_cluster_agent,go threads

--- a/datadog_cluster_agent/tests/fixtures/metrics.txt
+++ b/datadog_cluster_agent/tests/fixtures/metrics.txt
@@ -306,3 +306,6 @@ transactions__success_bytes{domain="https://1-13-1-app.agent.datadoghq.com",endp
 transactions__success_bytes{domain="https://1-13-1-app.agent.datadoghq.com",endpoint="intake"} 5867
 transactions__success_bytes{domain="https://1-13-1-app.agent.datadoghq.com",endpoint="series_v1"} 849
 transactions__success_bytes{domain="https://orchestrator.datadoghq.com",endpoint="orchestrator"} 22668
+# HELP secret_backend__elapsed_ms Elapsed time of secret backend invocation
+# TYPE secret_backend__elapsed_ms gauge
+secret_backend__elapsed_ms{command="/usr/local/bin/secrets",exit_code="0"} 156

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -37,6 +37,7 @@ METRICS = [
     'external_metrics.datadog_metrics',
     'external_metrics.delay_seconds',
     'external_metrics.processed_value',
+    'secret_backend.elapsed',
     'go.goroutines',
     'go.memstats.alloc_bytes',
     'go.threads',


### PR DESCRIPTION
### What does this PR do?

Add missing metric `secret_backend__elapsed_ms -> secret_backend.elapsed` to the `datadog_cluster_agent` check. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
