### PR TITLE
Remove integration style hostname submission validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/integration_style.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/integration_style.py
@@ -10,15 +10,6 @@ from ...testing import process_checks_option
 from ...utils import complete_valid_checks, get_check_files
 from ..console import CONTEXT_SETTINGS, echo_info, echo_warning
 
-HOSTNAME_REGEX = (
-    r"(self.rate|self.gauge|self.monotonic_count|self.service_check|self.count|self.histogram)\(((.|\n)*)hostname="
-)
-
-VALID_HOSTNAME_CHECKS = [
-    "sap_hana",
-    "vsphere",
-]
-
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate check style for python files')
 @click.argument('check', autocompletion=complete_valid_checks, required=False)
@@ -38,10 +29,6 @@ def integration_style(ctx, check, verbose):
         for file in files:
             validate_check_instance(check_name, file, verbose)
 
-            # Some integrations may submit hostname for valid reasons and should not warn on it
-            if check_name not in VALID_HOSTNAME_CHECKS:
-                validate_hostname_submission(check_name, file, verbose)
-
 
 def validate_check_instance(check_name, file, verbose):
     """
@@ -55,20 +42,5 @@ def validate_check_instance(check_name, file, verbose):
                 "The instance argument in the `check()` function is going to be "
                 "deprecated in Agent 8. Please use `self.instance` instead."
             )
-            echo_warning(f"{check_name}: " + message)
-            annotate_warning(file, message)
-
-
-def validate_hostname_submission(check_name, file, verbose):
-    """
-    Warns when hostname parameter is submitted on metric or service check
-    """
-    with open(file, 'r', encoding='utf-8') as f:
-        read_file = f.read()
-        found_match_arg = re.search(HOSTNAME_REGEX, read_file)
-        skip_validation = re.search(r"SKIP_CHECK_VALIDATION", read_file)
-
-        if found_match_arg and verbose and not skip_validation:
-            message = f"Detected `hostname` passed with {found_match_arg.groups()[0]}"
             echo_warning(f"{check_name}: " + message)
             annotate_warning(file, message)


### PR DESCRIPTION
### What does this PR do?
Don't warn on hostname parameter used in service check or metric submission. 

### Motivation
Datadog documentation supports these features so we shouldn't warn against them

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
