### PR TITLE
add internal debug metric for explain error cache length

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -336,6 +336,12 @@ class PostgresStatementSamples(DBMAsyncJob):
             tags=self._tags + self._check._get_debug_tags(),
             hostname=self._check.resolved_hostname,
         )
+        self._check.gauge(
+            "dd.postgres.collect_statement_samples.explain_errors_cache.len",
+            len(self._explain_errors_cache),
+            tags=self._tags + self._check._get_debug_tags(),
+            hostname=self._check.resolved_hostname,
+        )
 
     @staticmethod
     def _to_active_session(row):

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -750,6 +750,7 @@ def test_statement_run_explain_errors(
 
     check.check(dbm_instance)
     _, explain_err_code, err = check.statement_samples._run_explain_safe("datadog_test", query, query, query)
+    check.check(dbm_instance)
 
     assert explain_err_code == expected_explain_err_code
     assert err == expected_err
@@ -758,15 +759,23 @@ def test_statement_run_explain_errors(
         'db:{}'.format(DB_NAME),
         'port:{}'.format(PORT),
         'agent_hostname:stubbed.hostname',
-        expected_err_tag,
     ]
 
     aggregator.assert_metric(
         'dd.postgres.statement_samples.error',
         count=1,
-        tags=expected_tags,
+        tags=expected_tags + [expected_err_tag],
         hostname='stubbed.hostname',
     )
+
+    if expected_explain_err_code == DBExplainError.database_error:
+        aggregator.assert_metric(
+            'dd.postgres.collect_statement_samples.explain_errors_cache.len',
+            value=1,
+            tags=expected_tags,
+            hostname='stubbed.hostname',
+        )
+
 
 
 @pytest.mark.parametrize("dbstrict", [True, False])

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -777,7 +777,6 @@ def test_statement_run_explain_errors(
         )
 
 
-
 @pytest.mark.parametrize("dbstrict", [True, False])
 def test_statement_samples_dbstrict(aggregator, integration_check, dbm_instance, dbstrict):
     dbm_instance["dbstrict"] = dbstrict


### PR DESCRIPTION
### What does this PR do?

Tracking the gauge as an internal debug metric will help in troubleshooting failed explain error rates.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
