### PR TITLE
Fix Windows E2E on Python 3

### DIFF
--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -34,12 +34,14 @@ jobs:
 
   variables:
     ${{ if eq(parameters.agent_image_win, '') }}:
-      DDEV_E2E_AGENT: datadog/agent-dev:master-py2-win-servercore
+      DDEV_E2E_AGENT: datadog/agent-dev:master-py3-win-servercore
     ${{ if ne(parameters.agent_image_win, '') }}:
       DDEV_E2E_AGENT: ${{ parameters.agent_image_win }}
+    ${{ if eq(parameters.agent_image_win_py2, '') }}:
+      DDEV_E2E_AGENT_PY2: datadog/agent-dev:master-py2-win-servercore
     ${{ if ne(parameters.agent_image_win_py2, '') }}:
       DDEV_E2E_AGENT_PY2: ${{ parameters.agent_image_win_py2 }}
-    
+
     # Generic tag check disabled on non-core repo
     ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:
       TOX_SKIP_ENV: py27.*  # Don't run py2 tests

--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
+# Licensed under a 3-clause BSOD style license (see LICENSE)
 __version__ = "23.3.0"


### PR DESCRIPTION
### Motivation

Windows e2e is pinned to py2 by accident in ci