### PR TITLE
[HOLD for after Agent Freeze] Support e2e testing for SNMP Network Devices Metadata

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -487,7 +487,7 @@ class AggregatorStub(object):
             # we are replacing it with `0` if present
             if 'collect_timestamp' in event:
                 event['collect_timestamp'] = 0
-        assert expected_metadata_events == self._network_devices_metadata[event_type]
+        assert expected_events == actual_events
 
     def assert_no_duplicate_all(self):
         """

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -3,12 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division
 
-import itertools
 import json
 import os
 import re
 from collections import OrderedDict, defaultdict
-from copy import deepcopy
 
 from six import iteritems
 
@@ -475,16 +473,6 @@ class AggregatorStub(object):
                         )
 
         assert not errors, "Metadata assertion errors using metadata.csv:" + "\n\t- ".join([''] + sorted(errors))
-
-    def assert_event_platform_events(self, events, event_type, is_json=True):
-        actual_events = self.get_event_platform_events(event_type, parse_json=is_json)
-        expected_events = deepcopy(events)
-        for event in itertools.chain(actual_events, expected_events):
-            # `collect_timestamp` depend on check run time and cannot be asserted reliably,
-            # we are replacing it with `0` if present
-            if 'collect_timestamp' in event:
-                event['collect_timestamp'] = 0
-        assert expected_events == actual_events
 
     def assert_no_duplicate_all(self):
         """

--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -33,6 +33,13 @@ JMX_TO_INAPP_TYPES = {
     #       JMX histogram -> DSD histogram -> multiple in-app metrics (max, median, avg, count)
 }
 
+EVENT_PLATFORM_EVENT_TYPES = [
+    'dbm-samples',
+    'dbm-metrics',
+    'dbm-activity',
+    'network-devices-metadata',
+]
+
 
 def e2e_active():
     return (
@@ -135,14 +142,15 @@ def replay_check_run(agent_collector, stub_aggregator, stub_agent):
                     data.get('device'),
                 )
 
-        network_devices_events = aggregator.get('network-devices-metadata') or []
-        for data in network_devices_events:
-            stub_aggregator.submit_network_devices_metadata_e2e(
-                check_name,
-                check_id,
-                data['UnmarshalledEvent'],
-                data['EventType'],
-            )
+        for ep_event_type in EVENT_PLATFORM_EVENT_TYPES:
+            ep_events = aggregator.get(ep_event_type) or []
+            for event in ep_events:
+                stub_aggregator.submit_event_platform_event(
+                    check_name,
+                    check_id,
+                    json.dumps(event['UnmarshalledEvent']),
+                    event['EventType'],
+                )
 
         for data in aggregator.get('service_checks', []):
             stub_aggregator.submit_service_check(

--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -135,6 +135,15 @@ def replay_check_run(agent_collector, stub_aggregator, stub_agent):
                     data.get('device'),
                 )
 
+        network_devices_events = aggregator.get('network-devices-metadata') or []
+        for data in network_devices_events:
+            stub_aggregator.submit_network_devices_metadata_e2e(
+                check_name,
+                check_id,
+                data['UnmarshalledEvent'],
+                data['EventType'],
+            )
+
         for data in aggregator.get('service_checks', []):
             stub_aggregator.submit_service_check(
                 check_name, check_id, data['check'], data['status'], data['tags'], data['host_name'], data['message']

--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -1,12 +1,23 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+from copy import deepcopy
 
 import pytest
 
 from . import common
 
 pytestmark = [pytest.mark.e2e, common.snmp_integration_only]
+
+
+def assert_network_devices_metadata(aggregator, events):
+    actual_events = aggregator.get_event_platform_events("network-devices-metadata", parse_json=True)
+    for event in actual_events:
+        # `collect_timestamp` depend on check run time and cannot be asserted reliably,
+        # we are replacing it with `0` if present
+        if 'collect_timestamp' in event:
+            event['collect_timestamp'] = 0
+    assert events == actual_events
 
 
 def test_e2e_core_metadata(dd_agent_check):
@@ -114,4 +125,5 @@ def test_e2e_core_metadata(dd_agent_check):
             'subnet': '',
         },
     ]
-    aggregator.assert_event_platform_events(events, "network-devices-metadata")
+    assert_network_devices_metadata(aggregator, events)
+

--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -1,0 +1,117 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+import pytest
+
+from . import common
+
+pytestmark = [pytest.mark.e2e, common.snmp_integration_only]
+
+
+def test_e2e_core_metadata(dd_agent_check):
+    config = common.generate_container_instance_config([])
+    instance = config['instances'][0]
+    instance.update(
+        {
+            'community_string': 'f5-big-ip',
+            'loader': 'core',
+        }
+    )
+
+    aggregator = dd_agent_check(config, rate=False)
+
+    device_ip = instance['ip_address']
+    device_id = 'default:' + device_ip
+
+    events = [
+        {
+            'collect_timestamp': 0,
+            'devices': [
+                {
+                    'description': 'BIG-IP Virtual Edition : Linux '
+                    '3.10.0-862.14.4.el7.ve.x86_64 : BIG-IP software '
+                    'release 15.0.1, build 0.0.11',
+                    'id': device_id,
+                    'id_tags': [
+                        'device_namespace:default',
+                        'snmp_device:' + device_ip,
+                    ],
+                    'ip_address': device_ip,
+                    'name': 'f5-big-ip-adc-good-byol-1-vm.c.datadog-integrations-lab.internal',
+                    'profile': 'f5-big-ip',
+                    'status': 1,
+                    'subnet': '',
+                    'sys_object_id': '1.3.6.1.4.1.3375.2.1.3.4.43',
+                    'tags': [
+                        'device_namespace:default',
+                        'device_vendor:f5',
+                        'snmp_device:' + device_ip,
+                        'snmp_host:f5-big-ip-adc-good-byol-1-vm.c.datadog-integrations-lab.internal',
+                        'snmp_profile:f5-big-ip',
+                    ],
+                    'vendor': 'f5',
+                },
+            ],
+            'interfaces': [
+                {
+                    'admin_status': 1,
+                    'alias': 'desc5',
+                    'description': '/Common/internal',
+                    'device_id': device_id,
+                    'id_tags': ['interface:/Common/internal'],
+                    'index': 112,
+                    'mac_address': '0x42010aa40033',
+                    'name': '/Common/internal',
+                    'oper_status': 1,
+                },
+                {
+                    'admin_status': 1,
+                    'alias': 'desc1',
+                    'description': 'mgmt',
+                    'device_id': device_id,
+                    'id_tags': ['interface:mgmt'],
+                    'index': 32,
+                    'mac_address': '0x42010aa40033',
+                    'name': 'mgmt',
+                    'oper_status': 1,
+                },
+                {
+                    'admin_status': 1,
+                    'alias': 'desc2',
+                    'description': '1.0',
+                    'device_id': device_id,
+                    'id_tags': ['interface:1.0'],
+                    'index': 48,
+                    'mac_address': '0x42010aa40033',
+                    'name': '1.0',
+                    'oper_status': 1,
+                },
+                {
+                    'admin_status': 1,
+                    'alias': 'desc3',
+                    'description': '/Common/http-tunnel',
+                    'device_id': device_id,
+                    'id_tags': ['interface:/Common/http-tunnel'],
+                    'index': 80,
+                    'mac_address': '0x42010aa40034',
+                    'name': '/Common/http-tunnel',
+                    'oper_status': 4,
+                },
+                {
+                    'admin_status': 1,
+                    'alias': 'desc4',
+                    'description': '/Common/socks-tunnel',
+                    'device_id': device_id,
+                    'id_tags': ['interface:/Common/socks-tunnel'],
+                    'index': 96,
+                    'mac_address': '0x42010aa40034',
+                    'name': '/Common/socks-tunnel',
+                    'oper_status': 4,
+                },
+            ],
+            'namespace': 'default',
+            'subnet': '',
+        },
+    ]
+    aggregator.assert_network_devices_metadata(events, "network-devices-metadata")

--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -114,4 +114,4 @@ def test_e2e_core_metadata(dd_agent_check):
             'subnet': '',
         },
     ]
-    aggregator.assert_network_devices_metadata(events, "network-devices-metadata")
+    aggregator.assert_event_platform_events(events, "network-devices-metadata")


### PR DESCRIPTION
### What does this PR do?
Support e2e testing for SNMP - Network Devices Metadata

### Motivation

- Useful for testing SNMP Devices metadata 
- Useful for testing profile based metadata https://github.com/DataDog/datadog-agent/pull/9679

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
