### PR TITLE
Fix config spec options

### DIFF
--- a/aspdotnet/assets/configuration/spec.yaml
+++ b/aspdotnet/assets/configuration/spec.yaml
@@ -7,21 +7,11 @@ files:
       - template: init_config/default
   - template: instances
     options:
-    - name: host
-      description: |
-        ASP .NET host to connect to.
-        Using "." means the current host. Using any other value, the Agent attempts to connect to a remote host.
-        Note: Remote access requires additional permissions
-      required: true
-      value:
-        type: string
-        example: .
-        display_default: null
-    - name: port
-      description: ASP .NET port to connect to.
-      required: true
-      value:
-        type: integer
-        example: 26379
-        display_default: null
+    - template: instances/pdh_legacy
+      overrides:
+        host.enabled: true
+        host.description: |
+          ASP .NET host to connect to.
+          Using "." means the current host. Using any other value, the Agent attempts to connect to a remote host.
+          Note: Remote access requires additional permissions
     - template: instances/default

--- a/aspdotnet/datadog_checks/aspdotnet/config_models/defaults.py
+++ b/aspdotnet/datadog_checks/aspdotnet/config_models/defaults.py
@@ -8,6 +8,14 @@ def shared_service(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_additional_metrics(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_counter_data_types(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_disable_generic_tags(field, value):
     return False
 
@@ -16,8 +24,16 @@ def instance_empty_default_hostname(field, value):
     return False
 
 
+def instance_host(field, value):
+    return '.'
+
+
 def instance_min_collection_interval(field, value):
     return 15
+
+
+def instance_password(field, value):
+    return get_default_field_value(field, value)
 
 
 def instance_service(field, value):
@@ -25,4 +41,8 @@ def instance_service(field, value):
 
 
 def instance_tags(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_username(field, value):
     return get_default_field_value(field, value)

--- a/aspdotnet/datadog_checks/aspdotnet/config_models/instance.py
+++ b/aspdotnet/datadog_checks/aspdotnet/config_models/instance.py
@@ -17,13 +17,16 @@ class InstanceConfig(BaseModel):
     class Config:
         allow_mutation = False
 
+    additional_metrics: Optional[Sequence[Sequence[str]]]
+    counter_data_types: Optional[Sequence[str]]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]
-    host: str
+    host: Optional[str]
     min_collection_interval: Optional[float]
-    port: int
+    password: Optional[str]
     service: Optional[str]
     tags: Optional[Sequence[str]]
+    username: Optional[str]
 
     @root_validator(pre=True)
     def _initial_validation(cls, values):

--- a/aspdotnet/datadog_checks/aspdotnet/data/conf.yaml.example
+++ b/aspdotnet/datadog_checks/aspdotnet/data/conf.yaml.example
@@ -13,17 +13,52 @@ init_config:
 #
 instances:
 
-    ## @param host - string - required
+    ## @param host - string - optional - default: .
     ## ASP .NET host to connect to.
     ## Using "." means the current host. Using any other value, the Agent attempts to connect to a remote host.
     ## Note: Remote access requires additional permissions
     #
   - host: .
 
-    ## @param port - integer - required
-    ## ASP .NET port to connect to.
+    ## @param username - string - optional
+    ## The username from the credentials needed to connect to the host.
     #
-    port: 26379
+    # username: <USERNAME>
+
+    ## @param password - string - optional
+    ## The password from the credentials needed to connect to the host.
+    #
+    # password: <PASSWORD>
+
+    ## @param additional_metrics - list of lists - optional
+    ## The additional metrics is a list of items that represent additional counters to collect.
+    ## Each item is a list of strings, formatted as follows:
+    ##
+    ## ['<COUNTERSET_NAME>', <COUNTER_INSTANCE_NAME>, '<COUNTER_NAME>', <METRIC_NAME>, <METRIC_TYPE>]
+    ##
+    ## <COUNTERSET_NAME> is the name of the PDH counter set (the name of the counter).
+    ## <COUNTER_INSTANCE_NAME> is the specific counter instance to collect, for example
+    ##                         "Default Web Site".  Specify 'none' for all instances of
+    ##                         the counter.
+    ## <COUNTER_NAME> is the individual counter to report.
+    ## <METRIC_NAME> is the name that displays in Datadog.
+    ## <METRIC_TYPE> is from the standard choices for all Agent checks, such as gauge,
+    ##               rate, histogram, or count.
+    #
+    # additional_metrics:
+    #   - [Processor, none, '% Processor Time', processor.time, gauge]
+    #   - [Processor, none, '% User Time', processor.user.time, gauge]
+
+    ## @param counter_data_types - list of strings - optional
+    ## counter_data_types is a list of <METRIC_NAME>,<DATA_TYPE> elements that
+    ## allow the precision in which counters are queried on a per metric basis.
+    ## <METRIC_NAME>: The name of your metric
+    ## <DATA_TYPE>  : The type of your metric (int or float)
+    #
+    # counter_data_types:
+    #   - <METRIC_NAME>,<DATA_TYPE>
+    #   - processor.time,int
+    #   - processor.user.time,float
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`host` is not required
`port` is not used
aspdotnet integration is using PDHBaseCheck, so we should use `pdh_legacy` spec

### Motivation
<!-- What inspired you to submit this pull request? -->
QA #8886 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
