### PR TITLE
Validate use of legacy openmetrics config

### DIFF
--- a/linkerd/assets/configuration/spec.yaml
+++ b/linkerd/assets/configuration/spec.yaml
@@ -11,3 +11,7 @@ files:
       overrides:
         openmetrics_endpoint.required: false
         openmetrics_endpoint.value.example: http://localhost:9990/admin/metrics/prometheus
+    - template: instances/openmetrics_legacy_base
+      hidden: true
+      overrides:
+        prometheus_url.required: false

--- a/linkerd/datadog_checks/linkerd/config_models/defaults.py
+++ b/linkerd/datadog_checks/linkerd/config_models/defaults.py
@@ -44,6 +44,14 @@ def instance_aws_service(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_auth(field, value):
+    return False
+
+
+def instance_bearer_token_path(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_cache_metric_wildcards(field, value):
     return True
 
@@ -100,6 +108,10 @@ def instance_headers(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_health_service_check(field, value):
+    return True
+
+
 def instance_histogram_buckets_as_distributions(field, value):
     return False
 
@@ -109,6 +121,14 @@ def instance_hostname_format(field, value):
 
 
 def instance_hostname_label(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_ignore_metrics(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_ignore_metrics_by_labels(field, value):
     return get_default_field_value(field, value)
 
 
@@ -148,6 +168,18 @@ def instance_kerberos_principal(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_label_joins(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_label_to_hostname(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_labels_mapper(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_log_requests(field, value):
     return False
 
@@ -184,6 +216,14 @@ def instance_persist_connections(field, value):
     return False
 
 
+def instance_prometheus_metrics_prefix(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_prometheus_url(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_proxy(field, value):
     return get_default_field_value(field, value)
 
@@ -206,6 +246,30 @@ def instance_rename_labels(field, value):
 
 def instance_request_size(field, value):
     return 16
+
+
+def instance_send_distribution_buckets(field, value):
+    return False
+
+
+def instance_send_distribution_counts_as_monotonic(field, value):
+    return False
+
+
+def instance_send_distribution_sums_as_monotonic(field, value):
+    return False
+
+
+def instance_send_histograms_buckets(field, value):
+    return True
+
+
+def instance_send_monotonic_counter(field, value):
+    return True
+
+
+def instance_send_monotonic_with_gauge(field, value):
+    return False
 
 
 def instance_service(field, value):
@@ -254,6 +318,10 @@ def instance_tls_use_host_header(field, value):
 
 def instance_tls_verify(field, value):
     return True
+
+
+def instance_type_overrides(field, value):
+    return get_default_field_value(field, value)
 
 
 def instance_use_latest_spec(field, value):

--- a/linkerd/datadog_checks/linkerd/config_models/instance.py
+++ b/linkerd/datadog_checks/linkerd/config_models/instance.py
@@ -30,6 +30,29 @@ class ExtraMetric(BaseModel):
     type: Optional[str]
 
 
+class IgnoreMetricsByLabels(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    target_label_key: Optional[str]
+    target_label_value_list: Optional[Sequence[str]]
+
+
+class TargetMetric(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    label_to_match: Optional[str]
+    labels_to_get: Optional[Sequence[str]]
+
+
+class LabelJoins(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    target_metric: Optional[TargetMetric]
+
+
 class Metric(BaseModel):
     class Config:
         extra = Extra.allow
@@ -66,6 +89,8 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
+    bearer_token_auth: Optional[bool]
+    bearer_token_path: Optional[str]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]
     collect_counters_with_distributions: Optional[bool]
@@ -80,9 +105,12 @@ class InstanceConfig(BaseModel):
     extra_headers: Optional[Mapping[str, Any]]
     extra_metrics: Optional[Sequence[Union[str, Mapping[str, Union[str, ExtraMetric]]]]]
     headers: Optional[Mapping[str, Any]]
+    health_service_check: Optional[bool]
     histogram_buckets_as_distributions: Optional[bool]
     hostname_format: Optional[str]
     hostname_label: Optional[str]
+    ignore_metrics: Optional[Sequence[str]]
+    ignore_metrics_by_labels: Optional[IgnoreMetricsByLabels]
     ignore_tags: Optional[Sequence[str]]
     include_labels: Optional[Sequence[str]]
     kerberos_auth: Optional[str]
@@ -92,6 +120,9 @@ class InstanceConfig(BaseModel):
     kerberos_hostname: Optional[str]
     kerberos_keytab: Optional[str]
     kerberos_principal: Optional[str]
+    label_joins: Optional[LabelJoins]
+    label_to_hostname: Optional[str]
+    labels_mapper: Optional[Mapping[str, Any]]
     log_requests: Optional[bool]
     metrics: Optional[Sequence[Union[str, Mapping[str, Union[str, Metric]]]]]
     min_collection_interval: Optional[float]
@@ -101,12 +132,20 @@ class InstanceConfig(BaseModel):
     openmetrics_endpoint: Optional[str]
     password: Optional[str]
     persist_connections: Optional[bool]
+    prometheus_metrics_prefix: Optional[str]
+    prometheus_url: Optional[str]
     proxy: Optional[Proxy]
     raw_line_filters: Optional[Sequence[str]]
     raw_metric_prefix: Optional[str]
     read_timeout: Optional[float]
     rename_labels: Optional[Mapping[str, Any]]
     request_size: Optional[float]
+    send_distribution_buckets: Optional[bool]
+    send_distribution_counts_as_monotonic: Optional[bool]
+    send_distribution_sums_as_monotonic: Optional[bool]
+    send_histograms_buckets: Optional[bool]
+    send_monotonic_counter: Optional[bool]
+    send_monotonic_with_gauge: Optional[bool]
     service: Optional[str]
     share_labels: Optional[Mapping[str, Union[bool, ShareLabel]]]
     skip_proxy: Optional[bool]
@@ -119,6 +158,7 @@ class InstanceConfig(BaseModel):
     tls_private_key: Optional[str]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
+    type_overrides: Optional[Mapping[str, Any]]
     use_latest_spec: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]
     use_process_start_time: Optional[bool]

--- a/linkerd/tests/test_linkerd.py
+++ b/linkerd/tests/test_linkerd.py
@@ -31,14 +31,14 @@ def get_response(filename):
     return response
 
 
-def test_linkerd(aggregator):
+def test_linkerd(aggregator, dd_run_check):
     """
     Test the full check
     """
     check = LinkerdCheck('linkerd', {}, [MOCK_INSTANCE])
     with requests_mock.Mocker() as metric_request:
         metric_request.get('http://fake.tld/prometheus', text=get_response('linkerd.txt'))
-        check.check(MOCK_INSTANCE)
+        dd_run_check(check)
 
     for metric in LINKERD_FIXTURE_VALUES:
         aggregator.assert_metric(metric, LINKERD_FIXTURE_VALUES[metric])
@@ -52,11 +52,11 @@ def test_linkerd(aggregator):
     )
 
 
-def test_linkerd_v2(aggregator):
+def test_linkerd_v2(aggregator, dd_run_check):
     check = LinkerdCheck('linkerd', {}, [MOCK_INSTANCE])
     with requests_mock.Mocker() as metric_request:
         metric_request.get('http://fake.tld/prometheus', text=get_response('linkerd_v2.txt'))
-        check.check(MOCK_INSTANCE)
+        dd_run_check(check)
 
     for metric_name, metric_type in EXPECTED_METRICS_V2.items():
         aggregator.assert_metric(metric_name, metric_type=metric_type)
@@ -84,12 +84,12 @@ def test_linkerd_v2_new(aggregator, dd_run_check, mock_http_response):
     )
 
 
-def test_openmetrics_error(monkeypatch):
+def test_openmetrics_error(monkeypatch, dd_run_check):
     check = LinkerdCheck('linkerd', {}, [MOCK_INSTANCE])
     with requests_mock.Mocker() as metric_request:
         metric_request.get('http://fake.tld/prometheus', exc="Exception")
         with pytest.raises(Exception):
-            check.check(MOCK_INSTANCE)
+            dd_run_check(check)
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
### What does this PR do?
Adds a hidden config spec template so that if a user is using the openmetrics v1 spec, then those options will be validated. Additionally adds dd_run_check in tests to catch config errors

### Motivation
QA for https://github.com/DataDog/integrations-core/pull/8948

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
