### PR TITLE
Add missing config option to spec and update examples to match implementation

### DIFF
--- a/cacti/assets/configuration/spec.yaml
+++ b/cacti/assets/configuration/spec.yaml
@@ -27,6 +27,11 @@ files:
             description: Password to use to connect to MySQL in order to gather metrics.
             value:
               type: string
+          - name: mysql_db
+            description: The MySQL database to connect to
+            value:
+              example: cacti
+              type: string
           - name: rrd_path
             required: true
             description: |
@@ -42,8 +47,8 @@ files:
           - name: field_names
             description: |
               The `field_names` specifies which field_names should be used
-              to determine if a device is a real device. You can let it commented
-              out as the default values should satisfy your needs.
+              to determine if a device is a real device. You can leave it commented
+              out as the default values [ifName, dskDevice] should satisfy your needs.
               You can run the following query to determine your field names:
                     SELECT
                          h.hostname as hostname,
@@ -61,7 +66,6 @@ files:
               example:
                 - ifName
                 - dskDevice
-                - ifIndex
               type: array
               items:
                 type: string

--- a/cacti/datadog_checks/cacti/config_models/defaults.py
+++ b/cacti/datadog_checks/cacti/config_models/defaults.py
@@ -24,6 +24,10 @@ def instance_min_collection_interval(field, value):
     return 15
 
 
+def instance_mysql_db(field, value):
+    return 'cacti'
+
+
 def instance_mysql_password(field, value):
     return get_default_field_value(field, value)
 

--- a/cacti/datadog_checks/cacti/config_models/instance.py
+++ b/cacti/datadog_checks/cacti/config_models/instance.py
@@ -21,6 +21,7 @@ class InstanceConfig(BaseModel):
     empty_default_hostname: Optional[bool]
     field_names: Optional[Sequence[str]]
     min_collection_interval: Optional[float]
+    mysql_db: Optional[str]
     mysql_host: str
     mysql_password: Optional[str]
     mysql_port: Optional[int]

--- a/cacti/datadog_checks/cacti/data/conf.yaml.example
+++ b/cacti/datadog_checks/cacti/data/conf.yaml.example
@@ -50,8 +50,8 @@ instances:
 
     ## @param field_names - list of strings - optional
     ## The `field_names` specifies which field_names should be used
-    ## to determine if a device is a real device. You can let it commented
-    ## out as the default values should satisfy your needs.
+    ## to determine if a device is a real device. You can leave it commented
+    ## out as the default values [ifName, dskDevice] should satisfy your needs.
     ## You can run the following query to determine your field names:
     ##       SELECT
     ##            h.hostname as hostname,

--- a/cacti/datadog_checks/cacti/data/conf.yaml.example
+++ b/cacti/datadog_checks/cacti/data/conf.yaml.example
@@ -33,6 +33,11 @@ instances:
     #
     # mysql_password: <MYSQL_PASSWORD>
 
+    ## @param mysql_db - string - optional - default: cacti
+    ## The MySQL database to connect to
+    #
+    # mysql_db: cacti
+
     ## @param rrd_path - string - required
     ## The Cacti checks requires access to the Cacti DB in MySQL and to the RRD
     ## files that contain the metrics tracked in Cacti.
@@ -64,7 +69,6 @@ instances:
     # field_names:
     #   - ifName
     #   - dskDevice
-    #   - ifIndex
 
     ## @param rrd_whitelist - string - optional
     ## The `rrd_whitelist` is a path to a text file that has a list of file patterns,

--- a/cacti/tests/test_cacti.py
+++ b/cacti/tests/test_cacti.py
@@ -115,12 +115,12 @@ def check():
 pytestmark = pytest.mark.unit
 
 
-def test_check(aggregator, check):
+def test_check(aggregator, check, dd_run_check):
     mocks = _setup_mocks()
 
     # Run the check twice to set the timestamps and capture metrics on the second run
-    check.check(CACTI_CONFIG)
-    check.check(CACTI_CONFIG)
+    dd_run_check(check)
+    dd_run_check(check)
 
     for mock_func in mocks:
         mock_func.stop()
@@ -135,7 +135,7 @@ def test_check(aggregator, check):
     aggregator.assert_all_metrics_covered()
 
 
-def test_whitelist(aggregator):
+def test_whitelist(aggregator, dd_run_check):
     config = deepcopy(CACTI_CONFIG)
     config['rrd_whitelist'] = os.path.join(HERE, 'whitelist.txt')
     check = CactiCheck('cacti', {}, [config])
@@ -143,8 +143,8 @@ def test_whitelist(aggregator):
     mocks = _setup_mocks()
 
     # Run the check twice to set the timestamps and capture metrics on the second run
-    check.check(config)
-    check.check(config)
+    dd_run_check(check)
+    dd_run_check(check)
 
     for mock_func in mocks:
         mock_func.stop()


### PR DESCRIPTION
### What does this PR do?
- Adds `mysql_db` to the config spec, as it is a valid option in the check implementation
- Removes `ifIndex` from `field_names` example since it is not a default option
- Updates field_names documentation to fix typo and show default values
- Uses `dd_run_check` in tests to run check initializations in tests

### Motivation
QA for https://github.com/DataDog/integrations-core/pull/8889
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
