### PR TITLE
Use dd_run_check for azure_iot_edge

### DIFF
--- a/azure_iot_edge/tests/test_check.py
+++ b/azure_iot_edge/tests/test_check.py
@@ -8,6 +8,7 @@ import pytest
 import requests
 
 from datadog_checks.azure_iot_edge import AzureIoTEdgeCheck
+from datadog_checks.azure_iot_edge.types import Instance
 from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.base.stubs.datadog_agent import DatadogAgentStub
 from datadog_checks.dev.utils import get_metadata_metrics
@@ -16,13 +17,13 @@ from . import common
 
 
 @pytest.mark.usefixtures("mock_server")
-def test_check(aggregator, mock_instance):
-    # type: (AggregatorStub, dict) -> None
+def test_check(aggregator, mock_instance, dd_run_check):
+    # type: (AggregatorStub, Instance, Callable) -> None
     """
     Under normal conditions, metrics and service checks are collected as expected.
     """
     check = AzureIoTEdgeCheck('azure_iot_edge', {}, [mock_instance])
-    check.check(mock_instance)
+    dd_run_check(check)
 
     for metric, metric_type in common.HUB_METRICS:
         # Don't assert exact tags since they're very complex (many cross products).
@@ -58,7 +59,7 @@ def test_check(aggregator, mock_instance):
 
 @pytest.mark.usefixtures("mock_server")
 def test_version_metadata(datadog_agent, dd_run_check, mock_instance):
-    # type: (DatadogAgentStub, Callable, dict) -> None
+    # type: (DatadogAgentStub, Callable, Instance) -> None
     check = AzureIoTEdgeCheck('azure_iot_edge', {}, [mock_instance])
     check.check_id = 'test:123'
     dd_run_check(check)


### PR DESCRIPTION
### What does this PR do?
Updates integration tests with `dd_run_check`.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
