### PR TITLE
Group by host to return number of nodes

### DIFF
--- a/elastic/assets/dashboards/overview.json
+++ b/elastic/assets/dashboards/overview.json
@@ -65,7 +65,7 @@
               "type": "check_status",
               "check": "elasticsearch.can_connect",
               "grouping": "cluster",
-              "group_by": [],
+              "group_by": ["host"],
               "tags": []
             },
             "layout": { "x": 0, "y": 0, "width": 3, "height": 2 }
@@ -114,7 +114,7 @@
               "type": "check_status",
               "check": "elasticsearch.cluster_health",
               "grouping": "cluster",
-              "group_by": [],
+              "group_by": ["host"],
               "tags": []
             },
             "layout": { "x": 0, "y": 2, "width": 3, "height": 2 }


### PR DESCRIPTION
### What does this PR do?
Fix widgets that return number of nodes by grouping by host as there can be multiple instances per node

### Motivation
AGENT-7152

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
