### PR TITLE
[snmp] Support new profiles without throwing errors in translate-profiles

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
@@ -72,11 +72,15 @@ def translate_profile(ctx, profile_path, mib_source_url):
             fetch_mib(mib, source_url=mib_source_url)
         if 'table' in metric:
             table = metric['table']
+            if not isinstance(table, str):
+                continue
             node = mib_view_controller.mibBuilder.importSymbols(mib, table)[0]
             value = '.'.join([str(i) for i in node.getName()])
             table = {'name': table, 'OID': value}
             symbols = []
             for symbol in metric['symbols']:
+                if not isinstance(symbol, str):
+                    continue
                 node = mib_view_controller.mibBuilder.importSymbols(mib, symbol)[0]
                 value = '.'.join([str(i) for i in node.getName()])
                 symbols.append({'name': symbol, 'OID': value})
@@ -85,6 +89,8 @@ def translate_profile(ctx, profile_path, mib_source_url):
                 if 'column' in tag:
                     tag_mib = tag.get('MIB', mib)
                     key = tag['column']
+                    if not isinstance(key, str):
+                        continue
                     node = mib_view_controller.mibBuilder.importSymbols(tag_mib, key)[0]
                     value = '.'.join([str(i) for i in node.getName()])
                     tag = tag.copy()

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py
@@ -64,7 +64,8 @@ def translate_profile(ctx, profile_path, mib_source_url):
         data = yaml.safe_load(f.read())
 
     output = []
-    for metric in data['metrics']:
+    metrics = data.get('metrics', [])
+    for metric in metrics:
         mib = metric['MIB']
         try:
             mib_view_controller.mibBuilder.loadModule(mib)


### PR DESCRIPTION
### What does this PR do?

`ddev meta snmp translate-profile` migrates legacy MIB based profiles to the current OID based format. The tool was triggering exceptions when executed over OID based format, as it was expecting string values but was getting dictionaries.

This PR skips OID based format metrics.
 
### Motivation

Exceptions triggered when QAing https://github.com/DataDog/integrations-core/pull/10353

### Additional Notes

Testing:

Running `ddev meta snmp translate-profile snmp/datadog_checks/snmp/data/profiles/cisco-nexus.yaml` should not trigger any error.
Running `ddev meta snmp translate-profile snmp/datadog_checks/snmp/data/profiles/cisco-asa.yaml` should not trigger any error.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
