### PR TITLE
Update `test_instance_auth_token` to run check twice and add more header tests

### DIFF
--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -336,3 +336,5 @@ def test_instance_auth_token(dd_run_check):
     check = HTTPCheck('http_check', {'ca_certs': mock_get_ca_certs_path()}, [instance])
     dd_run_check(check)
     assert expected_headers == check.http.options['headers']
+    dd_run_check(check)
+    assert expected_headers == check.http.options['headers']

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -332,7 +332,7 @@ def test_instance_auth_token(dd_run_check):
         ]
     )
 
-    instance = {'url': 'https://example.com', 'name': 'UpService', "auth_token": auth_token}
+    instance = {'url': 'https://valid.mock', 'name': 'UpService', "auth_token": auth_token}
     check = HTTPCheck('http_check', {'ca_certs': mock_get_ca_certs_path()}, [instance])
     dd_run_check(check)
     assert expected_headers == check.http.options['headers']
@@ -344,7 +344,7 @@ def test_instance_auth_token(dd_run_check):
     ["instance", "expected_headers"],
     [
         (
-            {'url': 'https://example.com', 'name': 'UpService', 'extra_headers': {'Host': 'test'}},
+            {'url': 'https://valid.mock', 'name': 'UpService', 'extra_headers': {'Host': 'test'}},
             OrderedDict(
                 [
                     ('User-Agent', 'Datadog Agent/0.0.0'),
@@ -354,7 +354,15 @@ def test_instance_auth_token(dd_run_check):
                 ]
             ),
         ),
-        ({'url': 'https://example.com', 'name': 'UpService', 'include_default_headers': False}, OrderedDict()),
+        (
+            {'url': 'https://valid.mock', 'name': 'UpService', 'headers': {'Host': 'test'}},
+            OrderedDict(
+                [
+                    ('Host', 'test'),
+                ]
+            ),
+        ),
+        ({'url': 'https://valid.mock', 'name': 'UpService', 'include_default_headers': False}, OrderedDict()),
     ],
 )
 def test_expected_headers(dd_run_check, instance, expected_headers):

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -338,3 +338,30 @@ def test_instance_auth_token(dd_run_check):
     assert expected_headers == check.http.options['headers']
     dd_run_check(check)
     assert expected_headers == check.http.options['headers']
+
+
+@pytest.mark.parametrize(
+    ["instance", "expected_headers"],
+    [
+        (
+            {'url': 'https://example.com', 'name': 'UpService', 'extra_headers': {'Host': 'test'}},
+            OrderedDict(
+                [
+                    ('User-Agent', 'Datadog Agent/0.0.0'),
+                    ('Accept', '*/*'),
+                    ('Accept-Encoding', 'gzip, deflate'),
+                    ('Host', 'test'),
+                ]
+            ),
+        ),
+        ({'url': 'https://example.com', 'name': 'UpService', 'include_default_headers': False}, OrderedDict()),
+    ],
+)
+def test_expected_headers(dd_run_check, instance, expected_headers):
+
+    check = HTTPCheck('http_check', {'ca_certs': mock_get_ca_certs_path()}, [instance])
+    dd_run_check(check)
+    assert expected_headers == check.http.options['headers']
+
+    dd_run_check(check)
+    assert expected_headers == check.http.options['headers']


### PR DESCRIPTION
### What does this PR do?
- Update test to run check twice to properly catch when `Authorization` was getting removed from the request headers 
- Add more tests for when headers are set in different ways

### Motivation
QA for https://github.com/DataDog/integrations-core/pull/10388
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
