### PR TITLE
Fix use_mount required field 

### DIFF
--- a/disk/assets/configuration/spec.yaml
+++ b/disk/assets/configuration/spec.yaml
@@ -44,7 +44,6 @@ files:
       - template: instances
         options:
           - name: use_mount
-            required: true
             description: |
               If enabled, metrics are tagged using mount points (for example `device:/`) instead of volumes
               (for example `device:/dev/disk1s5`).

--- a/disk/assets/configuration/spec.yaml
+++ b/disk/assets/configuration/spec.yaml
@@ -44,6 +44,7 @@ files:
       - template: instances
         options:
           - name: use_mount
+            enabled: true
             description: |
               If enabled, metrics are tagged using mount points (for example `device:/`) instead of volumes
               (for example `device:/dev/disk1s5`).

--- a/disk/datadog_checks/disk/config_models/defaults.py
+++ b/disk/datadog_checks/disk/config_models/defaults.py
@@ -106,3 +106,7 @@ def instance_timeout(field, value):
 
 def instance_use_lsblk(field, value):
     return False
+
+
+def instance_use_mount(field, value):
+    return False

--- a/disk/datadog_checks/disk/config_models/instance.py
+++ b/disk/datadog_checks/disk/config_models/instance.py
@@ -51,7 +51,7 @@ class InstanceConfig(BaseModel):
     tags: Optional[Sequence[str]]
     timeout: Optional[int]
     use_lsblk: Optional[bool]
-    use_mount: bool
+    use_mount: Optional[bool]
 
     @root_validator(pre=True)
     def _initial_validation(cls, values):

--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -39,12 +39,11 @@ init_config:
 #
 instances:
 
-  -
     ## @param use_mount - boolean - optional - default: false
     ## If enabled, metrics are tagged using mount points (for example `device:/`) instead of volumes
     ## (for example `device:/dev/disk1s5`).
     #
-    # use_mount: false
+  - use_mount: false
 
     ## @param all_partitions - boolean - optional - default: false
     ## Instruct the check to collect from partitions even without device names.

--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -39,11 +39,12 @@ init_config:
 #
 instances:
 
-    ## @param use_mount - boolean - required
+  -
+    ## @param use_mount - boolean - optional - default: false
     ## If enabled, metrics are tagged using mount points (for example `device:/`) instead of volumes
     ## (for example `device:/dev/disk1s5`).
     #
-  - use_mount: false
+    # use_mount: false
 
     ## @param all_partitions - boolean - optional - default: false
     ## Instruct the check to collect from partitions even without device names.

--- a/disk/tests/test_check.py
+++ b/disk/tests/test_check.py
@@ -6,12 +6,12 @@ from itertools import chain
 from datadog_checks.disk import Disk
 
 
-def test_check(aggregator, instance_basic_volume, gauge_metrics, rate_metrics, count_metrics):
+def test_check(aggregator, instance_basic_volume, gauge_metrics, rate_metrics, count_metrics, dd_run_check):
     """
     Basic check to see if all metrics are there
     """
     c = Disk('disk', {}, [instance_basic_volume])
-    c.check(instance_basic_volume)
+    dd_run_check(c)
 
     for name in chain(gauge_metrics, rate_metrics, count_metrics):
         aggregator.assert_metric(name)

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -45,14 +45,14 @@ def test_bad_config():
 
 
 @pytest.mark.usefixtures('psutil_mocks')
-def test_default(aggregator, gauge_metrics, rate_metrics, count_metrics):
+def test_default(aggregator, gauge_metrics, rate_metrics, count_metrics, dd_run_check):
     """
     Mock psutil and run the check
     """
     for tag_by in ['true', 'false']:
         instance = {'tag_by_filesystem': tag_by, 'tag_by_label': False}
         c = Disk('disk', {}, [instance])
-        c.check(instance)
+        dd_run_check(c)
 
         if tag_by == 'true':
             tags = [
@@ -90,24 +90,24 @@ def test_default(aggregator, gauge_metrics, rate_metrics, count_metrics):
 
 
 @pytest.mark.usefixtures('psutil_mocks')
-def test_rw(aggregator):
+def test_rw(aggregator, dd_run_check):
     """
     Check for 'ro' option in the mounts
     """
     instance = {'service_check_rw': 'yes', 'tag_by_label': False}
     c = Disk('disk', {}, [instance])
-    c.check(instance)
+    dd_run_check(c)
 
     aggregator.assert_service_check('disk.read_write', status=Disk.CRITICAL)
 
 
 @pytest.mark.usefixtures('psutil_mocks')
-def test_use_mount(aggregator, instance_basic_mount, gauge_metrics, rate_metrics, count_metrics):
+def test_use_mount(aggregator, instance_basic_mount, gauge_metrics, rate_metrics, count_metrics, dd_run_check):
     """
     Same as above, using mount to tag
     """
     c = Disk('disk', {}, [instance_basic_mount])
-    c.check(instance_basic_mount)
+    dd_run_check(c)
 
     for name, value in iteritems(gauge_metrics):
         aggregator.assert_metric(
@@ -127,7 +127,7 @@ def test_use_mount(aggregator, instance_basic_mount, gauge_metrics, rate_metrics
 
 
 @pytest.mark.usefixtures('psutil_mocks')
-def test_device_tagging(aggregator, gauge_metrics, rate_metrics, count_metrics):
+def test_device_tagging(aggregator, gauge_metrics, rate_metrics, count_metrics, dd_run_check):
     instance = {
         'use_mount': 'no',
         'device_tag_re': {'{}.*'.format(DEFAULT_DEVICE_NAME[:-1]): 'type:dev,tag:two'},
@@ -140,7 +140,7 @@ def test_device_tagging(aggregator, gauge_metrics, rate_metrics, count_metrics):
         # _get_devices_label is only called on linux, so devices_label is manually filled
         # to make the test run on everything
         c.devices_label = {DEFAULT_DEVICE_NAME: ['label:mylab', 'device_label:mylab']}
-        c.check(instance)
+        dd_run_check(c)
 
     # Assert metrics
     tags = [
@@ -232,14 +232,14 @@ def test_get_devices_label_from_lsblk():
 
 
 @pytest.mark.usefixtures('psutil_mocks')
-def test_min_disk_size(aggregator, gauge_metrics, rate_metrics, count_metrics):
+def test_min_disk_size(aggregator, gauge_metrics, rate_metrics, count_metrics, dd_run_check):
     instance = {'min_disk_size': 0.001}
     c = Disk('disk', {}, [instance])
 
     m = MockDiskMetrics()
     m.total = 0
     with mock.patch('psutil.disk_usage', return_value=m, __name__='disk_usage'):
-        c.check(instance)
+        dd_run_check(c)
 
     for name in gauge_metrics:
         aggregator.assert_metric(name, count=0)
@@ -258,13 +258,13 @@ def test_min_disk_size(aggregator, gauge_metrics, rate_metrics, count_metrics):
 @pytest.mark.skipif(not Platform.is_linux(), reason='disk labels are only available on Linux')
 @pytest.mark.usefixtures('psutil_mocks')
 def test_labels_from_blkid_cache_file(
-    aggregator, instance_blkid_cache_file, gauge_metrics, rate_metrics, count_metrics
+    aggregator, instance_blkid_cache_file, gauge_metrics, rate_metrics, count_metrics, dd_run_check,
 ):
     """
     Verify that the disk labels are set when the blkid_cache_file option is set
     """
     c = Disk('disk', {}, [instance_blkid_cache_file])
-    c.check(instance_blkid_cache_file)
+    dd_run_check(c)
     for metric in chain(gauge_metrics, rate_metrics, count_metrics):
         aggregator.assert_metric(
             metric, tags=['device:/dev/sda1', 'device_name:sda1', 'label:MYLABEL', 'device_label:MYLABEL']
@@ -274,19 +274,19 @@ def test_labels_from_blkid_cache_file(
 @pytest.mark.skipif(not Platform.is_linux(), reason='disk labels are only available on Linux')
 @pytest.mark.usefixtures('psutil_mocks')
 def test_blkid_cache_file_contains_no_labels(
-    aggregator, instance_blkid_cache_file_no_label, gauge_metrics, rate_metrics, count_metrics
+    aggregator, instance_blkid_cache_file_no_label, gauge_metrics, rate_metrics, count_metrics, dd_run_check,
 ):
     """
     Verify that the disk labels are ignored if the cache file doesn't contain any
     """
     c = Disk('disk', {}, [instance_blkid_cache_file_no_label])
-    c.check(instance_blkid_cache_file_no_label)
+    dd_run_check(c)
     for metric in chain(gauge_metrics, rate_metrics, count_metrics):
         aggregator.assert_metric(metric, tags=['device:/dev/sda1', 'device_name:sda1'])
 
 
 @pytest.mark.usefixtures('psutil_mocks')
-def test_timeout_config(aggregator):
+def test_timeout_config(aggregator, dd_run_check):
     """Test timeout configuration value is used on every timeout on the check."""
 
     # Arbitrary value
@@ -301,13 +301,13 @@ def test_timeout_config(aggregator):
     with mock.patch('psutil.disk_partitions', return_value=[MockPart()]), mock.patch(
         'datadog_checks.disk.disk.timeout', return_value=no_timeout
     ) as mock_timeout:
-        c.check(instance)
+        dd_run_check(c)
 
     mock_timeout.assert_called_with(TIMEOUT_VALUE)
 
 
 @pytest.mark.usefixtures('psutil_mocks')
-def test_timeout_warning(aggregator, gauge_metrics, rate_metrics, count_metrics):
+def test_timeout_warning(aggregator, gauge_metrics, rate_metrics, count_metrics, dd_run_check):
     """Test a warning is raised when there is a Timeout exception."""
 
     # Raise exception for "/faulty" mountpoint
@@ -328,7 +328,7 @@ def test_timeout_warning(aggregator, gauge_metrics, rate_metrics, count_metrics)
     with mock.patch('psutil.disk_partitions', return_value=[MockPart(), MockPart(mountpoint="/faulty")]), mock.patch(
         'psutil.disk_usage', return_value=m, __name__='disk_usage'
     ), mock.patch('datadog_checks.disk.disk.timeout', return_value=faulty_timeout):
-        c.check({})
+        dd_run_check(c)
 
     # Check that the warning is called once for the faulty disk
     c.log.warning.assert_called_once()
@@ -344,11 +344,11 @@ def test_timeout_warning(aggregator, gauge_metrics, rate_metrics, count_metrics)
 
 
 @pytest.mark.usefixtures('psutil_mocks')
-def test_include_all_devices(aggregator, gauge_metrics, rate_metrics):
+def test_include_all_devices(aggregator, gauge_metrics, rate_metrics, dd_run_check):
     c = Disk('disk', {}, [{}])
 
     with mock.patch('psutil.disk_partitions', return_value=[]) as m:
-        c.check({})
+        dd_run_check(c)
         # By default, we include all devices
         m.assert_called_with(all=True)
 
@@ -356,5 +356,5 @@ def test_include_all_devices(aggregator, gauge_metrics, rate_metrics):
     c = Disk('disk', {}, [instance])
 
     with mock.patch('psutil.disk_partitions', return_value=[]) as m:
-        c.check({})
+        dd_run_check(c)
         m.assert_called_with(all=False)

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -258,7 +258,12 @@ def test_min_disk_size(aggregator, gauge_metrics, rate_metrics, count_metrics, d
 @pytest.mark.skipif(not Platform.is_linux(), reason='disk labels are only available on Linux')
 @pytest.mark.usefixtures('psutil_mocks')
 def test_labels_from_blkid_cache_file(
-    aggregator, instance_blkid_cache_file, gauge_metrics, rate_metrics, count_metrics, dd_run_check,
+    aggregator,
+    instance_blkid_cache_file,
+    gauge_metrics,
+    rate_metrics,
+    count_metrics,
+    dd_run_check,
 ):
     """
     Verify that the disk labels are set when the blkid_cache_file option is set
@@ -274,7 +279,12 @@ def test_labels_from_blkid_cache_file(
 @pytest.mark.skipif(not Platform.is_linux(), reason='disk labels are only available on Linux')
 @pytest.mark.usefixtures('psutil_mocks')
 def test_blkid_cache_file_contains_no_labels(
-    aggregator, instance_blkid_cache_file_no_label, gauge_metrics, rate_metrics, count_metrics, dd_run_check,
+    aggregator,
+    instance_blkid_cache_file_no_label,
+    gauge_metrics,
+    rate_metrics,
+    count_metrics,
+    dd_run_check,
 ):
     """
     Verify that the disk labels are ignored if the cache file doesn't contain any


### PR DESCRIPTION
### What does this PR do?
use_mount defaults to False, adding the required field makes the tests fail when use_mount is not explicitly defined in conf.yaml
### Motivation
Fix behavior
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
