### PR TITLE
Fix kubernetes OOTB dashboard and monitors

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_clusters.json
+++ b/kubernetes/assets/dashboards/kubernetes_clusters.json
@@ -3243,7 +3243,7 @@
                                             "value": 0
                                         }
                                     ],
-                                    "q": "top(sum:kubernetes_state.pod.status_phase{*,$cluster,!phase:running,!phase:succeeded,$scope} by {cluster_name,kube_namespace,phase}, 100, 'last', 'desc')"
+                                    "q": "top(sum:kubernetes_state.pod.status_phase{*,$cluster,!pod_phase:running,!pod_phase:succeeded,$scope} by {cluster_name,kube_namespace,pod_phase}, 100, 'last', 'desc')"
                                 }
                             ],
                             "title": "Pods in bad phase by namespaces",

--- a/kubernetes/assets/dashboards/kubernetes_dashboard.json
+++ b/kubernetes/assets/dashboards/kubernetes_dashboard.json
@@ -898,7 +898,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.replicaset.replicas_ready{$scope,$daemonset,$service,$namespace,$deployment,$label,$cluster,$node} by {replicaset}",
+                        "q": "sum:kubernetes_state.replicaset.replicas_ready{$scope,$daemonset,$service,$namespace,$deployment,$label,$cluster,$node} by {kube_replica_set}",
                         "display_type": "area",
                         "style": {
                             "palette": "purple",
@@ -930,7 +930,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.replicaset.replicas_desired{$scope,$daemonset,$service,$namespace,$deployment,$label,$cluster,$node} by {replicaset}-sum:kubernetes_state.replicaset.replicas_ready{$scope,$daemonset,$service,$namespace,$deployment,$label,$cluster,$node} by {replicaset}",
+                        "q": "sum:kubernetes_state.replicaset.replicas_desired{$scope,$daemonset,$service,$namespace,$deployment,$label,$cluster,$node} by {kube_replica_set}-sum:kubernetes_state.replicaset.replicas_ready{$scope,$daemonset,$service,$namespace,$deployment,$label,$cluster,$node} by {kube_replica_set}",
                         "display_type": "area",
                         "style": {
                             "palette": "orange",
@@ -1245,7 +1245,7 @@
                 "type": "toplist",
                 "requests": [
                     {
-                        "q": "top(sum:kubernetes_state.pod.status_phase{$scope,$cluster,$namespace,$deployment,$daemonset,!phase:running,!phase:succeeded,$label,$node,$service} by {kube_cluster_name,kube_namespace,phase}, 100, 'last', 'desc')",
+                        "q": "top(sum:kubernetes_state.pod.status_phase{$scope,$cluster,$namespace,$deployment,$daemonset,!pod_phase:running,!pod_phase:succeeded,$label,$node,$service} by {kube_cluster_name,kube_namespace,pod_phase}, 100, 'last', 'desc')",
                         "conditional_formats": [
                             {
                                 "comparator": ">",

--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -131,7 +131,7 @@
                     "response_format": "scalar",
                     "queries": [
                       {
-                        "query": "sum:kubernetes_state.pod.status_phase{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob,!phase:running,!phase:succeeded} by {phase,kube_namespace}",
+                        "query": "sum:kubernetes_state.pod.status_phase{$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,$cronjob,!pod_phase:running,!pod_phase:succeeded} by {pod_phase,kube_namespace}",
                         "data_source": "metrics",
                         "name": "query1",
                         "aggregator": "last"

--- a/kubernetes/assets/monitors/monitor_pods_failed_state.json
+++ b/kubernetes/assets/monitors/monitor_pods_failed_state.json
@@ -1,7 +1,7 @@
 {
 	"name": "[kubernetes] Monitor Kubernetes Failed Pods in Namespaces",
 	"type": "query alert",
-	"query": "change(avg(last_5m),last_5m):sum:kubernetes_state.pod.status_phase{phase:failed} by {kube_cluster_name,kube_namespace} > 10",
+	"query": "change(avg(last_5m),last_5m):sum:kubernetes_state.pod.status_phase{pod_phase:failed} by {kube_cluster_name,kube_namespace} > 10",
 	"message": "More than ten pods are failing in ({{kube_cluster_name.name}} cluster). \n The threshold of ten pods varies depending on your infrastructure. Change the threshold to suit your needs.",
 	"tags": [
 		"integration:kubernetes"


### PR DESCRIPTION
### What does this PR do?

* Replace `replicaset` by `kube_replica_set` tag on pod metrics.
* Replace `phase` by `pod_phase` tag on pod metrics.

### Motivation

OOTB Kubernetes Dashboards and monitors should be compatible with
`kubernetes_state` and `kubernetes_state_core` integration, and so
they should only use none deprecated tags.

 
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
