### PR TITLE
Support event platform events for e2e testing

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/_env.py
+++ b/datadog_checks_dev/datadog_checks/dev/_env.py
@@ -33,6 +33,13 @@ JMX_TO_INAPP_TYPES = {
     #       JMX histogram -> DSD histogram -> multiple in-app metrics (max, median, avg, count)
 }
 
+EVENT_PLATFORM_EVENT_TYPES = [
+    'dbm-samples',
+    'dbm-metrics',
+    'dbm-activity',
+    'network-devices-metadata',
+]
+
 
 def e2e_active():
     return (
@@ -133,6 +140,16 @@ def replay_check_run(agent_collector, stub_aggregator, stub_agent):
                     data['tags'],
                     data['host'],
                     data.get('device'),
+                )
+
+        for ep_event_type in EVENT_PLATFORM_EVENT_TYPES:
+            ep_events = aggregator.get(ep_event_type) or []
+            for event in ep_events:
+                stub_aggregator.submit_event_platform_event(
+                    check_name,
+                    check_id,
+                    json.dumps(event['UnmarshalledEvent']),
+                    event['EventType'],
                 )
 
         for data in aggregator.get('service_checks', []):


### PR DESCRIPTION
### What does this PR do?

Support event platform events for e2e testing

### Motivation
See related PR requiring/using this change: https://github.com/DataDog/integrations-core/pull/10664

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
