### PR TITLE
add more galera useful metrics for mysql

### DIFF
--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -237,7 +237,9 @@ GALERA_VARS = {
     'wsrep_local_send_queue_avg': ('mysql.galera.wsrep_local_send_queue_avg', GAUGE),
     'wsrep_replicated_bytes': ('mysql.galera.wsrep_replicated_bytes', GAUGE),
     'wsrep_received_bytes': ('mysql.galera.wsrep_received_bytes', GAUGE),
-    'wsrep_local_state_comment': ('mysql.galera.wsrep_local_state_comment', GAUGE),
+    'wsrep_received': ('mysql.galera.wsrep_received', GAUGE),
+    'wsrep_local_state': ('mysql.galera.wsrep_local_state', GAUGE),
+    'wsrep_local_cert_failures': ('mysql.galera.wsrep_local_cert_failures', GAUGE),
 }
 
 PERFORMANCE_VARS = {

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -239,7 +239,7 @@ GALERA_VARS = {
     'wsrep_received_bytes': ('mysql.galera.wsrep_received_bytes', GAUGE),
     'wsrep_received': ('mysql.galera.wsrep_received', GAUGE),
     'wsrep_local_state': ('mysql.galera.wsrep_local_state', GAUGE),
-    'wsrep_local_cert_failures': ('mysql.galera.wsrep_local_cert_failures', GAUGE),
+    'wsrep_local_cert_failures': ('mysql.galera.wsrep_local_cert_failures', MONOTONIC),
 }
 
 PERFORMANCE_VARS = {

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -235,6 +235,9 @@ GALERA_VARS = {
     'wsrep_flow_control_sent': ('mysql.galera.wsrep_flow_control_sent', MONOTONIC),
     'wsrep_cert_deps_distance': ('mysql.galera.wsrep_cert_deps_distance', GAUGE),
     'wsrep_local_send_queue_avg': ('mysql.galera.wsrep_local_send_queue_avg', GAUGE),
+    'wsrep_replicated_bytes': ('mysql.galera.wsrep_replicated_bytes', GAUGE),
+    'wsrep_received_bytes': ('mysql.galera.wsrep_received_bytes', GAUGE),
+    'wsrep_local_state_comment': ('mysql.galera.wsrep_local_state_comment', GAUGE),
 }
 
 PERFORMANCE_VARS = {

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -192,6 +192,9 @@ mysql.galera.wsrep_flow_control_recv,count,,,,"Shows the number of times the gal
 mysql.galera.wsrep_flow_control_sent,count,,,,"Shows the number of times the galera node has sent a pausing Flow Control message to others",0,mysql,mysql galera wsrep_flow_control_sent
 mysql.galera.wsrep_cert_deps_distance,gauge,,,,"Shows the average distance between the lowest and highest sequence number, or seqno, values that the node can possibly apply in parallel.",0,mysql,mysql galera wsrep_cert_deps_distance
 mysql.galera.wsrep_local_send_queue_avg,gauge,,,,"Show an average for the send queue length since the last FLUSH STATUS query.",0,mysql,mysql galera wsrep_local_send_queue_avg
+mysql.galera.wsrep_replicated_bytes,gauge,,,,"Total size (in bytes) of writesets sent to other nodes.",0,mysql,mysql galera wsrep_replicated_bytes
+mysql.galera.wsrep_received_bytes,gauge,,,,"Total size (in bytes) of writesets received from other nodes.",0,mysql,mysql galera wsrep_received_bytes
+mysql.galera.wsrep_local_state_comment,gauge,,,,"Comment of the node’s state.",0,mysql,mysql galera wsrep_local_state_comment
 mysql.performance.qcache.utilization,gauge,,fraction,,Fraction of the query cache memory currently being used.,0,mysql,mysql performance qcache utilization
 mysql.performance.digest_95th_percentile.avg_us,gauge,,microsecond,,Query response time 95th percentile per schema.,0,mysql,mysql response time 95th
 mysql.performance.query_run_time.avg,gauge,,microsecond,,Avg query response time per schema.,0,mysql,mysql response time avg

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -196,7 +196,7 @@ mysql.galera.wsrep_replicated_bytes,gauge,,,,"Total size (in bytes) of writesets
 mysql.galera.wsrep_received_bytes,gauge,,,,"Total size (in bytes) of writesets received from other nodes.",0,mysql,mysql galera wsrep_received_bytes
 mysql.galera.wsrep_received,gauge,,,,"Total number of write-sets received from other nodes.",0,mysql,mysql galera wsrep_received
 mysql.galera.wsrep_local_state,gauge,,,,"Internal Galera cluster state number",0,mysql,mysql galera wsrep_local_state
-mysql.galera.wsrep_local_cert_failures,gauge,,,,"Total number of local transactions that failed certification test.",0,mysql,mysql galera wsrep_local_cert_failures
+mysql.galera.wsrep_local_cert_failures,count,,,,"Total number of local transactions that failed certification test.",0,mysql,mysql galera wsrep_local_cert_failures
 mysql.performance.qcache.utilization,gauge,,fraction,,Fraction of the query cache memory currently being used.,0,mysql,mysql performance qcache utilization
 mysql.performance.digest_95th_percentile.avg_us,gauge,,microsecond,,Query response time 95th percentile per schema.,0,mysql,mysql response time 95th
 mysql.performance.query_run_time.avg,gauge,,microsecond,,Avg query response time per schema.,0,mysql,mysql response time avg

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -194,7 +194,9 @@ mysql.galera.wsrep_cert_deps_distance,gauge,,,,"Shows the average distance betwe
 mysql.galera.wsrep_local_send_queue_avg,gauge,,,,"Show an average for the send queue length since the last FLUSH STATUS query.",0,mysql,mysql galera wsrep_local_send_queue_avg
 mysql.galera.wsrep_replicated_bytes,gauge,,,,"Total size (in bytes) of writesets sent to other nodes.",0,mysql,mysql galera wsrep_replicated_bytes
 mysql.galera.wsrep_received_bytes,gauge,,,,"Total size (in bytes) of writesets received from other nodes.",0,mysql,mysql galera wsrep_received_bytes
-mysql.galera.wsrep_local_state_comment,gauge,,,,"Comment of the node’s state.",0,mysql,mysql galera wsrep_local_state_comment
+mysql.galera.wsrep_received,gauge,,,,"Total number of write-sets received from other nodes.",0,mysql,mysql galera wsrep_received
+mysql.galera.wsrep_local_state,gauge,,,,"Internal Galera cluster state number",0,mysql,mysql galera wsrep_local_state
+mysql.galera.wsrep_local_cert_failures,gauge,,,,"Total number of local transactions that failed certification test.",0,mysql,mysql galera wsrep_local_cert_failures
 mysql.performance.qcache.utilization,gauge,,fraction,,Fraction of the query cache memory currently being used.,0,mysql,mysql performance qcache utilization
 mysql.performance.digest_95th_percentile.avg_us,gauge,,microsecond,,Query response time 95th percentile per schema.,0,mysql,mysql response time 95th
 mysql.performance.query_run_time.avg,gauge,,microsecond,,Avg query response time per schema.,0,mysql,mysql response time avg


### PR DESCRIPTION
### What does this PR do?
This PR add more useful Galera metrics:
`wsrep_local_state`
`wsrep_replicated_bytes`
`wsrep_received_bytes`
`wsrep_received`
`wsrep_local_cert_failures`


### Motivation
`wsrep_local_state` to determine the Galera state (Synced,Joined,Donor/Desynced,Joining)
`wsrep_received`, `wsrep_replicated_bytes` and `wsrep_received_bytes`  to estimate the gcache size we need to know the amount of data transiting
`wsrep_local_cert_failures` to monitor the "conflicts" that we never want to have (because it refuses commits) on a production cluster

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
