### PR TITLE
Enable CI tracing

### DIFF
--- a/.azure-pipelines/all_pr.yml
+++ b/.azure-pipelines/all_pr.yml
@@ -14,10 +14,23 @@ trigger: none
 variables:
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
   DDEV_COLOR: 1
+  DD_TRACE_AGENT_PORT: 8127
+
+resources:
+  containers:
+    - container: dd_agent
+      image: gcr.io/datadoghq/agent:latest
+      ports:
+        - 8127:8126
+      env:
+        DD_API_KEY: $(DD_CI_API_KEY)
+        DD_HOSTNAME: "none"
+        DD_INSIDE_CI: "true"
 
 jobs:
 - template: './templates/test-all-checks.yml'
   parameters:
+    ddtrace_flag: '--ddtrace'
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
       restoreKeys: |

--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -12,12 +12,25 @@ pr:
 variables:
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
   DDEV_COLOR: 1
+  DD_TRACE_AGENT_PORT: 8127
+
+resources:
+  containers:
+    - container: dd_agent
+      image: gcr.io/datadoghq/agent:latest
+      ports:
+        - 8127:8126
+      env:
+        DD_API_KEY: $(DD_CI_API_KEY)
+        DD_HOSTNAME: "none"
+        DD_INSIDE_CI: "true"
 
 jobs:
 - template: './templates/test-single-linux.yml'
   parameters:
     job_name: Changed
     display: Linux
+    ddtrace_flag: '--ddtrace'
     validate: true
     validate_codeowners: false
     validate_changed: changed
@@ -32,6 +45,7 @@ jobs:
   parameters:
     job_name: Changed
     check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dns_check dotnetclr exchange_server iis network pdh_check sqlserver tcp_check win32_event_log windows_performance_counters windows_service wmi_check'
+    ddtrace_flag: '--ddtrace'
     validate_changed: changed
     display: Windows
     pip_cache_config:

--- a/.azure-pipelines/nightly_latest_base.yml
+++ b/.azure-pipelines/nightly_latest_base.yml
@@ -16,11 +16,24 @@ trigger: none
 variables:
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
   DDEV_COLOR: 1
+  DD_TRACE_AGENT_PORT: 8127
+
+resources:
+  containers:
+    - container: dd_agent
+      image: gcr.io/datadoghq/agent:latest
+      ports:
+        - 8127:8126
+      env:
+        DD_API_KEY: $(DD_CI_API_KEY)
+        DD_HOSTNAME: "none"
+        DD_INSIDE_CI: "true"
 
 jobs:
 - template: './templates/test-all-checks.yml'
   parameters:
     run_py2_tests: false  # Handled via separate nightly
+    ddtrace_flag: '--ddtrace'
     force_base_package: true
     test_e2e: false  # e2e tests run in a docker image so the base package wont be forced
     pip_cache_config:

--- a/.azure-pipelines/nightly_py2.yml
+++ b/.azure-pipelines/nightly_py2.yml
@@ -17,10 +17,23 @@ trigger: none
 variables:
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
   DDEV_COLOR: 1
+  DD_TRACE_AGENT_PORT: 8127
+
+resources:
+  containers:
+    - container: dd_agent
+      image: gcr.io/datadoghq/agent:latest
+      ports:
+        - 8127:8126
+      env:
+        DD_API_KEY: $(DD_CI_API_KEY)
+        DD_HOSTNAME: "none"
+        DD_INSIDE_CI: "true"
 
 jobs:
 - template: './templates/test-all-checks.yml'
   parameters:
+    ddtrace_flag: '--ddtrace'
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
       restoreKeys: |

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -146,6 +146,7 @@ def test(
         # Used for CI app product
         test_env_vars['TOX_TESTENV_PASSENV'] += ' TF_BUILD BUILD* SYSTEM*'
         test_env_vars['DD_SERVICE'] = os.getenv('DD_SERVICE', 'ddev-integrations')
+        test_env_vars['DD_ENV'] = os.getenv('DD_ENV', 'ddev-integrations')
 
     org_name = ctx.obj['org']
     org = ctx.obj['orgs'].get(org_name, {})


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Enable the CI product on all our azure pipelines, we already have it enable on `master` and `latest` CI

### Motivation
<!-- What inspired you to submit this pull request? -->
This PR is a first step to have more visibility on the integrations-core CI

### Additional Notes
<!-- Anything else we should know when reviewing? -->
https://docs.datadoghq.com/continuous_integration/setup_tests/agent/?tab=azurepipelines#ci-provider-configuration-examples

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
