### PR TITLE
Don't allow use of author, pricing, and terms fields for extras integrations

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v1/schema.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v1/schema.py
@@ -123,7 +123,12 @@ def get_manifest_schema():
                 },
                 {
                     "if": {"properties": {"support": {"const": "contrib"}}},
-                    "then": {"properties": {"maintainer": {"pattern": ".*"}}},
+                    "then": {
+                        "properties": {"maintainer": {"pattern": ".*"}},
+                        "not": {
+                            "anyOf": [{"required": ["author"]}, {"required": ["pricing"]}, {"required": ["terms"]}]
+                        },
+                    },
                 },
                 {
                     "if": {"properties": {"support": {"const": "partner"}}},


### PR DESCRIPTION
### What does this PR do?
Don't allow use of author, pricing, and terms fields for extras integrations since they are only for marketplace

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
