### PR TITLE
Add the option to set a reported hostname (Postgres)

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -38,9 +38,9 @@ files:
       value:
         type: string
         display_default: postgres
-    - name: display_hostname
+    - name: reported_hostname
       description: |
-        Set the hostname for this instance.
+        Set the reported hostname for this instance.
       value:
         type: string
     - name: dbstrict

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -40,7 +40,7 @@ files:
         display_default: postgres
     - name: display_hostname
       description: |
-        Override the resolved hostname.
+        Set the hostname for this instance.
       value:
         type: string
     - name: dbstrict

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -38,6 +38,11 @@ files:
       value:
         type: string
         display_default: postgres
+    - name: display_hostname
+      description: |
+        Override the resolved hostname.
+      value:
+        type: string
     - name: dbstrict
       description: |
         Whether to restrict the scope of the check to just the database in question.

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -40,7 +40,8 @@ files:
         display_default: postgres
     - name: reported_hostname
       description: |
-        Set the reported hostname for this instance.
+        Set the reported hostname for this instance. This value overrides the hostname detected by the Agent
+        and can be useful to set a custom hostname when connecting to a remote database through a proxy.
       value:
         type: string
     - name: dbstrict

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -35,6 +35,7 @@ class PostgresConfig:
             raise ConfigurationError('Please specify a user to connect to Postgres.')
         self.password = instance.get('password', '')
         self.dbname = instance.get('dbname', 'postgres')
+        self.display_hostname = instance.get('display_hostname', '')
         self.dbstrict = is_affirmative(instance.get('dbstrict', False))
         self.disable_generic_tags = is_affirmative(instance.get('disable_generic_tags', False)) if instance else False
 

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -35,7 +35,7 @@ class PostgresConfig:
             raise ConfigurationError('Please specify a user to connect to Postgres.')
         self.password = instance.get('password', '')
         self.dbname = instance.get('dbname', 'postgres')
-        self.display_hostname = instance.get('display_hostname', '')
+        self.reported_hostname = instance.get('reported_hostname', '')
         self.dbstrict = is_affirmative(instance.get('dbstrict', False))
         self.disable_generic_tags = is_affirmative(instance.get('disable_generic_tags', False)) if instance else False
 

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -64,6 +64,10 @@ def instance_disable_generic_tags(field, value):
     return False
 
 
+def instance_display_hostname(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_empty_default_hostname(field, value):
     return False
 

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -64,10 +64,6 @@ def instance_disable_generic_tags(field, value):
     return False
 
 
-def instance_display_hostname(field, value):
-    return get_default_field_value(field, value)
-
-
 def instance_empty_default_hostname(field, value):
     return False
 
@@ -117,6 +113,10 @@ def instance_query_timeout(field, value):
 
 
 def instance_relations(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_reported_hostname(field, value):
     return get_default_field_value(field, value)
 
 

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -79,6 +79,7 @@ class InstanceConfig(BaseModel):
     dbname: Optional[str]
     dbstrict: Optional[bool]
     disable_generic_tags: Optional[bool]
+    display_hostname: Optional[str]
     empty_default_hostname: Optional[bool]
     host: str
     ignore_databases: Optional[Sequence[str]]

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -79,7 +79,6 @@ class InstanceConfig(BaseModel):
     dbname: Optional[str]
     dbstrict: Optional[bool]
     disable_generic_tags: Optional[bool]
-    display_hostname: Optional[str]
     empty_default_hostname: Optional[bool]
     host: str
     ignore_databases: Optional[Sequence[str]]
@@ -94,6 +93,7 @@ class InstanceConfig(BaseModel):
     query_samples: Optional[QuerySamples]
     query_timeout: Optional[int]
     relations: Optional[Sequence[Union[str, Relation]]]
+    reported_hostname: Optional[str]
     service: Optional[str]
     ssl: Optional[str]
     ssl_cert: Optional[str]

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -41,6 +41,11 @@ instances:
     #
     # dbname: <DBNAME>
 
+    ## @param display_hostname - string - optional
+    ## Override the resolved hostname.
+    #
+    # display_hostname: <DISPLAY_HOSTNAME>
+
     ## @param dbstrict - boolean - optional - default: false
     ## Whether to restrict the scope of the check to just the database in question.
     ## Set to `true` if you only want to gather metrics from the database provided in the dbname parameter.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -41,10 +41,10 @@ instances:
     #
     # dbname: <DBNAME>
 
-    ## @param display_hostname - string - optional
-    ## Set the hostname for this instance.
+    ## @param reported_hostname - string - optional
+    ## Set the reported hostname for this instance.
     #
-    # display_hostname: <DISPLAY_HOSTNAME>
+    # reported_hostname: <REPORTED_HOSTNAME>
 
     ## @param dbstrict - boolean - optional - default: false
     ## Whether to restrict the scope of the check to just the database in question.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -42,7 +42,7 @@ instances:
     # dbname: <DBNAME>
 
     ## @param display_hostname - string - optional
-    ## Override the resolved hostname.
+    ## Set the hostname for this instance.
     #
     # display_hostname: <DISPLAY_HOSTNAME>
 

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -42,7 +42,8 @@ instances:
     # dbname: <DBNAME>
 
     ## @param reported_hostname - string - optional
-    ## Set the reported hostname for this instance.
+    ## Set the reported hostname for this instance. This value overrides the hostname detected by the Agent
+    ## and can be useful to set a custom hostname when connecting to a remote database through a proxy.
     #
     # reported_hostname: <REPORTED_HOSTNAME>
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -157,7 +157,9 @@ class PostgreSql(AgentCheck):
     def resolved_hostname(self):
         # type: () -> str
         if self._resolved_hostname is None:
-            if self._config.dbm_enabled or self.disable_generic_tags:
+            if self._config.display_hostname:
+                self._resolved_hostname = self._config.display_hostname
+            elif self._config.dbm_enabled or self.disable_generic_tags:
                 self._resolved_hostname = self.resolve_db_host()
             else:
                 self._resolved_hostname = self.agent_hostname

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -157,8 +157,8 @@ class PostgreSql(AgentCheck):
     def resolved_hostname(self):
         # type: () -> str
         if self._resolved_hostname is None:
-            if self._config.display_hostname:
-                self._resolved_hostname = self._config.display_hostname
+            if self._config.reported_hostname:
+                self._resolved_hostname = self._config.reported_hostname
             elif self._config.dbm_enabled or self.disable_generic_tags:
                 self._resolved_hostname = self.resolve_db_host()
             else:

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -227,7 +227,7 @@ def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance)
 
 @mock.patch.dict('os.environ', {'DDEV_SKIP_GENERIC_TAGS_CHECK': 'true'})
 @pytest.mark.parametrize(
-    'dbm_enabled, display_hostname, expected_hostname',
+    'dbm_enabled, reported_hostname, expected_hostname',
     [
         (True, '', 'resolved.hostname'),
         (False, '', 'stubbed.hostname'),
@@ -235,18 +235,18 @@ def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance)
         (True, 'forced_hostname', 'forced_hostname'),
     ],
 )
-def test_correct_hostname(dbm_enabled, display_hostname, expected_hostname, aggregator, pg_instance):
+def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, aggregator, pg_instance):
     pg_instance['dbm'] = dbm_enabled
     pg_instance['collect_activity_metrics'] = True
     pg_instance['disable_generic_tags'] = False  # This flag also affects the hostname
-    pg_instance['display_hostname'] = display_hostname
+    pg_instance['reported_hostname'] = reported_hostname
     check = PostgreSql('test_instance', {}, [pg_instance])
 
     with mock.patch(
         'datadog_checks.postgres.PostgreSql.resolve_db_host', return_value='resolved.hostname'
     ) as resolve_db_host:
         check.check(pg_instance)
-        if display_hostname:
+        if reported_hostname:
             assert resolve_db_host.called is False, 'Expected resolve_db_host.called to be False'
         else:
             assert resolve_db_host.called == dbm_enabled, 'Expected resolve_db_host.called to be ' + str(dbm_enabled)

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -226,11 +226,15 @@ def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance)
 
 
 @mock.patch.dict('os.environ', {'DDEV_SKIP_GENERIC_TAGS_CHECK': 'true'})
-@pytest.mark.parametrize('dbm_enabled, expected_hostname', [(True, 'resolved.hostname'), (False, 'stubbed.hostname')])
-def test_correct_hostname(dbm_enabled, expected_hostname, aggregator, pg_instance):
+@pytest.mark.parametrize(
+    'dbm_enabled, display_hostname, expected_hostname',
+    [(True, '', 'resolved.hostname'), (False, '', 'stubbed.hostname'), (False, 'forced_hostname', 'forced_hostname')]
+)
+def test_correct_hostname(dbm_enabled, display_hostname, expected_hostname, aggregator, pg_instance):
     pg_instance['dbm'] = dbm_enabled
     pg_instance['collect_activity_metrics'] = True
     pg_instance['disable_generic_tags'] = False  # This flag also affects the hostname
+    pg_instance['display_hostname'] = display_hostname
     check = PostgreSql('test_instance', {}, [pg_instance])
 
     with mock.patch(

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -228,7 +228,7 @@ def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance)
 @mock.patch.dict('os.environ', {'DDEV_SKIP_GENERIC_TAGS_CHECK': 'true'})
 @pytest.mark.parametrize(
     'dbm_enabled, display_hostname, expected_hostname',
-    [(True, '', 'resolved.hostname'), (False, '', 'stubbed.hostname'), (False, 'forced_hostname', 'forced_hostname')]
+    [(True, '', 'resolved.hostname'), (False, '', 'stubbed.hostname'), (False, 'forced_hostname', 'forced_hostname')],
 )
 def test_correct_hostname(dbm_enabled, display_hostname, expected_hostname, aggregator, pg_instance):
     pg_instance['dbm'] = dbm_enabled

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -228,7 +228,12 @@ def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance)
 @mock.patch.dict('os.environ', {'DDEV_SKIP_GENERIC_TAGS_CHECK': 'true'})
 @pytest.mark.parametrize(
     'dbm_enabled, display_hostname, expected_hostname',
-    [(True, '', 'resolved.hostname'), (False, '', 'stubbed.hostname'), (False, 'forced_hostname', 'forced_hostname')],
+    [
+        (True, '', 'resolved.hostname'),
+        (False, '', 'stubbed.hostname'),
+        (False, 'forced_hostname', 'forced_hostname'),
+        (True, 'forced_hostname', 'forced_hostname'),
+    ],
 )
 def test_correct_hostname(dbm_enabled, display_hostname, expected_hostname, aggregator, pg_instance):
     pg_instance['dbm'] = dbm_enabled
@@ -241,7 +246,10 @@ def test_correct_hostname(dbm_enabled, display_hostname, expected_hostname, aggr
         'datadog_checks.postgres.PostgreSql.resolve_db_host', return_value='resolved.hostname'
     ) as resolve_db_host:
         check.check(pg_instance)
-        assert resolve_db_host.called == dbm_enabled, 'Expected resolve_db_host.called to be ' + str(dbm_enabled)
+        if display_hostname:
+            assert resolve_db_host.called is False, 'Expected resolve_db_host.called to be False'
+        else:
+            assert resolve_db_host.called == dbm_enabled, 'Expected resolve_db_host.called to be ' + str(dbm_enabled)
 
     expected_tags_no_db = pg_instance['tags'] + ['server:{}'.format(HOST), 'port:{}'.format(PORT)]
     expected_tags_with_db = expected_tags_no_db + ['db:datadog_test']


### PR DESCRIPTION
### What does this PR do?
Adds a new optional config (`display_hostname`) to set the displayed hostname in Postgres. This mechanism overrides the resolved db hostname.

### Motivation
There are some unique cases where the resolved hostname does not (or should not) match the desired hostname.
e.g A local proxy proxying ports to multiple instances or the host is an IP address.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
