### PR TITLE
support non-executable files during pipeline setup

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py
@@ -51,8 +51,11 @@ def setup(checks, changed):
             echo_debug(f"Skip! No scripts for check `{check}` and platform `{cur_platform}`")
             continue
 
-        scripts = sorted(os.listdir(os.path.join(check_scripts_path, cur_platform)))
-        echo_info(f'Setting up: {check} with these config scripts: {scripts}')
+        setup_files = sorted(os.listdir(os.path.join(check_scripts_path, cur_platform)))
+        scripts = [s for s in setup_files if not s.startswith("_")]
+        non_exe = [s for s in setup_files if s.startswith("_")]
+        non_exe_msg = f" (Non-executable setup files: {non_exe})" if non_exe else ""
+        echo_info(f'Setting up: {check} with these config scripts: {scripts}{non_exe_msg}')
 
         for script in scripts:
             script_file = os.path.join(check_scripts_path, cur_platform, script)


### PR DESCRIPTION
### What does this PR do?

If a file in the pipeline setup scripts directory starts with an underscore, then it is treated as a "non-executable" file and it will not be executed.

This is required for https://github.com/DataDog/integrations-core/pull/10637 where a large SQL setup script is needed to be referenced by one of the other scripts, but the SQL script itself must not be executed.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
