### PR TITLE
fix `mmh3.hash64` unicode exception with python2

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/sql.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/sql.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import mmh3
 
+from datadog_checks.base import ensure_bytes
 from datadog_checks.base.utils.serialization import json, sort_keys_kwargs
 
 # Unicode character "Arabic Decimal Separator" (U+066B) is a character which looks like an ascii
@@ -22,7 +23,7 @@ def compute_sql_signature(normalized_query):
         return None
     # Note: please be cautious when changing this function as some features rely on this
     # hash matching the APM resource hash generated on our backend.
-    return format(mmh3.hash64(normalized_query, signed=False)[0], 'x')
+    return format(mmh3.hash64(ensure_bytes(normalized_query), signed=False)[0], 'x')
 
 
 def normalize_query_tag(query):

--- a/datadog_checks_base/tests/base/utils/db/test_db_sql.py
+++ b/datadog_checks_base/tests/base/utils/db/test_db_sql.py
@@ -16,6 +16,7 @@ class TestSQL:
         when changes are made to the hashing algorithm. Changes to the hash can have
         product impact since the backend expects consistency with the APM resource hash.
         """
+        assert '6db2e4f3905c3b5b' == compute_sql_signature('select * from dÒgs')
         assert '11b755a835280e8e' == compute_sql_signature('select * from dogs')
         assert 'd2a193f97126ad67' == compute_sql_signature('update dogs set name = ? where id = ?')
 


### PR DESCRIPTION
### What does this PR do?

Fixes `mmh3.hash64` UnicodeEncodeError when the query contained non-ascii characters in python2. 

```
datadog_checks/base/utils/db/sql.py:27: in compute_sql_signature
    return format(mmh3.hash64(normalized_query, signed=False)[0], 'x')
E   UnicodeEncodeError: 'ascii' codec can't encode character u'\xd2' in position 15: ordinal not in range(128)
```

### Motivation

Fix bug originally surfaced while working on https://github.com/DataDog/integrations-core/pull/10637

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
