### PR TITLE
add `query_name` as tag from Spark Structured Streaming metrics

### DIFF
--- a/spark/assets/configuration/spec.yaml
+++ b/spark/assets/configuration/spec.yaml
@@ -111,6 +111,15 @@ files:
           display_default: false
           example: true
         enabled: true
+      - name: enable_query_name_tag
+        description: |
+          Enable to add a `query_name` tag for Structured Streaming metrics.
+          This option should ONLY be enabled if the stream had a `.queryName` param supplied on `writeStream`,
+          otherwise the stream is given a default UUID.
+        value:
+          type: boolean
+          display_default: false
+          example: true
       - template: instances/http
         overrides:
           auth_token.description: |

--- a/spark/assets/configuration/spec.yaml
+++ b/spark/assets/configuration/spec.yaml
@@ -116,6 +116,7 @@ files:
           Enable to add a `query_name` tag for Structured Streaming metrics.
           This option should ONLY be enabled if the stream had a `.queryName` param supplied on `writeStream`,
           otherwise the stream is given a default UUID.
+          See: https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#starting-streaming-queries
         value:
           type: boolean
           display_default: false

--- a/spark/datadog_checks/spark/config_models/defaults.py
+++ b/spark/datadog_checks/spark/config_models/defaults.py
@@ -60,6 +60,10 @@ def instance_empty_default_hostname(field, value):
     return False
 
 
+def instance_enable_query_name_tag(field, value):
+    return False
+
+
 def instance_executor_level_metrics(field, value):
     return False
 

--- a/spark/datadog_checks/spark/config_models/instance.py
+++ b/spark/datadog_checks/spark/config_models/instance.py
@@ -45,6 +45,7 @@ class InstanceConfig(BaseModel):
     disable_generic_tags: Optional[bool]
     disable_legacy_cluster_tag: Optional[bool]
     empty_default_hostname: Optional[bool]
+    enable_query_name_tag: Optional[bool]
     executor_level_metrics: Optional[bool]
     extra_headers: Optional[Mapping[str, Any]]
     headers: Optional[Mapping[str, Any]]

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -118,14 +118,6 @@ instances:
     #
     # streaming_metrics: true
 
-    ## @param enable_query_name_tag - boolean - optional - default: false
-    ## Enable to add a tag for `query_name` to Structured Streaming metrics.
-    ## This option should ONLY be enabled if the stream had a `.queryName` param supplied on `writeStream`,
-    ## otherwise the stream is given a default UUID.
-    ## See: https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#starting-streaming-queries
-    #
-    # enable_query_name_tag: true
-
     ## @param metricsservlet_path - string - optional - default: /metrics/json
     ## Some Spark metrics are only available via a DropWizard sink, notably the Structured Streaming ones. The
     ## integration fetches a JSON metrics payload from each application by leveraging the default MetricsServlet
@@ -144,6 +136,14 @@ instances:
     ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `spark_cluster`.
     #
     disable_legacy_cluster_tag: true
+
+    ## @param enable_query_name_tag - boolean - optional - default: false
+    ## Enable to add a `query_name` tag for Structured Streaming metrics.
+    ## This option should ONLY be enabled if the stream had a `.queryName` param supplied on `writeStream`,
+    ## otherwise the stream is given a default UUID.
+    ## See: https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#starting-streaming-queries
+    #
+    # enable_query_name_tag: true
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -118,6 +118,14 @@ instances:
     #
     # streaming_metrics: true
 
+    ## @param enable_query_name_tag - boolean - optional - default: false
+    ## Enable to add a tag for `query_name` to Structured Streaming metrics.
+    ## This option should ONLY be enabled if the stream had a `.queryName` param supplied on `writeStream`,
+    ## otherwise the stream is given a default UUID.
+    ## See: https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#starting-streaming-queries
+    #
+    # enable_query_name_tag: true
+
     ## @param metricsservlet_path - string - optional - default: /metrics/json
     ## Some Spark metrics are only available via a DropWizard sink, notably the Structured Streaming ones. The
     ## integration fetches a JSON metrics payload from each application by leveraging the default MetricsServlet

--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -643,17 +643,19 @@ class SparkCheck(AgentCheck):
                 for gauge_name, value in iteritems(response):
                     match = STRUCTURED_STREAMS_METRICS_REGEX.match(gauge_name)
                     if not match:
+                        self.log.debug("No regex match found for gauge: '%s'", str(gauge_name))
                         continue
                     groups = match.groupdict()
                     metric_name = groups['metric_name']
-                    query_name = groups.get("query_name", '')
                     if metric_name not in SPARK_STRUCTURED_STREAMING_METRICS:
+                        self.log.debug("Unknown metric_name encountered: '%s'", str(metric_name))
                         continue
                     metric_name, submission_type = SPARK_STRUCTURED_STREAMING_METRICS[metric_name]
                     tags = ['app_name:%s' % str(app_name)]
                     tags.extend(addl_tags)
 
                     if self._enable_query_name_tag:
+                        query_name = groups['query_name']
                         tags.append('query_name:%s' % str(query_name))
 
                     self._set_metric(metric_name, submission_type, value, tags=tags)

--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -180,6 +180,8 @@ class SparkCheck(AgentCheck):
         self._disable_legacy_cluster_tag = is_affirmative(self.instance.get('disable_legacy_cluster_tag', False))
         self.metricsservlet_path = self.instance.get('metricsservlet_path', '/metrics/json')
 
+        self._enable_query_name_tag = is_affirmative(self.instance.get('enable_query_name_tag', False))
+
         # Get the cluster name from the instance configuration
         self.cluster_name = self.instance.get('cluster_name')
         if self.cluster_name is None:
@@ -648,8 +650,12 @@ class SparkCheck(AgentCheck):
                     if metric_name not in SPARK_STRUCTURED_STREAMING_METRICS:
                         continue
                     metric_name, submission_type = SPARK_STRUCTURED_STREAMING_METRICS[metric_name]
-                    tags = ['app_name:%s' % str(app_name), 'query_name:%s' % str(query_name)]
+                    tags = ['app_name:%s' % str(app_name)]
                     tags.extend(addl_tags)
+
+                    if self._enable_query_name_tag:
+                        tags.append('query_name:%s' % str(query_name))
+
                     self._set_metric(metric_name, submission_type, value, tags=tags)
             except HTTPError as e:
                 self.log.debug(

--- a/spark/datadog_checks/spark/spark.py
+++ b/spark/datadog_checks/spark/spark.py
@@ -42,7 +42,9 @@ SPARK_MASTER_APP_PATH = '/app/'
 MESOS_MASTER_APP_PATH = '/frameworks'
 
 # Extract the application name and the dd metric name from the structured streams metrics.
-STRUCTURED_STREAMS_METRICS_REGEX = re.compile(r"^[\w-]+\.driver\.spark\.streaming\.[\w-]+\.(?P<metric_name>[\w-]+)$")
+STRUCTURED_STREAMS_METRICS_REGEX = re.compile(
+    r"^[\w-]+\.driver\.spark\.streaming\.(?P<query_name>[\w-]+)\.(?P<metric_name>[\w-]+)$"
+)
 
 # Application type and states to collect
 YARN_APPLICATION_TYPES = 'SPARK'
@@ -642,10 +644,11 @@ class SparkCheck(AgentCheck):
                         continue
                     groups = match.groupdict()
                     metric_name = groups['metric_name']
+                    query_name = groups.get("query_name", '')
                     if metric_name not in SPARK_STRUCTURED_STREAMING_METRICS:
                         continue
                     metric_name, submission_type = SPARK_STRUCTURED_STREAMING_METRICS[metric_name]
-                    tags = ['app_name:%s' % str(app_name)]
+                    tags = ['app_name:%s' % str(app_name), 'query_name:%s' % str(query_name)]
                     tags.extend(addl_tags)
                     self._set_metric(metric_name, submission_type, value, tags=tags)
             except HTTPError as e:

--- a/spark/tests/docker/spark-apps/app2.py
+++ b/spark/tests/docker/spark-apps/app2.py
@@ -28,7 +28,13 @@ def main():
     )
 
     # Start running the query that prints the running counts to the console
-    query = word_counts.writeStream.outputMode("complete").format("console").option('truncate', 'false').start()
+    query = (
+        word_counts.writeStream.queryName("my_named_query")
+        .outputMode("complete")
+        .format("console")
+        .option('truncate', 'false')
+        .start()
+    )
 
     query.awaitTermination()
     print("Game over")

--- a/spark/tests/fixtures/metrics_json
+++ b/spark/tests/fixtures/metrics_json
@@ -121,22 +121,22 @@
     "app-20201120094950-0000.driver.LiveListenerBus.queue.streams.size": {
       "value": 0
     },
-    "app-20201120094950-0000.driver.spark.streaming.e8e4803f-cc76-4b53-82f9-361b54448fc4.eventTime-watermark": {
+    "app-20201120094950-0000.driver.spark.streaming.my_named_query.eventTime-watermark": {
       "value": 12
     },
-    "app-20201120094950-0000.driver.spark.streaming.e8e4803f-cc76-4b53-82f9-361b54448fc4.inputRate-total": {
+    "app-20201120094950-0000.driver.spark.streaming.my_named_query.inputRate-total": {
       "value": 12
     },
-    "app-20201120094950-0000.driver.spark.streaming.e8e4803f-cc76-4b53-82f9-361b54448fc4.latency": {
+    "app-20201120094950-0000.driver.spark.streaming.my_named_query.latency": {
       "value": 12
     },
-    "app-20201120094950-0000.driver.spark.streaming.e8e4803f-cc76-4b53-82f9-361b54448fc4.processingRate-total": {
+    "app-20201120094950-0000.driver.spark.streaming.my_named_query.processingRate-total": {
       "value": 12
     },
-    "app-20201120094950-0000.driver.spark.streaming.e8e4803f-cc76-4b53-82f9-361b54448fc4.states-rowsTotal": {
+    "app-20201120094950-0000.driver.spark.streaming.my_named_query.states-rowsTotal": {
       "value": 12
     },
-    "app-20201120094950-0000.driver.spark.streaming.e8e4803f-cc76-4b53-82f9-361b54448fc4.states-usedBytes": {
+    "app-20201120094950-0000.driver.spark.streaming.my_named_query.states-usedBytes": {
       "value": 12
     }
   },

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -552,6 +552,8 @@ SPARK_STREAMING_STATISTICS_METRIC_VALUES = {
     'spark.streaming.statistics.num_total_completed_batches': 28,
 }
 
+SPARK_STRUCTURED_STREAMING_METRIC_TAGS = ['query_name:my_named_query'] + COMMON_TAGS
+
 SPARK_STRUCTURED_STREAMING_METRIC_VALUES = {
     'spark.structured_streaming.input_rate': 12,
     'spark.structured_streaming.latency': 12,
@@ -601,7 +603,7 @@ def test_yarn(aggregator):
 
         # Check the structured streaming metrics
         for metric, value in iteritems(SPARK_STRUCTURED_STREAMING_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=SPARK_STRUCTURED_STREAMING_METRIC_TAGS + CUSTOM_TAGS)
 
         tags = ['url:http://localhost:8088'] + CLUSTER_TAGS + CUSTOM_TAGS
         tags.sort()
@@ -683,7 +685,7 @@ def test_mesos(aggregator):
 
         # Check the structured streaming metrics
         for metric, value in iteritems(SPARK_STRUCTURED_STREAMING_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=SPARK_STRUCTURED_STREAMING_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the service tests
 
@@ -761,7 +763,7 @@ def test_driver_unit(aggregator):
 
         # Check the structured streaming metrics
         for metric, value in iteritems(SPARK_STRUCTURED_STREAMING_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS + CUSTOM_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=SPARK_STRUCTURED_STREAMING_METRIC_TAGS + CUSTOM_TAGS)
 
         # Check the service tests
 
@@ -830,7 +832,7 @@ def test_standalone_unit(aggregator):
 
         # Check the structured streaming metrics
         for metric, value in iteritems(SPARK_STRUCTURED_STREAMING_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=SPARK_STRUCTURED_STREAMING_METRIC_TAGS)
 
         # Check the service tests
         for sc in aggregator.service_checks(STANDALONE_SERVICE_CHECK):
@@ -892,7 +894,7 @@ def test_standalone_unit_with_proxy_warning_page(aggregator):
 
         # Check the structured streaming metrics
         for metric, value in iteritems(SPARK_STRUCTURED_STREAMING_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=SPARK_STRUCTURED_STREAMING_METRIC_TAGS)
 
         # Check the service tests
         for sc in aggregator.service_checks(STANDALONE_SERVICE_CHECK):
@@ -954,7 +956,7 @@ def test_standalone_pre20(aggregator):
 
         # Check the structured streaming metrics
         for metric, value in iteritems(SPARK_STRUCTURED_STREAMING_METRIC_VALUES):
-            aggregator.assert_metric(metric, value=value, tags=COMMON_TAGS)
+            aggregator.assert_metric(metric, value=value, tags=SPARK_STRUCTURED_STREAMING_METRIC_TAGS)
 
         # Check the service tests
         for sc in aggregator.service_checks(STANDALONE_SERVICE_CHECK):


### PR DESCRIPTION
### What does this PR do?
Adds a `query_name` tag for Spark Structured Streaming metrics.  

Part of the implementation for Structured Streams added in #8078 included a regex pattern to capture and validate the `metric_name`s related to structured streaming, but didn't capture the stream's `query_name`, which is also a provided component within the metric key.

### Motivation
This is a necessary tag to have if a cluster is running more than 1 stream! Without the query_name tag there is no way to disambiguate which stream is producing the structured_streaming metrics for that cluster.

### Additional Notes
A query name is optionally set on the Structured Stream when [writing to a sink](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#starting-streaming-queries).  If the queryName param is not supplied, you will see a UUID in it's place, as evidenced by the diff in `spark/tests/fixtures/metrics_json`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
