### PR TITLE
Add support for only_custom_queries

### DIFF
--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -39,6 +39,20 @@ class SapHanaCheck(AgentCheck):
         self._tags = self.instance.get('tags', [])
         self._use_tls = self.instance.get('use_tls', False)
         self._only_custom_queries = is_affirmative(self.instance.get('only_custom_queries', False))
+        self._default_methods = [
+            self.query_master_database,
+            self.query_database_status,
+            self.query_backup_status,
+            self.query_licenses,
+            self.query_connection_overview,
+            self.query_disk_usage,
+            self.query_service_memory,
+            self.query_service_component_memory,
+            self.query_row_store_memory,
+            self.query_service_statistics,
+            self.query_volume_io,
+            self.query_custom,
+        ]
 
         # Add server & port tags
         self._tags.append('server:{}'.format(self._server))
@@ -76,25 +90,11 @@ class SapHanaCheck(AgentCheck):
         self.check_initializations.append(self.parse_config)
 
     def check(self, instance):
-        default_queries = [
-            self.query_master_database,
-            self.query_database_status,
-            self.query_backup_status,
-            self.query_licenses,
-            self.query_connection_overview,
-            self.query_disk_usage,
-            self.query_service_memory,
-            self.query_service_component_memory,
-            self.query_row_store_memory,
-            self.query_service_statistics,
-            self.query_volume_io,
-            self.query_custom,
-        ]
 
         if self._only_custom_queries:
             query_methods = [self.query_custom]
         else:
-            query_methods = default_queries
+            query_methods = self._default_methods
 
         if self._conn is None:
             connection = self.get_connection()

--- a/sap_hana/tests/conftest.py
+++ b/sap_hana/tests/conftest.py
@@ -70,3 +70,15 @@ def dd_environment():
 @pytest.fixture
 def instance():
     return deepcopy(CONFIG)
+
+@pytest.fixture
+def instance_custom_queries():
+    instance = deepcopy(CONFIG)
+    instance['custom_queries'] = [
+        {
+            'tags': ['test:sap_hana'],
+            'query': 'SELECT DATABASE_NAME, COUNT(*) FROM SYS_DATABASES.M_DATA_VOLUMES GROUP BY DATABASE_NAME',
+            'columns': [{'name': 'db', 'type': 'tag'}, {'name': 'data_volume.total', 'type': 'gauge'}],
+        }
+    ]
+    return instance

--- a/sap_hana/tests/conftest.py
+++ b/sap_hana/tests/conftest.py
@@ -71,6 +71,7 @@ def dd_environment():
 def instance():
     return deepcopy(CONFIG)
 
+
 @pytest.fixture
 def instance_custom_queries():
     instance = deepcopy(CONFIG)

--- a/sap_hana/tests/test_integration.py
+++ b/sap_hana/tests/test_integration.py
@@ -23,26 +23,43 @@ def test_check(aggregator, instance):
 
 
 @pytest.mark.usefixtures('dd_environment')
-def test_custom_queries(aggregator, instance):
-    instance['custom_queries'] = [
-        {
-            'tags': ['test:sap_hana'],
-            'query': 'SELECT DATABASE_NAME, COUNT(*) FROM SYS_DATABASES.M_DATA_VOLUMES GROUP BY DATABASE_NAME',
-            'columns': [{'name': 'db', 'type': 'tag'}, {'name': 'data_volume.total', 'type': 'gauge'}],
-        }
-    ]
-
-    check = SapHanaCheck('sap_hana', {}, [instance])
-    check.check(instance)
+def test_custom_queries(aggregator, instance_custom_queries):
+    check = SapHanaCheck('sap_hana', {}, [instance_custom_queries])
+    check.check(instance_custom_queries)
 
     for db in ('SYSTEMDB', 'HXE'):
         aggregator.assert_metric(
             'sap_hana.data_volume.total',
             metric_type=0,
             tags=[
-                'server:{}'.format(instance['server']),
-                'port:{}'.format(instance['port']),
+                'server:{}'.format(instance_custom_queries['server']),
+                'port:{}'.format(instance_custom_queries['port']),
                 'db:{}'.format(db),
                 'test:sap_hana',
             ],
         )
+
+
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize(
+    'custom_only',
+    [
+        pytest.param(True, id='Test collect only custom metrics'),
+        pytest.param(False, id='Test collect custom and default metrics')
+    ],
+)
+def test_only_custom_queries(aggregator, instance_custom_queries, custom_only):
+    instance_custom_queries['only_custom_queries'] = custom_only
+    check = SapHanaCheck('sap_hana', {}, [instance_custom_queries])
+    check.check(instance_custom_queries)
+
+    for metric in metrics.STANDARD:
+        if custom_only:
+            aggregator.assert_metric(metric, count=0)
+        else:
+            aggregator.assert_metric(metric, at_least=1)
+
+    for db in ('SYSTEMDB', 'HXE'):
+        aggregator.assert_metric('sap_hana.data_volume.total', count=2)
+
+    aggregator.assert_all_metrics_covered()

--- a/sap_hana/tests/test_integration.py
+++ b/sap_hana/tests/test_integration.py
@@ -11,9 +11,9 @@ pytestmark = pytest.mark.integration
 
 
 @pytest.mark.usefixtures('dd_environment')
-def test_check(aggregator, instance):
+def test_check(aggregator, instance, dd_run_check):
     check = SapHanaCheck('sap_hana', {}, [instance])
-    check.check(instance)
+    dd_run_check(check)
 
     for metric in metrics.STANDARD:
         aggregator.assert_metric_has_tag(metric, 'server:{}'.format(instance['server']))
@@ -23,9 +23,9 @@ def test_check(aggregator, instance):
 
 
 @pytest.mark.usefixtures('dd_environment')
-def test_custom_queries(aggregator, instance_custom_queries):
+def test_custom_queries(aggregator, instance_custom_queries, dd_run_check):
     check = SapHanaCheck('sap_hana', {}, [instance_custom_queries])
-    check.check(instance_custom_queries)
+    dd_run_check(check)
 
     for db in ('SYSTEMDB', 'HXE'):
         aggregator.assert_metric(
@@ -48,10 +48,10 @@ def test_custom_queries(aggregator, instance_custom_queries):
         pytest.param(False, id='Test collect custom and default metrics'),
     ],
 )
-def test_only_custom_queries(aggregator, instance_custom_queries, custom_only):
+def test_only_custom_queries(aggregator, dd_run_check, instance_custom_queries, custom_only):
     instance_custom_queries['only_custom_queries'] = custom_only
     check = SapHanaCheck('sap_hana', {}, [instance_custom_queries])
-    check.check(instance_custom_queries)
+    dd_run_check(check)
 
     for metric in metrics.STANDARD:
         if custom_only:

--- a/sap_hana/tests/test_integration.py
+++ b/sap_hana/tests/test_integration.py
@@ -45,7 +45,7 @@ def test_custom_queries(aggregator, instance_custom_queries):
     'custom_only',
     [
         pytest.param(True, id='Test collect only custom metrics'),
-        pytest.param(False, id='Test collect custom and default metrics')
+        pytest.param(False, id='Test collect custom and default metrics'),
     ],
 )
 def test_only_custom_queries(aggregator, instance_custom_queries, custom_only):
@@ -59,7 +59,7 @@ def test_only_custom_queries(aggregator, instance_custom_queries, custom_only):
         else:
             aggregator.assert_metric(metric, at_least=1)
 
-    for db in ('SYSTEMDB', 'HXE'):
+    for _db in ('SYSTEMDB', 'HXE'):
         aggregator.assert_metric('sap_hana.data_volume.total', count=2)
 
     aggregator.assert_all_metrics_covered()

--- a/sap_hana/tests/test_unit.py
+++ b/sap_hana/tests/test_unit.py
@@ -19,7 +19,7 @@ def error(*args, **kwargs):
     raise Exception('test')
 
 
-def test_error_query(instance):
+def test_error_query(instance, dd_run_check):
     check = SapHanaCheck('sap_hana', {}, [instance])
     check.log = mock.MagicMock()
 
@@ -29,11 +29,11 @@ def test_error_query(instance):
     conn.cursor = lambda: cursor
     check._conn = conn
 
-    check.check(None)
+    dd_run_check(check)
     check.log.error.assert_any_call('Error querying %s: %s', 'SYS.M_DATABASE', 'test')
 
 
-def test_error_unknown(instance):
+def test_error_unknown(instance, dd_run_check):
     def query_master_database():
         error()
 
@@ -46,9 +46,9 @@ def test_error_unknown(instance):
     conn.cursor = lambda: cursor
     check._conn = conn
 
-    check.query_master_database = query_master_database
+    check._default_methods.append(query_master_database)
 
-    check.check(None)
+    dd_run_check(check)
     check.log.exception.assert_any_call('Unexpected error running `%s`: %s', 'query_master_database', 'test')
 
 


### PR DESCRIPTION
### What does this PR do?
The sap_hana configuration spec was updated with the new `QueryManager` option, `only_custom_queries` via the db config templates, however the integration doesn't use the QueryManager, it only shares common configuration specs. This PR adds support for filtering out the default collected queries. 

### Motivation
Support case

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
