### PR TITLE
Remove `cpu.shares` from documentation as removed from check

### DIFF
--- a/container/metadata.csv
+++ b/container/metadata.csv
@@ -5,7 +5,6 @@ container.cpu.user,rate,,nanosecond,,The container userspace CPU usage,0,contain
 container.cpu.system,rate,,nanosecond,,The container system CPU usage,0,container,cpu_system
 container.cpu.throttled,rate,,nanosecond,,The total cpu throttled time,0,container,cpu_throttled
 container.cpu.throttled.periods,rate,,,,The number of periods during which the container was throttled,0,container,cpu_throttled_periods
-container.cpu.shares,gauge,,,,The number of CPU shares assigned to the container,0,container,cpu_shares
 container.cpu.limit,gauge,,nanosecond,,The maximum CPU time available to the container,0,container,cpu_limit
 container.memory.usage,gauge,,byte,,The container total memory usage,0,container,mem_usage
 container.memory.kernel,gauge,,byte,,The container kernel memory usage,0,container,mem_kernel_usage


### PR DESCRIPTION
### What does this PR do?

Remove `cpu.shares` from doc as removed from check: [#9969](https://github.com/DataDog/datadog-agent/pull/9969)

### Motivation
Align doc

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
