### PR TITLE
Refactor release troubleshooting section and add another case

### DIFF
--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -240,7 +240,7 @@ ddev release upload datadog_checks_[base|dev]
       
     1. Verify whether the hash signed in `.in-toto/tag.<KEYID>.link`, [(see example)](https://github.com/DataDog/integrations-core/blob/9836c71f15a0cb93c63c1d2950dcdc28b49479a7/.in-toto/tag.57ce2495.link) matches what's on `master` for the artifact in question.
         
-        To see the hash for the file, run the following `shasum` command (replace local file path):
+        To see the hash for the artifact, run the following `shasum` command (replace local file path):
         
         ```
         shasum -a 256 datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -237,12 +237,14 @@ ddev release upload datadog_checks_[base|dev]
       in_toto.exceptions.RuleVerificationError: 'DISALLOW *' matched the following artifacts: ['/shared/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py']
     ```
   
-  - Verify the signature signed in `.in_toto/tag.*.link` matches what's on master for the artifact in question.
+  - Verify the signature signed in [`.in_toto/tag.*.link`](https://github.com/DataDog/integrations-core/blob/9836c71f15a0cb93c63c1d2950dcdc28b49479a7/.in-toto/tag.57ce2495.link) matches what's on master for the artifact in question.
+
     ```shell script
         shasum -a 256 datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py
     ```
 
   - Release the integration again with a new version, bump the version appropriately.
+
     ```shell script
         ddev release make <INTEGRATION> --version <VERSION>
     ```

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -238,7 +238,7 @@ ddev release upload datadog_checks_[base|dev]
     in_toto.exceptions.RuleVerificationError: 'DISALLOW *' matched the following artifacts: ['/shared/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py']
     ```
       
-    1. Verify the hash signed in `.in-toto/tag.<KEYID>.link`, [(see example)](https://github.com/DataDog/integrations-core/blob/9836c71f15a0cb93c63c1d2950dcdc28b49479a7/.in-toto/tag.57ce2495.link), matches what's on master for the artifact in question.
+    1. Verify whether the hash signed in `.in-toto/tag.<KEYID>.link`, [(see example)](https://github.com/DataDog/integrations-core/blob/9836c71f15a0cb93c63c1d2950dcdc28b49479a7/.in-toto/tag.57ce2495.link) matches what's on `master` for the artifact in question.
         
         To see the hash for the file, run the following `shasum` command (replace local file path):
         

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -237,8 +237,9 @@ ddev release upload datadog_checks_[base|dev]
       in_toto.exceptions.RuleVerificationError: 'DISALLOW *' matched the following artifacts: ['/shared/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py']
     ```
   
-  - Verify the signature signed in [`.in_toto/tag.*.link`](https://github.com/DataDog/integrations-core/blob/9836c71f15a0cb93c63c1d2950dcdc28b49479a7/.in-toto/tag.57ce2495.link) matches what's on master for the artifact in question.
-
+  - Verify the signature signed in `.in-toto/tag.<hash>.link`, [(see example)](https://github.com/DataDog/integrations-core/blob/9836c71f15a0cb93c63c1d2950dcdc28b49479a7/.in-toto/tag.57ce2495.link), matches what's on master for the artifact in question.
+    
+    To see the signature for the file, run the following `shasum` command (replace local file path)
     ```shell script
         shasum -a 256 datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py
     ```

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -240,7 +240,7 @@ ddev release upload datadog_checks_[base|dev]
       
     1. Verify the hash signed in `.in-toto/tag.<KEYID>.link`, [(see example)](https://github.com/DataDog/integrations-core/blob/9836c71f15a0cb93c63c1d2950dcdc28b49479a7/.in-toto/tag.57ce2495.link), matches what's on master for the artifact in question.
         
-        To see the signature for the file, run the following `shasum` command (replace local file path):
+        To see the hash for the file, run the following `shasum` command (replace local file path):
         
         ```
         shasum -a 256 datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -238,7 +238,7 @@ ddev release upload datadog_checks_[base|dev]
     in_toto.exceptions.RuleVerificationError: 'DISALLOW *' matched the following artifacts: ['/shared/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py']
     ```
       
-    1. Verify the signature signed in `.in-toto/tag.<hash>.link`, [(see example)](https://github.com/DataDog/integrations-core/blob/9836c71f15a0cb93c63c1d2950dcdc28b49479a7/.in-toto/tag.57ce2495.link), matches what's on master for the artifact in question.
+    1. Verify the hash signed in `.in-toto/tag.<KEYID>.link`, [(see example)](https://github.com/DataDog/integrations-core/blob/9836c71f15a0cb93c63c1d2950dcdc28b49479a7/.in-toto/tag.57ce2495.link), matches what's on master for the artifact in question.
         
         To see the signature for the file, run the following `shasum` command (replace local file path):
         

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -187,9 +187,10 @@ ddev release upload datadog_checks_[base|dev]
 ## Troubleshooting
 
 #### Error signing with Yubikey
-    - If you encounter errors when signing with your Yubikey, ensure you ran `gpg --import <YOUR_KEY_ID>.gpg.pub`.
-    - If you receive this error when signing with your Yubikey, check if you have more than one Yubikey inserted in your computer. Try removing the Yubikey that's not used for signing and try signing again.
-    ```
+- If you encounter errors when signing with your Yubikey, ensure you ran `gpg --import <YOUR_KEY_ID>.gpg.pub`.
+- If you receive this error when signing with your Yubikey, check if you have more than one Yubikey inserted in your computer. Try removing the Yubikey that's not used for signing and try signing again.
+    
+  ```
       File "/Users/<USER>/.pyenv/versions/3.9.4/lib/python3.9/site-packages/in_toto/runlib.py", line 529, in in_toto_run
         securesystemslib.formats.KEYID_SCHEMA.check_match(gpg_keyid)
       File "/Users/<USER>/.pyenv/versions/3.9.4/lib/python3.9/site-packages/securesystemslib/schema.py", line 1004, in check_match
@@ -245,13 +246,27 @@ ddev release upload datadog_checks_[base|dev]
         shasum -a 256 datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py
         ```
     
-      - Release the integration again with a new version, bump the version appropriately.
+      - In order to include the changes merged after the initial release of the integration,
+
+        1. Checkout and pull the most recent version of the `master` branch.
+
+            ```
+            git checkout master
+            git pull
+            ```
+                
+       1. Release the integration again with a new version, bump the version appropriately.
     
-        ```
-        ddev release make <INTEGRATION> --version <VERSION>
-        ```
+            ```
+            ddev release make <INTEGRATION> --version <VERSION>
+            ```
         
-        Note: You may need to manually update the changelog field to reflect the feature PR.
+        1. Verify that the integration files are signed and update the integration changelog to reflect the feature PR title in the following format.
+            
+            ```
+            * [<Changelog label>] <PR Title>. [See #<PR Number>](<Github PR link>).
+            ```
+        1. After approval, merge PR to master for a new build to be triggered.
   
 
 ## Releasers

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -186,15 +186,18 @@ ddev release upload datadog_checks_[base|dev]
 
 ## Troubleshooting
 
-- If you encounter errors when signing with your Yubikey, ensure you ran `gpg --import <YOUR_KEY_ID>.gpg.pub`.
-- If you receive this error when signing with your Yubikey, check if you have more than one Yubikey inserted in your computer. Try removing the Yubikey that's not used for signing and try signing again.
-```
-  File "/Users/<USER>/.pyenv/versions/3.9.4/lib/python3.9/site-packages/in_toto/runlib.py", line 529, in in_toto_run
-    securesystemslib.formats.KEYID_SCHEMA.check_match(gpg_keyid)
-  File "/Users/<USER>/.pyenv/versions/3.9.4/lib/python3.9/site-packages/securesystemslib/schema.py", line 1004, in check_match
-    raise exceptions.FormatError(
-securesystemslib.exceptions.FormatError: '[none]' did not match 'pattern /[a-fA-F0-9]+$/'
-```
+#### Error signing with Yubikey
+    - If you encounter errors when signing with your Yubikey, ensure you ran `gpg --import <YOUR_KEY_ID>.gpg.pub`.
+    - If you receive this error when signing with your Yubikey, check if you have more than one Yubikey inserted in your computer. Try removing the Yubikey that's not used for signing and try signing again.
+    ```
+      File "/Users/<USER>/.pyenv/versions/3.9.4/lib/python3.9/site-packages/in_toto/runlib.py", line 529, in in_toto_run
+        securesystemslib.formats.KEYID_SCHEMA.check_match(gpg_keyid)
+      File "/Users/<USER>/.pyenv/versions/3.9.4/lib/python3.9/site-packages/securesystemslib/schema.py", line 1004, in check_match
+        raise exceptions.FormatError(
+    securesystemslib.exceptions.FormatError: '[none]' did not match 'pattern /[a-fA-F0-9]+$/'
+    ```
+    
+#### Build pipeline failed
 
 - If the [build pipeline](../meta/cd.md) failed, it is likely that you modified a file in the pull request
   without re-signing. To resolve this, you'll need to bootstrap metadata for every integration:
@@ -225,6 +228,27 @@ securesystemslib.exceptions.FormatError: '[none]' did not match 'pattern /[a-fA-
         deleted tags, so any subsequent manual trigger tags will need to increment the version number.
 
     1. Delete the branch and tag, locally and on GitHub.
+    
+- If the [build pipeline](../meta/cd.md) failed due to another feature PR being merged after the release PR is opened, the merged release PR will not have updated and signed the feature PR's files.
+  
+  You may see an error like so:
+  
+    ```text
+      in_toto.exceptions.RuleVerificationError: 'DISALLOW *' matched the following artifacts: ['/shared/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py']
+    ```
+  
+  - Verify the signature signed in `.in_toto/tag.*.link` matches what's on master for the artifact in question.
+    ```shell script
+        shasum -a 256 datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py
+    ```
+
+  - Release the integration again with a new version, bump the version appropriately.
+    ```shell script
+        ddev release make <INTEGRATION> --version <VERSION>
+    ```
+    
+    Note: You may need to manually update the changelog field to reflect the feature PR.
+  
 
 ## Releasers
 

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -246,7 +246,7 @@ ddev release upload datadog_checks_[base|dev]
         shasum -a 256 datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py
         ```
     
-    1. Checkout and pull the most recent version of the `master` branch.
+    1. If any artifact mismatches, check out and pull the most recent version of the `master` branch.
     
         ```
         git checkout master

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -230,7 +230,7 @@ ddev release upload datadog_checks_[base|dev]
 
     1. Delete the branch and tag, locally and on GitHub.
     
-- If the [build pipeline](../meta/cd.md) failed due to another feature PR being merged after the release PR is opened, the merged release PR will not have updated and signed the feature PR's files.
+- If the [build pipeline](../meta/cd.md) failed due to another feature PR conflicting with and being merged after the release PR is opened, the merged release PR will not have updated and signed the feature PR's files.
   
     You may see an error like so:
     

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -231,26 +231,27 @@ ddev release upload datadog_checks_[base|dev]
     
 - If the [build pipeline](../meta/cd.md) failed due to another feature PR being merged after the release PR is opened, the merged release PR will not have updated and signed the feature PR's files.
   
-  You may see an error like so:
-  
+    You may see an error like so:
+    
     ```text
-      in_toto.exceptions.RuleVerificationError: 'DISALLOW *' matched the following artifacts: ['/shared/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py']
+    in_toto.exceptions.RuleVerificationError: 'DISALLOW *' matched the following artifacts: ['/shared/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py']
     ```
-  
-  - Verify the signature signed in `.in-toto/tag.<hash>.link`, [(see example)](https://github.com/DataDog/integrations-core/blob/9836c71f15a0cb93c63c1d2950dcdc28b49479a7/.in-toto/tag.57ce2495.link), matches what's on master for the artifact in question.
-    
-    To see the signature for the file, run the following `shasum` command (replace local file path)
-    ```shell script
+      
+      - Verify the signature signed in `.in-toto/tag.<hash>.link`, [(see example)](https://github.com/DataDog/integrations-core/blob/9836c71f15a0cb93c63c1d2950dcdc28b49479a7/.in-toto/tag.57ce2495.link), matches what's on master for the artifact in question.
+        
+        To see the signature for the file, run the following `shasum` command (replace local file path):
+        
+        ```
         shasum -a 256 datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py
-    ```
-
-  - Release the integration again with a new version, bump the version appropriately.
-
-    ```shell script
-        ddev release make <INTEGRATION> --version <VERSION>
-    ```
+        ```
     
-    Note: You may need to manually update the changelog field to reflect the feature PR.
+      - Release the integration again with a new version, bump the version appropriately.
+    
+        ```
+        ddev release make <INTEGRATION> --version <VERSION>
+        ```
+        
+        Note: You may need to manually update the changelog field to reflect the feature PR.
   
 
 ## Releasers

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -196,7 +196,7 @@ ddev release upload datadog_checks_[base|dev]
       File "/Users/<USER>/.pyenv/versions/3.9.4/lib/python3.9/site-packages/securesystemslib/schema.py", line 1004, in check_match
         raise exceptions.FormatError(
     securesystemslib.exceptions.FormatError: '[none]' did not match 'pattern /[a-fA-F0-9]+$/'
-    ```
+  ```
     
 #### Build pipeline failed
 
@@ -238,7 +238,7 @@ ddev release upload datadog_checks_[base|dev]
     in_toto.exceptions.RuleVerificationError: 'DISALLOW *' matched the following artifacts: ['/shared/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py']
     ```
       
-      - Verify the signature signed in `.in-toto/tag.<hash>.link`, [(see example)](https://github.com/DataDog/integrations-core/blob/9836c71f15a0cb93c63c1d2950dcdc28b49479a7/.in-toto/tag.57ce2495.link), matches what's on master for the artifact in question.
+    1. Verify the signature signed in `.in-toto/tag.<hash>.link`, [(see example)](https://github.com/DataDog/integrations-core/blob/9836c71f15a0cb93c63c1d2950dcdc28b49479a7/.in-toto/tag.57ce2495.link), matches what's on master for the artifact in question.
         
         To see the signature for the file, run the following `shasum` command (replace local file path):
         
@@ -246,27 +246,26 @@ ddev release upload datadog_checks_[base|dev]
         shasum -a 256 datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py
         ```
     
-      - In order to include the changes merged after the initial release of the integration,
-
-        1. Checkout and pull the most recent version of the `master` branch.
-
-            ```
-            git checkout master
-            git pull
-            ```
-                
-       1. Release the integration again with a new version, bump the version appropriately.
+    1. Checkout and pull the most recent version of the `master` branch.
     
-            ```
-            ddev release make <INTEGRATION> --version <VERSION>
-            ```
-        
-        1. Verify that the integration files are signed and update the integration changelog to reflect the feature PR title in the following format.
+        ```
+        git checkout master
+        git pull
+        ```
             
-            ```
-            * [<Changelog label>] <PR Title>. [See #<PR Number>](<Github PR link>).
-            ```
-        1. After approval, merge PR to master for a new build to be triggered.
+    1. Release the integration again with a new version, bump the version appropriately.
+    
+        ```
+        ddev release make <INTEGRATION> --version <VERSION>
+        ```
+    
+    1. Verify that the integration files are signed and update the integration changelog to reflect the feature PR title in the following format.
+        
+        ```
+        * [<Changelog label>] <PR Title>. [See #<PR Number>](<Github PR link>).
+        ```
+       
+    1. After approval, merge PR to master for a new build to be triggered.
   
 
 ## Releasers

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -259,7 +259,7 @@ ddev release upload datadog_checks_[base|dev]
         ddev release make <INTEGRATION> --version <VERSION>
         ```
     
-    1. Verify that the integration files are signed and update the integration changelog to reflect the feature PR title in the following format.
+    1. Verify that the integration files are signed, and update the integration changelog to reflect the feature PR title in the following format.
         
         ```
         * [<Changelog label>] <PR Title>. [See #<PR Number>](<Github PR link>).

--- a/docs/developer/process/integration-release.md
+++ b/docs/developer/process/integration-release.md
@@ -200,8 +200,11 @@ ddev release upload datadog_checks_[base|dev]
     
 #### Build pipeline failed
 
-- If the [build pipeline](../meta/cd.md) failed, it is likely that you modified a file in the pull request
-  without re-signing. To resolve this, you'll need to bootstrap metadata for every integration:
+After merging the release PR, the [build pipeline](../meta/cd.md) can fail under a few cases. See below for steps on diagnosing the error and the corresponding fix.
+
+- A file in the pull request was modified without re-signing. View the `Files Changed` tab in the recently merged release PR and verify the `.in-toto/tag.<KEYID>.link` exists and the integration files were signed.
+
+  To resolve this, you'll need to bootstrap metadata for every integration:
 
     1. Checkout and pull the most recent version of the `master` branch.
 
@@ -230,7 +233,14 @@ ddev release upload datadog_checks_[base|dev]
 
     1. Delete the branch and tag, locally and on GitHub.
     
-- If the [build pipeline](../meta/cd.md) failed due to another feature PR conflicting with and being merged after the release PR is opened, the merged release PR will not have updated and signed the feature PR's files.
+- If a feature PR conflicting with the release PR is merged out of order.
+
+    The following is a possible sequence of events that can result in the build pipeline failing:
+    
+        1. A release PR is opened
+        2. A feature PR is opened and merged
+        3. The release PR is merged after the feature PR.
+        4. The release PR will not have updated and signed the feature PR's files, the released wheel will also not contain the changes from the feature PR.
   
     You may see an error like so:
     


### PR DESCRIPTION
### What does this PR do?
This PR refactors the troubleshooting section into 2 subsections (signing issues and build failure issues). I also added another case of release build failure that isn't covered.

### Motivation
Update docs

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
