### PR TITLE
Add clarification on supported NGINX Ingress distros

### DIFF
--- a/nginx_ingress_controller/README.md
+++ b/nginx_ingress_controller/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-This check monitors the kubernetes [NGINX Ingress Controller][1].
+This check monitors the kubernetes [NGINX Ingress Controller][1]. To monitor the F5 NGINX Ingress Controller, set up the [Datadog Prometheus integration][10] to monitor metrics of interest available from the list at [NGINX Prometheus Exporter][11]
+
+https://github.com/nginxinc/nginx-prometheus-exporter#exported-metrics
 
 ## Setup
 
@@ -110,3 +112,5 @@ Need help? Contact [Datadog support][9].
 [7]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [8]: https://github.com/DataDog/integrations-core/blob/master/nginx_ingress_controller/metadata.csv
 [9]: https://docs.datadoghq.com/help/
+[10]: https://docs.datadoghq.com/agent/kubernetes/prometheus/
+[11]: https://github.com/nginxinc/nginx-prometheus-exporter#exported-metrics

--- a/nginx_ingress_controller/README.md
+++ b/nginx_ingress_controller/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This check monitors the kubernetes [NGINX Ingress Controller][1]. To monitor the F5 NGINX Ingress Controller, set up the [Datadog Prometheus integration][10] to monitor metrics of interest available from the list at [NGINX Prometheus Exporter][11]
+This check monitors the Kubernetes [NGINX Ingress Controller][1]. To monitor the F5 NGINX Ingress Controller, set up the [Datadog Prometheus integration][10] to monitor desired metrics from the list provided by the [NGINX Prometheus Exporter][11].
 
 https://github.com/nginxinc/nginx-prometheus-exporter#exported-metrics
 

--- a/nginx_ingress_controller/README.md
+++ b/nginx_ingress_controller/README.md
@@ -4,7 +4,6 @@
 
 This check monitors the Kubernetes [NGINX Ingress Controller][1]. To monitor the F5 NGINX Ingress Controller, set up the [Datadog Prometheus integration][10] to monitor desired metrics from the list provided by the [NGINX Prometheus Exporter][11].
 
-https://github.com/nginxinc/nginx-prometheus-exporter#exported-metrics
 
 ## Setup
 


### PR DESCRIPTION
Added clarification that this integration currently only supports the Kubernetes distribution of NGINX Ingress Controller, while the F5 distribution needs to be configured separately using Prometheus for now.

### What does this PR do?
Clarification on out of scope use case, and workaround.

### Motivation
https://datadoghq.atlassian.net/browse/CONS-4307

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
