### PR TITLE
Add new `tls_only` choice to the `bearer_token` parameter that sends the bearer token only to secure HTTPS endpoints

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -348,12 +348,16 @@ class OpenMetricsScraperMixin(object):
         # INTERNAL FEATURE, might be removed in future versions
         config['_text_filter_blacklist'] = []
 
-        # Whether or not to use the service account bearer token for authentication
-        # if 'bearer_token_path' is not set, we use /var/run/secrets/kubernetes.io/serviceaccount/token
+        # Whether or not to use the service account bearer token for authentication.
+        # Can be explicitly set to true or false to send or not the bearer token.
+        # If set to the `tls_only` value, the bearer token will be sent only to https endpoints.
+        # If 'bearer_token_path' is not set, we use /var/run/secrets/kubernetes.io/serviceaccount/token
         # as a default path to get the token.
-        config['bearer_token_auth'] = is_affirmative(
-            instance.get('bearer_token_auth', default_instance.get('bearer_token_auth', False))
-        )
+        bearer_token_auth = _get_setting('bearer_token_auth', False)
+        if bearer_token_auth == 'tls_only':
+            config['bearer_token_auth'] = config['prometheus_url'].startswith("https://")
+        else:
+            config['bearer_token_auth'] = is_affirmative(bearer_token_auth)
 
         # Can be used to get a service account bearer token from files
         # other than /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_openmetrics_base_check.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_openmetrics_base_check.py
@@ -198,3 +198,19 @@ def test_bearer_token_not_found():
     }
     with pytest.raises(IOError):
         OpenMetricsBaseCheck('prometheus_check', {}, {}, [instance])
+
+
+def test_bearer_token_auto_http():
+    endpoint = "http://localhost:12345/metrics"
+    instance = {'prometheus_url': endpoint, 'namespace': 'default_namespace', 'bearer_token_auth': 'tls_only'}
+    with patch.object(OpenMetricsBaseCheck, 'KUBERNETES_TOKEN_PATH', os.path.join(FIXTURE_PATH, 'default_token')):
+        check = OpenMetricsBaseCheck('prometheus_check', {}, {}, [instance])
+        assert check.get_scraper_config(instance)['_bearer_token'] is None
+
+
+def test_bearer_token_auto_https():
+    endpoint = "https://localhost:12345/metrics"
+    instance = {'prometheus_url': endpoint, 'namespace': 'default_namespace', 'bearer_token_auth': 'tls_only'}
+    with patch.object(OpenMetricsBaseCheck, 'KUBERNETES_TOKEN_PATH', os.path.join(FIXTURE_PATH, 'default_token')):
+        check = OpenMetricsBaseCheck('prometheus_check', {}, {}, [instance])
+        assert check.get_scraper_config(instance)['_bearer_token'] == 'my default token'


### PR DESCRIPTION
### What does this PR do?

Change the meaning of the default value of the `bearer_token` parameter of the OpenMetrics based checks.
The default behaviour if not set is now to send the bearer token to secure `https` endpoints and not to clear text `http` endpoints.

### Motivation

This is useful for all the checks that are leveraging the `possible_prometheus_urls` to try to autodetect what is the usable endpoint url based on a list of commonly used ones.
This is the case for the Kubernetes control plane components checks.

### Additional Notes

* `kube_controller_manager`: #10708
* `kube_scheduler`: #10709
* `kube_apiserver_metrics`: #10772

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have `changelog/` and `integration/` labels attached
