### PR TITLE
Update the default value of the `bearer_token` parameter to send the bearer token only to secure https endpoints by default

### DIFF
--- a/kube_controller_manager/assets/configuration/spec.yaml
+++ b/kube_controller_manager/assets/configuration/spec.yaml
@@ -103,9 +103,11 @@ files:
         against the APIServer to retrieve metrics.
       enabled: true
       value:
-        type: boolean
-        example: true
+        example: tls_only
         display_default: false
+        anyOf:
+        - type: boolean
+        - type: string
     - name: ssl_verify
       description: Used to verify self signed certificates.
       enabled: true

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/auto_conf.yaml
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/auto_conf.yaml
@@ -31,11 +31,11 @@ instances:
     #
     # prometheus_url: http://%%host%%:10252/metrics
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## Used if you are using RBACs and need the Agent to authenticate
     ## against the APIServer to retrieve metrics.
     #
-    bearer_token_auth: true
+    bearer_token_auth: tls_only
 
     ## @param ssl_verify - boolean - optional - default: true
     ## Used to verify self signed certificates.


### PR DESCRIPTION
### What does this PR do?

Change the default behaviour of the auto-configuration of the `kube_controller_manager` check.
By default, when trying all the possible endpoints, the bearer token will be sent only to secure `https` endpoints.

### Motivation

Make the check work out of the box without leaking the token on an insecure connection on both clusters where only the insecure `http` endpoint is available and on clusters where only the secure `https` endpoint is available.

### Additional Notes

Leverages #10706 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have `changelog/` and `integration/` labels attached
