### PR TITLE
Update the default value of the `bearer_token` parameter to send the bearer token only to secure https endpoints by default

### DIFF
--- a/kube_scheduler/assets/configuration/spec.yaml
+++ b/kube_scheduler/assets/configuration/spec.yaml
@@ -77,9 +77,9 @@ files:
         against the APIServer to retrieve metrics.
       enabled: true
       value:
-        type: boolean
-        example: true
-        default: false
+        type: string
+        example: tls_only
+        default: "false"
     - name: bearer_token_path
       description: Used to specify the path where the service account token is located.
       value:

--- a/kube_scheduler/assets/configuration/spec.yaml
+++ b/kube_scheduler/assets/configuration/spec.yaml
@@ -77,9 +77,11 @@ files:
         against the APIServer to retrieve metrics.
       enabled: true
       value:
-        type: string
         example: tls_only
-        default: "false"
+        default: false
+        anyOf:
+        - type: boolean
+        - type: string
     - name: bearer_token_path
       description: Used to specify the path where the service account token is located.
       value:

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
@@ -31,7 +31,7 @@ instances:
     #
     # prometheus_url: http://%%host%%:10251/metrics
 
-    ## @param bearer_token_auth - string - optional - default: tls_only
+    ## @param bearer_token_auth - boolean or string - optional - default: tls_only
     ## Used if you are using RBACs and need the Agent to authenticate
     ## against the APIServer to retrieve metrics.
     #

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
@@ -31,11 +31,11 @@ instances:
     #
     # prometheus_url: http://%%host%%:10251/metrics
 
-    ## @param bearer_token_auth - boolean - optional - default: true
+    ## @param bearer_token_auth - string - optional - default: tls_only
     ## Used if you are using RBACs and need the Agent to authenticate
     ## against the APIServer to retrieve metrics.
     #
-    bearer_token_auth: true
+    bearer_token_auth: tls_only
 
     ## @param bearer_token_path - string - optional - default: /var/run/secrets/kubernetes.io/serviceaccount/token
     ## Used to specify the path where the service account token is located.


### PR DESCRIPTION
### What does this PR do?

Change the default behaviour of the auto-configuration of the `kube_scheduler` check.
By default, when trying all the possible endpoints, the bearer token will be sent only to secure https endpoints.

### Motivation

Make the check work out of the box without leaking the token on an insecure connection on both clusters where only the insecure `http` endpoint is available and on clusters where only the secure `https` endpoint is available.

### Additional Notes

Leverages #10706

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have `changelog/` and `integration/` labels attached
