### PR TITLE
Add missing assertion

### DIFF
--- a/redisdb/tests/test_e2e.py
+++ b/redisdb/tests/test_e2e.py
@@ -78,6 +78,7 @@ def test_e2e_v_3_2(dd_agent_check, master_instance):
     aggregator.assert_metric('redis.clients.biggest_input_buf', count=2, tags=tags)
     aggregator.assert_metric('redis.clients.longest_output_list', count=2, tags=tags)
 
+    assert_optional_slowlog_metrics(aggregator)
     assert_all(aggregator)
 
 


### PR DESCRIPTION
Add optional metrics assertions to tests to prevent the test from flaking

```
________________________________ test_e2e_v_3_2 ________________________________
tests/test_e2e.py:81: in test_e2e_v_3_2
    assert_all(aggregator)
tests/test_e2e.py:147: in assert_all
    aggregator.assert_all_metrics_covered()
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:419: in assert_all_metrics_covered
    assert condition, msg
E   AssertionError: Some metrics are missing:
E     Asserted Metrics:
...
E     Missing Metrics:
E     	- redis.slowlog.micros.95percentile
E     	- redis.slowlog.micros.avg
E     	- redis.slowlog.micros.count
E     	- redis.slowlog.micros.max
E     	- redis.slowlog.micros.median
E   assert False
```