### PR TITLE
Bump hatchling to 0.0.45

### DIFF
--- a/snowflake/tests/snowflake_connector_patch/pyproject.toml
+++ b/snowflake/tests/snowflake_connector_patch/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['hatchling==0.0.41']
+requires = ['hatchling==0.0.45']
 build-backend = 'hatchling.build'
 
 [project]


### PR DESCRIPTION
Build is failing with the following error:

```
Processing /home/snowflake_connector_patch
  Installing build dependencies: started
  Installing build dependencies: finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /opt/datadog-agent/embedded/bin/python3 /tmp/pip-standalone-pip-a3frtscc/__env_pip__.zip/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-jqnh44pq/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- hatchling==0.0.41
       cwd: None
  Complete output (2 lines):
  ERROR: Could not find a version that satisfies the requirement hatchling==0.0.41 (from versions: 0.0.45)
  ERROR: No matching distribution found for hatchling==0.0.41
  ----------------------------------------
```