### PR TITLE
fix broken unicode support for sqlserver

### DIFF
--- a/.azure-pipelines/scripts/sqlserver/windows/55_setup_sqlserver.bat
+++ b/.azure-pipelines/scripts/sqlserver/windows/55_setup_sqlserver.bat
@@ -1,5 +1,5 @@
 :: Setup SQL Server
-sqlcmd -i %~dp0\_sqlserver_setup.sql
+sqlcmd -f 65001 -i %~dp0\_sqlserver_setup.sql
 
 :: Enable port
 powershell -Command "stop-service MSSQLSERVER"

--- a/.azure-pipelines/scripts/sqlserver/windows/_sqlserver_setup.sql
+++ b/.azure-pipelines/scripts/sqlserver/windows/_sqlserver_setup.sql
@@ -20,8 +20,8 @@ GRANT CONNECT ANY DATABASE to bob;
 CREATE DATABASE datadog_test;
 GO
 USE datadog_test;
-CREATE TABLE datadog_test.dbo.things (id int, name varchar(255));
-INSERT INTO datadog_test.dbo.things VALUES (1, 'foo'), (2, 'bar');
+CREATE TABLE datadog_test.dbo.ϑings (id int, name varchar(255));
+INSERT INTO datadog_test.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
 CREATE USER bob FOR LOGIN bob;
 GO
 

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -5,7 +5,7 @@ from cachetools import TTLCache
 from lxml import etree as ET
 
 from datadog_checks.base import is_affirmative
-from datadog_checks.base.utils.common import ensure_bytes, ensure_unicode, to_native_string
+from datadog_checks.base.utils.common import ensure_unicode, to_native_string
 from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.statement_metrics import StatementMetrics
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, RateLimitingTTLCache, default_json_event_encoding
@@ -88,7 +88,7 @@ def obfuscate_xml_plan(raw_plan):
     Obfuscates SQL text & Parameters from the provided SQL Server XML Plan
     Also strips unnecessary whitespace
     """
-    tree = ET.fromstring(ensure_bytes((raw_plan)))
+    tree = ET.fromstring(raw_plan)
     for e in tree.iter():
         if e.text:
             e.text = e.text.strip()

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -189,7 +189,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                 obfuscated_statement = datadog_agent.obfuscate_sql(row['text'])
             except Exception as e:
                 # obfuscation errors are relatively common so only log them during debugging
-                self.log.exception("failed to normalized queries")
                 self.log.debug("Failed to obfuscate query: %s", e)
                 continue
             row['text'] = obfuscated_statement
@@ -343,7 +342,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                 try:
                     obfuscated_plan = obfuscate_xml_plan(raw_plan)
                 except Exception as e:
-                    self.log.exception("failed to obfuscate XML plan")
                     self.log.debug(
                         "failed to obfuscate XML Plan query_signature=%s query_hash=%s query_plan_hash=%s: %s",
                         row['query_signature'],

--- a/sqlserver/requirements.in
+++ b/sqlserver/requirements.in
@@ -5,3 +5,4 @@ pywin32==228; sys_platform == 'win32' and python_version < '3.0'
 pywin32==300; sys_platform == 'win32' and python_version > '3.0'
 selectors34==1.2.0; sys_platform == 'win32' and python_version < '3.4'
 serpent==1.27; sys_platform == 'win32'
+lxml==4.6.4

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -21,8 +21,8 @@ GO
 -- Create test database for integration tests
 -- only bob has read/write access to this database
 USE datadog_test;
-CREATE TABLE datadog_test.dbo.things (id int, name varchar(255));
-INSERT INTO datadog_test.dbo.things VALUES (1, 'foo'), (2, 'bar');
+CREATE TABLE datadog_test.dbo.ϑings (id int, name varchar(255));
+INSERT INTO datadog_test.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
 CREATE USER bob FOR LOGIN bob;
 GO
 

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -16,8 +16,10 @@ GRANT CONNECT ANY DATABASE to bob;
 CREATE DATABASE datadog_test;
 GO
 USE datadog_test;
-CREATE TABLE datadog_test.dbo.things (id int, name varchar(255));
-INSERT INTO datadog_test.dbo.things VALUES (1, 'foo'), (2, 'bar');
+-- This table is pronounced "things" except we've replaced "th" with the greek lower case "theta" to ensure we
+-- correctly support unicode throughout the integration.
+CREATE TABLE datadog_test.dbo.ϑings (id int, name varchar(255));
+INSERT INTO datadog_test.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
 CREATE USER bob FOR LOGIN bob;
 GO
 

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -1,14 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 import logging
 import os
 import re
-import xml.etree.ElementTree as ET
 from concurrent.futures.thread import ThreadPoolExecutor
 from copy import copy
 
 import mock
 import pytest
+from lxml import etree as ET
 
-from datadog_checks.base.utils.common import to_native_string
+from datadog_checks.base.utils.common import ensure_bytes, to_native_string
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.statements import SQL_SERVER_QUERY_METRICS_COLUMNS, obfuscate_xml_plan
@@ -101,15 +104,15 @@ test_statement_metrics_and_plans_parameterized = (
         [
             "datadog_test",
             "dbo",
-            "SELECT * FROM things",
-            r"SELECT \* FROM things",
+            "SELECT * FROM ϑings",
+            r"SELECT \* FROM ϑings",
             ((),),
         ],
         [
             "datadog_test",
             "dbo",
-            "SELECT * FROM things where id = ?",
-            r"\(@P1 \w+\)SELECT \* FROM things where id = @P1",
+            "SELECT * FROM ϑings where id = ?",
+            r"\(@P1 \w+\)SELECT \* FROM ϑings where id = @P1",
             (
                 (1,),
                 (2,),
@@ -119,8 +122,8 @@ test_statement_metrics_and_plans_parameterized = (
         [
             "master",
             None,
-            "SELECT * FROM datadog_test.dbo.things where id = ?",
-            r"\(@P1 \w+\)SELECT \* FROM datadog_test.dbo.things where id = @P1",
+            "SELECT * FROM datadog_test.dbo.ϑings where id = ?",
+            r"\(@P1 \w+\)SELECT \* FROM datadog_test.dbo.ϑings where id = @P1",
             (
                 (1,),
                 (2,),
@@ -130,8 +133,8 @@ test_statement_metrics_and_plans_parameterized = (
         [
             "datadog_test",
             "dbo",
-            "SELECT * FROM things where id = ? and name = ?",
-            r"\(@P1 \w+,@P2 (N)?VARCHAR\(\d+\)\)SELECT \* FROM things where id = @P1 and name = @P2",
+            "SELECT * FROM ϑings where id = ? and name = ?",
+            r"\(@P1 \w+,@P2 (N)?VARCHAR\(\d+\)\)SELECT \* FROM ϑings where id = @P1 and name = @P2",
             (
                 (1, "hello"),
                 (2, "there"),
@@ -252,7 +255,7 @@ def _run_test_statement_metrics_and_plans(
 
     for event in plan_events:
         assert event['db']['plan']['definition'], "event plan definition missing"
-        parsed_plan = ET.fromstring(event['db']['plan']['definition'])
+        parsed_plan = ET.fromstring(ensure_bytes(event['db']['plan']['definition']))
         assert parsed_plan.tag.endswith("ShowPlanXML"), "plan does not match expected structure"
 
     fqt_events = [s for s in dbm_samples if s['dbm_type'] == "fqt"]

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -11,7 +11,7 @@ import mock
 import pytest
 from lxml import etree as ET
 
-from datadog_checks.base.utils.common import ensure_bytes, to_native_string
+from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.statements import SQL_SERVER_QUERY_METRICS_COLUMNS, obfuscate_xml_plan
@@ -255,7 +255,7 @@ def _run_test_statement_metrics_and_plans(
 
     for event in plan_events:
         assert event['db']['plan']['definition'], "event plan definition missing"
-        parsed_plan = ET.fromstring(ensure_bytes(event['db']['plan']['definition']))
+        parsed_plan = ET.fromstring(event['db']['plan']['definition'])
         assert parsed_plan.tag.endswith("ShowPlanXML"), "plan does not match expected structure"
 
     fqt_events = [s for s in dbm_samples if s['dbm_type'] == "fqt"]


### PR DESCRIPTION
### What does this PR do?

* add a unicode character to the test schema to ensure we're testing the full statements flow to ensure unicode characters are properly supported.
* switch from the built-in XML library to `lxml` as the built-in one was not correctly able to encode utf-8 even when the encoding was specified.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
