### PR TITLE
Fix default field name of schema

### DIFF
--- a/snowflake/datadog_checks/snowflake/config_models/defaults.py
+++ b/snowflake/datadog_checks/snowflake/config_models/defaults.py
@@ -76,7 +76,7 @@ def instance_only_custom_queries(field, value):
     return False
 
 
-def instance_schema(field, value):
+def instance_schema_(field, value):
     return 'ACCOUNT_USAGE'
 
 

--- a/snowflake/tests/test_snowflake.py
+++ b/snowflake/tests/test_snowflake.py
@@ -22,6 +22,15 @@ def test_emits_critical_service_check_when_service_is_down(dd_run_check, aggrega
     aggregator.assert_service_check('snowflake.can_connect', SnowflakeCheck.CRITICAL)
 
 
+def test_no_schema(dd_run_check, aggregator, instance):
+    config = copy.deepcopy(instance)
+    del config['schema']
+    config['login_timeout'] = 5
+    check = SnowflakeCheck(CHECK_NAME, {}, [config])
+    dd_run_check(check)
+    aggregator.assert_service_check('snowflake.can_connect', SnowflakeCheck.CRITICAL)
+
+
 def test_storage_metrics(dd_run_check, aggregator, instance):
     # type: (Callable[[SnowflakeCheck], None], AggregatorStub, Dict[str, Any]) -> None
 


### PR DESCRIPTION
### What does this PR do?
- Fixes the field name for `schema`
- Allows users to optionally set the `schema` config option
- Currently, if `schema` is not specified, an error is thrown when it should not: 
 `AttributeError: module 'datadog_checks.snowflake.config_models.defaults' has no attribute 'instance_schema_'`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
