### PR TITLE
Allow BaseModel keywords as option names

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model.py
@@ -8,6 +8,7 @@ import yaml
 from datamodel_code_generator.format import CodeFormatter, PythonVersion
 from datamodel_code_generator.parser import LiteralType
 from datamodel_code_generator.parser.openapi import OpenAPIParser
+from pydantic import BaseModel
 
 from ..constants import OPENAPI_SCHEMA_PROPERTIES
 from ..utils import sanitize_openapi_object_properties
@@ -23,7 +24,7 @@ NO_DEFAULT = object()
 
 def normalize_option_name(option_name):
     # https://github.com/koxudaxi/datamodel-code-generator/blob/0.8.3/datamodel_code_generator/model/base.py#L82-L84
-    if iskeyword(option_name):
+    if iskeyword(option_name) or hasattr(BaseModel, option_name):
         option_name += '_'
 
     return option_name.replace('-', '_')


### PR DESCRIPTION
### What does this PR do?
- Allows BaseModel keywords as option names
- needed for https://github.com/DataDog/integrations-core/pull/10714/files to pass validation as schema is a attribute of BaseModel

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
