### PR TITLE
Add new metric for waiting queries where state is active

### DIFF
--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -218,6 +218,7 @@ ACTIVITY_METRICS_9_6 = [
     "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{dd__user}'))"
     "THEN 1 ELSE null END )",
     "COUNT(CASE WHEN wait_event is NOT NULL AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN wait_event is NOT NULL AND query !~ '^autovacuum:' AND state = 'active' THEN 1 ELSE null END )",
 ]
 
 # The metrics we retrieve from pg_stat_activity when the postgres version >= 9.2
@@ -227,6 +228,7 @@ ACTIVITY_METRICS_9_2 = [
     "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{dd__user}'))"
     "THEN 1 ELSE null END )",
     "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' AND state = 'active' THEN 1 ELSE null END )",
 ]
 
 # The metrics we retrieve from pg_stat_activity when the postgres version >= 8.3
@@ -236,6 +238,7 @@ ACTIVITY_METRICS_8_3 = [
     "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{dd__user}'))"
     "THEN 1 ELSE null END )",
     "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' AND state = 'active' THEN 1 ELSE null END )",
 ]
 
 # The metrics we retrieve from pg_stat_activity when the postgres version < 8.3
@@ -245,6 +248,7 @@ ACTIVITY_METRICS_LT_8_3 = [
     "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{dd__user}'))"
     "THEN 1 ELSE null END )",
     "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' AND state = 'active' THEN 1 ELSE null END )",
 ]
 
 # The metrics we collect from pg_stat_activity that we zip with one of the lists above
@@ -253,6 +257,7 @@ ACTIVITY_DD_METRICS = [
     ('postgresql.transactions.idle_in_transaction', AgentCheck.gauge),
     ('postgresql.active_queries', AgentCheck.gauge),
     ('postgresql.waiting_queries', AgentCheck.gauge),
+    ('postgresql.active_waiting_queries', AgentCheck.gauge),
 ]
 
 # The base query for postgres version >= 10

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -64,6 +64,7 @@ postgresql.transactions.open,gauge,,transaction,,The number of open transactions
 postgresql.transactions.idle_in_transaction,gauge,,transaction,,The number of 'idle in transaction' transactions in this database.,0,postgres,transactions idle_in_transaction
 postgresql.before_xid_wraparound,gauge,,transaction,,The number of transactions that can occur until a transaction wraparound.,0,postgres,tx before xid wraparound
 postgresql.active_queries,gauge,,,,The number of active queries in this database.,0,postgres,active queries
+postgresql.active_waiting_queries,gauge,,,,The number of waiting queries in this database in state active.,0,postgres,transactions active_waiting queries
 postgresql.waiting_queries,gauge,,,,The number of waiting queries in this database.,0,postgres,transactions waiting queries
 postgresql.queries.count,count,,query,,"The total query execution count per query_signature, db, and user. (DBM only)",0,postgres,postgres queries count
 postgresql.queries.time,count,,nanosecond,,"The total query execution time per query_signature, db, and user. (DBM only)",0,postgres,postgres queries time

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -31,6 +31,7 @@ ACTIVITY_METRICS = [
     'postgresql.transactions.idle_in_transaction',
     'postgresql.active_queries',
     'postgresql.waiting_queries',
+    'postgresql.active_waiting_queries',
 ]
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]


### PR DESCRIPTION
### What does this PR do?
Add a new `postgresql.active_waiting_queries` metric.

### Motivation
`postgresql.waiting_queries` isn't especially useful to track because it includes `idle` backends waiting on client input, thus giving an artificially high number of waiting queries.

### Additional Notes
Added a new metric instead of changing `waiting_queries` so as not to affect anyone with existing dashboards.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
