### PR TITLE
Document docker.cpu.limit metric

### DIFF
--- a/docker_daemon/metadata.csv
+++ b/docker_daemon/metadata.csv
@@ -1,4 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+docker.cpu.limit,gauge,,percent,,"Limit on CPU available to the container, expressed as percentage of a core",0,docker,docker.cpu.limit
 docker.cpu.system,gauge,,percent,,"The percent of time the CPU is executing system calls on behalf of processes of this container, unnormalized",0,docker,cpu system
 docker.cpu.system.95percentile,gauge,,percent,,95th percentile of docker.cpu.system,0,docker,cpu system 95%
 docker.cpu.system.avg,gauge,,percent,,Average value of docker.cpu.system,0,docker,cpu system avg


### PR DESCRIPTION
### What does this PR do?
Adds documentation for the `docker.cpu.limit` metric that was introduced in https://github.com/DataDog/datadog-agent/pull/5716

### Motivation
When monitoring CPU usage in ECS the `docker.cpu.usage` metric can be nonsense unless it's combined with `docker.cpu.limit`, but that metric isn't documented anywhere, so I only figured it out by reading the docker check implementation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
