### PR TITLE
proxysql support for non-admin user

### DIFF
--- a/proxysql/assets/configuration/spec.yaml
+++ b/proxysql/assets/configuration/spec.yaml
@@ -54,6 +54,15 @@ files:
         Timeout in seconds for reading data from ProxySQL. Unlimited by default.
       value:
         type: integer
+    - name: version_metadata
+      required: false
+      description: |
+        Retreive the ProxySQL version from the admin variables.
+        Set to `false` if you use a non-admin user.
+      value:
+        type: boolean
+        example: true
+      enabled: true
     - name: additional_metrics
       description: |
         List of additional metrics to collect in addition to the global ones.

--- a/proxysql/datadog_checks/proxysql/config_models/instance.py
+++ b/proxysql/datadog_checks/proxysql/config_models/instance.py
@@ -35,6 +35,7 @@ class InstanceConfig(BaseModel):
     tls_validate_hostname: Optional[bool]
     tls_verify: Optional[bool]
     username: str
+    version_metadata: Optional[bool]
 
     @root_validator(pre=True)
     def _initial_validation(cls, values):

--- a/proxysql/datadog_checks/proxysql/data/conf.yaml.example
+++ b/proxysql/datadog_checks/proxysql/data/conf.yaml.example
@@ -63,6 +63,12 @@ instances:
     #
     # read_timeout: <READ_TIMEOUT>
 
+    ## @param version_metadata - boolean - optional - default: true
+    ## Retreive the ProxySQL version from the admin variables.
+    ## Set to `false` if you use a non-admin user.
+    #
+    version_metadata: true
+
     ## @param additional_metrics - list of strings - optional
     ## List of additional metrics to collect in addition to the global ones.
     ## Learn more about these metrics at:

--- a/proxysql/datadog_checks/proxysql/proxysql.py
+++ b/proxysql/datadog_checks/proxysql/proxysql.py
@@ -58,8 +58,12 @@ class ProxysqlCheck(AgentCheck):
         self.tags.append("proxysql_server:{}".format(self.host))
         self.tags.append("proxysql_port:{}".format(self.port))
 
+        self.version_metadata = is_affirmative(self.instance.get('version_metadata', False))
+
         manager_queries = [STATS_MYSQL_GLOBAL]
         if self.is_metadata_collection_enabled():
+
+            if self.version_metadata:
             # Add the query to collect the ProxySQL version
             manager_queries.append(VERSION_METADATA)
 

--- a/proxysql/datadog_checks/proxysql/proxysql.py
+++ b/proxysql/datadog_checks/proxysql/proxysql.py
@@ -58,7 +58,7 @@ class ProxysqlCheck(AgentCheck):
         self.tags.append("proxysql_server:{}".format(self.host))
         self.tags.append("proxysql_port:{}".format(self.port))
 
-        self.version_metadata = is_affirmative(self.instance.get('version_metadata', False))
+        self.version_metadata = is_affirmative(self.instance.get('version_metadata', True))
 
         manager_queries = [STATS_MYSQL_GLOBAL]
         if self.is_metadata_collection_enabled():

--- a/proxysql/datadog_checks/proxysql/proxysql.py
+++ b/proxysql/datadog_checks/proxysql/proxysql.py
@@ -65,7 +65,7 @@ class ProxysqlCheck(AgentCheck):
 
             if self.version_metadata:
             # Add the query to collect the ProxySQL version
-            manager_queries.append(VERSION_METADATA)
+                manager_queries.append(VERSION_METADATA)
 
         additional_metrics = self.instance.get("additional_metrics", [])
         for additional_group in additional_metrics:

--- a/proxysql/tests/common.py
+++ b/proxysql/tests/common.py
@@ -150,6 +150,7 @@ INSTANCE_ALL_METRICS = {
     'username': PROXY_ADMIN_USER,
     'password': PROXY_ADMIN_PASS,
     'tags': ["application:test"],
+    'version_metadata': True
     'additional_metrics': [
         'command_counters_metrics',
         'connection_pool_metrics',
@@ -166,6 +167,7 @@ INSTANCE_ALL_METRICS_STATS = {
     'password': PROXY_STATS_PASS,
     'database_name': PROXY_MAIN_DATABASE,
     'tags': ["application:test"],
+    'version_metadata': True
     'additional_metrics': [
         'command_counters_metrics',
         'connection_pool_metrics',


### PR DESCRIPTION
### What does this PR do?
This PR add a parameter (default to true) that can disable the `version_metadata `metric.

This will allow the possibility to skip [the query on the proxysql admin variable](https://github.com/DataDog/integrations-core/blob/master/proxysql/datadog_checks/proxysql/queries.py#L246) `admin-version`.

With this parameter to false it will be possible to set a non-admin user with only permissions on [stats](https://proxysql.com/documentation/stats-statistics/) but without super administrator privileges.

### Motivation
Setting up the integration with an admin user for remote connection is not recommended. 
As only one metric needs admin privileges, we should let the possibility to skip this metric on ProxySql version and use a non-admin user with privileges on `stats` only. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
