### PR TITLE
Add ConnectRetryCount to connection string

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -347,7 +347,7 @@ class Connection(object):
         else:
             dsn, host, username, password, database, driver = self._get_access_info(db_key, db_name)
 
-        conn_str = ''
+        conn_str = 'ConnectRetryCount=2;'
         if dsn:
             conn_str = 'DSN={};'.format(dsn)
 
@@ -373,7 +373,7 @@ class Connection(object):
             _, host, username, password, database, _ = self._get_access_info(db_key, db_name)
 
         provider = self._get_adoprovider()
-        conn_str = 'Provider={};Data Source={};Initial Catalog={};'.format(provider, host, database)
+        conn_str = 'ConnectRetryCount=2;Provider={};Data Source={};Initial Catalog={};'.format(provider, host, database)
 
         if username:
             conn_str += 'User ID={};'.format(username)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add `ConnectRetryCount=2` to the default connection string.
It automatically retries the connection when it fails during a check run (https://docs.microsoft.com/en-us/sql/connect/odbc/connection-resiliency?view=sql-server-ver15).
It should fix error like below without customer needing to restart the agent manually

```
The connection is broken and recovery is not possible. The client driver attempted to recover the connection one or more times and all attempts failed. Increase the value of ConnectRetryCount to increase the number of recovery attempts.
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
`tests/test_activity.py::test_collect_activity` has been failing since https://github.com/DataDog/integrations-core/commit/5a006c40551741c73a7a1a7c63fd2a13406eb7d3

