### PR TITLE
Enable CI App on non-fork PRs

### DIFF
--- a/.azure-pipelines/all_pr.yml
+++ b/.azure-pipelines/all_pr.yml
@@ -14,10 +14,23 @@ trigger: none
 variables:
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
   DDEV_COLOR: 1
+  DD_TRACE_AGENT_PORT: 8127
+
+resources:
+  containers:
+    - container: dd_agent
+      image: gcr.io/datadoghq/agent:latest
+      ports:
+        - 8127:8126
+      env:
+        DD_API_KEY: $(DD_CI_API_KEY)
+        DD_HOSTNAME: "none"
+        DD_INSIDE_CI: "true"
 
 jobs:
 - template: './templates/test-all-checks.yml'
   parameters:
+    ddtrace_flag: '--ddtrace'
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
       restoreKeys: |

--- a/.azure-pipelines/all_pr.yml
+++ b/.azure-pipelines/all_pr.yml
@@ -18,19 +18,21 @@ variables:
 
 resources:
   containers:
-    - container: dd_agent
-      image: gcr.io/datadoghq/agent:latest
-      ports:
-        - 8127:8126
-      env:
-        DD_API_KEY: $(DD_CI_API_KEY)
-        DD_HOSTNAME: "none"
-        DD_INSIDE_CI: "true"
+    - ${{ if eq(variables['System.PullRequest.IsFork'], 'False') }}:
+      - container: dd_agent
+        image: gcr.io/datadoghq/agent:latest
+        ports:
+          - 8127:8126
+        env:
+          DD_API_KEY: $(DD_CI_API_KEY)
+          DD_HOSTNAME: "none"
+          DD_INSIDE_CI: "true"
 
 jobs:
 - template: './templates/test-all-checks.yml'
   parameters:
-    ddtrace_flag: '--ddtrace'
+    ${{ if eq(variables['System.PullRequest.IsFork'], 'False') }}:
+      ddtrace_flag: '--ddtrace'
     pip_cache_config:
       key: 'pip | $(Agent.OS) | datadog_checks_base/datadog_checks/base/data/agent_requirements.in'
       restoreKeys: |

--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -15,15 +15,16 @@ variables:
   DD_TRACE_AGENT_PORT: 8127
 
 resources:
-  containers:
-    - container: dd_agent
-      image: gcr.io/datadoghq/agent:latest
-      ports:
-        - 8127:8126
-      env:
-        DD_API_KEY: $(DD_CI_API_KEY)
-        DD_HOSTNAME: "none"
-        DD_INSIDE_CI: "true"
+    containers:
+      - ${{ if eq(variables['System.PullRequest.IsFork'], 'False') }}:
+        - container: dd_agent
+          image: gcr.io/datadoghq/agent:latest
+          ports:
+            - 8127:8126
+          env:
+            DD_API_KEY: $(DD_CI_API_KEY)
+            DD_HOSTNAME: "none"
+            DD_INSIDE_CI: "true"
 
 jobs:
 - template: './templates/test-single-linux.yml'

--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -16,7 +16,7 @@ variables:
 
 resources:
     containers:
-      - ${{ if eq(variables['System.PullRequest.IsFork'], 'False') }}:
+      - ${{ if eq(variables['System.PullRequest.IsFork'], 'True') }}:
         - container: dd_agent
           image: gcr.io/datadoghq/agent:latest
           ports:
@@ -31,7 +31,8 @@ jobs:
   parameters:
     job_name: Changed
     display: Linux
-    ddtrace_flag: '--ddtrace'
+    ${{ if eq(variables['System.PullRequest.IsFork'], 'True') }}:
+      ddtrace_flag: '--ddtrace'
     validate: true
     validate_codeowners: false
     validate_changed: changed
@@ -46,7 +47,8 @@ jobs:
   parameters:
     job_name: Changed
     check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dns_check dotnetclr exchange_server iis network pdh_check sqlserver tcp_check win32_event_log windows_performance_counters windows_service wmi_check'
-    ddtrace_flag: '--ddtrace'
+    ${{ if eq(variables['System.PullRequest.IsFork'], 'True') }}:
+      ddtrace_flag: '--ddtrace'
     validate_changed: changed
     display: Windows
     pip_cache_config:

--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -15,23 +15,23 @@ variables:
   DD_TRACE_AGENT_PORT: 8127
 
 resources:
-    containers:
-      - ${{ if eq(variables['System.PullRequest.IsFork'], 'True') }}:
-        - container: dd_agent
-          image: gcr.io/datadoghq/agent:latest
-          ports:
-            - 8127:8126
-          env:
-            DD_API_KEY: $(DD_CI_API_KEY)
-            DD_HOSTNAME: "none"
-            DD_INSIDE_CI: "true"
+  containers:
+    - ${{ if eq(variables['System.PullRequest.IsFork'], 'False') }}:
+      - container: dd_agent
+        image: gcr.io/datadoghq/agent:latest
+        ports:
+          - 8127:8126
+        env:
+          DD_API_KEY: $(DD_CI_API_KEY)
+          DD_HOSTNAME: "none"
+          DD_INSIDE_CI: "true"
 
 jobs:
 - template: './templates/test-single-linux.yml'
   parameters:
     job_name: Changed
     display: Linux
-    ${{ if eq(variables['System.PullRequest.IsFork'], 'True') }}:
+    ${{ if eq(variables['System.PullRequest.IsFork'], 'False') }}:
       ddtrace_flag: '--ddtrace'
     validate: true
     validate_codeowners: false
@@ -47,7 +47,7 @@ jobs:
   parameters:
     job_name: Changed
     check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dns_check dotnetclr exchange_server iis network pdh_check sqlserver tcp_check win32_event_log windows_performance_counters windows_service wmi_check'
-    ${{ if eq(variables['System.PullRequest.IsFork'], 'True') }}:
+    ${{ if eq(variables['System.PullRequest.IsFork'], 'False') }}:
       ddtrace_flag: '--ddtrace'
     validate_changed: changed
     display: Windows

--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -12,12 +12,25 @@ pr:
 variables:
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
   DDEV_COLOR: 1
+  DD_TRACE_AGENT_PORT: 8127
+
+resources:
+  containers:
+    - container: dd_agent
+      image: gcr.io/datadoghq/agent:latest
+      ports:
+        - 8127:8126
+      env:
+        DD_API_KEY: $(DD_CI_API_KEY)
+        DD_HOSTNAME: "none"
+        DD_INSIDE_CI: "true"
 
 jobs:
 - template: './templates/test-single-linux.yml'
   parameters:
     job_name: Changed
     display: Linux
+    ddtrace_flag: '--ddtrace'
     validate: true
     validate_codeowners: false
     validate_changed: changed
@@ -32,6 +45,7 @@ jobs:
   parameters:
     job_name: Changed
     check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dns_check dotnetclr exchange_server iis network pdh_check sqlserver tcp_check win32_event_log windows_performance_counters windows_service wmi_check'
+    ddtrace_flag: '--ddtrace'
     validate_changed: changed
     display: Windows
     pip_cache_config:


### PR DESCRIPTION
We removed the CI App product in #10732 because it was also running on fork PRs, which doesn't have access to the datadog api key

This PR enables the CI App product back on non-fork PRs relying on `System.PullRequest.IsFork` (see doc https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml)

Example of what would happen on a fork PR (commit https://github.com/DataDog/integrations-core/commit/93518225199ead5bf4b2189f7f71897ffdfcbf9c): https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=82250&view=results