### PR TITLE
Category and bugfix label gathered with merged-prs stats ddev command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/stats.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/stats.py
@@ -14,6 +14,8 @@ def parse_commit(commit):
     title = commit.title
     url = commit.url
     next_tag = None
+    category = None
+    regression = ''
 
     pull_request = commit.pull_request
 
@@ -23,12 +25,15 @@ def parse_commit(commit):
             teams = ['agent-integrations']
         title = pull_request.title
         url = pull_request.url
+        category = [label.rpartition('/')[-1] for label in pull_request.labels if label.startswith('category')]
+        category = category[0] if category else ''
+        if any(label == 'bugfix/regression' for label in pull_request.labels):
+            regression = 'yes'
 
     if commit.included_in_tag:
         next_tag = commit.included_in_tag.name
 
-    return {'sha': commit.sha, 'title': title, 'url': url, 'teams': ' & '.join(teams), 'next_tag': next_tag}
-
+    return {'sha': commit.sha, 'title': title, 'url': url, 'teams': ' & '.join(teams), 'next_tag': next_tag, 'category': category, 'regression': str(regression)}
 
 def export_changes_as_csv(changes, filename):
     with open(filename, "w") as release_csv:
@@ -43,10 +48,12 @@ def export_changes_as_csv(changes, filename):
                 'What RC was it included in?',
                 'Short description',
                 'Severity',
-                'Was this a bug or something else?',
+                'Category',
+                'Regression'
                 'What could we have done differently or what could we do differently to find this bug earlier',
             ]
         )
+
         for change in changes:
             writer.writerow(
                 [
@@ -55,7 +62,8 @@ def export_changes_as_csv(changes, filename):
                     change['next_tag'].split('-')[-1] if '-' in change['next_tag'] else change['next_tag'],
                     change['title'],
                     '',
-                    '',
+                    change['category'],
+                    change['regression'],
                     '',
                 ]
             )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/stats.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/stats/stats.py
@@ -33,7 +33,16 @@ def parse_commit(commit):
     if commit.included_in_tag:
         next_tag = commit.included_in_tag.name
 
-    return {'sha': commit.sha, 'title': title, 'url': url, 'teams': ' & '.join(teams), 'next_tag': next_tag, 'category': category, 'regression': str(regression)}
+    return {
+        'sha': commit.sha,
+        'title': title,
+        'url': url,
+        'teams': ' & '.join(teams),
+        'next_tag': next_tag,
+        'category': category,
+        'regression': str(regression),
+    }
+
 
 def export_changes_as_csv(changes, filename):
     with open(filename, "w") as release_csv:


### PR DESCRIPTION
### What does this PR do?
This PR modifies the ddev command `merged-prs`, so in addition to previous PR data, it also gathers information about `category` label and whether the `bugfix\regression` label is present on the PR. It adds that information to the output csv file.

### Motivation
Merged-prs tool is a convenient way to grab information about the merged PRs during the release cycle. New labels are an addition for analysis and it would be good to have them gathered automatically as well.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
