### PR TITLE
Fix active sessions sqlserver tests

### DIFF
--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -63,7 +63,7 @@ def test_collect_activity_windows(aggregator, instance_docker, dd_run_check, ins
 
 def _run_test_collect_activity(aggregator, instance_docker, dd_run_check, dbm_instance):
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    query = "select * from things"
+    query = "SELECT * FROM ϑings"
     bob_conn = _get_conn_for_user(instance_docker, "bob")
     with bob_conn.cursor() as cursor:
         cursor.execute("USE {}".format("datadog_test"))

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 import json
 import os
 from concurrent.futures.thread import ThreadPoolExecutor


### PR DESCRIPTION
### What does this PR do?

The table name `things` was changed in in this PR https://github.com/DataDog/integrations-core/pull/10713, which caused the activity tests to fail with `E   pyodbc.ProgrammingError: ('42S02', "[42S02] [FreeTDS][SQL Server]Invalid object name 'things'. (208) (SQLExecDirectW)")`

updating the table name should fix the issue 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
