### PR TITLE
Add datname to connections query for postgresql.connections

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -58,11 +58,11 @@ PG_ACTIVE_CONNECTIONS_QUERY = re.sub(
     r'\s+',
     ' ',
     """
-    SELECT application_name, state, usename, count(*) as connections
+    SELECT application_name, state, usename, datname, count(*) as connections
     FROM {pg_stat_activity_view}
     WHERE client_port IS NOT NULL
     {extra_filters}
-    GROUP BY application_name, state, usename
+    GROUP BY application_name, state, usename, datname
 """,
 ).strip()
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -522,6 +522,7 @@ def test_statement_samples_collect(
                 'usename': 'bob',
                 'state': 'idle in transaction',
                 'application_name': '',
+                'datname': 'datadog_test',
                 'connections': 1,
             },
         ),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Reported as an issue by a DBM customer after they upgraded their agent from 7.31 to 7.32. Updating this query is required to getting the `db` tag to work properly for this metric. Related Zendesk ticket. This is a regression only for customers who have DBM enabled. 

https://datadog.zendesk.com/agent/tickets/594763

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
