### PR TITLE
Add query_text to SQLServer integration failure to obfuscate debug log

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -189,7 +189,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                 obfuscated_statement = datadog_agent.obfuscate_sql(row['text'])
             except Exception as e:
                 # obfuscation errors are relatively common so only log them during debugging
-                self.log.debug("Failed to obfuscate query: %s", e)
+                self.log.debug("Failed to obfuscate query '%s': %s", row['query'], e)
                 continue
             row['text'] = obfuscated_statement
             row['query_signature'] = compute_sql_signature(obfuscated_statement)


### PR DESCRIPTION
### What does this PR do?
When the SQL query obfuscation fails, we log the obfuscation error as a debug log but, with SQLServer, we don't include the query text like we do for postgres and mysql and it makes it very hard to identify and fix bugs in the obfuscator. 

### Motivation
Saw many obfuscation debug logs which aren't enough to help us fix the obfuscator:
```
2021-11-24 21:51:22 UTC | CORE | DEBUG | (pkg/collector/python/datadog_agent.go:128 in LogMessage) | sqlserver:6fc456edead9257c | (statements.py:169) | Failed to obfuscate query: at position <line>: bind variables should start with letters, got "
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
