### PR TITLE
Fix hudi build

### DIFF
--- a/hudi/tests/docker/Dockerfile
+++ b/hudi/tests/docker/Dockerfile
@@ -18,7 +18,7 @@ ENV PATH /usr/local/sbt/bin:${PATH}
 RUN wget -P /opt https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
     && tar -xzf /opt/apache-maven-3.6.3-bin.tar.gz 
 
-RUN apk add git && git clone -b release-0.10.0 --single-branch https://github.com/apache/hudi.git
+RUN apk add git && git clone --depth 1 --branch release-0.10.0-rc2 https://github.com/apache/hudi.git
 RUN cd hudi && /apache-maven-3.6.3/bin/mvn --projects packaging/hudi-spark-bundle --also-make clean package -DskipTests -Dspark3 -Dscala-2.12
 
 COPY . /usr/src/app/

--- a/hudi/tests/docker/Dockerfile
+++ b/hudi/tests/docker/Dockerfile
@@ -18,7 +18,8 @@ ENV PATH /usr/local/sbt/bin:${PATH}
 RUN wget -P /opt https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
     && tar -xzf /opt/apache-maven-3.6.3-bin.tar.gz 
 
-RUN apk add git && git clone https://github.com/apache/hudi.git && cd hudi/ && /apache-maven-3.6.3/bin/mvn --projects packaging/hudi-spark-bundle --also-make clean package -DskipTests -Dspark3 -Dscala-2.12 
+RUN apk add git && git clone -b release-0.10.0 --single-branch https://github.com/apache/hudi.git
+RUN cd hudi && /apache-maven-3.6.3/bin/mvn --projects packaging/hudi-spark-bundle --also-make clean package -DskipTests -Dspark3 -Dscala-2.12
 
 COPY . /usr/src/app/
 RUN cd /usr/src/app && sbt update && sbt clean assembly && sbt package

--- a/hudi/tests/docker/build.sbt
+++ b/hudi/tests/docker/build.sbt
@@ -2,5 +2,5 @@ scalaVersion := "2.12.11"
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % "3.0.0" % "provided",
   "org.apache.spark" %% "spark-core" % "3.0.0" % "provided",
-  "org.apache.hudi" %% "hudi-spark-client" % "0.10.0-SNAPSHOT" from "file:///hudi/packaging/hudi-spark-bundle/target/hudi-spark3-bundle_2.12-0.10.0-SNAPSHOT.jar"
+  "org.apache.hudi" %% "hudi-spark-client" % "0.9.0-SNAPSHOT" from "file:///hudi/packaging/hudi-spark-bundle/target/hudi-spark3-bundle_2.12-0.9.0-SNAPSHOT.jar"
 )

--- a/hudi/tests/docker/build.sbt
+++ b/hudi/tests/docker/build.sbt
@@ -2,5 +2,5 @@ scalaVersion := "2.12.11"
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % "3.0.0" % "provided",
   "org.apache.spark" %% "spark-core" % "3.0.0" % "provided",
-  "org.apache.hudi" %% "hudi-spark-client" % "0.9.0-SNAPSHOT" from "file:///hudi/packaging/hudi-spark-bundle/target/hudi-spark3-bundle_2.12-0.9.0-SNAPSHOT.jar"
+  "org.apache.hudi" %% "hudi-spark-client" % "0.10.0-SNAPSHOT" from "file:///hudi/packaging/hudi-spark-bundle/target/hudi-spark3-bundle_2.12-0.10.0-SNAPSHOT.jar"
 )

--- a/hudi/tests/docker/build.sbt
+++ b/hudi/tests/docker/build.sbt
@@ -2,5 +2,5 @@ scalaVersion := "2.12.11"
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % "3.0.0" % "provided",
   "org.apache.spark" %% "spark-core" % "3.0.0" % "provided",
-  "org.apache.hudi" %% "hudi-spark-client" % "0.10.0-SNAPSHOT" from "file:///hudi/packaging/hudi-spark-bundle/target/hudi-spark3-bundle_2.12-0.10.0-SNAPSHOT.jar"
+  "org.apache.hudi" %% "hudi-spark-client" % "0.10.0-rc2" from "file:///hudi/packaging/hudi-spark-bundle/target/hudi-spark3-bundle_2.12-0.10.0-rc2.jar"
 )

--- a/hudi/tests/docker/docker-compose.yaml
+++ b/hudi/tests/docker/docker-compose.yaml
@@ -15,7 +15,13 @@ services:
     # - ./log4j.properties:/spark/conf/log4j.properties
     # - ${DD_LOG_1}:/var/log/hudi.log
     entrypoint: ["/spark/bin/spark-submit"]
-    command: ["--packages", "org.apache.spark:spark-avro_2.12:${SPARK_VERSION}", "--conf", "spark.serializer=org.apache.spark.serializer.KryoSerializer", "--jars", "/hudi/packaging/hudi-spark-bundle/target/hudi-spark3-bundle_2.12-0.10.0-SNAPSHOT.jar", "/usr/src/app/target/scala-2.12/app_2.12-0.1.0-SNAPSHOT.jar"]
+    command: [
+        "--packages", "org.apache.spark:spark-avro_2.12:${SPARK_VERSION}",
+        "--conf", "spark.serializer=org.apache.spark.serializer.KryoSerializer",
+        "--jars",
+        "/hudi/packaging/hudi-spark-bundle/target/hudi-spark3-bundle_2.12-0.10.0-rc2.jar",
+        "/usr/src/app/target/scala-2.12/app_2.12-0.1.0-SNAPSHOT.jar"
+    ]
     ports:
       - "4040:4040"
       - "9999:9999"


### PR DESCRIPTION
The build depended on a moving target (the master branch of hudi repo).
This change makes it depend on a release tag.