### PR TITLE
Test hudi with actual release candidate

### DIFF
--- a/hudi/tests/docker/Dockerfile
+++ b/hudi/tests/docker/Dockerfile
@@ -15,11 +15,7 @@ RUN wget -O - https://github.com/sbt/sbt/releases/download/v1.4.1/sbt-1.4.1.tgz 
 ENV PATH /usr/local/sbt/bin:${PATH}
 
 # we have to build hudi from source because the JMX fix has not been released yet
-RUN wget -P /opt https://dlcdn.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz \
-    && tar -xzf /opt/apache-maven-3.6.3-bin.tar.gz 
-
-RUN apk add git && git clone --depth 1 --branch release-0.10.0-rc2 https://github.com/apache/hudi.git
-RUN cd hudi && /apache-maven-3.6.3/bin/mvn --projects packaging/hudi-spark-bundle --also-make clean package -DskipTests -Dspark3 -Dscala-2.12
+#RUN wget -P /opt https://repository.apache.org/content/repositories/orgapachehudi-1047/org/apache/hudi/hudi-spark-bundle_2.12/0.10.0-rc2/hudi-spark-bundle_2.12-0.10.0-rc2.jar \
 
 COPY . /usr/src/app/
 RUN cd /usr/src/app && sbt update && sbt clean assembly && sbt package

--- a/hudi/tests/docker/Dockerfile
+++ b/hudi/tests/docker/Dockerfile
@@ -14,8 +14,5 @@ RUN wget -O - https://github.com/sbt/sbt/releases/download/v1.4.1/sbt-1.4.1.tgz 
 
 ENV PATH /usr/local/sbt/bin:${PATH}
 
-# we have to build hudi from source because the JMX fix has not been released yet
-#RUN wget -P /opt https://repository.apache.org/content/repositories/orgapachehudi-1047/org/apache/hudi/hudi-spark-bundle_2.12/0.10.0-rc2/hudi-spark-bundle_2.12-0.10.0-rc2.jar \
-
 COPY . /usr/src/app/
 RUN cd /usr/src/app && sbt update && sbt clean assembly && sbt package

--- a/hudi/tests/docker/build.sbt
+++ b/hudi/tests/docker/build.sbt
@@ -2,5 +2,5 @@ scalaVersion := "2.12.11"
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-sql" % "3.0.0" % "provided",
   "org.apache.spark" %% "spark-core" % "3.0.0" % "provided",
-  "org.apache.hudi" %% "hudi-spark-client" % "0.10.0-rc2" from "file:///hudi/packaging/hudi-spark-bundle/target/hudi-spark3-bundle_2.12-0.10.0-rc2.jar"
+  "org.apache.hudi" %% "hudi-spark-client" % "0.10.0-rc3" from "https://repository.apache.org/content/repositories/orgapachehudi-1048/org/apache/hudi/hudi-spark3-bundle_2.12/0.10.0-rc3/hudi-spark3-bundle_2.12-0.10.0-rc3.jar"
 )

--- a/hudi/tests/docker/docker-compose.yaml
+++ b/hudi/tests/docker/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
         "--packages", "org.apache.spark:spark-avro_2.12:${SPARK_VERSION}",
         "--conf", "spark.serializer=org.apache.spark.serializer.KryoSerializer",
         "--jars",
-        "https://repository.apache.org/content/repositories/orgapachehudi-1047/org/apache/hudi/hudi-spark3-bundle_2.12/0.10.0-rc3/hudi-spark3-bundle_2.12-0.10.0-rc3.jar",
+        "https://repository.apache.org/content/repositories/orgapachehudi-1047/org/apache/hudi/hudi-spark3-bundle_2.12/0.10.0-rc2/hudi-spark3-bundle_2.12-0.10.0-rc2.jar",
         "/usr/src/app/target/scala-2.12/app_2.12-0.1.0-SNAPSHOT.jar"
     ]
     ports:

--- a/hudi/tests/docker/docker-compose.yaml
+++ b/hudi/tests/docker/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
         "--packages", "org.apache.spark:spark-avro_2.12:${SPARK_VERSION}",
         "--conf", "spark.serializer=org.apache.spark.serializer.KryoSerializer",
         "--jars",
-        "/hudi/packaging/hudi-spark-bundle/target/hudi-spark3-bundle_2.12-0.10.0-rc2.jar",
+        "https://repository.apache.org/content/repositories/orgapachehudi-1047/org/apache/hudi/hudi-spark3-bundle_2.12/0.10.0-rc2/hudi-spark3-bundle_2.12-0.10.0-rc2.jar",
         "/usr/src/app/target/scala-2.12/app_2.12-0.1.0-SNAPSHOT.jar"
     ]
     ports:

--- a/hudi/tests/docker/docker-compose.yaml
+++ b/hudi/tests/docker/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
         "--packages", "org.apache.spark:spark-avro_2.12:${SPARK_VERSION}",
         "--conf", "spark.serializer=org.apache.spark.serializer.KryoSerializer",
         "--jars",
-        "https://repository.apache.org/content/repositories/orgapachehudi-1047/org/apache/hudi/hudi-spark3-bundle_2.12/0.10.0-rc2/hudi-spark3-bundle_2.12-0.10.0-rc2.jar",
+        "https://repository.apache.org/content/repositories/orgapachehudi-1047/org/apache/hudi/hudi-spark3-bundle_2.12/0.10.0-rc3/hudi-spark3-bundle_2.12-0.10.0-rc3.jar",
         "/usr/src/app/target/scala-2.12/app_2.12-0.1.0-SNAPSHOT.jar"
     ]
     ports:

--- a/hudi/tests/docker/docker-compose.yaml
+++ b/hudi/tests/docker/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
         "--packages", "org.apache.spark:spark-avro_2.12:${SPARK_VERSION}",
         "--conf", "spark.serializer=org.apache.spark.serializer.KryoSerializer",
         "--jars",
-        "https://repository.apache.org/content/repositories/orgapachehudi-1047/org/apache/hudi/hudi-spark3-bundle_2.12/0.10.0-rc3/hudi-spark3-bundle_2.12-0.10.0-rc3.jar",
+        "https://repository.apache.org/content/repositories/orgapachehudi-1048/org/apache/hudi/hudi-spark3-bundle_2.12/0.10.0-rc3/hudi-spark3-bundle_2.12-0.10.0-rc3.jar",
         "/usr/src/app/target/scala-2.12/app_2.12-0.1.0-SNAPSHOT.jar"
     ]
     ports:

--- a/hudi/tox.ini
+++ b/hudi/tox.ini
@@ -23,6 +23,6 @@ passenv =
     COMPOSE*
 commands =
     pytest -v {posargs}
-setenv =
+setenv =  
     spark3.0.1: SPARK_VERSION=3.0.1 
     spark3.0.1: HADOOP_VERSION=3.2


### PR DESCRIPTION
### What does this PR do?
A new version of Hudi (0.10.0) is going to be released with a fix for JMX, so we can finally stop building Hudi from source in tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
