### PR TITLE
Update SQLServer Query Metrics Collection Query to Improve Performance

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -1,4 +1,5 @@
 import binascii
+import math
 import time
 
 from cachetools import TTLCache
@@ -40,7 +41,7 @@ SQL_SERVER_QUERY_METRICS_COLUMNS = [
 
 STATEMENT_METRICS_QUERY = """\
 with qstats as (
-    select text, query_hash, query_plan_hash,
+    select text, query_hash, query_plan_hash, last_execution_time,
            (select value from sys.dm_exec_plan_attributes(plan_handle) where attribute = 'dbid') as dbid,
            (select value from sys.dm_exec_plan_attributes(plan_handle) where attribute = 'user_id') as user_id,
            {query_metrics_columns}
@@ -52,6 +53,7 @@ select text, query_hash, query_plan_hash, CAST(S.dbid as int) as dbid, D.name as
     from qstats S
     left join sys.databases D on S.dbid = D.database_id
     left join sys.sysusers U on S.user_id = U.uid
+    where S.last_execution_time > dateadd(second, -{collection_interval}, getdate())
     group by text, query_hash, query_plan_hash, S.dbid, D.name, U.name
 """
 
@@ -168,6 +170,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         self._statement_metrics_query = STATEMENT_METRICS_QUERY.format(
             query_metrics_columns=', '.join(available_columns),
             query_metrics_column_sums=', '.join(['sum({}) as {}'.format(c, c) for c in available_columns]),
+            collection_interval=int(math.ceil(self.collection_interval * 2)),
         )
         return self._statement_metrics_query
 

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -170,7 +170,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         self._statement_metrics_query = STATEMENT_METRICS_QUERY.format(
             query_metrics_columns=', '.join(available_columns),
             query_metrics_column_sums=', '.join(['sum({}) as {}'.format(c, c) for c in available_columns]),
-            collection_interval=int(math.ceil(self.collection_interval * 2)),
+            collection_interval=int(math.ceil(self.collection_interval) * 2),
         )
         return self._statement_metrics_query
 


### PR DESCRIPTION
### What does this PR do?
This adds a filter on the statement metrics query to only capture rows that have a `last_execution_time` more recent than the `collection interval * 2`. This helps performance dramatically on larger databases with a big plan cache size. 

### Motivation
Slow performance of the query metrics collection. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
