### PR TITLE
Add statement metadata to event payloads (MySQL)

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -77,7 +77,7 @@ class DatadogAgentStub(object):
 
     def obfuscate_sql(self, query, options=None):
         # This is only whitespace cleanup, NOT obfuscation. Full obfuscation implementation is in go code.
-        return json.dumps({'query': re.sub(r'\s+', ' ', query or '').strip(), 'metadata': None})
+        return json.dumps({'query': re.sub(r'\s+', ' ', query or '').strip(), 'metadata': {}})
 
     def obfuscate_sql_exec_plan(self, plan, normalize=False):
         # Passthrough stub: obfuscation implementation is in Go code.

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
 import re
 
 
@@ -76,7 +77,7 @@ class DatadogAgentStub(object):
 
     def obfuscate_sql(self, query, options=None):
         # This is only whitespace cleanup, NOT obfuscation. Full obfuscation implementation is in go code.
-        return re.sub(r'\s+', ' ', query or '').strip()
+        return json.dumps({'query': re.sub(r'\s+', ' ', query or '').strip(), 'metadata': None})
 
     def obfuscate_sql_exec_plan(self, plan, normalize=False):
         # Passthrough stub: obfuscation implementation is in Go code.

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -174,6 +174,7 @@ class DbRow:
             if not metadata:
                 metadata = {}
             self.comments = metadata.get('comments', None)
+            self.tables_csv = metadata.get('tables_csv', None)
 
 
 class DBMAsyncJob(object):

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -158,6 +158,24 @@ def default_json_event_encoding(o):
     raise TypeError
 
 
+class DbRow:
+    """
+    DbRow is a wrapper for database rows that additionally holds metadata.
+    """
+
+    def __init__(self, row, metadata=None):
+        # type: (Dict[str], Dict[str]) -> None
+        self.data = row
+        self.metadata = metadata if isinstance(metadata, self.Metadata) else self.Metadata(metadata)
+
+    class Metadata:
+        def __init__(self, metadata):
+            # type: (Dict[str]) -> None
+            if not metadata:
+                metadata = {}
+            self.comments = metadata.get('comments', None)
+
+
 class DBMAsyncJob(object):
     # Set an arbitrary high limit so that dbm async jobs (which aren't CPU bound) don't
     # get artificially limited by the default max_workers count. Note that since threads are

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -186,11 +186,8 @@ class MySQLStatementMetrics(DBMAsyncJob):
         for row in rows:
             normalized_row = dict(copy.copy(row))
             try:
-                obfuscated_statement = (
-                    datadog_agent.obfuscate_sql(row['digest_text'], self._obfuscate_options)
-                    if row['digest_text'] is not None
-                    else None
-                )
+                statement = json.loads(datadog_agent.obfuscate_sql(row['digest_text'], self._obfuscate_options))
+                obfuscated_statement = statement['query'] if row['digest_text'] is not None else None
             except Exception as e:
                 self.log.warning("Failed to obfuscate query '%s': %s", row['digest_text'], e)
                 continue


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add metadata about a SQL statement in the event payloads. More information regarding these changes can be found in the agent PR.

Agent: https://github.com/DataDog/datadog-agent/pull/10042

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Related changes: https://github.com/DataDog/integrations-core/pull/10730

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached