### PR TITLE
Add SNMP recommended monitor

### DIFF
--- a/snmp/assets/monitors/device_down.json
+++ b/snmp/assets/monitors/device_down.json
@@ -1,0 +1,32 @@
+{
+	"name": "[SNMP] Device down alert on {{snmp_device.name}} in namespace {{device_namespace.name}}",
+	"type": "service check",
+	"query": "\"snmp.can_check\".over(\"*\").by(\"device_namespace\",\"snmp_device\").last(2).count_by_status()",
+	"message": "{{#is_alert}} \nA network device with IP {{snmp_device.name}} in namespace {{device_namespace.name}} is reporting CRITICAL and can't be monitored anymore.\n{{/is_alert}}\n\n{{#is_alert_recovery}}\nA network device with IP {{snmp_device.name}} in namespace {{device_namespace.name}} is back online.\n{{/is_alert_recovery}}\n\nTo know more about the status of your device, you can have more information from the [NDM page](/infrastructure/devices/graph?inspectedDevice={{device_namespace.name}}%3A{{snmp_device.name}}).",
+	"tags": [
+		"integration:snmp"
+	],
+	"options": {
+		"notify_audit": false,
+		"locked": false,
+		"timeout_h": 0,
+		"silenced": {},
+		"include_tags": false,
+		"thresholds": {
+			"warning": 1,
+			"ok": 1,
+			"critical": 1
+		},
+		"notify_no_data": false,
+		"renotify_interval": 0,
+		"avalanche_window": 10,
+		"escalation_message": "",
+		"new_group_delay": 60,
+		"no_data_timeframe": 2
+	},
+	"priority": null,
+	"restricted_roles": null,
+    "recommended_monitor_metadata": {
+        "description": "Notify your team when a SNMP devices is down. Requires Datadog Agent 7.32+ or 6.32+."
+    }
+}

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -30,7 +30,9 @@
     "configuration": {
       "spec": "assets/configuration/spec.yaml"
     },
-    "monitors": {},
+    "monitors": {
+      "[SNMP] Device Down Alert": "assets/monitors/device_down.json"
+    },
     "dashboards": {
       "Interface Performance": "assets/dashboards/interface_performance.json",
       "Datacenter Overview": "assets/dashboards/datacenter_overview.json"


### PR DESCRIPTION
This recommended monitor is a very basic one that:
- Triggers when an snmp device is down (uniquely identified by `snmp_device` (the ip) and `snmp_namespace`
- Provides a link to the NDM page scoped on this device.

Monitor can be seen [here](https://dd.datad0g.com/monitors/6523705).
Note that the link unfortunately doesn't work on slack, but does on email and events

![image](https://user-images.githubusercontent.com/22912273/144241378-cde4fdb5-e1b1-4ef6-b912-d79324689843.png)
