### PR TITLE
Update the default value of the `bearer_token` parameter to send the bearer token only to secure https endpoints by default

### DIFF
--- a/kube_apiserver_metrics/assets/configuration/spec.yaml
+++ b/kube_apiserver_metrics/assets/configuration/spec.yaml
@@ -57,9 +57,11 @@ files:
       description: |
         Used if you are using RBACs and need the Agent to authenticate
         against the APIServer to retrieve metrics. Default to true.
+      enabled: true
       value:
-        type: boolean
-        example: true
+        type: string
+        example: tls_only
+        default: "false"
     - name: bearer_token_path
       description: Used to specify the path where the service account token is located.
       value:

--- a/kube_apiserver_metrics/assets/configuration/spec.yaml
+++ b/kube_apiserver_metrics/assets/configuration/spec.yaml
@@ -59,9 +59,11 @@ files:
         against the APIServer to retrieve metrics. Default to true.
       enabled: true
       value:
-        type: string
         example: tls_only
-        default: "false"
+        default: false
+        anyOf:
+        - type: boolean
+        - type: string
     - name: bearer_token_path
       description: Used to specify the path where the service account token is located.
       value:

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
@@ -29,11 +29,11 @@ instances:
     #
     # prometheus_url: https://%%host%%:6443/metrics
 
-    ## @param bearer_token_auth - boolean - optional - default: true
+    ## @param bearer_token_auth - string - optional - default: tls_only
     ## Used if you are using RBACs and need the Agent to authenticate
     ## against the APIServer to retrieve metrics. Default to true.
     #
-    # bearer_token_auth: true
+    bearer_token_auth: tls_only
 
     ## @param bearer_token_path - string - optional - default: /var/run/secrets/kubernetes.io/serviceaccount/token
     ## Used to specify the path where the service account token is located.

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/auto_conf.yaml
@@ -29,7 +29,7 @@ instances:
     #
     # prometheus_url: https://%%host%%:6443/metrics
 
-    ## @param bearer_token_auth - string - optional - default: tls_only
+    ## @param bearer_token_auth - boolean or string - optional - default: tls_only
     ## Used if you are using RBACs and need the Agent to authenticate
     ## against the APIServer to retrieve metrics. Default to true.
     #


### PR DESCRIPTION
### What does this PR do?

Change the default behaviour of the auto-configuration of the `kube_apiserver_metrics` check.
By default, when trying all the possible endpoints, the bearer token will be sent only to secure https endpoints.

### Motivation

Make the check work out of the box without leaking the token on an insecure connection on both clusters where only the insecure `http` endpoint is available and on clusters where only the secure `https` endpoint is available.

### Additional Notes

Leverages #10706

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have `changelog/` and `integration/` labels attached
