### PR TITLE
Update SQLServer activity query to get timestamps with the timezone

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -32,7 +32,12 @@ ACTIVITY_QUERY = re.sub(
     ' ',
     """\
 SELECT
-    at.transaction_begin_time,
+    CONVERT(
+        NVARCHAR, TODATETIMEOFFSET(at.transaction_begin_time, DATEPART(TZOFFSET, SYSDATETIMEOFFSET())), 126
+    ) as transaction_begin_time,
+    CONVERT(
+        NVARCHAR, TODATETIMEOFFSET(r.start_time, DATEPART(TZOFFSET, SYSDATETIMEOFFSET())), 126
+    ) as query_start,
     at.transaction_type,
     at.transaction_state,
     sess.login_name as user_name,
@@ -69,6 +74,8 @@ dm_exec_requests_exclude_keys = {
     'status',
     # remove session_id in favor of id
     'session_id',
+    # remove start_time in favor of query_start
+    'start_time',
 }
 
 

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -113,7 +113,7 @@ def _run_test_collect_activity(aggregator, instance_docker, dd_run_check, dbm_in
     assert bobs_row['transaction_begin_time'], "missing tx begin time"
 
     # assert that the tx begin time is being collected as an ISO timestamp with TZ info
-    assert parser.parse(bobs_row['transaction_begin_time']).tzinfo, "tx begin timestamp not formatted correctly"
+    assert parser.isoparse(bobs_row['transaction_begin_time']).tzinfo, "tx begin timestamp not formatted correctly"
 
     assert len(first['sqlserver_connections']) > 0
     b_conn = None

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -8,6 +8,7 @@ from copy import copy
 
 import mock
 import pytest
+from dateutil import parser
 
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding
 from datadog_checks.sqlserver import SQLServer
@@ -110,6 +111,9 @@ def _run_test_collect_activity(aggregator, instance_docker, dd_run_check, dbm_in
     assert bobs_row['session_status'] == "sleeping", "incorrect session_status"
     assert bobs_row['id'], "missing session id"
     assert bobs_row['transaction_begin_time'], "missing tx begin time"
+
+    # assert that the tx begin time is being collected as an ISO timestamp with TZ info
+    assert parser.parse(bobs_row['transaction_begin_time']).tzinfo, "tx begin timestamp not formatted correctly"
 
     assert len(first['sqlserver_connections']) > 0
     b_conn = None


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

SQLServer timestamps by default are of the `datetime` type, which does not include a timezone. This is problematic because when we need to know the timezone to correctly calculate the query/transaction duration on the backend. 

This update relies on the use of [CONVERT](https://docs.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver15#date-and-time-styles) to convert the `DATETIMEOFFSET` to a string (necessary for python to properly parse it) and also get the ISO 8601 format of the timestamp. 

Result of this query gives us timestamps with the proper formatting e.g.:

`2021-12-02T18:13:50.723+00:00` -> UTC 
`2021-12-02T18:13:50.740-08:00` -> PDT (Got this via `SYSDATETIMEOFFSET() AT TIME ZONE 'Pacific Standard Time'`)

### Motivation
<!-- What inspired you to submit this pull request? -->

DBM SQLServer Active Sessions beta feedback / Follow up PR from https://github.com/DataDog/integrations-core/pull/10610

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
