### PR TITLE
Update metadata.csv for nginx.net.request_per_s

### DIFF
--- a/nginx/metadata.csv
+++ b/nginx/metadata.csv
@@ -3,7 +3,7 @@ nginx.net.writing,gauge,,connection,,The number of connections waiting on upstre
 nginx.net.waiting,gauge,,connection,,The number of keep-alive connections waiting for work.,0,nginx,conns waiting
 nginx.net.reading,gauge,,connection,,The number of connections reading client requests.,0,nginx,conns reading
 nginx.net.connections,gauge,,connection,,The total number of active connections.,0,nginx,conns
-nginx.net.request_per_s,rate,,request,second,Rate of requests processed.,0,nginx,req/s
+nginx.net.request_per_s,rate,,request,second,Rate of requests processed. Measures both successful and failed requests.,0,nginx,req/s
 nginx.net.conn_opened_per_s,rate,,connection,second,Rate of connections opened.,0,nginx,conns opened/s
 nginx.net.conn_dropped_per_s,rate,,connection,second,Rate of connections dropped.,-1,nginx,conns dropped/s
 nginx.cache.bypass.bytes,gauge,,byte,,The total number of bytes read from the proxied server,0,nginx,cache bypass bytes


### PR DESCRIPTION
Added note for the description of the metric nginx.net.request_per_s. Measure both successful and failed requests.

### What does this PR do?
Adds addition description for the metric nginx.net.request_per_s
Saying that the metric value will include successful and failed requests. As a request doesn't have to be successful in order to be processed.

### Motivation

A customer on a support ticket asked for clarification on the metric description. Wondering if the metric looks at all requests, including failed ones. I reached out to Nginx for support and ended up calling them to clarify the information.

### Additional Notes
An Nginx request does not have to be successful in order to be processed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
