### PR TITLE
Add the cisco_aci service check to the minimal e2e test

### DIFF
--- a/cisco_aci/tests/conftest.py
+++ b/cisco_aci/tests/conftest.py
@@ -1,9 +1,17 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from copy import deepcopy
+
 import pytest
+
+INSTANCE = {'aci_url': 'http://localhost', 'username': 'admin', 'pwd': 'admin'}
 
 
 @pytest.fixture(scope="session")
 def dd_environment():
-    yield {'aci_urls': []}
+    yield deepcopy(INSTANCE)
+
+@pytest.fixture
+def instance():
+    return deepcopy(INSTANCE)

--- a/cisco_aci/tests/test_cisco.py
+++ b/cisco_aci/tests/test_cisco.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 import pytest
 from mock import MagicMock
 
+from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.containers import hash_mutable
 from datadog_checks.cisco_aci import CiscoACICheck
 from datadog_checks.cisco_aci.api import Api, SessionWrapper
@@ -96,6 +97,8 @@ def test_config(aggregator, extra_config, expected_http_kwargs):
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, dd_environment):
+def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
-        dd_agent_check(dd_environment)
+        dd_agent_check(instance)
+    aggregator.assert_service_check("cisco_aci.can_connect", AgentCheck.CRITICAL)
+


### PR DESCRIPTION
### What does this PR do?
Add the service check cisco_aci.can.connect to the e2e test.

### Motivation
Assigned task

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
