### PR TITLE
Add validation for invalid characters and sequences for service names

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
@@ -145,11 +145,20 @@ def service_checks(check, sync):
             elif invalid_chars or invalid_seq:
                 file_failed = True
                 if invalid_chars:
-                    display_queue.append((echo_failure, f'  {check} contains one or more invalid characters: {invalid_chars}'))
+                    display_queue.append(
+                        (echo_failure, f'  {check} contains one or more invalid characters: {invalid_chars}')
+                    )
                 if invalid_seq:
-                    display_queue.append((echo_failure, f'  {check} contains one or more invalid sequences: {invalid_seq}'))
+                    display_queue.append(
+                        (echo_failure, f'  {check} contains one or more invalid sequences: {invalid_seq}')
+                    )
                 if invalid_end:
-                    display_queue.append((echo_failure, f'  {check} contains the following invalid start or end character: {invalid_end}'))
+                    display_queue.append(
+                        (
+                            echo_failure,
+                            f'  {check} contains the following invalid start or end character: {invalid_end}',
+                        )
+                    )
             else:
                 if check in unique_checks:
                     file_failed = True

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
@@ -142,7 +142,7 @@ def service_checks(check, sync):
             if not check or not isinstance(check, str):
                 file_failed = True
                 display_queue.append((echo_failure, '  required non-null string: check'))
-            elif invalid_chars or invalid_seq:
+            elif invalid_chars or invalid_seq or invalid_end:
                 file_failed = True
                 if invalid_chars:
                     display_queue.append(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
@@ -47,7 +47,8 @@ CHECK_TO_NAME = {
 }
 
 INVALID_CHAR_RE = re.compile(r"[^a-zA-Z0-9_.]+")
-INVALID_SEQ_RE = re.compile(r"_{1,}\.+_*|_*\.+_{1,}")
+INVALID_SEQ_RE = re.compile(r"_{1,}\.+_*|_*\.+_{1,}|_{2,}|\.{2,}")
+INVALID_END_RE = re.compile(r"^_+|_+$")
 
 
 @click.command('service-checks', context_settings=CONTEXT_SETTINGS, short_help='Validate `service_checks.json` files')
@@ -137,6 +138,7 @@ def service_checks(check, sync):
             check = service_check.get('check')
             invalid_chars = INVALID_CHAR_RE.findall(check)
             invalid_seq = INVALID_SEQ_RE.findall(check)
+            invalid_end = INVALID_END_RE.findall(check)
             if not check or not isinstance(check, str):
                 file_failed = True
                 display_queue.append((echo_failure, '  required non-null string: check'))
@@ -146,6 +148,8 @@ def service_checks(check, sync):
                     display_queue.append((echo_failure, f'  {check} contains one or more invalid characters: {invalid_chars}'))
                 if invalid_seq:
                     display_queue.append((echo_failure, f'  {check} contains one or more invalid sequences: {invalid_seq}'))
+                if invalid_end:
+                    display_queue.append((echo_failure, f'  {check} contains the following invalid start or end character: {invalid_end}'))
             else:
                 if check in unique_checks:
                     file_failed = True

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
@@ -46,8 +46,8 @@ CHECK_TO_NAME = {
     'tcp_check': 'System',
 }
 
-SERVICE_CHECK_NAME_RE = re.compile(r"[^a-zA-Z0-9_.]+")
-SERVICE_CHECK_INVALID_SEQ_RE = re.compile(r"_{1,}\.+_*|_*\.+_{1,}")
+INVALID_CHAR_RE = re.compile(r"[^a-zA-Z0-9_.]+")
+INVALID_SEQ_RE = re.compile(r"_{1,}\.+_*|_*\.+_{1,}")
 
 
 @click.command('service-checks', context_settings=CONTEXT_SETTINGS, short_help='Validate `service_checks.json` files')
@@ -135,17 +135,17 @@ def service_checks(check, sync):
 
             # check
             check = service_check.get('check')
-            invalid_matches = SERVICE_CHECK_NAME_RE.findall(check)
-            invalid_seq = SERVICE_CHECK_INVALID_SEQ_RE.findall(check)
+            invalid_matches = INVALID_CHAR_RE.findall(check)
+            invalid_seq = INVALID_SEQ_RE.findall(check)
             if not check or not isinstance(check, str):
                 file_failed = True
                 display_queue.append((echo_failure, '  required non-null string: check'))
             elif invalid_matches or invalid_seq:
                 file_failed = True
                 if invalid_matches:
-                    display_queue.append((echo_failure, f'  {check} contains one or more invalid sequence: {invalid_matches}'))
+                    display_queue.append((echo_failure, f'  {check} contains one or more invalid characters: {invalid_matches}'))
                 if invalid_seq:
-                    display_queue.append((echo_failure, f'  {check} contains one or more invalid sequence: {invalid_seq}'))
+                    display_queue.append((echo_failure, f'  {check} contains one or more invalid sequences: {invalid_seq}'))
             else:
                 if check in unique_checks:
                     file_failed = True

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
@@ -135,15 +135,15 @@ def service_checks(check, sync):
 
             # check
             check = service_check.get('check')
-            invalid_matches = INVALID_CHAR_RE.findall(check)
+            invalid_chars = INVALID_CHAR_RE.findall(check)
             invalid_seq = INVALID_SEQ_RE.findall(check)
             if not check or not isinstance(check, str):
                 file_failed = True
                 display_queue.append((echo_failure, '  required non-null string: check'))
-            elif invalid_matches or invalid_seq:
+            elif invalid_chars or invalid_seq:
                 file_failed = True
-                if invalid_matches:
-                    display_queue.append((echo_failure, f'  {check} contains one or more invalid characters: {invalid_matches}'))
+                if invalid_chars:
+                    display_queue.append((echo_failure, f'  {check} contains one or more invalid characters: {invalid_chars}'))
                 if invalid_seq:
                     display_queue.append((echo_failure, f'  {check} contains one or more invalid sequences: {invalid_seq}'))
             else:


### PR DESCRIPTION
### What does this PR do?
Added logic to detect invalid characters and sequence to the CI pipeline.

### Motivation
To prevent service names containing invalid characters and sequences from being sync to our backend

### Additional Information
Test cases sequences:
```
a_.
a__.
a__..
a__.._
a__..__
b._
b.__
b..__
b_..__
c__
d_
_e
```

Invalid characters on anything that isn't `a-z`, `A-Z`, `0-9`, `_` and `.` 

Validated against integrations-core, extras and marketplace

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
