### PR TITLE
Add minimal twistlock e2e test

### DIFF
--- a/twistlock/tests/conftest.py
+++ b/twistlock/tests/conftest.py
@@ -1,5 +1,3 @@
-
-
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)

--- a/twistlock/tests/conftest.py
+++ b/twistlock/tests/conftest.py
@@ -1,0 +1,26 @@
+
+
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from copy import deepcopy
+
+import pytest
+
+INSTANCE = {
+    'username': 'admin',
+    'password': 'password',
+    'url': 'http://localhost:8081',
+    'tags': ["custom:tag"],
+    'ssl_verify': False,
+}
+
+
+@pytest.fixture(scope="session")
+def dd_environment():
+    yield deepcopy(INSTANCE)
+
+
+@pytest.fixture
+def instance():
+    return deepcopy(INSTANCE)

--- a/twistlock/tests/test_twistlock.py
+++ b/twistlock/tests/test_twistlock.py
@@ -4,8 +4,10 @@
 
 import os
 
+import logging
 import mock
 import pytest
+import pdb
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.dev import get_here
@@ -101,6 +103,9 @@ def test_err_response(aggregator, instance):
 
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, aggregator, instance):
-    with pytest.raises(Exception):
+    # caplog.set_level(logging.DEBUG)
+    # pdb.set_trace()
+    with pytest.raises(Exception) as e:
         dd_agent_check(instance)
     aggregator.assert_service_check("twistlock.license_ok", AgentCheck.CRITICAL)
+    assert "Max retries exceeded with url: /api/v1/settings/license" in str(e.value)

--- a/twistlock/tests/test_twistlock.py
+++ b/twistlock/tests/test_twistlock.py
@@ -4,10 +4,8 @@
 
 import os
 
-import logging
 import mock
 import pytest
-import pdb
 
 from datadog_checks.base import AgentCheck
 from datadog_checks.dev import get_here
@@ -103,8 +101,6 @@ def test_err_response(aggregator, instance):
 
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, aggregator, instance):
-    # caplog.set_level(logging.DEBUG)
-    # pdb.set_trace()
     with pytest.raises(Exception) as e:
         dd_agent_check(instance)
     aggregator.assert_service_check("twistlock.license_ok", AgentCheck.CRITICAL)

--- a/twistlock/tests/test_twistlock.py
+++ b/twistlock/tests/test_twistlock.py
@@ -13,7 +13,6 @@ from datadog_checks.dev.http import MockResponse
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.twistlock import TwistlockCheck
 
-
 METRICS = [
     'twistlock.registry.cve.details',
     'twistlock.registry.cve.count',
@@ -32,15 +31,6 @@ METRICS = [
 ]
 
 customtag = "custom:tag"
-
-instance = {
-    'username': 'admin',
-    'password': 'password',
-    'url': 'http://localhost:8081',
-    'tags': [customtag],
-    'ssl_verify': False,
-}
-
 HERE = get_here()
 
 
@@ -54,7 +44,7 @@ def mock_get_factory(fixture_group):
 
 
 @pytest.mark.parametrize('fixture_group', ['twistlock', 'prisma_cloud'])
-def test_check(aggregator, fixture_group):
+def test_check(aggregator, instance, fixture_group):
 
     check = TwistlockCheck('twistlock', {}, [instance])
 
@@ -71,7 +61,7 @@ def test_check(aggregator, fixture_group):
 
 
 @pytest.mark.parametrize('fixture_group', ['twistlock', 'prisma_cloud'])
-def test_config_project(aggregator, fixture_group):
+def test_config_project(aggregator, instance, fixture_group):
 
     project = 'foo'
     project_tag = 'project:{}'.format(project)
@@ -99,7 +89,7 @@ def test_config_project(aggregator, fixture_group):
         aggregator.assert_metric_has_tag(metric, project_tag)
 
 
-def test_err_response(aggregator):
+def test_err_response(aggregator, instance):
 
     check = TwistlockCheck('twistlock', {}, [instance])
 
@@ -114,4 +104,3 @@ def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance)
     aggregator.assert_service_check("twistlock.license_ok", AgentCheck.CRITICAL)
-    aggregator.assert_service_check("twistlock.can_connect", AgentCheck.CRITICAL)

--- a/twistlock/tox.ini
+++ b/twistlock/tox.ini
@@ -11,6 +11,8 @@ envdir =
     py27: {toxworkdir}/py27
     py38: {toxworkdir}/py38
 dd_check_style = true
+description =
+    py{27,38}: e2e ready
 usedevelop = true
 platform = linux|darwin|win32
 deps =


### PR DESCRIPTION
### What does this PR do?
Add a minimal twistlock e2e test to ensure the check is able to run. 

### Motivation
Expand testing to ensure integrations errors are caught in our CI pipeline

### Additional Notes
Only testing for one service check(`twistlock.license_ok`) since the check seems to stop after trying to get the license due to the [this line](https://github.com/DataDog/integrations-core/blob/master/twistlock/datadog_checks/twistlock/twistlock.py#L84).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
