### PR TITLE
Add unit to `system.core.*`

### DIFF
--- a/system_core/metadata.csv
+++ b/system_core/metadata.csv
@@ -1,5 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 system.core.count,gauge,,core,,The number of CPU cores on the host,0,system,cpu cores
-system.core.user,gauge,,,,A given core's user-space CPU time,0,system,cpu user
-system.core.system,gauge,,,,A given core's system CPU time,0,system,cpu system
-system.core.idle,gauge,,,,A given core's idle CPU time,0,system,cpu idle
+system.core.user,gauge,,second,,A given core's user-space CPU time,0,system,cpu user
+system.core.system,gauge,,second,,A given core's system CPU time,0,system,cpu system
+system.core.idle,gauge,,second,,A given core's idle CPU time,0,system,cpu idle


### PR DESCRIPTION
### What does this PR do?

Add `second` to following metrics as unit.
- system.core.user
- system.core.system
- system.idle

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/issues/10820

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
