### PR TITLE
Update default e2e config to use loader core

### DIFF
--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -32,7 +32,7 @@ SNMP_CONTAINER_NAME = 'dd-snmp'
 
 CHECK_TAGS = ['snmp_device:{}'.format(HOST)]
 
-SNMP_CONF = {'name': 'snmp_conf', 'ip_address': HOST, 'port': PORT, 'community_string': 'public'}
+SNMP_CONF = {'ip_address': HOST, 'port': PORT, 'community_string': 'public'}
 
 SNMP_V3_CONF = {
     'name': 'snmp_v3_conf',
@@ -198,8 +198,8 @@ snmp_integration_only = pytest.mark.skipif(SNMP_LISTENER_ENV != 'false', reason=
 def generate_instance_config(metrics, template=None):
     template = template if template else SNMP_CONF
     instance_config = copy.copy(template)
-    instance_config['metrics'] = metrics
-    instance_config['name'] = HOST
+    if metrics:
+        instance_config['metrics'] = metrics
     return instance_config
 
 

--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -16,11 +16,8 @@ from datadog_checks.dev.docker import get_container_ip
 from .common import (
     COMPOSE_DIR,
     PORT,
-    SCALAR_OBJECTS,
-    SCALAR_OBJECTS_WITH_TAGS,
     SNMP_CONTAINER_NAME,
     SNMP_LISTENER_ENV,
-    TABULAR_OBJECTS,
     TOX_ENV_NAME,
     generate_container_instance_config,
 )
@@ -57,9 +54,8 @@ def dd_environment():
                     '{}:/etc/datadog-agent/datadog.yaml'.format(create_datadog_conf_file(tmp_dir))
                 ]
             else:
-                instance_config = generate_container_instance_config(
-                    SCALAR_OBJECTS + SCALAR_OBJECTS_WITH_TAGS + TABULAR_OBJECTS
-                )
+                instance_config = generate_container_instance_config([])
+                instance_config['init_config']['loader'] = 'core'
             yield instance_config, new_e2e_metadata
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update default e2e config to use loader core

### Motivation
<!-- What inspired you to submit this pull request? -->

corecheck is now the recommended implementation

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
