### PR TITLE
Improve plan lookup performance

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -332,7 +332,10 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     obfuscated_plan = obfuscate_xml_plan(raw_plan)
                 except Exception as e:
                     self.log.debug(
-                        "failed to obfuscate XML Plan query_signature=%s query_hash=%s query_plan_hash=%s plan_handle=%s: %s",
+                        (
+                            "failed to obfuscate XML Plan query_signature=%s query_hash=%s "
+                            "query_plan_hash=%s plan_handle=%s: %s"
+                        ),
                         row['query_signature'],
                         row['query_hash'],
                         row['query_plan_hash'],

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -42,7 +42,7 @@ SQL_SERVER_QUERY_METRICS_COLUMNS = [
 
 STATEMENT_METRICS_QUERY = """\
 with qstats as (
-    select TOP {limit} text, query_hash, query_plan_hash,
+    select TOP {limit} text, query_hash, query_plan_hash, last_execution_time, plan_handle,
            (select value from sys.dm_exec_plan_attributes(plan_handle) where attribute = 'dbid') as dbid,
            (select value from sys.dm_exec_plan_attributes(plan_handle) where attribute = 'user_id') as user_id,
            {query_metrics_columns}
@@ -50,7 +50,7 @@ with qstats as (
         cross apply sys.dm_exec_sql_text(sql_handle)
     where last_execution_time > dateadd(second, -{collection_interval}, getdate())
 )
-select text, query_hash, query_plan_hash, CAST(S.dbid as int) as dbid, D.name as database_name, U.name as user_name,
+select text, query_hash, query_plan_hash, CAST(S.dbid as int) as dbid, D.name as database_name, U.name as user_name, max(plan_handle) as plan_handle,
     {query_metrics_column_sums}
     from qstats S
     left join sys.databases D on S.dbid = D.database_id
@@ -59,10 +59,7 @@ select text, query_hash, query_plan_hash, CAST(S.dbid as int) as dbid, D.name as
 """
 
 PLAN_LOOKUP_QUERY = """\
-select cast(query_plan as nvarchar(max)) as query_plan from sys.dm_exec_query_stats
-    cross apply sys.dm_exec_query_plan(plan_handle)
-where
-    query_hash = CONVERT(varbinary(max), ?, 1) and query_plan_hash = CONVERT(varbinary(max), ?, 1)
+select cast(query_plan as nvarchar(max)) as query_plan from sys.dm_exec_query_plan(CONVERT(varbinary(max), ?, 1))
 """
 
 
@@ -213,6 +210,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             row['query_signature'] = compute_sql_signature(obfuscated_statement)
             row['query_hash'] = _hash_to_hex(row['query_hash'])
             row['query_plan_hash'] = _hash_to_hex(row['query_plan_hash'])
+            row['plan_handle'] = _hash_to_hex(row['plan_handle'])
             normalized_rows.append(row)
         return normalized_rows
 
@@ -310,10 +308,10 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         self.collect_statement_metrics_and_plans()
 
     @tracked_method(agent_check_getter=agent_check_getter)
-    def _load_plan(self, query_hash, query_plan_hash, cursor):
-        self.log.debug("collecting plan. query_hash=%s query_plan_hash=%s", query_hash, query_plan_hash)
-        self.log.debug("Running query [%s] %s", PLAN_LOOKUP_QUERY, (query_hash, query_plan_hash))
-        cursor.execute(PLAN_LOOKUP_QUERY, ("0x" + query_hash, "0x" + query_plan_hash))
+    def _load_plan(self, plan_handle, cursor):
+        self.log.debug("collecting plan. plan_handle=%s", plan_handle)
+        self.log.debug("Running query [%s] %s", PLAN_LOOKUP_QUERY, (plan_handle,))
+        cursor.execute(PLAN_LOOKUP_QUERY, ("0x" + plan_handle))
         result = cursor.fetchall()
         if not result:
             self.log.debug("failed to loan plan, it must have just been expired out of the plan cache")
@@ -325,17 +323,18 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         for row in rows:
             plan_key = (row['query_signature'], row['query_hash'], row['query_plan_hash'])
             if self._seen_plans_ratelimiter.acquire(plan_key):
-                raw_plan = self._load_plan(row['query_hash'], row['query_plan_hash'], cursor)
+                raw_plan = self._load_plan(row['plan_handle'], cursor)
                 obfuscated_plan, collection_errors = None, None
 
                 try:
                     obfuscated_plan = obfuscate_xml_plan(raw_plan)
                 except Exception as e:
                     self.log.debug(
-                        "failed to obfuscate XML Plan query_signature=%s query_hash=%s query_plan_hash=%s: %s",
+                        "failed to obfuscate XML Plan query_signature=%s query_hash=%s query_plan_hash=%s plan_handle=%s: %s",
                         row['query_signature'],
                         row['query_hash'],
                         row['query_plan_hash'],
+                        row['plan_handle'],
                         e,
                     )
                     collection_errors = [{'code': "obfuscate_xml_plan_error", 'message': str(e)}]

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -313,7 +313,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
     def _load_plan(self, plan_handle, cursor):
         self.log.debug("collecting plan. plan_handle=%s", plan_handle)
         self.log.debug("Running query [%s] %s", PLAN_LOOKUP_QUERY, (plan_handle,))
-        cursor.execute(PLAN_LOOKUP_QUERY, ("0x" + plan_handle))
+        cursor.execute(PLAN_LOOKUP_QUERY, ("0x" + plan_handle,))
         result = cursor.fetchall()
         if not result:
             self.log.debug("failed to loan plan, it must have just been expired out of the plan cache")

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -50,7 +50,8 @@ with qstats as (
         cross apply sys.dm_exec_sql_text(sql_handle)
     where last_execution_time > dateadd(second, -{collection_interval}, getdate())
 )
-select text, query_hash, query_plan_hash, CAST(S.dbid as int) as dbid, D.name as database_name, U.name as user_name, max(plan_handle) as plan_handle,
+select text, query_hash, query_plan_hash, CAST(S.dbid as int) as dbid,
+       D.name as database_name, U.name as user_name, max(plan_handle) as plan_handle,
     {query_metrics_column_sums}
     from qstats S
     left join sys.databases D on S.dbid = D.database_id
@@ -59,7 +60,8 @@ select text, query_hash, query_plan_hash, CAST(S.dbid as int) as dbid, D.name as
 """
 
 PLAN_LOOKUP_QUERY = """\
-select cast(query_plan as nvarchar(max)) as query_plan from sys.dm_exec_query_plan(CONVERT(varbinary(max), ?, 1))
+select cast(query_plan as nvarchar(max)) as query_plan
+from sys.dm_exec_query_plan(CONVERT(varbinary(max), ?, 1))
 """
 
 


### PR DESCRIPTION
### What does this PR do?

Improves the performance of plans by looking up by the plan handle. This is a more efficient lookup which will cut down the lookup time of each plan by extracting the first plan handle from `dm_exec_query_stats`.

It also raises the TTL of plan caches, since these are identical plans and plan flips will be automatically detected due to the new plans being uncached.

### Motivation

Some high-cardinality workloads have long-running check run times. We were able to identify the plan lookup as the bottleneck.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
