### PR TITLE
Add `enforce_collection_interval_deadline` option to set plan collection deadline

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -244,6 +244,17 @@ files:
           value:
             type: integer
             example: 4
+        - name: enforce_collection_interval_deadline
+          description: |
+            By default, plan collection stops if it is time for the next run of the query metrics & plans loop. This
+            means that some plans may not be collected. If it is necessary to collect all of the plans and in doing so
+            cause delays in collecting query metrics, then this deadline can be disabled by setting this option to
+            false.
+          value:
+            type: boolean
+            example: True
+          hidden: true
+
     - name: query_activity
       description: Configure collection of active sessions monitoring
       options:

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -37,6 +37,7 @@ class QueryMetrics(BaseModel):
     collection_interval: Optional[float]
     dm_exec_query_stats_row_limit: Optional[int]
     enabled: Optional[bool]
+    enforce_collection_interval_deadline: Optional[bool]
     samples_per_hour_per_query: Optional[int]
 
 

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -365,9 +365,7 @@ def test_plan_collection_deadline(aggregator, dd_run_check, dbm_instance, slow_p
     if slow_plans:
         aggregator.assert_metric("dd.sqlserver.statements.deadline_exceeded", tags=expected_debug_tags)
     else:
-        assert "dd.sqlserver.statements.deadline_exceeded" not in aggregator.metrics(
-            "dd.sqlserver.statements.deadline_exceeded"
-        )
+        aggregator.assert_metric("dd.sqlserver.statements.deadline_exceeded", count=0)
 
 
 def _strip_whitespace(raw_plan):

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -39,7 +39,14 @@ def dbm_instance(instance_docker):
     instance_docker['dbm'] = True
     instance_docker['min_collection_interval'] = 1
     # set a very small collection interval so the tests go fast
-    instance_docker['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    instance_docker['query_metrics'] = {
+        'enabled': True,
+        'run_sync': True,
+        'collection_interval': 0.1,
+        # in tests sometimes things can slow down so we don't want this short deadline causing some events
+        # to fail to be collected on time
+        'enforce_collection_interval_deadline': False,
+    }
     return copy(instance_docker)
 
 
@@ -330,6 +337,37 @@ def test_statement_basic_metrics_query(datadog_conn_docker, dbm_instance):
 
 
 XML_PLANS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "xml_plans")
+
+
+@pytest.mark.parametrize("slow_plans", [True, False])
+@pytest.mark.skip(reason="skip to see if this test is why the tests get stuck")
+def test_plan_collection_deadline(aggregator, dd_run_check, dbm_instance, slow_plans):
+    dbm_instance['query_metrics']['enforce_collection_interval_deadline'] = True
+
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+
+    def _mock_slow_load_plan(*_):
+        if not slow_plans:
+            check.log.debug("_mock_slow_load_plan instant return")
+            return
+        interval = dbm_instance['query_metrics']['collection_interval']
+        check.log.debug("_mock_slow_load_plan sleeping %s seconds", interval)
+        time.sleep(interval)
+
+    aggregator.reset()
+
+    with mock.patch.object(check.statement_metrics, '_load_plan', passthrough=True) as mock_obj:
+        mock_obj.side_effect = _mock_slow_load_plan
+        dd_run_check(check)
+
+    expected_debug_tags = ['agent_hostname:stubbed.hostname'] + _expected_dbm_instance_tags(dbm_instance)
+
+    if slow_plans:
+        aggregator.assert_metric("dd.sqlserver.statements.deadline_exceeded", tags=expected_debug_tags)
+    else:
+        assert "dd.sqlserver.statements.deadline_exceeded" not in aggregator.metrics(
+            "dd.sqlserver.statements.deadline_exceeded"
+        )
 
 
 def _strip_whitespace(raw_plan):


### PR DESCRIPTION
### What does this PR do?

Set a collection deadline to make sure we stop collecting plans when it's time for the next collection.

### Motivation

If we find a large number of plans during a single collection run and the loading of those plans takes longer than usual, the total time required to collect all of the plans can take longer than the collection interval, which means the following run of the interval will be delayed. 

This ensures we stop collecting plans in time for the next collection run. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
