### PR TITLE
fix missing ConnectionRetryCount when DSN set

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -349,7 +349,7 @@ class Connection(object):
 
         conn_str = 'ConnectRetryCount=2;'
         if dsn:
-            conn_str = 'DSN={};'.format(dsn)
+            conn_str += 'DSN={};'.format(dsn)
 
         if driver:
             conn_str += 'DRIVER={};'.format(driver)


### PR DESCRIPTION
### What does this PR do?

If DSN is set then we need to append to the existing connection string instead of reassigning it.

Follow-up to https://github.com/DataDog/integrations-core/pull/10738

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
