### PR TITLE
Fix wrong example for MultiSubnetFailover in connection_string example

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -199,7 +199,7 @@ files:
     - name: connection_string
       description: |
         Specify a custom connection string to be used
-        Ex: "ApplicationIntent=ReadWrite" or "MultiSubnetFailover=True"
+        Ex: "ApplicationIntent=ReadWrite" or "MultiSubnetFailover=yes"
         "Trusted_Connection=yes" to use Windows Authentication (note that in this case the connection will be performed
         with the `ddagentuser` user, you can find more information about this user
         in https://docs.datadoghq.com/agent/faq/windows-agent-ddagent-user/)

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -189,7 +189,7 @@ instances:
 
     ## @param connection_string - string - optional
     ## Specify a custom connection string to be used
-    ## Ex: "ApplicationIntent=ReadWrite" or "MultiSubnetFailover=True"
+    ## Ex: "ApplicationIntent=ReadWrite" or "MultiSubnetFailover=yes"
     ## "Trusted_Connection=yes" to use Windows Authentication (note that in this case the connection will be performed
     ## with the `ddagentuser` user, you can find more information about this user
     ## in https://docs.datadoghq.com/agent/faq/windows-agent-ddagent-user/)


### PR DESCRIPTION
### What does this PR do?
`MultiSubnetFailover=True` causes a failure on startup because it's an invalid value for that connection string parameter. This updates the example for `connection_string` to use the correct value which is `yes`. 

### Motivation
Customer having issues trying to use `MultiSubnetFailover=true`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
