### PR TITLE
Make process check configuration notes clearer

### DIFF
--- a/process/assets/configuration/spec.yaml
+++ b/process/assets/configuration/spec.yaml
@@ -49,7 +49,7 @@ files:
           all the processes that match the string exactly by default. Change this behavior with the
           parameter `exact_match: false`.
 
-          Note: One and only one of search_string, pid or pid_file must be specified per instance.
+          Note: Exactly one of search_string, pid or pid_file must be specified per instance.
         value:
           type: array
           items:
@@ -61,7 +61,7 @@ files:
         description: |
           A Process id to match.
 
-          Note: One and only one of search_string, pid or pid_file must be specified per instance.
+          Note: Exactly one of search_string, pid or pid_file must be specified per instance.
         value:
           type: integer
       - name: pid_file
@@ -70,7 +70,7 @@ files:
           Notes:
             * agent v6.11+ on windows runs as an unprivileged `ddagentuser`, so make sure to grant it read access to
               the PID files you specify in this option.
-            * One and only one of search_string, pid or pid_file must be specified per instance.
+            * Exactly one of search_string, pid or pid_file must be specified per instance.
         value:
           type: string
       - name: exact_match

--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -49,7 +49,7 @@ instances:
     ## all the processes that match the string exactly by default. Change this behavior with the
     ## parameter `exact_match: false`.
     ##
-    ## Note: One and only one of search_string, pid or pid_file must be specified per instance.
+    ## Note: Exactly one of search_string, pid or pid_file must be specified per instance.
     #
     # search_string:
     #   - <SEARCH_STRING_1>
@@ -58,7 +58,7 @@ instances:
     ## @param pid - integer - optional
     ## A Process id to match.
     ##
-    ## Note: One and only one of search_string, pid or pid_file must be specified per instance.
+    ## Note: Exactly one of search_string, pid or pid_file must be specified per instance.
     #
     # pid: <PID>
 
@@ -67,7 +67,7 @@ instances:
     ## Notes:
     ##   * agent v6.11+ on windows runs as an unprivileged `ddagentuser`, so make sure to grant it read access to
     ##     the PID files you specify in this option.
-    ##   * One and only one of search_string, pid or pid_file must be specified per instance.
+    ##   * Exactly one of search_string, pid or pid_file must be specified per instance.
     #
     # pid_file: <PID_FILE>
 


### PR DESCRIPTION
### What does this PR do?

Improves notes on the process check configuration to make it clearer that exactly one of `search_string`, `pid` or `pid_file` must be specified.

### Motivation

User confusion.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
