### PR TITLE
Add a minimal e2e test for datadog_cluster_agent check

### DIFF
--- a/datadog_cluster_agent/tests/conftest.py
+++ b/datadog_cluster_agent/tests/conftest.py
@@ -6,15 +6,18 @@ import os
 import mock
 import pytest
 
+from copy import deepcopy
+
+INSTANCE = {'prometheus_url': 'http://localhost:5000/metrics'}
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    yield
+    yield deepcopy(INSTANCE)
 
 
 @pytest.fixture
 def instance():
-    return {'prometheus_url': 'http://localhost:5000/metrics'}
+    return deepcopy(INSTANCE)
 
 
 @pytest.fixture()

--- a/datadog_cluster_agent/tests/conftest.py
+++ b/datadog_cluster_agent/tests/conftest.py
@@ -2,13 +2,13 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+from copy import deepcopy
 
 import mock
 import pytest
 
-from copy import deepcopy
-
 INSTANCE = {'prometheus_url': 'http://localhost:5000/metrics'}
+
 
 @pytest.fixture(scope='session')
 def dd_environment():

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -1,12 +1,12 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-import pdb
 from typing import Any, Dict
 
-from datadog_checks.base.stubs.aggregator import AggregatorStub
+import pytest
+
 from datadog_checks.base import AgentCheck
+from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.datadog_cluster_agent import DatadogClusterAgentCheck
 from datadog_checks.dev.utils import get_metadata_metrics
 

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
+import pdb
 from typing import Any, Dict
 
 from datadog_checks.base.stubs.aggregator import AggregatorStub
@@ -66,6 +67,7 @@ def test_check(aggregator, instance, mock_metrics_endpoint):
 # Minimal E2E testing
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, aggregator, instance):
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as e:
         dd_agent_check(instance, rate=True)
     aggregator.assert_service_check("datadog.cluster_agent.prometheus.health", AgentCheck.CRITICAL)
+    assert "Max retries exceeded with url: /metrics" in str(e)

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -1,9 +1,11 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
 from typing import Any, Dict
 
 from datadog_checks.base.stubs.aggregator import AggregatorStub
+from datadog_checks.base import AgentCheck
 from datadog_checks.datadog_cluster_agent import DatadogClusterAgentCheck
 from datadog_checks.dev.utils import get_metadata_metrics
 
@@ -59,3 +61,11 @@ def test_check(aggregator, instance, mock_metrics_endpoint):
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+
+
+# Minimal E2E testing
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, aggregator, instance):
+    with pytest.raises(Exception):
+        dd_agent_check(instance, rate=True)
+    aggregator.assert_service_check("datadog.cluster_agent.prometheus.health", AgentCheck.CRITICAL)

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -70,4 +70,3 @@ def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception) as e:
         dd_agent_check(instance, rate=True)
     aggregator.assert_service_check("datadog.cluster_agent.prometheus.health", AgentCheck.CRITICAL)
-    assert "Max retries exceeded with url: /metrics" in str(e)

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -10,7 +10,6 @@ from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.datadog_cluster_agent import DatadogClusterAgentCheck
 from datadog_checks.dev.utils import get_metadata_metrics
 
-EXPECTED_TAGS = ['endpoint:http://localhost:5000/metrics']
 NAMESPACE = 'datadog.cluster_agent'
 
 METRICS = [
@@ -70,4 +69,5 @@ def test_check(aggregator, instance, mock_metrics_endpoint):
 def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
-    aggregator.assert_service_check("datadog.cluster_agent.prometheus.health", AgentCheck.CRITICAL, count=2, tags=EXPECTED_TAGS)
+    tag = "endpoint:" + instance.get('prometheus_url')
+    aggregator.assert_service_check("datadog.cluster_agent.prometheus.health", AgentCheck.CRITICAL, count=2, tags=[tag])

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -67,6 +67,6 @@ def test_check(aggregator, instance, mock_metrics_endpoint):
 # Minimal E2E testing
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, aggregator, instance):
-    with pytest.raises(Exception) as e:
+    with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
     aggregator.assert_service_check("datadog.cluster_agent.prometheus.health", AgentCheck.CRITICAL)

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -10,6 +10,7 @@ from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.datadog_cluster_agent import DatadogClusterAgentCheck
 from datadog_checks.dev.utils import get_metadata_metrics
 
+EXPECTED_TAGS = ['endpoint:http://localhost:5000/metrics']
 NAMESPACE = 'datadog.cluster_agent'
 
 METRICS = [
@@ -69,4 +70,4 @@ def test_check(aggregator, instance, mock_metrics_endpoint):
 def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
-    aggregator.assert_service_check("datadog.cluster_agent.prometheus.health", AgentCheck.CRITICAL)
+    aggregator.assert_service_check("datadog.cluster_agent.prometheus.health", AgentCheck.CRITICAL, count=2, tags=EXPECTED_TAGS)

--- a/datadog_cluster_agent/tox.ini
+++ b/datadog_cluster_agent/tox.ini
@@ -4,7 +4,7 @@ skip_missing_interpreters = true
 basepython = py38
 envlist =
     py{27,38}
-    
+
 [testenv]
 ensure_default_envdir = true
 envdir =

--- a/datadog_cluster_agent/tox.ini
+++ b/datadog_cluster_agent/tox.ini
@@ -4,13 +4,15 @@ skip_missing_interpreters = true
 basepython = py38
 envlist =
     py{27,38}
-
+    
 [testenv]
 ensure_default_envdir = true
 envdir =
     py27: {toxworkdir}/py27
     py38: {toxworkdir}/py38
 dd_check_style = true
+description =
+    py{27,38}: e2e ready
 usedevelop = true
 platform = linux|darwin|win32
 deps =


### PR DESCRIPTION
### What does this PR do?
Add a minimal e2e test for datadog_cluster_agent check

### Motivation
Expand testing to ensure integrations errors are caught in our CI pipeline

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
