### PR TITLE
use dynamic query stats interval and set common request timeout 

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -156,6 +156,7 @@ class Connection(object):
             else:
                 cs += self._conn_string_odbc(db_key, db_name=db_name)
                 rawconn = pyodbc.connect(cs, timeout=self.timeout, autocommit=True)
+                rawconn.timeout = self.timeout
 
             self.service_check_handler(AgentCheck.OK, host, database, is_default=is_default)
             if conn_key not in self._conns:

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -72,11 +72,13 @@ def _run_test_collect_activity(aggregator, instance_docker, dd_run_check, dbm_in
     with bob_conn.cursor() as cursor:
         cursor.execute("USE {}".format("datadog_test"))
         cursor.execute(query)
+        cursor.fetchall()
 
     fred_conn = _get_conn_for_user(instance_docker, "fred")
     with fred_conn.cursor() as cursor:
         cursor.execute("USE {}".format("datadog_test"))
         cursor.execute(query)
+        cursor.fetchall()
 
     dd_run_check(check)
     fred_conn.close()  # close the open tx that belongs to fred
@@ -207,6 +209,7 @@ def _get_conn_for_user(instance_docker, user):
         instance_docker['driver'], instance_docker['host'], user, "Password12!"
     )
     conn = pyodbc.connect(conn_str, timeout=30, autocommit=False)
+    conn.timeout = 30
     return conn
 
 

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -14,6 +14,7 @@ from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_e
 from datadog_checks.sqlserver import SQLServer
 
 from .common import CHECK_NAME
+from .conftest import DEFAULT_TIMEOUT
 from .utils import not_windows_ci, windows_ci
 
 try:
@@ -208,8 +209,8 @@ def _get_conn_for_user(instance_docker, user):
     conn_str = 'DRIVER={};Server={};Database=master;UID={};PWD={};'.format(
         instance_docker['driver'], instance_docker['host'], user, "Password12!"
     )
-    conn = pyodbc.connect(conn_str, timeout=30, autocommit=False)
-    conn.timeout = 30
+    conn = pyodbc.connect(conn_str, timeout=DEFAULT_TIMEOUT, autocommit=False)
+    conn.timeout = DEFAULT_TIMEOUT
     return conn
 
 

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -2,8 +2,10 @@
 from __future__ import unicode_literals
 
 import logging
+import math
 import os
 import re
+import time
 from concurrent.futures.thread import ThreadPoolExecutor
 from copy import copy
 
@@ -13,6 +15,7 @@ from lxml import etree as ET
 
 from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
+from datadog_checks.dev import WaitFor
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.statements import SQL_SERVER_QUERY_METRICS_COLUMNS, obfuscate_xml_plan
 
@@ -150,10 +153,19 @@ test_statement_metrics_and_plans_parameterized = (
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(*test_statement_metrics_and_plans_parameterized)
 def test_statement_metrics_and_plans(
-    aggregator, dd_run_check, dbm_instance, bob_conn, database, plan_user, query, param_groups, match_pattern
+    aggregator, dd_run_check, dbm_instance, bob_conn, database, plan_user, query, param_groups, match_pattern, caplog
 ):
     _run_test_statement_metrics_and_plans(
-        aggregator, dd_run_check, dbm_instance, bob_conn, database, plan_user, query, param_groups, match_pattern
+        aggregator,
+        dd_run_check,
+        dbm_instance,
+        bob_conn,
+        database,
+        plan_user,
+        query,
+        param_groups,
+        match_pattern,
+        caplog,
     )
 
 
@@ -170,6 +182,7 @@ def test_statement_metrics_and_plans_windows(
     query,
     param_groups,
     match_pattern,
+    caplog,
 ):
     _run_test_statement_metrics_and_plans(
         aggregator,
@@ -181,26 +194,35 @@ def test_statement_metrics_and_plans_windows(
         query,
         param_groups,
         match_pattern,
+        caplog,
     )
 
 
 def _run_test_statement_metrics_and_plans(
-    aggregator, dd_run_check, dbm_instance, bob_conn, database, plan_user, query, param_groups, match_pattern
+    aggregator, dd_run_check, dbm_instance, bob_conn, database, plan_user, query, param_groups, match_pattern, caplog
 ):
+    caplog.set_level(logging.INFO)
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-
-    with bob_conn.cursor() as cursor:
-        cursor.execute("USE {}".format(database))
 
     def _run_test_queries():
         with bob_conn.cursor() as cursor:
+            cursor.execute("USE {}".format(database))
             for params in param_groups:
+                logging.info("running query %s: %s", query, params)
                 cursor.execute(query, params)
+                cursor.fetchall()
 
-    _run_test_queries()
+    # the check must be run three times:
+    # 1) set _last_stats_query_time (this needs to happen before the 1st test queries to ensure the query time
+    # interval is correct)
+    # 2) load the test queries into the StatementMetrics state
+    # 3) emit the query metrics based on the diff of current and last state
+    dd_run_check(check)
+    # Use WaitFor to retry the bob_conn test query execution because sometimes they fail due to inexplicable timeouts
+    WaitFor(_run_test_queries, wait=1, attempts=3)()
     dd_run_check(check)
     aggregator.reset()
-    _run_test_queries()
+    WaitFor(_run_test_queries, wait=1, attempts=3)()
     dd_run_check(check)
 
     _conn_key_prefix = "dbm-"
@@ -273,6 +295,7 @@ def _run_test_statement_metrics_and_plans(
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_statement_basic_metrics_query(datadog_conn_docker, dbm_instance):
+    now = time.time()
     test_query = "select * from sys.databases"
 
     # run this test query to guarantee there's at least one application query in the query plan cache
@@ -294,8 +317,9 @@ def test_statement_basic_metrics_query(datadog_conn_docker, dbm_instance):
     # without the cast this is expected to fail with
     # pyodbc.ProgrammingError: ('ODBC SQL type -150 is not yet supported.  column-index=77  type=-150', 'HY106')
     with datadog_conn_docker.cursor() as cursor:
-        logging.debug("running statement_metrics_query: %s", statement_metrics_query)
-        cursor.execute(statement_metrics_query)
+        params = (math.ceil(time.time() - now),)
+        logging.debug("running statement_metrics_query [%s] %s", statement_metrics_query, params)
+        cursor.execute(statement_metrics_query, params)
 
         columns = [i[0] for i in cursor.description]
         # construct row dicts manually as there's no DictCursor for pyodbc

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -207,7 +207,9 @@ def _run_test_statement_metrics_and_plans(
     def _run_test_queries():
         with bob_conn.cursor() as cursor:
             cursor.execute("USE {}".format(database))
-            for params in param_groups:
+
+        for params in param_groups:
+            with bob_conn.cursor() as cursor:
                 logging.info("running query %s: %s", query, params)
                 cursor.execute(query, params)
                 cursor.fetchall()

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -204,10 +204,10 @@ def _run_test_statement_metrics_and_plans(
     caplog.set_level(logging.INFO)
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
-    def _run_test_queries():
-        with bob_conn.cursor() as cursor:
-            cursor.execute("USE {}".format(database))
+    with bob_conn.cursor() as cursor:
+        cursor.execute("USE {}".format(database))
 
+    def _run_test_queries():
         for params in param_groups:
             with bob_conn.cursor() as cursor:
                 logging.info("running query %s: %s", query, params)


### PR DESCRIPTION
### What does this PR do?

Update the `dm_exec_query_stats` query interval (how far we look back for recently executed queries) to be dynamic based on the last time the check ran (Follow-up to https://github.com/DataDog/integrations-core/pull/10810 and https://github.com/DataDog/integrations-core/pull/10763.). Benefits:
  * if in production the check is delayed for any reason (i.e. slow query, network slowness, slow host, agent overload), then the query interval may expand beyond the collection interval, which ensures that the query metrics counts are still correct and we don't lose any stats
  * integration tests where the collection interval is small (i.e. 100ms) were flaky as they would look back only 100ms, but sometimes the interval between queries was much larger than that, meaning the tests would fail as they'd miss the queries they were supposed to catch

Set the request timeout on all pyodbc connections to be the same as the connect timeout which is already being set. This means that long running queries made by the integration will time out instead of running indefinitely. 

Testing fixes:
* set request timeouts on all connections to prevent tests getting stuck indefinitely
* retry failed requests in situations where it's necessary (like the statement metrics & plans test which inexplicably times out sometimes but succeeds on retry). 
* always read out the full cursor contents for integration test queries. If we don't do this then sometimes the cursor can throw errors. 

### Motivation

Fix flaky tests and improve integration behavior in case of slow queries. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
