### PR TITLE
Make hudi public

### DIFF
--- a/hudi/manifest.json
+++ b/hudi/manifest.json
@@ -16,7 +16,7 @@
   ],
   "public_title": "Hudi",
   "type": "check",
-  "is_public": false,
+  "is_public": true,
   "integration_id": "hudi",
   "categories": [
     "log collection",


### PR DESCRIPTION
### What does this PR do?
Makes the hudi integration public

### Motivation
A new version of hudi was released that supports JMX: https://hudi.apache.org/

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
