### PR TITLE
Use `%` for MySQL integration setup document

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -28,20 +28,16 @@ The MySQL check is included in the [Datadog Agent][4] package. No additional ins
 On each MySQL server, create a database user for the Datadog Agent:
 
 ```shell
-mysql> CREATE USER 'datadog'@'localhost' IDENTIFIED BY '<UNIQUEPASSWORD>';
+mysql> CREATE USER 'datadog'@'%' IDENTIFIED BY '<UNIQUEPASSWORD>';
 Query OK, 0 rows affected (0.00 sec)
 ```
 
 For mySQL 8.0+ create the `datadog` user with the native password hashing method:
 
 ```shell
-mysql> CREATE USER 'datadog'@'localhost' IDENTIFIED WITH mysql_native_password by '<UNIQUEPASSWORD>';
+mysql> CREATE USER 'datadog'@'%' IDENTIFIED WITH mysql_native_password by '<UNIQUEPASSWORD>';
 Query OK, 0 rows affected (0.00 sec)
 ```
-
-**Note**: `@'localhost'` is only for local connections. For remote connections, use the hostname/IP of your Agent. For more information, see the [MySQL documentation][5].
-
-**Note**: If you encounter the following error message `(1045, u"Access denied for user 'datadog'@'127.0.0.1' (using password: YES)"))`, see the [MySQL Localhost Error documentation][6].
 
 Verify the user was created successfully using the following commands - replace `<UNIQUEPASSWORD>` with the password you created above:
 
@@ -60,17 +56,17 @@ echo -e "\033[0;31mMissing REPLICATION CLIENT grant\033[0m"
 The Agent needs a few privileges to collect metrics. Grant the user the following limited privileges ONLY:
 
 ```shell
-mysql> GRANT REPLICATION CLIENT ON *.* TO 'datadog'@'localhost' WITH MAX_USER_CONNECTIONS 5;
+mysql> GRANT REPLICATION CLIENT ON *.* TO 'datadog'@'%' WITH MAX_USER_CONNECTIONS 5;
 Query OK, 0 rows affected, 1 warning (0.00 sec)
 
-mysql> GRANT PROCESS ON *.* TO 'datadog'@'localhost';
+mysql> GRANT PROCESS ON *.* TO 'datadog'@'%';
 Query OK, 0 rows affected (0.00 sec)
 ```
 
 For MySQL 8.0+ set `max_user_connections` with:
 
 ```shell
-mysql> ALTER USER 'datadog'@'localhost' WITH MAX_USER_CONNECTIONS 5;
+mysql> ALTER USER 'datadog'@'%' WITH MAX_USER_CONNECTIONS 5;
 Query OK, 0 rows affected (0.00 sec)
 ```
 
@@ -85,7 +81,7 @@ mysql> show databases like 'performance_schema';
 +-------------------------------+
 1 row in set (0.00 sec)
 
-mysql> GRANT SELECT ON performance_schema.* TO 'datadog'@'localhost';
+mysql> GRANT SELECT ON performance_schema.* TO 'datadog'@'%';
 Query OK, 0 rows affected (0.00 sec)
 ```
 


### PR DESCRIPTION
### What does this PR do?

Replace `localhost` with `%`.

### Motivation

**Describe what happened:**

I've tried Agent based MySQL integration according to this [setup guide](https://docs.datadoghq.com/integrations/mysql/?tab=host#setup).
I could not create the connection between Agent and MySQL when I use `'datadog'@'localhost'` or `'datadog'@'127.0.0.1'`.

Therefore, I want to suggest to use `'datadog'@'%'` to prevent the connection error.

**Describe what you expected:**

No one faces the connection error when reading the [setup guide](https://docs.datadoghq.com/integrations/mysql/?tab=host#setup).

**Steps to reproduce the issue:**

Execute `docker compose up` after preparing following files.

`docker-compose.yaml`

```yaml
version: "3.8"
services:
  agent:
    image: gcr.io/datadoghq/agent:7
    environment:
      DD_API_KEY: "" # TODO: set your api key
    volumes:
      - ./conf.yaml:/conf.d/mysql.d/conf.yaml
      - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
      - /proc/:/host/proc/:ro
      - /var/run/docker.sock:/var/run/docker.sock:ro
    networks:
      - default
    depends_on:
      - mysql
  mysql:
    image: bitnami/mysql
    ports:
      - 3306:3306
    restart: always
    environment:
      ALLOW_EMPTY_PASSWORD: yes
    volumes:
      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
    networks:
      - default
```

`conf.yaml`

```yaml
init_config:

instances:
  - server: mysql
    user: datadog
    pass: "password"
    port: "3306"
    options:
      replication: false
      galera_cluster: true
      extra_status_metrics: true
      extra_innodb_metrics: true
      extra_performance_metrics: true
      schema_size_metrics: false
      disable_innodb_metrics: false
```

`init.sql`

use `localhost`  (This is going to fail)

```sql
CREATE USER 'datadog'@'localhost' IDENTIFIED BY 'password';
GRANT REPLICATION CLIENT ON *.* TO 'datadog'@'localhost';
ALTER USER 'datadog'@'localhost'
WITH MAX_USER_CONNECTIONS 5;
GRANT PROCESS ON * . * TO 'datadog'@'localhost';
```

use `127.0.0.1` according to [MySQL Localhost Error - Localhost VS 127.0.0.1](https://docs.datadoghq.com/integrations/faq/mysql-localhost-error-localhost-vs-127-0-0-1/)  (This is going to fail)

```sql
CREATE USER 'datadog'@'127.0.0.1' IDENTIFIED BY 'password';
GRANT REPLICATION CLIENT ON *.* TO 'datadog'@'127.0.0.1';
ALTER USER 'datadog'@'127.0.0.1'
WITH MAX_USER_CONNECTIONS 5;
GRANT PROCESS ON * . * TO 'datadog'@'127.0.0.1';
```

use `%` (This is going to success)

```sql
CREATE USER 'datadog'@'%' IDENTIFIED BY 'password';
GRANT REPLICATION CLIENT ON *.* TO 'datadog'@'%';
ALTER USER 'datadog'@'%'
WITH MAX_USER_CONNECTIONS 5;
GRANT PROCESS ON * . * TO 'datadog'@'%';
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
