### PR TITLE
Add multiple_ips option and address tag

### DIFF
--- a/tcp_check/assets/configuration/spec.yaml
+++ b/tcp_check/assets/configuration/spec.yaml
@@ -47,4 +47,10 @@ files:
         the cache will expire only upon error.
 
         Set ip_cache_duration to `0` if the check should resolve the IP address on every check run.
+    - name: multiple_ips
+      description: Enable to run the check against all IPs attached to `host`.
+      value:
+        default: false
+        example: false
+        type: boolean
     - template: instances/default

--- a/tcp_check/assets/service_checks.json
+++ b/tcp_check/assets/service_checks.json
@@ -8,6 +8,7 @@
             "critical"
         ],
         "groups": [
+            "address",
             "host",
             "instance",
             "port",

--- a/tcp_check/datadog_checks/tcp_check/config_models/defaults.py
+++ b/tcp_check/datadog_checks/tcp_check/config_models/defaults.py
@@ -28,6 +28,10 @@ def instance_min_collection_interval(field, value):
     return 15
 
 
+def instance_multiple_ips(field, value):
+    return False
+
+
 def instance_service(field, value):
     return get_default_field_value(field, value)
 

--- a/tcp_check/datadog_checks/tcp_check/config_models/instance.py
+++ b/tcp_check/datadog_checks/tcp_check/config_models/instance.py
@@ -23,6 +23,7 @@ class InstanceConfig(BaseModel):
     host: str
     ip_cache_duration: Optional[float]
     min_collection_interval: Optional[float]
+    multiple_ips: Optional[bool]
     name: str
     port: int
     service: Optional[str]

--- a/tcp_check/datadog_checks/tcp_check/data/conf.yaml.example
+++ b/tcp_check/datadog_checks/tcp_check/data/conf.yaml.example
@@ -48,6 +48,11 @@ instances:
     #
     # ip_cache_duration: 120
 
+    ## @param multiple_ips - boolean - optional - default: false
+    ## Enable to run the check against all IPs attached to `host`.
+    #
+    # multiple_ips: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -79,14 +79,14 @@ class TCPCheck(AgentCheck):
     def addrs(self):
         if self._addrs is None or self._addrs == []:
             try:
-                self.resolve_ip()
+                self.resolve_ips()
             except Exception as e:
                 self.log.error(str(e))
                 msg = "URL: {} could not be resolved".format(self.host)
                 raise CheckException(msg)
         return self._addrs
 
-    def resolve_ip(self):
+    def resolve_ips(self):
         if self.multiple_ips:
             _, _, self._addrs = socket.gethostbyname_ex(self.host)
         else:
@@ -96,7 +96,7 @@ class TCPCheck(AgentCheck):
             raise Exception("No IPs attached to host")
         self.log.debug("%s resolved to %s", self.host, self._addrs)
 
-    def should_resolve_ip(self):
+    def should_resolve_ips(self):
         if self.ip_cache_duration is None:
             return False
         return get_precise_time() - self.ip_cache_last_ts > self.ip_cache_duration
@@ -112,8 +112,8 @@ class TCPCheck(AgentCheck):
     def check(self, _):
         start = get_precise_time()  # Avoid initialisation warning
 
-        if self.should_resolve_ip():
-            self.resolve_ip()
+        if self.should_resolve_ips():
+            self.resolve_ips()
             self.ip_cache_last_ts = start
 
         self.log.debug("Connecting to %s on port %d", self.host, self.port)

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -25,9 +25,10 @@ class TCPCheck(AgentCheck):
         self.collect_response_time = instance.get('collect_response_time', False)
         self.host = instance.get('host', None)
         self.socket_type = None
-        self._addr = None
+        self._addrs = None
         self.ip_cache_last_ts = 0
         self.ip_cache_duration = self.DEFAULT_IP_CACHE_DURATION
+        self.multiple_ips = instance.get('multiple_ips', False)
 
         ip_cache_duration = instance.get('ip_cache_duration', None)
         if ip_cache_duration is not None:
@@ -68,37 +69,43 @@ class TCPCheck(AgentCheck):
                         self.CONFIGURATION_ERROR_MSG.format(self.host, 'IPv6 address', 'valid address')
                     )
             # It's a correct IP V6 address
-            self._addr = self.host
+            self._addrs = self.host
             self.socket_type = socket.AF_INET6
         else:
             self.socket_type = socket.AF_INET
             # IP will be resolved at check time
 
     @property
-    def addr(self):
-        if self._addr is None:
+    def addrs(self):
+        if self._addrs is None or self._addrs == []:
             try:
                 self.resolve_ip()
             except Exception as e:
                 self.log.error(str(e))
                 msg = "URL: {} could not be resolved".format(self.host)
                 raise CheckException(msg)
-        return self._addr
+        return self._addrs
 
     def resolve_ip(self):
-        self._addr = socket.gethostbyname(self.host)
-        self.log.debug("%s resolved to %s", self.host, self._addr)
+        if self.multiple_ips:
+            _, _, self._addrs = socket.gethostbyname_ex(self.host)
+        else:
+            self._addrs = [socket.gethostbyname(self.host)]
+
+        if self._addrs == []:
+            raise Exception("No IPs attached to host")
+        self.log.debug("%s resolved to %s", self.host, self._addrs)
 
     def should_resolve_ip(self):
         if self.ip_cache_duration is None:
             return False
         return get_precise_time() - self.ip_cache_last_ts > self.ip_cache_duration
 
-    def connect(self):
+    def connect(self, addr):
         with closing(socket.socket(self.socket_type)) as sock:
             sock.settimeout(self.timeout)
             start = get_precise_time()
-            sock.connect((self.addr, self.port))
+            sock.connect((addr, self.port))
             response_time = get_precise_time() - start
             return response_time
 
@@ -110,47 +117,60 @@ class TCPCheck(AgentCheck):
             self.ip_cache_last_ts = start
 
         self.log.debug("Connecting to %s on port %d", self.host, self.port)
-        try:
-            response_time = self.connect()
-            self.log.debug("%s:%d is UP", self.host, self.port)
-            self.report_as_service_check(AgentCheck.OK, 'UP')
-            if self.collect_response_time:
-                self.gauge(
-                    'network.tcp.response_time',
-                    response_time,
-                    tags=self.tags,
-                )
-        except Exception as e:
-            length = int((get_precise_time() - start) * 1000)
-            if isinstance(e, socket.error) and "timed out" in str(e):
-                # The connection timed out because it took more time than the system tcp stack allows
-                self.log.warning(
-                    'The connection timed out because it took more time '
-                    'than the system tcp stack allows. You might want to '
-                    'change this setting to allow longer timeouts'
-                )
-                self.log.info("System tcp timeout. Assuming that the checked system is down")
-                self.report_as_service_check(
-                    AgentCheck.CRITICAL,
-                    """Socket error: {}.
-                 The connection timed out after {} ms because it took more time than the system tcp stack allows.
-                 You might want to change this setting to allow longer timeouts""".format(
-                        str(e), length
-                    ),
-                )
-            else:
-                self.log.info("%s:%d is DOWN (%s). Connection failed after %d ms", self.host, self.port, str(e), length)
-                self.report_as_service_check(
-                    AgentCheck.CRITICAL, "{}. Connection failed after {} ms".format(str(e), length)
-                )
 
-            if self.socket_type == socket.AF_INET:
-                self.log.debug("Will attempt to re-resolve IP for %s:%d on next run", self.host, self.port)
-                self._addr = None
+        for addr in self.addrs:
+            try:
+                response_time = self.connect(addr)
+                self.log.debug("%s:%d is UP (%s)", self.host, self.port, addr)
+                self.report_as_service_check(AgentCheck.OK, addr, 'UP')
+                if self.collect_response_time:
+                    self.gauge(
+                        'network.tcp.response_time',
+                        response_time,
+                        tags=self.tags + ['address:{}'.format(addr)],
+                    )
+            except Exception as e:
+                length = int((get_precise_time() - start) * 1000)
+                if isinstance(e, socket.error) and "timed out" in str(e):
+                    # The connection timed out because it took more time than the system tcp stack allows
+                    self.log.warning(
+                        'The connection timed out because it took more time '
+                        'than the system tcp stack allows. You might want to '
+                        'change this setting to allow longer timeouts'
+                    )
+                    self.log.info("System tcp timeout. Assuming that the checked system is down")
+                    self.report_as_service_check(
+                        AgentCheck.CRITICAL,
+                        addr,
+                        """Socket error: {}.
+                    The connection timed out after {} ms because it took more time than the system tcp stack allows.
+                    You might want to change this setting to allow longer timeouts""".format(
+                            str(e), length
+                        ),
+                    )
+                else:
+                    self.log.info(
+                        "%s:%d is DOWN (%s) (%s). Connection failed after %d ms",
+                        self.host,
+                        self.port,
+                        addr,
+                        str(e),
+                        length,
+                    )
+                    self.report_as_service_check(
+                        AgentCheck.CRITICAL, addr, "{}. Connection failed after {} ms".format(str(e), length)
+                    )
 
-    def report_as_service_check(self, status, msg=None):
+                if self.socket_type == socket.AF_INET:
+                    self.log.debug("Will attempt to re-resolve IP for %s:%d on next run", self.host, self.port)
+                    self._addrs = None
+
+    def report_as_service_check(self, status, addr, msg=None):
         if status is AgentCheck.OK:
             msg = None
-        self.service_check(self.SERVICE_CHECK_NAME, status, tags=self.service_check_tags, message=msg)
+        extra_tags = ['address:{}'.format(addr)]
+        self.service_check(self.SERVICE_CHECK_NAME, status, tags=self.service_check_tags + extra_tags, message=msg)
         # Report as a metric as well
-        self.gauge("network.tcp.can_connect", 1 if status == AgentCheck.OK else 0, tags=self.service_check_tags)
+        self.gauge(
+            "network.tcp.can_connect", 1 if status == AgentCheck.OK else 0, tags=self.service_check_tags + extra_tags
+        )

--- a/tcp_check/tests/common.py
+++ b/tcp_check/tests/common.py
@@ -8,14 +8,19 @@ CHECK_NAME = "tcp_check"
 
 INSTANCE = {'host': 'datadoghq.com', 'port': 80, 'timeout': 1.5, 'name': 'UpService', 'tags': ["foo:bar"]}
 
+INSTANCE_MULTIPLE = {'multiple_ips': True}
+INSTANCE_MULTIPLE.update(INSTANCE)
+
 INSTANCE_KO = {'host': '127.0.0.1', 'port': 65530, 'timeout': 1.5, 'name': 'DownService', 'tags': ["foo:bar"]}
 
 E2E_METADATA = {'docker_platform': 'windows' if using_windows_containers() else 'linux'}
 
 
-def _test_check(aggregator):
-    expected_tags = ['foo:bar', 'target_host:datadoghq.com', 'port:80', 'instance:UpService']
-    aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags)
-    aggregator.assert_service_check('tcp.can_connect', status=TCPCheck.OK, tags=expected_tags)
+def _test_check(aggregator, addrs):
+    common_tags = ['foo:bar', 'target_host:datadoghq.com', 'port:80', 'instance:UpService']
+    for addr in addrs:
+        tags = common_tags + ['address:{}'.format(addr)]
+        aggregator.assert_metric('network.tcp.can_connect', value=1, tags=tags)
+        aggregator.assert_service_check('tcp.can_connect', status=TCPCheck.OK, tags=tags)
     aggregator.assert_all_metrics_covered()
-    assert len(aggregator.service_checks('tcp.can_connect')) == 1
+    assert len(aggregator.service_checks('tcp.can_connect')) == len(addrs)

--- a/tcp_check/tests/test_e2e.py
+++ b/tcp_check/tests/test_e2e.py
@@ -3,10 +3,15 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
-from . import common
+from datadog_checks.dev.utils import get_metadata_metrics
+from datadog_checks.tcp_check import TCPCheck
 
 
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, instance):
     aggregator = dd_agent_check(instance)
-    common._test_check(aggregator)
+    aggregator.assert_metric('network.tcp.can_connect', value=1, count=1)
+    aggregator.assert_service_check('tcp.can_connect', status=TCPCheck.OK, count=1)
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())

--- a/tcp_check/tests/test_integration.py
+++ b/tcp_check/tests/test_integration.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
+from datadog_checks.tcp_check import TCPCheck
+
 from . import common
 
 pytestmark = pytest.mark.integration
@@ -11,4 +13,13 @@ pytestmark = pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
 def test_check(aggregator, check, instance):
     check.check(instance)
-    common._test_check(aggregator)
+    common._test_check(aggregator, check._addrs)
+    assert len(check._addrs) == 1
+
+
+@pytest.mark.usefixtures("dd_environment")
+def test_check_multiple(aggregator):
+    check = TCPCheck(common.CHECK_NAME, {}, [common.INSTANCE_MULTIPLE])
+    check.check(ModuleNotFoundError)
+    common._test_check(aggregator, check._addrs)
+    assert len(check._addrs) == 4

--- a/tcp_check/tests/test_integration.py
+++ b/tcp_check/tests/test_integration.py
@@ -20,6 +20,6 @@ def test_check(aggregator, check, instance):
 @pytest.mark.usefixtures("dd_environment")
 def test_check_multiple(aggregator):
     check = TCPCheck(common.CHECK_NAME, {}, [common.INSTANCE_MULTIPLE])
-    check.check(ModuleNotFoundError)
+    check.check(None)
     common._test_check(aggregator, check._addrs)
     assert len(check._addrs) == 4

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -35,9 +35,9 @@ def test_reattempt_resolution_on_error():
     assert check.ip_cache_duration is None
 
     # IP is not normally re-resolved after the first check run
-    with mock.patch.object(check, 'resolve_ip', wraps=check.resolve_ip) as resolve_ip:
+    with mock.patch.object(check, 'resolve_ips', wraps=check.resolve_ips) as resolve_ips:
         check.check(instance)
-        assert not resolve_ip.called
+        assert not resolve_ips.called
 
     # Upon connection failure, cached resolved IP is cleared
     with mock.patch.object(check, 'connect', wraps=check.connect) as connect:
@@ -46,9 +46,9 @@ def test_reattempt_resolution_on_error():
         assert check._addrs is None
 
     # On next check run IP is re-resolved
-    with mock.patch.object(check, 'resolve_ip', wraps=check.resolve_ip) as resolve_ip:
+    with mock.patch.object(check, 'resolve_ips', wraps=check.resolve_ips) as resolve_ips:
         check.check(instance)
-        assert resolve_ip.called
+        assert resolve_ips.called
 
 
 def test_reattempt_resolution_on_duration():
@@ -60,13 +60,13 @@ def test_reattempt_resolution_on_duration():
     assert check.ip_cache_duration is not None
 
     # ip_cache_duration = 0 means IP is re-resolved every check run
-    with mock.patch.object(check, 'resolve_ip', wraps=check.resolve_ip) as resolve_ip:
+    with mock.patch.object(check, 'resolve_ips', wraps=check.resolve_ips) as resolve_ips:
         check.check(instance)
-        assert resolve_ip.called
+        assert resolve_ips.called
         check.check(instance)
-        assert resolve_ip.called
+        assert resolve_ips.called
         check.check(instance)
-        assert resolve_ip.called
+        assert resolve_ips.called
 
 
 def test_up(aggregator, check):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add `multiple_ips` configuration option
When enabled, integration calls `gethostbyname_ex` (https://docs.python.org/3/library/socket.html#socket.gethostbyname_ex) instead of `gethostbyname` (https://docs.python.org/3/library/socket.html#socket.gethostbyname)

A domain can have multiple IPs attached, and `gethostbyname` returns only one of the IPs, whereas `gethostbyname_ex` returns all of them.

So when `multiple_ips` is enabled, we run the check against all the IPs attached to the domain instead of one

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
