### PR TITLE
use read uncommitted isolation level to remove blocking risk

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -169,7 +169,7 @@ class Connection(object):
                     self.log.info("Could not close adodbapi db connection\n%s", e)
 
                 self._conns[conn_key] = rawconn
-            self._new_connection_setup(rawconn)
+            self._setup_new_connection(rawconn)
         except Exception as e:
             cx = "{} - {}".format(host, database)
 
@@ -185,7 +185,7 @@ class Connection(object):
 
             raise_from(SQLConnectionError(message), None)
 
-    def _new_connection_setup(self, rawconn):
+    def _setup_new_connection(self, rawconn):
         with rawconn.cursor() as cursor:
             # ensure that by default, the agent's reads can never block updates to any tables it's reading from
             cursor.execute("SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED")


### PR DESCRIPTION
### What does this PR do?

Apply `SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED` to all agent connections to SQL Server by default to mitigate risk of blocking others or being blocked by others.

From [the docs](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql): *Transactions running at the READ UNCOMMITTED level do not issue shared locks to prevent other transactions from modifying data read by the current transaction. READ UNCOMMITTED transactions are also not blocked by exclusive locks that would prevent the current transaction from reading rows that have been modified but not committed by other transactions.*

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
