### PR TITLE
add minimal e2e for external_dns check

### DIFF
--- a/external_dns/tests/conftest.py
+++ b/external_dns/tests/conftest.py
@@ -2,11 +2,14 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+from copy import deepcopy
 
 import mock
 import pytest
 
 from .common import FIXTURE_DIR
+
+INSTANCE = {'prometheus_url': 'http://localhost:7979/metrics', 'tags': ['custom:tag']}
 
 
 @pytest.fixture
@@ -24,6 +27,11 @@ def mock_external_dns():
         yield
 
 
+@pytest.fixture(scope='session')
+def dd_environment():
+    yield deepcopy(INSTANCE)
+
+
 @pytest.fixture
 def instance():
-    return {'prometheus_url': 'http://localhost:7979/metrics', 'tags': ['custom:tag']}
+    return deepcopy(INSTANCE)

--- a/external_dns/tests/test_external_dns.py
+++ b/external_dns/tests/test_external_dns.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
+from datadog_checks.base import AgentCheck
 from datadog_checks.external_dns import ExternalDNSCheck
 from datadog_checks.external_dns.metrics import DEFAULT_METRICS
 
@@ -24,3 +25,13 @@ def test_external_dns(aggregator, dd_run_check, instance):
             aggregator.assert_metric_has_tag(metric, tag)
 
     aggregator.assert_all_metrics_covered()
+
+
+# Minimal E2E testing
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, aggregator, instance):
+    with pytest.raises(Exception):
+        dd_agent_check(instance, rate=True)
+    tag = "endpoint:" + instance.get('prometheus_url')
+    tags = instance.get('tags').append(tag)
+    aggregator.assert_service_check("external_dns.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)

--- a/external_dns/tests/test_external_dns.py
+++ b/external_dns/tests/test_external_dns.py
@@ -32,6 +32,6 @@ def test_external_dns(aggregator, dd_run_check, instance):
 def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
-    tag = "endpoint:" + instance.get('prometheus_url')
-    tags = instance.get('tags').append(tag)
+    endpoint_tag = "endpoint:" + instance.get('prometheus_url')
+    tags = instance.get('tags').append(endpoint_tag)
     aggregator.assert_service_check("external_dns.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)

--- a/external_dns/tox.ini
+++ b/external_dns/tox.ini
@@ -10,6 +10,8 @@ envdir =
     py27: {toxworkdir}/py27
     py38: {toxworkdir}/py38
 dd_check_style = true
+description =
+    py{27,38}: e2e ready
 usedevelop = true
 platform = linux|darwin|win32
 deps =


### PR DESCRIPTION
### What does this PR do?
Add a minimal external_dns e2e test to ensure the check is able to run

### Motivation
Expand testing to ensure integrations errors are caught in our CI pipeline

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
