### PR TITLE
sqlserver: Add statement metadata to events and metrics payload

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -8,7 +8,7 @@ files:
       description: |
         Collect custom metrics and send them to Datadog based on
         your SQL server counters.
-        
+
         See https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/
       value:
         type: array
@@ -58,8 +58,8 @@ files:
         Regular expression for database names to include as part of `database_autodiscovery`.
         Will report metrics for databases that are found in this instance, ignores databases listed but not found.
 
-        Character casing is ignored. The regular expressions start matching from the beginning, so 
-        to match anywhere, prepend `.*`. For exact matches append `$`. 
+        Character casing is ignored. The regular expressions start matching from the beginning, so
+        to match anywhere, prepend `.*`. For exact matches append `$`.
 
         Defaults to `.*` to include everything.
       value:
@@ -262,6 +262,37 @@ files:
           value:
             type: number
             example: 10
+    - name: obfuscator_options
+      description: |
+        Configure how the SQL obfuscator behaves.
+        NOTE: that this option only applies when `dbm` is enabled.
+      options:
+        - name: replace_digits
+          description: |
+            Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
+            NOTE: This option also applies to extracted tables via `collect_tables`.
+          value:
+            type: boolean
+            example: false
+        - name: collect_tables
+          description: |
+            Set to `false` to disable the collection of tables in your SQL statements.
+          value:
+            type: boolean
+            example: true
+        - name: collect_commands
+          description: |
+            Set to `false` to disable the collection of commands in your SQL statements.
+            e.g. SELECT, UPDATE, DELETE, etc.
+          value:
+            type: boolean
+            example: true
+        - name: collect_comments
+          description: |
+            Set to `false` to disable the collection of comments in your SQL statements.
+          value:
+            type: boolean
+            example: true
     - name: command_timeout
       description: Timeout in seconds for the connection and each command run
       value:

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -5,7 +5,7 @@ import time
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.sql import compute_sql_signature
-from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding
+from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 
@@ -148,7 +148,7 @@ class SqlserverActivity(DBMAsyncJob):
         estimated_size = 0
         for row in rows:
             try:
-                obfuscated_statement = datadog_agent.obfuscate_sql(row['text'])
+                obfuscated_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)['query']
                 row['query_signature'] = compute_sql_signature(obfuscated_statement)
             except Exception as e:
                 # obfuscation errors are relatively common so only log them during debugging

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -124,6 +124,10 @@ def instance_min_collection_interval(field, value):
     return 15
 
 
+def instance_obfuscator_options(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_only_custom_queries(field, value):
     return False
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -22,6 +22,16 @@ class CustomQuery(BaseModel):
     tags: Optional[Sequence[str]]
 
 
+class ObfuscatorOptions(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    collect_commands: Optional[bool]
+    collect_comments: Optional[bool]
+    collect_tables: Optional[bool]
+    replace_digits: Optional[bool]
+
+
 class QueryActivity(BaseModel):
     class Config:
         allow_mutation = False
@@ -72,6 +82,7 @@ class InstanceConfig(BaseModel):
     include_master_files_metrics: Optional[bool]
     include_task_scheduler_metrics: Optional[bool]
     min_collection_interval: Optional[float]
+    obfuscator_options: Optional[ObfuscatorOptions]
     only_custom_queries: Optional[bool]
     only_emit_local: Optional[bool]
     password: Optional[str]

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -67,8 +67,8 @@ instances:
     ## Regular expression for database names to include as part of `database_autodiscovery`.
     ## Will report metrics for databases that are found in this instance, ignores databases listed but not found.
     ##
-    ## Character casing is ignored. The regular expressions start matching from the beginning, so 
-    ## to match anywhere, prepend `.*`. For exact matches append `$`. 
+    ## Character casing is ignored. The regular expressions start matching from the beginning, so
+    ## to match anywhere, prepend `.*`. For exact matches append `$`.
     ##
     ## Defaults to `.*` to include everything.
     #
@@ -245,6 +245,33 @@ instances:
         ## Running different instances with different collection intervals is not supported.
         #
         # collection_interval: 10
+
+    ## Configure how the SQL obfuscator behaves.
+    ## NOTE: that this option only applies when `dbm` is enabled.
+    #
+    obfuscator_options:
+
+        ## @param replace_digits - boolean - optional - default: false
+        ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
+        ## NOTE: This option also applies to extracted tables via `collect_tables`.
+        #
+        # replace_digits: false
+
+        ## @param collect_tables - boolean - optional - default: true
+        ## Set to `false` to disable the collection of tables in your SQL statements.
+        #
+        # collect_tables: true
+
+        ## @param collect_commands - boolean - optional - default: true
+        ## Set to `false` to disable the collection of commands in your SQL statements.
+        ## e.g. SELECT, UPDATE, DELETE, etc.
+        #
+        # collect_commands: true
+
+        ## @param collect_comments - boolean - optional - default: true
+        ## Set to `false` to disable the collection of comments in your SQL statements.
+        #
+        # collect_comments: true
 
     ## @param command_timeout - integer - optional - default: 5
     ## Timeout in seconds for the connection and each command run

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -13,8 +13,10 @@ from cachetools import TTLCache
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.config import is_affirmative
+from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db import QueryManager
 from datadog_checks.base.utils.db.utils import resolve_db_host
+from datadog_checks.base.utils.serialization import json
 from datadog_checks.sqlserver.activity import SqlserverActivity
 from datadog_checks.sqlserver.statements import SqlserverStatementMetrics
 
@@ -110,6 +112,17 @@ class SQLServer(AgentCheck):
         self.statement_metrics = SqlserverStatementMetrics(self)
         self.activity_config = self.instance.get('query_activity', {}) or {}
         self.activity = SqlserverActivity(self)
+        obfuscator_options_config = self.instance.get('obfuscator_options', {}) or {}
+        self.obfuscator_options = to_native_string(
+            json.dumps(
+                {
+                    'replace_digits': obfuscator_options_config.get('replace_digits', False),
+                    'table_names': obfuscator_options_config.get('collect_tables', True),
+                    'collect_commands': obfuscator_options_config.get('collect_commands', True),
+                    'collect_comments': obfuscator_options_config.get('collect_comments', True),
+                }
+            )
+        )
 
         self.static_info_cache = TTLCache(
             maxsize=100,

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -9,7 +9,12 @@ from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.common import ensure_unicode, to_native_string
 from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.statement_metrics import StatementMetrics
-from datadog_checks.base.utils.db.utils import DBMAsyncJob, RateLimitingTTLCache, default_json_event_encoding
+from datadog_checks.base.utils.db.utils import (
+    DBMAsyncJob,
+    RateLimitingTTLCache,
+    default_json_event_encoding,
+    obfuscate_sql_with_metadata,
+)
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 
@@ -90,7 +95,7 @@ def _hash_to_hex(hash):
     return to_native_string(binascii.hexlify(hash))
 
 
-def obfuscate_xml_plan(raw_plan):
+def obfuscate_xml_plan(raw_plan, obfuscator_options=None):
     """
     Obfuscates SQL text & Parameters from the provided SQL Server XML Plan
     Also strips unnecessary whitespace
@@ -104,7 +109,8 @@ def obfuscate_xml_plan(raw_plan):
         for k in XML_PLAN_OBFUSCATION_ATTRS:
             val = e.attrib.get(k, None)
             if val:
-                e.attrib[k] = ensure_unicode(datadog_agent.obfuscate_sql(val))
+                statement = obfuscate_sql_with_metadata(val, obfuscator_options)
+                e.attrib[k] = ensure_unicode(statement['query'])
     return to_native_string(ET.tostring(tree, encoding="UTF-8"))
 
 
@@ -199,7 +205,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         normalized_rows = []
         for row in rows:
             try:
-                obfuscated_statement = datadog_agent.obfuscate_sql(row['text'])
+                statement = obfuscate_sql_with_metadata(row['text'])
             except Exception as e:
                 # obfuscation errors are relatively common so only log them during debugging
                 self.log.debug("Failed to obfuscate query: %s", e)
@@ -209,10 +215,15 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     **self.check.debug_stats_kwargs(tags=["error:obfuscate-query-{}".format(type(e))])
                 )
                 continue
+            obfuscated_statement = statement['query']
             row['text'] = obfuscated_statement
             row['query_signature'] = compute_sql_signature(obfuscated_statement)
             row['query_hash'] = _hash_to_hex(row['query_hash'])
             row['query_plan_hash'] = _hash_to_hex(row['query_plan_hash'])
+            metadata = statement['metadata']
+            row['dd_tables'] = metadata.get('tables', None)
+            row['dd_commands'] = metadata.get('commands', None)
+            row['dd_comments'] = metadata.get('comments', None)
             normalized_rows.append(row)
         return normalized_rows
 
@@ -228,6 +239,8 @@ class SqlserverStatementMetrics(DBMAsyncJob):
     @staticmethod
     def _to_metrics_payload_row(row):
         row = {k: v for k, v in row.items()}
+        if 'dd_comments' in row:
+            del row['dd_comments']
         # truncate query text to the maximum length supported by metrics tags
         row['text'] = row['text'][0:200]
         return row
@@ -329,7 +342,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                 obfuscated_plan, collection_errors = None, None
 
                 try:
-                    obfuscated_plan = obfuscate_xml_plan(raw_plan)
+                    obfuscated_plan = obfuscate_xml_plan(raw_plan, self.check.obfuscator_options)
                 except Exception as e:
                     self.log.debug(
                         "failed to obfuscate XML Plan query_signature=%s query_hash=%s query_plan_hash=%s: %s",
@@ -363,6 +376,11 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                         "query_signature": row['query_signature'],
                         "user": row.get("user_name", None),
                         "statement": row['text'],
+                        "metadata": {
+                            "tables": row['dd_tables'],
+                            "commands": row['dd_commands'],
+                            "comments": row['dd_comments'],
+                        },
                     },
                     'sqlserver': {
                         'query_hash': row['query_hash'],

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -13,6 +13,7 @@ from lxml import etree as ET
 
 from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
+from datadog_checks.base.utils.serialization import json
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.statements import SQL_SERVER_QUERY_METRICS_COLUMNS, obfuscate_xml_plan
 
@@ -272,6 +273,68 @@ def _run_test_statement_metrics_and_plans(
 @not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize(
+    "metadata,expected_metadata_payload",
+    [
+        (
+            {'tables_csv': 'sys.databases', 'commands': ['SELECT'], 'comments': ['-- Test comment']},
+            {'tables': ['sys.databases'], 'commands': ['SELECT'], 'comments': ['-- Test comment']},
+        ),
+        (
+            {'tables_csv': '', 'commands': None, 'comments': None},
+            {'tables': None, 'commands': None, 'comments': None},
+        ),
+    ],
+)
+def test_statement_metadata(
+    aggregator, dd_run_check, dbm_instance, bob_conn, datadog_agent, metadata, expected_metadata_payload
+):
+    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
+
+    query = '''
+    -- Test comment
+    select * from sys.databases'''
+    query_signature = '6d1d070f9b6c5647'
+
+    def _run_query():
+        with bob_conn.cursor() as cursor:
+            cursor.execute(query)
+
+    def _obfuscate_sql(sql_query, options=None):
+        return json.dumps({'query': sql_query, 'metadata': metadata})
+
+    # Execute the query with the mocked obfuscate_sql. The result should produce an event payload with the metadata.
+    with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
+        mock_agent.side_effect = _obfuscate_sql
+        _run_query()
+        dd_run_check(check)
+        _run_query()
+        dd_run_check(check)
+
+    dbm_samples = aggregator.get_event_platform_events("dbm-samples")
+    assert dbm_samples, "should have collected at least one sample"
+
+    matching = [s for s in dbm_samples if s['db']['query_signature'] == query_signature and s['dbm_type'] == 'plan']
+    assert len(matching) == 1
+
+    sample = matching[0]
+    assert sample['db']['metadata']['tables'] == expected_metadata_payload['tables']
+    assert sample['db']['metadata']['commands'] == expected_metadata_payload['commands']
+    assert sample['db']['metadata']['comments'] == expected_metadata_payload['comments']
+
+    dbm_metrics = aggregator.get_event_platform_events("dbm-metrics")
+    assert len(dbm_metrics) == 1
+    metric = dbm_metrics[0]
+    matching_metrics = [m for m in metric['sqlserver_rows'] if m['query_signature'] == query_signature]
+    assert len(matching_metrics) == 1
+    metric = matching_metrics[0]
+    assert metric['dd_tables'] == expected_metadata_payload['tables']
+    assert metric['dd_commands'] == expected_metadata_payload['commands']
+
+
+@not_windows_ci
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 def test_statement_basic_metrics_query(datadog_conn_docker, dbm_instance):
     test_query = "select * from sys.databases"
 
@@ -331,10 +394,10 @@ def _load_test_xml_plan(filename):
         return f.read()
 
 
-def _mock_sql_obfuscate(sql_string):
+def _mock_sql_obfuscate(sql_string, options=None):
     sql_string = re.sub(r"'[^']+'", r"?", sql_string)
     sql_string = re.sub(r"([^@])[0-9]+", r"\1?", sql_string)
-    return sql_string
+    return json.dumps({'query': sql_string, 'metadata': {}})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add metadata about a SQL statement in the event payloads. More information regarding these changes can be found in the agent PR.

Agent: https://github.com/DataDog/datadog-agent/pull/10042

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
