### PR TITLE
[kube_apiserver_metrics] Make alpha and deprecated metrics comments consistent

### DIFF
--- a/kube_apiserver_metrics/metadata.csv
+++ b/kube_apiserver_metrics/metadata.csv
@@ -1,52 +1,52 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-kube_apiserver.longrunning_gauge,gauge,,request,,Gauge of all active long-running apiserver requests broken out by verb API resource and scope. Not all requests are tracked this way.,-1, kube_apiserver, long running gauges
-kube_apiserver.current_inflight_requests,gauge,,,,Maximal number of currently used inflight request limit of this apiserver per request kind in last second.,0,kube_apiserver, current inflight requests
-kube_apiserver.audit_event,gauge,,event,,Accumulated number audit events generated and sent to the audit backend,1, kube_apiserver, accumulated audit events
-kube_apiserver.go_threads,gauge,,thread,,Number of OS threads created,0, kube_apiserver, go threads
-kube_apiserver.go_goroutines,gauge,,,,Number of goroutines that currently exist,0, kube_apiserver, go routines
-kube_apiserver.APIServiceRegistrationController_depth,gauge,,,,Current depth of workqueue: APIServiceRegistrationController,0, kube_apiserver, service registration controller depth
+kube_apiserver.longrunning_gauge,gauge,,request,,The gauge of all active long-running apiserver requests broken out by verb API resource and scope. Not all requests are tracked this way.,-1, kube_apiserver, long running gauges
+kube_apiserver.current_inflight_requests,gauge,,,,The maximal number of currently used inflight request limit of this apiserver per request kind in last second.,0,kube_apiserver, current inflight requests
+kube_apiserver.audit_event,gauge,,event,,The accumulated number audit events generated and sent to the audit backend,1, kube_apiserver, accumulated audit events
+kube_apiserver.go_threads,gauge,,thread,,The number of OS threads created,0, kube_apiserver, go threads
+kube_apiserver.go_goroutines,gauge,,,,The number of goroutines that currently exist,0, kube_apiserver, go routines
+kube_apiserver.APIServiceRegistrationController_depth,gauge,,,,The current depth of workqueue: APIServiceRegistrationController,0, kube_apiserver, service registration controller depth
 kube_apiserver.etcd_request_duration_seconds.sum,gauge,,second,,Etcd request latencies for each operation and object type (alpha),0,kube_apiserver,etcd latency
 kube_apiserver.etcd_request_duration_seconds.count,count,,,,Etcd request latencies count for each operation and object type (alpha),0,kube_apiserver,etcd latency
-kube_apiserver.etcd_object_counts,gauge,,object,,Number of stored objects at the time of last check split by kind (alpha; deprecated in Kubernetes 1.22),0, kube_apiserver, etcd object counts
+kube_apiserver.etcd_object_counts,gauge,,object,,The number of stored objects at the time of last check split by kind (alpha; deprecated in Kubernetes 1.22),0, kube_apiserver, etcd object counts
 kube_apiserver.etcd.db.total_size,gauge,,byte,,The total size of the etcd database file physically allocated in bytes (alpha; Kubernetes 1.19+),0, kube_apiserver, etcd db total size
-kube_apiserver.rest_client_requests_total,gauge,,request,,Accumulated number of HTTP requests partitioned by status code method and host,1, kube_apiserver, accumulated rest client requests
-kube_apiserver.apiserver_request_count,gauge,,request,,Accumulated number of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (deprecated in Kubernetes 1.15),1, kube_apiserver, accumulated number of requests
-kube_apiserver.apiserver_dropped_requests_total,gauge,,request,,Accumulated number of requests dropped with 'Try again later' response,1, kube_apiserver, accumulated number of dropped requests
-kube_apiserver.http_requests_total,gauge,,request,,Accumulated number of HTTP requests made,1, kube_apiserver, accumulated total number of requests
-kube_apiserver.authenticated_user_requests,gauge,,request,,Accumulated number of authenticated requests broken out by username,1, kube_apiserver, accumulated number of authenticated requests
-kube_apiserver.audit_event.count,count,,event,,Monotonic count of audit events generated and sent to the audit backend,0, kube_apiserver, count of audit events
-kube_apiserver.rest_client_requests_total.count,count,,request,,Monotonic count of HTTP requests partitioned by status code method and host,0, kube_apiserver, total count of rest client requests
-kube_apiserver.apiserver_request_count.count,count,,request,,Monotonic count of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (deprecated in Kubernetes 1.15),0, kube_apiserver, count of requests
-kube_apiserver.apiserver_dropped_requests_total.count,count,,request,,Monotonic count of requests dropped with 'Try again later' response,0, kube_apiserver, count of dropped requests
-kube_apiserver.http_requests_total.count,count,,request,,Monotonic count of the number of HTTP requests made,0,kube_apiserver, total count of requests
-kube_apiserver.authenticated_user_requests.count,count,,request,,Monotonic count of authenticated requests broken out by username,0, kube_apiserver, count of authenticated requests
-kube_apiserver.apiserver_request_total,gauge,,request,,Accumulated number of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (Kubernetes 1.15+; replaces apiserver_request_count),1, kube_apiserver, accumulated number of requests
-kube_apiserver.apiserver_request_total.count,count,,request,,Monotonic count of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (Kubernetes 1.15+; replaces apiserver_request_count.count),0, kube_apiserver, count of requests
-kube_apiserver.rest_client_request_latency_seconds.sum,gauge,,second,,Request latency in seconds broken down by verb and URL,0,kube_apiserver,rest client request latency
-kube_apiserver.rest_client_request_latency_seconds.count,count,,,,Request latency in seconds broken down by verb and URL count,0,kube_apiserver,rest client request latency
-kube_apiserver.admission_webhook_admission_latencies_seconds.sum,gauge,,second,,Admission webhook latency identified by name and broken out for each operation and API resource and type (validate or admit),0,kube_apiserver,admission webhook admission latencies
-kube_apiserver.admission_webhook_admission_latencies_seconds.count,count,,,,Admission webhook latency identified by name and broken out for each operation and API resource and type (validate or admit) count,0,kube_apiserver,admission webhook admission latencies
-kube_apiserver.admission_step_admission_latencies_seconds.sum,gauge,,second,,Admission sub-step latency broken out for each operation and API resource and step type (validate or admit),0,kube_apiserver,admission step admission latencies
-kube_apiserver.admission_step_admission_latencies_seconds.count,count,,,,Admission sub-step latency histogram broken out for each operation and API resource and step type (validate or admit) count,0,kube_apiserver,admission step admission latencies
-kube_apiserver.admission_step_admission_latencies_seconds_summary.sum,gauge,,second,,Admission sub-step latency summary broken out for each operation and API resource and step type (validate or admit),0,kube_apiserver,admission step admission latencies summary
-kube_apiserver.admission_step_admission_latencies_seconds_summary.count,count,,,,Admission sub-step latency summary broken out for each operation and API resource and step type (validate or admit) count,0,kube_apiserver,admission step admission latencies summary
-kube_apiserver.admission_step_admission_latencies_seconds_summary.quantile,gauge,,second,,Admission sub-step latency summary broken out for each operation and API resource and step type (validate or admit) quantile,0,kube_apiserver,admission step admission latencies summary
-kube_apiserver.admission_controller_admission_duration_seconds.sum,gauge,,second,,Admission controller latency histogram in seconds identified by name and broken out for each operation and API resource and type (validate or admit),0,kube_apiserver,duration of admission controller admission
-kube_apiserver.admission_controller_admission_duration_seconds.count,count,,,,Admission controller latency histogram in seconds identified by name and broken out for each operation and API resource and type (validate or admit) count,0,kube_apiserver,duration of admission controller admission
-kube_apiserver.request_latencies.sum,gauge,,microsecond,,"Response latency distribution in microseconds for each verb, resource and subresource",0,kube_apiserver,response latency
-kube_apiserver.request_latencies.count,count,,,,"Response latency distribution in microseconds for each verb, resource and subresource count",0,kube_apiserver,response latency
-kube_apiserver.request_duration_seconds.sum,gauge,,second,,"Response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component",0,kube_apiserver,duration of request
-kube_apiserver.request_duration_seconds.count,count,,,,"Response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component count",0,kube_apiserver,duration of request
-kube_apiserver.registered_watchers,gauge,,object,,Number of currently registered watchers for a given resource,0,kube_apiserver,number of watchers
-kube_apiserver.process_resident_memory_bytes,gauge,,byte,,Resident memory size in bytes,0,kube_apiserver,process rss
-kube_apiserver.process_virtual_memory_bytes,gauge,,byte,,Virtual memory size in bytes,0,kube_apiserver,process virtual memory
-kube_apiserver.watch_events_sizes.sum,gauge,,byte,,Watch event size distribution (Kubernetes 1.16+),0,kube_apiserver,distribution of watch event sizes
-kube_apiserver.watch_events_sizes.count,count,,,,Watch event size distribution (Kubernetes 1.16+),0,kube_apiserver,distribution of watch event sizes
-kube_apiserver.authentication_duration_seconds.sum,gauge,,second,,Authentication duration histogram broken out by result (Kubernetes 1.17+),0,kube_apiserver,authentication latencies
-kube_apiserver.authentication_duration_seconds.count,count,,,,Authentication duration histogram broken out by result (Kubernetes 1.17+),0,kube_apiserver,authentication latencies
-kube_apiserver.authentication_attempts.count,count,,request,,Counter of authenticated attempts (Kubernetes 1.16+),0,kube_apiserver,count of authenticated attempts
-kube_apiserver.apiserver_request_terminations_total.count,count,,request,,Number of requests which apiserver terminated in self-defense (Kubernetes 1.17+),0,kube_apiserver,count of requests dropped in self-defense
-kube_apiserver.grpc_client_handled_total,count,,request,,Total number of RPCs completed by the client regardless of success or failure,1,kube_apiserver,gRPC client requests completed
-kube_apiserver.grpc_client_msg_received_total,count,,message,,Total number of gRPC stream messages received by the client,1,kube_apiserver,gRPC client messages received
-kube_apiserver.grpc_client_msg_sent_total,count,,message,, Total number of gRPC stream messages sent by the client,1,kube_apiserver,gRPC client messages sent
-kube_apiserver.grpc_client_started_total,count,,request,,Total number of RPCs started on the client,1,kube_apiserver,gRPC client requests started
+kube_apiserver.rest_client_requests_total,gauge,,request,,The accumulated number of HTTP requests partitioned by status code method and host,1, kube_apiserver, accumulated rest client requests
+kube_apiserver.apiserver_request_count,gauge,,request,,The accumulated number of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (deprecated in Kubernetes 1.15),1, kube_apiserver, accumulated number of requests
+kube_apiserver.apiserver_dropped_requests_total,gauge,,request,,The accumulated number of requests dropped with 'Try again later' response,1, kube_apiserver, accumulated number of dropped requests
+kube_apiserver.http_requests_total,gauge,,request,,The accumulated number of HTTP requests made,1, kube_apiserver, accumulated total number of requests
+kube_apiserver.authenticated_user_requests,gauge,,request,,The accumulated number of authenticated requests broken out by username,1, kube_apiserver, accumulated number of authenticated requests
+kube_apiserver.audit_event.count,count,,event,,The monotonic count of audit events generated and sent to the audit backend,0, kube_apiserver, count of audit events
+kube_apiserver.rest_client_requests_total.count,count,,request,,The monotonic count of HTTP requests partitioned by status code method and host,0, kube_apiserver, total count of rest client requests
+kube_apiserver.apiserver_request_count.count,count,,request,,The monotonic count of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (deprecated in Kubernetes 1.15),0, kube_apiserver, count of requests
+kube_apiserver.apiserver_dropped_requests_total.count,count,,request,,The monotonic count of requests dropped with 'Try again later' response,0, kube_apiserver, count of dropped requests
+kube_apiserver.http_requests_total.count,count,,request,,The monotonic count of the number of HTTP requests made,0,kube_apiserver, total count of requests
+kube_apiserver.authenticated_user_requests.count,count,,request,,The monotonic count of authenticated requests broken out by username,0, kube_apiserver, count of authenticated requests
+kube_apiserver.apiserver_request_total,gauge,,request,,The accumulated number of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (Kubernetes 1.15+; replaces apiserver_request_count),1, kube_apiserver, accumulated number of requests
+kube_apiserver.apiserver_request_total.count,count,,request,,The monotonic count of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (Kubernetes 1.15+; replaces apiserver_request_count.count),0, kube_apiserver, count of requests
+kube_apiserver.rest_client_request_latency_seconds.sum,gauge,,second,,The request latency in seconds broken down by verb and URL,0,kube_apiserver,rest client request latency
+kube_apiserver.rest_client_request_latency_seconds.count,count,,,,The request latency in seconds broken down by verb and URL count,0,kube_apiserver,rest client request latency
+kube_apiserver.admission_webhook_admission_latencies_seconds.sum,gauge,,second,,The admission webhook latency identified by name and broken out for each operation and API resource and type (validate or admit),0,kube_apiserver,admission webhook admission latencies
+kube_apiserver.admission_webhook_admission_latencies_seconds.count,count,,,,The admission webhook latency identified by name and broken out for each operation and API resource and type (validate or admit) count,0,kube_apiserver,admission webhook admission latencies
+kube_apiserver.admission_step_admission_latencies_seconds.sum,gauge,,second,,The admission sub-step latency broken out for each operation and API resource and step type (validate or admit),0,kube_apiserver,admission step admission latencies
+kube_apiserver.admission_step_admission_latencies_seconds.count,count,,,,The admission sub-step latency histogram broken out for each operation and API resource and step type (validate or admit) count,0,kube_apiserver,admission step admission latencies
+kube_apiserver.admission_step_admission_latencies_seconds_summary.sum,gauge,,second,,The admission sub-step latency summary broken out for each operation and API resource and step type (validate or admit),0,kube_apiserver,admission step admission latencies summary
+kube_apiserver.admission_step_admission_latencies_seconds_summary.count,count,,,,The admission sub-step latency summary broken out for each operation and API resource and step type (validate or admit) count,0,kube_apiserver,admission step admission latencies summary
+kube_apiserver.admission_step_admission_latencies_seconds_summary.quantile,gauge,,second,,The admission sub-step latency summary broken out for each operation and API resource and step type (validate or admit) quantile,0,kube_apiserver,admission step admission latencies summary
+kube_apiserver.admission_controller_admission_duration_seconds.sum,gauge,,second,,The admission controller latency histogram in seconds identified by name and broken out for each operation and API resource and type (validate or admit),0,kube_apiserver,duration of admission controller admission
+kube_apiserver.admission_controller_admission_duration_seconds.count,count,,,,The admission controller latency histogram in seconds identified by name and broken out for each operation and API resource and type (validate or admit) count,0,kube_apiserver,duration of admission controller admission
+kube_apiserver.request_latencies.sum,gauge,,microsecond,,"The response latency distribution in microseconds for each verb, resource and subresource",0,kube_apiserver,response latency
+kube_apiserver.request_latencies.count,count,,,,"The response latency distribution in microseconds for each verb, resource and subresource count",0,kube_apiserver,response latency
+kube_apiserver.request_duration_seconds.sum,gauge,,second,,"The response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component",0,kube_apiserver,duration of request
+kube_apiserver.request_duration_seconds.count,count,,,,"The response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component count",0,kube_apiserver,duration of request
+kube_apiserver.registered_watchers,gauge,,object,,The number of currently registered watchers for a given resource,0,kube_apiserver,number of watchers
+kube_apiserver.process_resident_memory_bytes,gauge,,byte,,The resident memory size in bytes,0,kube_apiserver,process rss
+kube_apiserver.process_virtual_memory_bytes,gauge,,byte,,The virtual memory size in bytes,0,kube_apiserver,process virtual memory
+kube_apiserver.watch_events_sizes.sum,gauge,,byte,,The watch event size distribution (Kubernetes 1.16+),0,kube_apiserver,distribution of watch event sizes
+kube_apiserver.watch_events_sizes.count,count,,,,The watch event size distribution (Kubernetes 1.16+),0,kube_apiserver,distribution of watch event sizes
+kube_apiserver.authentication_duration_seconds.sum,gauge,,second,,The authentication duration histogram broken out by result (Kubernetes 1.17+),0,kube_apiserver,authentication latencies
+kube_apiserver.authentication_duration_seconds.count,count,,,,The authentication duration histogram broken out by result (Kubernetes 1.17+),0,kube_apiserver,authentication latencies
+kube_apiserver.authentication_attempts.count,count,,request,,The counter of authenticated attempts (Kubernetes 1.16+),0,kube_apiserver,count of authenticated attempts
+kube_apiserver.apiserver_request_terminations_total.count,count,,request,,The number of requests which apiserver terminated in self-defense (Kubernetes 1.17+),0,kube_apiserver,count of requests dropped in self-defense
+kube_apiserver.grpc_client_handled_total,count,,request,,The total number of RPCs completed by the client regardless of success or failure,1,kube_apiserver,gRPC client requests completed
+kube_apiserver.grpc_client_msg_received_total,count,,message,,The total number of gRPC stream messages received by the client,1,kube_apiserver,gRPC client messages received
+kube_apiserver.grpc_client_msg_sent_total,count,,message,,The total number of gRPC stream messages sent by the client,1,kube_apiserver,gRPC client messages sent
+kube_apiserver.grpc_client_started_total,count,,request,,The total number of RPCs started on the client,1,kube_apiserver,gRPC client requests started

--- a/kube_apiserver_metrics/metadata.csv
+++ b/kube_apiserver_metrics/metadata.csv
@@ -34,9 +34,9 @@ kube_apiserver.admission_step_admission_latencies_seconds_summary.quantile,gauge
 kube_apiserver.admission_controller_admission_duration_seconds.sum,gauge,,second,,The admission controller latency histogram in seconds identified by name and broken out for each operation and API resource and type (validate or admit),0,kube_apiserver,duration of admission controller admission
 kube_apiserver.admission_controller_admission_duration_seconds.count,count,,,,The admission controller latency histogram in seconds identified by name and broken out for each operation and API resource and type (validate or admit) count,0,kube_apiserver,duration of admission controller admission
 kube_apiserver.request_latencies.sum,gauge,,microsecond,,"The response latency distribution in microseconds for each verb, resource and subresource",0,kube_apiserver,response latency
-kube_apiserver.request_latencies.count,count,,,,"The response latency distribution in microseconds for each verb, resource and subresource count",0,kube_apiserver,response latency
-kube_apiserver.request_duration_seconds.sum,gauge,,second,,"The response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component",0,kube_apiserver,duration of request
-kube_apiserver.request_duration_seconds.count,count,,,,"The response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component count",0,kube_apiserver,duration of request
+kube_apiserver.request_latencies.count,count,,,,"The response latency distribution in microseconds for each verb, resource, and subresource count",0,kube_apiserver,response latency
+kube_apiserver.request_duration_seconds.sum,gauge,,second,,"The response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope, and component",0,kube_apiserver,duration of request
+kube_apiserver.request_duration_seconds.count,count,,,,"The response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope, and component count",0,kube_apiserver,duration of request
 kube_apiserver.registered_watchers,gauge,,object,,The number of currently registered watchers for a given resource,0,kube_apiserver,number of watchers
 kube_apiserver.process_resident_memory_bytes,gauge,,byte,,The resident memory size in bytes,0,kube_apiserver,process rss
 kube_apiserver.process_virtual_memory_bytes,gauge,,byte,,The virtual memory size in bytes,0,kube_apiserver,process virtual memory
@@ -45,7 +45,7 @@ kube_apiserver.watch_events_sizes.count,count,,,,The watch event size distributi
 kube_apiserver.authentication_duration_seconds.sum,gauge,,second,,The authentication duration histogram broken out by result (Kubernetes 1.17+),0,kube_apiserver,authentication latencies
 kube_apiserver.authentication_duration_seconds.count,count,,,,The authentication duration histogram broken out by result (Kubernetes 1.17+),0,kube_apiserver,authentication latencies
 kube_apiserver.authentication_attempts.count,count,,request,,The counter of authenticated attempts (Kubernetes 1.16+),0,kube_apiserver,count of authenticated attempts
-kube_apiserver.apiserver_request_terminations_total.count,count,,request,,The number of requests which apiserver terminated in self-defense (Kubernetes 1.17+),0,kube_apiserver,count of requests dropped in self-defense
+kube_apiserver.apiserver_request_terminations_total.count,count,,request,,The number of requests the apiserver terminated in self-defense (Kubernetes 1.17+),0,kube_apiserver,count of requests dropped in self-defense
 kube_apiserver.grpc_client_handled_total,count,,request,,The total number of RPCs completed by the client regardless of success or failure,1,kube_apiserver,gRPC client requests completed
 kube_apiserver.grpc_client_msg_received_total,count,,message,,The total number of gRPC stream messages received by the client,1,kube_apiserver,gRPC client messages received
 kube_apiserver.grpc_client_msg_sent_total,count,,message,,The total number of gRPC stream messages sent by the client,1,kube_apiserver,gRPC client messages sent

--- a/kube_apiserver_metrics/metadata.csv
+++ b/kube_apiserver_metrics/metadata.csv
@@ -5,21 +5,23 @@ kube_apiserver.audit_event,gauge,,event,,Accumulated number audit events generat
 kube_apiserver.go_threads,gauge,,thread,,Number of OS threads created,0, kube_apiserver, go threads
 kube_apiserver.go_goroutines,gauge,,,,Number of goroutines that currently exist,0, kube_apiserver, go routines
 kube_apiserver.APIServiceRegistrationController_depth,gauge,,,,Current depth of workqueue: APIServiceRegistrationController,0, kube_apiserver, service registration controller depth
-kube_apiserver.etcd_object_counts,gauge,,object,,Number of stored objects at the time of last check split by kind,0, kube_apiserver, etcd object counts
-kube_apiserver.etcd.db.total_size,gauge,,byte,,The total size of the etcd database file physically allocated in bytes (Only present from Kubernetes 1.19; this metric can be removed in a future Kubernetes version since it is still in alpha),0, kube_apiserver, etcd db total size
+kube_apiserver.etcd_request_duration_seconds.sum,gauge,,second,,Etcd request latencies for each operation and object type (alpha),0,kube_apiserver,etcd latency
+kube_apiserver.etcd_request_duration_seconds.count,count,,,,Etcd request latencies count for each operation and object type (alpha),0,kube_apiserver,etcd latency
+kube_apiserver.etcd_object_counts,gauge,,object,,Number of stored objects at the time of last check split by kind (alpha; deprecated in Kubernetes 1.22),0, kube_apiserver, etcd object counts
+kube_apiserver.etcd.db.total_size,gauge,,byte,,The total size of the etcd database file physically allocated in bytes (alpha; Kubernetes 1.19+),0, kube_apiserver, etcd db total size
 kube_apiserver.rest_client_requests_total,gauge,,request,,Accumulated number of HTTP requests partitioned by status code method and host,1, kube_apiserver, accumulated rest client requests
-kube_apiserver.apiserver_request_count,gauge,,request,,Accumulated number of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (deprecated since kubernetes 1.15),1, kube_apiserver, accumulated number of requests
+kube_apiserver.apiserver_request_count,gauge,,request,,Accumulated number of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (deprecated in Kubernetes 1.15),1, kube_apiserver, accumulated number of requests
 kube_apiserver.apiserver_dropped_requests_total,gauge,,request,,Accumulated number of requests dropped with 'Try again later' response,1, kube_apiserver, accumulated number of dropped requests
 kube_apiserver.http_requests_total,gauge,,request,,Accumulated number of HTTP requests made,1, kube_apiserver, accumulated total number of requests
 kube_apiserver.authenticated_user_requests,gauge,,request,,Accumulated number of authenticated requests broken out by username,1, kube_apiserver, accumulated number of authenticated requests
 kube_apiserver.audit_event.count,count,,event,,Monotonic count of audit events generated and sent to the audit backend,0, kube_apiserver, count of audit events
 kube_apiserver.rest_client_requests_total.count,count,,request,,Monotonic count of HTTP requests partitioned by status code method and host,0, kube_apiserver, total count of rest client requests
-kube_apiserver.apiserver_request_count.count,count,,request,,Monotonic count of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (deprecated since kubernetes 1.15),0, kube_apiserver, count of requests
+kube_apiserver.apiserver_request_count.count,count,,request,,Monotonic count of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (deprecated in Kubernetes 1.15),0, kube_apiserver, count of requests
 kube_apiserver.apiserver_dropped_requests_total.count,count,,request,,Monotonic count of requests dropped with 'Try again later' response,0, kube_apiserver, count of dropped requests
 kube_apiserver.http_requests_total.count,count,,request,,Monotonic count of the number of HTTP requests made,0,kube_apiserver, total count of requests
 kube_apiserver.authenticated_user_requests.count,count,,request,,Monotonic count of authenticated requests broken out by username,0, kube_apiserver, count of authenticated requests
-kube_apiserver.apiserver_request_total,gauge,,request,,Accumulated number of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (Only present from kubernetes 1.15 to replace apiserver_request_count),1, kube_apiserver, accumulated number of requests
-kube_apiserver.apiserver_request_total.count,count,,request,,Monotonic count of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (Only present from kubernetes 1.15 to replace apiserver_request_count.count),0, kube_apiserver, count of requests
+kube_apiserver.apiserver_request_total,gauge,,request,,Accumulated number of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (Kubernetes 1.15+; replaces apiserver_request_count),1, kube_apiserver, accumulated number of requests
+kube_apiserver.apiserver_request_total.count,count,,request,,Monotonic count of apiserver requests broken out for each verb API resource client and HTTP response contentType and code (Kubernetes 1.15+; replaces apiserver_request_count.count),0, kube_apiserver, count of requests
 kube_apiserver.rest_client_request_latency_seconds.sum,gauge,,second,,Request latency in seconds broken down by verb and URL,0,kube_apiserver,rest client request latency
 kube_apiserver.rest_client_request_latency_seconds.count,count,,,,Request latency in seconds broken down by verb and URL count,0,kube_apiserver,rest client request latency
 kube_apiserver.admission_webhook_admission_latencies_seconds.sum,gauge,,second,,Admission webhook latency identified by name and broken out for each operation and API resource and type (validate or admit),0,kube_apiserver,admission webhook admission latencies
@@ -38,8 +40,6 @@ kube_apiserver.request_duration_seconds.count,count,,,,"Response latency distrib
 kube_apiserver.registered_watchers,gauge,,object,,Number of currently registered watchers for a given resource,0,kube_apiserver,number of watchers
 kube_apiserver.process_resident_memory_bytes,gauge,,byte,,Resident memory size in bytes,0,kube_apiserver,process rss
 kube_apiserver.process_virtual_memory_bytes,gauge,,byte,,Virtual memory size in bytes,0,kube_apiserver,process virtual memory
-kube_apiserver.etcd_request_duration_seconds.sum,gauge,,second,,Etcd request latencies for each operation and object type,0,kube_apiserver,etcd latency
-kube_apiserver.etcd_request_duration_seconds.count,count,,,,Etcd request latencies count for each operation and object type,0,kube_apiserver,etcd latency
 kube_apiserver.watch_events_sizes.sum,gauge,,byte,,Watch event size distribution (Kubernetes 1.16+),0,kube_apiserver,distribution of watch event sizes
 kube_apiserver.watch_events_sizes.count,count,,,,Watch event size distribution (Kubernetes 1.16+),0,kube_apiserver,distribution of watch event sizes
 kube_apiserver.authentication_duration_seconds.sum,gauge,,second,,Authentication duration histogram broken out by result (Kubernetes 1.17+),0,kube_apiserver,authentication latencies


### PR DESCRIPTION
### What does this PR do?
Update metadata.csv for the `kube_apiserver_metrics` check:
- indicate `kube_apiserver.etcd_*` metrics are in alpha
- be consistent in how we report alpha and deprecated metrics
- use articles consistently

### Motivation
Better information for user

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
