### PR TITLE
add minimal e2e test for vsphere

### DIFF
--- a/vsphere/tests/test_e2e.py
+++ b/vsphere/tests/test_e2e.py
@@ -1,0 +1,10 @@
+import pytest
+
+from datadog_checks.base import AgentCheck
+
+
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, aggregator, realtime_instance):
+    with pytest.raises(Exception):
+        dd_agent_check(realtime_instance)
+    aggregator.assert_service_check("vsphere.can_connect", AgentCheck.CRITICAL)

--- a/vsphere/tests/test_e2e.py
+++ b/vsphere/tests/test_e2e.py
@@ -7,4 +7,5 @@ from datadog_checks.base import AgentCheck
 def test_e2e(dd_agent_check, aggregator, realtime_instance):
     with pytest.raises(Exception):
         dd_agent_check(realtime_instance)
-    aggregator.assert_service_check("vsphere.can_connect", AgentCheck.CRITICAL)
+    tag = ['vcenter_server:' + realtime_instance.get('host')]
+    aggregator.assert_service_check("vsphere.can_connect", AgentCheck.CRITICAL, tags=tag)

--- a/vsphere/tests/test_e2e.py
+++ b/vsphere/tests/test_e2e.py
@@ -7,5 +7,5 @@ from datadog_checks.base import AgentCheck
 def test_e2e(dd_agent_check, aggregator, realtime_instance):
     with pytest.raises(Exception):
         dd_agent_check(realtime_instance)
-    tag = ['vcenter_server:' + realtime_instance.get('host')]
-    aggregator.assert_service_check("vsphere.can_connect", AgentCheck.CRITICAL, tags=tag)
+    vcenter_tag = ['vcenter_server:' + realtime_instance.get('host')]
+    aggregator.assert_service_check("vsphere.can_connect", AgentCheck.CRITICAL, tags=vcenter_tag)

--- a/vsphere/tox.ini
+++ b/vsphere/tox.ini
@@ -25,6 +25,8 @@ dd_mypy_args =
     datadog_checks/vsphere/metrics.py
     datadog_checks/vsphere/utils.py
     datadog_checks/vsphere/vsphere.py
+description =
+    py{27,38}: e2e ready
 usedevelop = true
 platform = linux|darwin
 passenv =


### PR DESCRIPTION
### What does this PR do?
Add a minimal vsphere e2e test to ensure the check is able to run

### Motivation
Expand testing to ensure integrations errors are caught in our CI pipeline

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
