### PR TITLE
Don't check empty tag list

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -40,7 +40,7 @@ def backend_normalize_metric_name(metric_name):
 
 
 def check_tag_names(metric, tags):
-    if not os.environ.get('DDEV_SKIP_GENERIC_TAGS_CHECK'):
+    if tags and not os.environ.get('DDEV_SKIP_GENERIC_TAGS_CHECK'):
         try:
             from datadog_checks.base.utils.tagging import GENERIC_TAGS
         except ImportError:


### PR DESCRIPTION
Check that `tags` is not `None` or empty before iterating on it

Caused CI to fail https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=84162&view=logs&j=155efd4a-3db6-57a2-0ce3-7e8c157a4e0a&t=4ad84dea-efb9-5139-10ad-4c7a65d30c32&l=57
