### PR TITLE
Add improved database file IO metrics and tags

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from datadog_checks.base import AgentCheck
+
 # Constant for SQLServer cntr_type
 PERF_LARGE_RAW_BASE = 1073939712
 PERF_RAW_LARGE_FRACTION = 537003264
@@ -159,14 +161,14 @@ DATABASE_MASTER_FILES = [
 ]
 
 DATABASE_FILES_IO = [
-    ('sqlserver.files.reads', 'num_of_reads'),
-    ('sqlserver.files.read_bytes', 'num_of_bytes_read'),
-    ('sqlserver.files.read_io_stall', 'io_stall_read_ms'),
-    ('sqlserver.files.read_io_stall_queued', 'io_stall_queued_read_ms'),
-    ('sqlserver.files.writes', 'num_of_writes'),
-    ('sqlserver.files.written_bytes', 'num_of_bytes_written'),
-    ('sqlserver.files.write_io_stall', 'io_stall_write_ms'),
-    ('sqlserver.files.write_io_stall_queued', 'io_stall_queued_write_ms'),
-    ('sqlserver.files.io_stall', 'io_stall'),
-    ('sqlserver.files.size_on_disk', 'size_on_disk_bytes'),
+    ('sqlserver.files.reads', 'num_of_reads', AgentCheck.monotonic_count),
+    ('sqlserver.files.read_bytes', 'num_of_bytes_read', AgentCheck.monotonic_count),
+    ('sqlserver.files.read_io_stall', 'io_stall_read_ms', AgentCheck.monotonic_count),
+    ('sqlserver.files.read_io_stall_queued', 'io_stall_queued_read_ms', AgentCheck.monotonic_count),
+    ('sqlserver.files.writes', 'num_of_writes', AgentCheck.monotonic_count),
+    ('sqlserver.files.written_bytes', 'num_of_bytes_written', AgentCheck.monotonic_count),
+    ('sqlserver.files.write_io_stall', 'io_stall_write_ms', AgentCheck.monotonic_count),
+    ('sqlserver.files.write_io_stall_queued', 'io_stall_queued_write_ms', AgentCheck.monotonic_count),
+    ('sqlserver.files.io_stall', 'io_stall', AgentCheck.monotonic_count),
+    ('sqlserver.files.size_on_disk', 'size_on_disk_bytes', AgentCheck.gauge),
 ]

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -157,3 +157,16 @@ DATABASE_MASTER_FILES = [
     ('sqlserver.database.master_files.size', 'sys.master_files', 'size'),
     ('sqlserver.database.master_files.state', 'sys.master_files', 'state'),
 ]
+
+DATABASE_FILES_IO = [
+    ('sqlserver.files.reads', 'num_of_reads'),
+    ('sqlserver.files.read_bytes', 'num_of_bytes_read'),
+    ('sqlserver.files.read_io_stall', 'io_stall_read_ms'),
+    ('sqlserver.files.read_io_stall_queued', 'io_stall_queued_read_ms'),
+    ('sqlserver.files.writes', 'num_of_writes'),
+    ('sqlserver.files.written_bytes', 'num_of_bytes_written'),
+    ('sqlserver.files.write_io_stall', 'io_stall_write_ms'),
+    ('sqlserver.files.write_io_stall_queued', 'io_stall_queued_write_ms'),
+    ('sqlserver.files.io_stall', 'io_stall'),
+    ('sqlserver.files.size_on_disk', 'size_on_disk_bytes'),
+]

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -161,6 +161,7 @@ DATABASE_MASTER_FILES = [
 ]
 
 DATABASE_FILES_IO = [
+    ('sqlserver.files.size_on_disk', 'size_on_disk_bytes', AgentCheck.gauge),
     ('sqlserver.files.reads', 'num_of_reads', AgentCheck.monotonic_count),
     ('sqlserver.files.read_bytes', 'num_of_bytes_read', AgentCheck.monotonic_count),
     ('sqlserver.files.read_io_stall', 'io_stall_read_ms', AgentCheck.monotonic_count),
@@ -170,5 +171,4 @@ DATABASE_FILES_IO = [
     ('sqlserver.files.write_io_stall', 'io_stall_write_ms', AgentCheck.monotonic_count),
     ('sqlserver.files.write_io_stall_queued', 'io_stall_queued_write_ms', AgentCheck.monotonic_count),
     ('sqlserver.files.io_stall', 'io_stall', AgentCheck.monotonic_count),
-    ('sqlserver.files.size_on_disk', 'size_on_disk_bytes', AgentCheck.gauge),
 ]

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -2,8 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from datadog_checks.base import AgentCheck
-
 # Constant for SQLServer cntr_type
 PERF_LARGE_RAW_BASE = 1073939712
 PERF_RAW_LARGE_FRACTION = 537003264
@@ -161,14 +159,14 @@ DATABASE_MASTER_FILES = [
 ]
 
 DATABASE_FILES_IO = [
-    ('sqlserver.files.size_on_disk', 'size_on_disk_bytes', AgentCheck.gauge),
-    ('sqlserver.files.reads', 'num_of_reads', AgentCheck.monotonic_count),
-    ('sqlserver.files.read_bytes', 'num_of_bytes_read', AgentCheck.monotonic_count),
-    ('sqlserver.files.read_io_stall', 'io_stall_read_ms', AgentCheck.monotonic_count),
-    ('sqlserver.files.read_io_stall_queued', 'io_stall_queued_read_ms', AgentCheck.monotonic_count),
-    ('sqlserver.files.writes', 'num_of_writes', AgentCheck.monotonic_count),
-    ('sqlserver.files.written_bytes', 'num_of_bytes_written', AgentCheck.monotonic_count),
-    ('sqlserver.files.write_io_stall', 'io_stall_write_ms', AgentCheck.monotonic_count),
-    ('sqlserver.files.write_io_stall_queued', 'io_stall_queued_write_ms', AgentCheck.monotonic_count),
-    ('sqlserver.files.io_stall', 'io_stall', AgentCheck.monotonic_count),
+    ('sqlserver.files.size_on_disk', 'size_on_disk_bytes', 'gauge'),
+    ('sqlserver.files.reads', 'num_of_reads', 'monotonic_count'),
+    ('sqlserver.files.read_bytes', 'num_of_bytes_read', 'monotonic_count'),
+    ('sqlserver.files.read_io_stall', 'io_stall_read_ms', 'monotonic_count'),
+    ('sqlserver.files.read_io_stall_queued', 'io_stall_queued_read_ms', 'monotonic_count'),
+    ('sqlserver.files.writes', 'num_of_writes', 'monotonic_count'),
+    ('sqlserver.files.written_bytes', 'num_of_bytes_written', 'monotonic_count'),
+    ('sqlserver.files.write_io_stall', 'io_stall_write_ms', 'monotonic_count'),
+    ('sqlserver.files.write_io_stall_queued', 'io_stall_queued_write_ms', 'monotonic_count'),
+    ('sqlserver.files.io_stall', 'io_stall', 'monotonic_count'),
 ]

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -610,7 +610,7 @@ class SqlFileStats(BaseSqlServerMetric):
     """
 
     def __init__(self, cfg_instance, base_name, report_function, column, logger):
-        super(SqlVirtualFileIOStats, self).__init__(cfg_instance, base_name, report_function, column, logger)
+        super(SqlFileStats, self).__init__(cfg_instance, base_name, report_function, column, logger)
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -561,7 +561,7 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
             self.report_function(metric_name, column_val, tags=metric_tags)
 
 
-class SqlVirtualFileIOStats(BaseSqlServerMetric):
+class SqlFileStats(BaseSqlServerMetric):
     CUSTOM_QUERIES_AVAILABLE = False
 
     # Default base query works for server-wide view of all master files

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -567,28 +567,6 @@ class SqlVirtualFileIOStats(BaseSqlServerMetric):
     # Default base query works for server-wide view of all master files
     QUERY_MASTER_FILES = """
         SELECT
-            DB_NAME() AS database_name,
-            df.state_desc AS state_desc,
-            df.name AS logical_name,
-            df.physical_name AS physical_name,
-            fs.num_of_reads AS num_of_reads,
-            fs.num_of_bytes_read AS num_of_bytes_read,
-            fs.io_stall_read_ms AS io_stall_read_ms,
-            fs.io_stall_queued_read_ms AS io_stall_queued_read_ms,
-            fs.num_of_writes AS num_of_writes,
-            fs.num_of_bytes_written AS num_of_bytes_written,
-            fs.io_stall_write_ms AS io_stall_write_ms,
-            fs.io_stall_queued_write_ms AS io_stall_queued_write_ms,
-            fs.io_stall AS io_stall,
-            fs.size_on_disk_bytes AS size_on_disk_bytes
-        FROM sys.dm_io_virtual_file_stats(NULL, NULL) fs
-            LEFT JOIN sys.database_files df
-                AND df.file_id = fs.file_id;
-    """
-
-    # Per-database query
-    QUERY_DATABASE_FILES = """
-        SELECT
             DB_NAME(fs.database_id) AS database_name,
             mf.state_desc AS state_desc,
             mf.name AS logical_name,
@@ -607,6 +585,28 @@ class SqlVirtualFileIOStats(BaseSqlServerMetric):
             LEFT JOIN sys.master_files mf
                 ON mf.database_id = fs.database_id
                 AND mf.file_id = fs.file_id;
+    """
+
+    # Per-database query
+    QUERY_DATABASE_FILES = """
+        SELECT
+            DB_NAME() AS database_name,
+            df.state_desc AS state_desc,
+            df.name AS logical_name,
+            df.physical_name AS physical_name,
+            fs.num_of_reads AS num_of_reads,
+            fs.num_of_bytes_read AS num_of_bytes_read,
+            fs.io_stall_read_ms AS io_stall_read_ms,
+            fs.io_stall_queued_read_ms AS io_stall_queued_read_ms,
+            fs.num_of_writes AS num_of_writes,
+            fs.num_of_bytes_written AS num_of_bytes_written,
+            fs.io_stall_write_ms AS io_stall_write_ms,
+            fs.io_stall_queued_write_ms AS io_stall_queued_write_ms,
+            fs.io_stall AS io_stall,
+            fs.size_on_disk_bytes AS size_on_disk_bytes
+        FROM sys.dm_io_virtual_file_stats(DB_ID(), NULL) fs
+            LEFT JOIN sys.database_files df
+                ON df.file_id = fs.file_id;
     """
 
     def __init__(self, cfg_instance, base_name, report_function, column, logger):
@@ -638,15 +638,11 @@ class SqlVirtualFileIOStats(BaseSqlServerMetric):
             for db in databases:
                 # use statements need to be executed separate from select queries
                 ctx = construct_use_statement(db)
-                try:
-                    logger.debug("%s: changing cursor context via use statement: %s", cls.__name__, ctx)
-                    cursor.execute(ctx)
-                    logger.debug("%s: fetch_all executing query: %s", cls.__name__, cls.QUERY_DATABASE_FILES)
-                    cursor.execute(cls.QUERY_DATABASE_FILES)
-                    data = cursor.fetchall()
-                except Exception as e:
-                    logger.error("Error when trying to query db %s - skipping.  Error: %s", db, e)
-                    continue
+                logger.debug("%s: changing cursor context via use statement: %s", cls.__name__, ctx)
+                cursor.execute(ctx)
+                logger.debug("%s: fetch_all executing query: %s", cls.__name__, cls.QUERY_DATABASE_FILES)
+                cursor.execute(cls.QUERY_DATABASE_FILES)
+                data = cursor.fetchall()
 
                 columns = [i[0] for i in cursor.description]
                 for r in data:
@@ -678,6 +674,7 @@ class SqlVirtualFileIOStats(BaseSqlServerMetric):
                 'logical_name:{}'.format(row[logical_name]),
                 'file_location:{}'.format(row[physical_name]),
             ]
+
             metric_tags.extend(self.tags)
             metric_name = '{}'.format(self.datadog_name)
             self.report_function(metric_name, val, tags=metric_tags)

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -672,7 +672,7 @@ class SqlVirtualFileIOStats(BaseSqlServerMetric):
                 continue
 
             metric_tags = [
-                'database:{}'.format(row[db_name]),
+                'db:{}'.format(row[db_name]),
                 'state:{}'.format(row[state_desc]),
                 'logical_name:{}'.format(row[logical_name]),
                 'file_location:{}'.format(row[physical_name]),

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -673,7 +673,7 @@ class SqlVirtualFileIOStats(BaseSqlServerMetric):
 
             metric_tags = [
                 'database:{}'.format(row[db_name]),
-                'state:{}'.format(row[state_desc].lower()),
+                'state:{}'.format(row[state_desc]),
                 'logical_name:{}'.format(row[logical_name]),
                 'file_location:{}'.format(row[physical_name]),
             ]

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -623,6 +623,7 @@ class SqlVirtualFileIOStats(BaseSqlServerMetric):
         if not databases:
             # No database list; use the server-wide master files DMV
             query = cls.QUERY_MASTER_FILES
+
             cursor.execute(query)
             rows = cursor.fetchall()
             columns = [i[0] for i in cursor.description]
@@ -630,6 +631,8 @@ class SqlVirtualFileIOStats(BaseSqlServerMetric):
 
         else:
             # Query each database in the list for the files in the current database
+            query = cls.QUERY_DATABASE_FILES
+
             cursor.execute('select DB_NAME()')  # This can return None in some implementations so it cannot be chained
             data = cursor.fetchall()
             current_db = data[0][0]
@@ -640,8 +643,8 @@ class SqlVirtualFileIOStats(BaseSqlServerMetric):
                 ctx = construct_use_statement(db)
                 logger.debug("%s: changing cursor context via use statement: %s", cls.__name__, ctx)
                 cursor.execute(ctx)
-                logger.debug("%s: fetch_all executing query: %s", cls.__name__, cls.QUERY_DATABASE_FILES)
-                cursor.execute(cls.QUERY_DATABASE_FILES)
+                logger.debug("%s: fetch_all executing query: %s", cls.__name__, query)
+                cursor.execute(query)
                 data = cursor.fetchall()
 
                 columns = [i[0] for i in cursor.description]

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -353,6 +353,8 @@ class SQLServer(AgentCheck):
                 cfg = {'name': name, 'table': table, 'column': column, 'instance_name': db_name, 'tags': tags}
                 metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
 
+        # Load database files
+        # TODO: if self.dbm_enabled
         for name, column, metric_fn in DATABASE_FILES_IO:
             cfg = {'name': name, 'column': column, 'tags': tags}
             metrics_to_collect.append(

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -18,6 +18,7 @@ from datadog_checks.base.utils.db import QueryManager
 from datadog_checks.base.utils.db.utils import resolve_db_host
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.sqlserver.activity import SqlserverActivity
+from datadog_checks.sqlserver.metrics import SqlVirtualFileIOStats
 from datadog_checks.sqlserver.statements import SqlserverStatementMetrics
 
 try:
@@ -34,6 +35,7 @@ from .const import (
     AUTODISCOVERY_QUERY,
     BASE_NAME_QUERY,
     COUNTER_TYPE_QUERY,
+    DATABASE_FILES_IO,
     DATABASE_FRAGMENTATION_METRICS,
     DATABASE_MASTER_FILES,
     DATABASE_METRICS,
@@ -350,6 +352,10 @@ class SQLServer(AgentCheck):
             for db_name in db_names:
                 cfg = {'name': name, 'table': table, 'column': column, 'instance_name': db_name, 'tags': tags}
                 metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
+
+        for name, column in DATABASE_FILES_IO:
+            cfg = {'name': name, 'column': column, 'tags': tags}
+            metrics_to_collect.append(SqlVirtualFileIOStats(cfg, None, self.monotonic_count, column, self.log))
 
         # Load AlwaysOn metrics
         if is_affirmative(self.instance.get('include_ao_metrics', False)):

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -357,9 +357,14 @@ class SQLServer(AgentCheck):
         # TODO: if self.dbm_enabled
         for name, column, metric_fn in DATABASE_FILES_IO:
             cfg = {'name': name, 'column': column, 'tags': tags}
+
+            # A wrapper around the metric function is required because `metric_fn` is mutable on each loop
+            def make_metric_function(metric_fn):
+                return lambda *args, **kwargs: metric_fn(self, *args, **kwargs)
+
             metrics_to_collect.append(
                 SqlVirtualFileIOStats(
-                    cfg, None, lambda *args, **kwargs: metric_fn(self, *args, **kwargs), column, self.log
+                    cfg, None, make_metric_function(metric_fn), column, self.log
                 )
             )
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -18,7 +18,7 @@ from datadog_checks.base.utils.db import QueryManager
 from datadog_checks.base.utils.db.utils import resolve_db_host
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.sqlserver.activity import SqlserverActivity
-from datadog_checks.sqlserver.metrics import SqlVirtualFileIOStats
+from datadog_checks.sqlserver.metrics import SqlFileStats
 from datadog_checks.sqlserver.statements import SqlserverStatementMetrics
 
 try:
@@ -357,7 +357,7 @@ class SQLServer(AgentCheck):
         for name, column, metric_type in DATABASE_FILES_IO:
             cfg = {'name': name, 'column': column, 'tags': tags}
 
-            metrics_to_collect.append(SqlVirtualFileIOStats(cfg, None, getattr(self, metric_type), column, self.log))
+            metrics_to_collect.append(SqlFileStats(cfg, None, getattr(self, metric_type), column, self.log))
 
         # Load AlwaysOn metrics
         if is_affirmative(self.instance.get('include_ao_metrics', False)):

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -362,9 +362,7 @@ class SQLServer(AgentCheck):
                 return lambda *args, **kwargs: metric_fn(self, *args, **kwargs)
 
             metrics_to_collect.append(
-                SqlVirtualFileIOStats(
-                    cfg, None, make_metric_function(metric_fn), column, self.log
-                )
+                SqlVirtualFileIOStats(cfg, None, make_metric_function(metric_fn), column, self.log)
             )
 
         # Load AlwaysOn metrics

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -354,16 +354,10 @@ class SQLServer(AgentCheck):
                 metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
 
         # Load database files
-        for name, column, metric_fn in DATABASE_FILES_IO:
+        for name, column, metric_name in DATABASE_FILES_IO:
             cfg = {'name': name, 'column': column, 'tags': tags}
 
-            # A wrapper around the metric function is required because `metric_fn` is mutable on each loop
-            def make_metric_function(metric_fn):
-                return lambda *args, **kwargs: metric_fn(self, *args, **kwargs)
-
-            metrics_to_collect.append(
-                SqlVirtualFileIOStats(cfg, None, make_metric_function(metric_fn), column, self.log)
-            )
+            metrics_to_collect.append(SqlVirtualFileIOStats(cfg, None, getattr(self, metric_name), column, self.log))
 
         # Load AlwaysOn metrics
         if is_affirmative(self.instance.get('include_ao_metrics', False)):

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -354,10 +354,10 @@ class SQLServer(AgentCheck):
                 metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
 
         # Load database files
-        for name, column, metric_name in DATABASE_FILES_IO:
+        for name, column, metric_type in DATABASE_FILES_IO:
             cfg = {'name': name, 'column': column, 'tags': tags}
 
-            metrics_to_collect.append(SqlVirtualFileIOStats(cfg, None, getattr(self, metric_name), column, self.log))
+            metrics_to_collect.append(SqlVirtualFileIOStats(cfg, None, getattr(self, metric_type), column, self.log))
 
         # Load AlwaysOn metrics
         if is_affirmative(self.instance.get('include_ao_metrics', False)):

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -354,7 +354,6 @@ class SQLServer(AgentCheck):
                 metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
 
         # Load database files
-        # TODO: if self.dbm_enabled
         for name, column, metric_fn in DATABASE_FILES_IO:
             cfg = {'name': name, 'column': column, 'tags': tags}
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -353,9 +353,13 @@ class SQLServer(AgentCheck):
                 cfg = {'name': name, 'table': table, 'column': column, 'instance_name': db_name, 'tags': tags}
                 metrics_to_collect.append(self.typed_metric(cfg_inst=cfg, table=table, column=column))
 
-        for name, column in DATABASE_FILES_IO:
+        for name, column, metric_fn in DATABASE_FILES_IO:
             cfg = {'name': name, 'column': column, 'tags': tags}
-            metrics_to_collect.append(SqlVirtualFileIOStats(cfg, None, self.monotonic_count, column, self.log))
+            metrics_to_collect.append(
+                SqlVirtualFileIOStats(
+                    cfg, None, lambda *args, **kwargs: metric_fn(self, *args, **kwargs), column, self.log
+                )
+            )
 
         # Load AlwaysOn metrics
         if is_affirmative(self.instance.get('include_ao_metrics', False)):

--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -39,6 +39,16 @@ sqlserver.database.avg_fragmentation_in_percent,gauge,,,,"Logical fragmentation 
 sqlserver.database.backup_count,gauge,,,,"The total count of successful backups made for a database.",0,sql_server,backup count
 sqlserver.database.fragment_count,gauge,,,,"The number of fragments in the leaf level of an IN_ROW_DATA allocation unit.",0,sql_server,fragment count
 sqlserver.database.is_sync_with_backup,gauge,,,,"Whether or not the database is marked for replication synchronization with backup. 0 = Not marked for replication sync, 1 = Marked for replication sync.",0,sql_server,is sync with backup
+sqlserver.files.reads,count,,read,,"Number of reads issued on the file. Tags: logical_name, file_location, database, state",0,sql_server,reads on database file
+sqlserver.files.read_bytes,count,,byte,,"Bytes read from the file. Tags: logical_name, file_location, database, state",0,sql_server,bytes read from database file
+sqlserver.files.read_io_stall,count,,millisecond,,"Total time that users waited for reads on the file. Tags: logical_name, file_location, database, state",-1,sql_server,read wait time on database file
+sqlserver.files.read_io_stall_queued,count,,millisecond,,"Total latency from IO governance pools for reads on the file. Tags: logical_name, file_location, database, state",-1,sql_server,read io queue time on database file
+sqlserver.files.writes,count,,write,,"Number of writes issued on the file. Tags: logical_name, file_location, database, state",0,sql_server,writes on database file
+sqlserver.files.written_bytes,count,,byte,,"Bytes written to the file. Tags: logical_name, file_location, database, state",0,sql_server,bytes written to the database file
+sqlserver.files.write_io_stall,count,,millisecond,,"Total time that users waited for writes on the file. Tags: logical_name, file_location, database, state",-1,sql_server,write wait time on database file
+sqlserver.files.write_io_stall_queued,count,,millisecond,,"Total latency from IO governance pools for writes on the file. Tags: logical_name, file_location, database, state",-1,sql_server,write io queue time on database file
+sqlserver.files.io_stall,count,,millisecond,,"Total time that users waited for I/O to complete on the file. Tags: logical_name, file_location, database, state",-1,sql_server,io wait time on database file
+sqlserver.files.size_on_disk,gauge,,byte,,"Number of bytes used on the disk for this file. Tags: logical_name, file_location, database, state",0,sql_server,bytes used for database file
 sqlserver.memory.memory_grants_pending,gauge,,,,Specifies the total number of processes waiting for a workspace memory grant,0,sql_server,memory grant pending
 sqlserver.memory.total_server_memory,gauge,,kibibyte,,Specifies the amount of memory the server has committed using the memory manager.,0,sql_server,memory total
 sqlserver.scheduler.current_tasks_count,gauge,,task,,Number of current tasks that are associated with this scheduler.,0,sql_server,task count

--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -39,12 +39,12 @@ sqlserver.database.avg_fragmentation_in_percent,gauge,,,,"Logical fragmentation 
 sqlserver.database.backup_count,gauge,,,,"The total count of successful backups made for a database.",0,sql_server,backup count
 sqlserver.database.fragment_count,gauge,,,,"The number of fragments in the leaf level of an IN_ROW_DATA allocation unit.",0,sql_server,fragment count
 sqlserver.database.is_sync_with_backup,gauge,,,,"Whether or not the database is marked for replication synchronization with backup. 0 = Not marked for replication sync, 1 = Marked for replication sync.",0,sql_server,is sync with backup
-sqlserver.files.reads,count,,read,,"Number of reads issued on the file. Tags: logical_name, file_location, database, state",0,sql_server,reads on database file
-sqlserver.files.read_bytes,count,,byte,,"Bytes read from the file. Tags: logical_name, file_location, database, state",0,sql_server,bytes read from database file
+sqlserver.files.reads,count,,read,second,"Number of reads issued on the file. Tags: logical_name, file_location, database, state",0,sql_server,reads on database file
+sqlserver.files.read_bytes,count,,byte,second,"Bytes read from the file. Tags: logical_name, file_location, database, state",0,sql_server,bytes read from database file
 sqlserver.files.read_io_stall,count,,millisecond,,"Total time that users waited for reads on the file. Tags: logical_name, file_location, database, state",-1,sql_server,read wait time on database file
 sqlserver.files.read_io_stall_queued,count,,millisecond,,"Total latency from IO governance pools for reads on the file. Tags: logical_name, file_location, database, state",-1,sql_server,read io queue time on database file
-sqlserver.files.writes,count,,write,,"Number of writes issued on the file. Tags: logical_name, file_location, database, state",0,sql_server,writes on database file
-sqlserver.files.written_bytes,count,,byte,,"Bytes written to the file. Tags: logical_name, file_location, database, state",0,sql_server,bytes written to the database file
+sqlserver.files.writes,count,,write,second,"Number of writes issued on the file. Tags: logical_name, file_location, database, state",0,sql_server,writes on database file
+sqlserver.files.written_bytes,count,,byte,second,"Bytes written to the file. Tags: logical_name, file_location, database, state",0,sql_server,bytes written to the database file
 sqlserver.files.write_io_stall,count,,millisecond,,"Total time that users waited for writes on the file. Tags: logical_name, file_location, database, state",-1,sql_server,write wait time on database file
 sqlserver.files.write_io_stall_queued,count,,millisecond,,"Total latency from IO governance pools for writes on the file. Tags: logical_name, file_location, database, state",-1,sql_server,write io queue time on database file
 sqlserver.files.io_stall,count,,millisecond,,"Total time that users waited for I/O to complete on the file. Tags: logical_name, file_location, database, state",-1,sql_server,io wait time on database file

--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -39,16 +39,16 @@ sqlserver.database.avg_fragmentation_in_percent,gauge,,,,"Logical fragmentation 
 sqlserver.database.backup_count,gauge,,,,"The total count of successful backups made for a database.",0,sql_server,backup count
 sqlserver.database.fragment_count,gauge,,,,"The number of fragments in the leaf level of an IN_ROW_DATA allocation unit.",0,sql_server,fragment count
 sqlserver.database.is_sync_with_backup,gauge,,,,"Whether or not the database is marked for replication synchronization with backup. 0 = Not marked for replication sync, 1 = Marked for replication sync.",0,sql_server,is sync with backup
-sqlserver.files.reads,count,,read,second,"Number of reads issued on the file. Tags: logical_name, file_location, database, state",0,sql_server,reads on database file
-sqlserver.files.read_bytes,count,,byte,second,"Bytes read from the file. Tags: logical_name, file_location, database, state",0,sql_server,bytes read from database file
-sqlserver.files.read_io_stall,count,,millisecond,,"Total time that users waited for reads on the file. Tags: logical_name, file_location, database, state",-1,sql_server,read wait time on database file
-sqlserver.files.read_io_stall_queued,count,,millisecond,,"Total latency from IO governance pools for reads on the file. Tags: logical_name, file_location, database, state",-1,sql_server,read io queue time on database file
-sqlserver.files.writes,count,,write,second,"Number of writes issued on the file. Tags: logical_name, file_location, database, state",0,sql_server,writes on database file
-sqlserver.files.written_bytes,count,,byte,second,"Bytes written to the file. Tags: logical_name, file_location, database, state",0,sql_server,bytes written to the database file
-sqlserver.files.write_io_stall,count,,millisecond,,"Total time that users waited for writes on the file. Tags: logical_name, file_location, database, state",-1,sql_server,write wait time on database file
-sqlserver.files.write_io_stall_queued,count,,millisecond,,"Total latency from IO governance pools for writes on the file. Tags: logical_name, file_location, database, state",-1,sql_server,write io queue time on database file
-sqlserver.files.io_stall,count,,millisecond,,"Total time that users waited for I/O to complete on the file. Tags: logical_name, file_location, database, state",-1,sql_server,io wait time on database file
-sqlserver.files.size_on_disk,gauge,,byte,,"Number of bytes used on the disk for this file. Tags: logical_name, file_location, database, state",0,sql_server,bytes used for database file
+sqlserver.files.reads,count,,read,second,"Number of reads issued on the file. Tags: `logical_name`, `file_location`, `database`, `state`",0,sql_server,reads on database file
+sqlserver.files.read_bytes,count,,byte,second,"Bytes read from the file. Tags: `logical_name`, `file_location`, `database`, `state`",0,sql_server,bytes read from database file
+sqlserver.files.read_io_stall,count,,millisecond,,"Total time that users waited for reads on the file. Tags: `logical_name`, `file_location`, `database`, `state`",-1,sql_server,read wait time on database file
+sqlserver.files.read_io_stall_queued,count,,millisecond,,"Total latency from IO governance pools for reads on the file. Tags: `logical_name`, `file_location`, `database`, `state`",-1,sql_server,read io queue time on database file
+sqlserver.files.writes,count,,write,second,"Number of writes issued on the file. Tags: `logical_name`, `file_location`, `database`, `state`",0,sql_server,writes on database file
+sqlserver.files.written_bytes,count,,byte,second,"Bytes written to the file. Tags: `logical_name`, `file_location`, `database`, `state`",0,sql_server,bytes written to the database file
+sqlserver.files.write_io_stall,count,,millisecond,,"Total time that users waited for writes on the file. Tags: `logical_name`, `file_location`, `database`, `state`",-1,sql_server,write wait time on database file
+sqlserver.files.write_io_stall_queued,count,,millisecond,,"Total latency from IO governance pools for writes on the file. Tags: `logical_name`, `file_location`, `database`, `state`",-1,sql_server,write io queue time on database file
+sqlserver.files.io_stall,count,,millisecond,,"Total time that users waited for I/O to complete on the file. Tags: `logical_name`, `file_location`, `database`, `state`",-1,sql_server,io wait time on database file
+sqlserver.files.size_on_disk,gauge,,byte,,"Number of bytes used on the disk for this file. Tags: `logical_name`, `file_location`, `database`, `state`",0,sql_server,bytes used for database file
 sqlserver.memory.memory_grants_pending,gauge,,,,Specifies the total number of processes waiting for a workspace memory grant,0,sql_server,memory grant pending
 sqlserver.memory.total_server_memory,gauge,,kibibyte,,Specifies the amount of memory the server has committed using the memory manager.,0,sql_server,memory total
 sqlserver.scheduler.current_tasks_count,gauge,,task,,Number of current tasks that are associated with this scheduler.,0,sql_server,task count

--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -39,16 +39,16 @@ sqlserver.database.avg_fragmentation_in_percent,gauge,,,,"Logical fragmentation 
 sqlserver.database.backup_count,gauge,,,,"The total count of successful backups made for a database.",0,sql_server,backup count
 sqlserver.database.fragment_count,gauge,,,,"The number of fragments in the leaf level of an IN_ROW_DATA allocation unit.",0,sql_server,fragment count
 sqlserver.database.is_sync_with_backup,gauge,,,,"Whether or not the database is marked for replication synchronization with backup. 0 = Not marked for replication sync, 1 = Marked for replication sync.",0,sql_server,is sync with backup
-sqlserver.files.reads,count,,read,second,"Number of reads issued on the file. Tags: `logical_name`, `file_location`, `database`, `state`",0,sql_server,reads on database file
-sqlserver.files.read_bytes,count,,byte,second,"Bytes read from the file. Tags: `logical_name`, `file_location`, `database`, `state`",0,sql_server,bytes read from database file
-sqlserver.files.read_io_stall,count,,millisecond,,"Total time that users waited for reads on the file. Tags: `logical_name`, `file_location`, `database`, `state`",-1,sql_server,read wait time on database file
-sqlserver.files.read_io_stall_queued,count,,millisecond,,"Total latency from IO governance pools for reads on the file. Tags: `logical_name`, `file_location`, `database`, `state`",-1,sql_server,read io queue time on database file
-sqlserver.files.writes,count,,write,second,"Number of writes issued on the file. Tags: `logical_name`, `file_location`, `database`, `state`",0,sql_server,writes on database file
-sqlserver.files.written_bytes,count,,byte,second,"Bytes written to the file. Tags: `logical_name`, `file_location`, `database`, `state`",0,sql_server,bytes written to the database file
-sqlserver.files.write_io_stall,count,,millisecond,,"Total time that users waited for writes on the file. Tags: `logical_name`, `file_location`, `database`, `state`",-1,sql_server,write wait time on database file
-sqlserver.files.write_io_stall_queued,count,,millisecond,,"Total latency from IO governance pools for writes on the file. Tags: `logical_name`, `file_location`, `database`, `state`",-1,sql_server,write io queue time on database file
-sqlserver.files.io_stall,count,,millisecond,,"Total time that users waited for I/O to complete on the file. Tags: `logical_name`, `file_location`, `database`, `state`",-1,sql_server,io wait time on database file
-sqlserver.files.size_on_disk,gauge,,byte,,"Number of bytes used on the disk for this file. Tags: `logical_name`, `file_location`, `database`, `state`",0,sql_server,bytes used for database file
+sqlserver.files.reads,count,,read,second,"Number of reads issued on the file. Tags: `logical_name`, `file_location`, `db`, `state`",0,sql_server,reads on database file
+sqlserver.files.read_bytes,count,,byte,second,"Bytes read from the file. Tags: `logical_name`, `file_location`, `db`, `state`",0,sql_server,bytes read from database file
+sqlserver.files.read_io_stall,count,,millisecond,,"Total time that users waited for reads on the file. Tags: `logical_name`, `file_location`, `db`, `state`",-1,sql_server,read wait time on database file
+sqlserver.files.read_io_stall_queued,count,,millisecond,,"Total latency from IO governance pools for reads on the file. Tags: `logical_name`, `file_location`, `db`, `state`",-1,sql_server,read io queue time on database file
+sqlserver.files.writes,count,,write,second,"Number of writes issued on the file. Tags: `logical_name`, `file_location`, `db`, `state`",0,sql_server,writes on database file
+sqlserver.files.written_bytes,count,,byte,second,"Bytes written to the file. Tags: `logical_name`, `file_location`, `db`, `state`",0,sql_server,bytes written to the database file
+sqlserver.files.write_io_stall,count,,millisecond,,"Total time that users waited for writes on the file. Tags: `logical_name`, `file_location`, `db`, `state`",-1,sql_server,write wait time on database file
+sqlserver.files.write_io_stall_queued,count,,millisecond,,"Total latency from IO governance pools for writes on the file. Tags: `logical_name`, `file_location`, `db`, `state`",-1,sql_server,write io queue time on database file
+sqlserver.files.io_stall,count,,millisecond,,"Total time that users waited for I/O to complete on the file. Tags: `logical_name`, `file_location`, `db`, `state`",-1,sql_server,io wait time on database file
+sqlserver.files.size_on_disk,gauge,,byte,,"Number of bytes used on the disk for this file. Tags: `logical_name`, `file_location`, `db`, `state`",0,sql_server,bytes used for database file
 sqlserver.memory.memory_grants_pending,gauge,,,,Specifies the total number of processes waiting for a workspace memory grant,0,sql_server,memory grant pending
 sqlserver.memory.total_server_memory,gauge,,kibibyte,,Specifies the amount of memory the server has committed using the memory manager.,0,sql_server,memory total
 sqlserver.scheduler.current_tasks_count,gauge,,task,,Number of current tasks that are associated with this scheduler.,0,sql_server,task count

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -11,6 +11,7 @@ from datadog_checks.sqlserver.const import (
     AO_METRICS,
     AO_METRICS_PRIMARY,
     AO_METRICS_SECONDARY,
+    DATABASE_FILES_IO,
     DATABASE_FRAGMENTATION_METRICS,
     DATABASE_MASTER_FILES,
     DATABASE_METRICS,
@@ -58,6 +59,7 @@ EXPECTED_METRICS = (
         m[0]
         for m in chain(
             TASK_SCHEDULER_METRICS,
+            DATABASE_FILES_IO,
             DATABASE_FRAGMENTATION_METRICS,
             DATABASE_MASTER_FILES,
         )

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -51,6 +51,7 @@ EXPECTED_DEFAULT_METRICS = [
         DBM_MIGRATED_METRICS,
         INSTANCE_METRICS_TOTAL,
         DATABASE_METRICS,
+        DATABASE_FILES_IO,
     )
 ]
 EXPECTED_METRICS = (
@@ -59,7 +60,6 @@ EXPECTED_METRICS = (
         m[0]
         for m in chain(
             TASK_SCHEDULER_METRICS,
-            DATABASE_FILES_IO,
             DATABASE_FRAGMENTATION_METRICS,
             DATABASE_MASTER_FILES,
         )


### PR DESCRIPTION
### What does this PR do?

This change adds file IO metrics for all files on the system. 

There are already a few different metrics which track files, but these are either tagged by things which are not super useful or only available as custom metrics.

* Custom metrics only exposing file I/O stats: https://github.com/DataDog/integrations-core/blob/master/sqlserver/datadog_checks/sqlserver/metrics.py#L261-L268. These do not contain the logical or physical name, however, and they require manual configuration by the customer.
* Master files are the most useful because they are cross-database views: https://github.com/DataDog/integrations-core/blob/master/sqlserver/datadog_checks/sqlserver/metrics.py#L414-L424, but tags are `database`, `file_id` (not super useful), `type`, `file_location`, `database_files_state_desc`. However they do not contain any IO stat metrics, which is what most users would care about.
* Database files: https://github.com/DataDog/integrations-core/blob/master/sqlserver/datadog_checks/sqlserver/metrics.py#L465-L469, but these are only available for the currently-connected database and do not contain IO stats.

I am hoping to sunset all of the above in favor of these canonical database file stats (https://xkcd.com/927/).

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes

Datadog employees can review the metrics being sent [here](https://ddstaging.datadoghq.com/dashboard/8dy-gbu-v6b/sql-server-file-metrics).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
