### PR TITLE
Add DD_TAGS section for cluster name, fix links

### DIFF
--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -129,6 +129,8 @@ spec:
            fieldRef:
              apiVersion: v1
              fieldPath: spec.nodeName
+       - name: DD_TAGS
+         value: "kube_cluster_name:<CLUSTER_NAME>"
       resources:
           requests:
             memory: "256Mi"
@@ -139,6 +141,8 @@ spec:
 ```
 
 **Note**: Don't forget to replace `<YOUR_DATADOG_API_KEY>` with the [Datadog API key from your organization][14].
+
+**Note**: Add your desired `kube_cluster_name:<CLUSTER_NAME>` to the list of `DD_TAGS` to ensure your metrics are tagged by your desired cluster. You can append additional tags here as space separated `<KEY>:<VALUE>` tags.
 
 ## Metrics collection
 
@@ -197,11 +201,11 @@ spec:
 **Notes**:
 
 - Don't forget to replace `<YOUR_DATADOG_API_KEY>` with the [Datadog API key from your organization][14].
-- Container metrics are not available in Fargate because the `cgroups` volume from the host can't be mounted into the Agent. The [Live Containers][17] view reports 0 for CPU and Memory.
+- Container metrics are not available in Fargate because the `cgroups` volume from the host can't be mounted into the Agent. The [Live Containers][19] view reports 0 for CPU and Memory.
 
 ### DogStatsD
 
-Set up the container port `8125` over your Agent container to forward [DogStatsD metrics][18] from your application container to Datadog.
+Set up the container port `8125` over your Agent container to forward [DogStatsD metrics][17] from your application container to Datadog.
 
 ```yaml
 apiVersion: apps/v1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Provide instructions on how to get the `kube_cluster_name` tag set on the K8s metrics when in EKS Fargate. As these metrics won't come in with that set otherwise. The normal `DD_CLUSTER_NAME` strategy does not currently work as this is a "host" tag but Fargate is a "hostless" setup.

Additionally fixed two links going to the wrong page. As for reference links 17-19
```
[17]: https://docs.datadoghq.com/developers/dogstatsd/
[18]: http://docs.datadoghq.com/tracing/setup
[19]: https://app.datadoghq.com/containers
```

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadoghq.atlassian.net/browse/CONS-4391

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
