### PR TITLE
Handle nested template name overrides in config specs

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
@@ -144,7 +144,6 @@ def options_validator(options, loader, file_name, *sections):
             overrides.update(option.pop('overrides', {}))
             try:
                 template = loader.templates.load(option.pop('template'))
-
             except Exception as e:
                 loader.errors.append(f'{loader.source}, {file_name}, {sections_display}option #{option_index}: {e}')
                 break

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
@@ -147,8 +147,7 @@ def options_validator(options, loader, file_name, *sections):
 
                 # Handle the case where a template name is overriden
                 if 'name' in option:
-                    substituted_name = option['name']
-                    template['name'] = substituted_name
+                    template['name'] = option['name']
             except Exception as e:
                 loader.errors.append(f'{loader.source}, {file_name}, {sections_display}option #{option_index}: {e}')
                 break

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
@@ -145,12 +145,14 @@ def options_validator(options, loader, file_name, *sections):
             try:
                 template = loader.templates.load(option.pop('template'))
 
-                # Handle the case where a template name is overriden
-                if 'name' in option:
-                    template['name'] = option['name']
             except Exception as e:
                 loader.errors.append(f'{loader.source}, {file_name}, {sections_display}option #{option_index}: {e}')
                 break
+
+            else:
+                # Handle the case where a template name is overriden
+                if 'name' in option:
+                    template['name'] = option['name']
 
             errors = loader.templates.apply_overrides(template, overrides)
             if errors:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
@@ -143,7 +143,13 @@ def options_validator(options, loader, file_name, *sections):
 
             overrides.update(option.pop('overrides', {}))
             try:
-                template = loader.templates.load(option.pop('template'))
+                original_template = option.pop('template')
+                template = loader.templates.load(original_template)
+
+                # Handle the case where a template name is overriden
+                if 'name' in option:
+                    substituted_name = option['name']
+                    template['name'] = substituted_name
             except Exception as e:
                 loader.errors.append(f'{loader.source}, {file_name}, {sections_display}option #{option_index}: {e}')
                 break

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
@@ -143,8 +143,7 @@ def options_validator(options, loader, file_name, *sections):
 
             overrides.update(option.pop('overrides', {}))
             try:
-                original_template = option.pop('template')
-                template = loader.templates.load(original_template)
+                template = loader.templates.load(option.pop('template'))
 
                 # Handle the case where a template name is overriden
                 if 'name' in option:


### PR DESCRIPTION
### What does this PR do?
Handle nested overrides in config specs where the template is renamed

### Motivation
We want to override the `extra_metrics` field in IIS and other windows integrations

### Additional Notes
Tested new behavior on windows_performance_counters and iis 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
