### PR TITLE
Update check versions from release 7.33.x

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - datadog_checks_base
 
+## 23.6.0 / 2021-12-20
+
+* [Security] Bump lxml package. See [#10904](https://github.com/DataDog/integrations-core/pull/10904).
+
 ## 23.5.0 / 2021-12-08
 
 * [Added] Add decorator for tracking execution statistics of check methods. See [#10809](https://github.com/DataDog/integrations-core/pull/10809).

--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = "23.5.0"
+__version__ = "23.6.0"

--- a/ibm_was/CHANGELOG.md
+++ b/ibm_was/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - IBM WAS
 
+## 1.12.0 / 2021-12-20
+
+* [Security] Bump lxml package. See [#10904](https://github.com/DataDog/integrations-core/pull/10904).
+
 ## 1.11.1 / 2021-11-16
 
 * [Fixed] Add dd_run_check and remove unused config options. See [#10623](https://github.com/DataDog/integrations-core/pull/10623).

--- a/ibm_was/datadog_checks/ibm_was/__about__.py
+++ b/ibm_was/datadog_checks/ibm_was/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.11.1'
+__version__ = '1.12.0'

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -14,7 +14,7 @@ datadog-cacti==1.9.1; sys_platform == 'linux2'
 datadog-cassandra-nodetool==1.9.0
 datadog-cassandra==1.14.1
 datadog-ceph==2.5.0; sys_platform != 'win32'
-datadog-checks-base==23.5.0
+datadog-checks-base==23.6.0
 datadog-checks-dependency-provider==1.2.0
 datadog-checks-downloader==3.4.1
 datadog-cilium==1.9.0
@@ -63,7 +63,7 @@ datadog-hyperv==1.4.0; sys_platform == 'win32'
 datadog-ibm-db2==1.9.0
 datadog-ibm-i==1.1.0
 datadog-ibm-mq==3.16.1; sys_platform != 'win32'
-datadog-ibm-was==1.11.1
+datadog-ibm-was==1.12.0
 datadog-ignite==2.1.1
 datadog-iis==2.13.0; sys_platform == 'win32'
 datadog-istio==3.16.0
@@ -128,7 +128,7 @@ datadog-snowflake==4.0.1
 datadog-solr==1.10.1
 datadog-sonarqube==1.5.1
 datadog-spark==2.1.0
-datadog-sqlserver==6.1.2
+datadog-sqlserver==6.2.0
 datadog-squid==1.11.0
 datadog-ssh-check==2.1.0
 datadog-statsd==1.8.0

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - sqlserver
 
+## 6.2.0 / 2021-12-20
+
+* [Security] Bump lxml package. See [#10904](https://github.com/DataDog/integrations-core/pull/10904).
+
 ## 6.1.2 / 2021-11-24
 
 * [Fixed] Fix broken unicode support. See [#10713](https://github.com/DataDog/integrations-core/pull/10713).

--- a/sqlserver/datadog_checks/sqlserver/__about__.py
+++ b/sqlserver/datadog_checks/sqlserver/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '6.1.2'
+__version__ = '6.2.0'


### PR DESCRIPTION
### What does this PR do?
Updates the check versions for datadog_checks_base, ibm_was, and sqlserver, which were released from the `7.33.x` release branch. 

https://github.com/DataDog/integrations-core/pull/10905
https://github.com/DataDog/integrations-core/pull/10908

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
