### PR TITLE
Add mysql_version and mysql_flavor to dbm query metrics payloads

### DIFF
--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -123,6 +123,8 @@ class MySQLStatementMetrics(DBMAsyncJob):
         payload = {
             'host': self._check.resolved_hostname,
             'timestamp': time.time() * 1000,
+            'mysql_version': self._check.version.version + '+' + self._check.version.build,
+            'mysql_flavor': self._check.version.flavor,
             'ddagentversion': datadog_agent.get_version(),
             'min_collection_interval': self._metric_collection_interval,
             'tags': self._tags,

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -131,6 +131,8 @@ def test_statement_metrics(
 
     assert event['host'] == 'stubbed.hostname'
     assert event['ddagentversion'] == datadog_agent.get_version()
+    assert event['mysql_version'] == mysql_check.version.version + '+' + mysql_check.version.build
+    assert event['mysql_flavor'] == mysql_check.version.flavor
     assert event['timestamp'] > 0
     assert event['min_collection_interval'] == dbm_instance['query_metrics']['collection_interval']
     expected_tags = set(tags.METRIC_TAGS + ['server:{}'.format(common.HOST), 'port:{}'.format(common.PORT)])


### PR DESCRIPTION
### What does this PR do?
This adds mysql_version to the query metrics payloads. 

### Motivation
Having the mysql version with query metrics is useful and it's more consistent with how we also have it for sqlserver and postgres. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
