### PR TITLE
Set coverage report to only core checks

### DIFF
--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -17,9 +17,9 @@ steps:
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
 
-- ${{ if and(eq(parameters.test, 'true'), not(eq(parameters.coverage, 'true'))) }}:
-    - script: ddev test --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}
-      displayName: 'Run Unit/Integration tests (no coverage)'
+- ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.repo, 'marketplace')) }}:
+    - script: ddev test --cov --min-cov ${{ parameters.min_cov }} --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}
+      displayName: 'Run Unit/Integration tests (marketplace)'
 
 # Nightly base package check
 - ${{ if and(eq(parameters.test, 'true'), eq(parameters.force_base_package, 'true')) }}:

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -17,9 +17,9 @@ steps:
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)
 
-- ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.repo, 'marketplace')) }}:
-    - script: ddev test --cov --min-cov ${{ parameters.min_cov }} --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}
-      displayName: 'Run Unit/Integration tests (marketplace)'
+- ${{ if and(eq(parameters.test, 'true'), not(eq(parameters.coverage, 'true'))) }}:
+    - script: ddev test --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}
+      displayName: 'Run Unit/Integration tests (no coverage)'
 
 # Nightly base package check
 - ${{ if and(eq(parameters.test, 'true'), eq(parameters.force_base_package, 'true')) }}:

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -12,7 +12,7 @@ parameters:
 
 steps:
 - ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.force_base_package, 'false')) }}:
-  - script: ddev test --cov --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }} --repo ${{ parameters.repo }}
+  - script: ddev test --cov --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}
     displayName: 'Run Unit/Integration tests'
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -12,7 +12,7 @@ parameters:
 
 steps:
 - ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.force_base_package, 'false')) }}:
-  - script: ddev test --cov --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}
+  - script: ddev test --cov --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }} --repo ${{ parameters.repo }}
     displayName: 'Run Unit/Integration tests'
     env:
       CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -35,7 +35,6 @@ def display_envs(check_envs):
 @click.option('--ddtrace', is_flag=True, help='Run tests using dd-trace-py')
 @click.option('--cov', '-c', 'coverage', is_flag=True, help='Measure code coverage')
 @click.option('--cov-missing', '-cm', is_flag=True, help='Show line numbers of statements that were not executed')
-@click.option('--min-cov', 'min_cov', type=int, help='Set a minimum code coverage % to pass tests.')
 @click.option('--junit', '-j', 'junit', is_flag=True, help='Generate junit reports')
 @click.option('--marker', '-m', help='Only run tests matching given marker expression')
 @click.option('--filter', '-k', 'test_filter', help='Only run tests matching given substring expression')
@@ -62,7 +61,6 @@ def test(
     e2e,
     ddtrace,
     coverage,
-    min_cov,
     junit,
     cov_missing,
     marker,
@@ -279,10 +277,7 @@ def test(
                 if not cov_keep:
                     echo_info('\n---------- Coverage report ----------\n')
 
-                    if min_cov is not None:
-                        result = run_command(f'coverage report --rcfile=../.coveragerc --fail-under={min_cov}')
-                    else:
-                        result = run_command('coverage report --rcfile=../.coveragerc')
+                    result = run_command('coverage report --rcfile=../.coveragerc')
 
                     if result.code:
                         abort('\nFailed!', code=result.code)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -35,7 +35,7 @@ def display_envs(check_envs):
 @click.option('--ddtrace', is_flag=True, help='Run tests using dd-trace-py')
 @click.option('--cov', '-c', 'coverage', is_flag=True, help='Measure code coverage')
 @click.option('--cov-missing', '-cm', is_flag=True, help='Show line numbers of statements that were not executed')
-@click.option('--min-cov', 'min_cov', default=1, type=int, help='Set minimum code coverage to pass for marketplace check. Default is 1')
+@click.option('--min-cov', 'min_cov', type=int, help='Set a minimum code coverage % to pass tests.')
 @click.option('--junit', '-j', 'junit', is_flag=True, help='Generate junit reports')
 @click.option('--marker', '-m', help='Only run tests matching given marker expression')
 @click.option('--filter', '-k', 'test_filter', help='Only run tests matching given substring expression')
@@ -279,8 +279,7 @@ def test(
                 if not cov_keep:
                     echo_info('\n---------- Coverage report ----------\n')
 
-                    # Marketplace PRs should fail CI if coverage is not greater than 0
-                    if repo == 'marketplace':
+                    if min_cov is not None:
                         result = run_command(f'coverage report --rcfile=../.coveragerc --fail-under={min_cov}')
                     else:
                         result = run_command('coverage report --rcfile=../.coveragerc')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -278,7 +278,6 @@ def test(
                     echo_info('\n---------- Coverage report ----------\n')
 
                     result = run_command('coverage report --rcfile=../.coveragerc')
-
                     if result.code:
                         abort('\nFailed!', code=result.code)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -50,6 +50,7 @@ def display_envs(check_envs):
 @click.option('--force-base-unpinned', is_flag=True, help='Force using datadog-checks-base as specified by check dep')
 @click.option('--force-base-min', is_flag=True, help='Force using lowest viable release version of datadog-checks-base')
 @click.option('--force-env-rebuild', is_flag=True, help='Force creating a new env')
+@click.option('--repo', help='Select repo. Possible options include: core, extras, and marketplace')
 @click.pass_context
 def test(
     ctx,
@@ -77,6 +78,7 @@ def test(
     force_base_unpinned,
     force_base_min,
     force_env_rebuild,
+    repo,
 ):
     """Run tests for Agent-based checks.
 
@@ -276,7 +278,7 @@ def test(
                 if not cov_keep:
                     echo_info('\n---------- Coverage report ----------\n')
 
-                    result = run_command('coverage report --rcfile=../.coveragerc')
+                    result = run_command('coverage report --rcfile=../.coveragerc --fail-under=1')
                     if result.code:
                         abort('\nFailed!', code=result.code)
 
@@ -286,7 +288,9 @@ def test(
                         abort('\nFailed!', code=result.code)
 
                     fix_coverage_report(check, 'coverage.xml')
-                    run_command(['codecov', '-X', 'gcov', '--root', root, '-F', check, '-f', 'coverage.xml'])
+
+                    if repo == 'core':
+                        run_command(['codecov', '-X', 'gcov', '--root', root, '-F', check, '-f', 'coverage.xml'])
                 else:
                     if not cov_keep:
                         remove_path('.coverage')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -278,7 +278,12 @@ def test(
                 if not cov_keep:
                     echo_info('\n---------- Coverage report ----------\n')
 
-                    result = run_command('coverage report --rcfile=../.coveragerc --fail-under=1')
+                    # Marketplace PRs should fail CI if coverage is not greater than 0
+                    if repo == 'marketplace':
+                        result = run_command('coverage report --rcfile=../.coveragerc --fail-under=1')
+                    else:
+                        result = run_command('coverage report --rcfile=../.coveragerc')
+
                     if result.code:
                         abort('\nFailed!', code=result.code)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -50,7 +50,6 @@ def display_envs(check_envs):
 @click.option('--force-base-unpinned', is_flag=True, help='Force using datadog-checks-base as specified by check dep')
 @click.option('--force-base-min', is_flag=True, help='Force using lowest viable release version of datadog-checks-base')
 @click.option('--force-env-rebuild', is_flag=True, help='Force creating a new env')
-@click.option('--repo', help='Select repo. Possible options include: core, extras, and marketplace')
 @click.pass_context
 def test(
     ctx,
@@ -78,7 +77,6 @@ def test(
     force_base_unpinned,
     force_base_min,
     force_env_rebuild,
-    repo,
 ):
     """Run tests for Agent-based checks.
 
@@ -98,6 +96,7 @@ def test(
     root = get_root()
     testing_on_ci = running_on_ci()
     color = ctx.obj['color']
+    repo = ctx.obj['repo_name']
 
     # Implicitly track coverage
     if cov_missing:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -35,6 +35,7 @@ def display_envs(check_envs):
 @click.option('--ddtrace', is_flag=True, help='Run tests using dd-trace-py')
 @click.option('--cov', '-c', 'coverage', is_flag=True, help='Measure code coverage')
 @click.option('--cov-missing', '-cm', is_flag=True, help='Show line numbers of statements that were not executed')
+@click.option('--min-cov', 'min_cov', default=1, type=int, help='Set minimum code coverage to pass for marketplace check. Default is 1')
 @click.option('--junit', '-j', 'junit', is_flag=True, help='Generate junit reports')
 @click.option('--marker', '-m', help='Only run tests matching given marker expression')
 @click.option('--filter', '-k', 'test_filter', help='Only run tests matching given substring expression')
@@ -61,6 +62,7 @@ def test(
     e2e,
     ddtrace,
     coverage,
+    min_cov,
     junit,
     cov_missing,
     marker,
@@ -279,7 +281,7 @@ def test(
 
                     # Marketplace PRs should fail CI if coverage is not greater than 0
                     if repo == 'marketplace':
-                        result = run_command('coverage report --rcfile=../.coveragerc --fail-under=1')
+                        result = run_command(f'coverage report --rcfile=../.coveragerc --fail-under={min_cov}')
                     else:
                         result = run_command('coverage report --rcfile=../.coveragerc')
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Marketplace CI will check for code coverage, but it doesn't use codecov. This PR allows codecov report to be generated only on core integrations. 

### Motivation
<!-- What inspired you to submit this pull request? -->
Add coverage for marketplace PRs.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
See https://github.com/DataDog/marketplace/pull/262
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
