### PR TITLE
Add `sysMultiHostCpuUsageRatio` to BIG-IP profile

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
@@ -97,6 +97,20 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.20.47.0
       name: sysGlobalHostSwapUsed
+  # CPU
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    table:
+      OID: 1.3.6.1.4.1.3375.2.1.7.5.2
+      name: sysMultiHostCpuTable
+    forced_type: gauge
+    symbols:
+      - OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.11
+        name: sysMultiHostCpuUsageRatio
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.3
+          name: sysMultiHostCpuId
+        tag: cpu
   - MIB: F5-BIGIP-SYSTEM-MIB
     table:
       OID: 1.3.6.1.4.1.3375.2.1.7.5.2
@@ -117,17 +131,6 @@ metrics:
         name: sysMultiHostCpuSoftirq
       - OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.10
         name: sysMultiHostCpuIowait
-    metric_tags:
-      - column:
-          OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.3
-          name: sysMultiHostCpuId
-        tag: cpu
-  - MIB: F5-BIGIP-SYSTEM-MIB
-    table:
-      OID: 1.3.6.1.4.1.3375.2.1.7.5.2
-      name: sysMultiHostCpuTable
-    symbols:
-        name: sysMultiHostCpuUsageRatio
     metric_tags:
       - column:
           OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.3

--- a/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
@@ -117,7 +117,16 @@ metrics:
         name: sysMultiHostCpuSoftirq
       - OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.10
         name: sysMultiHostCpuIowait
-      - OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.11
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.3
+          name: sysMultiHostCpuId
+        tag: cpu
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    table:
+      OID: 1.3.6.1.4.1.3375.2.1.7.5.2
+      name: sysMultiHostCpuTable
+    symbols:
         name: sysMultiHostCpuUsageRatio
     metric_tags:
       - column:

--- a/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
@@ -117,6 +117,8 @@ metrics:
         name: sysMultiHostCpuSoftirq
       - OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.10
         name: sysMultiHostCpuIowait
+      - OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.11
+        name: sysMultiHostCpuUsageRatio
     metric_tags:
       - column:
           OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.3

--- a/snmp/metadata.csv
+++ b/snmp/metadata.csv
@@ -211,6 +211,7 @@ snmp.sysGlobalTmmStatMemoryTotal,gauge,,byte,,[F5 BIG-IP] The total memory avail
 snmp.sysGlobalTmmStatMemoryUsed,gauge,,byte,,[F5 BIG-IP] The memory in use in bytes for TMM (Traffic Management Module).,0,snmp,
 snmp.sysMultiHostCpuIdle,gauge,,,,[F5 BIG-IP] The time spent by the specified processor doing nothing for the associated host.,0,snmp,
 snmp.sysMultiHostCpuIowait,gauge,,,,[F5 BIG-IP] The time spent by the specified processor waiting for external I/O to complete for the associated host.,0,snmp,
+snmp.sysMultiHostCpuUsageRatio,percent,,,,[F5 BIG-IP] This is usage ratio of CPU for the associated host.,0,snmp,
 snmp.sysMultiHostCpuIrq,gauge,,,,[F5 BIG-IP] The time spent by the specified processor servicing hardware interrupts for the associated host.,0,snmp,
 snmp.sysMultiHostCpuNice,gauge,,,,[F5 BIG-IP] The time spent by the specified processor running niced processes for the associated host.,0,snmp,
 snmp.sysMultiHostCpuSoftirq,gauge,,,,[F5 BIG-IP] The time spent by the specified processor servicing soft interrupts for the associated host.,0,snmp,

--- a/snmp/metadata.csv
+++ b/snmp/metadata.csv
@@ -211,7 +211,7 @@ snmp.sysGlobalTmmStatMemoryTotal,gauge,,byte,,[F5 BIG-IP] The total memory avail
 snmp.sysGlobalTmmStatMemoryUsed,gauge,,byte,,[F5 BIG-IP] The memory in use in bytes for TMM (Traffic Management Module).,0,snmp,
 snmp.sysMultiHostCpuIdle,gauge,,,,[F5 BIG-IP] The time spent by the specified processor doing nothing for the associated host.,0,snmp,
 snmp.sysMultiHostCpuIowait,gauge,,,,[F5 BIG-IP] The time spent by the specified processor waiting for external I/O to complete for the associated host.,0,snmp,
-snmp.sysMultiHostCpuUsageRatio,percent,,,,[F5 BIG-IP] This is usage ratio of CPU for the associated host.,0,snmp,
+snmp.sysMultiHostCpuUsageRatio,gauge,,fraction,,[F5 BIG-IP] This is usage ratio of CPU for the associated host.,0,snmp,
 snmp.sysMultiHostCpuIrq,gauge,,,,[F5 BIG-IP] The time spent by the specified processor servicing hardware interrupts for the associated host.,0,snmp,
 snmp.sysMultiHostCpuNice,gauge,,,,[F5 BIG-IP] The time spent by the specified processor running niced processes for the associated host.,0,snmp,
 snmp.sysMultiHostCpuSoftirq,gauge,,,,[F5 BIG-IP] The time spent by the specified processor servicing soft interrupts for the associated host.,0,snmp,

--- a/snmp/metadata.csv
+++ b/snmp/metadata.csv
@@ -211,7 +211,7 @@ snmp.sysGlobalTmmStatMemoryTotal,gauge,,byte,,[F5 BIG-IP] The total memory avail
 snmp.sysGlobalTmmStatMemoryUsed,gauge,,byte,,[F5 BIG-IP] The memory in use in bytes for TMM (Traffic Management Module).,0,snmp,
 snmp.sysMultiHostCpuIdle,gauge,,,,[F5 BIG-IP] The time spent by the specified processor doing nothing for the associated host.,0,snmp,
 snmp.sysMultiHostCpuIowait,gauge,,,,[F5 BIG-IP] The time spent by the specified processor waiting for external I/O to complete for the associated host.,0,snmp,
-snmp.sysMultiHostCpuUsageRatio,gauge,,fraction,,[F5 BIG-IP] This is usage ratio of CPU for the associated host.,0,snmp,
+snmp.sysMultiHostCpuUsageRatio,gauge,,percent,,[F5 BIG-IP] This is usage ratio of CPU for the associated host.,0,snmp,
 snmp.sysMultiHostCpuIrq,gauge,,,,[F5 BIG-IP] The time spent by the specified processor servicing hardware interrupts for the associated host.,0,snmp,
 snmp.sysMultiHostCpuNice,gauge,,,,[F5 BIG-IP] The time spent by the specified processor running niced processes for the associated host.,0,snmp,
 snmp.sysMultiHostCpuSoftirq,gauge,,,,[F5 BIG-IP] The time spent by the specified processor servicing soft interrupts for the associated host.,0,snmp,

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -64,7 +64,7 @@ def test_e2e_v3_explicit_version(dd_agent_check):
             'community_string': '',
         }
     )
-    assert_python_vs_core(dd_agent_check, config, expected_total_count=511 + 5)
+    assert_python_vs_core(dd_agent_check, config, expected_total_count=513 + 5)
 
 
 def test_e2e_regex_match(dd_agent_check):

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -47,7 +47,7 @@ def test_e2e_v3_version_autodetection(dd_agent_check):
             'community_string': '',
         }
     )
-    assert_python_vs_core(dd_agent_check, config, expected_total_count=513 + 5)
+    assert_python_vs_core(dd_agent_check, config, expected_total_count=515 + 5)
 
 
 def test_e2e_v3_explicit_version(dd_agent_check):
@@ -64,7 +64,7 @@ def test_e2e_v3_explicit_version(dd_agent_check):
             'community_string': '',
         }
     )
-    assert_python_vs_core(dd_agent_check, config, expected_total_count=513 + 5)
+    assert_python_vs_core(dd_agent_check, config, expected_total_count=515 + 5)
 
 
 def test_e2e_regex_match(dd_agent_check):

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -47,7 +47,7 @@ def test_e2e_v3_version_autodetection(dd_agent_check):
             'community_string': '',
         }
     )
-    assert_python_vs_core(dd_agent_check, config, expected_total_count=511 + 5)
+    assert_python_vs_core(dd_agent_check, config, expected_total_count=513 + 5)
 
 
 def test_e2e_v3_explicit_version(dd_agent_check):

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -300,6 +300,9 @@ def test_f5(aggregator):
         'sysMultiHostCpuSoftirq',
         'sysMultiHostCpuIowait',
     ]
+    cpu_gauges = [
+        'sysMultiHostCpuUsageRatio',
+    ]
 
     interfaces = [
         ('1.0', 'desc2'),
@@ -329,6 +332,9 @@ def test_f5(aggregator):
     for metric in cpu_rates:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=['cpu:0'] + tags, count=1)
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.RATE, tags=['cpu:1'] + tags, count=1)
+    for metric in cpu_gauges:
+        aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=['cpu:0'] + tags, count=1)
+        aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=['cpu:1'] + tags, count=1)
 
     for metric in IF_SCALAR_GAUGE:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -274,7 +274,6 @@ def test_f5(aggregator):
         'sysTcpStatTimeWait',
         'sysUdpStatOpen',
         'sysClientsslStatCurConns',
-        'sysMultiHostCpuUsageRatio',
     ]
     counts = [
         'sysTcpStatAccepts',

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -274,6 +274,7 @@ def test_f5(aggregator):
         'sysTcpStatTimeWait',
         'sysUdpStatOpen',
         'sysClientsslStatCurConns',
+        'sysMultiHostCpuUsageRatio',
     ]
     counts = [
         'sysTcpStatAccepts',
@@ -298,7 +299,6 @@ def test_f5(aggregator):
         'sysMultiHostCpuIrq',
         'sysMultiHostCpuSoftirq',
         'sysMultiHostCpuIowait',
-        'sysMultiHostCpuUsageRatio',
     ]
 
     interfaces = [

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -298,6 +298,7 @@ def test_f5(aggregator):
         'sysMultiHostCpuIrq',
         'sysMultiHostCpuSoftirq',
         'sysMultiHostCpuIowait',
+        'sysMultiHostCpuUsageRatio',
     ]
 
     interfaces = [


### PR DESCRIPTION
### What does this PR do?

Add `sysMultiHostCpuUsageRatio` to BIG-IP profile.

### Motivation

I think Getting CPU usage metric is common use case,
so adding `sysMultiHostCpuUsageRatio` to the example would be useful.

### Additional Notes

https://oidref.com/1.3.6.1.4.1.3375.2.1.7.5.2.1.11

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
