### PR TITLE
Bump base check requirement for JMX template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/setup.py
@@ -25,7 +25,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
 
 
 setup(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/setup.py
@@ -25,7 +25,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(


### PR DESCRIPTION
This is the version that will ship on 7.33 so it's the first one we can guarantee not to have the log4j issue.

Checks updated on: https://github.com/DataDog/integrations-core/pull/10926