### PR TITLE
Bump base check dependency

### DIFF
--- a/activemq/setup.py
+++ b/activemq/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.7.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/cassandra/setup.py
+++ b/cassandra/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/confluent_platform/setup.py
+++ b/confluent_platform/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/hazelcast/setup.py
+++ b/hazelcast/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/hive/setup.py
+++ b/hive/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/hivemq/setup.py
+++ b/hivemq/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/hudi/setup.py
+++ b/hudi/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/ignite/setup.py
+++ b/ignite/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/ignite/setup.py
+++ b/ignite/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.7.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
 
 
 setup(

--- a/jboss_wildfly/setup.py
+++ b/jboss_wildfly/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
 
 
 setup(

--- a/jboss_wildfly/setup.py
+++ b/jboss_wildfly/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/kafka/setup.py
+++ b/kafka/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/kafka/setup.py
+++ b/kafka/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.7.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
 
 
 setup(

--- a/presto/setup.py
+++ b/presto/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/presto/setup.py
+++ b/presto/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.7.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
 
 
 setup(

--- a/solr/setup.py
+++ b/solr/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/solr/setup.py
+++ b/solr/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.7.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
 
 
 setup(

--- a/sonarqube/setup.py
+++ b/sonarqube/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.8.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
 
 
 setup(

--- a/sonarqube/setup.py
+++ b/sonarqube/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/tomcat/setup.py
+++ b/tomcat/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/tomcat/setup.py
+++ b/tomcat/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.7.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
 
 
 setup(

--- a/weblogic/setup.py
+++ b/weblogic/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
 
 
 setup(

--- a/weblogic/setup.py
+++ b/weblogic/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.1.5'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
 
 
 setup(


### PR DESCRIPTION
This is the version that will ship on 7.33 so it's the first one we can guarantee not to have the log4j issue.

Template updated on:
https://github.com/DataDog/integrations-core/pull/10925