### PR TITLE
Generate example usage of custom config model validators

### DIFF
--- a/active_directory/datadog_checks/active_directory/config_models/validators.py
+++ b/active_directory/datadog_checks/active_directory/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/activemq/datadog_checks/activemq/config_models/validators.py
+++ b/activemq/datadog_checks/activemq/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/activemq_xml/datadog_checks/activemq_xml/config_models/validators.py
+++ b/activemq_xml/datadog_checks/activemq_xml/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/aerospike/datadog_checks/aerospike/config_models/validators.py
+++ b/aerospike/datadog_checks/aerospike/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/airflow/datadog_checks/airflow/config_models/validators.py
+++ b/airflow/datadog_checks/airflow/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/amazon_msk/datadog_checks/amazon_msk/config_models/validators.py
+++ b/amazon_msk/datadog_checks/amazon_msk/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/ambari/datadog_checks/ambari/config_models/validators.py
+++ b/ambari/datadog_checks/ambari/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/apache/datadog_checks/apache/config_models/validators.py
+++ b/apache/datadog_checks/apache/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/aspdotnet/datadog_checks/aspdotnet/config_models/validators.py
+++ b/aspdotnet/datadog_checks/aspdotnet/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/avi_vantage/datadog_checks/avi_vantage/config_models/validators.py
+++ b/avi_vantage/datadog_checks/avi_vantage/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/validators.py
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/btrfs/datadog_checks/btrfs/config_models/validators.py
+++ b/btrfs/datadog_checks/btrfs/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/cacti/datadog_checks/cacti/config_models/validators.py
+++ b/cacti/datadog_checks/cacti/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/cassandra/datadog_checks/cassandra/config_models/validators.py
+++ b/cassandra/datadog_checks/cassandra/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/cassandra_nodetool/datadog_checks/cassandra_nodetool/config_models/validators.py
+++ b/cassandra_nodetool/datadog_checks/cassandra_nodetool/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/ceph/datadog_checks/ceph/config_models/validators.py
+++ b/ceph/datadog_checks/ceph/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/cilium/datadog_checks/cilium/config_models/validators.py
+++ b/cilium/datadog_checks/cilium/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/cisco_aci/datadog_checks/cisco_aci/config_models/validators.py
+++ b/cisco_aci/datadog_checks/cisco_aci/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/citrix_hypervisor/datadog_checks/citrix_hypervisor/config_models/validators.py
+++ b/citrix_hypervisor/datadog_checks/citrix_hypervisor/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/clickhouse/datadog_checks/clickhouse/config_models/validators.py
+++ b/clickhouse/datadog_checks/clickhouse/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/config_models/validators.py
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/cockroachdb/datadog_checks/cockroachdb/config_models/validators.py
+++ b/cockroachdb/datadog_checks/cockroachdb/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/confluent_platform/datadog_checks/confluent_platform/config_models/validators.py
+++ b/confluent_platform/datadog_checks/confluent_platform/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/consul/datadog_checks/consul/config_models/validators.py
+++ b/consul/datadog_checks/consul/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/coredns/datadog_checks/coredns/config_models/validators.py
+++ b/coredns/datadog_checks/coredns/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/couch/datadog_checks/couch/config_models/validators.py
+++ b/couch/datadog_checks/couch/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/couchbase/datadog_checks/couchbase/config_models/validators.py
+++ b/couchbase/datadog_checks/couchbase/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/crio/datadog_checks/crio/config_models/validators.py
+++ b/crio/datadog_checks/crio/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/datadog_checks_base/tests/models/config_models/validators.py
+++ b/datadog_checks_base/tests/models/config_models/validators.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
-
 # Here you can include additional config validators or transformers
 #
 # def initialize_instance(values, **kwargs):

--- a/datadog_checks_base/tests/models/config_models/validators.py
+++ b/datadog_checks_base/tests/models/config_models/validators.py
@@ -1,3 +1,15 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/models.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/models.py
@@ -121,10 +121,11 @@ def models(ctx, check, sync, verbose):
             current_model_file_lines = []
             expected_model_file_lines = []
             if file_exists(model_file_path):
-                # No contents indicates a custom file
                 if not contents:
                     continue
-
+                if model_file == 'validators.py' and current_model_file_lines:
+                    # validators.py is a custom file, it should only be rendered the first time
+                    continue
                 current_model_file_lines.extend(read_file_lines(model_file_path))
 
                 for line in current_model_file_lines:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/models.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/models.py
@@ -120,13 +120,16 @@ def models(ctx, check, sync, verbose):
             model_file_lines = contents.splitlines(True)
             current_model_file_lines = []
             expected_model_file_lines = []
+
             if file_exists(model_file_path):
                 if not contents:
                     continue
-                if model_file == 'validators.py' and current_model_file_lines:
+
+                current_model_file_lines = read_file_lines(model_file_path)
+
+                if model_file == 'validators.py' and (len(current_model_file_lines) + 1) > len(license_header_lines):
                     # validators.py is a custom file, it should only be rendered the first time
                     continue
-                current_model_file_lines.extend(read_file_lines(model_file_path))
 
                 for line in current_model_file_lines:
                     if not line.startswith('#'):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model/model_consumer.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model/model_consumer.py
@@ -15,8 +15,6 @@ from datadog_checks.dev.tooling.configuration.consumers.openapi_document import 
 PYTHON_VERSION = PythonVersion.PY_38
 
 VALIDATORS_DOCUMENTATION = '''
-
-
 # Here you can include additional config validators or transformers
 #
 # def initialize_instance(values, **kwargs):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model/model_consumer.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model/model_consumer.py
@@ -14,6 +14,20 @@ from datadog_checks.dev.tooling.configuration.consumers.openapi_document import 
 
 PYTHON_VERSION = PythonVersion.PY_38
 
+VALIDATORS_DOCUMENTATION = '''
+
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values
+'''
+
 
 class ModelConsumer:
     def __init__(self, spec: dict, code_formatter: CodeFormatter = None):
@@ -124,13 +138,16 @@ class ModelConsumer:
             model_info,
         )
 
-    def _build_model_files(self, model_info: ModelInfo, package_info: List[Tuple[str, str]]):
+    def _build_model_files(
+        self, model_info: ModelInfo, package_info: List[Tuple[str, str]]
+    ) -> Dict[str, Tuple[str, List]]:
         """Builds the model files others than instace.py and shared.py
         In particular it builds, if relevant:
             - defaults.py
             - deprecations.py
             - __init__.py
             - validators.py
+        Returns a Dict[ file_name, Tuple[file_contents, List[errors])]
         """
         model_files = {}
         if model_info.defaults_file_lines:
@@ -145,7 +162,7 @@ class ModelConsumer:
         model_files['__init__.py'] = ('\n'.join(package_root_lines), [])
 
         # Custom
-        model_files['validators.py'] = ('', [])
+        model_files['validators.py'] = (VALIDATORS_DOCUMENTATION, [])
         return model_files
 
     def _merge_instances(self, section: dict, errors: List[str]) -> dict:

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/validators.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/directory/datadog_checks/directory/config_models/validators.py
+++ b/directory/datadog_checks/directory/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/disk/datadog_checks/disk/config_models/validators.py
+++ b/disk/datadog_checks/disk/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/dns_check/datadog_checks/dns_check/config_models/validators.py
+++ b/dns_check/datadog_checks/dns_check/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/dotnetclr/datadog_checks/dotnetclr/config_models/validators.py
+++ b/dotnetclr/datadog_checks/dotnetclr/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/druid/datadog_checks/druid/config_models/validators.py
+++ b/druid/datadog_checks/druid/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/ecs_fargate/datadog_checks/ecs_fargate/config_models/validators.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/eks_fargate/datadog_checks/eks_fargate/config_models/validators.py
+++ b/eks_fargate/datadog_checks/eks_fargate/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/elastic/datadog_checks/elastic/config_models/validators.py
+++ b/elastic/datadog_checks/elastic/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/envoy/datadog_checks/envoy/config_models/validators.py
+++ b/envoy/datadog_checks/envoy/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/etcd/datadog_checks/etcd/config_models/validators.py
+++ b/etcd/datadog_checks/etcd/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/exchange_server/datadog_checks/exchange_server/config_models/validators.py
+++ b/exchange_server/datadog_checks/exchange_server/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/external_dns/datadog_checks/external_dns/config_models/validators.py
+++ b/external_dns/datadog_checks/external_dns/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/fluentd/datadog_checks/fluentd/config_models/validators.py
+++ b/fluentd/datadog_checks/fluentd/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/gearmand/datadog_checks/gearmand/config_models/validators.py
+++ b/gearmand/datadog_checks/gearmand/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/gitlab/datadog_checks/gitlab/config_models/validators.py
+++ b/gitlab/datadog_checks/gitlab/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/gitlab_runner/datadog_checks/gitlab_runner/config_models/validators.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/glusterfs/datadog_checks/glusterfs/config_models/validators.py
+++ b/glusterfs/datadog_checks/glusterfs/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/go_expvar/datadog_checks/go_expvar/config_models/validators.py
+++ b/go_expvar/datadog_checks/go_expvar/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/gunicorn/datadog_checks/gunicorn/config_models/validators.py
+++ b/gunicorn/datadog_checks/gunicorn/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/harbor/datadog_checks/harbor/config_models/validators.py
+++ b/harbor/datadog_checks/harbor/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/hazelcast/datadog_checks/hazelcast/config_models/validators.py
+++ b/hazelcast/datadog_checks/hazelcast/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/config_models/validators.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/config_models/validators.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/hive/datadog_checks/hive/config_models/validators.py
+++ b/hive/datadog_checks/hive/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/hivemq/datadog_checks/hivemq/config_models/validators.py
+++ b/hivemq/datadog_checks/hivemq/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/http_check/datadog_checks/http_check/config_models/validators.py
+++ b/http_check/datadog_checks/http_check/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/hudi/datadog_checks/hudi/config_models/validators.py
+++ b/hudi/datadog_checks/hudi/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/hyperv/datadog_checks/hyperv/config_models/validators.py
+++ b/hyperv/datadog_checks/hyperv/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/ibm_db2/datadog_checks/ibm_db2/config_models/validators.py
+++ b/ibm_db2/datadog_checks/ibm_db2/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/ibm_i/datadog_checks/ibm_i/config_models/validators.py
+++ b/ibm_i/datadog_checks/ibm_i/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/ibm_mq/datadog_checks/ibm_mq/config_models/validators.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/ibm_was/datadog_checks/ibm_was/config_models/validators.py
+++ b/ibm_was/datadog_checks/ibm_was/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/ignite/datadog_checks/ignite/config_models/validators.py
+++ b/ignite/datadog_checks/ignite/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/iis/datadog_checks/iis/config_models/validators.py
+++ b/iis/datadog_checks/iis/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/jboss_wildfly/datadog_checks/jboss_wildfly/config_models/validators.py
+++ b/jboss_wildfly/datadog_checks/jboss_wildfly/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/kafka/datadog_checks/kafka/config_models/validators.py
+++ b/kafka/datadog_checks/kafka/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/validators.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/validators.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/kube_scheduler/datadog_checks/kube_scheduler/config_models/validators.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/kyototycoon/datadog_checks/kyototycoon/config_models/validators.py
+++ b/kyototycoon/datadog_checks/kyototycoon/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/lighttpd/datadog_checks/lighttpd/config_models/validators.py
+++ b/lighttpd/datadog_checks/lighttpd/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/linux_proc_extras/datadog_checks/linux_proc_extras/config_models/validators.py
+++ b/linux_proc_extras/datadog_checks/linux_proc_extras/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/mapr/datadog_checks/mapr/config_models/validators.py
+++ b/mapr/datadog_checks/mapr/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/mapreduce/datadog_checks/mapreduce/config_models/validators.py
+++ b/mapreduce/datadog_checks/mapreduce/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/marathon/datadog_checks/marathon/config_models/validators.py
+++ b/marathon/datadog_checks/marathon/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/marklogic/datadog_checks/marklogic/config_models/validators.py
+++ b/marklogic/datadog_checks/marklogic/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/mcache/datadog_checks/mcache/config_models/validators.py
+++ b/mcache/datadog_checks/mcache/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/mesos_master/datadog_checks/mesos_master/config_models/validators.py
+++ b/mesos_master/datadog_checks/mesos_master/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/mesos_slave/datadog_checks/mesos_slave/config_models/validators.py
+++ b/mesos_slave/datadog_checks/mesos_slave/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/nagios/datadog_checks/nagios/config_models/validators.py
+++ b/nagios/datadog_checks/nagios/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/network/datadog_checks/network/config_models/validators.py
+++ b/network/datadog_checks/network/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/nfsstat/datadog_checks/nfsstat/config_models/validators.py
+++ b/nfsstat/datadog_checks/nfsstat/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/nginx/datadog_checks/nginx/config_models/validators.py
+++ b/nginx/datadog_checks/nginx/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/validators.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/openldap/datadog_checks/openldap/config_models/validators.py
+++ b/openldap/datadog_checks/openldap/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/pdh_check/datadog_checks/pdh_check/config_models/validators.py
+++ b/pdh_check/datadog_checks/pdh_check/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/pgbouncer/datadog_checks/pgbouncer/config_models/validators.py
+++ b/pgbouncer/datadog_checks/pgbouncer/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/postfix/datadog_checks/postfix/config_models/validators.py
+++ b/postfix/datadog_checks/postfix/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/config_models/validators.py
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/presto/datadog_checks/presto/config_models/validators.py
+++ b/presto/datadog_checks/presto/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/process/datadog_checks/process/config_models/validators.py
+++ b/process/datadog_checks/process/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/proxysql/datadog_checks/proxysql/config_models/validators.py
+++ b/proxysql/datadog_checks/proxysql/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/rabbitmq/datadog_checks/rabbitmq/config_models/validators.py
+++ b/rabbitmq/datadog_checks/rabbitmq/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/redisdb/datadog_checks/redisdb/config_models/validators.py
+++ b/redisdb/datadog_checks/redisdb/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/rethinkdb/datadog_checks/rethinkdb/config_models/validators.py
+++ b/rethinkdb/datadog_checks/rethinkdb/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/riak/datadog_checks/riak/config_models/validators.py
+++ b/riak/datadog_checks/riak/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/riakcs/datadog_checks/riakcs/config_models/validators.py
+++ b/riakcs/datadog_checks/riakcs/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/sap_hana/datadog_checks/sap_hana/config_models/validators.py
+++ b/sap_hana/datadog_checks/sap_hana/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/scylla/datadog_checks/scylla/config_models/validators.py
+++ b/scylla/datadog_checks/scylla/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/singlestore/datadog_checks/singlestore/config_models/validators.py
+++ b/singlestore/datadog_checks/singlestore/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/solr/datadog_checks/solr/config_models/validators.py
+++ b/solr/datadog_checks/solr/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/sonarqube/datadog_checks/sonarqube/config_models/validators.py
+++ b/sonarqube/datadog_checks/sonarqube/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/spark/datadog_checks/spark/config_models/validators.py
+++ b/spark/datadog_checks/spark/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/sqlserver/datadog_checks/sqlserver/config_models/validators.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/squid/datadog_checks/squid/config_models/validators.py
+++ b/squid/datadog_checks/squid/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/ssh_check/datadog_checks/ssh_check/config_models/validators.py
+++ b/ssh_check/datadog_checks/ssh_check/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/statsd/datadog_checks/statsd/config_models/validators.py
+++ b/statsd/datadog_checks/statsd/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/system_core/datadog_checks/system_core/config_models/validators.py
+++ b/system_core/datadog_checks/system_core/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/system_swap/datadog_checks/system_swap/config_models/validators.py
+++ b/system_swap/datadog_checks/system_swap/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/tcp_check/datadog_checks/tcp_check/config_models/validators.py
+++ b/tcp_check/datadog_checks/tcp_check/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/teamcity/datadog_checks/teamcity/config_models/validators.py
+++ b/teamcity/datadog_checks/teamcity/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/tls/datadog_checks/tls/config_models/validators.py
+++ b/tls/datadog_checks/tls/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/tomcat/datadog_checks/tomcat/config_models/validators.py
+++ b/tomcat/datadog_checks/tomcat/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/twemproxy/datadog_checks/twemproxy/config_models/validators.py
+++ b/twemproxy/datadog_checks/twemproxy/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/twistlock/datadog_checks/twistlock/config_models/validators.py
+++ b/twistlock/datadog_checks/twistlock/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/varnish/datadog_checks/varnish/config_models/validators.py
+++ b/varnish/datadog_checks/varnish/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/vault/datadog_checks/vault/config_models/validators.py
+++ b/vault/datadog_checks/vault/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/vertica/datadog_checks/vertica/config_models/validators.py
+++ b/vertica/datadog_checks/vertica/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/voltdb/datadog_checks/voltdb/config_models/validators.py
+++ b/voltdb/datadog_checks/voltdb/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/weblogic/datadog_checks/weblogic/config_models/validators.py
+++ b/weblogic/datadog_checks/weblogic/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/windows_performance_counters/datadog_checks/windows_performance_counters/config_models/validators.py
+++ b/windows_performance_counters/datadog_checks/windows_performance_counters/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/windows_service/datadog_checks/windows_service/config_models/validators.py
+++ b/windows_service/datadog_checks/windows_service/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/wmi_check/datadog_checks/wmi_check/config_models/validators.py
+++ b/wmi_check/datadog_checks/wmi_check/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/yarn/datadog_checks/yarn/config_models/validators.py
+++ b/yarn/datadog_checks/yarn/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values

--- a/zk/datadog_checks/zk/config_models/validators.py
+++ b/zk/datadog_checks/zk/config_models/validators.py
@@ -1,3 +1,13 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+
+# Here you can include additional config validators or transformers
+#
+# def initialize_instance(values, **kwargs):
+#     if 'my_option' not in values and 'my_legacy_option' in values:
+#         values['my_option'] = values['my_legacy_option']
+#     if values.get('my_number') > 10:
+#         raise ValueError('my_number max value is 10, got %s' % str(values.get('my_number')))
+#
+#     return values


### PR DESCRIPTION
Add documentation on validators.py:

* when the file does not exist
* when the file only contains the license header