### PR TITLE
Bump base package dependency

### DIFF
--- a/active_directory/setup.py
+++ b/active_directory/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.7.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.3.2'
 
 setup(
     name='datadog-active_directory',

--- a/aspdotnet/setup.py
+++ b/aspdotnet/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.3.2'
 
 setup(
     name='datadog-aspdotnet',

--- a/dotnetclr/setup.py
+++ b/dotnetclr/setup.py
@@ -25,7 +25,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.8.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.3.2'
 
 setup(
     name='datadog-dotnetclr',

--- a/elastic/setup.py
+++ b/elastic/setup.py
@@ -29,7 +29,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=15.0.0'
 
 setup(
     name='datadog-elastic',

--- a/exchange_server/setup.py
+++ b/exchange_server/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.3.2'
 
 setup(
     name='datadog-exchange_server',

--- a/nginx/setup.py
+++ b/nginx/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=22.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=23.1.1'
 
 setup(
     name='datadog-nginx',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Bump base package for integration broken in the nightly base CI

* Windows integration bumping to `23.3.2` for windows performance counter
* `elastic` to `15.0.0` for `assert_metrics_using_metadata`
* `nginx` to `23.1.1` for `remove server from generic tag list`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

