### PR TITLE
add a note on how to restrict datadog user login to specific hosts

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -25,7 +25,9 @@ The MySQL check is included in the [Datadog Agent][4] package. No additional ins
 
 #### Prepare MySQL
 
-On each MySQL server, create a database user for the Datadog Agent:
+On each MySQL server, create a database user for the Datadog Agent.
+
+The following instructions grant the Agent permission to login from any host using `datadog@'%'`. You can restrict the `datadog` user to be allowed to login only from localhost by using `datadog@'localhost'`. See the [MySQL documentation][5] for more info.
 
 ```shell
 mysql> CREATE USER 'datadog'@'%' IDENTIFIED BY '<UNIQUEPASSWORD>';


### PR DESCRIPTION
### What does this PR do?

Follow-up to https://github.com/DataDog/integrations-core/pull/10861

Update to match what we say in https://docs.datadoghq.com/database_monitoring/setup_mysql/selfhosted/

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
