### PR TITLE
fix dangling connection on unhandled exception bug

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -77,8 +77,10 @@ class Connection(object):
     @contextmanager
     def get_managed_cursor(self, key_prefix=None):
         cursor = self.get_cursor(self.DEFAULT_DB_KEY, key_prefix=key_prefix)
-        yield cursor
-        self.close_cursor(cursor)
+        try:
+            yield cursor
+        finally:
+            self.close_cursor(cursor)
 
     def get_cursor(self, db_key, db_name=None, key_prefix=None):
         """
@@ -129,8 +131,10 @@ class Connection(object):
     @contextmanager
     def _open_managed_db_connections(self, db_key, db_name=None, key_prefix=None):
         self.open_db_connections(db_key, db_name, key_prefix=key_prefix)
-        yield
-        self.close_db_connections(db_key, db_name, key_prefix=key_prefix)
+        try:
+            yield
+        finally:
+            self.close_db_connections(db_key, db_name, key_prefix=key_prefix)
 
     def open_db_connections(self, db_key, db_name=None, is_default=True, key_prefix=None):
         """

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -138,23 +138,21 @@ def test_connection_cleanup(instance_docker):
     assert len(check.connection._conns) == 0, "connection should have been closed"
 
     # db exception
-    try:
+    with pytest.raises(Exception) as e:
         with check.connection.open_managed_default_connection():
             assert len(check.connection._conns) == 1
             with check.connection.get_managed_cursor() as cursor:
                 assert len(check.connection._conns) == 1
                 cursor.execute("gimme some data")
-    except Exception as e:
-        assert "incorrect syntax" in str(e).lower()
-        assert len(check.connection._conns) == 0, "connection should have been closed"
+    assert "incorrect syntax" in str(e).lower()
+    assert len(check.connection._conns) == 0, "connection should have been closed"
 
     # application exception
-    try:
+    with pytest.raises(Exception) as e:
         with check.connection.open_managed_default_connection():
             assert len(check.connection._conns) == 1
             with check.connection.get_managed_cursor():
                 assert len(check.connection._conns) == 1
                 raise Exception("oops")
-    except Exception as e:
-        assert "oops" in str(e)
-        assert len(check.connection._conns) == 0, "connection should have been closed"
+    assert "oops" in str(e)
+    assert len(check.connection._conns) == 0, "connection should have been closed"

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -120,3 +120,41 @@ def _run_test_query_timeout(aggregator, dd_run_check, instance):
 
                     assert type(e) == adodbapi.apibase.DatabaseError
                     assert 'timeout' in "".join(e.args).lower(), "must be a timeout"
+
+
+@not_windows_ci
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_connection_cleanup(instance_docker):
+    check = SQLServer(CHECK_NAME, {}, [instance_docker])
+    check.initialize_connection()
+
+    # regular operation
+    with check.connection.open_managed_default_connection():
+        assert len(check.connection._conns) == 1
+        with check.connection.get_managed_cursor() as cursor:
+            cursor.execute("select 1")
+            assert len(check.connection._conns) == 1
+    assert len(check.connection._conns) == 0, "connection should have been closed"
+
+    # db exception
+    try:
+        with check.connection.open_managed_default_connection():
+            assert len(check.connection._conns) == 1
+            with check.connection.get_managed_cursor() as cursor:
+                assert len(check.connection._conns) == 1
+                cursor.execute("gimme some data")
+    except Exception as e:
+        assert "incorrect syntax" in str(e).lower()
+        assert len(check.connection._conns) == 0, "connection should have been closed"
+
+    # application exception
+    try:
+        with check.connection.open_managed_default_connection():
+            assert len(check.connection._conns) == 1
+            with check.connection.get_managed_cursor():
+                assert len(check.connection._conns) == 1
+                raise Exception("oops")
+    except Exception as e:
+        assert "oops" in str(e)
+        assert len(check.connection._conns) == 0, "connection should have been closed"


### PR DESCRIPTION
### What does this PR do?

Wrap `yield` with try/finally in connection & cursor context manager to avoid leaving a dangling open connection in case of a database or application exception getting thrown.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
