### PR TITLE
Add plan handle to the plan event 

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -386,5 +386,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     'sqlserver': {
                         'query_hash': row['query_hash'],
                         'query_plan_hash': row['query_plan_hash'],
+                        'plan_handle': row['plan_handle'],
                     },
                 }


### PR DESCRIPTION
### What does this PR do?

Adds the query plan handle to the plan event.

### Motivation

This will allow users to use the plan outside of Datadog by looking it up directly in the DB.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
