### PR TITLE
improve common tracing instrumentation

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import datetime
 import decimal
+import functools
 import logging
 import os
 import socket
@@ -38,6 +39,27 @@ SUBMISSION_METHODS = {
     # and a value and therefore must be defined as a custom transformer.
     'service_check': '__service_check',
 }
+
+
+def _traced_dbm_async_job_method(f):
+    # traces DBMAsyncJob.run_job only if tracing is enabled
+    if os.getenv('DDEV_TRACE_ENABLED', 'false') == 'true':
+        try:
+            from ddtrace import tracer
+
+            @functools.wraps(f)
+            def wrapper(self, *args, **kwargs):
+                with tracer.trace(
+                    "run",
+                    service="{}-integration".format(self._check.name),
+                    resource="{}.run_job".format(type(self).__name__),
+                ):
+                    self.run_job()
+
+            return wrapper
+        except Exception:
+            return f
+    return f
 
 
 def create_submission_transformer(submit_method):
@@ -273,8 +295,12 @@ class DBMAsyncJob(object):
             self._rate_limiter = ConstantRateLimiter(rate_limit)
 
     def _run_job_rate_limited(self):
-        self.run_job()
+        self._run_job_traced()
         self._rate_limiter.sleep()
+
+    @_traced_dbm_async_job_method
+    def _run_job_traced(self):
+        return self.run_job()
 
     def run_job(self):
         raise NotImplementedError()

--- a/datadog_checks_base/tests/base/utils/test_tracing.py
+++ b/datadog_checks_base/tests/base/utils/test_tracing.py
@@ -71,7 +71,7 @@ def test_traced(aggregator, agent_config, init_config, called):
         check.check({})
 
         if called:
-            tracer.trace.assert_called_once_with('dummy', service='integrations-tracing', resource='check')
+            tracer.trace.assert_called_once_with('check', service='dummy-integration', resource='check')
         else:
             tracer.trace.assert_not_called()
         aggregator.assert_metric('dummy.metric', 10, count=1)
@@ -90,8 +90,8 @@ def test_traced_class(traces_enabled):
         if os.environ['DDEV_TRACE_ENABLED'] == 'true':
             tracer.trace.assert_has_calls(
                 [
-                    mock.call('__init__', resource='__init__'),
-                    mock.call('check', resource='check'),
+                    mock.call('__init__', resource='__init__', service='dummy-integration'),
+                    mock.call('check', resource='check', service='dummy-integration'),
                 ],
                 any_order=True,
             )


### PR DESCRIPTION
### What does this PR do?

* set `service` to be `{integration name}-integration` (i.e. `sqlserver-integration`). Previously the service name was left empty meaning we would get default service names like `unnamed-python-service`.
* add tracing for `DBMAsyncJob.run_job`. It uses the same `run` operation name as the main check run method, meaning when that operation name is selected, the list of resources will show `run` with an additional entry for each `DBMAsyncJob`.

### Motivation

Improve APM instrumentation for integrations. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
