### PR TITLE
Don't run validations on CI on PRs to the base check

### DIFF
--- a/.azure-pipelines/templates/test-all.yml
+++ b/.azure-pipelines/templates/test-all.yml
@@ -44,5 +44,5 @@ jobs:
 
       # Avoid max step limits
       ${{ if eq(check.checkName, 'datadog_checks_base') }}:
-        validate: true
+        validate: false
         validate_changed: all


### PR DESCRIPTION
### What does this PR do?
- Don't validate on CI on PRs to the base check

### Motivation
- We removed validation on Azure pipelines in most places but not in the specific case of making a PR to the base check
- Validation failures for other checks shouldn't block merging changes to the base check

### Additional Notes
Later investigate removing this entire block
```
${{ if eq(check.checkName, 'datadog_checks_base') }}:
        validate: false
        validate_changed: all
```
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
