### PR TITLE
Print the diff when the example file isn’t in sync with the spec

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import difflib
+
 import click
 import yaml
 
@@ -123,6 +125,12 @@ def config(ctx, check, sync, verbose):
                         else:
                             files_failed[example_file_path] = True
                             message = f'File `{example_file}` is not in sync, run "ddev validate config -s"'
+                            if file_exists(example_file_path):
+                                example_file = read_file(example_file_path)
+                                for diff_line in difflib.context_diff(
+                                    example_file.splitlines(), contents.splitlines(), "current", "expected"
+                                ):
+                                    message += f'\n{diff_line}'
                             check_display_queue.append(
                                 lambda example_file=example_file, **kwargs: echo_failure(message, **kwargs)
                             )


### PR DESCRIPTION
### What does this PR do?

Make the CI print its expectation when an example file isn’t in sync with the spec.

[Before](https://github.com/DataDog/integrations-core/runs/4648947989?check_suite_focus=true):
![image](https://user-images.githubusercontent.com/1437785/147557766-35b48177-dc24-4455-ae53-bc50ccb950b1.png)

[After](https://github.com/DataDog/integrations-core/runs/4649184862?check_suite_focus=true):
![image](https://user-images.githubusercontent.com/1437785/147557840-1813eeb1-fcd9-4421-a100-c135c4ce5dca.png)

### Motivation

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
