### PR TITLE
[docs] EKS Fargate Logging Documentation: Fix `auto_create_group` value in FluentBit ConfigMap

### DIFF
--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -284,7 +284,7 @@ Monitor EKS Fargate logs by using [Fluent Bit][22] to route EKS logs to CloudWat
             region us-east-1
             log_group_name awslogs-https
             log_stream_prefix awslogs-firelens-example
-            auto_create_group On
+            auto_create_group true
    ```
 2. Use the [Datadog Forwarder][23] to collect logs from Cloudwatch and send them to Datadog.
 


### PR DESCRIPTION
### What does this PR do?

Fixes the `auto_create_group` value from `On` to `true`. See [docs](https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch)

### Motivation

Working to get EKS Fargate logs into DD. Having copy/pasted this ConfigMap, kubectl wouldn't apply it, responding with an error like "auto_create_group value invalid"

### Additional Notes

To truly get  EKS Fargate logs working, I had to do a bit more, mostly outlined in the [EKS Fargate Logging docs](https://docs.aws.amazon.com/eks/latest/userguide/fargate-logging.html). Most specifically, I needed to create a policy giving the pod execution role abilities to deal with Cloudwatch (write entries, create log groups/streams, etc). I'm happy to write these steps down in this PR if y'all feel it's necessary to improve the documentation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
