### PR TITLE
run SQL Server in docker for windows integration tests

### DIFF
--- a/.azure-pipelines/scripts/sqlserver/windows/40_install_sqlserver.py
+++ b/.azure-pipelines/scripts/sqlserver/windows/40_install_sqlserver.py
@@ -4,19 +4,9 @@ from tenacity import wait_exponential, retry, stop_after_attempt
 
 
 @retry(wait=wait_exponential(min=2, max=60), stop=stop_after_attempt(5))
-def install_sqlserver():
-    """
-    Install with TCP/IP enabled, see: https://chocolatey.org/packages/sql-server-2017
-    """
-    print("Install sql-server-2017 ...")
-    subprocess.run(["choco", "install", "sql-server-2017", "--no-progress", "--params", "'/TCPENABLED:1'"], check=True)
-
-
-@retry(wait=wait_exponential(min=2, max=60), stop=stop_after_attempt(5))
 def install_msoledbsql():
     print("Install Microsoft OLE DB Driver for SQL Server ...")
     subprocess.run(["choco", "install", "msoledbsql", "--no-progress", "-y"], check=True)
 
 
-install_sqlserver()
 install_msoledbsql()

--- a/.azure-pipelines/scripts/sqlserver/windows/55_setup_sqlserver.bat
+++ b/.azure-pipelines/scripts/sqlserver/windows/55_setup_sqlserver.bat
@@ -1,9 +1,0 @@
-:: Setup SQL Server
-sqlcmd -f 65001 -i %~dp0\_sqlserver_setup.sql
-
-:: Enable port
-powershell -Command "stop-service MSSQLSERVER"
-powershell -Command "set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.MSSQLSERVER\mssqlserver\supersocketnetlib\tcp\ipall' -name tcpdynamicports -value ''"
-powershell -Command "set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.MSSQLSERVER\mssqlserver\supersocketnetlib\tcp\ipall' -name tcpport -value 1433"
-powershell -Command "set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql14.MSSQLSERVER\mssqlserver\' -name LoginMode -value 2"
-powershell -Command "start-service MSSQLSERVER"

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -39,7 +39,6 @@ def get_local_driver():
 HOST = get_docker_hostname()
 PORT = 1433
 DOCKER_SERVER = '{},{}'.format(HOST, PORT)
-LOCAL_SERVER = 'localhost,{}'.format(PORT)
 HERE = get_here()
 CHECK_NAME = "sqlserver"
 
@@ -72,20 +71,27 @@ EXPECTED_AO_METRICS_PRIMARY = [m[0] for m in AO_METRICS_PRIMARY]
 EXPECTED_AO_METRICS_SECONDARY = [m[0] for m in AO_METRICS_SECONDARY]
 EXPECTED_AO_METRICS_COMMON = [m[0] for m in AO_METRICS]
 
-INSTANCE_DOCKER = {
+INSTANCE_DOCKER_DEFAULTS = {
     'host': '{},1433'.format(HOST),
     'connector': 'odbc',
     'driver': get_local_driver(),
     'username': 'datadog',
     'password': 'Password12!',
-    'tags': ['optional:tag1'],
-    'include_task_scheduler_metrics': True,
-    'include_db_fragmentation_metrics': True,
-    'include_fci_metrics': True,
-    'include_ao_metrics': False,
-    'include_master_files_metrics': True,
     'disable_generic_tags': True,
+    'tags': ['optional:tag1'],
 }
+
+INSTANCE_DOCKER = INSTANCE_DOCKER_DEFAULTS.copy()
+INSTANCE_DOCKER.update(
+    {
+        'include_task_scheduler_metrics': True,
+        'include_db_fragmentation_metrics': True,
+        'include_fci_metrics': True,
+        'include_ao_metrics': False,
+        'include_master_files_metrics': True,
+        'disable_generic_tags': True,
+    }
+)
 
 INSTANCE_AO_DOCKER_SECONDARY = {
     'host': '{},1434'.format(HOST),
@@ -114,7 +120,7 @@ INSTANCE_E2E = INSTANCE_DOCKER.copy()
 INSTANCE_E2E['driver'] = 'FreeTDS'
 
 INSTANCE_SQL_DEFAULTS = {
-    'host': LOCAL_SERVER,
+    'host': DOCKER_SERVER,
     'username': 'sa',
     'password': 'Password12!',
     'disable_generic_tags': True,
@@ -186,9 +192,9 @@ INIT_CONFIG_ALT_TABLES = {
             'columns': ['num_of_reads', 'num_of_writes'],
         },
         {
-            'name': 'sqlserver.MEMORYCLERK_BITMAP',
+            'name': 'sqlserver.MEMORYCLERK_SQLGENERAL',
             'table': 'sys.dm_os_memory_clerks',
-            'counter_name': 'MEMORYCLERK_BITMAP',
+            'counter_name': 'MEMORYCLERK_SQLGENERAL',
             'columns': ['virtual_memory_reserved_kb', 'virtual_memory_committed_kb'],
         },
     ]

--- a/sqlserver/tests/compose-windows/Dockerfile
+++ b/sqlserver/tests/compose-windows/Dockerfile
@@ -1,0 +1,12 @@
+ARG SQLSERVER_BASE_IMAGE
+
+FROM $SQLSERVER_BASE_IMAGE
+
+COPY sqlserver-setup.ps1 sqlserver-setup.ps1
+RUN powershell -F .\sqlserver-setup.ps1
+
+COPY setup.sql setup.sql
+RUN sqlcmd -d master -i setup.sql -b -f 65001
+
+COPY sqlserver-entrypoint.ps1 sqlserver-entrypoint.ps1
+CMD powershell -F .\sqlserver-entrypoint.ps1

--- a/sqlserver/tests/compose-windows/docker-compose.yaml
+++ b/sqlserver/tests/compose-windows/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  sqlserver:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - SQLSERVER_BASE_IMAGE=${SQLSERVER_BASE_IMAGE}
+    ports:
+      - "1433:1433"

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -1,11 +1,6 @@
--- this setup is the same as the setup done for the docker-based sql server tests in the sqlserver integration
-ALTER LOGIN sa with PASSWORD = 'Password12!';
-ALTER LOGIN sa ENABLE;
-
 -- datadog user
 CREATE LOGIN datadog WITH PASSWORD = 'Password12!';
-CREATE USER datadog FOR LOGIN datadog;
-GRANT SELECT on sys.dm_os_performance_counters to datadog;
+CREATE USER datadog FOR LOGIN datadog;GRANT SELECT on sys.dm_os_performance_counters to datadog;
 GRANT VIEW SERVER STATE to datadog;
 GRANT CONNECT ANY DATABASE to datadog;
 GRANT VIEW ANY DEFINITION to datadog;
@@ -14,16 +9,18 @@ GRANT VIEW ANY DEFINITION to datadog;
 CREATE LOGIN bob WITH PASSWORD = 'Password12!';
 CREATE USER bob FOR LOGIN bob;
 GRANT CONNECT ANY DATABASE to bob;
-
 CREATE LOGIN fred WITH PASSWORD = 'Password12!';
 CREATE USER fred FOR LOGIN fred;
 GRANT CONNECT ANY DATABASE to fred;
+GO
 
 -- Create test database for integration tests
--- only bob and fred has read/write access to this database
+-- only bob and fred have read/write access to this database
 CREATE DATABASE datadog_test;
 GO
 USE datadog_test;
+-- This table is pronounced "things" except we've replaced "th" with the greek lower case "theta" to ensure we
+-- correctly support unicode throughout the integration.
 CREATE TABLE datadog_test.dbo.ϑings (id int, name varchar(255));
 INSERT INTO datadog_test.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
 CREATE USER bob FOR LOGIN bob;
@@ -40,19 +37,19 @@ USE master;
 GO
 CREATE PROCEDURE pyStoredProc AS
 BEGIN
-CREATE TABLE #Datadog
-(
-    [metric] varchar(255) not null,
-    [type] varchar(50) not null,
-    [value] float not null,
-    [tags] varchar(255)
+    CREATE TABLE #Datadog
+    (
+        [metric] varchar(255) not null,
+        [type] varchar(50) not null,
+        [value] float not null,
+        [tags] varchar(255)
     )
     SET NOCOUNT ON;
-INSERT INTO #Datadog (metric, type, value, tags) VALUES
-                                                     ('sql.sp.testa', 'gauge', 100, 'foo:bar,baz:qux'),
-                                                     ('sql.sp.testb', 'gauge', 1, 'foo:bar,baz:qux'),
-                                                     ('sql.sp.testb', 'gauge', 2, 'foo:bar,baz:qux');
-SELECT * FROM #Datadog;
+    INSERT INTO #Datadog (metric, type, value, tags) VALUES
+                                                         ('sql.sp.testa', 'gauge', 100, 'foo:bar,baz:qux'),
+                                                         ('sql.sp.testb', 'gauge', 1, 'foo:bar,baz:qux'),
+                                                         ('sql.sp.testb', 'gauge', 2, 'foo:bar,baz:qux');
+    SELECT * FROM #Datadog;
 END;
 GO
 GRANT EXECUTE on pyStoredProc to datadog;

--- a/sqlserver/tests/compose-windows/sqlserver-entrypoint.ps1
+++ b/sqlserver/tests/compose-windows/sqlserver-entrypoint.ps1
@@ -1,0 +1,2 @@
+echo "sqlserver setup completed"
+ping -t localhost | out-null

--- a/sqlserver/tests/compose-windows/sqlserver-setup.ps1
+++ b/sqlserver/tests/compose-windows/sqlserver-setup.ps1
@@ -1,0 +1,18 @@
+#### enable tcp
+# https://docs.microsoft.com/en-us/sql/powershell/how-to-enable-tcp-sqlps?view=sql-server-ver15
+[reflection.assembly]::LoadWithPartialName("Microsoft.SqlServer.SqlWmiManagement")
+$wmi = New-Object 'Microsoft.SqlServer.Management.Smo.Wmi.ManagedComputer' localhost
+$tcp = $wmi.ServerInstances['MSSQLSERVER'].ServerProtocols['Tcp']
+$tcp.IsEnabled = $true
+$tcp.Alter()
+
+### set login mode https://www.mode19.net/posts/changesqlauthmodewithps/
+[System.Reflection.Assembly]::LoadWithPartialName('Microsoft.SqlServer.SMO')
+$smo = New-Object 'Microsoft.SqlServer.Management.Smo.Server' localhost
+$smo.Settings.LoginMode = "Mixed"
+$smo.Alter()
+
+Restart-Service -Name MSSQLSERVER -Force
+
+sqlcmd -Q "ALTER login sa ENABLE;"
+sqlcmd -Q "ALTER login sa WITH PASSWORD = 'Password123';"

--- a/sqlserver/tests/compose/setup.sh
+++ b/sqlserver/tests/compose/setup.sh
@@ -16,9 +16,9 @@ done
 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P $SA_PASSWORD -d master -i setup.sql -b
 if [ $? -eq 0 ]
 then
-    echo "INFO: setup.sql completed."
+    echo "INFO: sqlserver setup completed"
     exit 0
 else
-    echo "ERROR: setup.sql failed."
+    echo "ERROR: sqlserver setup failed"
     exit 1
 fi

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -12,6 +12,7 @@ import pytest
 
 from datadog_checks.dev import WaitFor, docker_run
 from datadog_checks.dev.conditions import CheckDockerLogs
+from datadog_checks.dev.docker import using_windows_containers
 
 from .common import (
     DOCKER_SERVER,
@@ -22,6 +23,7 @@ from .common import (
     INIT_CONFIG_OBJECT_NAME,
     INSTANCE_AO_DOCKER_SECONDARY,
     INSTANCE_DOCKER,
+    INSTANCE_DOCKER_DEFAULTS,
     INSTANCE_E2E,
     INSTANCE_SQL,
     INSTANCE_SQL_DEFAULTS,
@@ -69,6 +71,11 @@ def instance_sql():
 @pytest.fixture
 def instance_docker():
     return deepcopy(INSTANCE_DOCKER)
+
+
+@pytest.fixture
+def instance_docker_defaults():
+    return deepcopy(INSTANCE_DOCKER_DEFAULTS)
 
 
 # the default timeout in the integration tests is deliberately elevated beyond the default timeout in the integration
@@ -215,6 +222,9 @@ def instance_autodiscovery():
     return deepcopy(instance)
 
 
+E2E_METADATA = {'docker_platform': 'windows' if using_windows_containers() else 'linux'}
+
+
 @pytest.fixture(scope='session')
 def dd_environment():
     if pyodbc is None:
@@ -229,20 +239,13 @@ def dd_environment():
         WaitFor(sqlserver_can_connect, wait=3, attempts=10),
     ]
 
+    completion_message = 'sqlserver setup completed'
     if os.environ["COMPOSE_FOLDER"] == 'compose-ha':
-        conditions += [
-            CheckDockerLogs(
-                compose_file,
-                'Always On Availability Groups connection with primary database established for secondary database',
-            )
-        ]
-    else:
-        conditions += [
-            CheckDockerLogs(
-                compose_file,
-                'setup.sql completed',
-            )
-        ]
+        completion_message = (
+            'Always On Availability Groups connection with primary database established ' 'for secondary database'
+        )
+
+    conditions += [CheckDockerLogs(compose_file, completion_message)]
 
     with docker_run(compose_file=compose_file, conditions=conditions, mount_logs=True, build=True, attempts=2):
-        yield FULL_E2E_CONFIG
+        yield FULL_E2E_CONFIG, E2E_METADATA

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -15,7 +15,6 @@ from datadog_checks.sqlserver import SQLServer
 
 from .common import CHECK_NAME
 from .conftest import DEFAULT_TIMEOUT
-from .utils import not_windows_ci, windows_ci
 
 try:
     import pyodbc
@@ -53,20 +52,9 @@ def instance_sql_msoledb_dbm(instance_sql_msoledb):
     return instance_sql_msoledb
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_collect_activity(aggregator, instance_docker, dd_run_check, dbm_instance):
-    _run_test_collect_activity(aggregator, instance_docker, dd_run_check, dbm_instance)
-
-
-@windows_ci
-@pytest.mark.integration
-def test_collect_activity_windows(aggregator, instance_docker, dd_run_check, instance_sql_msoledb_dbm):
-    _run_test_collect_activity(aggregator, instance_docker, dd_run_check, instance_sql_msoledb_dbm)
-
-
-def _run_test_collect_activity(aggregator, instance_docker, dd_run_check, dbm_instance):
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
     query = "SELECT * FROM ϑings"
     bob_conn = _get_conn_for_user(instance_docker, "bob")
@@ -231,7 +219,6 @@ def test_async_job_enabled(dd_run_check, dbm_instance, activity_enabled):
         assert check.activity._job_loop_future is None
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_async_job_inactive_stop(aggregator, dd_run_check, dbm_instance):
@@ -246,7 +233,6 @@ def test_async_job_inactive_stop(aggregator, dd_run_check, dbm_instance):
     )
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_async_job_cancel_cancel(aggregator, dd_run_check, dbm_instance):

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -12,7 +12,6 @@ from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import Connection
 
 from .common import CHECK_NAME
-from .utils import not_windows_ci, windows_ci
 
 pytestmark = pytest.mark.unit
 
@@ -89,22 +88,11 @@ def test_will_fail_for_wrong_parameters_in_the_connection_string(instance_sql_de
         connection._connection_options_validation('somekey', 'somedb')
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_query_timeout(aggregator, dd_run_check, instance_docker):
-    _run_test_query_timeout(aggregator, dd_run_check, instance_docker)
-
-
-@windows_ci
-@pytest.mark.integration
-def test_query_timeout_windows(aggregator, dd_run_check, instance_sql_msoledb):
-    _run_test_query_timeout(aggregator, dd_run_check, instance_sql_msoledb)
-
-
-def _run_test_query_timeout(aggregator, dd_run_check, instance):
-    instance['command_timeout'] = 1
-    check = SQLServer(CHECK_NAME, {}, [instance])
+def test_query_timeout(instance_docker):
+    instance_docker['command_timeout'] = 1
+    check = SQLServer(CHECK_NAME, {}, [instance_docker])
     check.initialize_connection()
     with check.connection.open_managed_default_connection():
         with check.connection.get_managed_cursor() as cursor:
@@ -122,7 +110,6 @@ def _run_test_query_timeout(aggregator, dd_run_check, instance):
                     assert 'timeout' in "".join(e.args).lower(), "must be a timeout"
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_connection_cleanup(instance_docker):

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -18,7 +18,6 @@ except ImportError:
     pyodbc = None
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_check_invalid_password(aggregator, dd_run_check, init_config, instance_docker):
@@ -36,7 +35,6 @@ def test_check_invalid_password(aggregator, dd_run_check, init_config, instance_
     )
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_check_docker(aggregator, dd_run_check, init_config, instance_docker):
@@ -49,7 +47,6 @@ def test_check_docker(aggregator, dd_run_check, init_config, instance_docker):
     assert_metrics(aggregator, expected_tags)
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_check_stored_procedure(aggregator, dd_run_check, init_config, instance_docker):
@@ -67,7 +64,6 @@ def test_check_stored_procedure(aggregator, dd_run_check, init_config, instance_
     aggregator.assert_metric('sql.sp.testb', tags=expected_tags, count=2)
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_check_stored_procedure_proc_if(aggregator, dd_run_check, init_config, instance_docker):
@@ -85,7 +81,6 @@ def test_check_stored_procedure_proc_if(aggregator, dd_run_check, init_config, i
     assert len(aggregator._metrics) == 0
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_custom_metrics_object_name(aggregator, dd_run_check, init_config_object_name, instance_docker):
@@ -96,7 +91,6 @@ def test_custom_metrics_object_name(aggregator, dd_run_check, init_config_object
     aggregator.assert_metric('sqlserver.active_requests', tags=['optional:tag1', 'optional_tag:tag1'], count=1)
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_custom_metrics_alt_tables(aggregator, dd_run_check, init_config_alt_tables, instance_docker):
@@ -109,10 +103,14 @@ def test_custom_metrics_alt_tables(aggregator, dd_run_check, init_config_alt_tab
     aggregator.assert_metric('sqlserver.LCK_M_S.max_wait_time_ms', tags=['optional:tag1'], count=1)
     aggregator.assert_metric('sqlserver.LCK_M_S.signal_wait_time_ms', tags=['optional:tag1'], count=1)
     aggregator.assert_metric(
-        'sqlserver.MEMORYCLERK_BITMAP.virtual_memory_committed_kb', tags=['memory_node_id:0', 'optional:tag1'], count=1
+        'sqlserver.MEMORYCLERK_SQLGENERAL.virtual_memory_committed_kb',
+        tags=['memory_node_id:0', 'optional:tag1'],
+        count=1,
     )
     aggregator.assert_metric(
-        'sqlserver.MEMORYCLERK_BITMAP.virtual_memory_reserved_kb', tags=['memory_node_id:0', 'optional:tag1'], count=1
+        'sqlserver.MEMORYCLERK_SQLGENERAL.virtual_memory_reserved_kb',
+        tags=['memory_node_id:0', 'optional:tag1'],
+        count=1,
     )
 
     # check a second time for io metrics to be processed
@@ -152,7 +150,6 @@ def test_autodiscovery_database_metrics(aggregator, dd_run_check, instance_autod
     aggregator.assert_metric('sqlserver.database.files.state', tags=msdb_tags)
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.parametrize(
     'service_check_enabled, default_count, extra_count',
@@ -189,7 +186,6 @@ def test_autodiscovery_db_service_checks(
     )
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_autodiscovery_exclude_db_service_checks(aggregator, dd_run_check, instance_autodiscovery):
@@ -213,7 +209,6 @@ def test_autodiscovery_exclude_db_service_checks(aggregator, dd_run_check, insta
     )
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_no_autodiscovery_service_checks(aggregator, dd_run_check, init_config, instance_docker):
@@ -224,7 +219,6 @@ def test_no_autodiscovery_service_checks(aggregator, dd_run_check, init_config, 
     aggregator.assert_service_check('sqlserver.database.can_connect', count=0)
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_autodiscovery_perf_counters(aggregator, dd_run_check, instance_autodiscovery):
@@ -256,7 +250,6 @@ def test_autodiscovery_perf_counters(aggregator, dd_run_check, instance_autodisc
         aggregator.assert_metric(metric, tags=base_tags)
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_autodiscovery_perf_counters_doesnt_duplicate_names_of_metrics_to_collect(dd_run_check, instance_autodiscovery):
@@ -269,7 +262,6 @@ def test_autodiscovery_perf_counters_doesnt_duplicate_names_of_metrics_to_collec
         assert sorted(metric_names) == sorted(expected)
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_autodiscovery_multiple_instances(aggregator, dd_run_check, instance_autodiscovery, caplog):
@@ -297,7 +289,6 @@ def test_autodiscovery_multiple_instances(aggregator, dd_run_check, instance_aut
     assert found_log == 1
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_custom_queries(aggregator, dd_run_check, instance_docker):
@@ -319,7 +310,6 @@ def test_custom_queries(aggregator, dd_run_check, instance_docker):
         aggregator.assert_metric('sqlserver.num', value=value, tags=custom_tags + ['query:another_custom_one'])
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_load_static_information(aggregator, dd_run_check, instance_docker):
@@ -332,8 +322,8 @@ def test_load_static_information(aggregator, dd_run_check, instance_docker):
 
 @windows_ci
 @pytest.mark.integration
-def test_check_windows_defaults(aggregator, dd_run_check, init_config, instance_sql_defaults):
-    check = SQLServer(CHECK_NAME, init_config, [instance_sql_defaults])
+def test_check_windows_defaults(aggregator, dd_run_check, init_config, instance_docker_defaults):
+    check = SQLServer(CHECK_NAME, init_config, [instance_docker_defaults])
     dd_run_check(check)
 
     aggregator.assert_metric_has_tag('sqlserver.db.commit_table_entries', 'db:master')
@@ -345,7 +335,6 @@ def test_check_windows_defaults(aggregator, dd_run_check, init_config, instance_
     aggregator.assert_all_metrics_covered()
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
@@ -363,7 +352,6 @@ def test_split_sqlserver_host(instance_docker, instance_host, split_host, split_
     assert (s_host, s_port) == (split_host, split_port)
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -19,7 +19,6 @@ from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.statements import SQL_SERVER_QUERY_METRICS_COLUMNS, obfuscate_xml_plan
 
 from .common import CHECK_NAME
-from .utils import not_windows_ci, windows_ci
 
 try:
     import pyodbc
@@ -59,7 +58,6 @@ def instance_sql_msoledb_dbm(instance_sql_msoledb):
     return instance_sql_msoledb
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
@@ -87,7 +85,6 @@ def test_get_available_query_metrics_columns(aggregator, dbm_instance, expected_
             assert result_available_columns == available_columns
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_get_statement_metrics_query_cached(aggregator, dbm_instance, caplog):
@@ -154,57 +151,10 @@ test_statement_metrics_and_plans_parameterized = (
 )
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(*test_statement_metrics_and_plans_parameterized)
 def test_statement_metrics_and_plans(
-    aggregator, dd_run_check, dbm_instance, bob_conn, database, plan_user, query, param_groups, match_pattern, caplog
-):
-    _run_test_statement_metrics_and_plans(
-        aggregator,
-        dd_run_check,
-        dbm_instance,
-        bob_conn,
-        database,
-        plan_user,
-        query,
-        param_groups,
-        match_pattern,
-        caplog,
-    )
-
-
-@windows_ci
-@pytest.mark.integration
-@pytest.mark.parametrize(*test_statement_metrics_and_plans_parameterized)
-def test_statement_metrics_and_plans_windows(
-    aggregator,
-    dd_run_check,
-    instance_sql_msoledb_dbm,
-    bob_conn,
-    database,
-    plan_user,
-    query,
-    param_groups,
-    match_pattern,
-    caplog,
-):
-    _run_test_statement_metrics_and_plans(
-        aggregator,
-        dd_run_check,
-        instance_sql_msoledb_dbm,
-        bob_conn,
-        database,
-        plan_user,
-        query,
-        param_groups,
-        match_pattern,
-        caplog,
-    )
-
-
-def _run_test_statement_metrics_and_plans(
     aggregator, dd_run_check, dbm_instance, bob_conn, database, plan_user, query, param_groups, match_pattern, caplog
 ):
     caplog.set_level(logging.INFO)
@@ -290,7 +240,6 @@ def _run_test_statement_metrics_and_plans(
     )
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_statement_basic_metrics_query(datadog_conn_docker, dbm_instance):
@@ -426,7 +375,6 @@ def test_async_job_enabled(dd_run_check, dbm_instance, statement_metrics_enabled
         assert check.statement_metrics._job_loop_future is None
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_async_job_inactive_stop(aggregator, dd_run_check, dbm_instance):
@@ -441,7 +389,6 @@ def test_async_job_inactive_stop(aggregator, dd_run_check, dbm_instance):
     )
 
 
-@not_windows_ci
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_async_job_cancel_cancel(aggregator, dd_run_check, dbm_instance):

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -15,7 +15,7 @@ from datadog_checks.sqlserver.metrics import SqlMasterDatabaseFileStats
 from datadog_checks.sqlserver.sqlserver import SQLConnectionError
 from datadog_checks.sqlserver.utils import set_default_driver_conf
 
-from .common import CHECK_NAME, LOCAL_SERVER, assert_metrics
+from .common import CHECK_NAME, DOCKER_SERVER, assert_metrics
 from .utils import windows_ci
 
 # mark the whole module
@@ -228,20 +228,19 @@ def test_set_default_driver_conf():
 
 
 @windows_ci
-def test_check_local(aggregator, dd_run_check, init_config, instance_sql):
-    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_sql])
+def test_check_local(aggregator, dd_run_check, init_config, instance_docker):
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
-    expected_tags = instance_sql.get('tags', []) + ['sqlserver_host:{}'.format(LOCAL_SERVER), 'db:master']
+    expected_tags = instance_docker.get('tags', []) + ['sqlserver_host:{}'.format(DOCKER_SERVER), 'db:master']
     assert_metrics(aggregator, expected_tags)
 
 
 @windows_ci
 @pytest.mark.parametrize('adoprovider', ['SQLOLEDB', 'SQLNCLI11', 'MSOLEDBSQL'])
-def test_check_adoprovider(aggregator, dd_run_check, init_config, instance_sql, adoprovider):
-    instance = copy.deepcopy(instance_sql)
-    instance['adoprovider'] = adoprovider
+def test_check_adoprovider(aggregator, dd_run_check, init_config, instance_docker, adoprovider):
+    instance_docker['adoprovider'] = adoprovider
 
-    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance])
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
-    expected_tags = instance.get('tags', []) + ['sqlserver_host:{}'.format(LOCAL_SERVER), 'db:master']
+    expected_tags = instance_docker.get('tags', []) + ['sqlserver_host:{}'.format(DOCKER_SERVER), 'db:master']
     assert_metrics(aggregator, expected_tags)

--- a/sqlserver/tests/utils.py
+++ b/sqlserver/tests/utils.py
@@ -11,5 +11,5 @@ windows_ci = pytest.mark.skipif(not running_on_windows_ci(), reason='Test can on
 not_windows_ci = pytest.mark.skipif(running_on_windows_ci(), reason='Test cannot be run on Windows CI')
 
 always_on = pytest.mark.skipif(
-    os.environ["COMPOSE_FOLDER"] == 'compose', reason='Test can only be run on AlwaysOn SQLServer instances'
+    os.environ["COMPOSE_FOLDER"] != 'compose-ha', reason='Test can only be run on AlwaysOn SQLServer instances'
 )

--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -2,7 +2,8 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{2017,2019}-{single,ha}
+    py{27,38}-linux-{2017,2019}-{single,ha}
+    py{27,38}-windows-{2016,2017,2019}-single
 
 [testenv]
 ensure_default_envdir = true
@@ -13,7 +14,9 @@ dd_check_style = true
 description =
     py{27,38}: e2e ready if platform_system != 'Windows'
 usedevelop = true
-platform = linux|darwin|win32
+platform =
+    linux: linux|darwin
+    windows: win32
 deps =
     --extra-index-url https://datadoghq.dev/ci-wheels/bin
     -e../datadog_checks_base[deps,db,json]
@@ -29,5 +32,14 @@ setenv =
     ODBCSYSINI = {toxinidir}/tests/odbc
     COMPOSE_FOLDER = compose
     ha: COMPOSE_FOLDER = compose-ha
-    2017: SQLSERVER_IMAGE_TAG = 2017-CU24-ubuntu-16.04
-    2019: SQLSERVER_IMAGE_TAG = 2019-CU11-ubuntu-16.04
+    windows: COMPOSE_FOLDER = compose-windows
+    linux-2017: SQLSERVER_IMAGE_TAG = 2017-CU24-ubuntu-16.04
+    linux-2019: SQLSERVER_IMAGE_TAG = 2019-CU11-ubuntu-16.04
+    # TODO: replace djova/docker-library with datadog/docker-library once these images are pushed there
+    windows-2016: SQLSERVER_BASE_IMAGE = djova/docker-library:sqlserver_2016
+    windows-2017: SQLSERVER_BASE_IMAGE = djova/docker-library:sqlserver_2017
+    windows-2019: SQLSERVER_BASE_IMAGE = djova/docker-library:sqlserver_2019
+    # we need SETUPTOOLS_USE_DISTUTILS=stdlib for setuptools versions 60+ in order for adodbapi to be able to install
+    # correctly for python3 on windows. If not set installation fails with the following error:
+    #    in ImportError: cannot import name 'build_py_2to3' from 'distutils.command.build_py'
+    windows: SETUPTOOLS_USE_DISTUTILS = "stdlib"


### PR DESCRIPTION
### What does this PR do?

Stop running SQL Server directly on the Azure Test VM in favor of running it in Windows docker containers (see DataDog/docker-library#76). We now test on SQL Server Windows Versions 2016, 2017, and 2019.

Update all integration tests (except for those that are truly platform specific) to now run on all docker containers, both linux and windows. Previously only a small set of integration tests were being run on Windows.

### Motivation

Improve Windows test coverage.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
