### PR TITLE
Remove `os_hostname` from f5 profile since redundant with device name

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
@@ -50,10 +50,6 @@ metadata:
         symbol:
           OID: 1.3.6.1.4.1.3375.2.1.6.3.0
           name: sysSystemRelease # The current system release level. e.g. 3.10.0-862.14.4.el7.ve.x86_64
-      os_hostname:
-        symbol:
-          OID: 1.3.6.1.4.1.3375.2.1.6.2.0
-          name: sysSystemNodeName # The host name of the system on the network.
 
 metrics:
   # Memory stats

--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -79,7 +79,6 @@ def test_e2e_core_metadata_f5(dd_agent_check):
                     u'model': u'Z100',
                     u'os_name': u'Linux',
                     u'os_version': u'3.10.0-862.14.4.el7.ve.x86_64',
-                    u'os_hostname': u'f5-big-ip-adc-good-byol-1-vm.c.datadog-integrations-lab.internal',
                 },
             ],
             u'interfaces': [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove `os_hostname` from f5 profile it is usually redundant with device name

TODO: REMOVE https://github.com/DataDog/integrations-core/blob/f152035cc90e98c1245a61cc786d9d814685e8e5/snmp/tests/test_e2e_core_metadata.py#L82

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
