### PR TITLE
CHANGELOG entry: Added a note on IIS Logs Permissions

### DIFF
--- a/iis/README.md
+++ b/iis/README.md
@@ -52,7 +52,7 @@ partial -->
 
 3. [Restart the Agent][6].
 
-**Note**: Please ensure the `datadog-agent` user has read access to tail the log files you want to collect from. See [Permission issues tailing log files][12] for more information.
+**Note**: Ensure the `datadog-agent` user has read access to tail the log files you want to collect from. See [Permission issues tailing log files][12] for more information.
 
 
 ### Validation

--- a/iis/README.md
+++ b/iis/README.md
@@ -52,6 +52,9 @@ partial -->
 
 3. [Restart the Agent][6].
 
+**Note**: Please ensure the `datadog-agent` user has read access to tail the log files you want to collect from. See [Permission issues tailing log files][12] for more information.
+
+
 ### Validation
 
 [Run the Agent's status subcommand][7] and look for `iis` under the Checks section.
@@ -86,3 +89,4 @@ Need help? Contact [Datadog support][10].
 [9]: https://github.com/DataDog/integrations-core/blob/master/iis/assets/service_checks.json
 [10]: https://docs.datadoghq.com/help/
 [11]: https://github.com/DataDog/integrations-core/blob/7.33.x/iis/datadog_checks/iis/data/conf.yaml.example
+[12]: https://docs.datadoghq.com/logs/guide/log-collection-troubleshooting-guide/#permission-issues-tailing-log-files


### PR DESCRIPTION
### What does this PR do?
Provide additional information for user to add ddagentuser permissions for logs files and link to the [Permission issues tailing log files](https://docs.datadoghq.com/logs/guide/log-collection-troubleshooting-guide/#permission-issues-tailing-log-files) page

### Motivation
https://datadog.zendesk.com/agent/tickets/582878
https://datadog.zendesk.com/agent/tickets/594740
https://datadog.zendesk.com/agent/tickets/606490

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
