### PR TITLE
Use a frozenset for plan obfuscation parameters

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -73,12 +73,12 @@ def _row_key(row):
     return row['database_name'], row['user_name'], row['query_signature'], row['query_hash'], row['query_plan_hash']
 
 
-XML_PLAN_OBFUSCATION_ATTRS = {
+XML_PLAN_OBFUSCATION_ATTRS = frozenset({
     "StatementText",
     "ConstValue",
     "ScalarString",
     "ParameterCompiledValue",
-}
+})
 
 
 def agent_check_getter(self):

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -73,12 +73,14 @@ def _row_key(row):
     return row['database_name'], row['user_name'], row['query_signature'], row['query_hash'], row['query_plan_hash']
 
 
-XML_PLAN_OBFUSCATION_ATTRS = frozenset({
-    "StatementText",
-    "ConstValue",
-    "ScalarString",
-    "ParameterCompiledValue",
-})
+XML_PLAN_OBFUSCATION_ATTRS = frozenset(
+    {
+        "StatementText",
+        "ConstValue",
+        "ScalarString",
+        "ParameterCompiledValue",
+    }
+)
 
 
 def agent_check_getter(self):


### PR DESCRIPTION
### What does this PR do?

Avoid accidental mutation of the set of plan obfuscation parameters.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
