### PR TITLE
Add `server` default group for all monitor special cases

### DIFF
--- a/apache/assets/service_checks.json
+++ b/apache/assets/service_checks.json
@@ -4,7 +4,8 @@
         "integration": "Apache",
         "groups": [
             "host",
-            "port"
+            "port",
+            "server"
         ],
         "check": "apache.can_connect",
         "statuses": [

--- a/elastic/assets/service_checks.json
+++ b/elastic/assets/service_checks.json
@@ -10,7 +10,8 @@
         ],
         "groups": [
             "host",
-            "port"
+            "port",
+            "server"
         ],
         "name": "Cluster Health",
         "description": "Returns the `status` from the Elasticsearch [Cluster Health API](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-health.html). Additional information about shard status at the time of collection is included in the check message."
@@ -25,7 +26,8 @@
         ],
         "groups": [
             "host",
-            "port"
+            "port",
+            "server"
         ],
         "name": "Can Connect",
         "description": "Returns `CRITICAL` if the Agent is unable to connect to the monitored Elasticsearch instance. Returns `OK` otherwise."

--- a/lighttpd/assets/service_checks.json
+++ b/lighttpd/assets/service_checks.json
@@ -9,7 +9,8 @@
         ],
         "groups": [
             "host",
-            "port"
+            "port",
+            "server"
         ],
         "name": "Can Connect",
         "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Lighttpd instance. Returns `OK` otherwise."

--- a/mcache/assets/service_checks.json
+++ b/mcache/assets/service_checks.json
@@ -9,7 +9,8 @@
         ],
         "groups": [
             "host",
-            "port"
+            "port",
+            "server"
         ],
         "name": "Can Connect",
         "description": "Returns `CRITICAL` if the Agent is unable to connect to the monitored Memcached instance. Returns `OK` otherwise."

--- a/mongo/assets/service_checks.json
+++ b/mongo/assets/service_checks.json
@@ -10,7 +10,8 @@
         "groups": [
             "host",
             "port",
-            "db"
+            "db",
+            "server"
         ],
         "name": "Can Connect",
         "description": "Returns `CRITICAL` if the Agent is unable to connect to the monitored MongoDB instance. Returns `OK` otherwise."

--- a/mysql/assets/service_checks.json
+++ b/mysql/assets/service_checks.json
@@ -9,7 +9,8 @@
         ],
         "groups": [
             "host",
-            "port"
+            "port",
+            "server"
         ],
         "name": "Can Connect",
         "description": "Returns `CRITICAL` if the Agent is unable to connect to the monitored MySQL instance. Returns `OK` otherwise."

--- a/nginx/assets/service_checks.json
+++ b/nginx/assets/service_checks.json
@@ -9,7 +9,8 @@
         ],
         "groups": [
             "host",
-            "port"
+            "port",
+            "server"
         ],
         "name": "Can Connect",
         "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Nginx instance. Returns `OK` otherwise."

--- a/pgbouncer/assets/service_checks.json
+++ b/pgbouncer/assets/service_checks.json
@@ -10,7 +10,8 @@
         "groups": [
             "host",
             "port",
-            "db"
+            "db",
+            "server"
         ],
         "name": "Can Connect",
         "description": "Returns `CRITICAL` if the Agent is unable to connect to the monitored PGBouncer instance. Returns `OK` otherwise."

--- a/sqlserver/assets/service_checks.json
+++ b/sqlserver/assets/service_checks.json
@@ -9,7 +9,8 @@
         ],
         "groups": [
             "host",
-            "db"
+            "db",
+            "server"
         ],
         "name": "Can Connect",
         "description": "Returns `CRITICAL` if the Agent is unable to connect to the monitored SQL Server instance. Returns `OK` otherwise."

--- a/tokumx/assets/service_checks.json
+++ b/tokumx/assets/service_checks.json
@@ -10,7 +10,8 @@
         "groups": [
             "host",
             "port",
-            "db"
+            "db",
+            "server"
         ],
         "name": "Can Connect",
         "description": "Returns `CRITICAL` if the Agent is unable to connect to the monitored TokuMX instance. Returns `OK` otherwise."

--- a/windows_service/assets/service_checks.json
+++ b/windows_service/assets/service_checks.json
@@ -11,7 +11,8 @@
         ],
         "groups": [
             "host",
-            "windows_service"
+            "windows_service",
+            "server"
         ],
         "name": "Service state",
         "description": "Returns `OK` if the windows service is in Running state, `CRITICAL` if it is Stopped, `UNKNOWN` if it is Unknown, and `WARNING` for the other service states."

--- a/zk/assets/service_checks.json
+++ b/zk/assets/service_checks.json
@@ -10,7 +10,8 @@
         ],
         "groups": [
             "host",
-            "port"
+            "port",
+            "server"
         ],
         "name": "ruok",
         "description": "Sends `ruok` to the monitored node. Returns `OK` with an `imok` response, `WARN` in the case of a different response and `CRITICAL` if no response is received."
@@ -25,7 +26,8 @@
         ],
         "groups": [
             "host",
-            "port"
+            "port",
+            "server"
         ],
         "name": "Expected Mode",
         "description": "Compares the current mode given by the `stat` command to the expected mode configured in `zk.yaml`. Returns `OK` when the modes match and `CRITICAL` otherwise. Only returns a status when there's a value for `expected_mode` in `zk.yaml`"


### PR DESCRIPTION
### What does this PR do?

The `groups` field is used as default grouping in service checks monitors. For some specific integrations we add the `server` tag in this grouping in the backend code to tackle edge cases where the `host` tag is replaced by `server`.

This PR is meant to reflect these edge cases in the configuration of the integration, in order to deprecate this in the backend.

### Motivation

Remove some edge cases in the backend code, and simplify the evaluator code.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
