### PR TITLE
Fix lighttpd service check name for monitors

### DIFF
--- a/lighttpd/assets/service_checks.json
+++ b/lighttpd/assets/service_checks.json
@@ -2,7 +2,7 @@
     {
         "agent_version": "5.1.0",
         "integration": "Lighttpd",
-        "check": "lighthttpd.can_connect",
+        "check": "lighttpd.can_connect",
         "statuses": [
             "ok",
             "critical"


### PR DESCRIPTION
### What does this PR do?
The lighttpd service check name is currently `lighttpd.can_connect` but the one use for monitor configuration is `lighthttpd.can_connect`. This means the default grouping is not correct right now.

Currently, this impacts 1 monitor.

### Motivation
Keep the codebase sane

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
