### PR TITLE
Fix the documentation of the `metrics` setting

### DIFF
--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -24,7 +24,7 @@ For each instance the following parameters are required:
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `openmetrics_endpoint` | The URL where your application metrics are exposed by Prometheus (must be unique).                                                                                                                         |
 | `namespace`      | The namespace to prepend to all metrics.                                                                                                                                                                                                                                 |
-| `metrics`        | A list of metrics to retrieve as custom metrics. Add each metric to the list as `metric_name` or `metric_name: renamed` to rename it. Use `*` as a wildcard (`metric*`) to fetch all matching metrics. **Note**: Wildcards can potentially send a lot of custom metrics. |
+| `metrics`        | A list of metrics to retrieve as custom metrics. Add each metric to the list as `metric_name` or `metric_name: renamed` to rename it. The metrics are interpreted as regular expressions. Use `.*` as a wildcard (`metric.*`) to fetch all matching metrics. **Note**: Regular expressions can potentially send a lot of custom metrics. |
 
 **Note**: This is a new default OpenMetrics check example. If you previously implemented this integration, see the [legacy example][5].
 


### PR DESCRIPTION
### What does this PR do?

Fix the documentation of the `metrics` parameter of the Openmetrics v2 check.
It’s a regular expression and not a glob pattern as it used to be with the the Prometheus v1 check.

### Motivation

With the Prometheus v1 check, `metrics` seemed to be a glob pattern and this configuration was working:
```
=== openmetrics check ===
Configuration provider: kubernetes
Configuration source: kubelet:containerd://543f4a8a2170333ca3efcd9fbb20c41f9ace1ea9e793925fb44a60ce71579265
Instance ID: openmetrics:openmetrics_gen:8329dd0b4377b5be
metrics:
- '*'
namespace: openmetrics_gen
prometheus_url: http://10.248.7.124:8080/metrics
```

But this Openmetrics v2 configuration produces the following error while trying to compile the regular expression:
```
=== openmetrics check ===
Configuration provider: kubernetes
Configuration source: kubelet:containerd://edebeab89d5d1bffdfdabb3cb43b64cc97d08476ca2a5d6f46d32058f30a130f
Instance ID: openmetrics:openmetrics_gen:cd9516f0abeeacdc
metrics:
- '*'
namespace: openmetrics_gen
openmetrics_endpoint: http://10.248.8.9:8080/metrics
```
```
      Error: nothing to repeat at position 0
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 992, in run
          initialization()
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/v2/base.py", line 70, in configure_scrapers
          scrapers[endpoint] = self.create_scraper(config)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/v2/base.py", line 77, in create_scraper
          return OpenMetricsScraper(self, self.get_config_with_defaults(config))
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 63, in __init__
          self.metric_transformer = MetricTransformer(self.check, config)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/v2/transform.py", line 50, in __init__
          self.metric_patterns.append((re.compile(raw_metric_name), config))
        File "/opt/datadog-agent/embedded/lib/python3.8/re.py", line 252, in compile
          return _compile(pattern, flags)
        File "/opt/datadog-agent/embedded/lib/python3.8/re.py", line 304, in _compile
          p = sre_compile.compile(pattern, flags)
        File "/opt/datadog-agent/embedded/lib/python3.8/sre_compile.py", line 764, in compile
          p = sre_parse.parse(p, flags)
        File "/opt/datadog-agent/embedded/lib/python3.8/sre_parse.py", line 948, in parse
          p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
        File "/opt/datadog-agent/embedded/lib/python3.8/sre_parse.py", line 443, in _parse_sub
          itemsappend(_parse(source, state, verbose, nested + 1,
        File "/opt/datadog-agent/embedded/lib/python3.8/sre_parse.py", line 668, in _parse
          raise source.error("nothing to repeat",
      re.error: nothing to repeat at position 0
```

Replacing `*` by `.*` like this fixes the issue:
```
=== openmetrics check ===
Configuration provider: kubernetes
Configuration source: kubelet:containerd://70fa32bc8ce659f45c5f2cdf59b2a398ac21ad42de60e9ed9777691f102de85b
Instance ID: openmetrics:openmetrics_gen:27e2f38a7481e8a1
metrics:
- .*
namespace: openmetrics_gen
openmetrics_endpoint: http://10.248.7.123:8080/metrics
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have `changelog/` and `integration/` labels attached
