### PR TITLE
run full test suite for every supported Windows SQL Server driver

### DIFF
--- a/.azure-pipelines/scripts/sqlserver/windows/40_install_sqlserver.py
+++ b/.azure-pipelines/scripts/sqlserver/windows/40_install_sqlserver.py
@@ -4,9 +4,20 @@ from tenacity import wait_exponential, retry, stop_after_attempt
 
 
 @retry(wait=wait_exponential(min=2, max=60), stop=stop_after_attempt(5))
+def install_sqlserver():
+    """
+    Install SQL Server locally for testing the native client.
+    See https://docs.microsoft.com/en-us/sql/relational-databases/native-client/sql-server-native-client
+    """
+    print("Install sql-server-2017 ...")
+    subprocess.run(["choco", "install", "sql-server-2017", "--no-progress"], check=True)
+
+
+@retry(wait=wait_exponential(min=2, max=60), stop=stop_after_attempt(5))
 def install_msoledbsql():
     print("Install Microsoft OLE DB Driver for SQL Server ...")
     subprocess.run(["choco", "install", "msoledbsql", "--no-progress", "-y"], check=True)
 
 
 install_msoledbsql()
+install_sqlserver()

--- a/.azure-pipelines/scripts/sqlserver/windows/41_stop_sqlserver.bat
+++ b/.azure-pipelines/scripts/sqlserver/windows/41_stop_sqlserver.bat
@@ -1,0 +1,2 @@
+:: stop SQL Server as the only reason we're installing it is for the native client
+powershell -Command "stop-service MSSQLSERVER"

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -77,39 +77,6 @@ EXPECTED_AO_METRICS_PRIMARY = [m[0] for m in AO_METRICS_PRIMARY]
 EXPECTED_AO_METRICS_SECONDARY = [m[0] for m in AO_METRICS_SECONDARY]
 EXPECTED_AO_METRICS_COMMON = [m[0] for m in AO_METRICS]
 
-INSTANCE_DOCKER_DEFAULTS = {
-    'host': '{},1433'.format(HOST),
-    'connector': 'odbc',
-    'driver': get_local_driver(),
-    'username': 'datadog',
-    'password': 'Password12!',
-    'disable_generic_tags': True,
-    'tags': ['optional:tag1'],
-}
-
-INSTANCE_DOCKER = INSTANCE_DOCKER_DEFAULTS.copy()
-INSTANCE_DOCKER.update(
-    {
-        'include_task_scheduler_metrics': True,
-        'include_db_fragmentation_metrics': True,
-        'include_fci_metrics': True,
-        'include_ao_metrics': False,
-        'include_master_files_metrics': True,
-        'disable_generic_tags': True,
-    }
-)
-
-INSTANCE_AO_DOCKER_SECONDARY = {
-    'host': '{},1434'.format(HOST),
-    'connector': 'odbc',
-    'driver': 'FreeTDS',
-    'username': 'datadog',
-    'password': 'Password12!',
-    'tags': ['optional:tag1'],
-    'include_ao_metrics': True,
-    'disable_generic_tags': True,
-}
-
 CUSTOM_QUERY_A = {
     'query': "SELECT letter, num FROM (VALUES (97, 'a'), (98, 'b'), (99, 'c')) AS t (num,letter)",
     'columns': [{'name': 'customtag', 'type': 'tag'}, {'name': 'num', 'type': 'gauge'}],
@@ -121,10 +88,6 @@ CUSTOM_QUERY_B = {
     'columns': [{'name': 'customtag', 'type': 'tag'}, {'name': 'num', 'type': 'gauge'}],
     'tags': ['query:another_custom_one'],
 }
-
-INSTANCE_E2E = INSTANCE_DOCKER.copy()
-INSTANCE_E2E['driver'] = 'FreeTDS'
-INSTANCE_E2E['dbm'] = True
 
 INSTANCE_SQL_DEFAULTS = {
     'host': DOCKER_SERVER,
@@ -206,8 +169,6 @@ INIT_CONFIG_ALT_TABLES = {
         },
     ]
 }
-
-FULL_E2E_CONFIG = {"init_config": INIT_CONFIG, "instances": [INSTANCE_E2E]}
 
 
 def assert_metrics(aggregator, expected_tags, dbm_enabled=False):

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -16,17 +16,11 @@ from datadog_checks.dev.docker import using_windows_containers
 
 from .common import (
     DOCKER_SERVER,
-    FULL_E2E_CONFIG,
     HERE,
+    HOST,
     INIT_CONFIG,
     INIT_CONFIG_ALT_TABLES,
     INIT_CONFIG_OBJECT_NAME,
-    INSTANCE_AO_DOCKER_SECONDARY,
-    INSTANCE_DOCKER,
-    INSTANCE_DOCKER_DEFAULTS,
-    INSTANCE_E2E,
-    INSTANCE_SQL,
-    INSTANCE_SQL_DEFAULTS,
     get_local_driver,
 )
 
@@ -51,31 +45,55 @@ def init_config_alt_tables():
     return deepcopy(INIT_CONFIG_ALT_TABLES)
 
 
-@pytest.fixture
-def instance_sql_defaults():
-    return deepcopy(INSTANCE_SQL_DEFAULTS)
-
-
-@pytest.fixture
-def instance_sql_msoledb():
-    instance = deepcopy(INSTANCE_SQL_DEFAULTS)
-    instance['adoprovider'] = "MSOLEDBSQL"
+@pytest.fixture(scope="session")
+def instance_session_default():
+    instance = {
+        'host': '{},1433'.format(HOST),
+        'connector': 'odbc',
+        'driver': get_local_driver(),
+        'username': 'datadog',
+        'password': 'Password12!',
+        'disable_generic_tags': True,
+        'tags': ['optional:tag1'],
+    }
+    windows_sqlserver_driver = os.environ.get('WINDOWS_SQLSERVER_DRIVER', None)
+    if not windows_sqlserver_driver or windows_sqlserver_driver == 'odbc':
+        return instance
+    instance['adoprovider'] = windows_sqlserver_driver
+    instance['connector'] = 'adodbapi'
     return instance
 
 
 @pytest.fixture
-def instance_sql():
-    return deepcopy(INSTANCE_SQL)
+def instance_docker_defaults(instance_session_default):
+    # deepcopy necessary here because we want to make sure each test invocation gets its own unique copy of the instance
+    # this also means that none of the test need to defensively make their own copies
+    return deepcopy(instance_session_default)
 
 
 @pytest.fixture
-def instance_docker():
-    return deepcopy(INSTANCE_DOCKER)
+def instance_minimal_defaults():
+    return {
+        'host': DOCKER_SERVER,
+        'username': 'sa',
+        'password': 'Password12!',
+        'disable_generic_tags': True,
+    }
 
 
 @pytest.fixture
-def instance_docker_defaults():
-    return deepcopy(INSTANCE_DOCKER_DEFAULTS)
+def instance_docker(instance_docker_defaults):
+    instance_docker_defaults.update(
+        {
+            'include_task_scheduler_metrics': True,
+            'include_db_fragmentation_metrics': True,
+            'include_fci_metrics': True,
+            'include_ao_metrics': False,
+            'include_master_files_metrics': True,
+            'disable_generic_tags': True,
+        }
+    )
+    return instance_docker_defaults
 
 
 # the default timeout in the integration tests is deliberately elevated beyond the default timeout in the integration
@@ -180,53 +198,55 @@ def sa_conn(instance_docker):
 
 
 @pytest.fixture
-def instance_e2e():
-    return deepcopy(INSTANCE_E2E)
+def instance_e2e(instance_docker):
+    instance_docker['driver'] = 'FreeTDS'
+    instance_docker['dbm'] = True
+    return instance_docker
 
 
 @pytest.fixture
-def instance_ao_docker_primary():
-    instance = deepcopy(INSTANCE_DOCKER)
-    instance['include_ao_metrics'] = True
-    instance['driver'] = 'FreeTDS'
-    return instance
+def instance_ao_docker_primary(instance_docker):
+    instance_docker['include_ao_metrics'] = True
+    return instance_docker
 
 
 @pytest.fixture
-def instance_ao_docker_primary_local_only():
-    instance = deepcopy(INSTANCE_DOCKER)
-    instance['include_ao_metrics'] = True
-    instance['driver'] = 'FreeTDS'
+def instance_ao_docker_primary_local_only(instance_ao_docker_primary):
+    instance = deepcopy(instance_ao_docker_primary)
     instance['only_emit_local'] = True
     return instance
 
 
 @pytest.fixture
-def instance_ao_docker_primary_non_existing_ag():
-    instance = deepcopy(INSTANCE_DOCKER)
-    instance['include_ao_metrics'] = True
-    instance['driver'] = 'FreeTDS'
+def instance_ao_docker_primary_non_existing_ag(instance_ao_docker_primary):
+    instance = deepcopy(instance_ao_docker_primary)
     instance['availability_group'] = 'AG2'
     return instance
 
 
 @pytest.fixture
-def instance_ao_docker_secondary():
-    return deepcopy(INSTANCE_AO_DOCKER_SECONDARY)
+def instance_ao_docker_secondary(instance_ao_docker_primary):
+    instance = deepcopy(instance_ao_docker_primary)
+    instance['host'] = '{},1434'.format(HOST)
+    return instance
 
 
 @pytest.fixture
-def instance_autodiscovery():
-    instance = deepcopy(INSTANCE_DOCKER)
-    instance['database_autodiscovery'] = True
-    return deepcopy(instance)
+def instance_autodiscovery(instance_docker):
+    instance_docker['database_autodiscovery'] = True
+    return instance_docker
 
 
 E2E_METADATA = {'docker_platform': 'windows' if using_windows_containers() else 'linux'}
 
 
 @pytest.fixture(scope='session')
-def dd_environment():
+def full_e2e_config(instance_session_default):
+    return {"init_config": INIT_CONFIG, "instances": [instance_session_default]}
+
+
+@pytest.fixture(scope='session')
+def dd_environment(full_e2e_config):
     if pyodbc is None:
         raise Exception("pyodbc is not installed!")
 
@@ -248,4 +268,4 @@ def dd_environment():
     conditions += [CheckDockerLogs(compose_file, completion_message)]
 
     with docker_run(compose_file=compose_file, conditions=conditions, mount_logs=True, build=True, attempts=2):
-        yield FULL_E2E_CONFIG, E2E_METADATA
+        yield full_e2e_config, E2E_METADATA

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -41,17 +41,6 @@ def dbm_instance(instance_docker):
     return copy(instance_docker)
 
 
-@pytest.fixture
-def instance_sql_msoledb_dbm(instance_sql_msoledb):
-    instance_sql_msoledb['dbm'] = True
-    instance_sql_msoledb['min_collection_interval'] = 1
-    instance_sql_msoledb['query_activity'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
-    # not needed for this test
-    instance_sql_msoledb['query_metrics'] = {'enabled': False}
-    instance_sql_msoledb['tags'] = ['optional:tag1']
-    return instance_sql_msoledb
-
-
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_collect_activity(aggregator, instance_docker, dd_run_check, dbm_instance):

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -24,9 +24,9 @@ pytestmark = pytest.mark.unit
         pytest.param('adodbapi', 'driver', id='Driver is ignored when using adodbapi'),
     ],
 )
-def test_will_warn_parameters_for_the_wrong_connection(instance_sql_defaults, connector, param):
-    instance_sql_defaults.update({'connector': connector, param: 'foo'})
-    connection = Connection({}, instance_sql_defaults, None)
+def test_will_warn_parameters_for_the_wrong_connection(instance_minimal_defaults, connector, param):
+    instance_minimal_defaults.update({'connector': connector, param: 'foo'})
+    connection = Connection({}, instance_minimal_defaults, None)
     connection.log = mock.MagicMock()
     connection._connection_options_validation('somekey', 'somedb')
     connection.log.warning.assert_called_once_with(
@@ -48,9 +48,9 @@ def test_will_warn_parameters_for_the_wrong_connection(instance_sql_defaults, co
         pytest.param('adodbapi', 'Password', 'password', id='Cannot define Password twice'),
     ],
 )
-def test_will_fail_for_duplicate_parameters(instance_sql_defaults, connector, cs, param):
-    instance_sql_defaults.update({'connector': connector, param: 'foo', 'connection_string': cs + "=foo"})
-    connection = Connection({}, instance_sql_defaults, None)
+def test_will_fail_for_duplicate_parameters(instance_minimal_defaults, connector, cs, param):
+    instance_minimal_defaults.update({'connector': connector, param: 'foo', 'connection_string': cs + "=foo"})
+    connection = Connection({}, instance_minimal_defaults, None)
     match = (
         "%s has been provided both in the connection string and as a configuration option (%s), "
         "please specify it only once" % (cs, param)
@@ -74,10 +74,10 @@ def test_will_fail_for_duplicate_parameters(instance_sql_defaults, connector, cs
         pytest.param('odbc', 'Password', id='Cannot define Password for odbc'),
     ],
 )
-def test_will_fail_for_wrong_parameters_in_the_connection_string(instance_sql_defaults, connector, cs):
-    instance_sql_defaults.update({'connector': connector, 'connection_string': cs + '=foo'})
+def test_will_fail_for_wrong_parameters_in_the_connection_string(instance_minimal_defaults, connector, cs):
+    instance_minimal_defaults.update({'connector': connector, 'connection_string': cs + '=foo'})
     other_connector = 'odbc' if connector != 'odbc' else 'adodbapi'
-    connection = Connection({}, instance_sql_defaults, None)
+    connection = Connection({}, instance_minimal_defaults, None)
     match = (
         "%s has been provided in the connection string. "
         "This option is only available for %s connections, however %s has been selected"

--- a/sqlserver/tests/test_e2e.py
+++ b/sqlserver/tests/test_e2e.py
@@ -14,7 +14,7 @@ from .common import (
     EXPECTED_METRICS_DBM_ENABLED,
     UNEXPECTED_METRICS,
 )
-from .utils import always_on, not_windows_ci
+from .utils import always_on, not_windows_ado, not_windows_ci
 
 try:
     import pyodbc
@@ -74,6 +74,7 @@ def test_check_ao_secondary(dd_agent_check, init_config, instance_ao_docker_seco
     aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=CUSTOM_METRICS)
 
 
+@not_windows_ado
 def test_check_docker(dd_agent_check, init_config, instance_e2e):
     # run run sync to ensure only a single run of both
     instance_e2e['query_activity'] = {'run_sync': True}

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -50,16 +50,14 @@ def test_check_docker(aggregator, dd_run_check, init_config, instance_docker):
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_check_stored_procedure(aggregator, dd_run_check, init_config, instance_docker):
-    instance_pass = deepcopy(instance_docker)
-
     proc = 'pyStoredProc'
     sp_tags = "foo:bar,baz:qux"
-    instance_pass['stored_procedure'] = proc
+    instance_docker['stored_procedure'] = proc
 
-    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_pass])
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
 
-    expected_tags = instance_pass.get('tags', []) + sp_tags.split(',')
+    expected_tags = instance_docker.get('tags', []) + sp_tags.split(',')
     aggregator.assert_metric('sql.sp.testa', value=100, tags=expected_tags, count=1)
     aggregator.assert_metric('sql.sp.testb', tags=expected_tags, count=2)
 
@@ -67,14 +65,13 @@ def test_check_stored_procedure(aggregator, dd_run_check, init_config, instance_
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_check_stored_procedure_proc_if(aggregator, dd_run_check, init_config, instance_docker):
-    instance_fail = deepcopy(instance_docker)
     proc = 'pyStoredProc'
     proc_only_fail = "select cntr_type from sys.dm_os_performance_counters where counter_name in ('FOO');"
 
-    instance_fail['proc_only_if'] = proc_only_fail
-    instance_fail['stored_procedure'] = proc
+    instance_docker['proc_only_if'] = proc_only_fail
+    instance_docker['stored_procedure'] = proc
 
-    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_fail])
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
 
     # apply a proc check that will never fail and assert that the metrics remain unchanged
@@ -94,10 +91,9 @@ def test_custom_metrics_object_name(aggregator, dd_run_check, init_config_object
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_custom_metrics_alt_tables(aggregator, dd_run_check, init_config_alt_tables, instance_docker):
-    instance = deepcopy(instance_docker)
-    instance['include_task_scheduler_metrics'] = False
+    instance_docker['include_task_scheduler_metrics'] = False
 
-    sqlserver_check = SQLServer(CHECK_NAME, init_config_alt_tables, [instance])
+    sqlserver_check = SQLServer(CHECK_NAME, init_config_alt_tables, [instance_docker])
     dd_run_check(sqlserver_check)
 
     aggregator.assert_metric('sqlserver.LCK_M_S.max_wait_time_ms', tags=['optional:tag1'], count=1)

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -50,15 +50,6 @@ def dbm_instance(instance_docker):
     return copy(instance_docker)
 
 
-@pytest.fixture
-def instance_sql_msoledb_dbm(instance_sql_msoledb):
-    instance_sql_msoledb['dbm'] = True
-    instance_sql_msoledb['min_collection_interval'] = 1
-    instance_sql_msoledb['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 2}
-    instance_sql_msoledb['tags'] = ['optional:tag1']
-    return instance_sql_msoledb
-
-
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -22,19 +22,19 @@ from .utils import windows_ci
 pytestmark = pytest.mark.unit
 
 
-def test_get_cursor(instance_sql):
+def test_get_cursor(instance_docker):
     """
     Ensure we don't leak connection info in case of a KeyError when the
     connection pool is empty or the params for `get_cursor` are invalid.
     """
-    check = SQLServer(CHECK_NAME, {}, [instance_sql])
+    check = SQLServer(CHECK_NAME, {}, [instance_docker])
     check.initialize_connection()
     with pytest.raises(SQLConnectionError):
         check.connection.get_cursor('foo')
 
 
-def test_missing_db(instance_sql, dd_run_check):
-    instance = copy.copy(instance_sql)
+def test_missing_db(instance_docker, dd_run_check):
+    instance = copy.copy(instance_docker)
     instance['ignore_missing_database'] = False
     with mock.patch('datadog_checks.sqlserver.connection.Connection.check_database', return_value=(False, 'db')):
         with pytest.raises(ConfigurationError):
@@ -51,7 +51,7 @@ def test_missing_db(instance_sql, dd_run_check):
 
 @mock.patch('datadog_checks.sqlserver.connection.Connection.open_managed_default_database')
 @mock.patch('datadog_checks.sqlserver.connection.Connection.get_cursor')
-def test_db_exists(get_cursor, mock_connect, instance_sql, dd_run_check):
+def test_db_exists(get_cursor, mock_connect, instance_docker_defaults, dd_run_check):
     Row = namedtuple('Row', 'name,collation_name')
     db_results = [
         Row('master', 'SQL_Latin1_General_CP1_CI_AS'),
@@ -67,7 +67,7 @@ def test_db_exists(get_cursor, mock_connect, instance_sql, dd_run_check):
     mock_results.__iter__.return_value = db_results
     get_cursor.return_value = mock_results
 
-    instance = copy.copy(instance_sql)
+    instance = copy.copy(instance_docker_defaults)
     # make sure check doesn't try to add metrics
     instance['stored_procedure'] = 'fake_proc'
 
@@ -229,17 +229,6 @@ def test_set_default_driver_conf():
 
 @windows_ci
 def test_check_local(aggregator, dd_run_check, init_config, instance_docker):
-    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
-    dd_run_check(sqlserver_check)
-    expected_tags = instance_docker.get('tags', []) + ['sqlserver_host:{}'.format(DOCKER_SERVER), 'db:master']
-    assert_metrics(aggregator, expected_tags)
-
-
-@windows_ci
-@pytest.mark.parametrize('adoprovider', ['SQLOLEDB', 'SQLNCLI11', 'MSOLEDBSQL'])
-def test_check_adoprovider(aggregator, dd_run_check, init_config, instance_docker, adoprovider):
-    instance_docker['adoprovider'] = adoprovider
-
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
     expected_tags = instance_docker.get('tags', []) + ['sqlserver_host:{}'.format(DOCKER_SERVER), 'db:master']

--- a/sqlserver/tests/utils.py
+++ b/sqlserver/tests/utils.py
@@ -13,3 +13,9 @@ not_windows_ci = pytest.mark.skipif(running_on_windows_ci(), reason='Test cannot
 always_on = pytest.mark.skipif(
     os.environ["COMPOSE_FOLDER"] != 'compose-ha', reason='Test can only be run on AlwaysOn SQLServer instances'
 )
+
+# Do not run in environments that specify Windows ADO drivers. This is mainly important for e2e tests where the agent
+# is running in Docker where we don't bundle any ADO drivers in the container.
+not_windows_ado = pytest.mark.skipif(
+    os.environ.get("WINDOWS_SQLSERVER_DRIVER", "odbc") != 'odbc', reason='Test cannot be run using Windows ADO drivers.'
+)

--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -4,7 +4,7 @@ basepython = py38
 envlist =
     py{27,38}-linux-{2017,2019}-{single,ha}
     py{27,38}-windows-odbc-{2016,2017,2019}-single
-    # ideally we'd test the full matrix of driver-version but that makes the tests take to long and time out
+    # ideally we'd test the full matrix of driver-version but that makes the tests take too long and time out
     # until we're able to modify and parallelize the work we'll limit the per-driver tests to only a single version
     py{27,38}-windows-{SQLOLEDB,SQLNCLI11,MSOLEDBSQL}-2019-single
 

--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -3,10 +3,13 @@ minversion = 2.0
 basepython = py38
 envlist =
     py{27,38}-linux-{2017,2019}-{single,ha}
-    py{27,38}-windows-odbc-{2016,2017,2019}-single
-    # ideally we'd test the full matrix of driver-version but that makes the tests take too long and time out
-    # until we're able to modify and parallelize the work we'll limit the per-driver tests to only a single version
-    py{27,38}-windows-{SQLOLEDB,SQLNCLI11,MSOLEDBSQL}-2019-single
+    # test the full combination of python-version/driver against a the latest sql server version
+    # ideally we'd test this against all sql server versions but that makes the test take too long and time out.
+    # time out. until we're able to modify and parallelize the work we'll limit the per-driver tests to only a single
+    # sqlserver version
+    py{27,38}-windows-{SQLOLEDB,SQLNCLI11,MSOLEDBSQL,odbc}-2019-single
+    # older sql server versions tested on only a single python version and driver
+    py38-windows-odbc-{2016,2017}-single
 
 [testenv]
 ensure_default_envdir = true

--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 basepython = py38
 envlist =
     py{27,38}-linux-{2017,2019}-{single,ha}
-    py{27,38}-windows-{2016,2017,2019}-single
+    py{27,38}-windows-{SQLOLEDB,SQLNCLI11,MSOLEDBSQL,odbc}-{2016,2017,2019}-single
 
 [testenv]
 ensure_default_envdir = true
@@ -33,6 +33,10 @@ setenv =
     COMPOSE_FOLDER = compose
     ha: COMPOSE_FOLDER = compose-ha
     windows: COMPOSE_FOLDER = compose-windows
+    windows-SQLOLEDB: WINDOWS_SQLSERVER_DRIVER=SQLOLEDB
+    windows-SQLNCLI11: WINDOWS_SQLSERVER_DRIVER=SQLNCLI11
+    windows-MSOLEDBSQL: WINDOWS_SQLSERVER_DRIVER=MSOLEDBSQL
+    windows-odbc: WINDOWS_SQLSERVER_DRIVER=odbc
     linux-2017: SQLSERVER_IMAGE_TAG = 2017-CU24-ubuntu-16.04
     linux-2019: SQLSERVER_IMAGE_TAG = 2019-CU11-ubuntu-16.04
     windows-2016: SQLSERVER_BASE_IMAGE = datadog/docker-library:sqlserver_2016

--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -3,7 +3,10 @@ minversion = 2.0
 basepython = py38
 envlist =
     py{27,38}-linux-{2017,2019}-{single,ha}
-    py{27,38}-windows-{SQLOLEDB,SQLNCLI11,MSOLEDBSQL,odbc}-{2016,2017,2019}-single
+    py{27,38}-windows-odbc-{2016,2017,2019}-single
+    # ideally we'd test the full matrix of driver-version but that makes the tests take to long and time out
+    # until we're able to modify and parallelize the work we'll limit the per-driver tests to only a single version
+    py{27,38}-windows-{SQLOLEDB,SQLNCLI11,MSOLEDBSQL}-2019-single
 
 [testenv]
 ensure_default_envdir = true


### PR DESCRIPTION
### What does this PR do?

Remove the limited _"can we connect to SQL Server using all supported drivers?"_ test in favor of running the full Windows test suite once per supported driver: SQLOLEDB, SQLNCLI11, MSOLEDBSQL, odbc.

We've had bugs in the past that are specific to a single driver and this will ensure that all supported drivers are fully tested.

Also cleanup instance configuration to ensure all instances are derived from the same base "default" instance, which is where we are varying the driver based on the current env. 

### Motivation

Improve Windows test coverage. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
