### PR TITLE
Disable check runners when running SNMP Listener e2e tests

### DIFF
--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -95,7 +95,6 @@ def create_datadog_conf_file(tmp_dir):
         # Setting check_runners to a negative number to disable check runners is a workaround,
         # Datadog Agent might not guarantee this behaviour in the future.
         'check_runners': -1,
-
         'snmp_listener': {
             'workers': 4,
             'discovery_interval': 10,

--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -91,6 +91,11 @@ def create_datadog_conf_file(tmp_dir):
     container_ip = get_container_ip(SNMP_CONTAINER_NAME)
     prefix = ".".join(container_ip.split('.')[:3])
     datadog_conf = {
+        # Set check_runners to -1 to avoid checks being run in background when running `agent check` for e2e testing
+        # Setting check_runners to a negative number to disable check runners is a workaround,
+        # Datadog Agent might not guarantee this behaviour in the future.
+        'check_runners': -1,
+
         'snmp_listener': {
             'workers': 4,
             'discovery_interval': 10,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Disable check runners when running SNMP Listener e2e tests

### Motivation
<!-- What inspired you to submit this pull request? -->

When running agent check command, in addition of the [check.Check.Run()](https://github.com/DataDog/datadog-agent/blob/582e59337b8d3bc5716171f3a5fea6cf250499be/cmd/agent/common/commands/check.go#L454) call made by agent check, it seems check runners workers (default 4) are added ([common.LoadComponents()](https://github.com/DataDog/datadog-agent/blob/582e59337b8d3bc5716171f3a5fea6cf250499be/cmd/agent/common/commands/check.go#L143)) and run in background.

Looks like this can cause checks being run more times than expected (direct call to check.Check.Run() is expected, but checks being run in background might not be expected)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
