### PR TITLE
Update deprecated can_connect service check name

### DIFF
--- a/mesos_slave/assets/service_checks.json
+++ b/mesos_slave/assets/service_checks.json
@@ -22,7 +22,7 @@
             "ok",
             "critical"
         ],
-        "name": "Can Connect",
+        "name": "Can Connect [Deprecated]",
         "groups": [
             "host",
             "url"


### PR DESCRIPTION
### What does this PR do?
Updates the deprecated `mesos.can_connect` service check name to avoid conflicting with the current service check name.

### Motivation
Fix CI

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
