### PR TITLE
Don't submit query name tag if query is a uuid

### DIFF
--- a/spark/tests/fixtures/metrics_json
+++ b/spark/tests/fixtures/metrics_json
@@ -124,10 +124,10 @@
     "app-20201120094950-0000.driver.spark.streaming.my_named_query.eventTime-watermark": {
       "value": 12
     },
-    "app-20201120094950-0000.driver.spark.streaming.my_named_query.inputRate-total": {
+    "app-20201120094950-0000.driver.spark.streaming.e8e4803f-cc76-4b53-82f9-361b54448fc4.inputRate-total": {
       "value": 12
     },
-    "app-20201120094950-0000.driver.spark.streaming.my_named_query.latency": {
+    "app-20201120094950-0000.driver.spark.streaming.e8e4803f-cc76-4b53-82f9-361b54448fc4.latency": {
       "value": 12
     },
     "app-20201120094950-0000.driver.spark.streaming.my_named_query.processingRate-total": {

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -561,6 +561,11 @@ SPARK_STRUCTURED_STREAMING_METRIC_VALUES = {
     'spark.structured_streaming.used_bytes': 12,
 }
 
+SPARK_STRUCTURED_STREAMING_METRIC_NO_TAGS = {
+    'spark.structured_streaming.input_rate',
+    'spark.structured_streaming.latency',
+}
+
 
 @pytest.mark.unit
 def test_yarn(aggregator):
@@ -1028,8 +1033,11 @@ def test_enable_query_name_tag_for_structured_streaming(aggregator, instance, re
         c = SparkCheck('spark', {}, [instance])
         c.check(instance)
 
-        tags = ["query_name:my_named_query"] + base_tags
         for metric, value in iteritems(SPARK_STRUCTURED_STREAMING_METRIC_VALUES):
+            tags = base_tags
+            if metric not in SPARK_STRUCTURED_STREAMING_METRIC_NO_TAGS:
+                tags = base_tags + ["query_name:my_named_query"]
+
             aggregator.assert_metric(metric, value=value, tags=tags)
 
 


### PR DESCRIPTION
### What does this PR do?
Ensures that we don't submit query name tag if query is a uuid

### Motivation
QA for the addition of the `query_name` tag 
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
