### PR TITLE
Fix default value for instance level oid_batch_size

### DIFF
--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -167,7 +167,7 @@ instances:
     #
     use_device_id_as_hostname: true
 
-    ## @param oid_batch_size - integer - optional - default: 10
+    ## @param oid_batch_size - integer - optional - default: 5
     ## The number of OIDs handled by each batch. Increasing this number improves performance but
     ## uses more resources.
     ## Only available for corecheck implementation (`loader: core`).


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix default value for instance level `oid_batch_size`

### Motivation
<!-- What inspired you to submit this pull request? -->

Instance level `oid_batch_size` is only available for corecheck SNMP integration and the default for `oid_batch_size` for corecheck SNMP integration is `5`: https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/corechecks/snmp/checkconfig/config.go#L30-L33

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
