### PR TITLE
Fix deprecations.py extra new line

### DIFF
--- a/datadog_checks_base/tests/models/config_models/deprecations.py
+++ b/datadog_checks_base/tests/models/config_models/deprecations.py
@@ -8,7 +8,6 @@
 #     ddev -x validate models -s <INTEGRATION_NAME>
 
 
-
 def shared():
     return {'deprecated': {'Release': '8.0.0', 'Migration': 'do this\nand that\n'}}
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix deprecations.py extra new line

### Motivation
<!-- What inspired you to submit this pull request? -->

```
./tests/models/config_models/deprecations.py:12:1: E303 too many blank lines (3)
```
https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=85856&view=logs&jobId=b9b61b1e-e7ad-5a75-8bb3-f1445ef55317&j=b9b61b1e-e7ad-5a75-8bb3-f1445ef55317&t=7c089b75-bae3-5b60-6359-24783737f19d

Lint issue introduced here https://github.com/DataDog/integrations-core/pull/10945


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
