### PR TITLE
Add support for OpenMetricsBaseCheckV2

### DIFF
--- a/coredns/README.md
+++ b/coredns/README.md
@@ -10,6 +10,8 @@ Get metrics from CoreDNS in real time to visualize and monitor DNS failures and 
 
 The CoreDNS check is included in the [Datadog Agent][1] package, so you don't need to install anything else on your servers.
 
+**Note**: The current version of the check (1.11.0+) uses [OpenMetrics][17] for metric collection, which requires Python 3. For hosts unable to use Python 3, or to use a legacy version of this check, see the following [config][18].
+
 ### Configuration
 <!-- xxx tabs xxx -->
 <!-- xxx tab "Docker" xxx -->
@@ -24,7 +26,7 @@ Set [Autodiscovery Integration Templates][2] as Docker labels on your applicatio
 ```yaml
 LABEL "com.datadoghq.ad.check_names"='["coredns"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"prometheus_url":"http://%%host%%:9153/metrics", "tags":["dns-pod:%%host%%"]}]'
+LABEL "com.datadoghq.ad.instances"='[{"openmetrics_endpoint":"http://%%host%%:9153/metrics", "tags":["dns-pod:%%host%%"]}]'
 ```
 
 **Notes**:
@@ -70,7 +72,7 @@ metadata:
     ad.datadoghq.com/coredns.instances: |
       [
         {
-          "prometheus_url": "http://%%host%%:9153/metrics", 
+          "openmetrics_endpoint": "http://%%host%%:9153/metrics", 
           "tags": ["dns-pod:%%host%%"]
         }
       ]
@@ -128,7 +130,7 @@ Set [Autodiscovery Integrations Templates][10] as Docker labels on your applicat
     "dockerLabels": {
       "com.datadoghq.ad.check_names": "[\"coredns\"]",
       "com.datadoghq.ad.init_configs": "[{}]",
-      "com.datadoghq.ad.instances": "[{\"prometheus_url\":\"http://%%host%%:9153/metrics\", \"tags\":[\"dns-pod:%%host%%\"]}]"
+      "com.datadoghq.ad.instances": "[{\"openmetrics_endpoint\":\"http://%%host%%:9153/metrics\", \"tags\":[\"dns-pod:%%host%%\"]}]"
     }
   }]
 }
@@ -204,3 +206,5 @@ Need help? Contact [Datadog support][16].
 [14]: https://github.com/DataDog/integrations-core/blob/master/coredns/metadata.csv
 [15]: https://github.com/DataDog/integrations-core/blob/master/coredns/assets/service_checks.json
 [16]: http://docs.datadoghq.com/help
+[17]: https://docs.datadoghq.com/integrations/openmetrics
+[18]: https://github.com/DataDog/integrations-core/blob/7.32.x/coredns/datadog_checks/coredns/data/conf.yaml.example

--- a/coredns/assets/configuration/spec.yaml
+++ b/coredns/assets/configuration/spec.yaml
@@ -20,6 +20,10 @@ files:
           - coredns_template_matches_total: template_matches_count
           - coredns_template_template_failures_total: template_templating_failures_count
           - coredns_template_rr_failures_total: template_resource_record_failures_count
+    - template: instances/openmetrics_legacy_base
+        hidden: true
+        overrides:
+          prometheus_url.required: false
 - name: auto_conf.yaml
   options:
   - template: ad_identifiers

--- a/coredns/assets/configuration/spec.yaml
+++ b/coredns/assets/configuration/spec.yaml
@@ -21,9 +21,9 @@ files:
           - coredns_template_template_failures_total: template_templating_failures_count
           - coredns_template_rr_failures_total: template_resource_record_failures_count
     - template: instances/openmetrics_legacy_base
-        hidden: true
-        overrides:
-          prometheus_url.required: false
+      hidden: true
+      overrides:
+        prometheus_url.required: false
 - name: auto_conf.yaml
   options:
   - template: ad_identifiers

--- a/coredns/assets/configuration/spec.yaml
+++ b/coredns/assets/configuration/spec.yaml
@@ -4,17 +4,14 @@ files:
   options:
   - template: init_config
     options:
-      - template: init_config/openmetrics_legacy
+      - template: init_config/openmetrics
   - template: instances
     options:
-    - template: instances/openmetrics_legacy
+    - template: instances/openmetrics
       overrides:
-        prometheus_url.description: |
-          To enable CoreDNS metrics you must specify the prometheus url
-          and enable the plugin within coredns.
-          See: https://coredns.io/plugins/metrics/
-        prometheus_url.value.example: "http://%%host%%:9153/metrics"
-        prometheus_url.display_priority: 2
+        openmetrics_endpoint.enabled: true
+        openmetrics_endpoint.required: false
+        openmetrics_endpoint.value.example: http://%%host%%:9153/metrics
         tags.display_priority: 1
         tags.value.example:
           - "dns-pod:%%host%%"
@@ -23,7 +20,6 @@ files:
           - coredns_template_matches_total: template_matches_count
           - coredns_template_template_failures_total: template_templating_failures_count
           - coredns_template_rr_failures_total: template_resource_record_failures_count
-
 - name: auto_conf.yaml
   options:
   - template: ad_identifiers
@@ -34,12 +30,12 @@ files:
     options: []
   - template: instances
     options:
-    - name: prometheus_url
+    - name: openmetrics_endpoint
       description: |
-        To enable CoreDNS metrics you must specify the prometheus url
+        To enable CoreDNS metrics you must specify the openmetrics endpoint url
         and enable the plugin within coredns
         See: https://coredns.io/plugins/metrics/
-      required: true
+      required: false
       value:
         type: string
         example: "http://%%host%%:9153/metrics"
@@ -55,18 +51,6 @@ files:
           type: string
         example:
           - "dns-pod:%%host%%"
-    - name: send_histograms_buckets
-      description: Set send_histograms_buckets to true to send the histograms bucket.
-      value:
-        type: boolean
-        example: True
-    - name: send_monotonic_counter
-      description: |
-        To send counters as monotonic counter
-        see: https://github.com/DataDog/integrations-core/issues/1303
-      value:
-        type: boolean
-        example: True
     - name: metrics
       description: |
         Metrics from the CoreDNS plugins for 'metrics', 'proxy', 'forward' and 'cache'

--- a/coredns/datadog_checks/coredns/check.py
+++ b/coredns/datadog_checks/coredns/check.py
@@ -1,7 +1,7 @@
 from datadog_checks.base import OpenMetricsBaseCheckV2
 from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
 
-from .common import DEFAULT_METRICS, GO_METRICS
+from .metrics import METRIC_MAP, construct_metrics_config
 
 
 class CoreDNS(OpenMetricsBaseCheckV2):
@@ -13,8 +13,7 @@ class CoreDNS(OpenMetricsBaseCheckV2):
         super().__init__(name, init_config, instances)
 
     def get_default_config(self):
-        metrics = [DEFAULT_METRICS, GO_METRICS]
-        return {'metrics': metrics}
+        return {'metrics': construct_metrics_config(METRIC_MAP)}
 
     def create_scraper(self, config):
         return OpenMetricsCompatibilityScraper(self, self.get_config_with_defaults(config))

--- a/coredns/datadog_checks/coredns/check.py
+++ b/coredns/datadog_checks/coredns/check.py
@@ -4,7 +4,7 @@
 from datadog_checks.base import OpenMetricsBaseCheckV2
 from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
 
-from .metrics import METRIC_MAP, METRIC_OVERRIDE, construct_metrics_config
+from .metrics import METRIC_MAP, construct_metrics_config
 
 
 class CoreDNS(OpenMetricsBaseCheckV2):
@@ -16,7 +16,7 @@ class CoreDNS(OpenMetricsBaseCheckV2):
         super().__init__(name, init_config, instances)
 
     def get_default_config(self):
-        return {'metrics': construct_metrics_config(METRIC_MAP, METRIC_OVERRIDE)}
+        return {'metrics': construct_metrics_config(METRIC_MAP)}
 
     def create_scraper(self, config):
         return OpenMetricsCompatibilityScraper(self, self.get_config_with_defaults(config))

--- a/coredns/datadog_checks/coredns/check.py
+++ b/coredns/datadog_checks/coredns/check.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 from datadog_checks.base import OpenMetricsBaseCheckV2
 from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
 

--- a/coredns/datadog_checks/coredns/check.py
+++ b/coredns/datadog_checks/coredns/check.py
@@ -4,7 +4,7 @@
 from datadog_checks.base import OpenMetricsBaseCheckV2
 from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
 
-from .metrics import METRIC_MAP, construct_metrics_config
+from .metrics import METRIC_MAP, METRIC_OVERRIDE, construct_metrics_config
 
 
 class CoreDNS(OpenMetricsBaseCheckV2):
@@ -16,7 +16,7 @@ class CoreDNS(OpenMetricsBaseCheckV2):
         super().__init__(name, init_config, instances)
 
     def get_default_config(self):
-        return {'metrics': construct_metrics_config(METRIC_MAP)}
+        return {'metrics': construct_metrics_config(METRIC_MAP, METRIC_OVERRIDE)}
 
     def create_scraper(self, config):
         return OpenMetricsCompatibilityScraper(self, self.get_config_with_defaults(config))

--- a/coredns/datadog_checks/coredns/check.py
+++ b/coredns/datadog_checks/coredns/check.py
@@ -1,0 +1,20 @@
+from datadog_checks.base import OpenMetricsBaseCheckV2
+from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsCompatibilityScraper
+
+from .common import DEFAULT_METRICS, GO_METRICS
+
+
+class CoreDNS(OpenMetricsBaseCheckV2):
+    __NAMESPACE__ = 'coredns'
+
+    DEFAULT_METRIC_LIMIT = 0
+
+    def __init__(self, name, init_config, instances):
+        super().__init__(name, init_config, instances)
+
+    def get_default_config(self):
+        metrics = [DEFAULT_METRICS, GO_METRICS]
+        return {'metrics': metrics}
+
+    def create_scraper(self, config):
+        return OpenMetricsCompatibilityScraper(self, self.get_config_with_defaults(config))

--- a/coredns/datadog_checks/coredns/common.py
+++ b/coredns/datadog_checks/coredns/common.py
@@ -1,0 +1,129 @@
+# Sorted per plugin, all prometheus metrics prior to version 1.7.0 which introduced a major renaming of metrics.
+DEFAULT_METRICS = {
+    # acl: https://github.com/coredns/coredns/blob/v1.6.9/plugin/acl/
+    'coredns_request_block_count_total': 'acl.blocked_requests',
+    'coredns_request_allow_count_total': 'acl.allowed_requests',
+    # autopath: https://github.com/coredns/coredns/blob/v1.6.9/plugin/autopath/
+    'coredns_autopath_success_count_total': 'autopath.success_count',
+    # cache: https://github.com/coredns/coredns/tree/v1.6.9/plugin/cache
+    'coredns_cache_size': 'cache_size.count',
+    'coredns_cache_hits_total': 'cache_hits_count',
+    'coredns_cache_misses_total': 'cache_misses_count',
+    'coredns_cache_drops_total': 'cache_drops_count',
+    'coredns_cache_prefetch_total': 'cache_prefetch_count',
+    'coredns_cache_served_stale_total': 'cache_stale_count',
+    # dnssec: https://github.com/coredns/coredns/tree/v1.6.9/plugin/dnssec
+    'coredns_dnssec_cache_size': 'dnssec.cache_size',
+    'coredns_dnssec_cache_hits_total': 'dnssec.cache_hits',
+    'coredns_dnssec_cache_misses_total': 'dnssec.cache_misses',
+    # forward: https://github.com/coredns/coredns/tree/v1.6.9/plugin/forward
+    'coredns_forward_request_duration_seconds': 'forward_request_duration.seconds',
+    'coredns_forward_request_count_total': 'forward_request_count',
+    'coredns_forward_response_rcode_count_total': 'forward_response_rcode_count',
+    'coredns_forward_healthcheck_failure_count_total': 'forward_healthcheck_failure_count',
+    'coredns_forward_healthcheck_broken_count_total': 'forward_healthcheck_broken_count',
+    'coredns_forward_sockets_open': 'forward_sockets_open',
+    'coredns_forward_max_concurrent_reject_count_total': 'forward_max_concurrent_rejects',
+    # grpc: https://github.com/coredns/coredns/tree/v1.6.9/plugin/grpc
+    'coredns_grpc_request_duration_seconds': 'grpc.request_duration',
+    'coredns_grpc_request_count_total': 'grpc.request_count',
+    'coredns_grpc_response_rcode_count_total': 'grpc.response_rcode_count',
+    # health: https://github.com/coredns/coredns/tree/v1.6.9/plugin/health
+    'coredns_health_request_duration_seconds': 'health_request_duration',
+    # hosts: https://github.com/coredns/coredns/tree/v1.6.9/plugin/hosts
+    'coredns_hosts_entries_count': 'hosts.entries_count',
+    'coredns_hosts_reload_timestamp_seconds': 'hosts.reload_timestamp',
+    # kubernetes: https://github.com/coredns/coredns/tree/v1.6.9/plugin/kubernetes
+    'coredns_kubernetes_dns_programming_duration_seconds': 'kubernetes.dns_programming_duration',
+    # metrics: https://github.com/coredns/coredns/tree/v1.6.9/plugin/metrics
+    'coredns_build_info': 'build_info',
+    'coredns_panic_count_total': 'panic_count.count',
+    'coredns_dns_request_count_total': 'request_count',
+    'coredns_dns_request_duration_seconds': 'request_duration.seconds',
+    'coredns_dns_request_size_bytes': 'request_size.bytes',
+    'coredns_dns_request_do_count_total': 'do_request_count',
+    'coredns_dns_request_type_count_total': 'request_type_count',
+    'coredns_dns_response_size_bytes': 'response_size.bytes',
+    'coredns_dns_response_rcode_count_total': 'response_code_count',
+    'coredns_plugin_enabled': 'plugin_enabled',
+    # reload: https://github.com/coredns/coredns/tree/v1.6.9/plugin/reload
+    'coredns_reload_failed_count_total': 'reload.failed_count',
+    # template: https://github.com/coredns/coredns/tree/v1.6.9/plugin/template
+    'coredns_template_matches_total': 'template.matches_count',
+    'coredns_template_template_failures_total': 'template.failures_count',
+    'coredns_template_rr_failures_total': 'template.rr_failures_count',
+    # proxy (deprecated): https://github.com/coredns/coredns/tree/v1.4.0/plugin/proxy
+    'coredns_proxy_request_count_total': 'proxy_request_count',
+    'coredns_proxy_request_duration_seconds': 'proxy_request_duration.seconds',
+}
+
+# Sorted per plugin, all prometheus metrics after version 1.7.0 which introduced a major renaming of metrics.
+NEW_METRICS = {
+    # acl: https://github.com/coredns/coredns/blob/v1.7.0/plugin/acl/README.md
+    'coredns_acl_blocked_requests_total': 'acl.blocked_requests',
+    'coredns_acl_allowed_requests_total': 'acl.allowed_requests',
+    # autopath: https://github.com/coredns/coredns/blob/v1.7.0/plugin/autopath/
+    'coredns_autopath_success_total': 'autopath.success_count',
+    # cache: https://github.com/coredns/coredns/tree/v1.8.5/plugin/cache
+    'coredns_cache_entries': 'cache_size.count',
+    'coredns_cache_requests_total': 'cache_request_count',
+    # dnssec: https://github.com/coredns/coredns/tree/v1.7.0/plugin/dnssec
+    'coredns_dnssec_cache_entries': 'dnssec.cache_size',
+    # forward: https://github.com/coredns/coredns/tree/v1.7.0/plugin/forward
+    'coredns_forward_requests_total': 'forward_request_count',
+    'coredns_forward_responses_total': 'forward_response_rcode_count',
+    'coredns_forward_healthcheck_failures_total': 'forward_healthcheck_failure_count',
+    'coredns_forward_healthcheck_broken_total': 'forward_healthcheck_broken_count',
+    'coredns_forward_max_concurrent_rejects_total': 'forward_max_concurrent_rejects',
+    # grpc: https://github.com/coredns/coredns/tree/v1.7.0/plugin/grpc
+    'coredns_grpc_requests_total': 'grpc.request_count',
+    'coredns_grpc_responses_total': 'grpc.response_rcode_count',
+    # hosts: https://github.com/coredns/coredns/tree/v1.7.0/plugin/hosts
+    'coredns_hosts_entries': 'hosts.entries_count',
+    # metrics: https://github.com/coredns/coredns/tree/v1.7.0/plugin/metrics
+    'coredns_panics_total': 'panic_count.count',
+    'coredns_dns_requests_total': 'request_count',
+    'coredns_dns_do_requests_total': 'do_request_count',
+    'coredns_dns_responses_total': 'response_code_count',
+    'coredns_plugin_enabled': 'plugin_enabled',
+    # reload: https://github.com/coredns/coredns/tree/v1.7.0/plugin/reload
+    'coredns_reload_failed_total': 'reload.failed_count',
+}
+
+DEFAULT_METRICS.update(NEW_METRICS)
+
+GO_METRICS = {
+    'go_gc_duration_seconds': 'go.gc_duration_seconds',
+    'go_goroutines': 'go.goroutines',
+    'go_info': 'go.info',
+    'go_memstats_alloc_bytes': 'go.memstats.alloc_bytes',
+    'go_memstats_alloc_bytes_total': 'go.memstats.alloc_bytes_total',
+    'go_memstats_buck_hash_sys_bytes': 'go.memstats.buck_hash_sys_bytes',
+    'go_memstats_frees_total': 'go.memstats.frees_total',
+    'go_memstats_gc_cpu_fraction': 'go.memstats.gc_cpu_fraction',
+    'go_memstats_gc_sys_bytes': 'go.memstats.gc_sys_bytes',
+    'go_memstats_heap_alloc_bytes': 'go.memstats.heap_alloc_bytes',
+    'go_memstats_heap_idle_bytes': 'go.memstats.heap_idle_bytes',
+    'go_memstats_heap_inuse_bytes': 'go.memstats.heap_inuse_bytes',
+    'go_memstats_heap_objects': 'go.memstats.heap_objects',
+    'go_memstats_heap_released_bytes': 'go.memstats.heap_released_bytes',
+    'go_memstats_heap_sys_bytes': 'go.memstats.heap_sys_bytes',
+    'go_memstats_last_gc_time_seconds': 'go.memstats.last_gc_time_seconds',
+    'go_memstats_lookups_total': 'go.memstats.lookups_total',
+    'go_memstats_mallocs_total': 'go.memstats.mallocs_total',
+    'go_memstats_mcache_inuse_bytes': 'go.memstats.mcache_inuse_bytes',
+    'go_memstats_mcache_sys_bytes': 'go.memstats.mcache_sys_bytes',
+    'go_memstats_mspan_inuse_bytes': 'go.memstats.mspan_inuse_bytes',
+    'go_memstats_mspan_sys_bytes': 'go.memstats.mspan_sys_bytes',
+    'go_memstats_next_gc_bytes': 'go.memstats.next_gc_bytes',
+    'go_memstats_other_sys_bytes': 'go.memstats.other_sys_bytes',
+    'go_memstats_stack_inuse_bytes': 'go.memstats.stack_inuse_bytes',
+    'go_memstats_stack_sys_bytes': 'go.memstats.stack_sys_bytes',
+    'go_memstats_sys_bytes': 'go.memstats.sys_bytes',
+    'process_cpu_seconds_total': 'process.cpu_seconds_total',
+    'process_max_fds': 'process.max_fds',
+    'process_open_fds': 'process.open_fds',
+    'process_resident_memory_bytes': 'process.resident_memory_bytes',
+    'process_start_time_seconds': 'process.start_time_seconds',
+    'process_virtual_memory_bytes': 'process.virtual_memory_bytes',
+}

--- a/coredns/datadog_checks/coredns/config_models/defaults.py
+++ b/coredns/datadog_checks/coredns/config_models/defaults.py
@@ -50,6 +50,14 @@ def instance_aws_service(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_auth(field, value):
+    return False
+
+
+def instance_bearer_token_path(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_cache_metric_wildcards(field, value):
     return True
 
@@ -106,6 +114,10 @@ def instance_headers(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_health_service_check(field, value):
+    return True
+
+
 def instance_histogram_buckets_as_distributions(field, value):
     return False
 
@@ -115,6 +127,14 @@ def instance_hostname_format(field, value):
 
 
 def instance_hostname_label(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_ignore_metrics(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_ignore_metrics_by_labels(field, value):
     return get_default_field_value(field, value)
 
 
@@ -154,6 +174,18 @@ def instance_kerberos_principal(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_label_joins(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_label_to_hostname(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_labels_mapper(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_log_requests(field, value):
     return False
 
@@ -190,6 +222,14 @@ def instance_persist_connections(field, value):
     return False
 
 
+def instance_prometheus_metrics_prefix(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_prometheus_url(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_proxy(field, value):
     return get_default_field_value(field, value)
 
@@ -212,6 +252,30 @@ def instance_rename_labels(field, value):
 
 def instance_request_size(field, value):
     return 16
+
+
+def instance_send_distribution_buckets(field, value):
+    return False
+
+
+def instance_send_distribution_counts_as_monotonic(field, value):
+    return False
+
+
+def instance_send_distribution_sums_as_monotonic(field, value):
+    return False
+
+
+def instance_send_histograms_buckets(field, value):
+    return True
+
+
+def instance_send_monotonic_counter(field, value):
+    return True
+
+
+def instance_send_monotonic_with_gauge(field, value):
+    return False
 
 
 def instance_service(field, value):
@@ -260,6 +324,10 @@ def instance_tls_use_host_header(field, value):
 
 def instance_tls_verify(field, value):
     return True
+
+
+def instance_type_overrides(field, value):
+    return get_default_field_value(field, value)
 
 
 def instance_use_latest_spec(field, value):

--- a/coredns/datadog_checks/coredns/config_models/defaults.py
+++ b/coredns/datadog_checks/coredns/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -50,12 +50,20 @@ def instance_aws_service(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_bearer_token_auth(field, value):
+def instance_cache_metric_wildcards(field, value):
+    return True
+
+
+def instance_cache_shared_labels(field, value):
+    return True
+
+
+def instance_collect_counters_with_distributions(field, value):
     return False
 
 
-def instance_bearer_token_path(field, value):
-    return get_default_field_value(field, value)
+def instance_collect_histogram_buckets(field, value):
+    return True
 
 
 def instance_connect_timeout(field, value):
@@ -70,7 +78,19 @@ def instance_empty_default_hostname(field, value):
     return False
 
 
+def instance_enable_health_service_check(field, value):
+    return True
+
+
 def instance_exclude_labels(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_exclude_metrics(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_exclude_metrics_by_labels(field, value):
     return get_default_field_value(field, value)
 
 
@@ -78,19 +98,23 @@ def instance_extra_headers(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_extra_metrics(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_headers(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_health_service_check(field, value):
-    return True
+def instance_histogram_buckets_as_distributions(field, value):
+    return False
 
 
-def instance_ignore_metrics(field, value):
+def instance_hostname_format(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_ignore_metrics_by_labels(field, value):
+def instance_hostname_label(field, value):
     return get_default_field_value(field, value)
 
 
@@ -130,18 +154,6 @@ def instance_kerberos_principal(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_label_joins(field, value):
-    return get_default_field_value(field, value)
-
-
-def instance_label_to_hostname(field, value):
-    return get_default_field_value(field, value)
-
-
-def instance_labels_mapper(field, value):
-    return get_default_field_value(field, value)
-
-
 def instance_log_requests(field, value):
     return False
 
@@ -155,11 +167,19 @@ def instance_min_collection_interval(field, value):
 
 
 def instance_namespace(field, value):
-    return 'service'
+    return get_default_field_value(field, value)
+
+
+def instance_non_cumulative_histogram_buckets(field, value):
+    return False
 
 
 def instance_ntlm_domain(field, value):
     return get_default_field_value(field, value)
+
+
+def instance_openmetrics_endpoint(field, value):
+    return 'http://%%host%%:9153/metrics'
 
 
 def instance_password(field, value):
@@ -170,11 +190,15 @@ def instance_persist_connections(field, value):
     return False
 
 
-def instance_prometheus_metrics_prefix(field, value):
+def instance_proxy(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_proxy(field, value):
+def instance_raw_line_filters(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_raw_metric_prefix(field, value):
     return get_default_field_value(field, value)
 
 
@@ -182,35 +206,19 @@ def instance_read_timeout(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_rename_labels(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_request_size(field, value):
-    return 10
-
-
-def instance_send_distribution_buckets(field, value):
-    return False
-
-
-def instance_send_distribution_counts_as_monotonic(field, value):
-    return False
-
-
-def instance_send_distribution_sums_as_monotonic(field, value):
-    return False
-
-
-def instance_send_histograms_buckets(field, value):
-    return True
-
-
-def instance_send_monotonic_counter(field, value):
-    return True
-
-
-def instance_send_monotonic_with_gauge(field, value):
-    return False
+    return 16
 
 
 def instance_service(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_share_labels(field, value):
     return get_default_field_value(field, value)
 
 
@@ -220,6 +228,10 @@ def instance_skip_proxy(field, value):
 
 def instance_tags(field, value):
     return get_default_field_value(field, value)
+
+
+def instance_telemetry(field, value):
+    return False
 
 
 def instance_timeout(field, value):
@@ -250,8 +262,8 @@ def instance_tls_verify(field, value):
     return True
 
 
-def instance_type_overrides(field, value):
-    return get_default_field_value(field, value)
+def instance_use_latest_spec(field, value):
+    return False
 
 
 def instance_use_legacy_auth_encoding(field, value):

--- a/coredns/datadog_checks/coredns/config_models/instance.py
+++ b/coredns/datadog_checks/coredns/config_models/instance.py
@@ -36,6 +36,29 @@ class ExtraMetric(BaseModel):
     type: Optional[str]
 
 
+class IgnoreMetricsByLabels(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    target_label_key: Optional[str]
+    target_label_value_list: Optional[Sequence[str]]
+
+
+class TargetMetric(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    label_to_match: Optional[str]
+    labels_to_get: Optional[Sequence[str]]
+
+
+class LabelJoins(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    target_metric: Optional[TargetMetric]
+
+
 class Metric(BaseModel):
     class Config:
         extra = Extra.allow
@@ -72,6 +95,8 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
+    bearer_token_auth: Optional[bool]
+    bearer_token_path: Optional[str]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]
     collect_counters_with_distributions: Optional[bool]
@@ -86,9 +111,12 @@ class InstanceConfig(BaseModel):
     extra_headers: Optional[Mapping[str, Any]]
     extra_metrics: Optional[Sequence[Union[str, Mapping[str, Union[str, ExtraMetric]]]]]
     headers: Optional[Mapping[str, Any]]
+    health_service_check: Optional[bool]
     histogram_buckets_as_distributions: Optional[bool]
     hostname_format: Optional[str]
     hostname_label: Optional[str]
+    ignore_metrics: Optional[Sequence[str]]
+    ignore_metrics_by_labels: Optional[IgnoreMetricsByLabels]
     ignore_tags: Optional[Sequence[str]]
     include_labels: Optional[Sequence[str]]
     kerberos_auth: Optional[str]
@@ -98,6 +126,9 @@ class InstanceConfig(BaseModel):
     kerberos_hostname: Optional[str]
     kerberos_keytab: Optional[str]
     kerberos_principal: Optional[str]
+    label_joins: Optional[LabelJoins]
+    label_to_hostname: Optional[str]
+    labels_mapper: Optional[Mapping[str, Any]]
     log_requests: Optional[bool]
     metrics: Optional[Sequence[Union[str, Mapping[str, Union[str, Metric]]]]]
     min_collection_interval: Optional[float]
@@ -107,12 +138,20 @@ class InstanceConfig(BaseModel):
     openmetrics_endpoint: Optional[str]
     password: Optional[str]
     persist_connections: Optional[bool]
+    prometheus_metrics_prefix: Optional[str]
+    prometheus_url: Optional[str]
     proxy: Optional[Proxy]
     raw_line_filters: Optional[Sequence[str]]
     raw_metric_prefix: Optional[str]
     read_timeout: Optional[float]
     rename_labels: Optional[Mapping[str, Any]]
     request_size: Optional[float]
+    send_distribution_buckets: Optional[bool]
+    send_distribution_counts_as_monotonic: Optional[bool]
+    send_distribution_sums_as_monotonic: Optional[bool]
+    send_histograms_buckets: Optional[bool]
+    send_monotonic_counter: Optional[bool]
+    send_monotonic_with_gauge: Optional[bool]
     service: Optional[str]
     share_labels: Optional[Mapping[str, Union[bool, ShareLabel]]]
     skip_proxy: Optional[bool]
@@ -125,6 +164,7 @@ class InstanceConfig(BaseModel):
     tls_private_key: Optional[str]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
+    type_overrides: Optional[Mapping[str, Any]]
     use_latest_spec: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]
     use_process_start_time: Optional[bool]

--- a/coredns/datadog_checks/coredns/config_models/instance.py
+++ b/coredns/datadog_checks/coredns/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping, Optional, Sequence, Union
 
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, Extra, Field, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -27,27 +27,22 @@ class AuthToken(BaseModel):
     writer: Optional[Mapping[str, Any]]
 
 
-class IgnoreMetricsByLabels(BaseModel):
+class ExtraMetric(BaseModel):
     class Config:
+        extra = Extra.allow
         allow_mutation = False
 
-    target_label_key: Optional[str]
-    target_label_value_list: Optional[Sequence[str]]
+    name: Optional[str]
+    type: Optional[str]
 
 
-class TargetMetric(BaseModel):
+class Metric(BaseModel):
     class Config:
+        extra = Extra.allow
         allow_mutation = False
 
-    label_to_match: Optional[str]
-    labels_to_get: Optional[Sequence[str]]
-
-
-class LabelJoins(BaseModel):
-    class Config:
-        allow_mutation = False
-
-    target_metric: Optional[TargetMetric]
+    name: Optional[str]
+    type: Optional[str]
 
 
 class Proxy(BaseModel):
@@ -57,6 +52,14 @@ class Proxy(BaseModel):
     http: Optional[str]
     https: Optional[str]
     no_proxy: Optional[Sequence[str]]
+
+
+class ShareLabel(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    labels: Optional[Sequence[str]]
+    match: Optional[Sequence[str]]
 
 
 class InstanceConfig(BaseModel):
@@ -69,17 +72,23 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
-    bearer_token_path: Optional[str]
+    cache_metric_wildcards: Optional[bool]
+    cache_shared_labels: Optional[bool]
+    collect_counters_with_distributions: Optional[bool]
+    collect_histogram_buckets: Optional[bool]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]
+    enable_health_service_check: Optional[bool]
     exclude_labels: Optional[Sequence[str]]
+    exclude_metrics: Optional[Sequence[str]]
+    exclude_metrics_by_labels: Optional[Mapping[str, Union[bool, Sequence[str]]]]
     extra_headers: Optional[Mapping[str, Any]]
+    extra_metrics: Optional[Sequence[Union[str, Mapping[str, Union[str, ExtraMetric]]]]]
     headers: Optional[Mapping[str, Any]]
-    health_service_check: Optional[bool]
-    ignore_metrics: Optional[Sequence[str]]
-    ignore_metrics_by_labels: Optional[IgnoreMetricsByLabels]
+    histogram_buckets_as_distributions: Optional[bool]
+    hostname_format: Optional[str]
+    hostname_label: Optional[str]
     ignore_tags: Optional[Sequence[str]]
     include_labels: Optional[Sequence[str]]
     kerberos_auth: Optional[str]
@@ -89,30 +98,26 @@ class InstanceConfig(BaseModel):
     kerberos_hostname: Optional[str]
     kerberos_keytab: Optional[str]
     kerberos_principal: Optional[str]
-    label_joins: Optional[LabelJoins]
-    label_to_hostname: Optional[str]
-    labels_mapper: Optional[Mapping[str, Any]]
     log_requests: Optional[bool]
-    metrics: Optional[Sequence[Union[str, Mapping[str, str]]]]
+    metrics: Optional[Sequence[Union[str, Mapping[str, Union[str, Metric]]]]]
     min_collection_interval: Optional[float]
-    namespace: Optional[str]
+    namespace: Optional[str] = Field(None, regex='\\w*')
+    non_cumulative_histogram_buckets: Optional[bool]
     ntlm_domain: Optional[str]
+    openmetrics_endpoint: Optional[str]
     password: Optional[str]
     persist_connections: Optional[bool]
-    prometheus_metrics_prefix: Optional[str]
-    prometheus_url: str
     proxy: Optional[Proxy]
+    raw_line_filters: Optional[Sequence[str]]
+    raw_metric_prefix: Optional[str]
     read_timeout: Optional[float]
+    rename_labels: Optional[Mapping[str, Any]]
     request_size: Optional[float]
-    send_distribution_buckets: Optional[bool]
-    send_distribution_counts_as_monotonic: Optional[bool]
-    send_distribution_sums_as_monotonic: Optional[bool]
-    send_histograms_buckets: Optional[bool]
-    send_monotonic_counter: Optional[bool]
-    send_monotonic_with_gauge: Optional[bool]
     service: Optional[str]
+    share_labels: Optional[Mapping[str, Union[bool, ShareLabel]]]
     skip_proxy: Optional[bool]
     tags: Optional[Sequence[str]]
+    telemetry: Optional[bool]
     timeout: Optional[float]
     tls_ca_cert: Optional[str]
     tls_cert: Optional[str]
@@ -120,7 +125,7 @@ class InstanceConfig(BaseModel):
     tls_private_key: Optional[str]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
-    type_overrides: Optional[Mapping[str, Any]]
+    use_latest_spec: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]
     use_process_start_time: Optional[bool]
     username: Optional[str]

--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2018-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from six import PY2

--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -5,7 +5,7 @@ from six import PY2
 
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck
 
-from .common import DEFAULT_METRICS, GO_METRICS
+from .metrics import DEFAULT_METRICS, GO_METRICS
 
 
 class CoreDNSCheck(OpenMetricsBaseCheck):

--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -1,143 +1,40 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from six import PY2
+
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck
 
-# Sorted per plugin, all prometheus metrics prior to version 1.7.0 which introduced a major renaming of metrics.
-DEFAULT_METRICS = {
-    # acl: https://github.com/coredns/coredns/blob/v1.6.9/plugin/acl/
-    'coredns_request_block_count_total': 'acl.blocked_requests',
-    'coredns_request_allow_count_total': 'acl.allowed_requests',
-    # autopath: https://github.com/coredns/coredns/blob/v1.6.9/plugin/autopath/
-    'coredns_autopath_success_count_total': 'autopath.success_count',
-    # cache: https://github.com/coredns/coredns/tree/v1.6.9/plugin/cache
-    'coredns_cache_size': 'cache_size.count',
-    'coredns_cache_hits_total': 'cache_hits_count',
-    'coredns_cache_misses_total': 'cache_misses_count',
-    'coredns_cache_drops_total': 'cache_drops_count',
-    'coredns_cache_prefetch_total': 'cache_prefetch_count',
-    'coredns_cache_served_stale_total': 'cache_stale_count',
-    # dnssec: https://github.com/coredns/coredns/tree/v1.6.9/plugin/dnssec
-    'coredns_dnssec_cache_size': 'dnssec.cache_size',
-    'coredns_dnssec_cache_hits_total': 'dnssec.cache_hits',
-    'coredns_dnssec_cache_misses_total': 'dnssec.cache_misses',
-    # forward: https://github.com/coredns/coredns/tree/v1.6.9/plugin/forward
-    'coredns_forward_request_duration_seconds': 'forward_request_duration.seconds',
-    'coredns_forward_request_count_total': 'forward_request_count',
-    'coredns_forward_response_rcode_count_total': 'forward_response_rcode_count',
-    'coredns_forward_healthcheck_failure_count_total': 'forward_healthcheck_failure_count',
-    'coredns_forward_healthcheck_broken_count_total': 'forward_healthcheck_broken_count',
-    'coredns_forward_sockets_open': 'forward_sockets_open',
-    'coredns_forward_max_concurrent_reject_count_total': 'forward_max_concurrent_rejects',
-    # grpc: https://github.com/coredns/coredns/tree/v1.6.9/plugin/grpc
-    'coredns_grpc_request_duration_seconds': 'grpc.request_duration',
-    'coredns_grpc_request_count_total': 'grpc.request_count',
-    'coredns_grpc_response_rcode_count_total': 'grpc.response_rcode_count',
-    # health: https://github.com/coredns/coredns/tree/v1.6.9/plugin/health
-    'coredns_health_request_duration_seconds': 'health_request_duration',
-    # hosts: https://github.com/coredns/coredns/tree/v1.6.9/plugin/hosts
-    'coredns_hosts_entries_count': 'hosts.entries_count',
-    'coredns_hosts_reload_timestamp_seconds': 'hosts.reload_timestamp',
-    # kubernetes: https://github.com/coredns/coredns/tree/v1.6.9/plugin/kubernetes
-    'coredns_kubernetes_dns_programming_duration_seconds': 'kubernetes.dns_programming_duration',
-    # metrics: https://github.com/coredns/coredns/tree/v1.6.9/plugin/metrics
-    'coredns_build_info': 'build_info',
-    'coredns_panic_count_total': 'panic_count.count',
-    'coredns_dns_request_count_total': 'request_count',
-    'coredns_dns_request_duration_seconds': 'request_duration.seconds',
-    'coredns_dns_request_size_bytes': 'request_size.bytes',
-    'coredns_dns_request_do_count_total': 'do_request_count',
-    'coredns_dns_request_type_count_total': 'request_type_count',
-    'coredns_dns_response_size_bytes': 'response_size.bytes',
-    'coredns_dns_response_rcode_count_total': 'response_code_count',
-    'coredns_plugin_enabled': 'plugin_enabled',
-    # reload: https://github.com/coredns/coredns/tree/v1.6.9/plugin/reload
-    'coredns_reload_failed_count_total': 'reload.failed_count',
-    # template: https://github.com/coredns/coredns/tree/v1.6.9/plugin/template
-    'coredns_template_matches_total': 'template.matches_count',
-    'coredns_template_template_failures_total': 'template.failures_count',
-    'coredns_template_rr_failures_total': 'template.rr_failures_count',
-    # proxy (deprecated): https://github.com/coredns/coredns/tree/v1.4.0/plugin/proxy
-    'coredns_proxy_request_count_total': 'proxy_request_count',
-    'coredns_proxy_request_duration_seconds': 'proxy_request_duration.seconds',
-}
-
-# Sorted per plugin, all prometheus metrics after version 1.7.0 which introduced a major renaming of metrics.
-NEW_METRICS = {
-    # acl: https://github.com/coredns/coredns/blob/v1.7.0/plugin/acl/README.md
-    'coredns_acl_blocked_requests_total': 'acl.blocked_requests',
-    'coredns_acl_allowed_requests_total': 'acl.allowed_requests',
-    # autopath: https://github.com/coredns/coredns/blob/v1.7.0/plugin/autopath/
-    'coredns_autopath_success_total': 'autopath.success_count',
-    # cache: https://github.com/coredns/coredns/tree/v1.8.5/plugin/cache
-    'coredns_cache_entries': 'cache_size.count',
-    'coredns_cache_requests_total': 'cache_request_count',
-    # dnssec: https://github.com/coredns/coredns/tree/v1.7.0/plugin/dnssec
-    'coredns_dnssec_cache_entries': 'dnssec.cache_size',
-    # forward: https://github.com/coredns/coredns/tree/v1.7.0/plugin/forward
-    'coredns_forward_requests_total': 'forward_request_count',
-    'coredns_forward_responses_total': 'forward_response_rcode_count',
-    'coredns_forward_healthcheck_failures_total': 'forward_healthcheck_failure_count',
-    'coredns_forward_healthcheck_broken_total': 'forward_healthcheck_broken_count',
-    'coredns_forward_max_concurrent_rejects_total': 'forward_max_concurrent_rejects',
-    # grpc: https://github.com/coredns/coredns/tree/v1.7.0/plugin/grpc
-    'coredns_grpc_requests_total': 'grpc.request_count',
-    'coredns_grpc_responses_total': 'grpc.response_rcode_count',
-    # hosts: https://github.com/coredns/coredns/tree/v1.7.0/plugin/hosts
-    'coredns_hosts_entries': 'hosts.entries_count',
-    # metrics: https://github.com/coredns/coredns/tree/v1.7.0/plugin/metrics
-    'coredns_panics_total': 'panic_count.count',
-    'coredns_dns_requests_total': 'request_count',
-    'coredns_dns_do_requests_total': 'do_request_count',
-    'coredns_dns_responses_total': 'response_code_count',
-    'coredns_plugin_enabled': 'plugin_enabled',
-    # reload: https://github.com/coredns/coredns/tree/v1.7.0/plugin/reload
-    'coredns_reload_failed_total': 'reload.failed_count',
-}
-
-DEFAULT_METRICS.update(NEW_METRICS)
-
-GO_METRICS = {
-    'go_gc_duration_seconds': 'go.gc_duration_seconds',
-    'go_goroutines': 'go.goroutines',
-    'go_info': 'go.info',
-    'go_memstats_alloc_bytes': 'go.memstats.alloc_bytes',
-    'go_memstats_alloc_bytes_total': 'go.memstats.alloc_bytes_total',
-    'go_memstats_buck_hash_sys_bytes': 'go.memstats.buck_hash_sys_bytes',
-    'go_memstats_frees_total': 'go.memstats.frees_total',
-    'go_memstats_gc_cpu_fraction': 'go.memstats.gc_cpu_fraction',
-    'go_memstats_gc_sys_bytes': 'go.memstats.gc_sys_bytes',
-    'go_memstats_heap_alloc_bytes': 'go.memstats.heap_alloc_bytes',
-    'go_memstats_heap_idle_bytes': 'go.memstats.heap_idle_bytes',
-    'go_memstats_heap_inuse_bytes': 'go.memstats.heap_inuse_bytes',
-    'go_memstats_heap_objects': 'go.memstats.heap_objects',
-    'go_memstats_heap_released_bytes': 'go.memstats.heap_released_bytes',
-    'go_memstats_heap_sys_bytes': 'go.memstats.heap_sys_bytes',
-    'go_memstats_last_gc_time_seconds': 'go.memstats.last_gc_time_seconds',
-    'go_memstats_lookups_total': 'go.memstats.lookups_total',
-    'go_memstats_mallocs_total': 'go.memstats.mallocs_total',
-    'go_memstats_mcache_inuse_bytes': 'go.memstats.mcache_inuse_bytes',
-    'go_memstats_mcache_sys_bytes': 'go.memstats.mcache_sys_bytes',
-    'go_memstats_mspan_inuse_bytes': 'go.memstats.mspan_inuse_bytes',
-    'go_memstats_mspan_sys_bytes': 'go.memstats.mspan_sys_bytes',
-    'go_memstats_next_gc_bytes': 'go.memstats.next_gc_bytes',
-    'go_memstats_other_sys_bytes': 'go.memstats.other_sys_bytes',
-    'go_memstats_stack_inuse_bytes': 'go.memstats.stack_inuse_bytes',
-    'go_memstats_stack_sys_bytes': 'go.memstats.stack_sys_bytes',
-    'go_memstats_sys_bytes': 'go.memstats.sys_bytes',
-    'process_cpu_seconds_total': 'process.cpu_seconds_total',
-    'process_max_fds': 'process.max_fds',
-    'process_open_fds': 'process.open_fds',
-    'process_resident_memory_bytes': 'process.resident_memory_bytes',
-    'process_start_time_seconds': 'process.start_time_seconds',
-    'process_virtual_memory_bytes': 'process.virtual_memory_bytes',
-}
+from .common import DEFAULT_METRICS, GO_METRICS
 
 
 class CoreDNSCheck(OpenMetricsBaseCheck):
     """
+    This is a legacy implementation that will be removed at some point, refer to check.py for the new implementation.
+    """
+
+    METRIC_PREFIX = 'coredns.'
+
+    """
     Collect CoreDNS metrics from its Prometheus endpoint
     """
+
+    def __new__(cls, name, init_config, instances):
+        instance = instances[0]
+
+        if 'openmetrics_endpoint' in instance:
+            if PY2:
+                raise ConfigurationError(
+                    "This version of the integration is only available when using py3. "
+                    "Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3 "
+                    "for more information or use the older style config."
+                )
+            # TODO: when we drop Python 2 move this import up top
+            from .check import CoreDNS
+
+            return CoreDNS(name, init_config, instances)
+        else:
+            return super(CoreDNSCheck, cls).__new__(cls)
 
     def __init__(self, name, init_config, instances=None):
 

--- a/coredns/datadog_checks/coredns/data/auto_conf.yaml
+++ b/coredns/datadog_checks/coredns/data/auto_conf.yaml
@@ -14,12 +14,13 @@ init_config:
 #
 instances:
 
-    ## @param prometheus_url - string - required
-    ## To enable CoreDNS metrics you must specify the prometheus url
+  -
+    ## @param openmetrics_endpoint - string - optional - default: http://%%host%%:9153/metrics
+    ## To enable CoreDNS metrics you must specify the openmetrics endpoint url
     ## and enable the plugin within coredns
     ## See: https://coredns.io/plugins/metrics/
     #
-  - prometheus_url: http://%%host%%:9153/metrics
+    # openmetrics_endpoint: http://%%host%%:9153/metrics
 
     ## @param tags - list of strings - required
     ## List of tags to attach to every metric and service check emitted by this integration.
@@ -28,17 +29,6 @@ instances:
     #
     tags:
       - dns-pod:%%host%%
-
-    ## @param send_histograms_buckets - boolean - optional - default: true
-    ## Set send_histograms_buckets to true to send the histograms bucket.
-    #
-    # send_histograms_buckets: true
-
-    ## @param send_monotonic_counter - boolean - optional - default: true
-    ## To send counters as monotonic counter
-    ## see: https://github.com/DataDog/integrations-core/issues/1303
-    #
-    # send_monotonic_counter: true
 
     ## @param metrics - list of strings - optional
     ## Metrics from the CoreDNS plugins for 'metrics', 'proxy', 'forward' and 'cache'

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -45,13 +45,7 @@ init_config:
 #
 instances:
 
-    ## @param prometheus_url - string - required
-    ## To enable CoreDNS metrics you must specify the prometheus url
-    ## and enable the plugin within coredns.
-    ## See: https://coredns.io/plugins/metrics/
-    #
-  - prometheus_url: http://%%host%%:9153/metrics
-
+  -
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##
@@ -60,82 +54,189 @@ instances:
     # tags:
     #   - dns-pod:%%host%%
 
+    ## @param openmetrics_endpoint - string - optional - default: http://%%host%%:9153/metrics
+    ## The URL exposing metrics in the OpenMetrics format.
+    #
+    openmetrics_endpoint: http://%%host%%:9153/metrics
+
+    ## @param raw_metric_prefix - string - optional
+    ## A prefix that will be removed from all exposed metric names, if present.
+    ## All configuration options will use the prefix-less name.
+    #
+    # raw_metric_prefix: <PREFIX>_
+
     ## @param metrics - (list of string or mapping) - optional
-    ## List of metrics to be fetched from the prometheus endpoint, if there's a
-    ## value it'll be renamed. This list should contain at least one metric.
+    ## This list defines which metrics to collect from the `openmetrics_endpoint`.
+    ## Metrics may be defined in 3 ways:
+    ##
+    ## 1. If the item is a string, then it represents the exposed metric name, and
+    ##    the sent metric name will be identical. For example:
+    ##
+    ##      metrics:
+    ##      - <METRIC_1>
+    ##      - <METRIC_2>
+    ## 2. If the item is a mapping, then the keys represent the exposed metric names.
+    ##
+    ##      a. If a value is a string, then it represents the sent metric name. For example:
+    ##
+    ##           metrics:
+    ##           - <EXPOSED_METRIC_1>: <SENT_METRIC_1>
+    ##           - <EXPOSED_METRIC_2>: <SENT_METRIC_2>
+    ##      b. If a value is a mapping, then it must have a `name` and/or `type` key.
+    ##         The `name` represents the sent metric name, and the `type` represents how
+    ##         the metric should be handled, overriding any type information the endpoint
+    ##         may provide. For example:
+    ##
+    ##           metrics:
+    ##           - <EXPOSED_METRIC_1>:
+    ##               name: <SENT_METRIC_1>
+    ##               type: <METRIC_TYPE_1>
+    ##           - <EXPOSED_METRIC_2>:
+    ##               name: <SENT_METRIC_2>
+    ##               type: <METRIC_TYPE_2>
+    ##
+    ##         The supported native types are `gauge`, `counter`, `histogram`, and `summary`.
+    ##
+    ## Regular expressions may be used to match the exposed metric names, for example:
+    ##
+    ##   metrics:
+    ##   - ^network_(ingress|egress)_.+
+    ##   - .+:
+    ##       type: gauge
     #
     # metrics:
     #   - coredns_template_matches_total: template_matches_count
     #   - coredns_template_template_failures_total: template_templating_failures_count
     #   - coredns_template_rr_failures_total: template_resource_record_failures_count
 
-    ## @param prometheus_metrics_prefix - string - optional
-    ## Removes a given <PREFIX> from exposed Prometheus metrics.
-    #
-    # prometheus_metrics_prefix: <PREFIX>_
-
-    ## @param health_service_check - boolean - optional - default: true
-    ## Send a service check reporting about the health of the Prometheus endpoint.
-    ## The service check is named <NAMESPACE>.prometheus.health
-    #
-    # health_service_check: true
-
-    ## @param label_to_hostname - string - optional
-    ## Override the hostname with the value of one label.
-    #
-    # label_to_hostname: <LABEL>
-
-    ## @param label_joins - mapping - optional
-    ## Allows targeting a metric to retrieve its label with a 1:1 mapping.
-    #
-    # label_joins:
-    #   target_metric:
-    #     label_to_match: <MATCHED_LABEL>
-    #     labels_to_get:
-    #     - <EXTRA_LABEL_1>
-    #     - <EXTRA_LABEL_2>
-
-    ## @param labels_mapper - mapping - optional
-    ## The label mapper allows you to rename labels.
-    ## Format is <LABEL_TO_RENAME>: <NEW_LABEL_NAME>
-    #
-    # labels_mapper:
-    #   flavor: origin
-
-    ## @param type_overrides - mapping - optional
-    ## Override a type in the Prometheus payload or type an untyped metric (ignored by default).
-    ## Supported <METRIC_TYPE> are `gauge`, `counter`, `histogram`, and `summary`.
-    ## The "*" wildcard can be used to match multiple metric names.
-    #
-    # type_overrides:
-    #   <METRIC_NAME>: <METRIC_TYPE>
-
-    ## @param send_histograms_buckets - boolean - optional - default: true
-    ## Set send_histograms_buckets to true to send the histograms bucket.
-    #
-    # send_histograms_buckets: true
-
-    ## @param send_distribution_buckets - boolean - optional - default: false
-    ## Set `send_distribution_buckets` to `true` to send histograms as Datadog distribution metrics.
+    ## @param extra_metrics - (list of string or mapping) - optional
+    ## This list defines metrics to collect from the `openmetrics_endpoint`, in addition to
+    ## what the check collects by default. If the check already collects a metric, then
+    ## metric definitions here take precedence. Metrics may be defined in 3 ways:
     ##
-    ## Learn more about distribution metrics: https://docs.datadoghq.com/developers/metrics/distributions/
+    ## 1. If the item is a string, then it represents the exposed metric name, and
+    ##    the sent metric name will be identical. For example:
+    ##
+    ##      metrics:
+    ##      - <METRIC_1>
+    ##      - <METRIC_2>
+    ## 2. If the item is a mapping, then the keys represent the exposed metric names.
+    ##
+    ##      a. If a value is a string, then it represents the sent metric name. For example:
+    ##
+    ##           metrics:
+    ##           - <EXPOSED_METRIC_1>: <SENT_METRIC_1>
+    ##           - <EXPOSED_METRIC_2>: <SENT_METRIC_2>
+    ##      b. If a value is a mapping, then it must have a `name` and/or `type` key.
+    ##         The `name` represents the sent metric name, and the `type` represents how
+    ##         the metric should be handled, overriding any type information the endpoint
+    ##         may provide. For example:
+    ##
+    ##           metrics:
+    ##           - <EXPOSED_METRIC_1>:
+    ##               name: <SENT_METRIC_1>
+    ##               type: <METRIC_TYPE_1>
+    ##           - <EXPOSED_METRIC_2>:
+    ##               name: <SENT_METRIC_2>
+    ##               type: <METRIC_TYPE_2>
+    ##
+    ##         The supported native types are `gauge`, `counter`, `histogram`, and `summary`.
+    ##
+    ## Regular expressions may be used to match the exposed metric names, for example:
+    ##
+    ##   metrics:
+    ##   - ^network_(ingress|egress)_.+
+    ##   - .+:
+    ##       type: gauge
     #
-    # send_distribution_buckets: false
+    # extra_metrics: []
 
-    ## @param send_monotonic_counter - boolean - optional - default: true
-    ## Set send_monotonic_counter to true to send counters as monotonic counter.
+    ## @param exclude_metrics - list of strings - optional
+    ## A list of metrics to exclude, with each entry being either
+    ## the exact metric name or a regular expression.
+    ## In order to exclude all metrics but the ones matching a specific filter,
+    ## you can use a negative lookahead regex like:
+    ##   - ^(?!foo).*$
     #
-    # send_monotonic_counter: true
+    # exclude_metrics: []
 
-    ## @param send_distribution_counts_as_monotonic - boolean - optional - default: false
-    ## If set to true, sends histograms and summary counters as monotonic counters (instead of gauges).
+    ## @param exclude_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label name and values are ignored. To match
+    ## all values of a label, set it to `true`.
+    ##
+    ## For example, the following configuration instructs the check to exclude all metrics with
+    ## a label `worker` or a label `pid` with the value of either `23` or `42`.
+    ##
+    ##   exclude_metrics_by_labels:
+    ##     worker: true
+    ##     pid:
+    ##     - '23'
+    ##     - '42'
     #
-    # send_distribution_counts_as_monotonic: false
+    # exclude_metrics_by_labels: {}
 
-    ## @param send_distribution_sums_as_monotonic - boolean - optional - default: false
-    ## If set to true, sends histograms and summary sums as monotonic counters (instead of gauges).
+    ## @param exclude_labels - list of strings - optional
+    ## A list of labels to exclude, useful for high cardinality values like timestamps or UUIDs.
+    ## May be used in conjunction with `include_labels`.
+    ## Labels defined in `excluded labels` will take precedence in case of overlap.
     #
-    # send_distribution_sums_as_monotonic: false
+    # exclude_labels: []
+
+    ## @param include_labels - list of strings - optional
+    ## A list of labels to include. May be used in conjunction with `exclude_labels`.
+    ## Labels defined in `excluded labels` will take precedence in case of overlap.
+    #
+    # include_labels: []
+
+    ## @param rename_labels - mapping - optional
+    ## A mapping of label names to how they should be renamed.
+    #
+    # rename_labels:
+    #   <LABEL_NAME_1>: <NEW_LABEL_NAME_1>
+    #   <LABEL_NAME_2>: <NEW_LABEL_NAME_2>
+
+    ## @param enable_health_service_check - boolean - optional - default: true
+    ## Whether or not to send a service check named `<NAMESPACE>.openmetrics.health` which reports
+    ## the health of the `openmetrics_endpoint`.
+    #
+    # enable_health_service_check: true
+
+    ## @param hostname_label - string - optional
+    ## Override the hostname for every metric submission with the value of one of its labels.
+    #
+    # hostname_label: <HOSTNAME_LABEL>
+
+    ## @param hostname_format - string - optional
+    ## When `hostname_label` is set, this instructs the check how to format the values. The string
+    ## `<HOSTNAME>` will be replaced by the value of the label defined by `hostname_label`.
+    #
+    # hostname_format: <HOSTNAME>
+
+    ## @param collect_histogram_buckets - boolean - optional - default: true
+    ## Whether or not to send histogram buckets.
+    #
+    # collect_histogram_buckets: true
+
+    ## @param non_cumulative_histogram_buckets - boolean - optional - default: false
+    ## Whether or not histogram buckets should be non-cumulative and to come with a `lower_bound` tag.
+    #
+    # non_cumulative_histogram_buckets: false
+
+    ## @param histogram_buckets_as_distributions - boolean - optional - default: false
+    ## Whether or not to send histogram buckets as Datadog distribution metrics. This implicitly
+    ## enables the `collect_histogram_buckets` and `non_cumulative_histogram_buckets` options.
+    ##
+    ## Learn more about distribution metrics:
+    ## https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#metric-types
+    #
+    # histogram_buckets_as_distributions: false
+
+    ## @param collect_counters_with_distributions - boolean - optional - default: false
+    ## Whether or not to also collect the observation counter metrics ending in `.sum` and `.count`
+    ## when sending histogram buckets as Datadog distribution metrics. This implicitly enables the
+    ## `histogram_buckets_as_distributions` option.
+    #
+    # collect_counters_with_distributions: false
 
     ## @param use_process_start_time - boolean - optional - default: false
     ## Whether to enable a heuristic for reporting counter values on the first scrape. When true,
@@ -145,50 +246,65 @@ instances:
     #
     # use_process_start_time: false
 
-    ## @param exclude_labels - list of strings - optional
-    ## A list of labels to be excluded. May be used in conjunction with `include_labels`.
-    ## Labels defined in `excluded labels` will take precedence in case of overlap.
+    ## @param share_labels - mapping - optional
+    ## This mapping allows for the sharing of labels across multiple metrics. The keys represent the
+    ## exposed metrics from which to share labels, and the values are mappings that configure the
+    ## sharing behavior. Each mapping must have at least one of the following keys:
+    ##
+    ##   labels - This is a list of labels to share. All labels are shared if this is not set.
+    ##   match - This is a list of labels to match on other metrics as a condition for sharing.
+    ##   values - This is a list of allowed values as a condition for sharing.
+    ##
+    ## To unconditionally share all labels of a metric, set it to `true`.
+    ##
+    ## For example, the following configuration instructs the check to apply all labels from `metric_a`
+    ## to all other metrics, the `node` label from `metric_b` to only those metrics that have a `pod`
+    ## label value that matches the `pod` label value of `metric_b`, and all labels from `metric_c`
+    ## to all other metrics if its value is equal to `23` or `42`.
+    ##
+    ##   share_labels:
+    ##     metric_a: true
+    ##     metric_b:
+    ##       labels:
+    ##       - node
+    ##       match:
+    ##       - pod
+    ##     metric_c:
+    ##       values:
+    ##       - 23
+    ##       - 42
     #
-    # exclude_labels:
-    #   - timestamp
+    # share_labels: {}
 
-    ## @param include_labels - list of strings - optional
-    ## A list of labels to include. May be used in conjunction with `exclude_labels`.
-    ## Labels defined in `excluded labels` will take precedence in case of overlap.
+    ## @param cache_shared_labels - boolean - optional - default: true
+    ## When `share_labels` is set, it instructs the check to cache labels collected from the first payload
+    ## for increased performance.
+    ##
+    ## Set this to `false` to compute label sharing for every payload at the risk of potentially increased memory usage.
     #
-    # include_labels: []
+    # cache_shared_labels: true
 
-    ## @param bearer_token_auth - boolean - optional - default: false
-    ## If set to true, adds a bearer token authentication header.
-    ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
+    ## @param raw_line_filters - list of strings - optional
+    ## A list of regular expressions used to exclude lines read from the `openmetrics_endpoint`
+    ## from being parsed.
     #
-    # bearer_token_auth: false
+    # raw_line_filters: []
 
-    ## @param bearer_token_path - string - optional
-    ## The path to a Kubernetes service account bearer token file. Make sure the file exists and is mounted correctly.
-    ## Note: bearer_token_auth should be set to true to enable adding the token to HTTP headers for authentication.
+    ## @param cache_metric_wildcards - boolean - optional - default: true
+    ## Whether or not to cache data from metrics that are defined by regular expressions rather
+    ## than the full metric name.
     #
-    # bearer_token_path: <TOKEN_PATH>
+    # cache_metric_wildcards: true
 
-    ## @param ignore_metrics - list of strings - optional
-    ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
-    ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.
+    ## @param use_latest_spec - boolean - optional - default: false
+    ## Whether or not the parser will strictly adhere to the latest version of the OpenMetrics specification.
     #
-    # ignore_metrics:
-    #   - <IGNORED_METRIC_NAME>
-    #   - <SUBSTRING_*>
-    #   - <*_SUBSTRING>
+    # use_latest_spec: false
 
-    ## @param ignore_metrics_by_labels - mapping - optional
-    ## A mapping of labels where metrics with matching label key and values are ignored.
-    ## Use the "*" wildcard to match all label values.
+    ## @param telemetry - boolean - optional - default: false
+    ## Whether or not to submit metrics prefixed by `<NAMESPACE>.telemetry.` for debugging purposes.
     #
-    # ignore_metrics_by_labels:
-    #   <KEY_1>:
-    #   - <LABEL_1>
-    #   - <LABEL_2>
-    #   <KEY_2>:
-    #   - '*'
+    # telemetry: false
 
     ## @param ignore_tags - list of strings - optional
     ## A list of regular expressions used to ignore tags added by autodiscovery and entries in the `tags` option.
@@ -466,10 +582,10 @@ instances:
     #
     # read_timeout: <READ_TIMEOUT>
 
-    ## @param request_size - number - optional - default: 10
+    ## @param request_size - number - optional - default: 16
     ## The number of kibibytes (KiB) to read from streaming HTTP responses at a time.
     #
-    # request_size: 10
+    # request_size: 16
 
     ## @param log_requests - boolean - optional - default: false
     ## Whether or not to debug log the HTTP(S) requests made, including the method and URL.

--- a/coredns/datadog_checks/coredns/metrics.py
+++ b/coredns/datadog_checks/coredns/metrics.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy
 
 # Sorted per plugin, all prometheus metrics prior to version 1.7.0 which introduced a major renaming of metrics.

--- a/coredns/datadog_checks/coredns/metrics.py
+++ b/coredns/datadog_checks/coredns/metrics.py
@@ -63,15 +63,7 @@ DEFAULT_METRICS = {
 }
 
 DEFAULT_METRICS_OVERRIDE = {
-    'coredns_cache_hits_total': 'cache_hits_count',
-    'coredns_cache_misses_total': 'cache_misses_count',
-    'coredns_forward_response_rcode_count_total': 'forward_response_rcode_count',
-    'coredns_forward_request_count_total': 'forward_request_count',
-    'coredns_dns_request_count_total': 'request_count',
-    'coredns_dns_request_type_count_total': 'request_type_count',
-    'coredns_dns_response_rcode_count_total': 'response_code_count',
-    'coredns_proxy_request_count_total': 'proxy_request_count',
-    'coredns_cache_prefetch_total': 'cache_prefetch_count',
+    'coredns_panic_count_total': 'panic_count',
 }
 
 # Sorted per plugin, all prometheus metrics after version 1.7.0 which introduced a major renaming of metrics.
@@ -108,13 +100,7 @@ NEW_METRICS = {
 }
 
 NEW_METRICS_OVERRIDE = {
-    'coredns_cache_requests_total': 'cache_request_count',
-    'coredns_forward_requests_total': 'forward_request_count',
-    'coredns_forward_responses_total': 'forward_response_rcode_count',
-    'coredns_forward_healthcheck_broken_total': 'forward_healthcheck_broken_count',
-    'coredns_dns_requests_total': 'request_count',
-    'coredns_reload_failed_total': 'reload.failed_count',
-    'coredns_dns_responses_total': 'response_code_count',
+    'coredns_panics_total': 'panic_count',
 }
 
 DEFAULT_METRICS.update(NEW_METRICS)
@@ -123,8 +109,8 @@ GO_METRICS = {
     'go_gc_duration_seconds': 'go.gc_duration_seconds',
     'go_goroutines': 'go.goroutines',
     'go_info': 'go.info',
-    'go_memstats_alloc_bytes': 'go.memstats.alloc_bytes',
     'go_memstats_alloc_bytes_total': 'go.memstats.alloc_bytes_total',
+    'go_memstats_alloc_bytes': 'go.memstats.alloc_bytes',
     'go_memstats_buck_hash_sys_bytes': 'go.memstats.buck_hash_sys_bytes',
     'go_memstats_frees_total': 'go.memstats.frees_total',
     'go_memstats_gc_cpu_fraction': 'go.memstats.gc_cpu_fraction',
@@ -155,37 +141,24 @@ GO_METRICS = {
     'process_virtual_memory_bytes': 'process.virtual_memory_bytes',
 }
 
-GO_METRICS_OVERRIDE = {
-    'go_memstats_lookups_total': 'go.memstats.lookups_total',
-    'go_memstats_mallocs_total': 'go.memstats.mallocs_total',
-    'process_cpu_seconds_total': 'process.cpu_seconds_total',
-}
-
 METRIC_MAP = deepcopy(DEFAULT_METRICS)
 METRIC_MAP.update(GO_METRICS)
 
 METRIC_OVERRIDE = deepcopy(DEFAULT_METRICS_OVERRIDE)
 METRIC_OVERRIDE.update(NEW_METRICS_OVERRIDE)
-METRIC_OVERRIDE.update(GO_METRICS_OVERRIDE)
 
 
-def construct_metrics_config(metric_map, overrides):
+def construct_metrics_config(metric_map, metric_overrides):
     metrics = []
     for raw_metric_name, metric_name in metric_map.items():
         if raw_metric_name.endswith('_total'):
-            if raw_metric_name in overrides:
-                metric_name = overrides[raw_metric_name]
-                raw_metric_name = raw_metric_name[:-6]
-            else:
-                raw_metric_name = raw_metric_name[:-6]
-                metric_name = metric_name[:-6]
+            if raw_metric_name in metric_overrides:
+                metric_name = metric_overrides[raw_metric_name]
+            raw_metric_name = raw_metric_name[:-6]
         elif raw_metric_name.endswith('_counter'):
-            if raw_metric_name in overrides:
-                metric_name = overrides[raw_metric_name]
-                raw_metric_name = raw_metric_name[:-8]
-            else:
-                raw_metric_name = raw_metric_name[:-8]
-                metric_name = metric_name[:-8]
+            if raw_metric_name in metric_overrides:
+                metric_name = metric_overrides[raw_metric_name]
+            raw_metric_name = raw_metric_name[:-8]
         config = {raw_metric_name: {'name': metric_name}}
         metrics.append(config)
     return metrics

--- a/coredns/datadog_checks/coredns/metrics.py
+++ b/coredns/datadog_checks/coredns/metrics.py
@@ -62,9 +62,6 @@ DEFAULT_METRICS = {
     'coredns_proxy_request_duration_seconds': 'proxy_request_duration.seconds',
 }
 
-DEFAULT_METRICS_OVERRIDE = {
-    'coredns_panic_count_total': 'panic_count',
-}
 
 # Sorted per plugin, all prometheus metrics after version 1.7.0 which introduced a major renaming of metrics.
 NEW_METRICS = {
@@ -99,9 +96,6 @@ NEW_METRICS = {
     'coredns_reload_failed_total': 'reload.failed_count',
 }
 
-NEW_METRICS_OVERRIDE = {
-    'coredns_panics_total': 'panic_count',
-}
 
 DEFAULT_METRICS.update(NEW_METRICS)
 
@@ -144,21 +138,18 @@ GO_METRICS = {
 METRIC_MAP = deepcopy(DEFAULT_METRICS)
 METRIC_MAP.update(GO_METRICS)
 
-METRIC_OVERRIDE = deepcopy(DEFAULT_METRICS_OVERRIDE)
-METRIC_OVERRIDE.update(NEW_METRICS_OVERRIDE)
 
-
-def construct_metrics_config(metric_map, metric_overrides):
+def construct_metrics_config(metric_map):
     metrics = []
     for raw_metric_name, metric_name in metric_map.items():
         if raw_metric_name.endswith('_total'):
-            if raw_metric_name in metric_overrides:
-                metric_name = metric_overrides[raw_metric_name]
+            if metric_name.endswith('.count'):
+                metric_name = metric_name[:-6]
             raw_metric_name = raw_metric_name[:-6]
-        elif raw_metric_name.endswith('_counter'):
-            if raw_metric_name in metric_overrides:
-                metric_name = metric_overrides[raw_metric_name]
-            raw_metric_name = raw_metric_name[:-8]
+        elif raw_metric_name.endswith('_count'):
+            if metric_name.endswith('.count'):
+                metric_name = metric_name[:-6]
+            raw_metric_name = raw_metric_name[:-6]
         config = {raw_metric_name: {'name': metric_name}}
         metrics.append(config)
     return metrics

--- a/coredns/datadog_checks/coredns/metrics.py
+++ b/coredns/datadog_checks/coredns/metrics.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 # Sorted per plugin, all prometheus metrics prior to version 1.7.0 which introduced a major renaming of metrics.
 DEFAULT_METRICS = {
     # acl: https://github.com/coredns/coredns/blob/v1.6.9/plugin/acl/
@@ -127,3 +129,22 @@ GO_METRICS = {
     'process_start_time_seconds': 'process.start_time_seconds',
     'process_virtual_memory_bytes': 'process.virtual_memory_bytes',
 }
+
+METRIC_MAP = deepcopy(DEFAULT_METRICS)
+METRIC_MAP.update(GO_METRICS)
+
+
+def construct_metrics_config(metric_map):
+    metrics = []
+    for raw_metric_name, metric_name in metric_map.items():
+        if raw_metric_name.endswith('_total'):
+            raw_metric_name = raw_metric_name[:-6]
+            metric_name = metric_name[:-6]
+        elif raw_metric_name.endswith('_counter'):
+            raw_metric_name = raw_metric_name[:-8]
+            metric_name = metric_name[:-8]
+
+        config = {raw_metric_name: {'name': metric_name}}
+        metrics.append(config)
+
+    return metrics

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -3,41 +3,43 @@ coredns.acl.allowed_requests,count,,request,,"[OpenMetrics V1] Counter of DNS re
 coredns.acl.blocked_requests,count,,request,,"[OpenMetrics V1] Counter of DNS requests being blocked.",0,coredns,dns blocked request
 coredns.autopath.success_count,count,,request,,"[OpenMetrics V1] Counter of requests that did autopath.",0,coredns,autopath success
 coredns.build_info,gauge,,,,"[OpenMetrics V1 and V2] A metric with a constant '1' value labeled by version, revision, and goversion from which CoreDNS was built.",0,coredns,build info
-coredns.response_code_count,count,,,,[OpenMetrics V1] number of responses per zone and rcode,1,coredns,response code
-coredns.response_code.count,count,,,,[OpenMetrics V2] number of responses per zone and rcode,1,coredns,response code
+coredns.response_code_count,count,,,,[OpenMetrics V1 and V2] number of responses per zone and rcode,1,coredns,response code
+coredns.response_code_count.count,count,,,,[OpenMetrics V2] number of responses per zone and rcode,1,coredns,response code
 coredns.cache_drops_count,count,,response,,"[OpenMetrics V1] Counter of responses excluded from the cache due to request/response question name mismatch.",0,coredns,cache drop
 coredns.cache_hits_count,count,,hit,,[OpenMetrics V1] Counter of cache hits by cache type,1,coredns,cache hit
+coredns.cache_hits_count.count,count,,hit,,[OpenMetrics V2] Counter of cache hits by cache type,1,coredns,cache hit
 coredns.cache_misses_count,count,,miss,,[OpenMetrics V1] Counter of cache misses.,1,coredns,cache miss
-coredns.cache_misses.count,count,,miss,,[OpenMetrics V2] Counter of cache misses.,1,coredns,cache miss
-coredns.cache_request_count,count,,request,,[OpenMetrics V1] Counter of cache requests.,1,coredns,cache request count
-coredns.cache_request.count,count,,request,,[OpenMetrics V2] Counter of cache requests.,1,coredns,cache request count
+coredns.cache_misses_count.count,count,,miss,,[OpenMetrics V2] Counter of cache misses.,1,coredns,cache miss
+coredns.cache_request_count,count,,request,,[OpenMetrics V1 and V2] Counter of cache requests.,1,coredns,cache request count
+coredns.cache_request_count.count,count,,request,,[OpenMetrics V2] Counter of cache requests.,1,coredns,cache request count
 coredns.cache_prefetch_count,count,,,,"[OpenMetrics V1] The number of time the cache has prefetched a cached item.",1,coredns,cache prefetch
+coredns.cache_prefetch_count.count,count,,,,"[OpenMetrics V2] The number of time the cache has prefetched a cached item.",1,coredns,cache prefetch
 coredns.cache_stale_count,count,,request,,"[OpenMetrics V1] Counter of requests served from stale cache entries.",0,coredns,cache stale
 coredns.dnssec.cache_size,gauge,,,,"[OpenMetrics V1 and V2] Total elements in the cache, type is signature.",0,coredns,dnssec cache size
 coredns.dnssec.cache_hits,count,,hit,,"[OpenMetrics V1] Counter of cache hits.",0,coredns,dnssec cache hit
 coredns.dnssec.cache_misses,count,,miss,,"[OpenMetrics V1] Counter of cache misses.",0,coredns,dnssec cache miss
-coredns.request_count,count,,request,,[OpenMetrics V1] total query count.,1,coredns,request count
-coredns.request.count,count,,request,,[OpenMetrics V2] total query count.,1,coredns,request count
-coredns.request_type_count,count,,,,[OpenMetrics V1] counter of queries per zone and type,1,coredns,request type
-coredns.request_type.count,count,,,,[OpenMetrics V2] counter of queries per zone and type,1,coredns,request type
+coredns.request_count,count,,request,,[OpenMetrics V1 and V2] total query count.,1,coredns,request count
+coredns.request_count.count,count,,request,,[OpenMetrics V2] total query count.,1,coredns,request count
+coredns.request_type_count,count,,,,[OpenMetrics V1 and V2] counter of queries per zone and type,1,coredns,request type
+coredns.request_type_count.count,count,,,,[OpenMetrics V2] counter of queries per zone and type,1,coredns,request type
 coredns.request_duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] duration to process each query,-1,coredns,request duration
 coredns.request_duration.seconds.count,count,,second,,[OpenMetrics V1 and V2] duration to process each query,-1,coredns,request duration
 coredns.request_duration.seconds.bucket,count,,second,,[OpenMetrics V2] sample duration to process each query,-1,coredns,request duration
-coredns.proxy_request_count,count,,request,,[OpenMetrics V1] query count per upstream.,1,coredns,proxy request count
-coredns.proxy_request.count,count,,request,,[OpenMetrics V2] query count per upstream.,1,coredns,proxy request count
+coredns.proxy_request_count,count,,request,,[OpenMetrics V1 and V2] query count per upstream.,1,coredns,proxy request count
+coredns.proxy_request_count.count,count,,request,,[OpenMetrics V2] query count per upstream.,1,coredns,proxy request count
 coredns.proxy_request_duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] duration per upstream interaction,-1,coredns,proxy request duration
 coredns.proxy_request_duration.seconds.count,count,,second,,[OpenMetrics V1 and V2] duration per upstream interaction,-1,coredns,proxy request duration
 coredns.proxy_request_duration.seconds.bucket,count,,second,,[OpenMetrics V2] sample of duration per upstream interaction,-1,coredns,proxy request duration
 coredns.forward_request_duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] duration per upstream interaction,-1,coredns,forward request duration
 coredns.forward_request_duration.seconds.count,count,,second,,[OpenMetrics V1 and V2] duration per upstream interaction,-1,coredns,forward request duration
 coredns.forward_request_duration.seconds.bucket,count,,second,,[OpenMetrics V2] duration per upstream interaction,-1,coredns,forward request duration
-coredns.forward_request_count,count,,request,,[OpenMetrics V1] query count per upstream,1,coredns,forward request count
-coredns.forward_request.count,count,,request,,[OpenMetrics V2] query count per upstream,1,coredns,forward request count
+coredns.forward_request_count,count,,request,,[OpenMetrics V1 and V2] query count per upstream,1,coredns,forward request count
+coredns.forward_request_count.count,count,,request,,[OpenMetrics V2] query count per upstream,1,coredns,forward request count
 coredns.forward_response_rcode_count,count,,response,,[OpenMetrics V1] count of RCODEs per upstream,0,coredns,forward rcodes
-coredns.forward_response_rcode.count,count,,response,,[OpenMetrics V2] count of RCODEs per upstream,0,coredns,forward rcodes
-coredns.forward_healthcheck_failure_count,count,,entry,,[OpenMetrics V1] number of failed health checks per upstream,-1,coredns,forward failed healthchecks
+coredns.forward_response_rcode_count.count,count,,response,,[OpenMetrics V2] count of RCODEs per upstream,0,coredns,forward rcodes
+coredns.forward_healthcheck_failure_count,gauge,,entry,,[OpenMetrics V1] number of failed health checks per upstream,-1,coredns,forward failed healthchecks
 coredns.forward_healthcheck_broken_count,count,,entry,,[OpenMetrics V1] counter of when all upstreams are unhealthy,-1,coredns,forward all healthchecks broken
-coredns.forward_healthcheck_broken.count,count,,entry,,[OpenMetrics V2] counter of when all upstreams are unhealthy,-1,coredns,forward all healthchecks broken
+coredns.forward_healthcheck_broken_count.count,count,,entry,,[OpenMetrics V2] counter of when all upstreams are unhealthy,-1,coredns,forward all healthchecks broken
 coredns.forward_max_concurrent_rejects,count,,query,,"[OpenMetrics V1] Counter of the number of queries rejected because the concurrent queries were at maximum.",-1,coredns,max concurrent queries
 coredns.forward_max_concurrent_r.count,count,,query,,"[OpenMetrics V2] Counter of the number of queries rejected because the concurrent queries were at maximum.",-1,coredns,max concurrent queries
 coredns.forward_sockets_open,gauge,,connection,,[OpenMetrics V1 and V2] number of sockets open per upstream,-1,coredns,forward open sockets
@@ -48,8 +50,8 @@ coredns.health_request_duration.sum,count,,,,"[OpenMetrics V1 and V2] Sum for th
 coredns.health_request_duration.bucket,count,,,,"[OpenMetrics V2] Sample for the histogram of the time (in seconds) each request took.",-1,coredns,health req duration count
 coredns.hosts.entries_count,gauge,,,,"[OpenMetrics V1] The combined number of entries in hosts and Corefile.",0,coredns,host entry
 coredns.hosts.reload_timestamp,gauge,,second,,"[OpenMetrics V1 and V2] The timestamp of the last reload of hosts file.",0,coredns,host reload ts
-coredns.reload.failed_count,count,,,,"[OpenMetrics V1] Counts the number of failed reload attempts.",0,coredns,reload failed count
-coredns.reload.failed.count,count,,,,"[OpenMetrics V2] Counts the number of failed reload attempts.",0,coredns,reload failed count
+coredns.reload.failed_count,count,,,,"[OpenMetrics V1 and V2] Counts the number of failed reload attempts.",0,coredns,reload failed count
+coredns.reload.failed_count.count,count,,,,"[OpenMetrics V2] Counts the number of failed reload attempts.",0,coredns,reload failed count
 coredns.request_size.bytes.sum,count,,byte,,[OpenMetrics V1 and V2] size of the request in bytes,0,coredns,request size
 coredns.request_size.bytes.count,count,,byte,,[OpenMetrics V1 and V2] size of the request in bytes,0,coredns,request size
 coredns.request_size.bytes.bucket,count,,byte,,[OpenMetrics V2] sample size of the request in bytes,0,coredns,request size
@@ -79,9 +81,9 @@ coredns.go.memstats.heap_released_bytes.count,count,,byte,,[OpenMetrics V2] Coun
 coredns.go.memstats.heap_sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes used by the heap,0,coredns,
 coredns.go.memstats.last_gc_time_seconds,gauge,,second,,[OpenMetrics V1 and V2] Length of last GC,0,coredns,gc time
 coredns.go.memstats.lookups_total,count,,operation,,[OpenMetrics V1] Number of lookups,0,coredns,lookups total
-coredns.go.memstats.lookups.count,count,,operation,,[OpenMetrics V2] Number of lookups,0,coredns,lookups total
+coredns.go.memstats.lookups_total.count,count,,operation,,[OpenMetrics V2] Number of lookups,0,coredns,lookups total
 coredns.go.memstats.mallocs_total,count,,operation,,[OpenMetrics V1] Number of mallocs,0,coredns,mallocs total
-coredns.go.memstats.mallocs.count,count,,operation,,[OpenMetrics V2] Number of mallocs,0,coredns,mallocs total
+coredns.go.memstats.mallocs_total.count,count,,operation,,[OpenMetrics V2] Number of mallocs,0,coredns,mallocs total
 coredns.go.memstats.mcache_inuse_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes in use by mcache structures.,0,coredns,
 coredns.go.memstats.mcache_sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes used for mcache structures obtained from system.,0,coredns,
 coredns.go.memstats.mspan_inuse_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes in use by mspan structures.,0,coredns,
@@ -93,8 +95,8 @@ coredns.go.memstats.stack_sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number 
 coredns.go.memstats.sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes obtained from system,0,coredns,
 coredns.go.threads,gauge,,thread,,[OpenMetrics V1 and V2] Number of OS threads created.,0,coredns,
 coredns.plugin_enabled,gauge,,,,"[OpenMetrics V1 and V2] A metric that indicates whether a plugin is enabled on per server and zone basis.",0,coredns,plugin enabled
-coredns.process.cpu_seconds.count,count,,second,,"[OpenMetrics V2] Count of user and system CPU time spent in seconds.",0,coredns,process cpu seconds
-coredns.process.cpu_seconds_total,count,,second,,"[OpenMetrics V1] Total user and system CPU time spent in seconds.",0,coredns,process cpu seconds
+coredns.process.cpu_seconds_total,count,,second,,"[OpenMetrics V1 and V2] Total user and system CPU time spent in seconds.",0,coredns,process cpu seconds
+coredns.process.cpu_seconds_total.count,count,,second,,"[OpenMetrics V2] Count of user and system CPU time spent in seconds.",0,coredns,process cpu seconds
 coredns.process.max_fds,gauge,,file,,[OpenMetrics V1 and V2] Maximum number of open file descriptors.,0,coredns,
 coredns.process.open_fds,gauge,,file,,[OpenMetrics V1 and V2] Number of open file descriptors.,0,coredns,
 coredns.process.resident_memory_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Resident memory size in bytes.,0,coredns,

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -1,83 +1,105 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
-coredns.acl.allowed_requests,count,,request,,"Counter of DNS requests being allowed.",0,coredns,dns allowed requests
-coredns.acl.blocked_requests,count,,request,,"Counter of DNS requests being blocked.",0,coredns,dns blocked request
-coredns.autopath.success_count,count,,request,,"Counter of requests that did autopath.",0,coredns,autopath success
-coredns.build_info,gauge,,,,"A metric with a constant '1' value labeled by version, revision, and goversion from which CoreDNS was built.",0,coredns,build info
-coredns.response_code_count,count,,,,number of responses per zone and rcode,1,coredns,response code
-coredns.proxy_request_count,count,,request,,query count per upstream.,1,coredns,proxy request count
-coredns.cache_drops_count,count,,response,,"Counter of responses excluded from the cache due to request/response question name mismatch.",0,coredns,cache drop
-coredns.cache_hits_count,count,,hit,,Counter of cache hits by cache type,1,coredns,cache hit
-coredns.cache_misses_count,count,,miss,,Counter of cache misses.,1,coredns,cache miss
-coredns.cache_request_count,count,,request,,Counter of cache requests.,1,coredns,cache request count
-coredns.cache_prefetch_count,count,,,,"The number of time the cache has prefetched a cached item.",1,coredns,cache prefetch
-coredns.cache_stale_count,count,,request,,"Counter of requests served from stale cache entries.",0,coredns,cache stale
-coredns.dnssec.cache_size,gauge,,,,"Total elements in the cache, type is signature.",0,coredns,dnssec cache size
-coredns.dnssec.cache_hits,count,,hit,,"Counter of cache hits.",0,coredns,dnssec cache hit
-coredns.dnssec.cache_misses,count,,miss,,"Counter of cache misses.",0,coredns,dnssec cache miss
-coredns.request_count,count,,request,,total query count.,1,coredns,request count
-coredns.request_type_count,count,,,,counter of queries per zone and type,1,coredns,request type
-coredns.request_duration.seconds.sum,gauge,,second,,duration to process each query,-1,coredns,request duration
-coredns.request_duration.seconds.count,gauge,,second,,duration to process each query,-1,coredns,request duration
-coredns.proxy_request_duration.seconds.sum,gauge,,second,,duration per upstream interaction,-1,coredns,proxy request duration
-coredns.proxy_request_duration.seconds.count,gauge,,second,,duration per upstream interaction,-1,coredns,proxy request duration
-coredns.forward_request_duration.seconds.sum,gauge,,second,,duration per upstream interaction,-1,coredns,forward request duration
-coredns.forward_request_duration.seconds.count,gauge,,second,,duration per upstream interaction,-1,coredns,forward request duration
-coredns.forward_request_count,count,,request,,query count per upstream,1,coredns,forward request count
-coredns.forward_response_rcode_count,count,,response,,count of RCODEs per upstream,0,coredns,forward rcodes
-coredns.forward_healthcheck_failure_count,count,,entry,,number of failed health checks per upstream,-1,coredns,forward failed healthchecks
-coredns.forward_healthcheck_broken_count,count,,entry,,counter of when all upstreams are unhealthy,-1,coredns,forward all healthchecks broken
-coredns.forward_max_concurrent_rejects,count,,query,,"Counter of the number of queries rejected because the concurrent queries were at maximum.",-1,coredns,max concurrent queries
-coredns.forward_sockets_open,gauge,,connection,,number of sockets open per upstream,-1,coredns,forward open sockets
-coredns.grpc.request_count,count,,,,"Query count per upstream.",0,coredns,grpc request count
-coredns.grpc.response_rcode_count,count,,,,"Count of RCODEs per upstream. and we are randomly (this always uses the random policy) spraying to an upstream.",0,coredns,grpc response code
-coredns.health_request_duration.count,gauge,,,,"Count for the histogram of the time (in seconds) each request took.",-1,coredns,health req duration count
-coredns.health_request_duration.sum,gauge,,,,"Sum for the histogram of the time (in seconds) each request took.",-1,coredns,health req duration count
-coredns.hosts.entries_count,gauge,,,,"The combined number of entries in hosts and Corefile.",0,coredns,host entry
-coredns.hosts.reload_timestamp,gauge,,second,,"The timestamp of the last reload of hosts file.",0,coredns,host reload ts
-coredns.reload.failed_count,count,,,,"Counts the number of failed reload attempts.",0,coredns,reload failed count
-coredns.request_size.bytes.sum,gauge,,byte,,size of the request in bytes,0,coredns,request size
-coredns.request_size.bytes.count,gauge,,byte,,size of the request in bytes,0,coredns,request size
-coredns.response_size.bytes.sum,gauge,,byte,,size of the request in bytes,0,coredns,response size
-coredns.response_size.bytes.count,gauge,,byte,,size of the request in bytes,0,coredns,response size
-coredns.cache_size.count,gauge,,entry,,,1,coredns,cache size
-coredns.panic_count.count,count,,entry,,,1,coredns,total number of panics
-coredns.go.gc_duration_seconds.count,gauge,,second,,Count of the GC invocation durations.,0,coredns,
-coredns.go.gc_duration_seconds.sum,gauge,,second,,Sum of the GC invocation durations.,0,coredns,
-coredns.go.gc_duration_seconds.quantile,gauge,,second,,Quantiles of the GC invocation durations.,0,coredns,
-coredns.go.goroutines,gauge,,thread,,Number of goroutines that currently exist.,0,coredns,
-coredns.go.info,gauge,,,,Information about the Go environment.,0,coredns,
-coredns.go.memstats.alloc_bytes,gauge,,byte,,Number of bytes allocated and still in use.,0,coredns,
-coredns.go.memstats.alloc_bytes_total,count,,byte,,Total number of bytes allocated even if freed.,0,coredns,
-coredns.go.memstats.buck_hash_sys_bytes,gauge,,byte,,Number of bytes used by the profiling bucket hash table.,0,coredns,bytes used by profiling
-coredns.go.memstats.frees_total,count,,,,Total number of frees.,0,coredns,
-coredns.go.memstats.gc_cpu_fraction,gauge,,percent,,CPU taken up by GC,0,coredns,CPU taken up by gc
-coredns.go.memstats.gc_sys_bytes,gauge,,byte,,Number of bytes used for garbage collection system metadata.,0,coredns,
-coredns.go.memstats.heap_alloc_bytes,gauge,,byte,,Bytes allocated to the heap,0,coredns,
-coredns.go.memstats.heap_idle_bytes,gauge,,byte,,Number of idle bytes in the heap,0,coredns,
-coredns.go.memstats.heap_inuse_bytes,gauge,,byte,,Number of Bytes in the heap,0,coredns,
-coredns.go.memstats.heap_objects,gauge,,object,,Number of objects in the heap,0,coredns,
-coredns.go.memstats.heap_released_bytes,gauge,,byte,,Number of bytes released to the system in the last gc,0,coredns,
-coredns.go.memstats.heap_sys_bytes,gauge,,byte,,Number of bytes used by the heap,0,coredns,
-coredns.go.memstats.last_gc_time_seconds,gauge,,second,,Length of last GC,0,coredns,gc time
-coredns.go.memstats.lookups_total,count,,operation,,Number of lookups,0,coredns,lookups total
-coredns.go.memstats.mallocs_total,count,,operation,,Number of mallocs,0,coredns,mallocs total
-coredns.go.memstats.mcache_inuse_bytes,gauge,,byte,,Number of bytes in use by mcache structures.,0,coredns,
-coredns.go.memstats.mcache_sys_bytes,gauge,,byte,,Number of bytes used for mcache structures obtained from system.,0,coredns,
-coredns.go.memstats.mspan_inuse_bytes,gauge,,byte,,Number of bytes in use by mspan structures.,0,coredns,
-coredns.go.memstats.mspan_sys_bytes,gauge,,byte,,Number of bytes used for mspan structures obtained from system.,0,coredns,
-coredns.go.memstats.next_gc_bytes,gauge,,byte,,Number of heap bytes when next garbage collection will take place,0,coredns,
-coredns.go.memstats.other_sys_bytes,gauge,,byte,,Number of bytes used for other system allocations,0,coredns,
-coredns.go.memstats.stack_inuse_bytes,gauge,,byte,,Number of bytes in use by the stack allocator,0,coredns,
-coredns.go.memstats.stack_sys_bytes,gauge,,byte,,Number of bytes obtained from system for stack allocator,0,coredns,
-coredns.go.memstats.sys_bytes,gauge,,byte,,Number of bytes obtained from system,0,coredns,
-coredns.go.threads,gauge,,thread,,Number of OS threads created.,0,coredns,
-coredns.plugin_enabled,gauge,,,,"A metric that indicates whether a plugin is enabled on per server and zone basis.",0,coredns,plugin enabled
-coredns.process.cpu_seconds_total,count,,second,,"Total user and system CPU time spent in seconds.",0,coredns,process cpu seconds
-coredns.process.max_fds,gauge,,file,,Maximum number of open file descriptors.,0,coredns,
-coredns.process.open_fds,gauge,,file,,Number of open file descriptors.,0,coredns,
-coredns.process.resident_memory_bytes,gauge,,byte,,Resident memory size in bytes.,0,coredns,
-coredns.process.start_time_seconds,gauge,,second,,Start time of the process since unix epoch in seconds.,0,coredns,
-coredns.process.virtual_memory_bytes,gauge,,byte,,Virtual memory size in bytes.,0,coredns,
-coredns.template.matches_count,count,,,,"The total number of matched requests by regex.",0,coredns,template matches
-coredns.template.failures_count,count,,error,,"The number of times the Go templating failed.",0,coredns,template failure
-coredns.template.rr_failures_count,count,,error,,"The number of times the templated resource record was invalid and could not be parsed.",0,coredns,template resource failure
+coredns.acl.allowed_requests,count,,request,,"[OpenMetrics V1] Counter of DNS requests being allowed.",0,coredns,dns allowed requests
+coredns.acl.blocked_requests,count,,request,,"[OpenMetrics V1] Counter of DNS requests being blocked.",0,coredns,dns blocked request
+coredns.autopath.success_count,count,,request,,"[OpenMetrics V1] Counter of requests that did autopath.",0,coredns,autopath success
+coredns.build_info,gauge,,,,"[OpenMetrics V1 and V2] A metric with a constant '1' value labeled by version, revision, and goversion from which CoreDNS was built.",0,coredns,build info
+coredns.response_code_count,count,,,,[OpenMetrics V1] number of responses per zone and rcode,1,coredns,response code
+coredns.response_code.count,count,,,,[OpenMetrics V2] number of responses per zone and rcode,1,coredns,response code
+coredns.cache_drops_count,count,,response,,"[OpenMetrics V1] Counter of responses excluded from the cache due to request/response question name mismatch.",0,coredns,cache drop
+coredns.cache_hits_count,count,,hit,,[OpenMetrics V1] Counter of cache hits by cache type,1,coredns,cache hit
+coredns.cache_misses_count,count,,miss,,[OpenMetrics V1] Counter of cache misses.,1,coredns,cache miss
+coredns.cache_misses.count,count,,miss,,[OpenMetrics V2] Counter of cache misses.,1,coredns,cache miss
+coredns.cache_request_count,count,,request,,[OpenMetrics V1] Counter of cache requests.,1,coredns,cache request count
+coredns.cache_request.count,count,,request,,[OpenMetrics V2] Counter of cache requests.,1,coredns,cache request count
+coredns.cache_prefetch_count,count,,,,"[OpenMetrics V1] The number of time the cache has prefetched a cached item.",1,coredns,cache prefetch
+coredns.cache_stale_count,count,,request,,"[OpenMetrics V1] Counter of requests served from stale cache entries.",0,coredns,cache stale
+coredns.dnssec.cache_size,gauge,,,,"[OpenMetrics V1 and V2] Total elements in the cache, type is signature.",0,coredns,dnssec cache size
+coredns.dnssec.cache_hits,count,,hit,,"[OpenMetrics V1] Counter of cache hits.",0,coredns,dnssec cache hit
+coredns.dnssec.cache_misses,count,,miss,,"[OpenMetrics V1] Counter of cache misses.",0,coredns,dnssec cache miss
+coredns.request_count,count,,request,,[OpenMetrics V1] total query count.,1,coredns,request count
+coredns.request.count,count,,request,,[OpenMetrics V2] total query count.,1,coredns,request count
+coredns.request_type_count,count,,,,[OpenMetrics V1] counter of queries per zone and type,1,coredns,request type
+coredns.request_type.count,count,,,,[OpenMetrics V2] counter of queries per zone and type,1,coredns,request type
+coredns.request_duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] duration to process each query,-1,coredns,request duration
+coredns.request_duration.seconds.count,count,,second,,[OpenMetrics V1 and V2] duration to process each query,-1,coredns,request duration
+coredns.request_duration.seconds.bucket,count,,second,,[OpenMetrics V2] sample duration to process each query,-1,coredns,request duration
+coredns.proxy_request_count,count,,request,,[OpenMetrics V1] query count per upstream.,1,coredns,proxy request count
+coredns.proxy_request.count,count,,request,,[OpenMetrics V2] query count per upstream.,1,coredns,proxy request count
+coredns.proxy_request_duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] duration per upstream interaction,-1,coredns,proxy request duration
+coredns.proxy_request_duration.seconds.count,count,,second,,[OpenMetrics V1 and V2] duration per upstream interaction,-1,coredns,proxy request duration
+coredns.proxy_request_duration.seconds.bucket,count,,second,,[OpenMetrics V2] sample of duration per upstream interaction,-1,coredns,proxy request duration
+coredns.forward_request_duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] duration per upstream interaction,-1,coredns,forward request duration
+coredns.forward_request_duration.seconds.count,count,,second,,[OpenMetrics V1 and V2] duration per upstream interaction,-1,coredns,forward request duration
+coredns.forward_request_duration.seconds.bucket,count,,second,,[OpenMetrics V2] duration per upstream interaction,-1,coredns,forward request duration
+coredns.forward_request_count,count,,request,,[OpenMetrics V1] query count per upstream,1,coredns,forward request count
+coredns.forward_request.count,count,,request,,[OpenMetrics V2] query count per upstream,1,coredns,forward request count
+coredns.forward_response_rcode_count,count,,response,,[OpenMetrics V1] count of RCODEs per upstream,0,coredns,forward rcodes
+coredns.forward_response_rcode.count,count,,response,,[OpenMetrics V2] count of RCODEs per upstream,0,coredns,forward rcodes
+coredns.forward_healthcheck_failure_count,count,,entry,,[OpenMetrics V1] number of failed health checks per upstream,-1,coredns,forward failed healthchecks
+coredns.forward_healthcheck_broken_count,count,,entry,,[OpenMetrics V1] counter of when all upstreams are unhealthy,-1,coredns,forward all healthchecks broken
+coredns.forward_healthcheck_broken.count,count,,entry,,[OpenMetrics V2] counter of when all upstreams are unhealthy,-1,coredns,forward all healthchecks broken
+coredns.forward_max_concurrent_rejects,count,,query,,"[OpenMetrics V1] Counter of the number of queries rejected because the concurrent queries were at maximum.",-1,coredns,max concurrent queries
+coredns.forward_max_concurrent_r.count,count,,query,,"[OpenMetrics V2] Counter of the number of queries rejected because the concurrent queries were at maximum.",-1,coredns,max concurrent queries
+coredns.forward_sockets_open,gauge,,connection,,[OpenMetrics V1 and V2] number of sockets open per upstream,-1,coredns,forward open sockets
+coredns.grpc.request_count,count,,,,"[OpenMetrics V1] Query count per upstream.",0,coredns,grpc request count
+coredns.grpc.response_rcode_count,count,,,,"[OpenMetrics V1] Count of RCODEs per upstream. and we are randomly (this always uses the random policy) spraying to an upstream.",0,coredns,grpc response code
+coredns.health_request_duration.count,count,,,,"[OpenMetrics V1 and V2] Count for the histogram of the time (in seconds) each request took.",-1,coredns,health req duration count
+coredns.health_request_duration.sum,count,,,,"[OpenMetrics V1 and V2] Sum for the histogram of the time (in seconds) each request took.",-1,coredns,health req duration count
+coredns.health_request_duration.bucket,count,,,,"[OpenMetrics V2] Sample for the histogram of the time (in seconds) each request took.",-1,coredns,health req duration count
+coredns.hosts.entries_count,gauge,,,,"[OpenMetrics V1] The combined number of entries in hosts and Corefile.",0,coredns,host entry
+coredns.hosts.reload_timestamp,gauge,,second,,"[OpenMetrics V1 and V2] The timestamp of the last reload of hosts file.",0,coredns,host reload ts
+coredns.reload.failed_count,count,,,,"[OpenMetrics V1] Counts the number of failed reload attempts.",0,coredns,reload failed count
+coredns.reload.failed.count,count,,,,"[OpenMetrics V2] Counts the number of failed reload attempts.",0,coredns,reload failed count
+coredns.request_size.bytes.sum,count,,byte,,[OpenMetrics V1 and V2] size of the request in bytes,0,coredns,request size
+coredns.request_size.bytes.count,count,,byte,,[OpenMetrics V1 and V2] size of the request in bytes,0,coredns,request size
+coredns.request_size.bytes.bucket,count,,byte,,[OpenMetrics V2] sample size of the request in bytes,0,coredns,request size
+coredns.response_size.bytes.sum,count,,byte,,[OpenMetrics V1 and V2] size of the request in bytes,0,coredns,response size
+coredns.response_size.bytes.count,count,,byte,,[OpenMetrics V1 and V2] size of the request in bytes,0,coredns,response size
+coredns.response_size.bytes.bucket,count,,byte,,[OpenMetrics V2] sample size of the request in bytes,0,coredns,response size
+coredns.cache_size.count,gauge,,entry,,[OpenMetrics V1 and V2],1,coredns,cache size
+coredns.panic_count.count,count,,entry,,[OpenMetrics V1 and V2],1,coredns,total number of panics
+coredns.go.gc_duration_seconds.count,count,,second,,[OpenMetrics V1 and V2] Count of the GC invocation durations.,0,coredns,
+coredns.go.gc_duration_seconds.sum,count,,second,,[OpenMetrics V1 and V2] Sum of the GC invocation durations.,0,coredns,
+coredns.go.gc_duration_seconds.quantile,gauge,,second,,[OpenMetrics V1 and V2] Quantiles of the GC invocation durations.,0,coredns,
+coredns.go.goroutines,gauge,,thread,,[OpenMetrics V1 and V2] Number of goroutines that currently exist.,0,coredns,
+coredns.go.info,gauge,,,,[OpenMetrics V1 and V2] Information about the Go environment.,0,coredns,
+coredns.go.memstats.alloc_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes allocated and still in use.,0,coredns,
+coredns.go.memstats.alloc_bytes_total,count,,byte,,[OpenMetrics V1] Total number of bytes allocated even if freed.,0,coredns,
+coredns.go.memstats.buck_hash_sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes used by the profiling bucket hash table.,0,coredns,bytes used by profiling
+coredns.go.memstats.frees_total,count,,,,[OpenMetrics V1] Total number of frees.,0,coredns,
+coredns.go.memstats.frees.count,count,,,,[OpenMetrics V2] Total number of frees.,0,coredns,
+coredns.go.memstats.gc_cpu_fraction,gauge,,percent,,[OpenMetrics V1 and V2] CPU taken up by GC,0,coredns,CPU taken up by gc
+coredns.go.memstats.gc_sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes used for garbage collection system metadata.,0,coredns,
+coredns.go.memstats.heap_alloc_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Bytes allocated to the heap,0,coredns,
+coredns.go.memstats.heap_idle_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of idle bytes in the heap,0,coredns,
+coredns.go.memstats.heap_inuse_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of Bytes in the heap,0,coredns,
+coredns.go.memstats.heap_objects,gauge,,object,,[OpenMetrics V1 and V2] Number of objects in the heap,0,coredns,
+coredns.go.memstats.heap_released_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes released to the system in the last gc,0,coredns,
+coredns.go.memstats.heap_released_bytes.count,count,,byte,,[OpenMetrics V2] Count of bytes released to the system in the last gc,0,coredns,
+coredns.go.memstats.heap_sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes used by the heap,0,coredns,
+coredns.go.memstats.last_gc_time_seconds,gauge,,second,,[OpenMetrics V1 and V2] Length of last GC,0,coredns,gc time
+coredns.go.memstats.lookups_total,count,,operation,,[OpenMetrics V1] Number of lookups,0,coredns,lookups total
+coredns.go.memstats.lookups.count,count,,operation,,[OpenMetrics V2] Number of lookups,0,coredns,lookups total
+coredns.go.memstats.mallocs_total,count,,operation,,[OpenMetrics V1] Number of mallocs,0,coredns,mallocs total
+coredns.go.memstats.mallocs.count,count,,operation,,[OpenMetrics V2] Number of mallocs,0,coredns,mallocs total
+coredns.go.memstats.mcache_inuse_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes in use by mcache structures.,0,coredns,
+coredns.go.memstats.mcache_sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes used for mcache structures obtained from system.,0,coredns,
+coredns.go.memstats.mspan_inuse_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes in use by mspan structures.,0,coredns,
+coredns.go.memstats.mspan_sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes used for mspan structures obtained from system.,0,coredns,
+coredns.go.memstats.next_gc_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of heap bytes when next garbage collection will take place,0,coredns,
+coredns.go.memstats.other_sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes used for other system allocations,0,coredns,
+coredns.go.memstats.stack_inuse_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes in use by the stack allocator,0,coredns,
+coredns.go.memstats.stack_sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes obtained from system for stack allocator,0,coredns,
+coredns.go.memstats.sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes obtained from system,0,coredns,
+coredns.go.threads,gauge,,thread,,[OpenMetrics V1 and V2] Number of OS threads created.,0,coredns,
+coredns.plugin_enabled,gauge,,,,"[OpenMetrics V1 and V2] A metric that indicates whether a plugin is enabled on per server and zone basis.",0,coredns,plugin enabled
+coredns.process.cpu_seconds.count,count,,second,,"[OpenMetrics V2] Count of user and system CPU time spent in seconds.",0,coredns,process cpu seconds
+coredns.process.cpu_seconds_total,count,,second,,"[OpenMetrics V1] Total user and system CPU time spent in seconds.",0,coredns,process cpu seconds
+coredns.process.max_fds,gauge,,file,,[OpenMetrics V1 and V2] Maximum number of open file descriptors.,0,coredns,
+coredns.process.open_fds,gauge,,file,,[OpenMetrics V1 and V2] Number of open file descriptors.,0,coredns,
+coredns.process.resident_memory_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Resident memory size in bytes.,0,coredns,
+coredns.process.start_time_seconds,gauge,,second,,[OpenMetrics V1 and V2] Start time of the process since unix epoch in seconds.,0,coredns,
+coredns.process.virtual_memory_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Virtual memory size in bytes.,0,coredns,
+coredns.template.matches_count,count,,,,"[OpenMetrics V1] The total number of matched requests by regex.",0,coredns,template matches
+coredns.template.failures_count,count,,error,,"[OpenMetrics V1] The number of times the Go templating failed.",0,coredns,template failure
+coredns.template.rr_failures_count,count,,error,,"[OpenMetrics V1] The number of times the templated resource record was invalid and could not be parsed.",0,coredns,template resource failure

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -6,7 +6,7 @@ coredns.acl.blocked_requests.count,count,,request,,"[OpenMetrics V2] Counter of 
 coredns.autopath.success_count,count,,request,,"[OpenMetrics V1] Counter of requests that did autopath.",0,coredns,autopath success
 coredns.autopath.success_count.count,count,,request,,"[OpenMetrics V2] Counter of requests that did autopath.",0,coredns,autopath success
 coredns.build_info,gauge,,,,"[OpenMetrics V1 and V2] A metric with a constant '1' value labeled by version, revision, and goversion from which CoreDNS was built.",0,coredns,build info
-coredns.response_code_count,count,,,,[OpenMetrics V1 and V2] number of responses per zone and rcode,1,coredns,response code
+coredns.response_code_count,count,,,,[OpenMetrics V1] number of responses per zone and rcode,1,coredns,response code
 coredns.response_code_count.count,count,,,,[OpenMetrics V2] number of responses per zone and rcode,1,coredns,response code
 coredns.cache_drops_count,count,,response,,"[OpenMetrics V1] Counter of responses excluded from the cache due to request/response question name mismatch.",0,coredns,cache drop
 coredns.cache_drops_count.count,count,,response,,"[OpenMetrics V2] Counter of responses excluded from the cache due to request/response question name mismatch.",0,coredns,cache drop
@@ -14,7 +14,7 @@ coredns.cache_hits_count,count,,hit,,[OpenMetrics V1] Counter of cache hits by c
 coredns.cache_hits_count.count,count,,hit,,[OpenMetrics V2] Counter of cache hits by cache type,1,coredns,cache hit
 coredns.cache_misses_count,count,,miss,,[OpenMetrics V1] Counter of cache misses.,1,coredns,cache miss
 coredns.cache_misses_count.count,count,,miss,,[OpenMetrics V2] Counter of cache misses.,1,coredns,cache miss
-coredns.cache_request_count,count,,request,,[OpenMetrics V1 and V2] Counter of cache requests.,1,coredns,cache request count
+coredns.cache_request_count,count,,request,,[OpenMetrics V1] Counter of cache requests.,1,coredns,cache request count
 coredns.cache_request_count.count,count,,request,,[OpenMetrics V2] Counter of cache requests.,1,coredns,cache request count
 coredns.cache_prefetch_count,count,,,,"[OpenMetrics V1] The number of time the cache has prefetched a cached item.",1,coredns,cache prefetch
 coredns.cache_prefetch_count.count,count,,,,"[OpenMetrics V2] The number of time the cache has prefetched a cached item.",1,coredns,cache prefetch
@@ -25,14 +25,14 @@ coredns.dnssec.cache_hits,count,,hit,,"[OpenMetrics V1] Counter of cache hits.",
 coredns.dnssec.cache_hits.count,count,,hit,,"[OpenMetrics V2] Counter of cache hits.",0,coredns,dnssec cache hit
 coredns.dnssec.cache_misses,count,,miss,,"[OpenMetrics V1] Counter of cache misses.",0,coredns,dnssec cache miss
 coredns.dnssec.cache_misses.count,count,,miss,,"[OpenMetrics V2] Counter of cache misses.",0,coredns,dnssec cache miss
-coredns.request_count,count,,request,,[OpenMetrics V1 and V2] total query count.,1,coredns,request count
+coredns.request_count,count,,request,,[OpenMetrics V1] total query count.,1,coredns,request count
 coredns.request_count.count,count,,request,,[OpenMetrics V2] total query count.,1,coredns,request count
-coredns.request_type_count,count,,,,[OpenMetrics V1 and V2] counter of queries per zone and type,1,coredns,request type
+coredns.request_type_count,count,,,,[OpenMetrics V1] counter of queries per zone and type,1,coredns,request type
 coredns.request_type_count.count,count,,,,[OpenMetrics V2] counter of queries per zone and type,1,coredns,request type
 coredns.request_duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] duration to process each query,-1,coredns,request duration
 coredns.request_duration.seconds.count,count,,second,,[OpenMetrics V1 and V2] duration to process each query,-1,coredns,request duration
 coredns.request_duration.seconds.bucket,count,,second,,[OpenMetrics V2] sample duration to process each query,-1,coredns,request duration
-coredns.proxy_request_count,count,,request,,[OpenMetrics V1 and V2] query count per upstream.,1,coredns,proxy request count
+coredns.proxy_request_count,count,,request,,[OpenMetrics V1] query count per upstream.,1,coredns,proxy request count
 coredns.proxy_request_count.count,count,,request,,[OpenMetrics V2] query count per upstream.,1,coredns,proxy request count
 coredns.proxy_request_duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] duration per upstream interaction,-1,coredns,proxy request duration
 coredns.proxy_request_duration.seconds.count,count,,second,,[OpenMetrics V1 and V2] duration per upstream interaction,-1,coredns,proxy request duration
@@ -40,11 +40,11 @@ coredns.proxy_request_duration.seconds.bucket,count,,second,,[OpenMetrics V2] sa
 coredns.forward_request_duration.seconds.sum,count,,second,,[OpenMetrics V1 and V2] duration per upstream interaction,-1,coredns,forward request duration
 coredns.forward_request_duration.seconds.count,count,,second,,[OpenMetrics V1 and V2] duration per upstream interaction,-1,coredns,forward request duration
 coredns.forward_request_duration.seconds.bucket,count,,second,,[OpenMetrics V2] duration per upstream interaction,-1,coredns,forward request duration
-coredns.forward_request_count,count,,request,,[OpenMetrics V1 and V2] query count per upstream,1,coredns,forward request count
+coredns.forward_request_count,count,,request,,[OpenMetrics V1] query count per upstream,1,coredns,forward request count
 coredns.forward_request_count.count,count,,request,,[OpenMetrics V2] query count per upstream,1,coredns,forward request count
 coredns.forward_response_rcode_count,count,,response,,[OpenMetrics V1] count of RCODEs per upstream,0,coredns,forward rcodes
 coredns.forward_response_rcode_count.count,count,,response,,[OpenMetrics V2] count of RCODEs per upstream,0,coredns,forward rcodes
-coredns.forward_healthcheck_failure_count,gauge,,entry,,[OpenMetrics V1] number of failed health checks per upstream,-1,coredns,forward failed healthchecks
+coredns.forward_healthcheck_failure_count,count,,entry,,[OpenMetrics V1] number of failed health checks per upstream,-1,coredns,forward failed healthchecks
 coredns.forward_healthcheck_failure_count.count,count,,entry,,[OpenMetrics V2] number of failed health checks per upstream,-1,coredns,forward failed healthchecks
 coredns.forward_healthcheck_broken_count,count,,entry,,[OpenMetrics V1] counter of when all upstreams are unhealthy,-1,coredns,forward all healthchecks broken
 coredns.forward_healthcheck_broken_count.count,count,,entry,,[OpenMetrics V2] counter of when all upstreams are unhealthy,-1,coredns,forward all healthchecks broken
@@ -58,9 +58,9 @@ coredns.grpc.response_rcode_count.count,count,,,,"[OpenMetrics V2] Count of RCOD
 coredns.health_request_duration.count,count,,,,"[OpenMetrics V1 and V2] Count for the histogram of the time (in seconds) each request took.",-1,coredns,health req duration count
 coredns.health_request_duration.sum,count,,,,"[OpenMetrics V1 and V2] Sum for the histogram of the time (in seconds) each request took.",-1,coredns,health req duration count
 coredns.health_request_duration.bucket,count,,,,"[OpenMetrics V2] Sample for the histogram of the time (in seconds) each request took.",-1,coredns,health req duration count
-coredns.hosts.entries_count,gauge,,,,"[OpenMetrics V1] The combined number of entries in hosts and Corefile.",0,coredns,host entry
+coredns.hosts.entries_count,gauge,,,,"[OpenMetrics V1 and V2] The combined number of entries in hosts and Corefile.",0,coredns,host entry
 coredns.hosts.reload_timestamp,gauge,,second,,"[OpenMetrics V1 and V2] The timestamp of the last reload of hosts file.",0,coredns,host reload ts
-coredns.reload.failed_count,count,,,,"[OpenMetrics V1 and V2] Counts the number of failed reload attempts.",0,coredns,reload failed count
+coredns.reload.failed_count,count,,,,"[OpenMetrics V1] Counts the number of failed reload attempts.",0,coredns,reload failed count
 coredns.reload.failed_count.count,count,,,,"[OpenMetrics V2] Counts the number of failed reload attempts.",0,coredns,reload failed count
 coredns.request_size.bytes.sum,count,,byte,,[OpenMetrics V1 and V2] size of the request in bytes,0,coredns,request size
 coredns.request_size.bytes.count,count,,byte,,[OpenMetrics V1 and V2] size of the request in bytes,0,coredns,request size

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -117,4 +117,4 @@ coredns.template.matches_count.count,count,,,,"[OpenMetrics V2] The total number
 coredns.template.failures_count,count,,error,,"[OpenMetrics V1] The number of times the Go templating failed.",0,coredns,template failure
 coredns.template.failures_count.count,count,,error,,"[OpenMetrics V2] The number of times the Go templating failed.",0,coredns,template failure
 coredns.template.rr_failures_count,count,,error,,"[OpenMetrics V1] The number of times the templated resource record was invalid and could not be parsed.",0,coredns,template resource failure
-coredns.template.rr_failures_count,count,,error,,"[OpenMetrics V2] The number of times the templated resource record was invalid and could not be parsed.",0,coredns,template resource failure
+coredns.template.rr_failures_count.count,count,,error,,"[OpenMetrics V2] The number of times the templated resource record was invalid and could not be parsed.",0,coredns,template resource failure

--- a/coredns/metadata.csv
+++ b/coredns/metadata.csv
@@ -1,11 +1,15 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
 coredns.acl.allowed_requests,count,,request,,"[OpenMetrics V1] Counter of DNS requests being allowed.",0,coredns,dns allowed requests
+coredns.acl.allowed_requests.count,count,,request,,"[OpenMetrics V2] Counter of DNS requests being allowed.",0,coredns,dns allowed requests
 coredns.acl.blocked_requests,count,,request,,"[OpenMetrics V1] Counter of DNS requests being blocked.",0,coredns,dns blocked request
+coredns.acl.blocked_requests.count,count,,request,,"[OpenMetrics V2] Counter of DNS requests being blocked.",0,coredns,dns blocked request
 coredns.autopath.success_count,count,,request,,"[OpenMetrics V1] Counter of requests that did autopath.",0,coredns,autopath success
+coredns.autopath.success_count.count,count,,request,,"[OpenMetrics V2] Counter of requests that did autopath.",0,coredns,autopath success
 coredns.build_info,gauge,,,,"[OpenMetrics V1 and V2] A metric with a constant '1' value labeled by version, revision, and goversion from which CoreDNS was built.",0,coredns,build info
 coredns.response_code_count,count,,,,[OpenMetrics V1 and V2] number of responses per zone and rcode,1,coredns,response code
 coredns.response_code_count.count,count,,,,[OpenMetrics V2] number of responses per zone and rcode,1,coredns,response code
 coredns.cache_drops_count,count,,response,,"[OpenMetrics V1] Counter of responses excluded from the cache due to request/response question name mismatch.",0,coredns,cache drop
+coredns.cache_drops_count.count,count,,response,,"[OpenMetrics V2] Counter of responses excluded from the cache due to request/response question name mismatch.",0,coredns,cache drop
 coredns.cache_hits_count,count,,hit,,[OpenMetrics V1] Counter of cache hits by cache type,1,coredns,cache hit
 coredns.cache_hits_count.count,count,,hit,,[OpenMetrics V2] Counter of cache hits by cache type,1,coredns,cache hit
 coredns.cache_misses_count,count,,miss,,[OpenMetrics V1] Counter of cache misses.,1,coredns,cache miss
@@ -15,9 +19,12 @@ coredns.cache_request_count.count,count,,request,,[OpenMetrics V2] Counter of ca
 coredns.cache_prefetch_count,count,,,,"[OpenMetrics V1] The number of time the cache has prefetched a cached item.",1,coredns,cache prefetch
 coredns.cache_prefetch_count.count,count,,,,"[OpenMetrics V2] The number of time the cache has prefetched a cached item.",1,coredns,cache prefetch
 coredns.cache_stale_count,count,,request,,"[OpenMetrics V1] Counter of requests served from stale cache entries.",0,coredns,cache stale
+coredns.cache_stale_count.count,count,,request,,"[OpenMetrics V2] Counter of requests served from stale cache entries.",0,coredns,cache stale
 coredns.dnssec.cache_size,gauge,,,,"[OpenMetrics V1 and V2] Total elements in the cache, type is signature.",0,coredns,dnssec cache size
 coredns.dnssec.cache_hits,count,,hit,,"[OpenMetrics V1] Counter of cache hits.",0,coredns,dnssec cache hit
+coredns.dnssec.cache_hits.count,count,,hit,,"[OpenMetrics V2] Counter of cache hits.",0,coredns,dnssec cache hit
 coredns.dnssec.cache_misses,count,,miss,,"[OpenMetrics V1] Counter of cache misses.",0,coredns,dnssec cache miss
+coredns.dnssec.cache_misses.count,count,,miss,,"[OpenMetrics V2] Counter of cache misses.",0,coredns,dnssec cache miss
 coredns.request_count,count,,request,,[OpenMetrics V1 and V2] total query count.,1,coredns,request count
 coredns.request_count.count,count,,request,,[OpenMetrics V2] total query count.,1,coredns,request count
 coredns.request_type_count,count,,,,[OpenMetrics V1 and V2] counter of queries per zone and type,1,coredns,request type
@@ -38,13 +45,16 @@ coredns.forward_request_count.count,count,,request,,[OpenMetrics V2] query count
 coredns.forward_response_rcode_count,count,,response,,[OpenMetrics V1] count of RCODEs per upstream,0,coredns,forward rcodes
 coredns.forward_response_rcode_count.count,count,,response,,[OpenMetrics V2] count of RCODEs per upstream,0,coredns,forward rcodes
 coredns.forward_healthcheck_failure_count,gauge,,entry,,[OpenMetrics V1] number of failed health checks per upstream,-1,coredns,forward failed healthchecks
+coredns.forward_healthcheck_failure_count.count,count,,entry,,[OpenMetrics V2] number of failed health checks per upstream,-1,coredns,forward failed healthchecks
 coredns.forward_healthcheck_broken_count,count,,entry,,[OpenMetrics V1] counter of when all upstreams are unhealthy,-1,coredns,forward all healthchecks broken
 coredns.forward_healthcheck_broken_count.count,count,,entry,,[OpenMetrics V2] counter of when all upstreams are unhealthy,-1,coredns,forward all healthchecks broken
 coredns.forward_max_concurrent_rejects,count,,query,,"[OpenMetrics V1] Counter of the number of queries rejected because the concurrent queries were at maximum.",-1,coredns,max concurrent queries
-coredns.forward_max_concurrent_r.count,count,,query,,"[OpenMetrics V2] Counter of the number of queries rejected because the concurrent queries were at maximum.",-1,coredns,max concurrent queries
+coredns.forward_max_concurrent_rejects.count,count,,query,,"[OpenMetrics V2] Counter of the number of queries rejected because the concurrent queries were at maximum.",-1,coredns,max concurrent queries
 coredns.forward_sockets_open,gauge,,connection,,[OpenMetrics V1 and V2] number of sockets open per upstream,-1,coredns,forward open sockets
 coredns.grpc.request_count,count,,,,"[OpenMetrics V1] Query count per upstream.",0,coredns,grpc request count
+coredns.grpc.request_count.count,count,,,,"[OpenMetrics V2] Query count per upstream.",0,coredns,grpc request count
 coredns.grpc.response_rcode_count,count,,,,"[OpenMetrics V1] Count of RCODEs per upstream. and we are randomly (this always uses the random policy) spraying to an upstream.",0,coredns,grpc response code
+coredns.grpc.response_rcode_count.count,count,,,,"[OpenMetrics V2] Count of RCODEs per upstream. and we are randomly (this always uses the random policy) spraying to an upstream.",0,coredns,grpc response code
 coredns.health_request_duration.count,count,,,,"[OpenMetrics V1 and V2] Count for the histogram of the time (in seconds) each request took.",-1,coredns,health req duration count
 coredns.health_request_duration.sum,count,,,,"[OpenMetrics V1 and V2] Sum for the histogram of the time (in seconds) each request took.",-1,coredns,health req duration count
 coredns.health_request_duration.bucket,count,,,,"[OpenMetrics V2] Sample for the histogram of the time (in seconds) each request took.",-1,coredns,health req duration count
@@ -69,7 +79,7 @@ coredns.go.memstats.alloc_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of b
 coredns.go.memstats.alloc_bytes_total,count,,byte,,[OpenMetrics V1] Total number of bytes allocated even if freed.,0,coredns,
 coredns.go.memstats.buck_hash_sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes used by the profiling bucket hash table.,0,coredns,bytes used by profiling
 coredns.go.memstats.frees_total,count,,,,[OpenMetrics V1] Total number of frees.,0,coredns,
-coredns.go.memstats.frees.count,count,,,,[OpenMetrics V2] Total number of frees.,0,coredns,
+coredns.go.memstats.frees_total.count,count,,,,[OpenMetrics V2] Total number of frees.,0,coredns,
 coredns.go.memstats.gc_cpu_fraction,gauge,,percent,,[OpenMetrics V1 and V2] CPU taken up by GC,0,coredns,CPU taken up by gc
 coredns.go.memstats.gc_sys_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Number of bytes used for garbage collection system metadata.,0,coredns,
 coredns.go.memstats.heap_alloc_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Bytes allocated to the heap,0,coredns,
@@ -103,5 +113,8 @@ coredns.process.resident_memory_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Resid
 coredns.process.start_time_seconds,gauge,,second,,[OpenMetrics V1 and V2] Start time of the process since unix epoch in seconds.,0,coredns,
 coredns.process.virtual_memory_bytes,gauge,,byte,,[OpenMetrics V1 and V2] Virtual memory size in bytes.,0,coredns,
 coredns.template.matches_count,count,,,,"[OpenMetrics V1] The total number of matched requests by regex.",0,coredns,template matches
+coredns.template.matches_count.count,count,,,,"[OpenMetrics V2] The total number of matched requests by regex.",0,coredns,template matches
 coredns.template.failures_count,count,,error,,"[OpenMetrics V1] The number of times the Go templating failed.",0,coredns,template failure
+coredns.template.failures_count.count,count,,error,,"[OpenMetrics V2] The number of times the Go templating failed.",0,coredns,template failure
 coredns.template.rr_failures_count,count,,error,,"[OpenMetrics V1] The number of times the templated resource record was invalid and could not be parsed.",0,coredns,template resource failure
+coredns.template.rr_failures_count,count,,error,,"[OpenMetrics V2] The number of times the templated resource record was invalid and could not be parsed.",0,coredns,template resource failure

--- a/coredns/tests/common.py
+++ b/coredns/tests/common.py
@@ -68,6 +68,62 @@ COMMON_METRICS = [
     NAMESPACE + '.forward_response_rcode_count',
 ]
 
+COMMON_METRICS_OMV2 = [
+    NAMESPACE + '.build_info',
+    NAMESPACE + '.go.gc_duration_seconds.count',
+    NAMESPACE + '.go.gc_duration_seconds.quantile',
+    NAMESPACE + '.go.gc_duration_seconds.sum',
+    NAMESPACE + '.go.goroutines',
+    NAMESPACE + '.go.memstats.alloc_bytes',
+    NAMESPACE + '.go.memstats.buck_hash_sys_bytes',
+    NAMESPACE + '.go.memstats.frees.count',
+    NAMESPACE + '.go.memstats.gc_sys_bytes',
+    NAMESPACE + '.go.memstats.heap_alloc_bytes',
+    NAMESPACE + '.go.memstats.heap_idle_bytes',
+    NAMESPACE + '.go.memstats.heap_inuse_bytes',
+    NAMESPACE + '.go.memstats.heap_objects',
+    NAMESPACE + '.go.memstats.heap_sys_bytes',
+    NAMESPACE + '.go.memstats.last_gc_time_seconds',
+    NAMESPACE + '.go.memstats.lookups.count',
+    NAMESPACE + '.go.memstats.mallocs.count',
+    NAMESPACE + '.go.memstats.mcache_inuse_bytes',
+    NAMESPACE + '.go.memstats.mcache_sys_bytes',
+    NAMESPACE + '.go.memstats.mspan_inuse_bytes',
+    NAMESPACE + '.go.memstats.mspan_sys_bytes',
+    NAMESPACE + '.go.memstats.next_gc_bytes',
+    NAMESPACE + '.go.memstats.other_sys_bytes',
+    NAMESPACE + '.go.memstats.stack_inuse_bytes',
+    NAMESPACE + '.go.memstats.stack_sys_bytes',
+    NAMESPACE + '.go.memstats.sys_bytes',
+    NAMESPACE + '.health_request_duration.count',
+    NAMESPACE + '.health_request_duration.sum',
+    NAMESPACE + '.health_request_duration.bucket',
+    NAMESPACE + '.panic_count.count',
+    NAMESPACE + '.process.cpu_seconds.count',
+    NAMESPACE + '.process.max_fds',
+    NAMESPACE + '.process.open_fds',
+    NAMESPACE + '.process.resident_memory_bytes',
+    NAMESPACE + '.process.start_time_seconds',
+    NAMESPACE + '.process.virtual_memory_bytes',
+    NAMESPACE + '.request.count',
+    NAMESPACE + '.cache_size.count',
+    NAMESPACE + '.cache_misses.count',
+    NAMESPACE + '.response_code.count',
+    NAMESPACE + '.response_size.bytes.sum',
+    NAMESPACE + '.response_size.bytes.count',
+    NAMESPACE + '.response_size.bytes.bucket',
+    NAMESPACE + '.request_size.bytes.sum',
+    NAMESPACE + '.request_size.bytes.count',
+    NAMESPACE + '.request_size.bytes.bucket',
+    NAMESPACE + '.request_duration.seconds.sum',
+    NAMESPACE + '.request_duration.seconds.count',
+    NAMESPACE + '.request_duration.seconds.bucket',
+    NAMESPACE + '.forward_request.count',
+    NAMESPACE + '.forward_request_duration.seconds.sum',
+    NAMESPACE + '.forward_request_duration.seconds.count',
+    NAMESPACE + '.forward_request_duration.seconds.bucket',
+    NAMESPACE + '.forward_response_rcode.count',
+]
 
 METRICS_V1_2 = COMMON_METRICS + [
     # Has been removed from v1.7.0
@@ -77,6 +133,18 @@ METRICS_V1_2 = COMMON_METRICS + [
     NAMESPACE + '.proxy_request_duration.seconds.sum',
     NAMESPACE + '.proxy_request_duration.seconds.count',
     NAMESPACE + '.forward_sockets_open',
+]
+
+METRICS_V1_2_OMV2 = COMMON_METRICS_OMV2 + [
+    # Has been removed from v1.7.0
+    NAMESPACE + '.proxy_request.count',
+    NAMESPACE + '.proxy_request_duration.seconds.bucket',
+    NAMESPACE + '.request_type.count',
+    # The proxy plugin has been deprecated
+    NAMESPACE + '.proxy_request_duration.seconds.sum',
+    NAMESPACE + '.proxy_request_duration.seconds.count',
+    NAMESPACE + '.forward_sockets_open',
+    NAMESPACE + '.go.memstats.heap_released_bytes.count',
 ]
 
 METRICS_V1_8 = COMMON_METRICS + [
@@ -91,4 +159,18 @@ METRICS_V1_8 = COMMON_METRICS + [
     NAMESPACE + '.reload.failed_count',
 ]
 
+METRICS_V1_8_OMV2 = COMMON_METRICS_OMV2 + [
+    NAMESPACE + '.forward_max_concurrent_r.count',
+    NAMESPACE + '.go.info',
+    NAMESPACE + '.go.memstats.gc_cpu_fraction',
+    NAMESPACE + '.go.memstats.heap_released_bytes',
+    NAMESPACE + '.cache_request.count',
+    NAMESPACE + '.plugin_enabled',
+    NAMESPACE + '.forward_healthcheck_broken.count',
+    NAMESPACE + '.hosts.reload_timestamp',
+    NAMESPACE + '.reload.failed.count',
+]
+
 METRICS = METRICS_V1_8 if COREDNS_VERSION[:2] == [1, 8] else METRICS_V1_2
+
+METRICS_V2 = METRICS_V1_8_OMV2 if COREDNS_VERSION[:2] == [1, 8] else METRICS_V1_2_OMV2

--- a/coredns/tests/common.py
+++ b/coredns/tests/common.py
@@ -79,7 +79,7 @@ COMMON_METRICS_OMV2 = [
     NAMESPACE + '.go.goroutines',
     NAMESPACE + '.go.memstats.alloc_bytes',
     NAMESPACE + '.go.memstats.buck_hash_sys_bytes',
-    NAMESPACE + '.go.memstats.frees.count',
+    NAMESPACE + '.go.memstats.frees_total.count',
     NAMESPACE + '.go.memstats.gc_sys_bytes',
     NAMESPACE + '.go.memstats.heap_alloc_bytes',
     NAMESPACE + '.go.memstats.heap_idle_bytes',
@@ -163,7 +163,7 @@ METRICS_V1_8 = COMMON_METRICS + [
 ]
 
 METRICS_V1_8_OMV2 = COMMON_METRICS_OMV2 + [
-    NAMESPACE + '.forward_max_concurrent_r.count',
+    NAMESPACE + '.forward_max_concurrent_rejects.count',
     NAMESPACE + '.go.info',
     NAMESPACE + '.go.memstats.gc_cpu_fraction',
     NAMESPACE + '.go.memstats.heap_released_bytes',

--- a/coredns/tests/common.py
+++ b/coredns/tests/common.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
 from datadog_checks.dev import get_docker_hostname
@@ -137,9 +140,9 @@ METRICS_V1_2 = COMMON_METRICS + [
 
 METRICS_V1_2_OMV2 = COMMON_METRICS_OMV2 + [
     # Has been removed from v1.7.0
+    NAMESPACE + '.request_type.count',
     NAMESPACE + '.proxy_request.count',
     NAMESPACE + '.proxy_request_duration.seconds.bucket',
-    NAMESPACE + '.request_type.count',
     # The proxy plugin has been deprecated
     NAMESPACE + '.proxy_request_duration.seconds.sum',
     NAMESPACE + '.proxy_request_duration.seconds.count',

--- a/coredns/tests/common.py
+++ b/coredns/tests/common.py
@@ -87,8 +87,8 @@ COMMON_METRICS_OMV2 = [
     NAMESPACE + '.go.memstats.heap_objects',
     NAMESPACE + '.go.memstats.heap_sys_bytes',
     NAMESPACE + '.go.memstats.last_gc_time_seconds',
-    NAMESPACE + '.go.memstats.lookups.count',
-    NAMESPACE + '.go.memstats.mallocs.count',
+    NAMESPACE + '.go.memstats.lookups_total.count',
+    NAMESPACE + '.go.memstats.mallocs_total.count',
     NAMESPACE + '.go.memstats.mcache_inuse_bytes',
     NAMESPACE + '.go.memstats.mcache_sys_bytes',
     NAMESPACE + '.go.memstats.mspan_inuse_bytes',
@@ -102,16 +102,16 @@ COMMON_METRICS_OMV2 = [
     NAMESPACE + '.health_request_duration.sum',
     NAMESPACE + '.health_request_duration.bucket',
     NAMESPACE + '.panic_count.count',
-    NAMESPACE + '.process.cpu_seconds.count',
+    NAMESPACE + '.process.cpu_seconds_total.count',
     NAMESPACE + '.process.max_fds',
     NAMESPACE + '.process.open_fds',
     NAMESPACE + '.process.resident_memory_bytes',
     NAMESPACE + '.process.start_time_seconds',
     NAMESPACE + '.process.virtual_memory_bytes',
-    NAMESPACE + '.request.count',
+    NAMESPACE + '.request_count.count',
     NAMESPACE + '.cache_size.count',
-    NAMESPACE + '.cache_misses.count',
-    NAMESPACE + '.response_code.count',
+    NAMESPACE + '.cache_misses_count.count',
+    NAMESPACE + '.response_code_count.count',
     NAMESPACE + '.response_size.bytes.sum',
     NAMESPACE + '.response_size.bytes.count',
     NAMESPACE + '.response_size.bytes.bucket',
@@ -121,11 +121,11 @@ COMMON_METRICS_OMV2 = [
     NAMESPACE + '.request_duration.seconds.sum',
     NAMESPACE + '.request_duration.seconds.count',
     NAMESPACE + '.request_duration.seconds.bucket',
-    NAMESPACE + '.forward_request.count',
+    NAMESPACE + '.forward_request_count.count',
     NAMESPACE + '.forward_request_duration.seconds.sum',
     NAMESPACE + '.forward_request_duration.seconds.count',
     NAMESPACE + '.forward_request_duration.seconds.bucket',
-    NAMESPACE + '.forward_response_rcode.count',
+    NAMESPACE + '.forward_response_rcode_count.count',
 ]
 
 METRICS_V1_2 = COMMON_METRICS + [
@@ -140,8 +140,8 @@ METRICS_V1_2 = COMMON_METRICS + [
 
 METRICS_V1_2_OMV2 = COMMON_METRICS_OMV2 + [
     # Has been removed from v1.7.0
-    NAMESPACE + '.request_type.count',
-    NAMESPACE + '.proxy_request.count',
+    NAMESPACE + '.request_type_count.count',
+    NAMESPACE + '.proxy_request_count.count',
     NAMESPACE + '.proxy_request_duration.seconds.bucket',
     # The proxy plugin has been deprecated
     NAMESPACE + '.proxy_request_duration.seconds.sum',
@@ -167,11 +167,11 @@ METRICS_V1_8_OMV2 = COMMON_METRICS_OMV2 + [
     NAMESPACE + '.go.info',
     NAMESPACE + '.go.memstats.gc_cpu_fraction',
     NAMESPACE + '.go.memstats.heap_released_bytes',
-    NAMESPACE + '.cache_request.count',
+    NAMESPACE + '.cache_request_count.count',
     NAMESPACE + '.plugin_enabled',
-    NAMESPACE + '.forward_healthcheck_broken.count',
+    NAMESPACE + '.forward_healthcheck_broken_count.count',
     NAMESPACE + '.hosts.reload_timestamp',
-    NAMESPACE + '.reload.failed.count',
+    NAMESPACE + '.reload.failed_count.count',
 ]
 
 METRICS = METRICS_V1_8 if COREDNS_VERSION[:2] == [1, 8] else METRICS_V1_2

--- a/coredns/tests/conftest.py
+++ b/coredns/tests/conftest.py
@@ -49,7 +49,7 @@ def instance():
 
 
 @pytest.fixture(scope="session")
-def openmetrics_instance():
+def omv2_instance():
     return {'openmetrics_endpoint': URL}
 
 

--- a/coredns/tests/conftest.py
+++ b/coredns/tests/conftest.py
@@ -27,12 +27,12 @@ def init_coredns():
 
 
 @pytest.fixture(scope="session")
-def dd_environment(instance):
+def dd_environment(omv2_instance):
     compose_file = os.path.join(HERE, 'docker', 'docker-compose.yml')
     env = {'COREDNS_CONFIG_FILE': CONFIG_FILE}
 
     with docker_run(compose_file, conditions=[WaitFor(init_coredns)], env_vars=env):
-        yield instance
+        yield omv2_instance
 
 
 @pytest.fixture

--- a/coredns/tests/conftest.py
+++ b/coredns/tests/conftest.py
@@ -15,6 +15,8 @@ from .common import ATHOST, CONFIG_FILE, HERE, URL
 # One lookup each for the forward and proxy plugins
 DIG_ARGS = ["dig", "google.com", ATHOST, "example.com", ATHOST, "-p", "54"]
 
+COREDNS_VERSION = [int(i) for i in os.environ['COREDNS_VERSION'].split(".")]
+
 
 def init_coredns():
     res = requests.get(URL)
@@ -55,5 +57,9 @@ def omv2_instance():
 
 @pytest.fixture
 def mock_get(mock_http_response):
-    mesh_file_path = os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics.txt')
-    yield mock_http_response(file_path=mesh_file_path)
+    if COREDNS_VERSION[:2] == [1, 8]:
+        metric_file = 'metrics_18.txt'
+    elif COREDNS_VERSION[:2] == [1, 2]:
+        metric_file = 'metrics_12.txt'
+    metric_file_path = os.path.join(os.path.dirname(__file__), 'fixtures', metric_file)
+    yield mock_http_response(file_path=metric_file_path)

--- a/coredns/tests/conftest.py
+++ b/coredns/tests/conftest.py
@@ -38,9 +38,19 @@ def dockerinstance():
     return {'prometheus_url': URL}
 
 
+@pytest.fixture
+def docker_omv2_instance():
+    return {'openmetrics_endpoint': URL}
+
+
 @pytest.fixture(scope="session")
 def instance():
     return {'prometheus_url': URL}
+
+
+@pytest.fixture(scope="session")
+def openmetrics_instance():
+    return {'openmetrics_endpoint': URL}
 
 
 @pytest.fixture

--- a/coredns/tests/fixtures/metrics_12.txt
+++ b/coredns/tests/fixtures/metrics_12.txt
@@ -1,0 +1,592 @@
+# HELP coredns_build_info A metric with a constant '1' value labeled by version, revision, and goversion from which CoreDNS was built.
+# TYPE coredns_build_info gauge
+coredns_build_info{goversion="go1.10",revision="c8d91500",version="1.1.0"} 1
+# HELP coredns_cache_capacity The cache's capacity.
+# TYPE coredns_cache_capacity gauge
+coredns_cache_capacity{type="denial"} 10000
+coredns_cache_capacity{type="success"} 10000
+# HELP coredns_cache_hits_total The count of cache hits.
+# TYPE coredns_cache_hits_total counter
+coredns_cache_hits_total{type="denial"} 8.051403e+06
+coredns_cache_hits_total{type="success"} 167389
+# HELP coredns_cache_misses_total The count of cache misses.
+# TYPE coredns_cache_misses_total counter
+coredns_cache_misses_total 882
+# HELP coredns_cache_requests_total The count of cache requests.
+# TYPE coredns_cache_requests_total counter
+coredns_cache_requests_total{server="dns://:53"} 104
+# HELP coredns_cache_prefetch_total The number of time the cache has prefetched a cached item.
+# TYPE coredns_cache_prefetch_total counter
+coredns_cache_prefetch_total 0
+# HELP coredns_cache_size The number of elements in the cache.
+# TYPE coredns_cache_size gauge
+coredns_cache_size{type="denial"} 836
+coredns_cache_size{type="success"} 52
+# HELP coredns_dns_request_count_total Counter of DNS requests made per zone, protocol and family.
+# TYPE coredns_dns_request_count_total counter
+coredns_dns_request_count_total{family="1",proto="tcp",zone="."} 4
+coredns_dns_request_count_total{family="1",proto="udp",zone="."} 8.21967e+06
+# HELP coredns_dns_request_duration_seconds Histogram of the time (in seconds) each request took.
+# TYPE coredns_dns_request_duration_seconds histogram
+coredns_dns_request_duration_seconds_bucket{zone=".",le="0.00025"} 7.794767e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="0.0005"} 8.191211e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="0.001"} 8.210776e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="0.002"} 8.214042e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="0.004"} 8.215829e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="0.008"} 8.217124e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="0.016"} 8.21794e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="0.032"} 8.219049e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="0.064"} 8.219583e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="0.128"} 8.219654e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="0.256"} 8.21967e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="0.512"} 8.219673e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="1.024"} 8.219673e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="2.048"} 8.219674e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="4.096"} 8.219674e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="8.192"} 8.219674e+06
+coredns_dns_request_duration_seconds_bucket{zone=".",le="+Inf"} 8.219674e+06
+coredns_dns_request_duration_seconds_sum{zone="."} 1440.4034843871038
+coredns_dns_request_duration_seconds_count{zone="."} 8.219674e+06
+# HELP coredns_dns_request_size_bytes Size of the EDNS0 UDP buffer in bytes (64K for TCP).
+# TYPE coredns_dns_request_size_bytes histogram
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="0"} 0
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="100"} 4
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="200"} 4
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="300"} 4
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="400"} 4
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="511"} 4
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="1023"} 4
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="2047"} 4
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="4095"} 4
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="8291"} 4
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="16000"} 4
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="32000"} 4
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="48000"} 4
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="64000"} 4
+coredns_dns_request_size_bytes_bucket{proto="tcp",zone=".",le="+Inf"} 4
+coredns_dns_request_size_bytes_sum{proto="tcp",zone="."} 248
+coredns_dns_request_size_bytes_count{proto="tcp",zone="."} 4
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="0"} 0
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="100"} 8.216442e+06
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="200"} 8.21967e+06
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="300"} 8.21967e+06
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="400"} 8.21967e+06
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="511"} 8.21967e+06
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="1023"} 8.21967e+06
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="2047"} 8.21967e+06
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="4095"} 8.21967e+06
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="8291"} 8.21967e+06
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="16000"} 8.21967e+06
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="32000"} 8.21967e+06
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="48000"} 8.21967e+06
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="64000"} 8.21967e+06
+coredns_dns_request_size_bytes_bucket{proto="udp",zone=".",le="+Inf"} 8.21967e+06
+coredns_dns_request_size_bytes_sum{proto="udp",zone="."} 5.25624061e+08
+coredns_dns_request_size_bytes_count{proto="udp",zone="."} 8.21967e+06
+# HELP coredns_dns_request_type_count_total Counter of DNS requests per type, per zone.
+# TYPE coredns_dns_request_type_count_total counter
+coredns_dns_request_type_count_total{type="A",zone="."} 4.898455e+06
+coredns_dns_request_type_count_total{type="AAAA",zone="."} 3.321219e+06
+# HELP coredns_dns_response_rcode_count_total Counter of response status codes.
+# TYPE coredns_dns_response_rcode_count_total counter
+coredns_dns_response_rcode_count_total{rcode="NOERROR",zone="."} 2.011725e+06
+coredns_dns_response_rcode_count_total{rcode="NXDOMAIN",zone="."} 6.207949e+06
+# HELP coredns_dns_response_size_bytes Size of the returned response in bytes.
+# TYPE coredns_dns_response_size_bytes histogram
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="0"} 0
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="100"} 0
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="200"} 0
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="300"} 0
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="400"} 0
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="511"} 0
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="1023"} 4
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="2047"} 4
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="4095"} 4
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="8291"} 4
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="16000"} 4
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="32000"} 4
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="48000"} 4
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="64000"} 4
+coredns_dns_response_size_bytes_bucket{proto="tcp",zone=".",le="+Inf"} 4
+coredns_dns_response_size_bytes_sum{proto="tcp",zone="."} 2104
+coredns_dns_response_size_bytes_count{proto="tcp",zone="."} 4
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="0"} 0
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="100"} 1.718537e+06
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="200"} 8.219652e+06
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="300"} 8.219662e+06
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="400"} 8.219666e+06
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="511"} 8.21967e+06
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="1023"} 8.21967e+06
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="2047"} 8.21967e+06
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="4095"} 8.21967e+06
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="8291"} 8.21967e+06
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="16000"} 8.21967e+06
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="32000"} 8.21967e+06
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="48000"} 8.21967e+06
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="64000"} 8.21967e+06
+coredns_dns_response_size_bytes_bucket{proto="udp",zone=".",le="+Inf"} 8.21967e+06
+coredns_dns_response_size_bytes_sum{proto="udp",zone="."} 9.00318837e+08
+coredns_dns_response_size_bytes_count{proto="udp",zone="."} 8.21967e+06
+# HELP coredns_health_request_duration_seconds Histogram of the time (in seconds) each request took.
+# TYPE coredns_health_request_duration_seconds histogram
+coredns_health_request_duration_seconds_bucket{le="0.00025"} 0
+coredns_health_request_duration_seconds_bucket{le="0.0005"} 1.020171e+06
+coredns_health_request_duration_seconds_bucket{le="0.001"} 1.31957e+06
+coredns_health_request_duration_seconds_bucket{le="0.002"} 1.322017e+06
+coredns_health_request_duration_seconds_bucket{le="0.004"} 1.323692e+06
+coredns_health_request_duration_seconds_bucket{le="0.008"} 1.324232e+06
+coredns_health_request_duration_seconds_bucket{le="0.016"} 1.324341e+06
+coredns_health_request_duration_seconds_bucket{le="0.032"} 1.324375e+06
+coredns_health_request_duration_seconds_bucket{le="0.064"} 1.324393e+06
+coredns_health_request_duration_seconds_bucket{le="0.128"} 1.324405e+06
+coredns_health_request_duration_seconds_bucket{le="0.256"} 1.32441e+06
+coredns_health_request_duration_seconds_bucket{le="0.512"} 1.32441e+06
+coredns_health_request_duration_seconds_bucket{le="1.024"} 1.32441e+06
+coredns_health_request_duration_seconds_bucket{le="2.048"} 1.32441e+06
+coredns_health_request_duration_seconds_bucket{le="4.096"} 1.32441e+06
+coredns_health_request_duration_seconds_bucket{le="8.192"} 1.32441e+06
+coredns_health_request_duration_seconds_bucket{le="+Inf"} 1.32441e+06
+coredns_health_request_duration_seconds_sum 643.1446459869876
+coredns_health_request_duration_seconds_count 1.32441e+06
+# HELP coredns_panic_count_total A metrics that counts the number of panics.
+# TYPE coredns_panic_count_total counter
+coredns_panic_count_total 0
+# HELP coredns_forward_max_concurrent_rejects_total Counter of the number of queries rejected because the concurrent queries were at maximum.
+# TYPE coredns_forward_max_concurrent_rejects_total counter
+coredns_forward_max_concurrent_rejects_total 0
+# HELP coredns_forward_request_count_total Counter of requests made per upstream.
+# TYPE coredns_forward_request_count_total counter
+coredns_forward_request_count_total{to="10.0.0.2:53"} 22000
+# HELP coredns_forward_request_duration_seconds Histogram of the time each request took.
+# TYPE coredns_forward_request_duration_seconds histogram
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.00025"} 6163
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.0005"} 6548
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.001"} 14705
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.002"} 20805
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.004"} 21318
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.008"} 21698
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.016"} 21874
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.032"} 21957
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.064"} 21982
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.128"} 21996
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.256"} 21999
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="0.512"} 21999
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="1.024"} 21999
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="2.048"} 22000
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="4.096"} 22000
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="8.192"} 22000
+coredns_forward_request_duration_seconds_bucket{to="10.0.0.2:53",le="+Inf"} 22000
+coredns_forward_request_duration_seconds_sum{to="10.0.0.2:53"} 27.835685092999963
+coredns_forward_request_duration_seconds_count{to="10.0.0.2:53"} 22000
+# HELP coredns_forward_response_rcode_count_total Counter of requests made per upstream.
+# TYPE coredns_forward_response_rcode_count_total counter
+coredns_forward_response_rcode_count_total{rcode="NOERROR",to="10.0.0.2:53"} 1518
+coredns_forward_response_rcode_count_total{rcode="NXDOMAIN",to="10.0.0.2:53"} 20482
+# HELP coredns_forward_sockets_open Gauge of open sockets per upstream.
+# TYPE coredns_forward_sockets_open gauge
+coredns_forward_sockets_open{to="10.0.0.2:53"} 2
+# HELP coredns_proxy_request_count_total Counter of requests made per protocol, proxy protocol, family and upstream.
+# TYPE coredns_proxy_request_count_total counter
+coredns_proxy_request_count_total{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53"} 2031
+# HELP coredns_proxy_request_duration_seconds Histogram of the time (in seconds) each request took.
+# TYPE coredns_proxy_request_duration_seconds histogram
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="0.00025"} 0
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="0.0005"} 0
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="0.001"} 2
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="0.002"} 6
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="0.004"} 16
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="0.008"} 112
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="0.016"} 487
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="0.032"} 1475
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="0.064"} 1960
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="0.128"} 2016
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="0.256"} 2027
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="0.512"} 2030
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="1.024"} 2030
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="2.048"} 2031
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="4.096"} 2031
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="8.192"} 2031
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53",le="+Inf"} 2031
+coredns_proxy_request_duration_seconds_sum{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53"} 58.02421483200004
+coredns_proxy_request_duration_seconds_count{family="1",proto="udp",proxy_proto="dns",to="10.205.0.2:53"} 2031
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 7.1142e-05
+go_gc_duration_seconds{quantile="0.25"} 9.808e-05
+go_gc_duration_seconds{quantile="0.5"} 0.000112345
+go_gc_duration_seconds{quantile="0.75"} 0.000148037
+go_gc_duration_seconds{quantile="1"} 0.002014808
+go_gc_duration_seconds_sum 2.738122256
+go_gc_duration_seconds_count 14800
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 48
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 1.7080392e+07
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 1.910192252e+11
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.871573e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 2.012275711e+09
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 1.503232e+06
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 1.7080392e+07
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 1.2345344e+07
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 2.5731072e+07
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 189233
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes 5.9359232e+07
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 3.8076416e+07
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.5344784296191692e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 6.450174e+06
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 2.012464944e+09
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 13888
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 478800
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 507904
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 3.396504e+07
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 1.448483e+06
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 1.769472e+06
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 1.769472e+06
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 4.5193464e+07
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 4985.38
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 14
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 6.6215936e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.53315401874e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 7.8966784e+07
+
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{version="go1.14.4"} 1
+# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
+# TYPE go_memstats_gc_cpu_fraction gauge
+go_memstats_gc_cpu_fraction 0.026803372433412194
+# HELP coredns_plugin_enabled A metric that indicates whether a plugin is enabled on per server and zone basis.
+# TYPE coredns_plugin_enabled gauge
+coredns_plugin_enabled{name="cache",server="dns://:53",zone="."} 1
+coredns_plugin_enabled{name="errors",server="dns://:53",zone="."} 1
+coredns_plugin_enabled{name="forward",server="dns://:53",zone="."} 1
+coredns_plugin_enabled{name="prometheus",server="dns://:53",zone="."} 1
+
+# HELP coredns_forward_healthcheck_broken_total Counter of the number of complete failures of the healthchecks.
+# TYPE coredns_forward_healthcheck_broken_total counter
+coredns_forward_healthcheck_broken_total 0
+# HELP coredns_hosts_reload_timestamp_seconds The timestamp of the last reload of hosts file.
+# TYPE coredns_hosts_reload_timestamp_seconds gauge
+coredns_hosts_reload_timestamp_seconds 0
+# HELP coredns_reload_failed_total Counter of the number of failed reload attempts.
+# TYPE coredns_reload_failed_total counter
+coredns_reload_failed_total 0
+
+# HELP coredns_build_info A metric with a constant '1' value labeled by version, revision, and goversion from which CoreDNS was built.
+# TYPE coredns_build_info gauge
+coredns_build_info{goversion="go1.10.3",revision="2e322f6",version="1.2.0"} 1
+# HELP coredns_cache_misses_total The count of cache misses.
+# TYPE coredns_cache_misses_total counter
+coredns_cache_misses_total{server="dns://:53"} 2
+# HELP coredns_cache_size The number of elements in the cache.
+# TYPE coredns_cache_size gauge
+coredns_cache_size{server="dns://:53",type="denial"} 0
+coredns_cache_size{server="dns://:53",type="success"} 2
+# HELP coredns_dns_request_count_total Counter of DNS requests made per zone, protocol and family.
+# TYPE coredns_dns_request_count_total counter
+coredns_dns_request_count_total{family="1",proto="udp",server="dns://:53",zone="."} 2
+# HELP coredns_dns_request_duration_seconds Histogram of the time (in seconds) each request took.
+# TYPE coredns_dns_request_duration_seconds histogram
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.00025"} 0
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.0005"} 0
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.001"} 0
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.002"} 0
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.004"} 0
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.008"} 0
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.016"} 1
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.032"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.064"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.128"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.256"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.512"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="1.024"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="2.048"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="4.096"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="8.192"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="+Inf"} 2
+coredns_dns_request_duration_seconds_sum{server="dns://:53",zone="."} 0.0393353
+coredns_dns_request_duration_seconds_count{server="dns://:53",zone="."} 2
+# HELP coredns_dns_request_size_bytes Size of the EDNS0 UDP buffer in bytes (64K for TCP).
+# TYPE coredns_dns_request_size_bytes histogram
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="0"} 0
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="100"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="200"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="300"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="400"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="511"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="1023"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="2047"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="4095"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="8291"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="16000"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="32000"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="48000"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="64000"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="+Inf"} 2
+coredns_dns_request_size_bytes_sum{proto="udp",server="dns://:53",zone="."} 81
+coredns_dns_request_size_bytes_count{proto="udp",server="dns://:53",zone="."} 2
+# HELP coredns_dns_request_type_count_total Counter of DNS requests per type, per zone.
+# TYPE coredns_dns_request_type_count_total counter
+coredns_dns_request_type_count_total{server="dns://:53",type="A",zone="."} 2
+# HELP coredns_dns_response_rcode_count_total Counter of response status codes.
+# TYPE coredns_dns_response_rcode_count_total counter
+coredns_dns_response_rcode_count_total{rcode="NOERROR",server="dns://:53",zone="."} 2
+# HELP coredns_dns_response_size_bytes Size of the returned response in bytes.
+# TYPE coredns_dns_response_size_bytes histogram
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="0"} 0
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="100"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="200"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="300"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="400"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="511"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="1023"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="2047"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="4095"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="8291"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="16000"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="32000"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="48000"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="64000"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="+Inf"} 2
+coredns_dns_response_size_bytes_sum{proto="udp",server="dns://:53",zone="."} 110
+coredns_dns_response_size_bytes_count{proto="udp",server="dns://:53",zone="."} 2
+# HELP coredns_forward_request_count_total Counter of requests made per upstream.
+# TYPE coredns_forward_request_count_total counter
+coredns_forward_request_count_total{to="127.0.0.11:53"} 1
+# HELP coredns_forward_request_duration_seconds Histogram of the time each request took.
+# TYPE coredns_forward_request_duration_seconds histogram
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="0.00025"} 0
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="0.0005"} 0
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="0.001"} 0
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="0.002"} 0
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="0.004"} 0
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="0.008"} 1
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="0.016"} 1
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="0.032"} 1
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="0.064"} 1
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="0.128"} 1
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="0.256"} 1
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="0.512"} 1
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="1.024"} 1
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="2.048"} 1
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="4.096"} 1
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="8.192"} 1
+coredns_forward_request_duration_seconds_bucket{to="127.0.0.11:53",le="+Inf"} 1
+coredns_forward_request_duration_seconds_sum{to="127.0.0.11:53"} 0.0063349
+coredns_forward_request_duration_seconds_count{to="127.0.0.11:53"} 1
+# HELP coredns_forward_response_rcode_count_total Counter of requests made per upstream.
+# TYPE coredns_forward_response_rcode_count_total counter
+coredns_forward_response_rcode_count_total{rcode="NOERROR",to="127.0.0.11:53"} 1
+# HELP coredns_forward_sockets_open Gauge of open sockets per upstream.
+# TYPE coredns_forward_sockets_open gauge
+coredns_forward_sockets_open{to="127.0.0.11:53"} 1
+# HELP coredns_health_request_duration_seconds Histogram of the time (in seconds) each request took.
+# TYPE coredns_health_request_duration_seconds histogram
+coredns_health_request_duration_seconds_bucket{le="0.00025"} 0
+coredns_health_request_duration_seconds_bucket{le="0.0005"} 0
+coredns_health_request_duration_seconds_bucket{le="0.001"} 3
+coredns_health_request_duration_seconds_bucket{le="0.002"} 16
+coredns_health_request_duration_seconds_bucket{le="0.004"} 20
+coredns_health_request_duration_seconds_bucket{le="0.008"} 25
+coredns_health_request_duration_seconds_bucket{le="0.016"} 25
+coredns_health_request_duration_seconds_bucket{le="0.032"} 25
+coredns_health_request_duration_seconds_bucket{le="0.064"} 25
+coredns_health_request_duration_seconds_bucket{le="0.128"} 25
+coredns_health_request_duration_seconds_bucket{le="0.256"} 25
+coredns_health_request_duration_seconds_bucket{le="0.512"} 25
+coredns_health_request_duration_seconds_bucket{le="1.024"} 25
+coredns_health_request_duration_seconds_bucket{le="2.048"} 25
+coredns_health_request_duration_seconds_bucket{le="4.096"} 25
+coredns_health_request_duration_seconds_bucket{le="8.192"} 25
+coredns_health_request_duration_seconds_bucket{le="+Inf"} 25
+coredns_health_request_duration_seconds_sum 0.052979899999999996
+coredns_health_request_duration_seconds_count 25
+# HELP coredns_panic_count_total A metrics that counts the number of panics.
+# TYPE coredns_panic_count_total counter
+coredns_panic_count_total 0
+# HELP coredns_proxy_request_count_total Counter of requests made per protocol, proxy protocol, family and upstream.
+# TYPE coredns_proxy_request_count_total counter
+coredns_proxy_request_count_total{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53"} 1
+# HELP coredns_proxy_request_duration_seconds Histogram of the time (in seconds) each request took.
+# TYPE coredns_proxy_request_duration_seconds histogram
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="0.00025"} 0
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="0.0005"} 0
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="0.001"} 0
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="0.002"} 0
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="0.004"} 0
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="0.008"} 0
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="0.016"} 0
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="0.032"} 1
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="0.064"} 1
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="0.128"} 1
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="0.256"} 1
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="0.512"} 1
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="1.024"} 1
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="2.048"} 1
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="4.096"} 1
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="8.192"} 1
+coredns_proxy_request_duration_seconds_bucket{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53",le="+Inf"} 1
+coredns_proxy_request_duration_seconds_sum{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53"} 0.0309546
+coredns_proxy_request_duration_seconds_count{family="1",proto="udp",proxy_proto="dns",server="dns://:53",to="127.0.0.11:53"} 1
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0005617
+go_gc_duration_seconds{quantile="0.25"} 0.0005617
+go_gc_duration_seconds{quantile="0.5"} 0.0011068
+go_gc_duration_seconds{quantile="0.75"} 0.0011068
+go_gc_duration_seconds{quantile="1"} 0.0011068
+go_gc_duration_seconds_sum 0.0016685
+go_gc_duration_seconds_count 2
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 27
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 4.21336e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 6.498232e+06
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.446275e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 11381
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 438272
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 4.21336e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 729088
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 5.69344e+06
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 24231
+# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes_total counter
+go_memstats_heap_released_bytes_total 0
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 6.422528e+06
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.6414159308046913e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 151
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 35612
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 10416
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 72352
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 81920
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 5.264496e+06
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 1.005429e+06
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 917504
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 917504
+# HELP go_memstats_sys_bytes Number of bytes obtained by system. Sum of all system allocations.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 1.0328312e+07
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 0.27
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 10
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 2.6075136e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.64141592975e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 4.460544e+07

--- a/coredns/tests/fixtures/metrics_18.txt
+++ b/coredns/tests/fixtures/metrics_18.txt
@@ -248,9 +248,6 @@ go_memstats_heap_inuse_bytes 2.5731072e+07
 # HELP go_memstats_heap_objects Number of allocated objects.
 # TYPE go_memstats_heap_objects gauge
 go_memstats_heap_objects 189233
-# HELP go_memstats_heap_released_bytes_total Total number of heap bytes released to OS.
-# TYPE go_memstats_heap_released_bytes_total counter
-go_memstats_heap_released_bytes_total 0
 # HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
 # TYPE go_memstats_heap_released_bytes gauge
 go_memstats_heap_released_bytes 5.9359232e+07
@@ -334,3 +331,261 @@ coredns_hosts_reload_timestamp_seconds 0
 # HELP coredns_reload_failed_total Counter of the number of failed reload attempts.
 # TYPE coredns_reload_failed_total counter
 coredns_reload_failed_total 0
+
+# HELP coredns_build_info A metric with a constant '1' value labeled by version, revision, and goversion from which CoreDNS was built.
+# TYPE coredns_build_info gauge
+coredns_build_info{goversion="go1.17.1",revision="8ddb631",version="1.8.5"} 1
+# HELP coredns_cache_entries The number of elements in the cache.
+# TYPE coredns_cache_entries gauge
+coredns_cache_entries{server="dns://:53",type="denial"} 0
+coredns_cache_entries{server="dns://:53",type="success"} 1
+# HELP coredns_cache_misses_total The count of cache misses. Deprecated, derive misses from cache hits/requests counters.
+# TYPE coredns_cache_misses_total counter
+coredns_cache_misses_total{server="dns://:53"} 2
+# HELP coredns_cache_requests_total The count of cache requests.
+# TYPE coredns_cache_requests_total counter
+coredns_cache_requests_total{server="dns://:53"} 2
+# HELP coredns_dns_request_duration_seconds Histogram of the time (in seconds) each request took per zone.
+# TYPE coredns_dns_request_duration_seconds histogram
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.00025"} 1
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.0005"} 1
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.001"} 1
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.002"} 1
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.004"} 1
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.008"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.016"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.032"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.064"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.128"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.256"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="0.512"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="1.024"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="2.048"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="4.096"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="8.192"} 2
+coredns_dns_request_duration_seconds_bucket{server="dns://:53",zone=".",le="+Inf"} 2
+coredns_dns_request_duration_seconds_sum{server="dns://:53",zone="."} 0.0081078
+coredns_dns_request_duration_seconds_count{server="dns://:53",zone="."} 2
+# HELP coredns_dns_request_size_bytes Size of the EDNS0 UDP buffer in bytes (64K for TCP) per zone and protocol.
+# TYPE coredns_dns_request_size_bytes histogram
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="0"} 0
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="100"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="200"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="300"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="400"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="511"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="1023"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="2047"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="4095"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="8291"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="16000"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="32000"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="48000"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="64000"} 2
+coredns_dns_request_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="+Inf"} 2
+coredns_dns_request_size_bytes_sum{proto="udp",server="dns://:53",zone="."} 79
+coredns_dns_request_size_bytes_count{proto="udp",server="dns://:53",zone="."} 2
+# HELP coredns_dns_requests_total Counter of DNS requests made per zone, protocol and family.
+# TYPE coredns_dns_requests_total counter
+coredns_dns_requests_total{family="1",proto="udp",server="dns://:53",type="A",zone="."} 2
+# HELP coredns_dns_response_size_bytes Size of the returned response in bytes.
+# TYPE coredns_dns_response_size_bytes histogram
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="0"} 1
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="100"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="200"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="300"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="400"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="511"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="1023"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="2047"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="4095"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="8291"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="16000"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="32000"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="48000"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="64000"} 2
+coredns_dns_response_size_bytes_bucket{proto="udp",server="dns://:53",zone=".",le="+Inf"} 2
+coredns_dns_response_size_bytes_sum{proto="udp",server="dns://:53",zone="."} 56
+coredns_dns_response_size_bytes_count{proto="udp",server="dns://:53",zone="."} 2
+# HELP coredns_dns_responses_total Counter of response status codes.
+# TYPE coredns_dns_responses_total counter
+coredns_dns_responses_total{rcode="NOERROR",server="dns://:53",zone="."} 1
+coredns_dns_responses_total{rcode="SERVFAIL",server="dns://:53",zone="."} 1
+# HELP coredns_forward_conn_cache_misses_total Counter of connection cache misses per upstream and protocol.
+# TYPE coredns_forward_conn_cache_misses_total counter
+coredns_forward_conn_cache_misses_total{proto="udp",to="127.0.0.11:53"} 1
+# HELP coredns_forward_healthcheck_broken_total Counter of the number of complete failures of the healthchecks.
+# TYPE coredns_forward_healthcheck_broken_total counter
+coredns_forward_healthcheck_broken_total 0
+# HELP coredns_forward_max_concurrent_rejects_total Counter of the number of queries rejected because the concurrent queries were at maximum.
+# TYPE coredns_forward_max_concurrent_rejects_total counter
+coredns_forward_max_concurrent_rejects_total 0
+# HELP coredns_forward_request_duration_seconds Histogram of the time each request took.
+# TYPE coredns_forward_request_duration_seconds histogram
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="0.00025"} 0
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="0.0005"} 0
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="0.001"} 0
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="0.002"} 0
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="0.004"} 0
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="0.008"} 1
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="0.016"} 1
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="0.032"} 1
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="0.064"} 1
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="0.128"} 1
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="0.256"} 1
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="0.512"} 1
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="1.024"} 1
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="2.048"} 1
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="4.096"} 1
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="8.192"} 1
+coredns_forward_request_duration_seconds_bucket{rcode="NOERROR",to="127.0.0.11:53",le="+Inf"} 1
+coredns_forward_request_duration_seconds_sum{rcode="NOERROR",to="127.0.0.11:53"} 0.0075804
+coredns_forward_request_duration_seconds_count{rcode="NOERROR",to="127.0.0.11:53"} 1
+# HELP coredns_forward_requests_total Counter of requests made per upstream.
+# TYPE coredns_forward_requests_total counter
+coredns_forward_requests_total{to="127.0.0.11:53"} 1
+# HELP coredns_forward_responses_total Counter of responses received per upstream.
+# TYPE coredns_forward_responses_total counter
+coredns_forward_responses_total{rcode="NOERROR",to="127.0.0.11:53"} 1
+# HELP coredns_health_request_duration_seconds Histogram of the time (in seconds) each request took.
+# TYPE coredns_health_request_duration_seconds histogram
+coredns_health_request_duration_seconds_bucket{le="0.00025"} 0
+coredns_health_request_duration_seconds_bucket{le="0.0025"} 132
+coredns_health_request_duration_seconds_bucket{le="0.025"} 263
+coredns_health_request_duration_seconds_bucket{le="0.25"} 263
+coredns_health_request_duration_seconds_bucket{le="2.5"} 263
+coredns_health_request_duration_seconds_bucket{le="+Inf"} 263
+coredns_health_request_duration_seconds_sum 0.7070575999999998
+coredns_health_request_duration_seconds_count 263
+# HELP coredns_health_request_failures_total The number of times the health check failed.
+# TYPE coredns_health_request_failures_total counter
+coredns_health_request_failures_total 0
+# HELP coredns_hosts_reload_timestamp_seconds The timestamp of the last reload of hosts file.
+# TYPE coredns_hosts_reload_timestamp_seconds gauge
+coredns_hosts_reload_timestamp_seconds 0
+# HELP coredns_local_localhost_requests_total Counter of localhost.<domain> requests.
+# TYPE coredns_local_localhost_requests_total counter
+coredns_local_localhost_requests_total 0
+# HELP coredns_panics_total A metrics that counts the number of panics.
+# TYPE coredns_panics_total counter
+coredns_panics_total 0
+# HELP coredns_plugin_enabled A metric that indicates whether a plugin is enabled on per server and zone basis.
+# TYPE coredns_plugin_enabled gauge
+coredns_plugin_enabled{name="cache",server="dns://:53",zone="."} 1
+coredns_plugin_enabled{name="errors",server="dns://:53",zone="."} 1
+coredns_plugin_enabled{name="forward",server="dns://:53",zone="."} 1
+coredns_plugin_enabled{name="prometheus",server="dns://:53",zone="."} 1
+# HELP coredns_reload_failed_total Counter of the number of failed reload attempts.
+# TYPE coredns_reload_failed_total counter
+coredns_reload_failed_total 0
+# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0.0002631
+go_gc_duration_seconds{quantile="0.25"} 0.0003688
+go_gc_duration_seconds{quantile="0.5"} 0.0003724
+go_gc_duration_seconds{quantile="0.75"} 0.0007523
+go_gc_duration_seconds{quantile="1"} 0.0009835
+go_gc_duration_seconds_sum 0.003109
+go_gc_duration_seconds_count 6
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+go_goroutines 20
+# HELP go_info Information about the Go environment.
+# TYPE go_info gauge
+go_info{version="go1.17.1"} 1
+# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+# TYPE go_memstats_alloc_bytes gauge
+go_memstats_alloc_bytes 8.597472e+06
+# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+# TYPE go_memstats_alloc_bytes_total counter
+go_memstats_alloc_bytes_total 2.113624e+07
+# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+# TYPE go_memstats_buck_hash_sys_bytes gauge
+go_memstats_buck_hash_sys_bytes 1.454476e+06
+# HELP go_memstats_frees_total Total number of frees.
+# TYPE go_memstats_frees_total counter
+go_memstats_frees_total 65792
+# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
+# TYPE go_memstats_gc_cpu_fraction gauge
+go_memstats_gc_cpu_fraction 3.2383404317272646e-05
+# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+# TYPE go_memstats_gc_sys_bytes gauge
+go_memstats_gc_sys_bytes 5.396544e+06
+# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+# TYPE go_memstats_heap_alloc_bytes gauge
+go_memstats_heap_alloc_bytes 8.597472e+06
+# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+# TYPE go_memstats_heap_idle_bytes gauge
+go_memstats_heap_idle_bytes 5.128192e+06
+# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+# TYPE go_memstats_heap_inuse_bytes gauge
+go_memstats_heap_inuse_bytes 1.0829824e+07
+# HELP go_memstats_heap_objects Number of allocated objects.
+# TYPE go_memstats_heap_objects gauge
+go_memstats_heap_objects 24413
+# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+# TYPE go_memstats_heap_released_bytes gauge
+go_memstats_heap_released_bytes 868352
+# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+# TYPE go_memstats_heap_sys_bytes gauge
+go_memstats_heap_sys_bytes 1.5958016e+07
+# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+# TYPE go_memstats_last_gc_time_seconds gauge
+go_memstats_last_gc_time_seconds 1.6414150694971173e+09
+# HELP go_memstats_lookups_total Total number of pointer lookups.
+# TYPE go_memstats_lookups_total counter
+go_memstats_lookups_total 0
+# HELP go_memstats_mallocs_total Total number of mallocs.
+# TYPE go_memstats_mallocs_total counter
+go_memstats_mallocs_total 90205
+# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+# TYPE go_memstats_mcache_inuse_bytes gauge
+go_memstats_mcache_inuse_bytes 7200
+# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+# TYPE go_memstats_mcache_sys_bytes gauge
+go_memstats_mcache_sys_bytes 16384
+# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+# TYPE go_memstats_mspan_inuse_bytes gauge
+go_memstats_mspan_inuse_bytes 147832
+# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+# TYPE go_memstats_mspan_sys_bytes gauge
+go_memstats_mspan_sys_bytes 163840
+# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+# TYPE go_memstats_next_gc_bytes gauge
+go_memstats_next_gc_bytes 1.57536e+07
+# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+# TYPE go_memstats_other_sys_bytes gauge
+go_memstats_other_sys_bytes 1.440316e+06
+# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+# TYPE go_memstats_stack_inuse_bytes gauge
+go_memstats_stack_inuse_bytes 819200
+# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+# TYPE go_memstats_stack_sys_bytes gauge
+go_memstats_stack_sys_bytes 819200
+# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+# TYPE go_memstats_sys_bytes gauge
+go_memstats_sys_bytes 2.5248776e+07
+# HELP go_threads Number of OS threads created.
+# TYPE go_threads gauge
+go_threads 11
+# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+# TYPE process_cpu_seconds_total counter
+process_cpu_seconds_total 2.33
+# HELP process_max_fds Maximum number of open file descriptors.
+# TYPE process_max_fds gauge
+process_max_fds 1.048576e+06
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
+process_open_fds 13
+# HELP process_resident_memory_bytes Resident memory size in bytes.
+# TYPE process_resident_memory_bytes gauge
+process_resident_memory_bytes 4.630528e+07
+# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+# TYPE process_start_time_seconds gauge
+process_start_time_seconds 1.64141483483e+09
+# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+# TYPE process_virtual_memory_bytes gauge
+process_virtual_memory_bytes 7.69593344e+08
+# HELP process_virtual_memory_max_bytes Maximum amount of virtual memory available in bytes.
+# TYPE process_virtual_memory_max_bytes gauge
+process_virtual_memory_max_bytes 1.8446744073709552e+19

--- a/coredns/tests/test_check.py
+++ b/coredns/tests/test_check.py
@@ -2,58 +2,57 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
+from six import PY2
 
 from datadog_checks.coredns import CoreDNSCheck
-from datadog_checks.dev.utils import ON_WINDOWS, get_metadata_metrics
+from datadog_checks.dev.utils import ON_WINDOWS
 
-from .common import CHECK_NAME, METRICS, NAMESPACE
+from .common import CHECK_NAME, METRICS, METRICS_V2, NAMESPACE
 
 
 class TestCoreDNS:
     """Basic Test for CoreDNS integration."""
 
-    def test_check(self, aggregator, mock_get, instance):
+    def test_check(self, aggregator, mock_get, dd_run_check, instance):
         """
         Testing CoreDNS check.
         """
 
         check = CoreDNSCheck(CHECK_NAME, {}, [instance])
-        check.check(instance)
+        dd_run_check(check)
 
         # check that we then get the count metrics also
-        check.check(instance)
+        dd_run_check(check)
 
         metrics = METRICS + [NAMESPACE + '.cache_hits_count']
 
         for metric in metrics:
             aggregator.assert_metric(metric)
-        aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 
     @pytest.mark.skipif(ON_WINDOWS, reason='No `dig` utility on Windows')
-    def test_docker(self, aggregator, dd_environment, dockerinstance):
+    def test_docker(self, aggregator, dd_environment, dd_run_check, dockerinstance):
         """
         Testing metrics emitted from docker container.
         """
 
         check = CoreDNSCheck(CHECK_NAME, {}, [dockerinstance])
-        check.check(dockerinstance)
+        dd_run_check(check)
 
         for metric in METRICS:
             aggregator.assert_metric(metric)
 
         aggregator.assert_all_metrics_covered()
-        aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 
-    def test_omv2_docker(self, aggregator, dd_environment, docker_omv2_instance):
+    @pytest.mark.skipif(PY2, reason='OpenMetrics V2 is only available with Python 3')
+    def test_docker_omv2(self, aggregator, dd_environment, dd_run_check, docker_omv2_instance):
         """
         Testing OpenMetricsV2 metrics emitted from docker container.
         """
 
         check = CoreDNSCheck(CHECK_NAME, {}, [docker_omv2_instance])
-        check.check(docker_omv2_instance)
+        dd_run_check(check)
 
-        for metric in METRICS:
+        for metric in METRICS_V2:
             aggregator.assert_metric(metric)
 
         aggregator.assert_all_metrics_covered()
-        aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)

--- a/coredns/tests/test_check.py
+++ b/coredns/tests/test_check.py
@@ -24,6 +24,8 @@ class TestCoreDNS:
         # check that we then get the count metrics also
         dd_run_check(check)
 
+        # `.cache_hits_count` metric is only tested against the metrics fixtures file
+        # because the metric is not available in docker/e2e.
         metrics = METRICS + [NAMESPACE + '.cache_hits_count']
 
         for metric in metrics:
@@ -41,6 +43,8 @@ class TestCoreDNS:
         # check that we then get the count metrics also
         dd_run_check(check)
 
+        # `.cache_hits_count.count` metric is only tested against the metrics fixtures file
+        # because the metric is not available in docker/e2e.
         metrics = METRICS_V2 + [NAMESPACE + '.cache_hits_count.count']
 
         for metric in metrics:

--- a/coredns/tests/test_check.py
+++ b/coredns/tests/test_check.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2018-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest

--- a/coredns/tests/test_check.py
+++ b/coredns/tests/test_check.py
@@ -5,7 +5,7 @@ import pytest
 from six import PY2
 
 from datadog_checks.coredns import CoreDNSCheck
-from datadog_checks.dev.utils import ON_WINDOWS
+from datadog_checks.dev.utils import ON_WINDOWS, get_metadata_metrics
 
 from .common import CHECK_NAME, METRICS, METRICS_V2, NAMESPACE
 
@@ -41,10 +41,11 @@ class TestCoreDNS:
         # check that we then get the count metrics also
         dd_run_check(check)
 
-        metrics = METRICS_V2 + [NAMESPACE + '.cache_hits.count']
+        metrics = METRICS_V2 + [NAMESPACE + '.cache_hits_count.count']
 
         for metric in metrics:
             aggregator.assert_metric(metric)
+        aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 
     @pytest.mark.skipif(ON_WINDOWS, reason='No `dig` utility on Windows')
     def test_docker(self, aggregator, dd_environment, dd_run_check, dockerinstance):
@@ -73,3 +74,4 @@ class TestCoreDNS:
             aggregator.assert_metric(metric)
 
         aggregator.assert_all_metrics_covered()
+        aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)

--- a/coredns/tests/test_check.py
+++ b/coredns/tests/test_check.py
@@ -29,6 +29,23 @@ class TestCoreDNS:
         for metric in metrics:
             aggregator.assert_metric(metric)
 
+    @pytest.mark.skipif(PY2, reason='OpenMetrics V2 is only available with Python 3')
+    def test_check_omv2(self, aggregator, mock_get, dd_run_check, omv2_instance):
+        """
+        Testing CoreDNS check OpenMetrics V2.
+        """
+
+        check = CoreDNSCheck(CHECK_NAME, {}, [omv2_instance])
+        dd_run_check(check)
+
+        # check that we then get the count metrics also
+        dd_run_check(check)
+
+        metrics = METRICS_V2 + [NAMESPACE + '.cache_hits.count']
+
+        for metric in metrics:
+            aggregator.assert_metric(metric)
+
     @pytest.mark.skipif(ON_WINDOWS, reason='No `dig` utility on Windows')
     def test_docker(self, aggregator, dd_environment, dd_run_check, dockerinstance):
         """

--- a/coredns/tests/test_check.py
+++ b/coredns/tests/test_check.py
@@ -43,3 +43,17 @@ class TestCoreDNS:
 
         aggregator.assert_all_metrics_covered()
         aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
+
+    def test_omv2_docker(self, aggregator, dd_environment, docker_omv2_instance):
+        """
+        Testing OpenMetricsV2 metrics emitted from docker container.
+        """
+
+        check = CoreDNSCheck(CHECK_NAME, {}, [docker_omv2_instance])
+        check.check(docker_omv2_instance)
+
+        for metric in METRICS:
+            aggregator.assert_metric(metric)
+
+        aggregator.assert_all_metrics_covered()
+        aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)

--- a/coredns/tests/test_e2e.py
+++ b/coredns/tests/test_e2e.py
@@ -2,9 +2,7 @@ import platform
 
 import pytest
 
-from datadog_checks.dev.utils import get_metadata_metrics
-
-from .common import METRICS
+from .common import METRICS, METRICS_V2
 
 
 @pytest.mark.e2e
@@ -13,16 +11,14 @@ def test_check_ok(dd_agent_check, instance):
     for metric in METRICS:
         aggregator.assert_metric(metric)
 
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
     aggregator.assert_all_metrics_covered()
 
 
 @pytest.mark.skipif(platform.python_version() < "3", reason='OpenMetrics V2 is only available with Python 3')
 @pytest.mark.e2e
-def test_om_check_ok(dd_agent_check, openmetrics_instance):
-    aggregator = dd_agent_check(openmetrics_instance, rate=True)
-    for metric in METRICS:
+def test_om_check_ok(dd_agent_check, omv2_instance):
+    aggregator = dd_agent_check(omv2_instance, rate=True)
+    for metric in METRICS_V2:
         aggregator.assert_metric(metric)
 
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
     aggregator.assert_all_metrics_covered()

--- a/coredns/tests/test_e2e.py
+++ b/coredns/tests/test_e2e.py
@@ -5,6 +5,8 @@ import platform
 
 import pytest
 
+from datadog_checks.dev.utils import get_metadata_metrics
+
 from .common import METRICS, METRICS_V2
 
 
@@ -25,3 +27,4 @@ def test_check_ok_omv2(dd_agent_check, omv2_instance):
         aggregator.assert_metric(metric)
 
     aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)

--- a/coredns/tests/test_e2e.py
+++ b/coredns/tests/test_e2e.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 import platform
 
 import pytest
@@ -16,7 +19,7 @@ def test_check_ok(dd_agent_check, instance):
 
 @pytest.mark.skipif(platform.python_version() < "3", reason='OpenMetrics V2 is only available with Python 3')
 @pytest.mark.e2e
-def test_om_check_ok(dd_agent_check, omv2_instance):
+def test_check_ok_omv2(dd_agent_check, omv2_instance):
     aggregator = dd_agent_check(omv2_instance, rate=True)
     for metric in METRICS_V2:
         aggregator.assert_metric(metric)

--- a/coredns/tests/test_e2e.py
+++ b/coredns/tests/test_e2e.py
@@ -1,3 +1,5 @@
+import platform
+
 import pytest
 
 from datadog_checks.dev.utils import get_metadata_metrics
@@ -8,6 +10,17 @@ from .common import METRICS
 @pytest.mark.e2e
 def test_check_ok(dd_agent_check, instance):
     aggregator = dd_agent_check(instance, rate=True)
+    for metric in METRICS:
+        aggregator.assert_metric(metric)
+
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+    aggregator.assert_all_metrics_covered()
+
+
+@pytest.mark.skipif(platform.python_version() < "3", reason='OpenMetrics V2 is only available with Python 3')
+@pytest.mark.e2e
+def test_om_check_ok(dd_agent_check, openmetrics_instance):
+    aggregator = dd_agent_check(openmetrics_instance, rate=True)
     for metric in METRICS:
         aggregator.assert_metric(metric)
 

--- a/coredns/tox.ini
+++ b/coredns/tox.ini
@@ -11,7 +11,7 @@ envdir =
     py38: {toxworkdir}/py38
 dd_check_style = true
 description =
-    py{27,38}-{1.2.0}: e2e ready 
+    py{27,38}-{1.2.0,1.8.5}: e2e ready
 usedevelop = true
 platform = linux|darwin|win32
 setenv =


### PR DESCRIPTION
### What does this PR do?
This change adds support for OpenMetricsBaseCheckV2 and enables the check to use it by default. OpenMetrics V1 and V2 can be switched by using either `prometheus_url` for OpenMetrics V1 or `openmetrics_endpoint` for OpenMetrics V2.

OpenMetrics V2 collects different metrics compared to OpenMetrics V1.

Here's what changes between OpenMetrics V1 and OpenMetrics V2:

* All `*.sum` and `*.count` metrics have been changed from gauge to monotonic_count (except for `coredns.cache_size.count`)
* New metrics are added

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
