### PR TITLE
Don't add new line to license header

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/utils.py
@@ -35,9 +35,7 @@ def get_license_header():
     return (
         '# (C) Datadog, Inc. {year}-present\n'
         '# All rights reserved\n'
-        '# Licensed under a 3-clause BSD style license (see LICENSE)\n'.format(
-            year=str(datetime.now(timezone.utc).year)
-        )
+        '# Licensed under a 3-clause BSD style license (see LICENSE)'.format(year=str(datetime.now(timezone.utc).year))
     )
 
 


### PR DESCRIPTION
### What does this PR do?
- Don't add new line to license header
- Check for equality of generated files regardless of generation of new lines

### Motivation
ddev tests are failing because new files with only the header failed style- they had an extra new line

### Additional Notes
Tested a few cases where adding a new line to a generated file still fails validation

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
