### PR TITLE
Add support for manifest V2 to "ddev create"

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -103,6 +103,7 @@ def create(ctx, name, integration_type, location, manifest_v2, non_interactive, 
 
     if name.islower():
         echo_warning('Make sure to use the display name. e.g. MapR, Ambari, IBM MQ, vSphere, ...')
+        click.confirm('Do you want to continue?', abort=True)
 
     repo_choice = ctx.obj['repo_choice']
     root = resolve_path(location) if location else get_root()
@@ -118,7 +119,7 @@ def create(ctx, name, integration_type, location, manifest_v2, non_interactive, 
     if repo_choice == 'marketplace':
         manifest_v2 = True
 
-    template_fields = {'manifest_version': '1.0.0' if not manifest_v2 else '2.0.0'}
+    template_fields = {'manifest_version': '1.0.0'}
     if non_interactive and repo_choice != 'core':
         abort(f'Cannot use non-interactive mode with repo_choice: {repo_choice}')
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -9,9 +9,9 @@ import click
 from ...fs import resolve_path
 from ..constants import get_root
 from ..create import construct_template_fields, create_template_files, get_valid_templates
+from ..manifest_validator.v2.migration import migrate_manifest
 from ..utils import kebab_case_name, normalize_package_name
 from .console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_warning
-from ..manifest_validator.v2.migration import migrate_manifest, TODO_FILL_IN
 
 HYPHEN = b'\xe2\x94\x80\xe2\x94\x80'.decode('utf-8')
 PIPE = b'\xe2\x94\x82'.decode('utf-8')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
@@ -1,115 +1,11 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-import json
-import uuid
-
 import click
 
-from ....fs import write_file
-from ...datastructures import JSONDict
-from ...utils import get_manifest_file, get_valid_integrations, load_manifest
+from ...utils import get_valid_integrations
 from ..console import CONTEXT_SETTINGS, abort, echo_info, echo_success
-
-# This means the value is either not present in the old manifest, or there's logic needed to compute it
-SKIP_IF_FOUND = "SKIP"
-
-# Static text to let users know these values need updating by hand
-TODO_FILL_IN = "TODO Please Fill In"
-
-# Validate what manifest versions we can support and what we can upgrade from->to
-SUPPORTED_MANIFEST_VERSIONS = ["1.0.0", "2.0.0"]
-SUPPORTED_VERSION_UPGRADE_PATHS = {"1.0.0": ["2.0.0"]}
-
-# JSONDict map all v2 fields to their v1 counterparts
-# Skipping any fields that need manual intervention of custom logic
-V2_TO_V1_MAP = JSONDict(
-    {
-        "/manifest_version": SKIP_IF_FOUND,
-        "/app_id": "/integration_id",
-        "/classifier_tags": [],
-        "/display_on_public_website": "/is_public",
-        "/tile": {},
-        "/tile/overview": "README.md#Overview",
-        "/tile/configuration": "README.md#Setup",
-        "/tile/support": "README.md#Support",
-        "/tile/changelog": "CHANGELOG.md",
-        "/tile/description": "/short_description",
-        "/tile/title": "/public_title",
-        "/tile/media": [],
-        "/author": {},
-        "/author/homepage": "/author/homepage",
-        "/author/name": "/author/name",
-        "/author/support_email": "/maintainer",
-        "/oauth": {},
-        "/assets": {},
-        "/assets/integration": {},
-        "/assets/integration/source_type_name": "/display_name",
-        "/assets/integration/configuration": {},
-        "/assets/integration/configuration/spec": "/assets/configuration/spec",
-        "/assets/integration/events": {},
-        "/assets/integration/events/creates_events": "/creates_events",
-        "/assets/integration/metrics": {},
-        "/assets/integration/metrics/prefix": "/metric_prefix",
-        "/assets/integration/metrics/check": "/metric_to_check",
-        "/assets/integration/metrics/metadata_path": "/assets/metrics_metadata",
-        "/assets/integration/service_checks": {},
-        "/assets/integration/service_checks/metadata_path": "/assets/service_checks",
-        "/assets/dashboards": "/assets/dashboards",
-        "/assets/monitors": "/assets/monitors",
-        "/assets/saved_views": "/assets/saved_views",
-        "/assets/logs": "/assets/logs",
-    }
-)
-
-OS_TO_CLASSIFIER_TAGS = {
-    "linux": "Supported OS::Linux",
-    "mac_os": "Supported OS::Mac OS",
-    "windows": "Supported OS::Windows",
-}
-
-CATEGORIES_TO_CLASSIFIER_TAGS = {
-    "alerting": "Category::Alerting",
-    "autodiscovery": "Category::Autodiscovery",
-    "automation": "Category::Automation",
-    "aws": "Category::AWS",
-    "azure": "Category::Azure",
-    "caching": "Category::Caching",
-    "cloud": "Category::Cloud",
-    "collaboration": "Category::Collaboration",
-    "compliance": "Category::Compliance",
-    "configuration & deployment": "Category::Configuration Deployment",
-    "containers": "Category::Containers",
-    "cost management": "Category::Cost Management",
-    "data store": "Category::Data Store",
-    "developer tools": "Category::Developer Tools",
-    "event management": "Category::Event Management",
-    "exceptions": "Category::Exceptions",
-    "google cloud": "Category::Google Cloud",
-    "incidents": "Category::Incidents",
-    "iot": "Category::IOT",
-    "isp": "Category::ISP",
-    "issue tracking": "Category::Issue Tracking",
-    "languages": "Category::Languages",
-    "log collection": "Category::Log Collection",
-    "marketplace": "Category::Marketplace",
-    "messaging": "Category::Messaging",
-    "metrics": "Category::Metrics",
-    "monitoring": "Category::Monitoring",
-    "network": "Category::Network",
-    "notification": "Category::Notification",
-    "oracle": "Category::Oracle",
-    "orchestration": "Category::Orchestration",
-    "os & system": "Category::OS System",
-    "processing": "Category::Processing",
-    "profiling": "Category::Profiling",
-    "provisioning": "Category::Provisioning",
-    "security": "Category::Security",
-    "snmp": "Category::SNMP",
-    "source control": "Category::Source Control",
-    "testing": "Category::Testing",
-    "web": "Category::Web",
-}
+from ...manifest_validator.v2.migration import migrate_manifest, TODO_FILL_IN
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Manifest utilities')
@@ -137,79 +33,7 @@ def migrate(ctx, integration, to_version):
     if integration and integration not in get_valid_integrations():
         abort(f'    Unknown integration `{integration}`, is your repo set properly in `ddev config`?')
 
-    loaded_manifest = JSONDict(load_manifest(integration))
-    manifest_version = loaded_manifest.get_path("/manifest_version")
-
-    if to_version not in SUPPORTED_MANIFEST_VERSIONS:
-        abort(f"    Unknown to_version: `{to_version}`. Valid options are: {SUPPORTED_MANIFEST_VERSIONS}")
-    if to_version == manifest_version:
-        abort(f"    {integration} is already on version `{manifest_version}`")
-    if to_version not in SUPPORTED_VERSION_UPGRADE_PATHS.get(manifest_version, []):
-        abort(
-            f"    Can't migrate from version `{manifest_version}` to version: `{to_version}`. Unsupported upgrade path"
-        )
-
-    migrated_manifest = JSONDict()
-
-    # Explicitly set the manifest_version first so it appears at the top of the manifest
-    migrated_manifest.set_path("/manifest_version", "2.0.0")
-
-    # Generate and introduce a uuid
-    app_uuid = str(uuid.uuid4())
-    migrated_manifest.set_path("/app_uuid", app_uuid)
-
-    for key, val in V2_TO_V1_MAP.items():
-        if val == SKIP_IF_FOUND:
-            continue
-        # If the value is a string and is a JSONPath, then load the value from the JSON Path
-        elif isinstance(val, str) and val.startswith("/"):
-            final_value = loaded_manifest.get_path(val)
-        else:
-            final_value = val
-
-        # We need to remove any of the underlying "assets" that are just an empty dictionary
-        if key in ["/assets/dashboards", "/assets/monitors", "/assets/saved_views"] and not final_value:
-            continue
-
-        if final_value is not None:
-            migrated_manifest.set_path(key, final_value)
-
-    # Update any previously skipped field in which we can use logic to assume the value of
-    # Also iterate through any lists to include new/updated fields at each index of the list
-    migrated_manifest.set_path("/classifier_tags", TODO_FILL_IN)
-
-    # Retrieve and map all categories from other fields
-    classifier_tags = []
-    supported_os = loaded_manifest.get_path("/supported_os")
-    for os in supported_os:
-        os_tag = OS_TO_CLASSIFIER_TAGS.get(os.lower())
-        if os_tag:
-            classifier_tags.append(os_tag)
-
-    categories = loaded_manifest.get_path("/categories")
-    for category in categories:
-        category_tag = CATEGORIES_TO_CLASSIFIER_TAGS.get(category.lower())
-        if category_tag:
-            classifier_tags.append(category_tag)
-
-    # Write the manifest back to disk
-    migrated_manifest.set_path("/classifier_tags", classifier_tags)
-
-    # Marketplace-only fields:
-    if ctx.obj['repo_name'] == "marketplace":
-        migrated_manifest.set_path("/author/vendor_id", TODO_FILL_IN)
-        migrated_manifest.set_path("/author/sales_email", loaded_manifest.get_path("/terms/legal_email"))
-
-        migrated_manifest.set_path("/pricing", loaded_manifest.get_path("/pricing"))
-        migrated_manifest.set_path("/legal_terms", {})
-        migrated_manifest.set_path("/legal_terms/eula", loaded_manifest.get_path("/terms/eula"))
-
-        for idx, _ in enumerate(migrated_manifest.get_path("/pricing") or []):
-            migrated_manifest.set_path(f"/pricing/{idx}/product_id", TODO_FILL_IN)
-            migrated_manifest.set_path(f"/pricing/{idx}/short_description", TODO_FILL_IN)
-            migrated_manifest.set_path(f"/pricing/{idx}/includes_assets", True)
-
-    write_file(get_manifest_file(integration), json.dumps(migrated_manifest, indent=2))
+    migrate_manifest(ctx.obj['repo_name'], integration, to_version)
 
     echo_success(
         f"Successfully migrated {integration} manifest to version {to_version}. Please update any needed fields, "

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/manifest.py
@@ -3,9 +3,9 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import click
 
+from ...manifest_validator.v2.migration import TODO_FILL_IN, migrate_manifest
 from ...utils import get_valid_integrations
 from ..console import CONTEXT_SETTINGS, abort, echo_info, echo_success
-from ...manifest_validator.v2.migration import migrate_manifest, TODO_FILL_IN
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='Manifest utilities')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -86,6 +86,7 @@ To install the {integration_name} check on your host:
         test_dev_dep = 'datadog-checks-dev'
         tox_base_dep = datadog_checks_base_req
         integration_links = integration_type_links.get(integration_type)
+
     config = {
         'author': author,
         'check_class': f"{''.join(part.capitalize() for part in normalized_integration_name.split('_'))}Check",

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/migration.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/migration.py
@@ -6,10 +6,9 @@ import json
 import uuid
 
 from ....fs import write_file
+from ...commands.console import abort
 from ...datastructures import JSONDict
-from ...utils import get_manifest_file, get_valid_integrations, load_manifest
-from ...commands.console import CONTEXT_SETTINGS, abort, echo_info, echo_success
-
+from ...utils import get_manifest_file, load_manifest
 
 # This means the value is either not present in the old manifest, or there's logic needed to compute it
 SKIP_IF_FOUND = "SKIP"
@@ -187,4 +186,3 @@ def migrate_manifest(repo_name, integration, to_version):
             migrated_manifest.set_path(f"/pricing/{idx}/includes_assets", True)
 
     write_file(get_manifest_file(integration), json.dumps(migrated_manifest, indent=2))
-

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/migration.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/migration.py
@@ -1,0 +1,190 @@
+#  (C) Datadog, Inc. 2022-present
+#  All rights reserved
+#  Licensed under a 3-clause BSD style license (see LICENSE)
+
+import json
+import uuid
+
+from ....fs import write_file
+from ...datastructures import JSONDict
+from ...utils import get_manifest_file, get_valid_integrations, load_manifest
+from ...commands.console import CONTEXT_SETTINGS, abort, echo_info, echo_success
+
+
+# This means the value is either not present in the old manifest, or there's logic needed to compute it
+SKIP_IF_FOUND = "SKIP"
+
+# Static text to let users know these values need updating by hand
+TODO_FILL_IN = "TODO Please Fill In"
+
+# Validate what manifest versions we can support and what we can upgrade from->to
+SUPPORTED_MANIFEST_VERSIONS = ["1.0.0", "2.0.0"]
+SUPPORTED_VERSION_UPGRADE_PATHS = {"1.0.0": ["2.0.0"]}
+
+# JSONDict map all v2 fields to their v1 counterparts
+# Skipping any fields that need manual intervention of custom logic
+V2_TO_V1_MAP = JSONDict(
+    {
+        "/manifest_version": SKIP_IF_FOUND,
+        "/app_id": "/integration_id",
+        "/classifier_tags": [],
+        "/display_on_public_website": "/is_public",
+        "/tile": {},
+        "/tile/overview": "README.md#Overview",
+        "/tile/configuration": "README.md#Setup",
+        "/tile/support": "README.md#Support",
+        "/tile/changelog": "CHANGELOG.md",
+        "/tile/description": "/short_description",
+        "/tile/title": "/public_title",
+        "/tile/media": [],
+        "/author": {},
+        "/author/homepage": "/author/homepage",
+        "/author/name": "/author/name",
+        "/author/support_email": "/maintainer",
+        "/oauth": {},
+        "/assets": {},
+        "/assets/integration": {},
+        "/assets/integration/source_type_name": "/display_name",
+        "/assets/integration/configuration": {},
+        "/assets/integration/configuration/spec": "/assets/configuration/spec",
+        "/assets/integration/events": {},
+        "/assets/integration/events/creates_events": "/creates_events",
+        "/assets/integration/metrics": {},
+        "/assets/integration/metrics/prefix": "/metric_prefix",
+        "/assets/integration/metrics/check": "/metric_to_check",
+        "/assets/integration/metrics/metadata_path": "/assets/metrics_metadata",
+        "/assets/integration/service_checks": {},
+        "/assets/integration/service_checks/metadata_path": "/assets/service_checks",
+        "/assets/dashboards": "/assets/dashboards",
+        "/assets/monitors": "/assets/monitors",
+        "/assets/saved_views": "/assets/saved_views",
+        "/assets/logs": "/assets/logs",
+    }
+)
+
+OS_TO_CLASSIFIER_TAGS = {
+    "linux": "Supported OS::Linux",
+    "mac_os": "Supported OS::Mac OS",
+    "windows": "Supported OS::Windows",
+}
+
+CATEGORIES_TO_CLASSIFIER_TAGS = {
+    "alerting": "Category::Alerting",
+    "autodiscovery": "Category::Autodiscovery",
+    "automation": "Category::Automation",
+    "aws": "Category::AWS",
+    "azure": "Category::Azure",
+    "caching": "Category::Caching",
+    "cloud": "Category::Cloud",
+    "collaboration": "Category::Collaboration",
+    "compliance": "Category::Compliance",
+    "configuration & deployment": "Category::Configuration Deployment",
+    "containers": "Category::Containers",
+    "cost management": "Category::Cost Management",
+    "data store": "Category::Data Store",
+    "developer tools": "Category::Developer Tools",
+    "event management": "Category::Event Management",
+    "exceptions": "Category::Exceptions",
+    "google cloud": "Category::Google Cloud",
+    "incidents": "Category::Incidents",
+    "iot": "Category::IOT",
+    "isp": "Category::ISP",
+    "issue tracking": "Category::Issue Tracking",
+    "languages": "Category::Languages",
+    "log collection": "Category::Log Collection",
+    "marketplace": "Category::Marketplace",
+    "messaging": "Category::Messaging",
+    "metrics": "Category::Metrics",
+    "monitoring": "Category::Monitoring",
+    "network": "Category::Network",
+    "notification": "Category::Notification",
+    "oracle": "Category::Oracle",
+    "orchestration": "Category::Orchestration",
+    "os & system": "Category::OS System",
+    "processing": "Category::Processing",
+    "profiling": "Category::Profiling",
+    "provisioning": "Category::Provisioning",
+    "security": "Category::Security",
+    "snmp": "Category::SNMP",
+    "source control": "Category::Source Control",
+    "testing": "Category::Testing",
+    "web": "Category::Web",
+}
+
+
+def migrate_manifest(repo_name, integration, to_version):
+
+    loaded_manifest = JSONDict(load_manifest(integration))
+    manifest_version = loaded_manifest.get_path("/manifest_version")
+
+    if to_version not in SUPPORTED_MANIFEST_VERSIONS:
+        abort(f"    Unknown to_version: `{to_version}`. Valid options are: {SUPPORTED_MANIFEST_VERSIONS}")
+    if to_version == manifest_version:
+        abort(f"    {integration} is already on version `{manifest_version}`")
+    if to_version not in SUPPORTED_VERSION_UPGRADE_PATHS.get(manifest_version, []):
+        abort(
+            f"    Can't migrate from version `{manifest_version}` to version: `{to_version}`. Unsupported upgrade path"
+        )
+
+    migrated_manifest = JSONDict()
+
+    # Explicitly set the manifest_version first so it appears at the top of the manifest
+    migrated_manifest.set_path("/manifest_version", "2.0.0")
+
+    # Generate and introduce a uuid
+    app_uuid = str(uuid.uuid4())
+    migrated_manifest.set_path("/app_uuid", app_uuid)
+
+    for key, val in V2_TO_V1_MAP.items():
+        if val == SKIP_IF_FOUND:
+            continue
+        # If the value is a string and is a JSONPath, then load the value from the JSON Path
+        elif isinstance(val, str) and val.startswith("/"):
+            final_value = loaded_manifest.get_path(val)
+        else:
+            final_value = val
+
+        # We need to remove any of the underlying "assets" that are just an empty dictionary
+        if key in ["/assets/dashboards", "/assets/logs", "/assets/monitors", "/assets/saved_views"] and not final_value:
+            continue
+
+        if final_value is not None:
+            migrated_manifest.set_path(key, final_value)
+
+    # Update any previously skipped field in which we can use logic to assume the value of
+    # Also iterate through any lists to include new/updated fields at each index of the list
+    migrated_manifest.set_path("/classifier_tags", TODO_FILL_IN)
+
+    # Retrieve and map all categories from other fields
+    classifier_tags = []
+    supported_os = loaded_manifest.get_path("/supported_os")
+    for os in supported_os:
+        os_tag = OS_TO_CLASSIFIER_TAGS.get(os.lower())
+        if os_tag:
+            classifier_tags.append(os_tag)
+
+    categories = loaded_manifest.get_path("/categories")
+    for category in categories:
+        category_tag = CATEGORIES_TO_CLASSIFIER_TAGS.get(category.lower())
+        if category_tag:
+            classifier_tags.append(category_tag)
+
+    # Write the manifest back to disk
+    migrated_manifest.set_path("/classifier_tags", classifier_tags)
+
+    # Marketplace-only fields:
+    if repo_name == "marketplace":
+        migrated_manifest.set_path("/author/vendor_id", TODO_FILL_IN)
+        migrated_manifest.set_path("/author/sales_email", loaded_manifest.get_path("/terms/legal_email"))
+
+        migrated_manifest.set_path("/pricing", loaded_manifest.get_path("/pricing"))
+        migrated_manifest.set_path("/legal_terms", {})
+        migrated_manifest.set_path("/legal_terms/eula", loaded_manifest.get_path("/terms/eula"))
+
+        for idx, _ in enumerate(migrated_manifest.get_path("/pricing") or []):
+            migrated_manifest.set_path(f"/pricing/{idx}/product_id", TODO_FILL_IN)
+            migrated_manifest.set_path(f"/pricing/{idx}/short_description", TODO_FILL_IN)
+            migrated_manifest.set_path(f"/pricing/{idx}/includes_assets", True)
+
+    write_file(get_manifest_file(integration), json.dumps(migrated_manifest, indent=2))
+


### PR DESCRIPTION
### What does this PR do?
Adds support for creating new checks with Manifest V2 for Marketplace and other apps via CLI option `--manifest-v2`.

This takes the module previously created to migrate from V1 to V2, and uses that as part of the creation process.  This should help keep the migration code in sync as changes occur over time.

### Motivation
With ManifestV2 now the default (and only) option for Marketplace integrations, this will streamline the process and avoid the need for manual migrations afterwards.

Adding the additional optional argument, should make it easier for tile-only creations to be made on integrations-extras as well.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
