### PR TITLE
Migrate mesos master service check

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/service_checks.py
@@ -34,7 +34,6 @@ CHECK_TO_NAME = {
     'http_check': 'System',
     'kubelet': 'Kubernetes',
     'kubernetes_state': 'Kubernetes',
-    'mesos_master': 'mesos',
     'mesos_slave': 'Mesos',
     'ntp': 'System',
     'openstack_controller': 'OpenStack',

--- a/mesos_master/assets/service_checks.json
+++ b/mesos_master/assets/service_checks.json
@@ -1,7 +1,7 @@
 [
     {
         "agent_version": "5.2.0",
-        "integration": "mesos",
+        "integration": "Mesos Master",
         "check": "mesos_master.can_connect",
         "statuses": [
             "ok",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Attach `mesos_master.can_connect` service check to `Mesos Master` instead of `Mesos` (== `Mesos Slave`)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
