### PR TITLE
Do not drop the first kubelet eviction event

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -206,6 +206,8 @@ class KubeletCheck(
         ]:
             self.transformers.update(d)
 
+        self.first_run = True
+
     def _create_kubelet_prometheus_instance(self, instance):
         """
         Create a copy of the instance and set default values.
@@ -353,6 +355,8 @@ class KubeletCheck(
         if self.kubelet_scraper_config['prometheus_url']:  # Prometheus
             self.log.debug('processing kubelet metrics')
             self.process(self.kubelet_scraper_config, metric_transformers=self.transformers)
+
+        self.first_run = False
 
         # Free up memory
         self.pod_list = None
@@ -619,7 +623,13 @@ class KubeletCheck(
             custom_hostname = self._get_hostname(hostname, sample, scraper_config)
             # Determine the tags to send
             tags = self._metric_tags(metric.name, val, sample, scraper_config, hostname=custom_hostname)
-            self.monotonic_count(metric_name_with_namespace, val, tags=tags, hostname=custom_hostname)
+            self.monotonic_count(
+                metric_name_with_namespace,
+                val,
+                tags=tags,
+                hostname=custom_hostname,
+                flush_first_value=not self.first_run,
+            )
 
     def append_pod_tags_to_volume_metrics(self, metric, scraper_config, hostname=None):
         metric_name_with_namespace = '{}.{}'.format(scraper_config['namespace'], self.VOLUME_METRICS[metric.name])


### PR DESCRIPTION
### What does this PR do?

Do not drop the first kubelet eviction event.

### Motivation

When the kubelet performs its first eviction, it creates a new time series to count the total number of eviction performed since the kubelet start:

```
# HELP kubelet_evictions [ALPHA] Cumulative number of pod evictions by eviction signal
# TYPE kubelet_evictions counter
kubelet_evictions{eviction_signal="nodefs.available"} 1
```

But before this first eviction, the Openmetrics endpoint of the kubelet didn’t show the time serie.
As a consequence, the counter aggregator has no previous value to compare with this new value and it doesn’t emit a counter of `1` to represent this first eviction.

This issue can be fixed thanks to the `flush_first_value` parameter.
But if we were unconditionally setting `flush_first_value` to `True`, we would have an issue when the agent is rolled out.
If the eviction kubelet counter is non-null when an agent restart, the agent mustn’t consider the initial value.
That’s why `flush_first_value` should be set to `True` only if the check has already run before.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
