### PR TITLE
[docs] Fix ECS Fargate Windows working directory format

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -53,7 +53,7 @@ The instructions below show you how to configure the task using the [AWS CLI too
 12. For **Env Variables**, add the **Key** `DD_API_KEY` and enter your [Datadog API Key][6] as the value. _If you feel more comfortable storing secrets in s3, see the [ECS Configuration guide][7]._
 13. Add another environment variable using the **Key** `ECS_FARGATE` and the value `true`. Click **Add** to add the container.
 14. Add another environment variable using the **Key** `DD_SITE` and the value {{< region-param key="dd_site" code="true" >}}. This defaults to `datadoghq.com` if you don't set it.
-15. (Windows Only) Select "C:\" as the working directory.
+15. (Windows Only) Select `C:\` as the working directory.
 16. Add your other containers such as your app. For details on collecting integration metrics, see [Integration Setup for ECS Fargate][8].
 17. Click **Create** to create the task definition.
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Changes the formatting for the instruction to set the ECS Fargate working directory on Windows. It currently shows up in the public docs as `“C:"` when it should be `C:\`. Using `C:` will result in an entrypoint error:
```
[ENTRYPOINT][ERROR] directory_iterator::directory_iterator: The system cannot find the path specified.: "entrypoint-ps1"
```

### Motivation
<!-- What inspired you to submit this pull request? -->
Support ticket

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
