### PR TITLE
datadog_checks_base: Fix obfuscate_sql_with_metadata wrapper not handling json.loads() edge case

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -194,13 +194,10 @@ def obfuscate_sql_with_metadata(query, options=None):
             # Assume we're running against an older agent and return the obfuscated query without metadata.
             return {'query': statement, 'metadata': {}}
 
-    try:
-        obfuscated_statement = datadog_agent.obfuscate_sql(query, options)
-        if options and json.loads(options).get('return_json_metadata', False):
-            return _load_metadata(obfuscated_statement)
-        return {'query': obfuscated_statement, 'metadata': {}}
-    except Exception as e:
-        raise e
+    obfuscated_statement = datadog_agent.obfuscate_sql(query, options)
+    if options and json.loads(options).get('return_json_metadata', False):
+        return _load_metadata(obfuscated_statement)
+    return {'query': obfuscated_statement, 'metadata': {}}
 
 
 class DBMAsyncJob(object):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We found that the json decoder (`json.loads()`) does not throw an error for a string integer (e.g. '1'). This causes unwanted behavior and this PR aims to fix that.

How?
Because we know we only want to load json when a particular option is enabled, we use that to determine the action rather than always decoding.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
