### PR TITLE
Revert "Add DD_TAGS section for cluster name, fix links"

### DIFF
--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -129,8 +129,6 @@ spec:
            fieldRef:
              apiVersion: v1
              fieldPath: spec.nodeName
-       - name: DD_TAGS
-         value: "kube_cluster_name:<CLUSTER_NAME>"
       resources:
           requests:
             memory: "256Mi"
@@ -141,8 +139,6 @@ spec:
 ```
 
 **Note**: Don't forget to replace `<YOUR_DATADOG_API_KEY>` with the [Datadog API key from your organization][14].
-
-**Note**: Add your desired `kube_cluster_name:<CLUSTER_NAME>` to the list of `DD_TAGS` to ensure your metrics are tagged by your desired cluster. You can append additional tags here as space separated `<KEY>:<VALUE>` tags.
 
 ## Metrics collection
 
@@ -201,11 +197,11 @@ spec:
 **Notes**:
 
 - Don't forget to replace `<YOUR_DATADOG_API_KEY>` with the [Datadog API key from your organization][14].
-- Container metrics are not available in Fargate because the `cgroups` volume from the host can't be mounted into the Agent. The [Live Containers][19] view reports 0 for CPU and Memory.
+- Container metrics are not available in Fargate because the `cgroups` volume from the host can't be mounted into the Agent. The [Live Containers][17] view reports 0 for CPU and Memory.
 
 ### DogStatsD
 
-Set up the container port `8125` over your Agent container to forward [DogStatsD metrics][17] from your application container to Datadog.
+Set up the container port `8125` over your Agent container to forward [DogStatsD metrics][18] from your application container to Datadog.
 
 ```yaml
 apiVersion: apps/v1


### PR DESCRIPTION
Reverts DataDog/integrations-core#10909

https://github.com/DataDog/datadog-agent/pull/10449 fixes the bug.