### PR TITLE
Fix tracing_method using self argument

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/tracing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tracing.py
@@ -56,10 +56,10 @@ def traced(fn):
 
 def tracing_method(f, tracer):
     @functools.wraps(f)
-    def wrapper(self, *args, **kwargs):
+    def wrapper(*args, **kwargs):
         service_name = None
-        if hasattr(self, "name"):
-            service_name = "{}-integration".format(self.name)
+        if args and len(args) > 0 and hasattr(args[0], "name"):
+            service_name = "{}-integration".format(args[0].name)
         elif f.__name__ == "__init__":
             # copy the logic that the AgentCheck init method uses to determine the check name
             name = kwargs.get('name', '')
@@ -69,7 +69,7 @@ def tracing_method(f, tracer):
                 service_name = "{}-integration".format(name)
 
         with tracer.trace(f.__name__, resource=f.__name__, service=service_name):
-            return f(self, *args, **kwargs)
+            return f(*args, **kwargs)
 
     return wrapper
 

--- a/datadog_checks_base/datadog_checks/base/utils/tracing.py
+++ b/datadog_checks_base/datadog_checks/base/utils/tracing.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import functools
+import inspect
 import os
 
 from ..config import is_affirmative
@@ -55,21 +56,38 @@ def traced(fn):
 
 
 def tracing_method(f, tracer):
-    @functools.wraps(f)
-    def wrapper(*args, **kwargs):
-        service_name = None
-        if args and len(args) > 0 and hasattr(args[0], "name"):
-            service_name = "{}-integration".format(args[0].name)
-        elif f.__name__ == "__init__":
-            # copy the logic that the AgentCheck init method uses to determine the check name
-            name = kwargs.get('name', '')
-            if len(args) > 0:
-                name = args[0]
-            if name:
-                service_name = "{}-integration".format(name)
+    signature = inspect.signature(f)
+    if signature.parameters.get('self'):
+        @functools.wraps(f)
+        def wrapper(self, *args, **kwargs):
+            service_name = None
+            if hasattr(self, "name"):
+                service_name = "{}-integration".format(self.name)
+            elif f.__name__ == "__init__":
+                # copy the logic that the AgentCheck init method uses to determine the check name
+                name = kwargs.get('name', '')
+                if len(args) > 0:
+                    name = args[0]
+                if name:
+                    service_name = "{}-integration".format(name)
+            
+            with tracer.trace(f.__name__, resource=f.__name__, service=service_name):
+                return f(self, *args, **kwargs)
 
-        with tracer.trace(f.__name__, resource=f.__name__, service=service_name):
-            return f(*args, **kwargs)
+    else:
+        @functools.wraps(f)
+        def wrapper(*args, **kwargs):
+            service_name = None
+            if f.__name__ == "__init__":
+                # copy the logic that the AgentCheck init method uses to determine the check name
+                name = kwargs.get('name', '')
+                if len(args) > 0:
+                    name = args[0]
+                if name:
+                    service_name = "{}-integration".format(name)
+
+            with tracer.trace(f.__name__, resource=f.__name__, service=service_name):
+                return f(*args, **kwargs)
 
     return wrapper
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove the explicit `self` argument of the tracing wrapper method ; and manually check if it's here

### Motivation
<!-- What inspired you to submit this pull request? -->
Kubernetes_state failing since #10947 ; as we explicitly expect a self argument in the wrapped method

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
