### PR TITLE
Add discovery options to ddev check command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
@@ -49,8 +49,8 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
     help='duration between retries until Autodiscovery resolves the check template (in seconds)',
 )
 @click.option(
-    '--discovery-check-count',
-    'discovery_check_count',
+    '--discovery-min-instances',
+    'discovery_min_instances',
     type=click.INT,
     help='number of checks to wait, retry until the specified number of checks is reached',
 )
@@ -69,7 +69,7 @@ def check_run(
     jmx_list,
     discovery_timeout,
     discovery_retry_interval,
-    discovery_check_count,
+    discovery_min_instances,
 ):
     """Run an Agent check."""
     envs = get_configured_envs(check)
@@ -104,7 +104,7 @@ def check_run(
         jmx_list=jmx_list,
         discovery_timeout=discovery_timeout,
         discovery_retry_interval=discovery_retry_interval,
-        discovery_check_count=discovery_check_count,
+        discovery_min_instances=discovery_min_instances,
     )
 
     if config_file:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
@@ -49,8 +49,8 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
     help='duration between retries until Autodiscovery resolves the check template (in seconds)',
 )
 @click.option(
-    '--discovery-retry-check-count',
-    'discovery_retry_check_count',
+    '--discovery-check-count',
+    'discovery_check_count',
     type=click.INT,
     help='number of checks to wait, retry until the specified number of checks is reached',
 )
@@ -69,7 +69,7 @@ def check_run(
     jmx_list,
     discovery_timeout,
     discovery_retry_interval,
-    discovery_retry_check_count,
+    discovery_check_count,
 ):
     """Run an Agent check."""
     envs = get_configured_envs(check)
@@ -104,7 +104,7 @@ def check_run(
         jmx_list=jmx_list,
         discovery_timeout=discovery_timeout,
         discovery_retry_interval=discovery_retry_interval,
-        discovery_retry_check_count=discovery_retry_check_count,
+        discovery_check_count=discovery_check_count,
     )
 
     if config_file:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
@@ -36,7 +36,41 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
 )
 @click.option('--config', 'config_file', help='Path to a JSON check configuration to use')
 @click.option('--jmx-list', 'jmx_list', help='JMX metrics listing method')
-def check_run(check, env, rate, times, pause, delay, log_level, as_json, as_table, break_point, config_file, jmx_list):
+@click.option(
+    '--discovery-timeout',
+    'discovery_timeout',
+    type=click.INT,
+    help='max retry duration until Autodiscovery resolves the check template (in seconds)',
+)
+@click.option(
+    '--discovery-retry-interval',
+    'discovery_retry_interval',
+    type=click.INT,
+    help='duration between retries until Autodiscovery resolves the check template (in seconds)',
+)
+@click.option(
+    '--discovery-retry-check-count',
+    'discovery_retry_check_count',
+    type=click.INT,
+    help='number of checks to wait, retry until the specified number of checks is reached',
+)
+def check_run(
+    check,
+    env,
+    rate,
+    times,
+    pause,
+    delay,
+    log_level,
+    as_json,
+    as_table,
+    break_point,
+    config_file,
+    jmx_list,
+    discovery_timeout,
+    discovery_retry_interval,
+    discovery_retry_check_count,
+):
     """Run an Agent check."""
     envs = get_configured_envs(check)
     if not envs:
@@ -68,6 +102,9 @@ def check_run(check, env, rate, times, pause, delay, log_level, as_json, as_tabl
         as_table=as_table,
         break_point=break_point,
         jmx_list=jmx_list,
+        discovery_timeout=discovery_timeout,
+        discovery_retry_interval=discovery_retry_interval,
+        discovery_retry_check_count=discovery_retry_check_count,
     )
 
     if config_file:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
@@ -40,19 +40,19 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
     '--discovery-timeout',
     'discovery_timeout',
     type=click.INT,
-    help='max retry duration until Autodiscovery resolves the check template (in seconds)',
+    help='Max retry duration until Autodiscovery resolves the check template (in seconds)',
 )
 @click.option(
     '--discovery-retry-interval',
     'discovery_retry_interval',
     type=click.INT,
-    help='duration between retries until Autodiscovery resolves the check template (in seconds)',
+    help='Duration between retries until Autodiscovery resolves the check template (in seconds)',
 )
 @click.option(
     '--discovery-min-instances',
     'discovery_min_instances',
     type=click.INT,
-    help='number of checks to wait, retry until the specified number of checks is reached',
+    help='Number of checks to wait, retry until the specified number of checks is reached',
 )
 def check_run(
     check,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -138,7 +138,7 @@ class DockerInterface(object):
         jmx_list=None,
         discovery_timeout=None,
         discovery_retry_interval=None,
-        discovery_retry_check_count=None,
+        discovery_check_count=None,
     ):
         # JMX check
         if jmx_list:
@@ -175,8 +175,8 @@ class DockerInterface(object):
             if discovery_retry_interval is not None:
                 command.extend(['--discovery-retry-interval', str(discovery_retry_interval)])
 
-            if discovery_retry_check_count is not None:
-                command.extend(['--discovery-retry-check-count', str(discovery_retry_check_count)])
+            if discovery_check_count is not None:
+                command.extend(['--discovery-check-count', str(discovery_check_count)])
 
         if log_level is not None:
             command.extend(['--log-level', log_level])

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -136,6 +136,9 @@ class DockerInterface(object):
         as_table=False,
         break_point=None,
         jmx_list=None,
+        discovery_timeout=None,
+        discovery_retry_interval=None,
+        discovery_retry_check_count=None,
     ):
         # JMX check
         if jmx_list:
@@ -165,6 +168,15 @@ class DockerInterface(object):
 
             if as_table:
                 command.append('--table')
+
+            if discovery_timeout is not None:
+                command.extend(['--discovery-timeout', str(discovery_timeout)])
+
+            if discovery_retry_interval is not None:
+                command.extend(['--discovery-retry-interval', str(discovery_retry_interval)])
+
+            if discovery_retry_check_count is not None:
+                command.extend(['--discovery-retry-check-count', str(discovery_retry_check_count)])
 
         if log_level is not None:
             command.extend(['--log-level', log_level])

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -138,7 +138,7 @@ class DockerInterface(object):
         jmx_list=None,
         discovery_timeout=None,
         discovery_retry_interval=None,
-        discovery_check_count=None,
+        discovery_min_instances=None,
     ):
         # JMX check
         if jmx_list:
@@ -175,8 +175,8 @@ class DockerInterface(object):
             if discovery_retry_interval is not None:
                 command.extend(['--discovery-retry-interval', str(discovery_retry_interval)])
 
-            if discovery_check_count is not None:
-                command.extend(['--discovery-check-count', str(discovery_check_count)])
+            if discovery_min_instances is not None:
+                command.extend(['--discovery-min-instances', str(discovery_min_instances)])
 
         if log_level is not None:
             command.extend(['--log-level', log_level])

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -151,7 +151,7 @@ class LocalAgentInterface(object):
         jmx_list=None,
         discovery_timeout=None,
         discovery_retry_interval=None,
-        discovery_check_count=None,
+        discovery_min_instances=None,
     ):
         # JMX check
         if jmx_list:
@@ -188,8 +188,8 @@ class LocalAgentInterface(object):
             if discovery_retry_interval is not None:
                 command += f'--discovery-retry-interval {discovery_retry_interval}'
 
-            if discovery_check_count is not None:
-                command += f'--discovery-check-count {discovery_check_count}'
+            if discovery_min_instances is not None:
+                command += f'--discovery-min-instances {discovery_min_instances}'
 
         if log_level is not None:
             command += f' --log-level {log_level}'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -149,6 +149,9 @@ class LocalAgentInterface(object):
         as_table=False,
         break_point=None,
         jmx_list=None,
+        discovery_timeout=None,
+        discovery_retry_interval=None,
+        discovery_retry_check_count=None,
     ):
         # JMX check
         if jmx_list:
@@ -178,6 +181,15 @@ class LocalAgentInterface(object):
 
             if break_point is not None:
                 command += f' --breakpoint {break_point}'
+
+            if discovery_timeout is not None:
+                command += f'--discovery-timeout {discovery_timeout}'
+
+            if discovery_retry_interval is not None:
+                command += f'--discovery-retry-interval {discovery_retry_interval}'
+
+            if discovery_retry_check_count is not None:
+                command += f'--discovery-retry-check-count {discovery_retry_check_count}'
 
         if log_level is not None:
             command += f' --log-level {log_level}'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -151,7 +151,7 @@ class LocalAgentInterface(object):
         jmx_list=None,
         discovery_timeout=None,
         discovery_retry_interval=None,
-        discovery_retry_check_count=None,
+        discovery_check_count=None,
     ):
         # JMX check
         if jmx_list:
@@ -188,8 +188,8 @@ class LocalAgentInterface(object):
             if discovery_retry_interval is not None:
                 command += f'--discovery-retry-interval {discovery_retry_interval}'
 
-            if discovery_retry_check_count is not None:
-                command += f'--discovery-retry-check-count {discovery_retry_check_count}'
+            if discovery_check_count is not None:
+                command += f'--discovery-check-count {discovery_check_count}'
 
         if log_level is not None:
             command += f' --log-level {log_level}'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add discovery options to check command

### Motivation
<!-- What inspired you to submit this pull request? -->

Needed for e2e testing listeners (snmp listener) that schedules multiple check instances.

Needed for https://github.com/DataDog/integrations-core/pull/11055

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Agent PR: https://github.com/DataDog/datadog-agent/pull/10448

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
