### PR TITLE
Fix StatementMetric not Emitting Rows on First Presence of New Queries

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 
+from cachetools import LRUCache
+
 logger = logging.getLogger(__name__)
 
 
@@ -18,16 +20,17 @@ class StatementMetrics:
         - DB2: mon_db_summary
 
     These tables are monotonically increasing, so the metrics are computed from the difference
-    in values between check runs.
+    in values between query metrics collection runs.
     """
 
-    def __init__(self):
-        self._previous_statements = None
+    def __init__(self, max_cache_size=10000):
+        self._statement_cache = None
+        self._max_cache_size = max_cache_size
 
     def compute_derivative_rows(self, rows, metrics, key):
         """
         Compute the first derivative of column-based metrics for a given set of rows. This function
-        takes the difference of the previous check run's values and the current check run's values
+        takes the difference of the previous check runs' values and the current check run's values
         to produce a new set of rows whose values represent the total counts in the time elapsed
         between check runs.
 
@@ -36,14 +39,14 @@ class StatementMetrics:
         metric tags. There is also custom logic around stats resets to discard all rows when a
         negative value is found, rather than just the single metric of that row/column.
 
-        This function resets the statement cache so it should only be called once per check run.
+        This function should only be called once per query metrics collection run.
 
         - **rows** (_List[dict]_) - rows from current check run
         - **metrics** (_List[str]_) - the metrics to compute for each row
         - **key** (_callable_) - function for an ID which uniquely identifies a row across runs
         """
         result = []
-        new_cache = {}
+        new_statements = {}
         metrics = set(metrics)
 
         rows = _merge_duplicate_rows(rows, metrics, key)
@@ -56,26 +59,26 @@ class StatementMetrics:
 
         for row in rows:
             row_key = key(row)
-            if row_key in new_cache:
+            if row_key in new_statements:
                 logger.error(
                     'Unexpected collision in cached query metrics. Dropping existing row, row_key=%s new=%s dropped=%s',
                     row_key,
                     row,
-                    new_cache[row_key],
+                    new_statements[row_key],
                 )
 
             # Set the row on the new cache to be checked the next run. This should happen for every row, regardless of
             # whether a metric is submitted for the row during this run or not.
-            new_cache[row_key] = row
+            new_statements[row_key] = row
 
             # Only generate derivative rows when the cache has already been initialized
-            if self._previous_statements is None:
+            if self._statement_cache is None:
                 continue
 
             metric_columns = metrics & set(row.keys())
 
             # A row missing from cache is interpreted as one with zero values for all columns
-            prev = self._previous_statements.get(row_key, {k: 0 for k in metric_columns})
+            prev = self._statement_cache.get(row_key, {k: 0 for k in metric_columns})
 
             # Take the diff of all metric values between the current row and the previous run's row.
             # There are a couple of edge cases to be aware of:
@@ -93,7 +96,7 @@ class StatementMetrics:
             # Check for negative values, but only in the columns used for metrics
             if any(diffed_row[k] < 0 for k in metric_columns):
                 # A "break" might be expected here instead of "continue," but there are cases where a subset of rows
-                # are removed. To avoid situations where all results are discarded every check run, we err on the side
+                # is removed. To avoid situations where all results are discarded every check run, we err on the side
                 # of potentially including truncated rows that exceed previous run counts.
                 continue
 
@@ -103,7 +106,11 @@ class StatementMetrics:
 
             result.append(diffed_row)
 
-        self._previous_statements = new_cache
+        if self._statement_cache is None:
+            self._statement_cache = LRUCache(self._max_cache_size)
+
+        for row_key, row in new_statements.items():
+            self._statement_cache[row_key] = row
 
         return result
 

--- a/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
@@ -23,7 +23,8 @@ class StatementMetrics:
     in values between query metrics collection runs.
     """
 
-    def __init__(self, max_cache_size=10000):
+    def __init__(self, check, max_cache_size=10000):
+        self._check = check
         self._statement_cache = None
         self._max_cache_size = max_cache_size
 
@@ -111,6 +112,12 @@ class StatementMetrics:
 
         for row_key, row in new_statements.items():
             self._statement_cache[row_key] = row
+
+        self._check.gauge(
+            "dd.{}.statements.seen_plans_cache.len".format(self._check.name),
+            len(self._statement_cache),
+            **self._check.debug_stats_kwargs()
+        )
 
         return result
 

--- a/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
@@ -22,8 +22,7 @@ class StatementMetrics:
     """
 
     def __init__(self):
-        self._previous_statements = {}
-        self._cache_initialized = False
+        self._previous_statements = None
 
     def compute_derivative_rows(self, rows, metrics, key):
         """
@@ -69,13 +68,14 @@ class StatementMetrics:
             # whether a metric is submitted for the row during this run or not.
             new_cache[row_key] = row
 
+            # Only generate derivative rows when the cache has already been initialized
+            if self._previous_statements is None:
+                continue
+
             metric_columns = metrics & set(row.keys())
 
             # A row missing from cache is interpreted as one with zero values for all columns
             prev = self._previous_statements.get(row_key, {k: 0 for k in metric_columns})
-            # Only generate derivative rows when the cache has already been initialized
-            if not self._cache_initialized:
-                continue
 
             # Take the diff of all metric values between the current row and the previous run's row.
             # There are a couple of edge cases to be aware of:
@@ -104,7 +104,6 @@ class StatementMetrics:
             result.append(diffed_row)
 
         self._previous_statements = new_cache
-        self._cache_initialized = True
 
         return result
 

--- a/datadog_checks_base/tests/base/utils/db/test_db_statements.py
+++ b/datadog_checks_base/tests/base/utils/db/test_db_statements.py
@@ -57,6 +57,7 @@ class TestStatementMetrics:
         assert [] == sm.compute_derivative_rows(rows1, metrics, key=key)
 
         rows2 = [
+            # New query in the second execution
             {'count': 1, 'time': 1, 'errors': 1, 'query': 'SELECT CURRENT_TIME', 'db': 'puppies', 'user': 'dog'},
             add_to_dict(rows1[0], {'count': 0, 'time': 0, 'errors': 15}),
             add_to_dict(rows1[1], {'count': 1, 'time': 15, 'errors': 0}),
@@ -74,6 +75,16 @@ class TestStatementMetrics:
                 'query': 'update kennel set breed="dalmatian" where id = ?',
                 'db': 'puppies',
                 'user': 'rover',
+            },
+            # The new query is omitted in the output since its absence from the saved rows from the first run
+            # implies all counts need to be accounted for
+            {
+                'count': 1,
+                'time': 1,
+                'errors': 1,
+                'query': 'SELECT CURRENT_TIME',
+                'db': 'puppies',
+                'user': 'dog',
             },
         ]
 

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -78,7 +78,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
         self._db = None
         self._config = config
         self.log = get_check_logger()
-        self._state = StatementMetrics()
+        self._state = StatementMetrics(self)
         self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
         # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature
         self._full_statement_text_cache = TTLCache(

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -114,7 +114,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
         )
         self._metrics_collection_interval = collection_interval
         self._config = config
-        self._state = StatementMetrics()
+        self._state = StatementMetrics(DEFAULT_STATEMENTS_LIMIT)
         self._stat_column_cache = []
         self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
         # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -114,7 +114,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
         )
         self._metrics_collection_interval = collection_interval
         self._config = config
-        self._state = StatementMetrics(DEFAULT_STATEMENTS_LIMIT)
+        self._state = StatementMetrics(self, DEFAULT_STATEMENTS_LIMIT)
         self._stat_column_cache = []
         self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
         # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -114,7 +114,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
         )
         self._metrics_collection_interval = collection_interval
         self._config = config
-        self._state = StatementMetrics(self, DEFAULT_STATEMENTS_LIMIT)
+        self._state = StatementMetrics(self, DEFAULT_STATEMENTS_LIMIT * 5)
         self._stat_column_cache = []
         self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
         # full_statement_text_cache: limit the ingestion rate of full statement text events per query_signature

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -268,6 +268,16 @@ files:
             type: boolean
             example: True
           hidden: true
+        - name: statement_cache_size_multiplier
+          description: |
+            A cache of statement statistics is kept to compute statistics sent as query metrics. The cache
+            size is a multiplier of the dm_exec_query_stats_row_limit configuration. Raising the multiplier reduces
+            the likelyhood of a statement getting purged from the cache which can result in erroneous statistics when
+            the query is executed again but it increases the memory usage.
+          value:
+            type: integer
+            example: 5
+          hidden: true
 
     - name: query_activity
       description: Configure collection of active sessions monitoring

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -57,6 +57,7 @@ class QueryMetrics(BaseModel):
     enabled: Optional[bool]
     enforce_collection_interval_deadline: Optional[bool]
     samples_per_hour_per_query: Optional[int]
+    statement_cache_size_multiplier: Optional[int]
 
 
 class InstanceConfig(BaseModel):

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -218,7 +218,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         self._statement_metrics_query = statements_query.format(
             query_metrics_columns=', '.join(available_columns),
             query_metrics_column_sums=', '.join(['sum({}) as {}'.format(c, c) for c in available_columns]),
-            collection_interval=int(math.ceil(self.collection_interval) * 2),
             limit=self.dm_exec_query_stats_row_limit,
         )
         return self._statement_metrics_query
@@ -228,7 +227,8 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         self.log.debug("collecting sql server statement metrics")
         statement_metrics_query = self._get_statement_metrics_query_cached(cursor)
         now = time.time()
-        query_interval = self.collection_interval
+        # Look back 10 years the first time the check runs to initialize the cache
+        query_interval = 10 * 365 * 24 * 60 * 60
         if self._last_stats_query_time:
             query_interval = now - self._last_stats_query_time
         self._last_stats_query_time = now

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -170,7 +170,9 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         self.enforce_collection_interval_deadline = is_affirmative(
             check.statement_metrics_config.get('enforce_collection_interval_deadline', True)
         )
-        self._state = StatementMetrics(self.dm_exec_query_stats_row_limit)
+        statement_metrics_cache_size = self.dm_exec_query_stats_row_limit * check.statement_metrics_config.get(
+            'statement_cache_size_multiplier', 5)
+        self._state = StatementMetrics(statement_metrics_cache_size)
         self._init_caches()
         self._conn_key_prefix = "dbm-"
         self._statement_metrics_query = None

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -170,7 +170,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         self.enforce_collection_interval_deadline = is_affirmative(
             check.statement_metrics_config.get('enforce_collection_interval_deadline', True)
         )
-        self._state = StatementMetrics()
+        self._state = StatementMetrics(self.dm_exec_query_stats_row_limit)
         self._init_caches()
         self._conn_key_prefix = "dbm-"
         self._statement_metrics_query = None

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -172,7 +172,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         )
         statement_metrics_cache_size = self.dm_exec_query_stats_row_limit * check.statement_metrics_config.get(
             'statement_cache_size_multiplier', 5)
-        self._state = StatementMetrics(statement_metrics_cache_size)
+        self._state = StatementMetrics(self, statement_metrics_cache_size)
         self._init_caches()
         self._conn_key_prefix = "dbm-"
         self._statement_metrics_query = None

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -189,14 +189,10 @@ def test_statement_metrics_and_plans(
         dbm_instance['query_metrics']['disable_secondary_tags'] = True
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
-    # the check must be run three times:
+    # the check must be run two times:
     # 1) set _last_stats_query_time (this needs to happen before the 1st test queries to ensure the query time
     # interval is correct)
-    # 2) load the test queries into the StatementMetrics state
-    # 3) emit the query metrics based on the diff of current and last state
-    dd_run_check(check)
-    for params in param_groups:
-        bob_conn.execute_with_retries(query, params, database=database)
+    # 2) emit the query metrics based on the diff of current and initial state
     dd_run_check(check)
     aggregator.reset()
     for params in param_groups:


### PR DESCRIPTION
### What does this PR do?
This fixes the situation where a new query is found after the first run of database integrations. Before this change, that first time a new query was executed would not have any rows emitted (but would be added to the local "cache" of rows). This can cause some confusion when someone runs ad-hoc queries and expects to see query metrics for them. 

This changes fixes that by interpreting the absence of a query in the local cached rows as a row filled with 0 values for all metrics.

### Complications and edge-cases
For postgres and mysql, the impact should be minimal since we mostly query all of the statistics on every run. For `sqlserver`, there are additional considerations because of how the `dm_exec_query_stats` has a filter on the executions seen since the last run. Because of that filter, we can have statements coming in and out of the `previous_rows` cache which would lead to greatly inflated counts. 

*Solution*:
Instead of keeping a cache of `previous_rows` for the previous run, keep a `LRUCache` which is bigger than our row limit of 10k. Every run, we update the cache with the newly fetched rows so, even if a query goes out and back in, we still have the most recent stats for it and can correctly compute a delta. There are still edge-cases when the cache is full and entries are evicted but this should be greatly reduced in practice? 

### Motivation
Provide a less confusing user-experience in some scenarios.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
