### PR TITLE
sqlserver: Indicate DBMS type in obfuscator

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -117,6 +117,9 @@ class SQLServer(AgentCheck):
         self.obfuscator_options = to_native_string(
             json.dumps(
                 {
+                    # Valid values for this can be found at
+                    # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#connection-level-attributes
+                    'dbms': 'mssql',
                     'replace_digits': obfuscator_options_config.get('replace_digits', False),
                     'return_json_metadata': obfuscator_options_config.get('collect_metadata', False),
                     'table_names': obfuscator_options_config.get('collect_tables', True),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Include the SQL Server DBMS type for the obfuscator.

Relevant PR: https://github.com/DataDog/datadog-agent/pull/10440

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Why is the type for SQL Server not "sqlserver"?
- Some of our tracer clients report the type based off the [open-telemetry ](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#connection-level-attributes) specifications, so to have the obfuscator be compatible with most of our stuff, we should follow it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
