### PR TITLE
Add discovery_min_instances to SNMP Listener test

### DIFF
--- a/snmp/tests/test_e2e_snmp_listener.py
+++ b/snmp/tests/test_e2e_snmp_listener.py
@@ -40,7 +40,9 @@ def test_e2e_snmp_listener(dd_agent_check, container_ip, autodiscovery_ready):
     """
     snmp_device = _build_device_ip(container_ip)
     subnet_prefix = ".".join(container_ip.split('.')[:3])
-    aggregator = dd_agent_check({'init_config': {}, 'instances': []}, rate=True)
+    aggregator = dd_agent_check(
+        {'init_config': {}, 'instances': []}, rate=True, discovery_min_instances=5, discovery_timeout=10
+    )
 
     # === network profile ===
     common_tags = [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add discovery_min_instances to SNMP Listener test

### Motivation
<!-- What inspired you to submit this pull request? -->

More reliable test.

Fix e2e failures like this:
https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=86177&view=logs&jobId=475ea3e3-a9fc-55a6-2e22-b5a67273560a&j=475ea3e3-a9fc-55a6-2e22-b5a67273560a&t=1a1f47dd-bcf6-5ffb-3d85-8c5dbec3db65

### Additional Notes
<!-- Anything else we should know when reviewing? -->

More info about discovery_min_instances: https://github.com/DataDog/datadog-agent/pull/10448

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
