### PR TITLE
Fix tests by excluding `agent_version` tag

### DIFF
--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -27,7 +27,7 @@ steps:
       displayName: 'Run Unit/Integration tests (forced install of minimum datadog_checks_base package)'
 
 - ${{ if and(eq(parameters.test_e2e, 'true'), eq(parameters.repo, 'core'))}}:
-  - script: ddev env test --base --new-env --junit ${{ parameters.check }} --agent datadog/agent-dev:alex-snmp-add-agent-version-v2-py2py3-jmx
+  - script: ddev env test --base --new-env --junit ${{ parameters.check }}
     displayName: 'Run E2E tests against latest base package'
     env:
       DD_API_KEY: $(DD_API_KEY)

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -27,7 +27,7 @@ steps:
       displayName: 'Run Unit/Integration tests (forced install of minimum datadog_checks_base package)'
 
 - ${{ if and(eq(parameters.test_e2e, 'true'), eq(parameters.repo, 'core'))}}:
-  - script: ddev env test --base --new-env --junit ${{ parameters.check }}
+  - script: ddev env test --base --new-env --junit ${{ parameters.check }} --agent datadog/agent-dev:alex-snmp-add-agent-version-v2-py2py3-jmx
     displayName: 'Run E2E tests against latest base package'
     env:
       DD_API_KEY: $(DD_API_KEY)

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -305,13 +305,13 @@ def assert_common_device_metrics(
     )
 
 
-def filter_tags(tags, exclude_tag_keys):
+def remove_tags(tags, tags_keys_to_remove):
     """
-    Filter tags by excluding tags with specific keys.
+    Remove tags by excluding tags with specific keys.
     """
     new_tags = []
     for tag in tags:
-        for tag_key in exclude_tag_keys:
+        for tag_key in tags_keys_to_remove:
             if tag.startswith(tag_key + ':'):
                 break
         else:
@@ -330,7 +330,7 @@ def dd_agent_check_wrapper(dd_agent_check, *args, **kwargs):
         new_metrics = []
         for metric in metric_list:
             # metric is a Namedtuple, to modify namedtuple fields we need to use `._replace()`
-            new_metric = metric._replace(tags=filter_tags(metric.tags, EXCLUDED_E2E_TAG_KEYS))
+            new_metric = metric._replace(tags=remove_tags(metric.tags, EXCLUDED_E2E_TAG_KEYS))
             new_metrics.append(new_metric)
         new_agg_metrics[metric_name] = new_metrics
 

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -322,7 +322,7 @@ def filter_tags(tags, exclude_tag_keys):
 def dd_agent_check_wrapper(dd_agent_check, *args, **kwargs):
     """
     dd_agent_check_wrapper is a wrapper around dd_agent_check that will return an aggregator.
-    The wrapper will modify tags by excluding EXCLUDED_E2E_TAGS.
+    The wrapper will modify tags by excluding EXCLUDED_E2E_TAG_KEYS.
     """
     aggregator = dd_agent_check(*args, **kwargs)
     new_agg_metrics = defaultdict(list)

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -299,3 +299,14 @@ def assert_common_device_metrics(
     aggregator.assert_metric(
         'snmp.devices_monitored', metric_type=aggregator.GAUGE, tags=tags, count=count, value=devices_monitored_value
     )
+
+
+def filter_tags(tags, exclude_tag_keys):
+    new_tags = []
+    for tag in tags:
+        for tag_key in exclude_tag_keys:
+            if tag.startswith(tag_key + ':'):
+                break
+        else:
+            new_tags.append(tag)
+    return new_tags

--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -305,13 +305,13 @@ def assert_common_device_metrics(
     )
 
 
-def remove_tags(tags, tags_keys_to_remove):
+def remove_tags(tags, tag_keys_to_remove):
     """
     Remove tags by excluding tags with specific keys.
     """
     new_tags = []
     for tag in tags:
-        for tag_key in tags_keys_to_remove:
+        for tag_key in tag_keys_to_remove:
             if tag.startswith(tag_key + ':'):
                 break
         else:

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -1,8 +1,11 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+from collections import defaultdict
 
 import pytest
+from six import iteritems
+
 from tests.common import SNMP_CONTAINER_NAME
 
 from datadog_checks.dev.docker import get_container_ip
@@ -10,6 +13,21 @@ from datadog_checks.dev.docker import get_container_ip
 from . import common, metrics
 
 pytestmark = [pytest.mark.e2e, common.py3_plus_only, common.snmp_integration_only]
+
+
+def dd_agent_check_wrapper(dd_agent_check, *args, **kwargs):
+    aggregator = dd_agent_check(*args, **kwargs)
+    new_agg_metrics = defaultdict(list)
+    for metric_name, metric_list in iteritems(aggregator._metrics):
+        new_metrics = []
+        for metric in metric_list:
+            # metric is a Namedtuple, to modify namedtuple fields we need to use `._replace()`
+            new_metric = metric._replace(tags=common.filter_tags(metric.tags, ['agent_version']))
+            new_metrics.append(new_metric)
+        new_agg_metrics[metric_name] = new_metrics
+
+    aggregator._metrics = new_agg_metrics
+    return aggregator
 
 
 def test_e2e_v1_with_apc_ups_profile(dd_agent_check):
@@ -70,7 +88,7 @@ def test_e2e_v1_with_apc_ups_profile_batch_size_1(dd_agent_check):
 def assert_apc_ups_metrics(dd_agent_check, config):
     config['init_config']['loader'] = 'core'
     instance = config['instances'][0]
-    aggregator = dd_agent_check(config, rate=True)
+    aggregator = dd_agent_check_wrapper(dd_agent_check, config, rate=True)
 
     profile_tags = [
         'snmp_profile:apc_ups',

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -5,7 +5,6 @@ from collections import defaultdict
 
 import pytest
 from six import iteritems
-
 from tests.common import SNMP_CONTAINER_NAME
 
 from datadog_checks.dev.docker import get_container_ip

--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -17,7 +17,7 @@ def get_events(aggregator):
         # we are replacing it with `0` if present
         if 'collect_timestamp' in event:
             event['collect_timestamp'] = 0
-        for device in event['devices']:
+        for device in event.get('devices', []):
             device['tags'] = common.filter_tags(device['tags'], ['agent_version'])
     return events
 
@@ -166,7 +166,7 @@ def test_e2e_core_metadata_cisco_3850(dd_agent_check):
 
     device_ip = instance['ip_address']
 
-    events = aggregator.get_event_platform_events("network-devices-metadata", parse_json=True)
+    events = get_events(aggregator)
 
     # since there are >100 resources (device+interfaces), the interfaces are split into 2 events
     assert len(events) == 2

--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -18,7 +18,7 @@ def get_events(aggregator):
         if 'collect_timestamp' in event:
             event['collect_timestamp'] = 0
         for device in event.get('devices', []):
-            device['tags'] = common.filter_tags(device['tags'], common.EXCLUDED_E2E_TAG_KEYS)
+            device['tags'] = common.remove_tags(device['tags'], common.EXCLUDED_E2E_TAG_KEYS)
     return events
 
 

--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -18,7 +18,7 @@ def get_events(aggregator):
         if 'collect_timestamp' in event:
             event['collect_timestamp'] = 0
         for device in event.get('devices', []):
-            device['tags'] = common.filter_tags(device['tags'], ['agent_version'])
+            device['tags'] = common.filter_tags(device['tags'], common.EXCLUDED_E2E_TAG_KEYS)
     return events
 
 

--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -891,6 +891,7 @@ def test_e2e_core_metadata_isilon(dd_agent_check):
         'status': 1,
         'sys_object_id': '1.3.6.1.4.1.12325.1.1.2.1.1',
         'tags': [
+            'abc',
             'cluster_name:testcluster1',
             'device_namespace:default',
             'device_vendor:dell',

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -424,7 +424,7 @@ def assert_python_vs_core(
 
     # building core metrics (core)
     aggregator.reset()
-    aggregator = dd_agent_check(core_config, rate=rate, pause=pause, times=times)
+    aggregator = common.dd_agent_check_wrapper(dd_agent_check, core_config, rate=rate, pause=pause, times=times)
     aggregator_metrics = aggregator._metrics
     aggregator._metrics = defaultdict(list)
     for metric_name in aggregator_metrics:

--- a/snmp/tests/test_e2e_snmp_listener.py
+++ b/snmp/tests/test_e2e_snmp_listener.py
@@ -40,8 +40,13 @@ def test_e2e_snmp_listener(dd_agent_check, container_ip, autodiscovery_ready):
     """
     snmp_device = _build_device_ip(container_ip)
     subnet_prefix = ".".join(container_ip.split('.')[:3])
-    aggregator = dd_agent_check(
-        {'init_config': {}, 'instances': []}, rate=True, discovery_min_instances=5, discovery_timeout=10
+
+    aggregator = common.dd_agent_check_wrapper(
+        dd_agent_check,
+        {'init_config': {}, 'instances': []},
+        rate=True,
+        discovery_min_instances=5,
+        discovery_timeout=10,
     )
 
     # === network profile ===


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix tests by excluding `agent_version` tag

### Motivation
<!-- What inspired you to submit this pull request? -->

`agent_version` might have different value in e2e depending on the agent version

An alternative is to fetch the Agent Version from the docker agent and assert agent_version, but there is not that much value to test the agent version (we already have some unit tests in agent-core testing the agent_version tags).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
