### PR TITLE
Fix urllib3 import statement

### DIFF
--- a/http_check/datadog_checks/http_check/adapters.py
+++ b/http_check/datadog_checks/http_check/adapters.py
@@ -7,8 +7,14 @@ import warnings
 import urllib3
 from requests.adapters import HTTPAdapter
 from urllib3.exceptions import SecurityWarning
-from urllib3.packages.ssl_match_hostname import match_hostname
 from urllib3.util import ssl_
+
+# `ssl_match_hostname` package has moved locations from `urllib3.packages.ssl_match_hostname`
+# to `urllib3.util.ssl_match_hostname` in urllib3 >= 1.26.8
+try:
+    from urllib3.packages.ssl_match_hostname import match_hostname
+except ImportError:
+    from urllib3.util.ssl_match_hostname import match_hostname
 
 
 class WeakCiphersHTTPSConnection(urllib3.connection.VerifiedHTTPSConnection):

--- a/http_check/datadog_checks/http_check/adapters.py
+++ b/http_check/datadog_checks/http_check/adapters.py
@@ -12,9 +12,9 @@ from urllib3.util import ssl_
 # `ssl_match_hostname` package has moved locations from `urllib3.packages.ssl_match_hostname`
 # to `urllib3.util.ssl_match_hostname` in urllib3 >= 1.26.8
 try:
-    from urllib3.packages.ssl_match_hostname import match_hostname
-except ImportError:
     from urllib3.util.ssl_match_hostname import match_hostname
+except ImportError:
+    from urllib3.packages.ssl_match_hostname import match_hostname
 
 
 class WeakCiphersHTTPSConnection(urllib3.connection.VerifiedHTTPSConnection):


### PR DESCRIPTION
### What does this PR do?
This change adds a try/except block to the urllib3 import statement for the `match_hostname` method to account for the package location change in [urllib3 v1.26.8](https://github.com/urllib3/urllib3/blob/1.26.8/CHANGES.rst#1268-2022-01-07). 

> Changed location of the vendored ssl.match_hostname function from urllib3.packages.ssl_match_hostname to urllib3.util.ssl_match_hostname to ensure Python 3.10+ compatibility after being repackaged by downstream distributors.

It first tries to import from the new location and falls back on the old location if urllib3 < v1.26.8 is being used.

### Motivation
Fix broken CI.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
