### PR TITLE
Add urllib3 as a dependency

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -2,8 +2,8 @@ adodbapi==2.6.2.0; sys_platform == "win32"
 aerospike==4.0.0; sys_platform != "win32" and sys_platform != "darwin" and python_version < "3.0"
 aerospike==6.0.0; sys_platform != "win32" and sys_platform != "darwin" and python_version > "3.0"
 aws-requests-auth==0.4.3
-beautifulsoup4==4.9.3; python_version < "3.0"
 beautifulsoup4==4.10.0; python_version > "3.0"
+beautifulsoup4==4.9.3; python_version < "3.0"
 binary==1.0.0
 boto3==1.17.112; python_version < "3.0"
 boto3==1.19.12; python_version > "3.0"
@@ -73,8 +73,8 @@ pyvmomi==v7.0.2
 pywin32==228; sys_platform == "win32" and python_version < "3.0"
 pywin32==300; sys_platform == "win32" and python_version > "3.0"
 pyyaml==5.4.1
-redis==3.5.3; python_version < '3.0'
-redis==4.0.1; python_version > '3.0'
+redis==3.5.3; python_version < "3.0"
+redis==4.0.1; python_version > "3.0"
 requests-kerberos==0.12.0
 requests-unixsocket==0.2.0
 requests==2.25.0
@@ -95,6 +95,7 @@ tuf==0.17.0; python_version < "3.0"
 tuf==0.19.0; python_version > "3.0"
 typing==3.7.4.1; python_version < "3.0"
 uptime==3.0.1
+urllib3==1.26.8
 vertica-python==0.10.1
 win-inet-pton==1.1.0; sys_platform == "win32" and python_version < "3.0"
 wrapt==1.12.1

--- a/http_check/datadog_checks/http_check/adapters.py
+++ b/http_check/datadog_checks/http_check/adapters.py
@@ -8,13 +8,7 @@ import urllib3
 from requests.adapters import HTTPAdapter
 from urllib3.exceptions import SecurityWarning
 from urllib3.util import ssl_
-
-# `ssl_match_hostname` package has moved locations from `urllib3.packages.ssl_match_hostname`
-# to `urllib3.util.ssl_match_hostname` in urllib3 >= 1.26.8
-try:
-    from urllib3.util.ssl_match_hostname import match_hostname
-except ImportError:
-    from urllib3.packages.ssl_match_hostname import match_hostname
+from urllib3.util.ssl_match_hostname import match_hostname
 
 
 class WeakCiphersHTTPSConnection(urllib3.connection.VerifiedHTTPSConnection):

--- a/http_check/datadog_checks/http_check/adapters.py
+++ b/http_check/datadog_checks/http_check/adapters.py
@@ -7,8 +7,14 @@ import warnings
 import urllib3
 from requests.adapters import HTTPAdapter
 from urllib3.exceptions import SecurityWarning
-from urllib3.packages.ssl_match_hostname import match_hostname
 from urllib3.util import ssl_
+
+# `ssl_match_hostname` package has moved locations from `urllib3.packages.ssl_match_hostname`
+# to `urllib3.util.ssl_match_hostname` in urllib3 >= 1.26.8
+try:
+    from urllib3.packages.ssl_match_hostname import match_hostname
+except ImportError:
+    from urllib3.util.ssl_match_hostname import match_hostname
 
 
 class WeakCiphersHTTPSConnection(urllib3.connection.VerifiedHTTPSConnection):

--- a/http_check/datadog_checks/http_check/adapters.py
+++ b/http_check/datadog_checks/http_check/adapters.py
@@ -12,9 +12,9 @@ from urllib3.util import ssl_
 # `ssl_match_hostname` package has moved locations from `urllib3.packages.ssl_match_hostname`
 # to `urllib3.util.ssl_match_hostname` in urllib3 >= 1.26.8
 try:
-    from urllib3.packages.ssl_match_hostname import match_hostname
-except ImportError:
     from urllib3.util.ssl_match_hostname import match_hostname
+except ImportError:
+    from urllib3.packages.ssl_match_hostname import match_hostname
 
 
 class WeakCiphersHTTPSConnection(urllib3.connection.VerifiedHTTPSConnection):

--- a/http_check/requirements.in
+++ b/http_check/requirements.in
@@ -1,3 +1,4 @@
 cryptography==3.3.2; python_version < '3.0'
 cryptography==3.4.8; python_version > "3.0"
 requests_ntlm==1.1.0
+urllib3==1.26.8


### PR DESCRIPTION
### What does this PR do?
Adds urllib3 as a dependency and pins it to v1.26.8.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
