### PR TITLE
Backport (#11069) to rc14

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -90,6 +90,7 @@ tuf,PyPI,Apache-2.0,https://www.updateframework.com
 tuf,PyPI,MIT,https://www.updateframework.com
 typing,PyPI,PSF,"Guido van Rossum, Jukka Lehtosalo, Łukasz Langa, Ivan Levkivskyi"
 uptime,PyPI,BSD-2-Clause,Koen Crolla
+urllib3,PyPI,MIT,Andrey Petrov
 vertica-python,PyPI,Apache-2.0,"Justin Berka, Alex Kim, Siting Ren"
 win-inet-pton,PyPI,Unlicense,Ryan Vennell
 wrapt,PyPI,BSD-3-Clause,Graham Dumpleton

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -95,6 +95,7 @@ tuf==0.17.0; python_version < "3.0"
 tuf==0.19.0; python_version > "3.0"
 typing==3.7.4.1; python_version < "3.0"
 uptime==3.0.1
+urllib3==1.26.8
 vertica-python==0.10.1
 win-inet-pton==1.1.0; sys_platform == "win32" and python_version < "3.0"
 wrapt==1.12.1

--- a/http_check/datadog_checks/http_check/adapters.py
+++ b/http_check/datadog_checks/http_check/adapters.py
@@ -7,8 +7,8 @@ import warnings
 import urllib3
 from requests.adapters import HTTPAdapter
 from urllib3.exceptions import SecurityWarning
-from urllib3.packages.ssl_match_hostname import match_hostname
 from urllib3.util import ssl_
+from urllib3.util.ssl_match_hostname import match_hostname
 
 
 class WeakCiphersHTTPSConnection(urllib3.connection.VerifiedHTTPSConnection):

--- a/http_check/requirements.in
+++ b/http_check/requirements.in
@@ -1,3 +1,4 @@
 cryptography==3.3.2; python_version < '3.0'
 cryptography==3.4.8; python_version > "3.0"
 requests_ntlm==1.1.0
+urllib3==1.26.8


### PR DESCRIPTION
### What does this PR do?
Backports PR #11069 to 7.33.x for rc14.

**Add urllib3 as dependency (#11069)**

* add urllib3 as dependency, remove try/catch

* sync deps

* sync licenses

(cherry picked from commit 3ef05627440c4a4977d9402f22eef7fb3090752d)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
