### PR TITLE
Export release_branch as an env variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,7 +75,7 @@ trigger-agent-build:
     - git --no-pager diff --exit-code --name-only HEAD $BASE_REF -- datadog_checks_base/datadog_checks/base/data/agent_requirements.in || export AGENT_REQUIREMENTS_CHANGED="true" || true
     - |
       if [[ "$AGENT_REQUIREMENTS_CHANGED" = "true" ]]; then
-          RELEASE_BRANCH=$(git tag -l '7\.*' --points-at $BASE_REF | cat | sed 's/\..-.*/\.x/')
+          export RELEASE_BRANCH=$(git tag -l '7\.*' --points-at $BASE_REF | cat | sed 's/\..-.*/\.x/')
           echo "File agent_requirements.in has been modified, triggering an agent build pipeline."
           DATADOG_AGENT_PIPELINE_URL=$DATADOG_AGENT_PIPELINE_URL RELEASE_BRANCH=$RELEASE_BRANCH python -u /trigger_agent_build.py --output-file pipeline_id.txt
 


### PR DESCRIPTION
### What does this PR do?
Exports `RELEASE_BRANCH` as an environment variable so that it is accessible in the `trigger_agent_build.py` gitlab CI script. 

This should fix this error:
```
  File "/trigger_agent_build.py", line 7, in <module>
    RELEASE_BRANCH = os.environ['RELEASE_BRANCH']
  File "/usr/lib/python3.9/os.py", line 679, in __getitem__
    raise KeyError(key) from None
KeyError: 'RELEASE_BRANCH'
```

### Motivation
Fix broken manual integration release from the release branch.

### Additional Notes
I'm not sure if any additional variables should be exported as env variables. I'm assuming the other the env variables referenced in the scripts are already available as secrets in the gitlab CI. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
