### PR TITLE
Make the `container` integration public

### DIFF
--- a/container/manifest.json
+++ b/container/manifest.json
@@ -16,7 +16,7 @@
     "containers"
   ],
   "type": "check",
-  "is_public": false,
+  "is_public": true,
   "display_name": "Container",
   "creates_events": true,
   "integration_id": "container",


### PR DESCRIPTION
### What does this PR do?
Makes the `container` integration public.

Hold until 7.33 is released.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
