### PR TITLE
Update metadata for platform-specific metrics

### DIFF
--- a/network/metadata.csv
+++ b/network/metadata.csv
@@ -44,10 +44,10 @@ system.net.conntrack.tcp_timeout,gauge,,second,,,0,system,timeout
 system.net.conntrack.tcp_timeout_stream,gauge,,second,,,0,system,timeout stream
 system.net.conntrack.timestamp,gauge,,unit,,Boolean to enable connection tracking flow timestamping.,0,system,timestamp
 system.net.packets_in.count,gauge,,packet,second,The number of packets of data received by the interface.,0,system,packets in
-system.net.packets_in.drop,gauge,,packet,second,The number of packet receive drops detected by the device driver.,-1,system,pkts in drop
+system.net.packets_in.drop,gauge,,packet,second,The number of packet receive drops detected by the device driver. This metric is only available on Linux or Windows.,-1,system,pkts in drop
 system.net.packets_in.error,gauge,,error,second,The number of packet receive errors detected by the device driver.,-1,system,pkts in err
 system.net.packets_out.count,gauge,,packet,second,The number of packets of data transmitted by the interface.,0,system,packets out
-system.net.packets_out.drop,gauge,,packet,second,The number of packet transmit drops detected by the device driver.,-1,system,pkts out drop
+system.net.packets_out.drop,gauge,,packet,second,The number of packet transmit drops detected by the device driver. This metric is only available on Linux or Windows.,-1,system,pkts out drop
 system.net.packets_out.error,gauge,,error,second,The number of packet transmit errors detected by the device driver.,-1,system,pkts out err
 system.net.tcp.failed_retransmits,gauge,,packet,,Number of TCP packets that failed to be retransmitted (Linux only),0,system,failed retransmit
 system.net.tcp.failed_retransmits.count,count,,packet,,Number of TCP packets that failed to be retransmitted (Linux only),0,system,failed retransmit monotonic count


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Small PR updating metadata.csv to note that saturation metrics are only available on Linux or Windows.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/integrations-core/pull/10551
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
