### PR TITLE
Add Broker-Zookeeper latency metric

### DIFF
--- a/confluent_platform/datadog_checks/confluent_platform/data/metrics.yaml
+++ b/confluent_platform/datadog_checks/confluent_platform/data/metrics.yaml
@@ -136,6 +136,17 @@ jmx_metrics:
           alias: confluent.$domain.session.$name.rate
           metric_type: rate
 
+  # Kafka Broker ZooKeeper Metrics (Yammer Metric Meter)
+  - include:
+      domain: kafka.server
+      bean:
+        # Zookeeper latency from client
+        - kafka.server:type=ZooKeeperClientMetrics,name=ZooKeeperRequestLatencyMs
+      attribute:
+        Count:
+          alias: confluent.$domain.session.$name
+          metric_type: gauge
+
   # Kafka Broker Request Metrics (Yammer Metric Meter)
   - include:
       domain: kafka.network

--- a/confluent_platform/metadata.csv
+++ b/confluent_platform/metadata.csv
@@ -30,6 +30,7 @@ confluent.kafka.server.session.zoo_keeper_sync_connects_per_sec.rate,gauge,,unit
 confluent.kafka.server.session.zoo_keeper_auth_failures_per_sec.rate,gauge,,,second,An attempt to connect to the ensemble failed because the client has not provided correct credentials.,0,confluent_platform,session zk auth failures
 confluent.kafka.server.session.zoo_keeper_read_only_connects_per_sec.rate,gauge,,unit,second,"The server the client is connected to is currently LOOKING, which means that it is neither FOLLOWING nor LEADING.",0,confluent_platform,session zk read only connects
 confluent.kafka.server.session.zoo_keeper_sasl_authentications_per_sec.rate,gauge,,unit,second,Client has successfully authenticated.,0,confluent_platform,session zk sasl authentications
+confluent.kafka.server.session.zoo_keeper_request_latency_ms,gauge,,unit,millisecond,Client request latency,0,confluent_platform,latency from client requests
 confluent.kafka.network.request.requests_per_sec.rate,gauge,,request,second,Request rate.,0,confluent_platform,net req reqs
 confluent.kafka.controller.unclean_leader_elections_per_sec.rate,gauge,,unit,second,Unclean leader election rate.,0,confluent_platform,controller unclean leader elections rate
 confluent.kafka.controller.unclean_leader_elections_per_sec.avg,gauge,,unit,second,Unclean leader election rate avg.,0,confluent_platform,controller unclean leader elections avg

--- a/confluent_platform/tests/metrics.py
+++ b/confluent_platform/tests/metrics.py
@@ -78,6 +78,7 @@ BROKER_METRICS = [
     'confluent.kafka.server.session.zoo_keeper_read_only_connects_per_sec.rate',
     'confluent.kafka.server.session.zoo_keeper_sasl_authentications_per_sec.rate',
     'confluent.kafka.server.session.zoo_keeper_sync_connects_per_sec.rate',
+    'confluent.kafka.server.session.zoo_keeper_request_latency_ms',
     'confluent.kafka.server.topic.bytes_in_per_sec.rate',
     'confluent.kafka.server.topic.bytes_out_per_sec.rate',
     'confluent.kafka.server.topic.bytes_rejected_per_sec.rate',


### PR DESCRIPTION
### What does this PR do?
Adds an extra metric to the Confluent Platform Integration

### Motivation
This metric will help measure latencies between brokers and zookeepers

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
