### PR TITLE
Add minimal e2e test for iis

### DIFF
--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2019-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -5,10 +5,7 @@ from copy import deepcopy
 
 import pytest
 
-INSTANCE = {'server': 'localhost', 
-            'username': 'admin', 
-            'password': 'admin',
-            'sites': 'include: - test'}
+INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'sites': 'include: - test'}
 
 
 @pytest.fixture(scope="session")

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -5,7 +5,10 @@ from copy import deepcopy
 
 import pytest
 
-INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin'}
+INSTANCE = {'server': 'localhost', 
+            'username': 'admin', 
+            'password': 'admin',
+            'sites': 'include: - test'}
 
 
 @pytest.fixture(scope="session")

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -14,9 +14,11 @@ from .common import INSTANCE
 def dd_environment():
     yield INSTANCE, {'docker_platform': 'windows'}
 
+
 @pytest.fixture
 def check():
     return lambda instance: IIS('iis', {}, [instance])
+
 
 @pytest.fixture
 def instance():

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -10,6 +10,7 @@ INSTANCE = {
 }
 @pytest.fixture(scope="session")
 def dd_environment():
+      yield deepcopy(INSTANCE)
 @pytest.fixture
 def instance():
       return deepcopy(INSTANCE)

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -2,16 +2,17 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy
+
 import pytest
-INSTANCE = {
-  'server': 'localhost'
-  'username': 'admin'
-  'password': 'admin'
-}
+
+INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin'}
+
+
 @pytest.fixture(scope="session")
 def dd_environment():
-      yield deepcopy(INSTANCE)
+    yield deepcopy(INSTANCE)
+
+
 @pytest.fixture
 def instance():
-      return deepcopy(INSTANCE)
-@pytest.fixture
+    return deepcopy(INSTANCE)

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -10,6 +10,7 @@ INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin'}
 
 @pytest.fixture(scope="session")
 def dd_environment():
+    yield INSTANCE, {'docker_platform': 'windows'}
     yield deepcopy(INSTANCE)
 
 

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -5,13 +5,14 @@ from copy import deepcopy
 
 import pytest
 
-INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'site': 'test', 'app_pools': 'test'}
+# INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'site': 'test', 'app_pools': 'test'}
+from .common import INSTANCE
 
 
 @pytest.fixture(scope="session")
 def dd_environment():
     yield INSTANCE, {'docker_platform': 'windows'}
-    yield deepcopy(INSTANCE)
+    # yield deepcopy(INSTANCE)
 
 
 @pytest.fixture

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 import pytest
 
-INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'site': 'test'}
+INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'site': 'test', 'app_pools': 'test'}
 
 
 @pytest.fixture(scope="session")

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -5,15 +5,18 @@ from copy import deepcopy
 
 import pytest
 
-# INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'site': 'test', 'app_pools': 'test'}
+from datadog_checks.iis import IIS
+
 from .common import INSTANCE
 
 
 @pytest.fixture(scope="session")
 def dd_environment():
     yield INSTANCE, {'docker_platform': 'windows'}
-    # yield deepcopy(INSTANCE)
 
+@pytest.fixture
+def check():
+    return lambda instance: IIS('iis', {}, [instance])
 
 @pytest.fixture
 def instance():

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 import pytest
 
-INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin'}
+INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'site': 'test'}
 
 
 @pytest.fixture(scope="session")

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -3,5 +3,14 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy
 import pytest
-INSTANCE = {"tbd"
+INSTANCE = {
+  'server': 'localhost'
+  'username': 'admin'
+  'password': 'admin'
 }
+@pytest.fixture(scope="session")
+def dd_environment():
+@pytest.fixture
+def instance():
+      return deepcopy(INSTANCE)
+@pytest.fixture

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 import pytest
 
-INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'sites': 'include: - test'}
+INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin'}
 
 
 @pytest.fixture(scope="session")

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -1,3 +1,7 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from copy import deepcopy
+import pytest
+INSTANCE = {"tbd"
+}

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -4,9 +4,8 @@
 
 import pytest
 
-from datadog_checks.iis import IIS
-
 from datadog_checks.dev.testing import requires_py3
+from datadog_checks.iis import IIS
 
 # from .common import instance
 # INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'site': 'test', 'app_pools': 'test'}

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -7,8 +7,7 @@ import pytest
 # from .common import instance
 INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'site': 'test', 'app_pools': 'test'}
 
-
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, aggregator, instance):
-    aggregator = dd_agent_check(instance)
+def test_e2e(dd_agent_check, aggregator, INSTANCE, check):
+    aggregator = dd_agent_check(INSTANCE)
     aggregator.assert_service_check('iis.windows.perf.health')

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -4,15 +4,8 @@
 
 import pytest
 
-from datadog_checks.dev.testing import requires_py2, requires_py3
+from datadog_checks.dev.testing import requires_py3
 from datadog_checks.iis import IIS
-
-
-@pytest.mark.e2e
-@requires_py2
-def test_e2e_py2(dd_agent_check, aggregator, instance, check):
-    aggregator = dd_agent_check(instance)
-    aggregator.assert_service_check('iis.site_up', IIS.CRITICAL)
 
 
 @pytest.mark.e2e

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -10,6 +10,6 @@ from datadog_checks.iis import IIS
 
 @pytest.mark.e2e
 @requires_py3
-def test_e2e_py3(dd_agent_check, aggregator, instance, check):
+def test_e2e_py3(dd_agent_check, aggregator, instance):
     aggregator = dd_agent_check(instance)
     aggregator.assert_service_check('iis.windows.perf.health', IIS.CRITICAL)

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -10,6 +10,6 @@ from datadog_checks.iis import IIS
 
 @pytest.mark.e2e
 @requires_py3
-def test_e2e_py3(dd_agent_check, aggregator, instance):
+def test_e2e_py3(dd_agent_check, aggregator, instance, check):
     aggregator = dd_agent_check(instance)
     aggregator.assert_service_check('iis.windows.perf.health', IIS.CRITICAL)

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -4,6 +4,8 @@
 
 import pytest
 
+from datadog_checks.iis import IIS
+
 from datadog_checks.dev.testing import requires_py3
 
 # from .common import instance
@@ -15,4 +17,4 @@ pytestmark = [requires_py3]
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, aggregator, instance, check):
     aggregator = dd_agent_check(instance)
-    aggregator.assert_service_check('iis.windows.perf.health')
+    aggregator.assert_service_check('iis.windows.perf.health', IIS.CRITICAL)

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2010-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -4,13 +4,19 @@
 
 import pytest
 
-from datadog_checks.dev.testing import requires_py3
+from datadog_checks.dev.testing import requires_py2, requires_py3
 from datadog_checks.iis import IIS
-
-pytestmark = [requires_py3]
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, aggregator, instance, check):
+@requires_py2
+def test_e2e_py2(dd_agent_check, aggregator, instance, check):
+    aggregator = dd_agent_check(instance)
+    aggregator.assert_service_check('iis.site_up', IIS.CRITICAL)
+
+
+@pytest.mark.e2e
+@requires_py3
+def test_e2e_py3(dd_agent_check, aggregator, instance, check):
     aggregator = dd_agent_check(instance)
     aggregator.assert_service_check('iis.windows.perf.health', IIS.CRITICAL)

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -7,7 +7,6 @@ import pytest
 from datadog_checks.dev.testing import requires_py3
 from datadog_checks.iis import IIS
 
-
 pytestmark = [requires_py3]
 
 

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -3,11 +3,14 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import pytest
+from datadog_checks.dev.testing import requires_py3
 
 # from .common import instance
-INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'site': 'test', 'app_pools': 'test'}
+# INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'site': 'test', 'app_pools': 'test'}
+
+pytestmark = [requires_py3]
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, aggregator, INSTANCE, check):
-    aggregator = dd_agent_check(INSTANCE)
+def test_e2e(dd_agent_check, aggregator, instance, check):
+    aggregator = dd_agent_check(instance)
     aggregator.assert_service_check('iis.windows.perf.health')

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -7,8 +7,6 @@ import pytest
 from datadog_checks.dev.testing import requires_py3
 from datadog_checks.iis import IIS
 
-# from .common import instance
-# INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'site': 'test', 'app_pools': 'test'}
 
 pytestmark = [requires_py3]
 

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -3,12 +3,14 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import pytest
+
 from datadog_checks.dev.testing import requires_py3
 
 # from .common import instance
 # INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'site': 'test', 'app_pools': 'test'}
 
 pytestmark = [requires_py3]
+
 
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, aggregator, instance, check):

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -1,0 +1,14 @@
+# (C) Datadog, Inc. 2010-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+import pytest
+
+# from .common import instance
+INSTANCE = {'server': 'localhost', 'username': 'admin', 'password': 'admin', 'site': 'test', 'app_pools': 'test'}
+
+
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, aggregator, instance):
+    aggregator = dd_agent_check(instance)
+    aggregator.assert_service_check('iis.windows.perf.health')

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -199,4 +199,4 @@ def test_check_without_sites_specified(aggregator, dd_run_check):
 def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
-    aggregator.assert_service_check("AgentCheck.site_up", IIS.CRITICAL)
+    aggregator.assert_service_check("iis.site_up", AgentCheck.CRITICAL)

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -10,6 +10,8 @@ from datadog_test_libs.win.pdh_mocks import initialize_pdh_tests, pdh_mocks_fixt
 
 from datadog_checks.dev.testing import requires_py2
 from datadog_checks.iis import IIS
+from datadog_checks.base import AgentCheck
+
 
 from .common import (
     APP_POOL_METRICS,
@@ -197,4 +199,4 @@ def test_check_without_sites_specified(aggregator, dd_run_check):
 def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
-    aggregator.assert_service_check("iis.site_up", IIS.CRITICAL)
+    aggregator.assert_service_check("AgentCheck.site_up", IIS.CRITICAL)

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -197,4 +197,4 @@ def test_check_without_sites_specified(aggregator, dd_run_check):
 def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
-    aggregator.assert_service_check('iis.site_up', IIS.CRITICAL)
+    aggregator.assert_service_check('iis.windows.perf.health', IIS.CRITICAL)

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -206,6 +206,6 @@ def test_check_without_sites_specified(aggregator, dd_run_check):
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, check, instance):
+def test_e2e(dd_agent_check, aggregator, instance):
     aggregator = dd_agent_check(instance)
     aggregator.assert_service_check('iis.windows.perf.health')

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -196,10 +196,16 @@ def test_check_without_sites_specified(aggregator, dd_run_check):
     aggregator.assert_all_metrics_covered()
 
 
+# @pytest.mark.e2e
+# def test_e2e(dd_agent_check, aggregator, instance):
+# with pytest.raises(Exception):
+# dd_agent_check(instance, rate=True)
+# aggregator.assert_service_check('iis.windows.perf.health')
+# aggregator.assert_service_check('iis.windows.perf.health', ServiceCheck.CRITICAL)
+# aggregator.assert_service_check('iis.windows.perf.health', IIS.CRITICAL)
+
+
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, aggregator, instance):
-    with pytest.raises(Exception):
-        dd_agent_check(instance, rate=True)
+def test_e2e(dd_agent_check, check, instance):
+    aggregator = dd_agent_check(instance)
     aggregator.assert_service_check('iis.windows.perf.health')
-    # aggregator.assert_service_check('iis.windows.perf.health', ServiceCheck.CRITICAL)
-    # aggregator.assert_service_check('iis.windows.perf.health', IIS.CRITICAL)

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -8,7 +8,6 @@ import re
 import pytest
 from datadog_test_libs.win.pdh_mocks import initialize_pdh_tests, pdh_mocks_fixture  # noqa: F401
 
-# from datadog_checks.base import AgentCheck
 from datadog_checks.dev.testing import requires_py2
 from datadog_checks.iis import IIS
 

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -8,6 +8,7 @@ import re
 import pytest
 from datadog_test_libs.win.pdh_mocks import initialize_pdh_tests, pdh_mocks_fixture  # noqa: F401
 
+from datadog_checks.base import AgentCheck
 from datadog_checks.dev.testing import requires_py2
 from datadog_checks.iis import IIS
 
@@ -191,9 +192,10 @@ def test_check_without_sites_specified(aggregator, dd_run_check):
             )
 
     aggregator.assert_all_metrics_covered()
-    
+
+
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
-    aggregator.assert_service_check("iis.can_connect", AgentCheck.CRITICAL)
+    aggregator.assert_service_check("iis.site_up", AgentCheck.CRITICAL)

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -197,4 +197,4 @@ def test_check_without_sites_specified(aggregator, dd_run_check):
 def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
-    aggregator.assert_service_check("iis.site_up", IIS.CRITICAL)
+    aggregator.assert_service_check('iis.site_up', IIS.CRITICAL)

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -203,9 +203,3 @@ def test_check_without_sites_specified(aggregator, dd_run_check):
 # aggregator.assert_service_check('iis.windows.perf.health')
 # aggregator.assert_service_check('iis.windows.perf.health', ServiceCheck.CRITICAL)
 # aggregator.assert_service_check('iis.windows.perf.health', IIS.CRITICAL)
-
-
-@pytest.mark.e2e
-def test_e2e(dd_agent_check, aggregator, instance):
-    aggregator = dd_agent_check(instance)
-    aggregator.assert_service_check('iis.windows.perf.health')

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -191,3 +191,9 @@ def test_check_without_sites_specified(aggregator, dd_run_check):
             )
 
     aggregator.assert_all_metrics_covered()
+    
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, aggregator, instance):
+    with pytest.raises(Exception):
+        dd_agent_check(instance, rate=True)
+    aggregator.assert_service_check("iis.can_connect", AgentCheck.CRITICAL)

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -24,6 +24,9 @@ from .common import (
     WIN_SERVICES_MINIMAL_CONFIG,
 )
 
+# from datadog_checks.base.constants import ServiceCheck
+
+
 pytestmark = [requires_py2, pytest.mark.usefixtures('pdh_mocks_fixture')]
 
 
@@ -197,4 +200,6 @@ def test_check_without_sites_specified(aggregator, dd_run_check):
 def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
-    aggregator.assert_service_check('iis.windows.perf.health', IIS.CRITICAL)
+    aggregator.assert_service_check('iis.windows.perf.health')
+    # aggregator.assert_service_check('iis.windows.perf.health', ServiceCheck.CRITICAL)
+    # aggregator.assert_service_check('iis.windows.perf.health', IIS.CRITICAL)

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -10,8 +10,6 @@ from datadog_test_libs.win.pdh_mocks import initialize_pdh_tests, pdh_mocks_fixt
 
 from datadog_checks.dev.testing import requires_py2
 from datadog_checks.iis import IIS
-from datadog_checks.base import AgentCheck
-
 
 from .common import (
     APP_POOL_METRICS,
@@ -199,4 +197,4 @@ def test_check_without_sites_specified(aggregator, dd_run_check):
 def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
-    aggregator.assert_service_check("iis.site_up", AgentCheck.CRITICAL)
+    aggregator.assert_service_check("iis.site_up", IIS.CRITICAL)

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -24,9 +24,6 @@ from .common import (
     WIN_SERVICES_MINIMAL_CONFIG,
 )
 
-# from datadog_checks.base.constants import ServiceCheck
-
-
 pytestmark = [requires_py2, pytest.mark.usefixtures('pdh_mocks_fixture')]
 
 
@@ -194,12 +191,3 @@ def test_check_without_sites_specified(aggregator, dd_run_check):
             )
 
     aggregator.assert_all_metrics_covered()
-
-
-# @pytest.mark.e2e
-# def test_e2e(dd_agent_check, aggregator, instance):
-# with pytest.raises(Exception):
-# dd_agent_check(instance, rate=True)
-# aggregator.assert_service_check('iis.windows.perf.health')
-# aggregator.assert_service_check('iis.windows.perf.health', ServiceCheck.CRITICAL)
-# aggregator.assert_service_check('iis.windows.perf.health', IIS.CRITICAL)

--- a/iis/tox.ini
+++ b/iis/tox.ini
@@ -10,6 +10,8 @@ envdir =
     py27: {toxworkdir}/py27
     py38: {toxworkdir}/py38
 dd_check_style = true
+description =
+    py{27,38}: e2e ready
 usedevelop = true
 platform = win32
 deps =

--- a/iis/tox.ini
+++ b/iis/tox.ini
@@ -11,9 +11,9 @@ envdir =
     py38: {toxworkdir}/py38
 dd_check_style = true
 description =
-    py{38}: e2e ready
+    py{27,38}: e2e ready
 usedevelop = true
-platform = darwin|win32
+platform = win32
 deps =
     -e../datadog_checks_base[deps]
     ../datadog_checks_tests_helper

--- a/iis/tox.ini
+++ b/iis/tox.ini
@@ -11,7 +11,7 @@ envdir =
     py38: {toxworkdir}/py38
 dd_check_style = true
 description =
-    py{38}: e2e ready
+    py{27,38}: e2e ready
 usedevelop = true
 platform = win32
 deps =

--- a/iis/tox.ini
+++ b/iis/tox.ini
@@ -11,7 +11,7 @@ envdir =
     py38: {toxworkdir}/py38
 dd_check_style = true
 description =
-    py{27,38}: e2e ready
+    py{38}: e2e ready
 usedevelop = true
 platform = win32
 deps =

--- a/iis/tox.ini
+++ b/iis/tox.ini
@@ -11,9 +11,9 @@ envdir =
     py38: {toxworkdir}/py38
 dd_check_style = true
 description =
-    py{27,38}: e2e ready
+    py{38}: e2e ready
 usedevelop = true
-platform = win32
+platform = darwin|win32
 deps =
     -e../datadog_checks_base[deps]
     ../datadog_checks_tests_helper


### PR DESCRIPTION
### What does this PR do?
Add barebones E2E testing for IIS integration

### Motivation
https://datadoghq.atlassian.net/browse/AI-1760
David's project for Agent Integrations Team embed
### Additional Notes
Please note that IIS v1 will not support an E2E test. There are unhandled errors on startup of the check when IIS is not running, and this causes the check to not start. This E2E test is only for v2 with py3.
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
