### PR TITLE
datadog_checks_base: Fix obfuscate_sql_with_metadata query being None

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -182,6 +182,9 @@ def default_json_event_encoding(o):
 
 
 def obfuscate_sql_with_metadata(query, options=None):
+    if not query:
+        return {'query': None, 'metadata': {}}
+
     def _load_metadata(statement):
         try:
             statement_with_metadata = json.loads(statement)

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -159,6 +159,11 @@ def test_obfuscate_sql_with_metadata(obfuscator_return_value, expected_value, re
         )
         assert statement == expected_value
 
+    # Check that it can handle null values
+    statement = obfuscate_sql_with_metadata(None)
+    assert statement['query'] is None
+    assert statement['metadata'] == {}
+
 
 class TestJob(DBMAsyncJob):
     def __init__(self, check, run_sync=False, enabled=True, rate_limit=10, min_collection_interval=15):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes a bug where the SQL obfuscator attempts to obfuscate a None value.

### Motivation
<!-- What inspired you to submit this pull request? -->
Came across a scenario where this could happen.
Log: `Failed to obfuscate query 'None': argument 1 must be str, not None`

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This will require a new base version and three follow up PRs to update the following integrations:
- MySQL
- SQL Server
- Postgres

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
