### PR TITLE
Update release docs with release category label process

### DIFF
--- a/docs/developer/process/agent-release/pre-release.md
+++ b/docs/developer/process/agent-release/pre-release.md
@@ -103,8 +103,9 @@ The main Agent release manager will increment and build a new `rc` every day a b
 
 Before each build is triggered:
 
-1. Merge any fixes that have been approved, then pull `master`
-1. Release [all changed integrations](../integration-release.md#bulk-releases) with the exception of `datadog_checks_dev`
+1. Ensure all PRs have a `category/X` label. See list of Agent Release category labels [here](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/2250408413/Merging+PRs+during+RC+development#PR-categories).
+2. Merge any fixes that have been approved, then pull `master`
+3. Release [all changed integrations](../integration-release.md#bulk-releases) with the exception of `datadog_checks_dev`
 
 For each fix merged, you must cherry-pick to the [branch](#branch):
 

--- a/docs/developer/process/agent-release/pre-release.md
+++ b/docs/developer/process/agent-release/pre-release.md
@@ -103,9 +103,9 @@ The main Agent release manager will increment and build a new `rc` every day a b
 
 Before each build is triggered:
 
-1. Ensure all PRs have a `category/X` label. See list of Agent Release category labels [here](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/2250408413/Merging+PRs+during+RC+development#PR-categories).
-2. Merge any fixes that have been approved, then pull `master`
-3. Release [all changed integrations](../integration-release.md#bulk-releases) with the exception of `datadog_checks_dev`
+1. Ensure all PRs have a `category/X` label.
+2. Merge any fixes that have been approved and pull `master`.
+3. Release [all changed integrations](../integration-release.md#bulk-releases) except for `datadog_checks_dev`.
 
 For each fix merged, you must cherry-pick to the [branch](#branch):
 


### PR DESCRIPTION
### What does this PR do?
Adds step about assigning agent release category labels to PRs for release candidates. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
