### PR TITLE
Ensure RELEASE_BRANCH env variable is defined

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,6 +73,7 @@ trigger-agent-build:
     - git fetch origin master
     - BASE_REF=$(git merge-base HEAD FETCH_HEAD)
     - git --no-pager diff --exit-code --name-only HEAD $BASE_REF -- datadog_checks_base/datadog_checks/base/data/agent_requirements.in || export AGENT_REQUIREMENTS_CHANGED="true" || true
+    - export RELEASE_BRANCH=""
     - |
       if [[ "$AGENT_REQUIREMENTS_CHANGED" = "true" ]]; then
           export RELEASE_BRANCH=$(git tag -l '7\.*' --points-at $BASE_REF | cat | sed 's/\..-.*/\.x/')


### PR DESCRIPTION
### What does this PR do?
Ensure `RELEASE_BRANCH` env variable is defined in `.gitlab-ci.yml` prior to running `trigger_agent_build.py` script.

### Motivation
Fix the key error in `trigger_agent_build.py` script to allow the release manual job to proceed 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
