### PR TITLE
Fix CODEOWNERS Rules not attributing correct ownership of base dbm files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,10 @@ auto_conf.yaml        @DataDog/documentation @DataDog/agent-integrations @DataDo
 manifest.json         @DataDog/documentation @DataDog/agent-integrations
 assets/               @DataDog/agent-integrations
 
+# Checks base
+/datadog_checks_base/                                          @DataDog/agent-core @DataDog/agent-integrations
+/datadog_checks_base/datadog_checks/base/checks/openmetrics/   @DataDog/agent-core @DataDog/agent-integrations @DataDog/container-integrations
+/datadog_checks_base/datadog_checks/base/checks/kube_leader/   @DataDog/agent-core @DataDog/agent-integrations @DataDog/container-integrations
 
 # Container monitoring
 /containerd/                              @DataDog/container-integrations @DataDog/agent-integrations
@@ -107,7 +111,7 @@ assets/               @DataDog/agent-integrations
 
 # Database monitoring
 **/base/utils/db/utils.py                           @DataDog/agent-integrations @DataDog/database-monitoring
-datadog_checks_base/tests/**/test_db_util.py        @DataDog/agent-integrations @DataDog/database-monitoring
+datadog_checks_base/tests/**/test_util.py           @DataDog/agent-integrations @DataDog/database-monitoring
 **/base/utils/db/sql.py                             @DataDog/database-monitoring @DataDog/agent-integrations
 datadog_checks_base/tests/**/test_db_sql.py         @DataDog/database-monitoring @DataDog/agent-integrations
 **/base/utils/db/statement_metrics.py               @DataDog/database-monitoring @DataDog/agent-integrations
@@ -124,12 +128,6 @@ datadog_checks_base/tests/**/test_db_statements.py  @DataDog/database-monitoring
 /oracle/                                            @DataDog/agent-integrations @DataDog/database-monitoring
 /oracle/*.md                                        @DataDog/agent-integrations @DataDog/database-monitoring @DataDog/documentation
 /oracle/manifest.json                               @DataDog/agent-integrations @DataDog/database-monitoring @DataDog/documentation
-
-
-# Checks base
-/datadog_checks_base/                                          @DataDog/agent-core @DataDog/agent-integrations
-/datadog_checks_base/datadog_checks/base/checks/openmetrics/   @DataDog/agent-core @DataDog/agent-integrations @DataDog/container-integrations
-/datadog_checks_base/datadog_checks/base/checks/kube_leader/   @DataDog/agent-core @DataDog/agent-integrations @DataDog/container-integrations
 
 # To keep Security up-to-date with changes to the signing tool.
 /datadog_checks_dev/datadog_checks/dev/tooling/signing.py             @DataDog/software-integrity-and-trust


### PR DESCRIPTION
### What does this PR do?
@djmitche pointed out on [this PR](https://github.com/DataDog/integrations-core/pull/11046) that agent-core should not be flagged for review on dbm owned files in the `datadog_checks_base`. In reviewing the `CODEOWNERS`, it looks like this was already the intention but that wasn't done correctly. I used [codeowners](https://github.com/hmarr/codeowners) to evaluate the codeowner rules and figured out that the problem was the ordering. Since the last matching rule wins, we need to have the defaults/fallbacks earlier and the more specific rules lower down. 

Taking the files modified in https://github.com/DataDog/integrations-core/pull/11046 as a test, I previously got:
```
codeowners datadog_checks_base/tests/base/utils/db/test_db_statements.py
datadog_checks_base/tests/base/utils/db/test_db_statements.py           @DataDog/agent-core @DataDog/agent-integrations

codeowners datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py
datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py   @DataDog/agent-core @DataDog/agent-integrations
```

And with the changes:
```
codeowners datadog_checks_base/tests/base/utils/db/test_db_statements.py                      
datadog_checks_base/tests/base/utils/db/test_db_statements.py           @DataDog/database-monitoring @DataDog/agent-integrations

codeowners datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py       
datadog_checks_base/datadog_checks/base/utils/db/statement_metrics.py   @DataDog/database-monitoring @DataDog/agent-integrations

# this one just to confirm that anything non-dbm still goes to the default agent-core/agent-integrations
codeowners datadog_checks_base/datadog_checks/base/utils/time.py       
datadog_checks_base/datadog_checks/base/utils/time.py                   @DataDog/agent-core @DataDog/agent-integrations
```

### Motivation
The wrongly tagged reviewers on https://github.com/DataDog/integrations-core/pull/11046.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
