### PR TITLE
Remap value 'unknown' to 'warning' for KSM 'node.ready' service check

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -86,7 +86,7 @@ class KubernetesState(OpenMetricsBaseCheck):
 
         self.condition_to_status_positive = {'true': self.OK, 'false': self.CRITICAL, 'unknown': self.WARNING}
 
-        self.condition_to_status_negative = {'true': self.CRITICAL, 'false': self.OK, 'unknown': self.WARNING}
+        self.condition_to_status_negative = {'true': self.CRITICAL, 'false': self.OK, 'unknown': self.UNKNOWN}
 
         # Parameters for the count_objects_by_tags method
         self.object_count_params = {

--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -84,9 +84,9 @@ class KubernetesState(OpenMetricsBaseCheck):
         generic_instances = [kubernetes_state_instance]
         super(KubernetesState, self).__init__(name, init_config, instances=generic_instances)
 
-        self.condition_to_status_positive = {'true': self.OK, 'false': self.CRITICAL, 'unknown': self.UNKNOWN}
+        self.condition_to_status_positive = {'true': self.OK, 'false': self.CRITICAL, 'unknown': self.WARNING}
 
-        self.condition_to_status_negative = {'true': self.CRITICAL, 'false': self.OK, 'unknown': self.UNKNOWN}
+        self.condition_to_status_negative = {'true': self.CRITICAL, 'false': self.OK, 'unknown': self.WARNING}
 
         # Parameters for the count_objects_by_tags method
         self.object_count_params = {

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -299,6 +299,7 @@ kube_node_status_condition{condition="OutOfDisk",node="minikube",status="unknown
 kube_node_status_condition{condition="Ready",node="minikube",status="false"} 0
 kube_node_status_condition{condition="Ready",node="minikube",status="true"} 1
 kube_node_status_condition{condition="Ready",node="minikube",status="unknown"} 0
+kube_node_status_condition{condition="Ready",node="test-test-node",status="unknown"} 1
 # HELP kube_node_status_network_unavailable Whether the network is correctly configured for the node.
 # TYPE kube_node_status_network_unavailable gauge
 kube_node_status_network_unavailable{node="127.0.0.1",condition="false"} 1

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -290,6 +290,9 @@ def test_update_kube_state_metrics(aggregator, instance, check):
         check.check(instance)
 
     aggregator.assert_service_check(NAMESPACE + '.node.ready', check.OK)
+    aggregator.assert_service_check(
+        NAMESPACE + '.node.ready', check.WARNING, tags=['node:test-test-node', 'optional:tag1']
+    )
     aggregator.assert_service_check(NAMESPACE + '.node.out_of_disk', check.OK)
     aggregator.assert_service_check(NAMESPACE + '.node.memory_pressure', check.OK)
     aggregator.assert_service_check(NAMESPACE + '.node.network_unavailable', check.OK)
@@ -303,7 +306,7 @@ def test_update_kube_state_metrics(aggregator, instance, check):
         NAMESPACE + '.nodes.by_condition', tags=['condition:ready', 'status:false', 'optional:tag1'], value=0
     )
     aggregator.assert_metric(
-        NAMESPACE + '.nodes.by_condition', tags=['condition:ready', 'status:unknown', 'optional:tag1'], value=0
+        NAMESPACE + '.nodes.by_condition', tags=['condition:ready', 'status:unknown', 'optional:tag1'], value=1
     )
 
     # Make sure we send counts for all phases to avoid no-data graphing issues
@@ -886,9 +889,9 @@ def test_telemetry(aggregator, instance):
 
     for _ in range(2):
         check.check(instance)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=94412.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=1002.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1334.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=94499.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=1004.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1336.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.blacklist.count', tags=['optional:tag1'], value=24.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=332.0)
     aggregator.assert_metric(


### PR DESCRIPTION
### What does this PR do?
Remaps the value of the KSM `node.ready` service check from 'unknown' to 'warning' when a node enters an unknown state.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
