### PR TITLE
Enable openmetrics_endpoint in auto_conf.yaml

### DIFF
--- a/coredns/assets/configuration/spec.yaml
+++ b/coredns/assets/configuration/spec.yaml
@@ -36,7 +36,7 @@ files:
         To enable CoreDNS metrics you must specify the openmetrics endpoint url
         and enable the plugin within coredns
         See: https://coredns.io/plugins/metrics/
-      required: false
+      required: true
       value:
         type: string
         example: "http://%%host%%:9153/metrics"

--- a/coredns/assets/configuration/spec.yaml
+++ b/coredns/assets/configuration/spec.yaml
@@ -36,7 +36,7 @@ files:
         To enable CoreDNS metrics you must specify the openmetrics endpoint url
         and enable the plugin within coredns
         See: https://coredns.io/plugins/metrics/
-      required: true
+      enabled: true
       value:
         type: string
         example: "http://%%host%%:9153/metrics"

--- a/coredns/datadog_checks/coredns/data/auto_conf.yaml
+++ b/coredns/datadog_checks/coredns/data/auto_conf.yaml
@@ -14,13 +14,12 @@ init_config:
 #
 instances:
 
-  -
-    ## @param openmetrics_endpoint - string - optional - default: http://%%host%%:9153/metrics
+    ## @param openmetrics_endpoint - string - required
     ## To enable CoreDNS metrics you must specify the openmetrics endpoint url
     ## and enable the plugin within coredns
     ## See: https://coredns.io/plugins/metrics/
     #
-    # openmetrics_endpoint: http://%%host%%:9153/metrics
+  - openmetrics_endpoint: http://%%host%%:9153/metrics
 
     ## @param tags - list of strings - required
     ## List of tags to attach to every metric and service check emitted by this integration.

--- a/coredns/datadog_checks/coredns/data/auto_conf.yaml
+++ b/coredns/datadog_checks/coredns/data/auto_conf.yaml
@@ -14,7 +14,7 @@ init_config:
 #
 instances:
 
-    ## @param openmetrics_endpoint - string - required
+    ## @param openmetrics_endpoint - string - optional - default: http://%%host%%:9153/metrics
     ## To enable CoreDNS metrics you must specify the openmetrics endpoint url
     ## and enable the plugin within coredns
     ## See: https://coredns.io/plugins/metrics/


### PR DESCRIPTION
### What does this PR do?
Fixes bug where `openmetrics_endpoint` was disabled in the auto_conf.yaml

### Motivation
QA for https://github.com/DataDog/integrations-core/pull/11024

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
