### PR TITLE
Comment on changelog/changed label

### DIFF
--- a/.github/workflows/changelog-label-check.yml
+++ b/.github/workflows/changelog-label-check.yml
@@ -26,4 +26,4 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-          github.issues.createComment({ issue_number, owner, repo, body: "Label `changelog/Changed` was added to this Pull Request, so the next release will bump major version. Please make sur this is a breaking change, or use the `changelog/Fixed` label." });
+          github.issues.createComment({ issue_number, owner, repo, body: "Label `changelog/Changed` was added to this Pull Request, so the next release will bump major version. Please make sure this is a breaking change, or use the `changelog/Fixed` label." });

--- a/.github/workflows/changelog-label-check.yml
+++ b/.github/workflows/changelog-label-check.yml
@@ -18,3 +18,12 @@ jobs:
       
     - name: Check changelog label
       run: python .github/workflows/changelog-label-check.py
+
+    - name: Comment
+      if: ${{ github.event.action == 'labeled' && contains( github.event.pull_request.labels.*.name, 'changelog/Changed') }}
+      uses: actions/github-script@0.3.0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+          github.issues.createComment({ issue_number, owner, repo, body: "Label `changelog/Changed` was added to this Pull Request, so the next release will bump major version. Please make sur this is a breaking change, or use the `changelog/Fixed` label." });


### PR DESCRIPTION
Using `changelog/Changed` label on a pull request will bump major version of the integration in the next release, and it usually means it introduces a breaking change.
Sometimes people are using `changelog/Changed` when they should be using `changelog/Fixed` (bumping patch version).

Comment is only posted when `Changed` is added and it's the only one attached to the PR.