### PR TITLE
Be more precise with version testing

### DIFF
--- a/haproxy/tests/conftest.py
+++ b/haproxy/tests/conftest.py
@@ -94,11 +94,12 @@ def prometheus_metrics():
         metrics.pop('haproxy_process_uptime_seconds')
         metrics.pop('haproxy_sticktable_size')
         metrics.pop('haproxy_sticktable_used')
-        metrics.pop('haproxy_backend_agg_server_check_status')
         metrics_cpy = metrics.copy()
         for metric in metrics_cpy:
             if metric.startswith('haproxy_listener'):
                 metrics.pop(metric)
+    if HAPROXY_VERSION < version.parse('2.4.9'):
+        metrics.pop('haproxy_backend_agg_server_check_status')
 
     metrics = list(metrics.values())
     return metrics

--- a/haproxy/tox.ini
+++ b/haproxy/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{17,18,20}-legacy
+    py{27,38}-{18,20}-legacy
     py{27,38}-{20,22,23,24,25}
 
 [testenv]
@@ -25,12 +25,17 @@ setenv =
   DDEV_SKIP_GENERIC_TAGS_CHECK=true
   HAPROXY_LEGACY=false
   legacy: HAPROXY_LEGACY=true
-  17: HAPROXY_VERSION=1.7.14
+  # EOL 2022-Q4
   18: HAPROXY_VERSION=1.8.30
+  # 2024-Q2 (LTS)
   20: HAPROXY_VERSION=2.0.25
+  # 2025-Q2 (LTS)
   22: HAPROXY_VERSION=2.2.19
+  # EOL 2022-Q1
   23: HAPROXY_VERSION=2.3.16
-  24: HAPROXY_VERSION=2.4.9
+  # EOL 2026-Q2 (LTS)
+  24: HAPROXY_VERSION=2.4.8
+  # EOL 2023-Q1
   25: HAPROXY_VERSION=2.5.0
 commands =
     pip install -r requirements.in


### PR DESCRIPTION
QA for https://github.com/DataDog/integrations-core/pull/10796
The change has been introduced in 2.4.9
Also removing EOLed version from tox