### PR TITLE
openmetrics: Fix the type of `bearer_token_auth`

### DIFF
--- a/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/defaults.py
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/instance.py
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -69,7 +69,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
@@ -144,8 +144,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/cilium/datadog_checks/cilium/config_models/defaults.py
+++ b/cilium/datadog_checks/cilium/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -55,7 +55,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/cilium/datadog_checks/cilium/config_models/instance.py
+++ b/cilium/datadog_checks/cilium/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -96,7 +96,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]

--- a/cockroachdb/datadog_checks/cockroachdb/config_models/defaults.py
+++ b/cockroachdb/datadog_checks/cockroachdb/config_models/defaults.py
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/cockroachdb/datadog_checks/cockroachdb/config_models/instance.py
+++ b/cockroachdb/datadog_checks/cockroachdb/config_models/instance.py
@@ -95,7 +95,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]

--- a/coredns/datadog_checks/coredns/config_models/defaults.py
+++ b/coredns/datadog_checks/coredns/config_models/defaults.py
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/coredns/datadog_checks/coredns/config_models/instance.py
+++ b/coredns/datadog_checks/coredns/config_models/instance.py
@@ -95,7 +95,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]

--- a/crio/datadog_checks/crio/config_models/defaults.py
+++ b/crio/datadog_checks/crio/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/crio/datadog_checks/crio/config_models/instance.py
+++ b/crio/datadog_checks/crio/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -69,7 +69,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]

--- a/crio/datadog_checks/crio/data/conf.yaml.example
+++ b/crio/datadog_checks/crio/data/conf.yaml.example
@@ -139,8 +139,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy_base.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy_base.yaml
@@ -147,10 +147,13 @@
 - name: bearer_token_auth
   description: |
     If set to true, adds a bearer token authentication header.
+    If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
   value:
     example: false
-    type: boolean
+    anyOf:
+      - type: boolean
+      - type: string
 - name: bearer_token_path
   description: |
     The path to a Kubernetes service account bearer token file. Make sure the file exists and is mounted correctly.

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/defaults.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/instance.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -69,7 +69,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
@@ -147,8 +147,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
@@ -139,8 +139,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/etcd/datadog_checks/etcd/config_models/defaults.py
+++ b/etcd/datadog_checks/etcd/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/etcd/datadog_checks/etcd/config_models/instance.py
+++ b/etcd/datadog_checks/etcd/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -69,7 +69,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -145,8 +145,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/external_dns/datadog_checks/external_dns/config_models/defaults.py
+++ b/external_dns/datadog_checks/external_dns/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/external_dns/datadog_checks/external_dns/config_models/instance.py
+++ b/external_dns/datadog_checks/external_dns/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -69,7 +69,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]

--- a/external_dns/datadog_checks/external_dns/data/conf.yaml.example
+++ b/external_dns/datadog_checks/external_dns/data/conf.yaml.example
@@ -139,8 +139,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/gitlab/datadog_checks/gitlab/config_models/defaults.py
+++ b/gitlab/datadog_checks/gitlab/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -59,7 +59,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/gitlab/datadog_checks/gitlab/config_models/instance.py
+++ b/gitlab/datadog_checks/gitlab/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -70,7 +70,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -110,8 +110,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/gitlab_runner/datadog_checks/gitlab_runner/config_models/defaults.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/gitlab_runner/datadog_checks/gitlab_runner/config_models/instance.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -69,7 +69,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -193,8 +193,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/haproxy/datadog_checks/haproxy/config_models/defaults.py
+++ b/haproxy/datadog_checks/haproxy/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -55,7 +55,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/haproxy/datadog_checks/haproxy/config_models/instance.py
+++ b/haproxy/datadog_checks/haproxy/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -70,7 +70,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     collate_status_tags_per_host: Optional[bool]
     collect_aggregates_only: Optional[Union[bool, str]]

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -286,8 +286,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/istio/datadog_checks/istio/config_models/defaults.py
+++ b/istio/datadog_checks/istio/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/istio/datadog_checks/istio/config_models/instance.py
+++ b/istio/datadog_checks/istio/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -95,7 +95,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/instance.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -69,7 +69,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -146,8 +146,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: true
+    ## @param bearer_token_auth - boolean or string - optional - default: true
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: true

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
@@ -181,8 +181,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
+++ b/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
@@ -139,8 +139,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
@@ -146,8 +146,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
+++ b/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
@@ -139,8 +139,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/kube_scheduler/datadog_checks/kube_scheduler/config_models/defaults.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/kube_scheduler/datadog_checks/kube_scheduler/config_models/instance.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -69,7 +69,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -160,8 +160,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/linkerd/datadog_checks/linkerd/config_models/defaults.py
+++ b/linkerd/datadog_checks/linkerd/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/linkerd/datadog_checks/linkerd/config_models/instance.py
+++ b/linkerd/datadog_checks/linkerd/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -95,7 +95,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/defaults.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/instance.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -69,7 +69,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     collect_nginx_histograms: Optional[bool]
     connect_timeout: Optional[float]

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -147,8 +147,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false

--- a/openmetrics/datadog_checks/openmetrics/config_models/defaults.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/openmetrics/datadog_checks/openmetrics/config_models/instance.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -95,7 +95,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]

--- a/scylla/datadog_checks/scylla/config_models/defaults.py
+++ b/scylla/datadog_checks/scylla/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -51,7 +51,7 @@ def instance_aws_service(field, value):
 
 
 def instance_bearer_token_auth(field, value):
-    return False
+    return get_default_field_value(field, value)
 
 
 def instance_bearer_token_path(field, value):

--- a/scylla/datadog_checks/scylla/config_models/instance.py
+++ b/scylla/datadog_checks/scylla/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -69,7 +69,7 @@ class InstanceConfig(BaseModel):
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
-    bearer_token_auth: Optional[bool]
+    bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -156,8 +156,9 @@ instances:
     #
     # include_labels: []
 
-    ## @param bearer_token_auth - boolean - optional - default: false
+    ## @param bearer_token_auth - boolean or string - optional - default: false
     ## If set to true, adds a bearer token authentication header.
+    ## If set to 'tls_only', only adds a bearer token authentication header if the endpoint is secure https.
     ## Note: If bearer_token_path is not set, the default path is /var/run/secrets/kubernetes.io/serviceaccount/token.
     #
     # bearer_token_auth: false


### PR DESCRIPTION
### What does this PR do?

Update the type of the `bearer_token_auth` parameter of the `openmetrics` base check from `boolean` to `boolean or string`.

### Motivation

The change was initiated by #10706, but it was incomplete.

In particular, the `kube_apiserver_metrics` is currently failing with the following error:
```
      Error: Detected 1 error while loading configuration model `InstanceConfig`:
bearer_token_auth
  value could not be parsed to a boolean
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 1008, in run
          initialization()
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 423, in load_configuration_models
          instance_config = self.load_configuration_model(package_path, 'InstanceConfig', raw_instance_config)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 463, in load_configuration_model
          raise_from(ConfigurationError('\n'.join(message_lines)), None)
        File "<string>", line 3, in raise_from
      datadog_checks.base.errors.ConfigurationError: Detected 1 error while loading configuration model `InstanceConfig`:
      bearer_token_auth
        value could not be parsed to a boolean
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
