### PR TITLE
openmetrics/base: provide a better user feedback in case of connectivity issue

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -123,9 +123,8 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
                         except (IOError, requests.HTTPError, requests.exceptions.SSLError) as e:
                             self.log.info("Couldn't connect to %s: %s, trying next possible URL.", url, str(e))
                     else:
-                        self.log.error(
-                            "The agent could connect to none of the following URL: %s.",
-                            possible_urls,
+                        raise CheckException(
+                            "The agent could connect to none of the following URL: %s." % possible_urls
                         )
                 else:
                     self.get_scraper_config(instance)


### PR DESCRIPTION
### What does this PR do?

Provide a better user feedback when an `openmetrics`-based check leveraging the `possible_prometheus_urls` parameter fails to connect to all the possible endpoints.

### Motivation

Kubernetes components used to expose an unauthenticated plain http openmetrics endpoint in oldest versions.
They now expose an authenticated secure https endpoint in more recent versions.
By default, now, they only bind the loopback interface on `127.0.0.1` which is not accessible from an agent pod not started with `hostNetwork: true`. But they can be explicitly configured to bind `0.0.0.0` to be visible from non-`hostNetwork: true` agent pods.

Because of this variety of setups, in order to work out-of-the-box on as much setups as possible, the Kubernetes control-plane components checks are trying several possible endpoints at initialisation time.

In the case where nothing can work (the Kube component binds only the loopback on `127.0.0.1` and the agent is not started with `hostNetwork: true`), the initialisation of the check fails.

In previous versions of the agent, this failure used to not be visible from the output of the `agent status` where the check wasn’t showing up at all.
So, users would go to the logs where they would have found the error log saying that no possible urls were reachable.

The agent now shows check initialisation failures in the output of `agent status`.

But the currently displayed failure is currently not describing correctly its cause:

```
Check Initialization Errors
  ===========================


      kube_controller_manager (3.0.0)
      -------------------------------

      instance 0:

        could not invoke 'kube_controller_manager' python check constructor. New constructor API returned:
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/kube_controller_manager/kube_controller_manager.py", line 136, in __init__
    if url is None and re.search(r'/metrics$', prometheus_url):
  File "/opt/datadog-agent/embedded/lib/python3.8/re.py", line 201, in search
    return _compile(pattern, flags).search(string)
TypeError: expected string or bytes-like object
Deprecated constructor API returned:
__init__() got an unexpected keyword argument 'agentConfig'
```

This error is raised because `prometheus_url` is `None`.

This change produces a clearer message to the end user by moving what was logged as an error to the output of `agent status`:

```
  Check Initialization Errors
  ===========================


      kube_controller_manager (3.0.0)
      -------------------------------

      instance 0:

        could not invoke 'kube_controller_manager' python check constructor. New constructor API returned:
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/kube_controller_manager/kube_controller_manager.py", line 108, in __init__
    super(KubeControllerManagerCheck, self).__init__(
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/base_check.py", line 126, in __init__
    raise CheckException(
datadog_checks.base.errors.CheckException: The agent could connect to none of the following URL: ['https://172.18.0.3:10257/metrics', 'https://localhost:10257/metrics', 'http://172.18.0.3:10252/metrics', 'http://localhost:10252/metrics'].
Deprecated constructor API returned:
__init__() got an unexpected keyword argument 'agentConfig'
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
