### PR TITLE
Add prepared_stmt_count metrics to mysql integration

### DIFF
--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -11,7 +11,7 @@ PROC_NAME = 'mysqld'
 # Vars found in "SHOW STATUS;"
 STATUS_VARS = {
     # Command Metrics
-    'Prepared_stmt_count': ('mysql.performance.prepared_stmt_count', COUNT),
+    'Prepared_stmt_count': ('mysql.performance.prepared_stmt_count', GAUGE),
     'Slow_queries': ('mysql.performance.slow_queries', RATE),
     'Questions': ('mysql.performance.questions', RATE),
     'Queries': ('mysql.performance.queries', RATE),

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -64,7 +64,7 @@ VARIABLES_VARS = {
     'Key_buffer_size': ('mysql.myisam.key_buffer_size', GAUGE),
     'Key_cache_utilization': ('mysql.performance.key_cache_utilization', GAUGE),
     'max_connections': ('mysql.net.max_connections_available', GAUGE),
-    'max_prepared_stmt_count': ('mysql.performance.max_prepared_stmt_count', COUNT),
+    'max_prepared_stmt_count': ('mysql.performance.max_prepared_stmt_count', GAUGE),
     'query_cache_size': ('mysql.performance.qcache_size', GAUGE),
     'table_open_cache': ('mysql.performance.table_open_cache', GAUGE),
     'thread_cache_size': ('mysql.performance.thread_cache_size', GAUGE),

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -11,6 +11,7 @@ PROC_NAME = 'mysqld'
 # Vars found in "SHOW STATUS;"
 STATUS_VARS = {
     # Command Metrics
+    'Prepared_stmt_count': ('mysql.performance.prepared_stmt_count', COUNT),
     'Slow_queries': ('mysql.performance.slow_queries', RATE),
     'Questions': ('mysql.performance.questions', RATE),
     'Queries': ('mysql.performance.queries', RATE),

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -64,6 +64,7 @@ VARIABLES_VARS = {
     'Key_buffer_size': ('mysql.myisam.key_buffer_size', GAUGE),
     'Key_cache_utilization': ('mysql.performance.key_cache_utilization', GAUGE),
     'max_connections': ('mysql.net.max_connections_available', GAUGE),
+    'max_prepared_stmt_count': ('mysql.performance.max_prepared_stmt_count', COUNT),
     'query_cache_size': ('mysql.performance.qcache_size', GAUGE),
     'table_open_cache': ('mysql.performance.table_open_cache', GAUGE),
     'thread_cache_size': ('mysql.performance.thread_cache_size', GAUGE),

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -34,6 +34,7 @@ mysql.performance.open_files,gauge,,file,,The number of open files.,0,mysql,open
 mysql.performance.open_tables,gauge,,table,,The number of of tables that are open.,0,mysql,open tables
 mysql.performance.qcache_hits,gauge,,hit,second,The rate of query cache hits.,0,mysql,query cache hits
 mysql.performance.questions,gauge,,query,second,The rate of statements executed by the server.,0,mysql,questions
+mysql.performance.prepared_stmt_count,count,,query,second,The current number of prepared statements.,0,mysql,prepared stmt count
 mysql.performance.slow_queries,gauge,,query,second,The rate of slow queries.,-1,mysql,slow queries
 mysql.performance.table_locks_waited,gauge,,,,The total number of times that a request for a table lock could not be granted immediately and a wait was needed.,-1,mysql,table locks waited
 mysql.performance.table_locks_waited.rate,gauge,,,,"The rate of times that a request for a table lock could not be granted immediately and a wait was needed.",0,mysql,table locks waited rate

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -61,7 +61,7 @@ mysql.myisam.key_reads,gauge,,read,second,"The number of physical reads of a key
 mysql.myisam.key_write_requests,gauge,,write,second,"The number of requests to write a key block to the MyISAM key cache.",0,mysql,mysql myisam key_write_requests
 mysql.myisam.key_writes,gauge,,write,second,"The number of physical writes of a key block from the MyISAM key cache to disk.",0,mysql,mysql myisam key_writes
 mysql.myisam.key_buffer_size,gauge,,byte,,"Size of the buffer used for index blocks.",0,mysql,mysql myisam key_buffer_size
-mysql.performance.max_prepared_stmt_count,count,,,,"The total number of prepared statements in the server.",0,mysql,mysql performance prepared_stmt_count
+mysql.performance.max_prepared_stmt_count,gauge,,,,"The maximum allowed prepared statements on the server.",0,mysql,max prepared statements
 mysql.performance.qcache_size,gauge,,byte,,"The amount of memory allocated for caching query results.",0,mysql,mysql performance qcache_size
 mysql.performance.table_open_cache,gauge,,,,"The number of open tables for all threads. Increasing this value increases the number of file descriptors that mysqld requires.",0,mysql,mysql performance table_open_cache
 mysql.performance.thread_cache_size,gauge,,byte,,"How many threads the server should cache for reuse. When a client disconnects, the client's threads are put in the cache if there are fewer than thread_cache_size threads there.",0,mysql,mysql performance thread_cache_size

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -34,7 +34,7 @@ mysql.performance.open_files,gauge,,file,,The number of open files.,0,mysql,open
 mysql.performance.open_tables,gauge,,table,,The number of of tables that are open.,0,mysql,open tables
 mysql.performance.qcache_hits,gauge,,hit,second,The rate of query cache hits.,0,mysql,query cache hits
 mysql.performance.questions,gauge,,query,second,The rate of statements executed by the server.,0,mysql,questions
-mysql.performance.prepared_stmt_count,count,,query,second,The current number of prepared statements.,0,mysql,prepared stmt count
+mysql.performance.prepared_stmt_count,gauge,,query,second,The current number of prepared statements.,0,mysql,current prepared statements
 mysql.performance.slow_queries,gauge,,query,second,The rate of slow queries.,-1,mysql,slow queries
 mysql.performance.table_locks_waited,gauge,,,,The total number of times that a request for a table lock could not be granted immediately and a wait was needed.,-1,mysql,table locks waited
 mysql.performance.table_locks_waited.rate,gauge,,,,"The rate of times that a request for a table lock could not be granted immediately and a wait was needed.",0,mysql,table locks waited rate

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -61,6 +61,7 @@ mysql.myisam.key_reads,gauge,,read,second,"The number of physical reads of a key
 mysql.myisam.key_write_requests,gauge,,write,second,"The number of requests to write a key block to the MyISAM key cache.",0,mysql,mysql myisam key_write_requests
 mysql.myisam.key_writes,gauge,,write,second,"The number of physical writes of a key block from the MyISAM key cache to disk.",0,mysql,mysql myisam key_writes
 mysql.myisam.key_buffer_size,gauge,,byte,,"Size of the buffer used for index blocks.",0,mysql,mysql myisam key_buffer_size
+mysql.performance.max_prepared_stmt_count,count,,,,"The total number of prepared statements in the server.",0,mysql,mysql performance prepared_stmt_count
 mysql.performance.qcache_size,gauge,,byte,,"The amount of memory allocated for caching query results.",0,mysql,mysql performance qcache_size
 mysql.performance.table_open_cache,gauge,,,,"The number of open tables for all threads. Increasing this value increases the number of file descriptors that mysqld requires.",0,mysql,mysql performance table_open_cache
 mysql.performance.thread_cache_size,gauge,,byte,,"How many threads the server should cache for reuse. When a client disconnects, the client's threads are put in the cache if there are fewer than thread_cache_size threads there.",0,mysql,mysql performance thread_cache_size

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -59,6 +59,7 @@ VARIABLES_VARS = [
     'mysql.myisam.key_buffer_size',
     'mysql.performance.key_cache_utilization',
     'mysql.net.max_connections_available',
+    'mysql.performance.max_prepared_stmt_count',
     'mysql.performance.table_open_cache',
     'mysql.performance.thread_cache_size',
 ]

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 STATUS_VARS = [
     # Command Metrics
+    'mysql.performance.prepared_stmt_count',
     'mysql.performance.slow_queries',
     'mysql.performance.questions',
     'mysql.performance.queries',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add following metrics:
- `mysql.performance.prepared_stmt_count`
- `mysql.performance.max_prepared_stmt_count`

### Motivation
<!-- What inspired you to submit this pull request? -->

`mysql.performance.prepared_stmt_count` is to get the current number of prepared statements.
https://dev.mysql.com/doc/refman/8.0/en/server-status-variables.html#statvar_Prepared_stmt_count 

`mysql.performance.prepared_stmt_count` is to get the total number of prepared statements in the server.
https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_prepared_stmt_count

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
