### PR TITLE
Change queries date aggregation to last 24 hours

### DIFF
--- a/snowflake/datadog_checks/snowflake/queries.py
+++ b/snowflake/datadog_checks/snowflake/queries.py
@@ -34,8 +34,9 @@ CreditUsage = {
     'query': (
         'select SERVICE_TYPE, NAME, sum(CREDITS_USED_COMPUTE), avg(CREDITS_USED_COMPUTE), '
         'sum(CREDITS_USED_CLOUD_SERVICES), avg(CREDITS_USED_CLOUD_SERVICES), '
-        'sum(CREDITS_USED), avg(CREDITS_USED) from METERING_HISTORY '
-        'where start_time >= date_trunc(day, current_date) group by 1, 2;'
+        'sum(CREDITS_USED), avg(CREDITS_USED) '
+        'from METERING_HISTORY where start_time >= DATEADD(hour, -24, CURRENT_TIMESTAMP()) '
+        'group by 1, 2;'
     ),
     'columns': [
         {'name': 'service_type', 'type': 'tag'},
@@ -56,8 +57,9 @@ WarehouseCreditUsage = {
     'query': (
         'select WAREHOUSE_NAME, sum(CREDITS_USED_COMPUTE), avg(CREDITS_USED_COMPUTE), '
         'sum(CREDITS_USED_CLOUD_SERVICES), avg(CREDITS_USED_CLOUD_SERVICES), '
-        'sum(CREDITS_USED), avg(CREDITS_USED) from WAREHOUSE_METERING_HISTORY '
-        'where start_time >= date_trunc(day, current_date) group by 1;'
+        'sum(CREDITS_USED), avg(CREDITS_USED) '
+        'from WAREHOUSE_METERING_HISTORY where start_time >= DATEADD(hour, -24, CURRENT_TIMESTAMP()) '
+        'group by 1;'
     ),
     'columns': [
         {'name': 'warehouse', 'type': 'tag'},
@@ -90,9 +92,8 @@ LoginMetrics = {
 WarehouseLoad = {
     'name': 'warehouse_load.metrics',
     'query': (
-        'select WAREHOUSE_NAME, AVG(AVG_RUNNING), AVG(AVG_QUEUED_LOAD), AVG(AVG_QUEUED_PROVISIONING), '
-        'AVG(AVG_BLOCKED) from WAREHOUSE_LOAD_HISTORY '
-        'where start_time >= date_trunc(day, current_date) group by 1;'
+        'select WAREHOUSE_NAME, AVG(AVG_RUNNING), AVG(AVG_QUEUED_LOAD), AVG(AVG_QUEUED_PROVISIONING), AVG(AVG_BLOCKED) '
+        'from WAREHOUSE_LOAD_HISTORY where start_time >= DATEADD(hour, -24, CURRENT_TIMESTAMP()) group by 1;'
     ),
     'columns': [
         {'name': 'warehouse', 'type': 'tag'},
@@ -110,7 +111,7 @@ QueryHistory = {
         'select QUERY_TYPE, WAREHOUSE_NAME, DATABASE_NAME, SCHEMA_NAME, AVG(EXECUTION_TIME), '
         'AVG(COMPILATION_TIME), AVG(BYTES_SCANNED), AVG(BYTES_WRITTEN), AVG(BYTES_DELETED), '
         'AVG(BYTES_SPILLED_TO_LOCAL_STORAGE), AVG(BYTES_SPILLED_TO_REMOTE_STORAGE) '
-        'from QUERY_HISTORY where start_time >= date_trunc(day, current_date) '
+        'from QUERY_HISTORY WHERE start_time >= DATEADD(hour, -24, CURRENT_TIMESTAMP()) '
         'group by 1, 2, 3, 4;'
     ),
     'columns': [
@@ -133,8 +134,9 @@ DataTransferHistory = {
     'name': 'data_transfer.metrics',
     'query': (
         'select source_cloud, source_region, target_cloud, target_region, transfer_type, '
-        'avg(bytes_transferred), sum(bytes_transferred) from DATA_TRANSFER_HISTORY '
-        'where start_time >= date_trunc(day, current_date) group by 1, 2, 3, 4, 5;'
+        'avg(bytes_transferred), sum(bytes_transferred) '
+        'from DATA_TRANSFER_HISTORY where start_time >= DATEADD(hour, -24, CURRENT_TIMESTAMP()) '
+        'group by 1, 2, 3, 4, 5;'
     ),
     'columns': [
         {'name': 'source_cloud', 'type': 'tag'},
@@ -154,7 +156,8 @@ AutoReclusterHistory = {
         'select table_name, database_name, schema_name, avg(credits_used), sum(credits_used), '
         'avg(num_bytes_reclustered), sum(num_bytes_reclustered), '
         'avg(num_rows_reclustered), sum(num_rows_reclustered) '
-        'from automatic_clustering_history where start_time >= date_trunc(day, current_date) group by 1, 2, 3;'
+        'from automatic_clustering_history where start_time >= DATEADD(hour, -24, CURRENT_TIMESTAMP()) '
+        'group by 1, 2, 3;'
     ),
     'columns': [
         {'name': 'table', 'type': 'tag'},
@@ -191,8 +194,9 @@ PipeHistory = {
     'name': 'pipe.metrics',
     'query': (
         'select pipe_name, avg(credits_used), sum(credits_used), avg(bytes_inserted), sum(bytes_inserted), '
-        'avg(files_inserted), sum(files_inserted) from pipe_usage_history '
-        'where start_time >= date_trunc(day, current_date) group by 1;'
+        'avg(files_inserted), sum(files_inserted) '
+        'from pipe_usage_history where start_time >= DATEADD(hour, -24, CURRENT_TIMESTAMP()) '
+        'group by 1;'
     ),
     'columns': [
         {'name': 'pipe', 'type': 'tag'},
@@ -210,8 +214,9 @@ ReplicationUsage = {
     'name': 'replication.metrics',
     'query': (
         'select database_name, avg(credits_used), sum(credits_used), '
-        'avg(bytes_transferred), sum(bytes_transferred) from replication_usage_history '
-        'where start_time >= date_trunc(day, current_date) group by 1;'
+        'avg(bytes_transferred), sum(bytes_transferred) '
+        'from replication_usage_history where start_time >= DATEADD(hour, -24, CURRENT_TIMESTAMP()) '
+        'group by 1;'
     ),
     'columns': [
         {'name': 'database', 'type': 'tag'},


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The queries where aggregating entries `since the beginning of the day`, this PR is aggregating the entries in `the last 24 hours` instead.

### Motivation
<!-- What inspired you to submit this pull request? -->
Since some tables could have a 3 hours latency, the queries `since the beginning of the day` could be empty and leads to missing metrics. Aggregating the entries in the last 24 hours instead is more consistent.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This is a **breaking change** in the metrics meaning, and probably require updates in dashboards and monitors.

