### PR TITLE
Add token_path config option

### DIFF
--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -98,19 +98,19 @@ files:
       - name: authenticator
         description: |
           Authenticator for Snowflake. The default `snowflake` uses the internal Snowflake authenticator.
-          Use `oauth` to authenticate with OAuth, be sure to set the `token` or `token_path` option as well.
+          Use `oauth` to authenticate with OAuth. Also, set the `token` or `token_path` option.
         value:
           type: string
           display_default: snowflake
       - name: token
-        description: Token used for OAuth connection to Snowflake. Can't be used along side with `token_path`.
+        description: Token used for OAuth connection to Snowflake. You cannot use this alongside `token_path`.
         value:
           type: string
       - name: token_path
         description: |
-          Path to the file containing the token used for OAuth connection to snowflake.
-          Can't be used along side with `token`.
-          The token will be re-read at each check run.
+          Path to the file that contains the token used for OAuth connection to Snowflake.
+          You cannot use this alongside `token`.
+          The token is re-read at every check run.
         value:
           type: string
           example: /path/to/token

--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -44,7 +44,6 @@ files:
           type: string
           example: <USER>
       - name: password
-        required: true
         description: Password for the user
         value:
           type: string
@@ -99,14 +98,22 @@ files:
       - name: authenticator
         description: |
           Authenticator for Snowflake. The default `snowflake` uses the internal Snowflake authenticator.
-          Use `oauth` to authenticate with OAuth, be sure to set the `token` option as well.
+          Use `oauth` to authenticate with OAuth, be sure to set the `token` or `token_path` option as well.
         value:
           type: string
           display_default: snowflake
       - name: token
-        description: Token used for OAuth connection to Snowflake.
+        description: Token used for OAuth connection to Snowflake. Can't be used along side with `token_path`.
         value:
           type: string
+      - name: token_path
+        description: |
+          Path to the file containing the token used for OAuth connection to snowflake.
+          Can't be used along side with `token`.
+          The token will be re-read at each check run.
+        value:
+          type: string
+          example: /path/to/token
       - name: client_session_keep_alive
         description: |
           If set to true, Snowflake keeps the session active indefinitely as long as the connection is active,

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -72,6 +72,11 @@ class SnowflakeCheck(AgentCheck):
         self._query_manager = QueryManager(self, self.execute_query_raw, queries=self.metric_queries, tags=self._tags)
         self.check_initializations.append(self._query_manager.compile_queries)
 
+    def renew_token(self):
+        self.log.debug("Renewing Snowflake client token")
+        with open(self._config.token_path, 'rb', encoding="UTF-8") as f:
+            self._config.token = f.read()
+
     def check(self, _):
         if self.instance.get('user'):
             self._log_deprecation('_config_renamed', 'user', 'username')
@@ -115,6 +120,9 @@ class SnowflakeCheck(AgentCheck):
             self.proxy_host,
             self.proxy_port,
         )
+
+        if self._config.token_path:
+            self.renew_token()
 
         try:
             conn = sf.connect(

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -40,6 +40,7 @@ class Config(object):
         tags = instance.get('tags', [])
         authenticator = instance.get('authenticator', 'snowflake')
         token = instance.get('token', None)
+        token_path = instance.get('token_path', None)
         client_keep_alive = instance.get('client_session_keep_alive', False)
 
         metric_groups = instance.get('metric_groups', self.DEFAULT_METRIC_GROUP)
@@ -57,12 +58,15 @@ class Config(object):
             if password is None:
                 raise ConfigurationError('Must specify a password if using snowflake authentication')
 
-        else:
-            if authenticator == 'oauth' and token is None:
-                raise ConfigurationError('If using OAuth, you must specify a token')
+        elif authenticator == 'oauth':
+            if token is None and token_path is None:
+                raise ConfigurationError('If using OAuth, you must specify a `token` or a `token_path`')
 
-            if authenticator not in self.AUTHENTICATION_MODES:
-                raise ConfigurationError('The Authenticator method set is invalid: {}'.format(authenticator))
+            if token and token_path:
+                raise ConfigurationError('`token` and `token_path` are set, please set only one option')
+
+        elif authenticator not in self.AUTHENTICATION_MODES:
+            raise ConfigurationError('The Authenticator method set is invalid: {}'.format(authenticator))
 
         if not isinstance(tags, list):
             raise ConfigurationError('tags {!r} must be a list (got {!r})'.format(tags, type(tags)))
@@ -86,4 +90,5 @@ class Config(object):
         self.metric_groups = metric_groups
         self.authenticator = authenticator
         self.token = token
+        self.token_path = token_path
         self.client_keep_alive = client_keep_alive

--- a/snowflake/datadog_checks/snowflake/config_models/defaults.py
+++ b/snowflake/datadog_checks/snowflake/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2022-present
+# (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 

--- a/snowflake/datadog_checks/snowflake/config_models/defaults.py
+++ b/snowflake/datadog_checks/snowflake/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -82,6 +82,10 @@ def instance_only_custom_queries(field, value):
     return False
 
 
+def instance_password(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_schema_(field, value):
     return 'ACCOUNT_USAGE'
 
@@ -96,6 +100,10 @@ def instance_tags(field, value):
 
 def instance_token(field, value):
     return get_default_field_value(field, value)
+
+
+def instance_token_path(field, value):
+    return '/path/to/token'
 
 
 def instance_use_global_custom_queries(field, value):

--- a/snowflake/datadog_checks/snowflake/config_models/instance.py
+++ b/snowflake/datadog_checks/snowflake/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2022-present
+# (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 

--- a/snowflake/datadog_checks/snowflake/config_models/instance.py
+++ b/snowflake/datadog_checks/snowflake/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -45,12 +45,13 @@ class InstanceConfig(BaseModel):
     min_collection_interval: Optional[float]
     ocsp_response_cache_filename: Optional[str]
     only_custom_queries: Optional[bool]
-    password: str
+    password: Optional[str]
     role: str
     schema_: Optional[str] = Field(None, alias='schema')
     service: Optional[str]
     tags: Optional[Sequence[str]]
     token: Optional[str]
+    token_path: Optional[str]
     use_global_custom_queries: Optional[str]
     username: str
     warehouse: Optional[str]

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -106,19 +106,19 @@ instances:
 
     ## @param authenticator - string - optional - default: snowflake
     ## Authenticator for Snowflake. The default `snowflake` uses the internal Snowflake authenticator.
-    ## Use `oauth` to authenticate with OAuth, be sure to set the `token` or `token_path` option as well.
+    ## Use `oauth` to authenticate with OAuth. Also, set the `token` or `token_path` option.
     #
     # authenticator: <AUTHENTICATOR>
 
     ## @param token - string - optional
-    ## Token used for OAuth connection to Snowflake. Can't be used along side with `token_path`.
+    ## Token used for OAuth connection to Snowflake. You cannot use this alongside `token_path`.
     #
     # token: <TOKEN>
 
     ## @param token_path - string - optional - default: /path/to/token
-    ## Path to the file containing the token used for OAuth connection to snowflake.
-    ## Can't be used along side with `token`.
-    ## The token will be re-read at each check run.
+    ## Path to the file that contains the token used for OAuth connection to Snowflake.
+    ## You cannot use this alongside `token`.
+    ## The token is re-read at every check run.
     #
     # token_path: /path/to/token
 

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -56,10 +56,10 @@ instances:
     #
     username: <USER>
 
-    ## @param password - string - required
+    ## @param password - string - optional
     ## Password for the user
     #
-    password: <PASSWORD>
+    # password: <PASSWORD>
 
     ## @param role - string - required
     ## Name of the role to use.
@@ -106,14 +106,21 @@ instances:
 
     ## @param authenticator - string - optional - default: snowflake
     ## Authenticator for Snowflake. The default `snowflake` uses the internal Snowflake authenticator.
-    ## Use `oauth` to authenticate with OAuth, be sure to set the `token` option as well.
+    ## Use `oauth` to authenticate with OAuth, be sure to set the `token` or `token_path` option as well.
     #
     # authenticator: <AUTHENTICATOR>
 
     ## @param token - string - optional
-    ## Token used for OAuth connection to Snowflake.
+    ## Token used for OAuth connection to Snowflake. Can't be used along side with `token_path`.
     #
     # token: <TOKEN>
+
+    ## @param token_path - string - optional - default: /path/to/token
+    ## Path to the file containing the token used for OAuth connection to snowflake.
+    ## Can't be used along side with `token`.
+    ## The token will be re-read at each check run.
+    #
+    # token_path: /path/to/token
 
     ## @param client_session_keep_alive - boolean - optional - default: false
     ## If set to true, Snowflake keeps the session active indefinitely as long as the connection is active,

--- a/snowflake/tests/test_snowflake.py
+++ b/snowflake/tests/test_snowflake.py
@@ -159,6 +159,53 @@ def test_warehouse_load(dd_run_check, aggregator, instance):
     aggregator.assert_metric('snowflake.query.blocked', value=0, count=1, tags=expected_tags)
 
 
+def test_token_path(dd_run_check, aggregator):
+    instance = {
+        'user': 'testuser',
+        'account': 'account',
+        'role': 'ACCOUNTADMIN',
+        'authenticator': 'oauth',
+        'token_path': '/path/to/token',
+    }
+
+    default_args = {
+        'user': 'testuser',
+        'password': None,
+        'account': 'account',
+        'database': 'SNOWFLAKE',
+        'schema': 'ACCOUNT_USAGE',
+        'warehouse': None,
+        'role': 'ACCOUNTADMIN',
+        'passcode_in_password': False,
+        'passcode': None,
+        'client_prefetch_threads': 4,
+        'login_timeout': 60,
+        'ocsp_response_cache_filename': None,
+        'authenticator': 'oauth',
+        'client_session_keep_alive': False,
+        'proxy_host': None,
+        'proxy_port': None,
+        'proxy_user': None,
+        'proxy_password': None,
+    }
+
+    tokens = ['mytoken1', 'mytoken2', 'mytoken3']
+
+    check = SnowflakeCheck(CHECK_NAME, {}, [instance])
+    with mock.patch(
+        'datadog_checks.snowflake.check.open',
+        side_effect=[mock.mock_open(read_data=tok).return_value for tok in tokens],
+    ), mock.patch('datadog_checks.snowflake.check.sf') as sf:
+        dd_run_check(check)
+        sf.connect.assert_called_once_with(token='mytoken1', **default_args)
+
+        dd_run_check(check)
+        sf.connect.assert_called_with(token='mytoken2', **default_args)
+
+        dd_run_check(check)
+        sf.connect.assert_called_with(token='mytoken3', **default_args)
+
+
 def test_query_metrics(dd_run_check, aggregator, instance):
     # type: (Callable[[SnowflakeCheck], None], AggregatorStub, Dict[str, Any]) -> None
 

--- a/snowflake/tests/test_unit.py
+++ b/snowflake/tests/test_unit.py
@@ -50,7 +50,7 @@ def test_invalid_oauth(oauth_instance):
     # Test oauth without token
     no_token_config = copy.deepcopy(INVALID_CONFIG)
     no_token_config['user'] = "test_user"
-    with pytest.raises(Exception, match='If using OAuth, you must specify a token'):
+    with pytest.raises(Exception, match='If using OAuth, you must specify a `token` or a `token_path`'):
         SnowflakeCheck(CHECK_NAME, {}, [no_token_config])
 
     oauth_inst = copy.deepcopy(oauth_instance)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add `token_path` config option so the token can be refreshed at each check run

### Motivation
<!-- What inspired you to submit this pull request? -->
Feature request to be able to rotate tokens, vault integration does something similar https://github.com/DataDog/integrations-core/blob/3616496318dae81470aa66a6c5e2c822a1a1b88e/vault/datadog_checks/vault/vault.py#L320

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Password is actually not required

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
