### PR TITLE
Update default dashboard CPU metric

### DIFF
--- a/ibm_i/assets/dashboards/ibm_i_overview.json
+++ b/ibm_i/assets/dashboards/ibm_i_overview.json
@@ -14,7 +14,7 @@
                     {
                         "id": 6448129333592938,
                         "definition": {
-                            "title": "Average LPAR CPU ",
+                            "title": "LPAR CPU",
                             "title_size": "16",
                             "title_align": "left",
                             "show_legend": true,
@@ -38,7 +38,7 @@
                                     "on_right_yaxis": false,
                                     "queries": [
                                         {
-                                            "query": "avg:ibm_i.system.cpu_usage{$host} by {host}",
+                                            "query": "avg:ibm_i.system.normalized_cpu_usage{$host} by {host}",
                                             "data_source": "metrics",
                                             "name": "query1"
                                         }


### PR DESCRIPTION
### What does this PR do?

Updates the LPAR CPU widget of the default IBM i dashboard to use the new and more accurate `ibm_i.system.normalized_cpu_usage` metric.

### Motivation

Use new CPU metrics added in #11081.

### Additional notes

Switching to the new metric is fine, the integration is currently only used by one customer that is using a version of the integration that produces the metric.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
