### PR TITLE
Add back display priority for `tags` config

### DIFF
--- a/coredns/assets/configuration/spec.yaml
+++ b/coredns/assets/configuration/spec.yaml
@@ -9,8 +9,10 @@ files:
     options:
     - template: instances/openmetrics
       overrides:
+        openmetrics_endpoint.display_priority: 1
         openmetrics_endpoint.required: false
         openmetrics_endpoint.value.example: http://%%host%%:9153/metrics
+        tags.display_priority: 1
         tags.value.example:
           - "dns-pod:%%host%%"
         extra_metrics.value.example:

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -51,6 +51,14 @@ instances:
     #
     # openmetrics_endpoint: http://%%host%%:9153/metrics
 
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    #
+    # tags:
+    #   - dns-pod:%%host%%
+
     ## @param raw_metric_prefix - string - optional
     ## A prefix that will be removed from all exposed metric names, if present.
     ## All configuration options will use the prefix-less name.
@@ -552,14 +560,6 @@ instances:
     ## Whether or not to allow URL redirection.
     #
     # allow_redirects: true
-
-    ## @param tags - list of strings - optional
-    ## A list of tags to attach to every metric and service check emitted by this instance.
-    ##
-    ## Learn more about tagging at https://docs.datadoghq.com/tagging
-    #
-    # tags:
-    #   - dns-pod:%%host%%
 
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.


### PR DESCRIPTION
### What does this PR do?
Reverts the display priority change for tags from https://github.com/DataDog/integrations-core/pull/11109/s, as it wasn't updated in https://github.com/DataDog/integrations-core/pull/11024/s and it's included in `auto_conf.yaml`
### Motivation
QA for https://github.com/DataDog/integrations-core/pull/11109/s
### Additional Notes
Sets display priority for `openmetrics_endpoint` since it should be at the top of the file
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
