### PR TITLE
Clarify `aws_host` config hostname

### DIFF
--- a/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
+++ b/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
@@ -254,7 +254,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
+++ b/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
@@ -254,6 +254,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
+++ b/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
@@ -255,6 +255,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -225,6 +225,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -225,7 +225,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -226,6 +226,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -486,6 +486,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -485,7 +485,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -485,6 +485,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/ambari/datadog_checks/ambari/data/conf.yaml.example
+++ b/ambari/datadog_checks/ambari/data/conf.yaml.example
@@ -254,7 +254,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/ambari/datadog_checks/ambari/data/conf.yaml.example
+++ b/ambari/datadog_checks/ambari/data/conf.yaml.example
@@ -254,6 +254,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/ambari/datadog_checks/ambari/data/conf.yaml.example
+++ b/ambari/datadog_checks/ambari/data/conf.yaml.example
@@ -255,6 +255,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -225,6 +225,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -225,7 +225,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -226,6 +226,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
+++ b/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
@@ -447,7 +447,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
+++ b/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
@@ -447,6 +447,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
+++ b/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
@@ -448,6 +448,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
@@ -361,6 +361,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
@@ -360,6 +360,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
@@ -360,7 +360,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/cilium/datadog_checks/cilium/data/conf.yaml.example
+++ b/cilium/datadog_checks/cilium/data/conf.yaml.example
@@ -453,6 +453,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/cilium/datadog_checks/cilium/data/conf.yaml.example
+++ b/cilium/datadog_checks/cilium/data/conf.yaml.example
@@ -452,6 +452,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/cilium/datadog_checks/cilium/data/conf.yaml.example
+++ b/cilium/datadog_checks/cilium/data/conf.yaml.example
@@ -452,7 +452,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
+++ b/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
@@ -225,6 +225,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
+++ b/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
@@ -225,7 +225,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
+++ b/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
@@ -226,6 +226,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -438,6 +438,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -437,6 +437,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -437,7 +437,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -308,6 +308,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -309,6 +309,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -308,7 +308,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -462,6 +462,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -463,6 +463,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -462,7 +462,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/couch/datadog_checks/couch/data/conf.yaml.example
+++ b/couch/datadog_checks/couch/data/conf.yaml.example
@@ -290,6 +290,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/couch/datadog_checks/couch/data/conf.yaml.example
+++ b/couch/datadog_checks/couch/data/conf.yaml.example
@@ -290,7 +290,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/couch/datadog_checks/couch/data/conf.yaml.example
+++ b/couch/datadog_checks/couch/data/conf.yaml.example
@@ -291,6 +291,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/couchbase/datadog_checks/couchbase/data/conf.yaml.example
+++ b/couchbase/datadog_checks/couchbase/data/conf.yaml.example
@@ -243,6 +243,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/couchbase/datadog_checks/couchbase/data/conf.yaml.example
+++ b/couchbase/datadog_checks/couchbase/data/conf.yaml.example
@@ -243,7 +243,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/couchbase/datadog_checks/couchbase/data/conf.yaml.example
+++ b/couchbase/datadog_checks/couchbase/data/conf.yaml.example
@@ -244,6 +244,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/crio/datadog_checks/crio/data/conf.yaml.example
+++ b/crio/datadog_checks/crio/data/conf.yaml.example
@@ -355,7 +355,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/crio/datadog_checks/crio/data/conf.yaml.example
+++ b/crio/datadog_checks/crio/data/conf.yaml.example
@@ -356,6 +356,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/crio/datadog_checks/crio/data/conf.yaml.example
+++ b/crio/datadog_checks/crio/data/conf.yaml.example
@@ -355,6 +355,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
@@ -201,7 +201,7 @@
     type: string
   description: |
     If your services require AWS Signature Version 4 signing, set the host.
-    This only needs the hostname and does not needs the protocol (http, https, etc).
+    This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
 
     Note: This setting is not necessary for official integrations.
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
@@ -201,6 +201,7 @@
     type: string
   description: |
     If your services require AWS Signature Version 4 signing, set the host.
+    This only needs the hostname and does not needs the protocol (http, https, etc).
 
     Note: This setting is not necessary for official integrations.
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
@@ -202,6 +202,7 @@
   description: |
     If your services require AWS Signature Version 4 signing, set the host.
     This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
 
     Note: This setting is not necessary for official integrations.
 

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
@@ -363,6 +363,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
@@ -364,6 +364,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
@@ -363,7 +363,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
@@ -355,7 +355,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
@@ -356,6 +356,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
@@ -355,6 +355,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/druid/datadog_checks/druid/data/conf.yaml.example
+++ b/druid/datadog_checks/druid/data/conf.yaml.example
@@ -225,6 +225,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/druid/datadog_checks/druid/data/conf.yaml.example
+++ b/druid/datadog_checks/druid/data/conf.yaml.example
@@ -225,7 +225,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/druid/datadog_checks/druid/data/conf.yaml.example
+++ b/druid/datadog_checks/druid/data/conf.yaml.example
@@ -226,6 +226,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
+++ b/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
@@ -221,6 +221,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
+++ b/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
@@ -221,7 +221,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
+++ b/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
@@ -222,6 +222,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
+++ b/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
@@ -221,6 +221,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
+++ b/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
@@ -221,7 +221,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
+++ b/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
@@ -222,6 +222,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -386,6 +386,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -386,7 +386,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -387,6 +387,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -448,7 +448,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -449,6 +449,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -448,6 +448,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -361,7 +361,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -362,6 +362,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -361,6 +361,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/external_dns/datadog_checks/external_dns/data/conf.yaml.example
+++ b/external_dns/datadog_checks/external_dns/data/conf.yaml.example
@@ -355,7 +355,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/external_dns/datadog_checks/external_dns/data/conf.yaml.example
+++ b/external_dns/datadog_checks/external_dns/data/conf.yaml.example
@@ -356,6 +356,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/external_dns/datadog_checks/external_dns/data/conf.yaml.example
+++ b/external_dns/datadog_checks/external_dns/data/conf.yaml.example
@@ -355,6 +355,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/fluentd/datadog_checks/fluentd/data/conf.yaml.example
+++ b/fluentd/datadog_checks/fluentd/data/conf.yaml.example
@@ -279,6 +279,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/fluentd/datadog_checks/fluentd/data/conf.yaml.example
+++ b/fluentd/datadog_checks/fluentd/data/conf.yaml.example
@@ -278,6 +278,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/fluentd/datadog_checks/fluentd/data/conf.yaml.example
+++ b/fluentd/datadog_checks/fluentd/data/conf.yaml.example
@@ -278,7 +278,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -327,6 +327,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -326,7 +326,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -326,6 +326,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -409,6 +409,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -410,6 +410,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -409,7 +409,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
+++ b/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
@@ -265,6 +265,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
+++ b/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
@@ -264,6 +264,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
+++ b/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
@@ -264,7 +264,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -502,7 +502,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -502,6 +502,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -503,6 +503,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/harbor/datadog_checks/harbor/data/conf.yaml.example
+++ b/harbor/datadog_checks/harbor/data/conf.yaml.example
@@ -228,6 +228,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/harbor/datadog_checks/harbor/data/conf.yaml.example
+++ b/harbor/datadog_checks/harbor/data/conf.yaml.example
@@ -227,7 +227,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/harbor/datadog_checks/harbor/data/conf.yaml.example
+++ b/harbor/datadog_checks/harbor/data/conf.yaml.example
@@ -227,6 +227,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -403,6 +403,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -402,7 +402,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -402,6 +402,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
@@ -231,7 +231,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
@@ -232,6 +232,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
@@ -231,6 +231,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
@@ -231,7 +231,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
@@ -232,6 +232,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
@@ -231,6 +231,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -386,6 +386,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -386,7 +386,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -387,6 +387,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
+++ b/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
@@ -226,6 +226,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
+++ b/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
@@ -227,6 +227,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
+++ b/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
@@ -226,7 +226,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -455,6 +455,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -454,6 +454,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -454,7 +454,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -447,7 +447,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -447,6 +447,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -448,6 +448,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -362,6 +362,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -363,6 +363,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -362,7 +362,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
@@ -397,6 +397,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
@@ -398,6 +398,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
@@ -397,7 +397,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
+++ b/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
@@ -355,7 +355,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
+++ b/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
@@ -356,6 +356,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
+++ b/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
@@ -355,6 +355,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
@@ -362,6 +362,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
@@ -363,6 +363,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
@@ -362,7 +362,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
+++ b/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
@@ -355,7 +355,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
+++ b/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
@@ -356,6 +356,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
+++ b/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
@@ -355,6 +355,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -376,7 +376,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -377,6 +377,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -376,6 +376,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
+++ b/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
@@ -230,6 +230,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
+++ b/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
@@ -230,7 +230,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
+++ b/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
@@ -231,6 +231,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
+++ b/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
@@ -225,6 +225,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
+++ b/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
@@ -225,7 +225,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
+++ b/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
@@ -226,6 +226,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/linkerd/datadog_checks/linkerd/data/conf.yaml.example
+++ b/linkerd/datadog_checks/linkerd/data/conf.yaml.example
@@ -438,6 +438,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/linkerd/datadog_checks/linkerd/data/conf.yaml.example
+++ b/linkerd/datadog_checks/linkerd/data/conf.yaml.example
@@ -437,6 +437,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/linkerd/datadog_checks/linkerd/data/conf.yaml.example
+++ b/linkerd/datadog_checks/linkerd/data/conf.yaml.example
@@ -437,7 +437,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
+++ b/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
@@ -287,7 +287,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
+++ b/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
@@ -287,6 +287,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
+++ b/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
@@ -288,6 +288,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/marathon/datadog_checks/marathon/data/conf.yaml.example
+++ b/marathon/datadog_checks/marathon/data/conf.yaml.example
@@ -276,6 +276,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/marathon/datadog_checks/marathon/data/conf.yaml.example
+++ b/marathon/datadog_checks/marathon/data/conf.yaml.example
@@ -277,6 +277,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/marathon/datadog_checks/marathon/data/conf.yaml.example
+++ b/marathon/datadog_checks/marathon/data/conf.yaml.example
@@ -276,7 +276,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/marklogic/datadog_checks/marklogic/data/conf.yaml.example
+++ b/marklogic/datadog_checks/marklogic/data/conf.yaml.example
@@ -250,6 +250,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/marklogic/datadog_checks/marklogic/data/conf.yaml.example
+++ b/marklogic/datadog_checks/marklogic/data/conf.yaml.example
@@ -249,6 +249,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/marklogic/datadog_checks/marklogic/data/conf.yaml.example
+++ b/marklogic/datadog_checks/marklogic/data/conf.yaml.example
@@ -249,7 +249,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
+++ b/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
@@ -231,7 +231,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
+++ b/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
@@ -232,6 +232,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
+++ b/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
@@ -231,6 +231,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
+++ b/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
@@ -248,7 +248,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
+++ b/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
@@ -248,6 +248,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
+++ b/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
@@ -249,6 +249,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/nginx/datadog_checks/nginx/data/conf.yaml.example
+++ b/nginx/datadog_checks/nginx/data/conf.yaml.example
@@ -269,7 +269,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/nginx/datadog_checks/nginx/data/conf.yaml.example
+++ b/nginx/datadog_checks/nginx/data/conf.yaml.example
@@ -270,6 +270,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/nginx/datadog_checks/nginx/data/conf.yaml.example
+++ b/nginx/datadog_checks/nginx/data/conf.yaml.example
@@ -269,6 +269,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -363,6 +363,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -364,6 +364,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -363,7 +363,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -484,6 +484,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -483,7 +483,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -483,6 +483,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
+++ b/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
@@ -261,7 +261,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
+++ b/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
@@ -262,6 +262,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
+++ b/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
@@ -261,6 +261,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
@@ -250,7 +250,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
@@ -251,6 +251,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
@@ -250,6 +250,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -317,6 +317,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -318,6 +318,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -317,7 +317,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/riak/datadog_checks/riak/data/conf.yaml.example
+++ b/riak/datadog_checks/riak/data/conf.yaml.example
@@ -225,6 +225,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/riak/datadog_checks/riak/data/conf.yaml.example
+++ b/riak/datadog_checks/riak/data/conf.yaml.example
@@ -225,7 +225,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/riak/datadog_checks/riak/data/conf.yaml.example
+++ b/riak/datadog_checks/riak/data/conf.yaml.example
@@ -226,6 +226,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -372,6 +372,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -373,6 +373,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -372,7 +372,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -316,6 +316,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -315,6 +315,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -315,7 +315,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -327,6 +327,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -326,7 +326,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -326,6 +326,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/squid/datadog_checks/squid/data/conf.yaml.example
+++ b/squid/datadog_checks/squid/data/conf.yaml.example
@@ -265,6 +265,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/squid/datadog_checks/squid/data/conf.yaml.example
+++ b/squid/datadog_checks/squid/data/conf.yaml.example
@@ -264,6 +264,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/squid/datadog_checks/squid/data/conf.yaml.example
+++ b/squid/datadog_checks/squid/data/conf.yaml.example
@@ -264,7 +264,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/teamcity/datadog_checks/teamcity/data/conf.yaml.example
+++ b/teamcity/datadog_checks/teamcity/data/conf.yaml.example
@@ -258,7 +258,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/teamcity/datadog_checks/teamcity/data/conf.yaml.example
+++ b/teamcity/datadog_checks/teamcity/data/conf.yaml.example
@@ -258,6 +258,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/teamcity/datadog_checks/teamcity/data/conf.yaml.example
+++ b/teamcity/datadog_checks/teamcity/data/conf.yaml.example
@@ -259,6 +259,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/twistlock/datadog_checks/twistlock/data/conf.yaml.example
+++ b/twistlock/datadog_checks/twistlock/data/conf.yaml.example
@@ -231,7 +231,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/twistlock/datadog_checks/twistlock/data/conf.yaml.example
+++ b/twistlock/datadog_checks/twistlock/data/conf.yaml.example
@@ -232,6 +232,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/twistlock/datadog_checks/twistlock/data/conf.yaml.example
+++ b/twistlock/datadog_checks/twistlock/data/conf.yaml.example
@@ -231,6 +231,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/vault/datadog_checks/vault/data/conf.yaml.example
+++ b/vault/datadog_checks/vault/data/conf.yaml.example
@@ -251,6 +251,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/vault/datadog_checks/vault/data/conf.yaml.example
+++ b/vault/datadog_checks/vault/data/conf.yaml.example
@@ -252,6 +252,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/vault/datadog_checks/vault/data/conf.yaml.example
+++ b/vault/datadog_checks/vault/data/conf.yaml.example
@@ -251,7 +251,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -562,7 +562,7 @@ instances:
 
         ## @param aws_host - string - optional
         ## If your services require AWS Signature Version 4 signing, set the host.
-        ## This only needs the hostname and does not needs the protocol (http, https, etc).
+        ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
         ##
         ## Note: This setting is not necessary for official integrations.
         ##

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -563,6 +563,7 @@ instances:
         ## @param aws_host - string - optional
         ## If your services require AWS Signature Version 4 signing, set the host.
         ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+        ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
         ##
         ## Note: This setting is not necessary for official integrations.
         ##

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -562,6 +562,7 @@ instances:
 
         ## @param aws_host - string - optional
         ## If your services require AWS Signature Version 4 signing, set the host.
+        ## This only needs the hostname and does not needs the protocol (http, https, etc).
         ##
         ## Note: This setting is not necessary for official integrations.
         ##

--- a/yarn/datadog_checks/yarn/data/conf.yaml.example
+++ b/yarn/datadog_checks/yarn/data/conf.yaml.example
@@ -306,6 +306,7 @@ instances:
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
     ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
+    ## For example, if connecting to https://us-east-1.amazonaws.com/, set `aws_host` to `us-east-1.amazonaws.com`.
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/yarn/datadog_checks/yarn/data/conf.yaml.example
+++ b/yarn/datadog_checks/yarn/data/conf.yaml.example
@@ -305,7 +305,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
-    ## This only needs the hostname and does not needs the protocol (http, https, etc).
+    ## This only needs the hostname and does not require the protocol (HTTP, HTTPS, and more).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##

--- a/yarn/datadog_checks/yarn/data/conf.yaml.example
+++ b/yarn/datadog_checks/yarn/data/conf.yaml.example
@@ -305,6 +305,7 @@ instances:
 
     ## @param aws_host - string - optional
     ## If your services require AWS Signature Version 4 signing, set the host.
+    ## This only needs the hostname and does not needs the protocol (http, https, etc).
     ##
     ## Note: This setting is not necessary for official integrations.
     ##


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR clarifies that the `aws_host` config does not require the protocol (http, https) of a URL in its value. 
### Motivation
<!-- What inspired you to submit this pull request? -->
Support case
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
