### PR TITLE
Improve documentation for metric groups

### DIFF
--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -202,6 +202,11 @@ To verify the result, search for the metrics using [Metrics Summary][10]:
 
 ## Data Collected
 
+<div class="alert alert-info"><bold>Note</bold>: Only metrics from the following metric groups are enabled by default: <code>snowflake.query.*</code>, <code>snowflake.billing.*</code>, <code>snowflake.storage.*</code>, and <code>snowflake.logins.*</code>.
+
+If you would like to collect metrics from other metric groups, please refer <a href="https://github.com/DataDog/integrations-core/blob/master/snowflake/datadog_checks/snowflake/data/conf.yaml.example">to the example config file for this integration</a>.
+</div>
+
 ### Metrics
 
 See [metadata.csv][13] for a list of metrics provided by this check.

--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -125,7 +125,7 @@ files:
             - snowflake.query (enabled by default)
             - snowflake.billing (enabled by default)
             - snowflake.storage (enabled by default)
-            - snowflake.storage.database 
+            - snowflake.storage.database
             - snowflake.storage.table
             - snowflake.logins (enabled by default)
             - snowflake.data_transfer

--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -122,12 +122,12 @@ files:
 
           The available metric groups are:
 
-            - snowflake.query
-            - snowflake.billing
-            - snowflake.storage
-            - snowflake.storage.database
+            - snowflake.query (enabled by default)
+            - snowflake.billing (enabled by default)
+            - snowflake.storage (enabled by default)
+            - snowflake.storage.database 
             - snowflake.storage.table
-            - snowflake.logins
+            - snowflake.logins (enabled by default)
             - snowflake.data_transfer
             - snowflake.auto_recluster
             - snowflake.pipe

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -128,12 +128,12 @@ instances:
     ##
     ## The available metric groups are:
     ##
-    ##   - snowflake.query
-    ##   - snowflake.billing
-    ##   - snowflake.storage
+    ##   - snowflake.query (enabled by default)
+    ##   - snowflake.billing (enabled by default)
+    ##   - snowflake.storage (enabled by default)
     ##   - snowflake.storage.database
     ##   - snowflake.storage.table
-    ##   - snowflake.logins
+    ##   - snowflake.logins (enabled by default)
     ##   - snowflake.data_transfer
     ##   - snowflake.auto_recluster
     ##   - snowflake.pipe


### PR DESCRIPTION
### What does this PR do?
Snowflake integration does not currently include details that explain what specific metrics are collected by default. This information is not clearly defined in our docs or the example `conf.yaml` file today. 

I was able to find the correct set of default metrics in the check code: https://github.com/DataDog/integrations-core/blob/master/snowflake/datadog_checks/snowflake/config.py#L15-L20

### Motivation
To add additional clarity and prevent confusion during setup. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
