### PR TITLE
Discover and validate defined projects

### DIFF
--- a/sonarqube/assets/configuration/spec.yaml
+++ b/sonarqube/assets/configuration/spec.yaml
@@ -58,6 +58,8 @@ files:
           items:
             type: string
       - name: components
+        required: true
+        enabled: false
         description: |
           The components for which metrics should be collected. Each object may override the default
           options. The following example gathers all default metrics for "some-project",

--- a/sonarqube/datadog_checks/sonarqube/__init__.py
+++ b/sonarqube/datadog_checks/sonarqube/__init__.py
@@ -2,6 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from .__about__ import __version__
-from .check import SonarqubeCheck
+from .sonarqube import SonarqubeCheck
 
 __all__ = ['__version__', 'SonarqubeCheck']

--- a/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
+++ b/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -72,10 +72,6 @@ def instance_aws_service(field, value):
 
 def instance_collect_default_jvm_metrics(field, value):
     return True
-
-
-def instance_components(field, value):
-    return get_default_field_value(field, value)
 
 
 def instance_connect_timeout(field, value):

--- a/sonarqube/datadog_checks/sonarqube/config_models/instance.py
+++ b/sonarqube/datadog_checks/sonarqube/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -56,7 +56,7 @@ class InstanceConfig(BaseModel):
     aws_region: Optional[str]
     aws_service: Optional[str]
     collect_default_jvm_metrics: Optional[bool]
-    components: Optional[Components]
+    components: Components
     connect_timeout: Optional[float]
     default_exclude: Optional[Sequence[str]]
     default_include: Optional[Sequence[str]]

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -124,7 +124,7 @@ instances:
     #
     # default_exclude: []
 
-    ## @param components - mapping - optional
+    ## @param components - mapping - required
     ## The components for which metrics should be collected. Each object may override the default
     ## options. The following example gathers all default metrics for "some-project",
     ## and only what is included/excluded for "another-project":

--- a/sonarqube/datadog_checks/sonarqube/sonarqube.py
+++ b/sonarqube/datadog_checks/sonarqube/sonarqube.py
@@ -36,29 +36,41 @@ class SonarqubeCheck(AgentCheck):
 
     def collect_metrics(self):
         available_metrics = self.discover_available_metrics()
+        components_available = self.discover_components_available()
+        components_notfound = []
 
         for component, (tag_name, should_collect_metric) in self._components.items():
-            keys_to_query = []
+            if component in components_available:
+                keys_to_query = []
 
-            for key, metric in available_metrics.items():
-                if should_collect_metric(metric):
-                    keys_to_query.append(key)
+                for key, metric in available_metrics.items():
+                    if should_collect_metric(metric):
+                        keys_to_query.append(key)
 
-            if not keys_to_query:
-                self.log.warning('Pattern for component `%s` does not match any available metrics', component)
+                if not keys_to_query:
+                    self.log.warning('Pattern for component `%s` does not match any available metrics.', component)
 
-            response = self.http.get(
-                '{}/api/measures/component'.format(self._web_endpoint),
-                params={'component': component, 'metricKeys': ','.join(keys_to_query)},
+                self.log.debug('Querying metricKeys for component `%s`', component)
+                response = self.http.get(
+                    '{}/api/measures/component'.format(self._web_endpoint),
+                    params={'component': component, 'metricKeys': ','.join(keys_to_query)},
+                )
+                response.raise_for_status()
+                metric_data = response.json()
+
+                for measure in metric_data['component']['measures']:
+                    tags = ['{}:{}'.format(tag_name, component)]
+                    tags.extend(self._tags)
+
+                    self.gauge(available_metrics[measure['metric']], measure['value'], tags=tags)
+            else:
+                components_notfound.append(component)
+
+        if components_notfound:
+            self.log.warning(
+                'The following components specified did not match any available components: %s',
+                components_notfound,
             )
-            response.raise_for_status()
-            metric_data = response.json()
-
-            for measure in metric_data['component']['measures']:
-                tags = ['{}:{}'.format(tag_name, component)]
-                tags.extend(self._tags)
-
-                self.gauge(available_metrics[measure['metric']], measure['value'], tags=tags)
 
     def discover_available_metrics(self):
         metadata_collected = False
@@ -98,6 +110,35 @@ class SonarqubeCheck(AgentCheck):
             page += 1
 
         return available_metrics
+
+    def discover_components_available(self):
+        #  https://next.sonarqube.com/sonarqube/web_api/api/components/search
+        components_available = list()
+
+        page = 1
+        seen = 0
+        total = -1
+
+        while seen != total:
+            response = self.http.get(
+                '{}/api/components/search'.format(self._web_endpoint), params={'qualifiers': 'TRK', 'p': page}
+            )
+            response.raise_for_status()
+
+            search_results = response.json()
+            if total < 0:
+                total = search_results.get('paging', page).get('total', page)
+
+            for component in search_results['components']:
+                seen += 1
+
+                components_available.append(component['key'])
+
+            page += 1
+
+        self.log.debug("Available components: %s", components_available)
+
+        return components_available
 
     @AgentCheck.metadata_entrypoint
     def collect_version(self, response):


### PR DESCRIPTION
### What does this PR do?

- Discovers available projects/components and logs them at debug level.
- Logs a warning if projects/components defined in config were not found.

### Motivation
- As of current, if an invalid project/component is specified, the integration does not return any metrics and no indication why. Looking in the logs, we get an HTTP error 404
- AGENT-7116

### Additional Notes
- List of available components is queried from the API and is logged on debug mode

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
