### PR TITLE
Fix test to add events_statements_cpu consumer for the correct MySQL versions

### DIFF
--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -676,7 +676,11 @@ def test_statement_samples_enable_consumers(dd_run_check, dbm_instance, root_con
         )
 
     original_enabled_consumers = mysql_check._statement_samples._get_enabled_performance_schema_consumers()
-    assert original_enabled_consumers == {'events_statements_current', 'events_statements_history'}
+    expected_enabled_consumers = {'events_statements_current', 'events_statements_history'}
+    # CPU consumer was added in MySQL 8.0.28
+    if mysql_check.version.version_compatible((8, 0, 28)):
+        expected_enabled_consumers.union({'events_statements_cpu'})
+    assert original_enabled_consumers == expected_enabled_consumers
 
     dd_run_check(mysql_check)
 

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -668,6 +668,9 @@ def test_statement_samples_enable_consumers(dd_run_check, dbm_instance, root_con
     dbm_instance['query_samples']['events_statements_enable_procedure'] = events_statements_enable_procedure
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
+    all_consumers = {'events_statements_current', 'events_statements_history', 'events_statements_history_long'}
+    all_consumers_gt_8_0_28 = all_consumers.union({'events_statements_cpu'})  # CPU consumer was added in MySQL 8.0.28
+
     # deliberately disable one of the consumers
     consumer_to_disable = 'events_statements_history_long'
     with closing(root_conn.cursor()) as cursor:
@@ -683,13 +686,10 @@ def test_statement_samples_enable_consumers(dd_run_check, dbm_instance, root_con
 
     enabled_consumers = mysql_check._statement_samples._get_enabled_performance_schema_consumers()
     if events_statements_enable_procedure == "datadog.enable_events_statements_consumers":
-        expected_consumers = original_enabled_consumers.union({consumer_to_disable})
-        # CPU consumer was added in MySQL 8.0.28
-        if mysql_check.version.version_compatible((8, 0, 28)):
-            expected_consumers.union({'events_statements_cpu'})
-
-        assert enabled_consumers == expected_consumers
+        # ensure that the consumer was re-enabled by the check run
+        assert enabled_consumers == all_consumers or enabled_consumers == all_consumers_gt_8_0_28
     else:
+        # the consumer should not have been re-enabled
         assert enabled_consumers == original_enabled_consumers
 
 

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -682,7 +682,12 @@ def test_statement_samples_enable_consumers(dd_run_check, dbm_instance, root_con
 
     enabled_consumers = mysql_check._statement_samples._get_enabled_performance_schema_consumers()
     if events_statements_enable_procedure == "datadog.enable_events_statements_consumers":
-        assert enabled_consumers == original_enabled_consumers.union({'events_statements_history_long'})
+        expected_consumers = original_enabled_consumers.union({'events_statements_history_long'})
+        # CPU consumer was added in MySQL 8.0.28
+        if mysql_check.version.version_compatible((8, 0, 28)):
+            expected_consumers.union({'events_statements_cpu'})
+
+        assert enabled_consumers == expected_consumers
     else:
         assert enabled_consumers == original_enabled_consumers
 


### PR DESCRIPTION
### What does this PR do?

8.0.28 released a new consumer for CPU time: 

https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-28.html

This PR addresses the tests where it is expected but not available on newer versions.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
