### PR TITLE
Reload bearer token from disk to work with kubernetes bound-service-a…

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/base_check.py
@@ -139,6 +139,8 @@ class OpenMetricsBaseCheck(OpenMetricsScraperMixin, AgentCheck):
                 "You have to collect at least one metric from the endpoint: {}".format(scraper_config['prometheus_url'])
             )
 
+        scraper_config['_bearer_token'] = self._get_bearer_token(scraper_config['bearer_token_auth'], scraper_config['bearer_token_path'])
+
         self.process(scraper_config)
 
     def get_scraper_config(self, instance):

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -110,6 +110,12 @@ class KubeAPIServerMetricsCheck(OpenMetricsBaseCheck):
         if not self.kube_apiserver_config['metrics_mapper']:
             url = self.kube_apiserver_config['prometheus_url']
             raise CheckException("You have to collect at least one metric from the endpoint: {}".format(url))
+
+        # reload from path in case the token was refreshed
+        # see https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/1205-bound-service-account-tokens/README.md
+        # same as datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+        self.kube_apiserver_config['_bearer_token'] = self._get_bearer_token(self.kube_apiserver_config['bearer_token_auth'], self.kube_apiserver_config['bearer_token_path'])
+
         self.process(self.kube_apiserver_config, metric_transformers=self.metric_transformers)
 
     def get_scraper_config(self, instance):

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
@@ -142,6 +142,10 @@ class KubeControllerManagerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
         # Get the configuration for this specific instance
         scraper_config = self.get_scraper_config(instance)
 
+        # TODO: load given token path when set
+        token = open('/var/run/secrets/kubernetes.io/serviceaccount/token', 'r').read().rstrip()
+        scraper_config['_bearer_token'] = token
+
         # Populate the metric transformers dict
         transformers = {}
         limiters = self.DEFAUT_RATE_LIMITERS + instance.get("extra_limiters", [])

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -344,6 +344,10 @@ class KubeletCheck(
         self.process_stats_summary(
             self.pod_list_utils, self.stats, self.instance_tags, self.use_stats_summary_as_source
         )
+        # TODO: load given token path when set
+        token = open('/var/run/secrets/kubernetes.io/serviceaccount/token', 'r').read().rstrip()
+        self.cadvisor_scraper_config['_bearer_token'] = token
+        self.kubelet_scraper_config['_bearer_token'] = token
 
         if self.cadvisor_legacy_url:  # Legacy cAdvisor
             self.log.debug('processing legacy cadvisor metrics')


### PR DESCRIPTION
…ccount-tokens

### What does this PR do?
fixes https://github.com/DataDog/datadog-agent/issues/10604
... still need to confirm this works
... also needs to be an opt-in flag since this check could be used for anything

### Motivation
the token on disk is expired every 1h by kubernetes so we need to reload it

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
