### PR TITLE
kube_scheduler: do not validate ssl certificate by default with auto-conf

### DIFF
--- a/kube_scheduler/assets/configuration/spec.yaml
+++ b/kube_scheduler/assets/configuration/spec.yaml
@@ -89,6 +89,8 @@ files:
         example: /var/run/secrets/kubernetes.io/serviceaccount/token
     - name: ssl_verify
       description: Used to verify self signed certificates.
+      enabled: true
       value:
         type: boolean
-        example: true
+        example: false
+        display_default: true

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/auto_conf.yaml
@@ -45,4 +45,4 @@ instances:
     ## @param ssl_verify - boolean - optional - default: true
     ## Used to verify self signed certificates.
     #
-    # ssl_verify: true
+    ssl_verify: false


### PR DESCRIPTION
### What does this PR do?

Set `ssl_verify: false` in `conf.d/kube_scheduler.d/auto_conf.yaml`.

### Motivation

The goal of the default configuration in `auto_conf.yaml` files is to make as much checks as possible work out of the box.
With Kubernetes, it’s not uncommon to have setups using self-signed certificates or certificates signed by CA the cert of which is not available inside the datadog agent container. In order to show as much value as possible with the minimum of user configuration, we can disable ssl certificate validation.

That’s already what we do for the checks of other Kubernetes control plane components. Ex for `kube_controller_manager`: https://github.com/DataDog/integrations-core/blob/3616496318dae81470aa66a6c5e2c822a1a1b88e/kube_controller_manager/datadog_checks/kube_controller_manager/data/auto_conf.yaml#L43

### Additional Notes

This fixes a regression introduced by: https://github.com/DataDog/integrations-core/pull/10382/files#diff-69463f598e0e713aefaacd109c085ecfcf8a94908982d818b4cc3629e390ce42R48

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
