### PR TITLE
Remove new kube proxy metric with high cardinality

### DIFF
--- a/kube_proxy/datadog_checks/kube_proxy/kube_proxy.py
+++ b/kube_proxy/datadog_checks/kube_proxy/kube_proxy.py
@@ -8,7 +8,6 @@ METRICS = {
     'process_resident_memory_bytes': 'mem.resident',
     'process_virtual_memory_bytes': 'mem.virtual',
     # Alpha metrics
-    'kubeproxy_network_programming_duration_seconds': 'network_programming.duration',
     'kubeproxy_sync_proxy_rules_duration_seconds': 'sync_proxy.rules.duration',
     'kubeproxy_sync_proxy_rules_endpoint_changes_pending': 'sync_proxy.rules.endpoint_changes.pending',
     'kubeproxy_sync_proxy_rules_endpoint_changes_total': 'sync_proxy.rules.endpoint_changes.total',

--- a/kube_proxy/tests/test_kube_proxy_1_21_1.py
+++ b/kube_proxy/tests/test_kube_proxy_1_21_1.py
@@ -63,8 +63,6 @@ def test_check_iptables(aggregator, mock_iptables):
     )
     aggregator.assert_metric(NAMESPACE + '.sync_proxy.rules.duration.count')
     aggregator.assert_metric(NAMESPACE + '.sync_proxy.rules.duration.sum')
-    aggregator.assert_metric(NAMESPACE + '.network_programming.duration.count')
-    aggregator.assert_metric(NAMESPACE + '.network_programming.duration.sum')
     aggregator.assert_metric(NAMESPACE + '.rest.client.exec_plugin.certificate.rotation.count')
     aggregator.assert_metric(NAMESPACE + '.rest.client.exec_plugin.certificate.rotation.sum')
     aggregator.assert_metric(NAMESPACE + '.rest.client.request.duration.count')


### PR DESCRIPTION
### What does this PR do?
Removes network_programming metric for now as it results in a high number of tags.

Related to https://github.com/DataDog/integrations-core/pull/11052

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
