### PR TITLE
Add `dynamic_queue_name` config option

### DIFF
--- a/ibm_mq/assets/configuration/spec.yaml
+++ b/ibm_mq/assets/configuration/spec.yaml
@@ -88,7 +88,6 @@ files:
       - name: dynamic_queue_name
         description: |
           Specify a dynamic queue name for the reply-to queue. By default, pymqi sets the dynamic queue to 'PYMQPCF.*'.
-          See https://github.com/dsuch/pymqi/blob/061492082248989436d174c8a081b51a922c6e6a/code/pymqi/__init__.py#L2805
         value:
           example: 'PYMQPCF.*'
           type: string

--- a/ibm_mq/assets/configuration/spec.yaml
+++ b/ibm_mq/assets/configuration/spec.yaml
@@ -87,7 +87,7 @@ files:
             type: string
       - name: dynamic_queue_name
         description: |
-          Specify a dynamic queue name for the reply-to queue. By default, pymqi sets the dynamic queue to 'PYMQPCF.*'.
+          Specify a dynamic queue name for the reply-to queue. By default, the dynamic queue is set to 'PYMQPCF.*'.
         value:
           example: 'PYMQPCF.*'
           type: string

--- a/ibm_mq/assets/configuration/spec.yaml
+++ b/ibm_mq/assets/configuration/spec.yaml
@@ -85,6 +85,12 @@ files:
           type: array
           items:
             type: string
+      - name: dynamic_queue_name
+        description: |
+          Specify a dynamic queue name.
+        value:
+          example: 'PYMQPCF.*'
+          type: string
       - name: channels
         description: Check the status of the following channels
         value:

--- a/ibm_mq/assets/configuration/spec.yaml
+++ b/ibm_mq/assets/configuration/spec.yaml
@@ -87,7 +87,8 @@ files:
             type: string
       - name: dynamic_queue_name
         description: |
-          Specify a dynamic queue name.
+          Specify a dynamic queue name for the reply-to queue. By default, pymqi sets the dynamic queue to 'PYMQPCF.*'.
+          See https://github.com/dsuch/pymqi/blob/061492082248989436d174c8a081b51a922c6e6a/code/pymqi/__init__.py#L2805
         value:
           example: 'PYMQPCF.*'
           type: string

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -48,7 +48,7 @@ class ChannelMetricCollector(object):
         args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ensure_bytes('*')}
         try:
             pcf = pymqi.PCFExecute(
-                queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
             )
             response = pcf.MQCMD_INQUIRE_CHANNEL(args)
         except pymqi.MQMIError as e:
@@ -92,7 +92,7 @@ class ChannelMetricCollector(object):
         try:
             args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ensure_bytes(search_channel_name)}
             pcf = pymqi.PCFExecute(
-                queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
             )
             response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(args)
             self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.OK, search_channel_tags)

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -48,7 +48,10 @@ class ChannelMetricCollector(object):
         args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ensure_bytes('*')}
         try:
             pcf = pymqi.PCFExecute(
-                queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager,
+                dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name),
+                response_wait_interval=self.config.timeout,
+                convert=self.config.convert_endianness,
             )
             response = pcf.MQCMD_INQUIRE_CHANNEL(args)
         except pymqi.MQMIError as e:
@@ -92,7 +95,10 @@ class ChannelMetricCollector(object):
         try:
             args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ensure_bytes(search_channel_name)}
             pcf = pymqi.PCFExecute(
-                queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager,
+                dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name),
+                response_wait_interval=self.config.timeout,
+                convert=self.config.convert_endianness,
             )
             response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(args)
             self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.OK, search_channel_tags)

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -48,7 +48,7 @@ class ChannelMetricCollector(object):
         args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ensure_bytes('*')}
         try:
             pcf = pymqi.PCFExecute(
-                queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
             )
             response = pcf.MQCMD_INQUIRE_CHANNEL(args)
         except pymqi.MQMIError as e:
@@ -92,7 +92,7 @@ class ChannelMetricCollector(object):
         try:
             args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ensure_bytes(search_channel_name)}
             pcf = pymqi.PCFExecute(
-                queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
             )
             response = pcf.MQCMD_INQUIRE_CHANNEL_STATUS(args)
             self.service_check(self.CHANNEL_SERVICE_CHECK, AgentCheck.OK, search_channel_tags)

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/metadata_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/metadata_collector.py
@@ -28,7 +28,7 @@ class MetadataCollector(object):
 
     def _get_version(self, queue_manager):
         pcf = pymqi.PCFExecute(
-            queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+            queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
         )
         resp = pcf.MQCMD_INQUIRE_Q_MGR({pymqi.CMQCFC.MQIACF_Q_MGR_ATTRS: [pymqi.CMQC.MQCA_VERSION]})
 

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/metadata_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/metadata_collector.py
@@ -28,7 +28,10 @@ class MetadataCollector(object):
 
     def _get_version(self, queue_manager):
         pcf = pymqi.PCFExecute(
-            queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+            queue_manager,
+            dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name),
+            response_wait_interval=self.config.timeout,
+            convert=self.config.convert_endianness,
         )
         resp = pcf.MQCMD_INQUIRE_Q_MGR({pymqi.CMQCFC.MQIACF_Q_MGR_ATTRS: [pymqi.CMQC.MQCA_VERSION]})
 

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/metadata_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/metadata_collector.py
@@ -28,7 +28,7 @@ class MetadataCollector(object):
 
     def _get_version(self, queue_manager):
         pcf = pymqi.PCFExecute(
-            queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+            queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
         )
         resp = pcf.MQCMD_INQUIRE_Q_MGR({pymqi.CMQCFC.MQIACF_Q_MGR_ATTRS: [pymqi.CMQC.MQCA_VERSION]})
 

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
@@ -93,7 +93,10 @@ class QueueMetricCollector(object):
             pcf = None
             try:
                 pcf = pymqi.PCFExecute(
-                    queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                    queue_manager,
+                    dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name),
+                    response_wait_interval=self.config.timeout,
+                    convert=self.config.convert_endianness,
                 )
                 response = pcf.MQCMD_INQUIRE_Q(args)
             except pymqi.MQMIError as e:
@@ -150,7 +153,10 @@ class QueueMetricCollector(object):
         try:
             args = {pymqi.CMQC.MQCA_Q_NAME: pymqi.ensure_bytes(queue_name), pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_ALL}
             pcf = pymqi.PCFExecute(
-                queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager,
+                dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name),
+                response_wait_interval=self.config.timeout,
+                convert=self.config.convert_endianness,
             )
             response = pcf.MQCMD_INQUIRE_Q(args)
         except pymqi.MQMIError as e:
@@ -193,7 +199,10 @@ class QueueMetricCollector(object):
                 pymqi.CMQCFC.MQIACF_Q_STATUS_ATTRS: pymqi.CMQCFC.MQIACF_ALL,
             }
             pcf = pymqi.PCFExecute(
-                queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager,
+                dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name),
+                response_wait_interval=self.config.timeout,
+                convert=self.config.convert_endianness,
             )
             response = pcf.MQCMD_INQUIRE_Q_STATUS(args)
         except pymqi.MQMIError as e:
@@ -243,7 +252,10 @@ class QueueMetricCollector(object):
         try:
             args = {pymqi.CMQC.MQCA_Q_NAME: pymqi.ensure_bytes(queue_name)}
             pcf = pymqi.PCFExecute(
-                queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager,
+                dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name),
+                response_wait_interval=self.config.timeout,
+                convert=self.config.convert_endianness,
             )
             response = pcf.MQCMD_RESET_Q_STATS(args)
         except pymqi.MQMIError as e:

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
@@ -93,7 +93,7 @@ class QueueMetricCollector(object):
             pcf = None
             try:
                 pcf = pymqi.PCFExecute(
-                    queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                    queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
                 )
                 response = pcf.MQCMD_INQUIRE_Q(args)
             except pymqi.MQMIError as e:
@@ -150,7 +150,7 @@ class QueueMetricCollector(object):
         try:
             args = {pymqi.CMQC.MQCA_Q_NAME: pymqi.ensure_bytes(queue_name), pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_ALL}
             pcf = pymqi.PCFExecute(
-                queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
             )
             response = pcf.MQCMD_INQUIRE_Q(args)
         except pymqi.MQMIError as e:
@@ -193,7 +193,7 @@ class QueueMetricCollector(object):
                 pymqi.CMQCFC.MQIACF_Q_STATUS_ATTRS: pymqi.CMQCFC.MQIACF_ALL,
             }
             pcf = pymqi.PCFExecute(
-                queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
             )
             response = pcf.MQCMD_INQUIRE_Q_STATUS(args)
         except pymqi.MQMIError as e:
@@ -243,7 +243,7 @@ class QueueMetricCollector(object):
         try:
             args = {pymqi.CMQC.MQCA_Q_NAME: pymqi.ensure_bytes(queue_name)}
             pcf = pymqi.PCFExecute(
-                queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager, dynamic_queue_name=pymqi.ensure_bytes(self.config.dynamic_queue_name), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
             )
             response = pcf.MQCMD_RESET_Q_STATS(args)
         except pymqi.MQMIError as e:

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/queue_metric_collector.py
@@ -93,7 +93,7 @@ class QueueMetricCollector(object):
             pcf = None
             try:
                 pcf = pymqi.PCFExecute(
-                    queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                    queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
                 )
                 response = pcf.MQCMD_INQUIRE_Q(args)
             except pymqi.MQMIError as e:
@@ -150,7 +150,7 @@ class QueueMetricCollector(object):
         try:
             args = {pymqi.CMQC.MQCA_Q_NAME: pymqi.ensure_bytes(queue_name), pymqi.CMQC.MQIA_Q_TYPE: pymqi.CMQC.MQQT_ALL}
             pcf = pymqi.PCFExecute(
-                queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
             )
             response = pcf.MQCMD_INQUIRE_Q(args)
         except pymqi.MQMIError as e:
@@ -193,7 +193,7 @@ class QueueMetricCollector(object):
                 pymqi.CMQCFC.MQIACF_Q_STATUS_ATTRS: pymqi.CMQCFC.MQIACF_ALL,
             }
             pcf = pymqi.PCFExecute(
-                queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
             )
             response = pcf.MQCMD_INQUIRE_Q_STATUS(args)
         except pymqi.MQMIError as e:
@@ -243,7 +243,7 @@ class QueueMetricCollector(object):
         try:
             args = {pymqi.CMQC.MQCA_Q_NAME: pymqi.ensure_bytes(queue_name)}
             pcf = pymqi.PCFExecute(
-                queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
+                queue_manager, dynamic_queue_name=bytearray(self.config.dynamic_queue_name, "utf-8"), response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
             )
             response = pcf.MQCMD_RESET_Q_STATS(args)
         except pymqi.MQMIError as e:

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -70,6 +70,7 @@ class IBMMQConfig:
         self.queues = instance.get('queues', [])  # type: List[str]
         self.queue_patterns = instance.get('queue_patterns', [])  # type: List[str]
         self.queue_regex = [re.compile(regex) for regex in instance.get('queue_regex', [])]  # type: List[Pattern]
+        self.dynamic_queue_name = instance.get('dynamic_queue_name', 'PYMQPCF.*')  # type: str
 
         self.auto_discover_queues = is_affirmative(instance.get('auto_discover_queues', False))  # type: bool
 

--- a/ibm_mq/datadog_checks/ibm_mq/config_models/defaults.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2022-present
+# (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 

--- a/ibm_mq/datadog_checks/ibm_mq/config_models/defaults.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config_models/defaults.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -40,6 +40,10 @@ def instance_convert_endianness(field, value):
 
 def instance_disable_generic_tags(field, value):
     return False
+
+
+def instance_dynamic_queue_name(field, value):
+    return 'PYMQPCF.*'
 
 
 def instance_empty_default_hostname(field, value):

--- a/ibm_mq/datadog_checks/ibm_mq/config_models/instance.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2022-present
+# (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 

--- a/ibm_mq/datadog_checks/ibm_mq/config_models/instance.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config_models/instance.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -31,6 +31,7 @@ class InstanceConfig(BaseModel):
     connection_name: Optional[str]
     convert_endianness: Optional[bool]
     disable_generic_tags: Optional[bool]
+    dynamic_queue_name: Optional[str]
     empty_default_hostname: Optional[bool]
     host: Optional[str]
     min_collection_interval: Optional[float]

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -82,6 +82,11 @@ instances:
     #   - ^DEV\..*$
     #   - ^SYSTEM\..*$
 
+    ## @param dynamic_queue_name - string - optional - default: PYMQPCF.*
+    ## Specify a dynamic queue name.
+    #
+    # dynamic_queue_name: PYMQPCF.*
+
     ## @param channels - list of strings - optional
     ## Check the status of the following channels
     #

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -83,7 +83,8 @@ instances:
     #   - ^SYSTEM\..*$
 
     ## @param dynamic_queue_name - string - optional - default: PYMQPCF.*
-    ## Specify a dynamic queue name.
+    ## Specify a dynamic queue name for the reply-to queue. By default, pymqi sets the dynamic queue to 'PYMQPCF.*'.
+    ## See https://github.com/dsuch/pymqi/blob/061492082248989436d174c8a081b51a922c6e6a/code/pymqi/__init__.py#L2805
     #
     # dynamic_queue_name: PYMQPCF.*
 

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -84,7 +84,6 @@ instances:
 
     ## @param dynamic_queue_name - string - optional - default: PYMQPCF.*
     ## Specify a dynamic queue name for the reply-to queue. By default, pymqi sets the dynamic queue to 'PYMQPCF.*'.
-    ## See https://github.com/dsuch/pymqi/blob/061492082248989436d174c8a081b51a922c6e6a/code/pymqi/__init__.py#L2805
     #
     # dynamic_queue_name: PYMQPCF.*
 

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -83,7 +83,7 @@ instances:
     #   - ^SYSTEM\..*$
 
     ## @param dynamic_queue_name - string - optional - default: PYMQPCF.*
-    ## Specify a dynamic queue name for the reply-to queue. By default, pymqi sets the dynamic queue to 'PYMQPCF.*'.
+    ## Specify a dynamic queue name for the reply-to queue. By default, the dynamic queue is set to 'PYMQPCF.*'.
     #
     # dynamic_queue_name: PYMQPCF.*
 

--- a/ibm_mq/tests/common.py
+++ b/ibm_mq/tests/common.py
@@ -89,7 +89,7 @@ INSTANCE_CUSTOM_DYNAMIC_QUEUE = {
     'channels': [CHANNEL, BAD_CHANNEL],
     'auto_discover_queues': True,
     'collect_statistics_metrics': True,
-    'dynamic_queue_name': 'TEST.DYNAMIC.QUEUE'  # custom dynamic queue name
+    'dynamic_queue_name': 'TEST.DYNAMIC.QUEUE',  # custom dynamic queue name
 }
 
 INSTANCE_METADATA = {

--- a/ibm_mq/tests/common.py
+++ b/ibm_mq/tests/common.py
@@ -78,6 +78,20 @@ INSTANCE_SSL = {
     'ssl_certificate_label': SSL_CLIENT_LABEL,
 }
 
+INSTANCE_CUSTOM_DYNAMIC_QUEUE = {
+    'channel': CHANNEL,
+    'queue_manager': QUEUE_MANAGER,
+    'host': HOST,
+    'port': PORT,
+    'username': USERNAME,
+    'password': PASSWORD,
+    'queues': [QUEUE],
+    'channels': [CHANNEL, BAD_CHANNEL],
+    'auto_discover_queues': True,
+    'collect_statistics_metrics': True,
+    'dynamic_queue_name': 'TEST.DYNAMIC.QUEUE'  # custom dynamic queue name
+}
+
 INSTANCE_METADATA = {
     'channel': CHANNEL,
     'queue_manager': QUEUE_MANAGER,

--- a/ibm_mq/tests/conftest.py
+++ b/ibm_mq/tests/conftest.py
@@ -39,6 +39,12 @@ def instance_ssl():
 
 
 @pytest.fixture
+def instance_dynamic_queue():
+    inst = copy.deepcopy(common.INSTANCE_CUSTOM_DYNAMIC_QUEUE)
+    return inst
+
+
+@pytest.fixture
 def instance_with_connection_name():
     inst = copy.deepcopy(common.INSTANCE_WITH_CONNECTION_NAME)
     return inst

--- a/ibm_mq/tests/test_ibm_mq_int.py
+++ b/ibm_mq/tests/test_ibm_mq_int.py
@@ -330,7 +330,7 @@ def test_check_custom_dynamic_queue(aggregator, get_check, instance_dynamic_queu
         'connection_name:{}({})'.format(common.HOST, common.PORT),
         'definition_type:temporary_dynamic',
         'queue_type:local',
-        'queue:TEST.DYNAMIC.QUEUE'
+        'queue:TEST.DYNAMIC.QUEUE',
     ]
 
     # Queue stats metrics are not present in every check run


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add a new config option for IBM MQ to allow a custom `dynamic_queue_name` to be used rather than the default `PYMQPCF.*`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Customer request

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
