### PR TITLE
Fix configuration error for custom queries

### DIFF
--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -71,8 +71,8 @@ class SnowflakeCheck(AgentCheck):
 
         if self.errors:
             self.log.warning('Invalid metric_groups found in snowflake conf.yaml: %s', (', '.join(self.errors)))
-        if not self.metric_queries:
-            raise ConfigurationError('No valid metric_groups configured, please list at least one.')
+        if not self.metric_queries and not self._config.custom_queries_defined:
+            raise ConfigurationError('No valid metric_groups or custom query configured, please list at least one.')
 
         self._query_manager = QueryManager(self, self.execute_query_raw, queries=self.metric_queries, tags=self._tags)
         self.check_initializations.append(self._query_manager.compile_queries)

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -42,6 +42,7 @@ class Config(object):
         token = instance.get('token', None)
         client_keep_alive = instance.get('client_session_keep_alive', False)
         aggregate_last_24_hours = instance.get('aggregate_last_24_hours', False)
+        custom_queries_defined = len(instance.get('custom_queries', [])) > 0
 
         metric_groups = instance.get('metric_groups', self.DEFAULT_METRIC_GROUP)
 
@@ -89,3 +90,4 @@ class Config(object):
         self.token = token
         self.client_keep_alive = client_keep_alive
         self.aggregate_last_24_hours = aggregate_last_24_hours
+        self.custom_queries_defined = custom_queries_defined


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
An instance can be configured to run custom queries only, so `metric_groups` can be set as empty

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
