### PR TITLE
Fix relations config parsing when multiple relations are specified

### DIFF
--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -310,7 +310,7 @@ class RelationsManager(object):
     @staticmethod
     def _build_relations_config(yamlconfig):
         # type:  (List[Union[str, Dict]]) -> List[Dict[str, Any]]
-        """Builds a dictionary from relations configuration while maintaining compatibility"""
+        """Builds a list from relations configuration while maintaining compatibility"""
         relations = []
         for element in yamlconfig:
             config = {}

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -259,7 +259,7 @@ class RelationsManager(object):
         # type (str, str) -> str
         """Build a WHERE clause filtering relations based on relations_config and applies it to the given query"""
         relations_filter = []
-        for r in self.config.values():
+        for r in self.config:
             relation_filter = []
             if r.get(RELATION_NAME):
                 relation_filter.append("( relname = '{}'".format(r[RELATION_NAME]))
@@ -267,11 +267,11 @@ class RelationsManager(object):
                 relation_filter.append("( relname ~ '{}'".format(r[RELATION_REGEX]))
 
             if ALL_SCHEMAS not in r[SCHEMAS]:
-                schema_filter = ' ,'.join("'{}'".format(s) for s in r[SCHEMAS])
+                schema_filter = ','.join("'{}'".format(s) for s in r[SCHEMAS])
                 relation_filter.append('AND {} = ANY(array[{}]::text[])'.format(schema_field, schema_filter))
 
             if r.get(RELKIND) and 'FROM pg_locks' in query:
-                relkind_filter = ' ,'.join("'{}'".format(s) for s in r[RELKIND])
+                relkind_filter = ','.join("'{}'".format(s) for s in r[RELKIND])
                 relation_filter.append('AND relkind = ANY(array[{}])'.format(relkind_filter))
 
             relation_filter.append(')')
@@ -309,18 +309,16 @@ class RelationsManager(object):
 
     @staticmethod
     def _build_relations_config(yamlconfig):
-        # type:  (List[Union[str, Dict]]) -> Dict[str, Dict[str, Any]]
+        # type:  (List[Union[str, Dict]]) -> List[Dict[str, Any]]
         """Builds a dictionary from relations configuration while maintaining compatibility"""
-        config = {}
+        relations = []
         for element in yamlconfig:
+            config = {}
             if isinstance(element, str):
-                config[element] = {RELATION_NAME: element, SCHEMAS: [ALL_SCHEMAS]}
+                config = {RELATION_NAME: element, SCHEMAS: [ALL_SCHEMAS]}
             elif isinstance(element, dict):
-                relname = str(element.get(RELATION_NAME))  # type: str
-                rel_regex = str(element.get(RELATION_REGEX))  # type: str
-                schemas = element.get(SCHEMAS, [])  # type: List
-                name = relname or rel_regex  # type: str
-                config[name] = element.copy()
-                if len(schemas) == 0:
-                    config[name][SCHEMAS] = [ALL_SCHEMAS]
-        return config
+                config = element.copy()
+                if len(config.get(SCHEMAS, [])) == 0:
+                    config[SCHEMAS] = [ALL_SCHEMAS]
+            relations.append(config)
+        return relations

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -270,6 +270,7 @@ class RelationsManager(object):
                 schema_filter = ','.join("'{}'".format(s) for s in r[SCHEMAS])
                 relation_filter.append('AND {} = ANY(array[{}]::text[])'.format(schema_field, schema_filter))
 
+            # TODO: explicitly declare `relkind` compatiblity in the query rather than implicitly checking query text
             if r.get(RELKIND) and 'FROM pg_locks' in query:
                 relkind_filter = ','.join("'{}'".format(s) for s in r[RELKIND])
                 relation_filter.append('AND relkind = ANY(array[{}])'.format(relkind_filter))

--- a/postgres/tests/test_relationsmanager.py
+++ b/postgres/tests/test_relationsmanager.py
@@ -10,6 +10,44 @@ from .common import SCHEMA_NAME
 pytestmark = pytest.mark.unit
 
 
+@pytest.mark.parametrize(
+    'relations_config,expected_filter',
+    [
+        (
+            [
+                {'relation_regex': 'ix.*', 'schemas': ['public', 's1', 's2']},
+                {'relation_regex': 'ibx.*', 'schemas': ['public']},
+                {'relation_regex': 'icx.*', 'schemas': ['public']},
+            ],
+            "( relname ~ 'ix.*' AND schemaname = ANY(array['public','s1','s2']::text[]) ) "
+            "OR ( relname ~ 'ibx.*' AND schemaname = ANY(array['public']::text[]) ) "
+            "OR ( relname ~ 'icx.*' AND schemaname = ANY(array['public']::text[]) )",
+        ),
+        (
+            [
+                {'relation_regex': '.+_archive'},
+            ],
+            "( relname ~ '.+_archive' )",
+        ),
+        (
+            [
+                {'relation_name': 'my_table', 'schemas': ['public', 'app'], 'relkind': ['r']},  # relkind ignored
+                {'relation_name': 'my_table2', 'relkind': ['p', 'r']},  # relkind ignored
+                {'relation_regex': 'table.*'},
+            ],
+            "( relname = 'my_table' AND schemaname = ANY(array['public','app']::text[]) ) "
+            "OR ( relname = 'my_table2' ) "
+            "OR ( relname ~ 'table.*' )",
+        ),
+    ],
+)
+def test_relations_cases(relations_config, expected_filter):
+    query = '{relations}'
+    relations = RelationsManager(relations_config)
+    query_filter = relations.filter_relation_query(query, SCHEMA_NAME)
+    assert query_filter == expected_filter
+
+
 def test_relation_filter():
     query = "Select foo from bar where {relations}"
     relations_config = [{'relation_name': 'breed', 'schemas': ['public']}]
@@ -45,7 +83,7 @@ def test_relation_filter_relkind():
     relations = RelationsManager(relations_config)
 
     query_filter = relations.filter_relation_query(query, SCHEMA_NAME)
-    assert "AND relkind = ANY(array['r' ,'t'])" in query_filter
+    assert "AND relkind = ANY(array['r','t'])" in query_filter
 
 
 def test_relkind_does_not_apply_to_index_metrics():

--- a/postgres/tests/test_relationsmanager.py
+++ b/postgres/tests/test_relationsmanager.py
@@ -39,6 +39,10 @@ pytestmark = pytest.mark.unit
             "OR ( relname = 'my_table2' ) "
             "OR ( relname ~ 'table.*' )",
         ),
+        (
+            ['table1', 'table2'],
+            "( relname = 'table1' ) OR ( relname = 'table2' )",
+        ),
     ],
 )
 def test_relations_cases(relations_config, expected_filter):


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in Postgres relations config that only takes the last value of the relations list. The bug was introduced in Agent version 7.29.

For instance, the example config here: https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example#L151-L158 will actually not work correctly:

```yaml
relations:
   - relation_name: <TABLE_NAME>  # <- will be ignored
     schemas:
     - <SCHEMA_NAME1>
   - relation_regex: <TABLE_PATTERN>. # <- will be used
     relkind:
     - r
     - p
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
