### PR TITLE
postgres enable dbm by default for E2E

### DIFF
--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -67,7 +67,9 @@ def pg_instance():
 
 @pytest.fixture(scope='session')
 def e2e_instance():
-    return copy.deepcopy(INSTANCE)
+    instance = copy.deepcopy(INSTANCE)
+    instance['dbm'] = True
+    return instance
 
 
 @pytest.fixture()


### PR DESCRIPTION
### What does this PR do?

Enable DBM by default for the E2E env to ensure DBM data is always flowing whenever anyone starts up a local env.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
