### PR TITLE
mysql enable dbm by default for E2E

### DIFF
--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -23,6 +23,7 @@ COMPOSE_FILE = os.getenv('COMPOSE_FILE')
 
 @pytest.fixture(scope='session')
 def config_e2e(instance_basic):
+    instance_basic['dbm'] = True
     logs_path = _mysql_logs_path()
 
     return {

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import copy
 import logging
 import os
 
@@ -23,12 +24,13 @@ COMPOSE_FILE = os.getenv('COMPOSE_FILE')
 
 @pytest.fixture(scope='session')
 def config_e2e(instance_basic):
-    instance_basic['dbm'] = True
+    instance = copy.deepcopy(instance_basic)
+    instance['dbm'] = True
     logs_path = _mysql_logs_path()
 
     return {
         'init_config': {},
-        'instances': [instance_basic],
+        'instances': [instance],
         'logs': [
             {'type': 'file', 'path': '{}/mysql.log'.format(logs_path), 'source': 'mysql', 'service': 'local_mysql'},
             {


### PR DESCRIPTION
### What does this PR do?

Enable DBM by default for the E2E env to ensure DBM data is always flowing whenever anyone starts up a local env.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
