### PR TITLE
Refactor snowflake validators

### DIFF
--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -97,8 +97,11 @@ files:
           example: <OCSP_RESPONSE_CACHE_FILENAME>
       - name: authenticator
         description: |
-          Authenticator for Snowflake. The default `snowflake` uses the internal Snowflake authenticator.
-          Use `oauth` to authenticate with OAuth. Also, set the `token` or `token_path` option.
+          Authenticator for Snowflake. Supported methods are:
+          * `snowflake`, the default value, uses the internal Snowflake authenticator. It needs `password` or 
+            `private_key_path` option.
+          * `snowflake_jwt`, uses key pair authentication. It needs `private_key_path` option.
+          * `oauth`, to authenticate with OAuth method. It needs `token` or `token_path` option.
         value:
           type: string
           display_default: snowflake

--- a/snowflake/datadog_checks/snowflake/config_models/validators.py
+++ b/snowflake/datadog_checks/snowflake/config_models/validators.py
@@ -42,30 +42,7 @@ def _validate_authenticator_option(values):
         'snowflake_jwt': ['private_key_path'],
         'oauth': ['token', 'token_path'],
     }
-    # if (
-    #     authenticator == 'snowflake'
-    #     and 'password' not in values
-    #     and 'private_key_path' not in values
-    # ):
-    #     raise Exception(
-    #         'Authenticator option `snowflake` (default) needs `password` or `private_key_path` option to be set.'
-    #     )
 
-    # if authenticator == 'oauth' and 'token' not in values and 'token_path' not in values:
-    #     raise Exception('Authenticator option `oauth` needs `token` or `token_path` option, please set one.')
-
-    # if authenticator == 'snowflake_jwt'and 'private_key_path' not in values:
-    #     raise Exception(
-    #         'Authenticator option `snowflake_jwt` needs `private_key_path` option to be set.'
-    #     )
-
-    # authenticator_options = ['snowflake', 'oauth', 'snowflake_jwt']
-    # if authenticator not in authenticator_options:
-    #     raise Exception(
-    #         'Unkwown authenticator option {}, supported options are {}'.format(
-    #             authenticator, authenticator_options
-    #         )
-    #     )
     if authenticator not in authenticator_dependencies:
         raise Exception(
             'Unkwown authenticator option {}, supported options are {}.'.format(

--- a/snowflake/datadog_checks/snowflake/config_models/validators.py
+++ b/snowflake/datadog_checks/snowflake/config_models/validators.py
@@ -10,15 +10,6 @@ def initialize_instance(values, **kwargs):
 
     _validate_authenticator_option(values)
 
-    # auth_options = ['password', 'token', 'token_path', 'private_key_path']
-    # auth_options_configured = [opt for opt in auth_options if opt in values]
-    # if len(auth_options_configured) > 1:
-    #     warning(
-    #         'Multiple authentication options are configured ({}), only one should be set.'.format(
-    #             auth_options_configured
-    #         )
-    #     )
-
     if 'private_key_password' in values and 'private_key_path' not in values:
         raise Exception(
             'Option `private_key_password` is set but not option `private_key_path`. '

--- a/snowflake/datadog_checks/snowflake/config_models/validators.py
+++ b/snowflake/datadog_checks/snowflake/config_models/validators.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.base import ConfigurationError
 
 
 def initialize_instance(values, **kwargs):
@@ -11,14 +12,14 @@ def initialize_instance(values, **kwargs):
     _validate_authenticator_option(values)
 
     if 'private_key_password' in values and 'private_key_path' not in values:
-        raise Exception(
+        raise ConfigurationError(
             'Option `private_key_password` is set but not option `private_key_path`. '
             'Set `private_key_path` or remove `private_key_password` entry.'
         )
 
     if values.get('only_custom_queries', False) and len(values('metric_groups', [])) > 0:
-        raise Exception(
-            'Option `only_custom_queries` and `metric_groups` are not compatible.'
+        raise ConfigurationError(
+            'Option `only_custom_queries` and `metric_groups` are not compatible. '
             '`only_custom_queries` prevents `metric_groups` to be collected.'
         )
 
@@ -27,7 +28,7 @@ def initialize_instance(values, **kwargs):
 
 def _validate_authenticator_option(values):
     authenticator = values.get('authenticator', 'snowflake')
-    # `key` needs at list one item in `values` to be set
+    # `key` needs at least one item in `values` to be set
     authenticator_dependencies = {
         'snowflake': ['password', 'private_key_path'],
         'snowflake_jwt': ['private_key_path'],
@@ -35,14 +36,14 @@ def _validate_authenticator_option(values):
     }
 
     if authenticator not in authenticator_dependencies:
-        raise Exception(
+        raise ConfigurationError(
             'Unkwown authenticator option {}, supported options are {}.'.format(
                 authenticator, authenticator_dependencies.keys()
             )
         )
 
     if not any([opt in values for opt in authenticator_dependencies[authenticator]]):
-        raise Exception(
+        raise ConfigurationError(
             'Authenticator option `{}` needs `{}` option to be set.'.format(
                 authenticator, '` or `'.join(authenticator_dependencies[authenticator])
             )

--- a/snowflake/datadog_checks/snowflake/config_models/validators.py
+++ b/snowflake/datadog_checks/snowflake/config_models/validators.py
@@ -8,10 +8,74 @@ def initialize_instance(values, **kwargs):
     if 'username' not in values and 'user' in values:
         values['username'] = values['user']
 
+    _validate_authenticator_option(values)
+
+    # auth_options = ['password', 'token', 'token_path', 'private_key_path']
+    # auth_options_configured = [opt for opt in auth_options if opt in values]
+    # if len(auth_options_configured) > 1:
+    #     warning(
+    #         'Multiple authentication options are configured ({}), only one should be set.'.format(
+    #             auth_options_configured
+    #         )
+    #     )
+
     if 'private_key_password' in values and 'private_key_path' not in values:
         raise Exception(
             'Option `private_key_password` is set but not option `private_key_path`. '
             'Set `private_key_path` or remove `private_key_password` entry.'
         )
 
+    if values.get('only_custom_queries', False) and len(values('metric_groups', [])) > 0:
+        raise Exception(
+            'Option `only_custom_queries` and `metric_groups` are not compatible.'
+            '`only_custom_queries` prevents `metric_groups` to be collected.'
+        )
+
     return values
+
+
+def _validate_authenticator_option(values):
+    authenticator = values.get('authenticator', 'snowflake')
+    # `key` needs at list one item in `values` to be set
+    authenticator_dependencies = {
+        'snowflake': ['password', 'private_key_path'],
+        'snowflake_jwt': ['private_key_path'],
+        'oauth': ['token', 'token_path'],
+    }
+    # if (
+    #     authenticator == 'snowflake'
+    #     and 'password' not in values
+    #     and 'private_key_path' not in values
+    # ):
+    #     raise Exception(
+    #         'Authenticator option `snowflake` (default) needs `password` or `private_key_path` option to be set.'
+    #     )
+
+    # if authenticator == 'oauth' and 'token' not in values and 'token_path' not in values:
+    #     raise Exception('Authenticator option `oauth` needs `token` or `token_path` option, please set one.')
+
+    # if authenticator == 'snowflake_jwt'and 'private_key_path' not in values:
+    #     raise Exception(
+    #         'Authenticator option `snowflake_jwt` needs `private_key_path` option to be set.'
+    #     )
+
+    # authenticator_options = ['snowflake', 'oauth', 'snowflake_jwt']
+    # if authenticator not in authenticator_options:
+    #     raise Exception(
+    #         'Unkwown authenticator option {}, supported options are {}'.format(
+    #             authenticator, authenticator_options
+    #         )
+    #     )
+    if authenticator not in authenticator_dependencies:
+        raise Exception(
+            'Unkwown authenticator option {}, supported options are {}.'.format(
+                authenticator, authenticator_dependencies.keys()
+            )
+        )
+
+    if not any([opt in values for opt in authenticator_dependencies[authenticator]]):
+        raise Exception(
+            'Authenticator option `{}` needs `{}` option to be set.'.format(
+                authenticator, '` or `'.join(authenticator_dependencies[authenticator])
+            )
+        )

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -105,8 +105,11 @@ instances:
     # ocsp_response_cache_filename: <OCSP_RESPONSE_CACHE_FILENAME>
 
     ## @param authenticator - string - optional - default: snowflake
-    ## Authenticator for Snowflake. The default `snowflake` uses the internal Snowflake authenticator.
-    ## Use `oauth` to authenticate with OAuth. Also, set the `token` or `token_path` option.
+    ## Authenticator for Snowflake. Supported methods are:
+    ## * `snowflake`, the default value, uses the internal Snowflake authenticator. It needs `password` or 
+    ##   `private_key_path` option.
+    ## * `snowflake_jwt`, uses key pair authentication. It needs `private_key_path` option.
+    ## * `oauth`, to authenticate with OAuth method. It needs `token` or `token_path` option.
     #
     # authenticator: <AUTHENTICATOR>
 

--- a/snowflake/tests/test_config.py
+++ b/snowflake/tests/test_config.py
@@ -1,0 +1,60 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.base import ConfigurationError
+from datadog_checks.snowflake import SnowflakeCheck
+
+from .common import CHECK_NAME
+
+
+@pytest.mark.parametrize(
+    'options',
+    [
+        pytest.param({}, id='default'),
+        pytest.param({'token': 'mytoken'}, id='wrong parameters'),
+        pytest.param({'authenticator': 'unknown'}, id='wrong authenticator'),
+        pytest.param({'password': 'pass', 'private_key_password': 'pass'}, id='missing private_key_path'),
+        pytest.param({'only_custom_queries': True, 'metric_groups': ['snowflake.billing']}, id='incompatible options'),
+    ],
+)
+def test_authenticator_option_fail(options):
+    instance = {
+        # Common configuration
+        'account': 'test_acct.us-central1.gcp',
+        'database': 'SNOWFLAKE',
+        'schema': 'ACCOUNT_USAGE',
+        'role': 'ACCOUNTADMIN',
+        'user': 'testuser',
+    }
+
+    instance.update(options)
+
+    with pytest.raises(ConfigurationError):
+        check = SnowflakeCheck(CHECK_NAME, {}, [instance])
+        check.load_configuration_models()
+
+
+@pytest.mark.parametrize(
+    'options',
+    [
+        pytest.param({'password': 'pass'}, id='password'),
+        pytest.param({'authenticator': 'snowflake_jwt', 'private_key_path': '/path/to/key'}, id='key pair auth'),
+        pytest.param({'authenticator': 'oauth', 'token_path': '/path/to/token'}, id='token path'),
+        pytest.param({'authenticator': 'oauth', 'token': 'mytoken'}, id='token'),
+    ],
+)
+def test_authenticator_option_pass(options):
+    instance = {
+        # Common configuration
+        'account': 'test_acct.us-central1.gcp',
+        'database': 'SNOWFLAKE',
+        'schema': 'ACCOUNT_USAGE',
+        'role': 'ACCOUNTADMIN',
+        'user': 'testuser',
+    }
+    instance.update(options)
+
+    check = SnowflakeCheck(CHECK_NAME, {}, [instance])
+    check.load_configuration_models()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Refactor `snowflake` validators so most of the issue are caught during initialization. We currently support 3 authentications:
* Password authentication
* Oauth token authentication
* Key pair authentication

### Motivation
<!-- What inspired you to submit this pull request? -->
Validation clarification