### PR TITLE
Report known postgres database configuration errors as warnings

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -60,10 +60,15 @@ class PostgreSql(AgentCheck):
         self._relations_manager = RelationsManager(self._config.relations)
         self._clean_state()
         self.check_initializations.append(lambda: RelationsManager.validate_relations_config(self._config.relations))
-
+        if self._config.dbm_enabled:
+            self.check_initializations.append(self.validate_dbm_setup)
         # map[dbname -> psycopg connection]
         self._db_pool = {}
         self._db_pool_lock = threading.Lock()
+
+    def validate_dbm_setup(self):
+        self.statement_metrics.validate_db_config()
+        self.statement_samples.validate_db_config()
 
     def cancel(self):
         self.statement_samples.cancel()

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -568,10 +568,12 @@ class PostgreSql(AgentCheck):
         self._warnings_by_code[code] = message
 
     def _report_warnings(self):
-        for warning in self._warnings_by_code.values():
-            self.warning(warning)
+        messages = self._warnings_by_code.values()
         # Clear the warnings for the next check run
-        self._warnings_by_code = {}
+        self._warnings_by_code.clear()
+
+        for warning in messages:
+            self.warning(warning)
 
     def check(self, _):
         tags = copy.copy(self._config.tags)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -568,9 +568,9 @@ class PostgreSql(AgentCheck):
         self._warnings_by_code[code] = message
 
     def _report_warnings(self):
-        messages = list(self._warnings_by_code.values())
-        # Clear the warnings for the next check run
-        self._warnings_by_code.clear()
+        messages = self._warnings_by_code.values()
+        # Reset the warnings for the next check run
+        self._warnings_by_code = {}
 
         for warning in messages:
             self.warning(warning)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -18,7 +18,7 @@ from datadog_checks.postgres.statement_samples import PostgresStatementSamples
 from datadog_checks.postgres.statements import PostgresStatementMetrics
 
 from .config import PostgresConfig
-from .util import CONNECTION_METRICS, FUNCTION_METRICS, REPLICATION_METRICS, fmt, get_schema_field, DatabaseConfigurationError
+from .util import CONNECTION_METRICS, FUNCTION_METRICS, REPLICATION_METRICS, fmt, get_schema_field
 from .version_utils import V9, V10, VersionUtils
 
 try:
@@ -60,25 +60,9 @@ class PostgreSql(AgentCheck):
         self._relations_manager = RelationsManager(self._config.relations)
         self._clean_state()
         self.check_initializations.append(lambda: RelationsManager.validate_relations_config(self._config.relations))
-        if self._config.dbm_enabled:
-            self.check_initializations.append(self.validate_dbm_setup)
         # map[dbname -> psycopg connection]
         self._db_pool = {}
         self._db_pool_lock = threading.Lock()
-
-    def validate_dbm_setup(self):
-        try:
-            self.statement_metrics.validate_db_config()
-            self.statement_samples.validate_db_config()
-        except DatabaseConfigurationError as e:
-            self.service_check(
-                self.SERVICE_CHECK_NAME,
-                AgentCheck.WARNING,
-                tags=self._get_service_check_tags(),
-                message=str(e),
-                hostname=self.resolved_hostname,
-            )
-            raise
 
     def cancel(self):
         self.statement_samples.cancel()

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -568,7 +568,7 @@ class PostgreSql(AgentCheck):
         self._warnings_by_code[code] = message
 
     def _report_warnings(self):
-        messages = self._warnings_by_code.values()
+        messages = list(self._warnings_by_code.values())
         # Clear the warnings for the next check run
         self._warnings_by_code.clear()
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -564,7 +564,7 @@ class PostgreSql(AgentCheck):
                             getattr(self, method)(metric, value, tags=set(query_tags), hostname=self.resolved_hostname)
 
     def record_warning(self, code, message):
-        # type: (DatabaseConfigurationError, str) -> ()
+        # type: (DatabaseConfigurationError, str) -> None
         self._warnings_by_code[code] = message
 
     def _report_warnings(self):

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -391,9 +391,8 @@ class PostgresStatementSamples(DBMAsyncJob):
                 "missing 'datadog' schema in the database. See https://docs.datadoghq.com/database_monitoring/"
                 "setup_postgres/troubleshooting#explain-invalid-schema for more details: %s",
                 dbname,
-                repr(e),
+                str(e),
             )
-            self._log.warning("cannot collect execution plans due to invalid schema in dbname=%s: %s", dbname, repr(e))
             return DBExplainError.invalid_schema, e
         except psycopg2.DatabaseError as e:
             # if the schema is valid then it's some problem with the function (missing, or invalid permissions,
@@ -404,7 +403,7 @@ class PostgresStatementSamples(DBMAsyncJob):
                 "troubleshooting#explain-undefined-function for more details: %s",
                 dbname,
                 self._explain_function,
-                repr(e),
+                str(e),
             )
             return DBExplainError.failed_function, e
 

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -25,7 +25,7 @@ from datadog_checks.base.utils.db.utils import (
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.time import get_timestamp
 
-from .util import DatabaseConfigurationError, warning_tags
+from .util import DatabaseConfigurationError, warning_with_tags
 
 # according to https://unicodebook.readthedocs.io/unicode_encodings.html, the max supported size of a UTF-8 encoded
 # character is 6 bytes
@@ -393,16 +393,17 @@ class PostgresStatementSamples(DBMAsyncJob):
         except psycopg2.DatabaseError as e:
             # if the schema is valid then it's some problem with the function (missing, or invalid permissions,
             # incorrect definition)
-            self._check.warning(
-                "Unable to collect execution plans in dbname=%s. Check that the function "
-                "%s exists in the database. See "
-                "https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#%s "
-                "for more details: %s\n%s",
-                dbname,
-                self._explain_function,
-                DatabaseConfigurationError.undefined_explain_function.value,
-                str(e),
-                warning_tags(
+            self._check.record_warning(
+                DatabaseConfigurationError.undefined_explain_function,
+                warning_with_tags(
+                    "Unable to collect execution plans in dbname=%s. Check that the function "
+                    "%s exists in the database. See "
+                    "https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#%s "
+                    "for more details: %s",
+                    dbname,
+                    self._explain_function,
+                    DatabaseConfigurationError.undefined_explain_function.value,
+                    str(e),
                     host=self._check.resolved_hostname,
                     dbname=dbname,
                     code=DatabaseConfigurationError.undefined_explain_function.value,

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -391,7 +391,7 @@ class PostgresStatementSamples(DBMAsyncJob):
                 "missing 'datadog' schema in the database. See https://docs.datadoghq.com/database_monitoring/"
                 "setup_postgres/selfhosted/?tab=postgres10 for more details: %s",
                 dbname,
-                repr(e)
+                repr(e),
             )
             self._log.warning("cannot collect execution plans due to invalid schema in dbname=%s: %s", dbname, repr(e))
             return DBExplainError.invalid_schema, e
@@ -403,7 +403,7 @@ class PostgresStatementSamples(DBMAsyncJob):
                 "%s exists in the database. See https://datadoghq.com for more details: %s",
                 dbname,
                 self._explain_function,
-                repr(e)
+                repr(e),
             )
             return DBExplainError.failed_function, e
 

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -389,7 +389,7 @@ class PostgresStatementSamples(DBMAsyncJob):
             self._check.warning(
                 "Unable to collect execution plans due to invalid schema in database '%s'. This could be due to a "
                 "missing 'datadog' schema in the database. See https://docs.datadoghq.com/database_monitoring/"
-                "setup_postgres/selfhosted/?tab=postgres10 for more details: %s",
+                "setup_postgres/troubleshooting#explain-invalid-schema for more details: %s",
                 dbname,
                 repr(e),
             )
@@ -400,7 +400,8 @@ class PostgresStatementSamples(DBMAsyncJob):
             # incorrect definition)
             self._check.warning(
                 "Unable to collect execution plans in dbname=%s. Check that the function "
-                "%s exists in the database. See https://datadoghq.com for more details: %s",
+                "%s exists in the database. See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
+                "troubleshooting#explain-undefined-function for more details: %s",
                 dbname,
                 self._explain_function,
                 repr(e),

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -658,3 +658,6 @@ class PostgresStatementSamples(DBMAsyncJob):
         statement_bytes = bytes(statement) if PY2 else bytes(statement, "utf-8")
         truncated = len(statement_bytes) >= track_activity_query_size - (MAX_CHARACTER_SIZE_IN_BYTES + 1)
         return StatementTruncationState.truncated if truncated else StatementTruncationState.not_truncated
+
+    def validate_db_config(self):
+        pass

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -17,7 +17,7 @@ from datadog_checks.base.utils.db.statement_metrics import StatementMetrics
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
 from datadog_checks.base.utils.serialization import json
 
-from .util import DatabaseConfigurationError, warning_tags
+from .util import DatabaseConfigurationError, warning_with_tags
 from .version_utils import V9_4
 
 try:
@@ -236,14 +236,15 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 isinstance(e, psycopg2.errors.ObjectNotInPrerequisiteState)
             ) and 'pg_stat_statements must be loaded' in str(e.pgerror):
                 error_tag = "error:database-{}-pg_stat_statements_not_loaded".format(type(e).__name__)
-                self._check.warning(
-                    "Unable to collect statement metrics because pg_stat_statements "
-                    "extension is not loaded in database '%s'. "
-                    "See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
-                    "troubleshooting#%s for more details\n%s",
-                    self._config.dbname,
-                    DatabaseConfigurationError.pg_stat_statement_not_loaded.value,
-                    warning_tags(
+                self._check.record_warning(
+                    DatabaseConfigurationError.pg_stat_statement_not_loaded,
+                    warning_with_tags(
+                        "Unable to collect statement metrics because pg_stat_statements "
+                        "extension is not loaded in database '%s'. "
+                        "See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
+                        "troubleshooting#%s for more details",
+                        self._config.dbname,
+                        DatabaseConfigurationError.pg_stat_statement_not_loaded.value,
                         host=self._check.resolved_hostname,
                         dbname=self._config.dbname,
                         code=DatabaseConfigurationError.pg_stat_statement_not_loaded.value,
@@ -251,13 +252,14 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 )
             elif isinstance(e, psycopg2.errors.UndefinedTable) and 'pg_stat_statements' in str(e.pgerror):
                 error_tag = "error:database-{}-pg_stat_statements_not_created".format(type(e).__name__)
-                self._check.warning(
-                    "Unable to collect statement metrics because pg_stat_statements is not created "
-                    "in database '%s'. See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
-                    "troubleshooting#%s for more details\n%s",
-                    self._config.dbname,
-                    DatabaseConfigurationError.pg_stat_statement_not_created.value,
-                    warning_tags(
+                self._check.record_warning(
+                    DatabaseConfigurationError.pg_stat_statement_not_created,
+                    warning_with_tags(
+                        "Unable to collect statement metrics because pg_stat_statements is not created "
+                        "in database '%s'. See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
+                        "troubleshooting#%s for more details",
+                        self._config.dbname,
+                        DatabaseConfigurationError.pg_stat_statement_not_created.value,
                         host=self._check.resolved_hostname,
                         dbname=self._config.dbname,
                         code=DatabaseConfigurationError.pg_stat_statement_not_created.value,

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -17,7 +17,6 @@ from datadog_checks.base.utils.db.statement_metrics import StatementMetrics
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
 from datadog_checks.base.utils.serialization import json
 
-from .util import DatabaseConfigurationError
 from .version_utils import V9_4
 
 try:
@@ -81,16 +80,6 @@ PG_STAT_ALL_DESIRED_COLUMNS = (
 )
 
 
-class MissingColumnsError(Exception):
-    def __init__(self, missing_columns, message="pg_stat_statements is missing required columns"):
-        self.missing_columns = missing_columns
-        self.message = message
-        super(MissingColumnsError, self).__init__(self.message)
-
-    def __str__(self):
-        return '{message}: {missing_columns}'.format(message=self.message, missing_columns=self.missing_columns)
-
-
 def _row_key(row):
     """
     :param row: a normalized row from pg_stat_statements
@@ -133,29 +122,6 @@ class PostgresStatementMetrics(DBMAsyncJob):
             maxsize=config.full_statement_text_cache_max_size,
             ttl=60 * 60 / config.full_statement_text_samples_per_hour_per_query,
         )
-
-    def validate_db_config(self):
-        try:
-            if is_affirmative(self._config.statement_metrics_config.get('enabled', True)):
-                self._query_pg_stat_statements(1)
-        except MissingColumnsError:
-            raise DatabaseConfigurationError("Missing columns in pg_stat_statements", reference_doc="https://TODO")
-        except psycopg2.Error as e:
-            if (
-                isinstance(e, psycopg2.errors.ObjectNotInPrerequisiteState)
-            ) and 'pg_stat_statements must be loaded' in str(e.pgerror):
-                raise DatabaseConfigurationError(
-                    "pg_stat_statements extension is not loaded",
-                    reference_doc="https://docs.datadoghq.com/database_monitoring/troubleshooting/?tab=postgres",
-                )
-            elif isinstance(e, psycopg2.errors.UndefinedTable) and 'pg_stat_statements' in str(e.pgerror):
-                raise DatabaseConfigurationError(
-                    "pg_stat_statements is not created in database '{db}'".format(db=self._config.dbname),
-                    reference_doc="https://docs.datadoghq.com/database_monitoring/troubleshooting#"
-                    "pg_stat_statements_not_created",
-                )
-            else:
-                self._log.warning("Unable to collect statement metrics because of an error running queries: %s", e)
 
     def _execute_query(self, cursor, query, params=()):
         try:
@@ -226,23 +192,41 @@ class PostgresStatementMetrics(DBMAsyncJob):
 
     def _load_pg_stat_statements(self):
         try:
-            return self._query_pg_stat_statements(DEFAULT_STATEMENTS_LIMIT)
-        except MissingColumnsError as e:
-            self._log.warning(
-                'Unable to collect statement metrics because required fields are unavailable: %s',
-                ', '.join(list(e.missing_columns)),
+            available_columns = set(self._get_pg_stat_statements_columns())
+            missing_columns = PG_STAT_STATEMENTS_REQUIRED_COLUMNS - available_columns
+            if len(missing_columns) > 0:
+                self._log.warning(
+                    'Unable to collect statement metrics because required fields are unavailable: %s',
+                    ', '.join(list(missing_columns)),
+                )
+                self._check.count(
+                    "dd.postgres.statement_metrics.error",
+                    1,
+                    tags=self._tags
+                    + [
+                        "error:database-missing_pg_stat_statements_required_columns",
+                    ]
+                    + self._check._get_debug_tags(),
+                    hostname=self._check.resolved_hostname,
+                )
+                return []
+
+            query_columns = sorted(list(available_columns & PG_STAT_ALL_DESIRED_COLUMNS))
+            params = ()
+            filters = ""
+            if self._config.dbstrict:
+                filters = "AND pg_database.datname = %s"
+                params = (self._config.dbname,)
+            return self._execute_query(
+                self._check._get_db(self._config.dbname).cursor(cursor_factory=psycopg2.extras.DictCursor),
+                STATEMENTS_QUERY.format(
+                    cols=', '.join(query_columns),
+                    pg_stat_statements_view=self._config.pg_stat_statements_view,
+                    filters=filters,
+                    limit=DEFAULT_STATEMENTS_LIMIT,
+                ),
+                params=params,
             )
-            self._check.count(
-                "dd.postgres.statement_metrics.error",
-                1,
-                tags=self._tags
-                + [
-                    "error:database-missing_pg_stat_statements_required_columns",
-                ]
-                + self._check._get_debug_tags(),
-                hostname=self._check.resolved_hostname,
-            )
-            return []
         except psycopg2.Error as e:
             error_tag = "error:database-{}".format(type(e).__name__)
 
@@ -250,16 +234,19 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 isinstance(e, psycopg2.errors.ObjectNotInPrerequisiteState)
             ) and 'pg_stat_statements must be loaded' in str(e.pgerror):
                 error_tag = "error:database-{}-pg_stat_statements_not_loaded".format(type(e).__name__)
-                self._check.warning("pg_stat_statements is not loaded in this database. See https//datadoghq.com")
+                self._check.warning("Unable to collect statement metrics because pg_stat_statements extension is not "
+                                    "loaded in database '%s'. See https://docs.datadoghq.com/database_monitoring/"
+                                    "troubleshooting/?tab=postgres#query-metrics-are-missing for more details",
+                                    self._config.dbname)
                 self._log.warning(
                     "Unable to collect statement metrics because pg_stat_statements shared library is not loaded"
                 )
             elif isinstance(e, psycopg2.errors.UndefinedTable) and 'pg_stat_statements' in str(e.pgerror):
                 error_tag = "error:database-{}-pg_stat_statements_not_created".format(type(e).__name__)
-                self._check.warning("pg_stat_statements is not created in this database. See https//datadoghq.com")
-                self._log.warning(
-                    "Unable to collect statement metrics because pg_stat_statements is not created in this database"
-                )
+                self._check.warning("Unable to collect statement metrics because pg_stat_statements is not created "
+                                    "in database '%s'. See See https://docs.datadoghq.com/database_monitoring/"
+                                    "troubleshooting/?tab=postgres#query-metrics-are-missing for more details",
+                                    self._config.dbname)
             else:
                 self._log.warning("Unable to collect statement metrics because of an error running queries: %s", e)
 
@@ -271,30 +258,6 @@ class PostgresStatementMetrics(DBMAsyncJob):
             )
 
             return []
-
-    def _query_pg_stat_statements(self, row_limit):
-        self._log.warning("In query_pg_stat_statements with limit %d", row_limit)
-        available_columns = set(self._get_pg_stat_statements_columns())
-        missing_columns = PG_STAT_STATEMENTS_REQUIRED_COLUMNS - available_columns
-        if len(missing_columns) > 0:
-            raise MissingColumnsError(missing_columns)
-
-        query_columns = sorted(list(available_columns & PG_STAT_ALL_DESIRED_COLUMNS))
-        params = ()
-        filters = ""
-        if self._config.dbstrict:
-            filters = "AND pg_database.datname = %s"
-            params = (self._config.dbname,)
-        return self._execute_query(
-            self._check._get_db(self._config.dbname).cursor(cursor_factory=psycopg2.extras.DictCursor),
-            STATEMENTS_QUERY.format(
-                cols=', '.join(query_columns),
-                pg_stat_statements_view=self._config.pg_stat_statements_view,
-                filters=filters,
-                limit=row_limit,
-            ),
-            params=params,
-        )
 
     def _emit_pg_stat_statements_metrics(self):
         query = PG_STAT_STATEMENTS_COUNT_QUERY_LT_9_4 if self._check.version < V9_4 else PG_STAT_STATEMENTS_COUNT_QUERY

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -250,11 +250,13 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 isinstance(e, psycopg2.errors.ObjectNotInPrerequisiteState)
             ) and 'pg_stat_statements must be loaded' in str(e.pgerror):
                 error_tag = "error:database-{}-pg_stat_statements_not_loaded".format(type(e).__name__)
+                self._check.warning("pg_stat_statements is not loaded in this database. See https//datadoghq.com")
                 self._log.warning(
                     "Unable to collect statement metrics because pg_stat_statements shared library is not loaded"
                 )
             elif isinstance(e, psycopg2.errors.UndefinedTable) and 'pg_stat_statements' in str(e.pgerror):
                 error_tag = "error:database-{}-pg_stat_statements_not_created".format(type(e).__name__)
+                self._check.warning("pg_stat_statements is not created in this database. See https//datadoghq.com")
                 self._log.warning(
                     "Unable to collect statement metrics because pg_stat_statements is not created in this database"
                 )

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -197,17 +197,12 @@ class PostgresStatementMetrics(DBMAsyncJob):
             available_columns = set(self._get_pg_stat_statements_columns())
             missing_columns = PG_STAT_STATEMENTS_REQUIRED_COLUMNS - available_columns
             if len(missing_columns) > 0:
-                self._check.record_warning(
-                    DatabaseConfigurationError.pg_stat_statements_missing_columns,
+                self._check.warning(
                     warning_with_tags(
-                        "Unable to collect statement metrics because required fields are unavailable: %s. "
-                        "See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
-                        "troubleshooting#%s for help.",
+                        "Unable to collect statement metrics because required fields are unavailable: %s.",
                         ', '.join(sorted(list(missing_columns))),
-                        DatabaseConfigurationError.pg_stat_statements_missing_columns.value,
                         host=self._check.resolved_hostname,
                         dbname=self._config.dbname,
-                        code=DatabaseConfigurationError.pg_stat_statements_missing_columns.value,
                     ),
                 )
                 self._check.count(
@@ -275,8 +270,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                     ),
                 )
             else:
-                self._check.record_warning(
-                    DatabaseConfigurationError.unable_to_collect_statement_metrics,
+                self._check.warning(
                     warning_with_tags(
                         "Unable to collect statement metrics because of an error running queries "
                         "in database '%s'. See https://docs.datadoghq.com/database_monitoring/troubleshooting for "
@@ -285,7 +279,6 @@ class PostgresStatementMetrics(DBMAsyncJob):
                         str(e),
                         host=self._check.resolved_hostname,
                         dbname=self._config.dbname,
-                        code=DatabaseConfigurationError.unable_to_collect_statement_metrics.value,
                     ),
                 )
 

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -247,7 +247,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 error_tag = "error:database-{}-pg_stat_statements_not_created".format(type(e).__name__)
                 self._check.warning(
                     "Unable to collect statement metrics because pg_stat_statements is not created "
-                    "in database '%s'. See See https://docs.datadoghq.com/database_monitoring/"
+                    "in database '%s'. See https://docs.datadoghq.com/database_monitoring/"
                     "troubleshooting/?tab=postgres#query-metrics-are-missing for more details",
                     self._config.dbname,
                 )

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -17,6 +17,7 @@ from datadog_checks.base.utils.db.statement_metrics import StatementMetrics
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
 from datadog_checks.base.utils.serialization import json
 
+from .util import DatabaseConfigurationWarning
 from .version_utils import V9_4
 
 try:
@@ -235,21 +236,29 @@ class PostgresStatementMetrics(DBMAsyncJob):
             ) and 'pg_stat_statements must be loaded' in str(e.pgerror):
                 error_tag = "error:database-{}-pg_stat_statements_not_loaded".format(type(e).__name__)
                 self._check.warning(
-                    "Unable to collect statement metrics because pg_stat_statements extension is not "
-                    "loaded in database '%s'. See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
-                    "troubleshooting#pg-stat-statement-not-loaded for more details",
-                    self._config.dbname,
-                )
-                self._log.warning(
-                    "Unable to collect statement metrics because pg_stat_statements shared library is not loaded"
+                    str(
+                        DatabaseConfigurationWarning(
+                            {'host': self._check.resolved_hostname, 'dbname': self._config.dbname},
+                            "Unable to collect statement metrics because pg_stat_statements "
+                            "extension is not loaded in database '%s'. "
+                            "See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
+                            "troubleshooting#pg-stat-statement-not-loaded for more details",
+                            self._config.dbname,
+                        ),
+                    )
                 )
             elif isinstance(e, psycopg2.errors.UndefinedTable) and 'pg_stat_statements' in str(e.pgerror):
                 error_tag = "error:database-{}-pg_stat_statements_not_created".format(type(e).__name__)
                 self._check.warning(
-                    "Unable to collect statement metrics because pg_stat_statements is not created "
-                    "in database '%s'. See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
-                    "troubleshooting#pg-stat-statement-not-created for more details",
-                    self._config.dbname,
+                    str(
+                        DatabaseConfigurationWarning(
+                            {'host': self._check.resolved_hostname, 'dbname': self._config.dbname},
+                            "Unable to collect statement metrics because pg_stat_statements is not created "
+                            "in database '%s'. See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
+                            "troubleshooting#pg-stat-statement-not-created for more details",
+                            self._config.dbname,
+                        )
+                    )
                 )
             else:
                 self._log.warning("Unable to collect statement metrics because of an error running queries: %s", e)

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -236,8 +236,8 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 error_tag = "error:database-{}-pg_stat_statements_not_loaded".format(type(e).__name__)
                 self._check.warning(
                     "Unable to collect statement metrics because pg_stat_statements extension is not "
-                    "loaded in database '%s'. See https://docs.datadoghq.com/database_monitoring/"
-                    "troubleshooting/?tab=postgres#query-metrics-are-missing for more details",
+                    "loaded in database '%s'. See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
+                    "troubleshooting#pg-stat-statement-not-loaded for more details",
                     self._config.dbname,
                 )
                 self._log.warning(
@@ -247,8 +247,8 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 error_tag = "error:database-{}-pg_stat_statements_not_created".format(type(e).__name__)
                 self._check.warning(
                     "Unable to collect statement metrics because pg_stat_statements is not created "
-                    "in database '%s'. See https://docs.datadoghq.com/database_monitoring/"
-                    "troubleshooting/?tab=postgres#query-metrics-are-missing for more details",
+                    "in database '%s'. See https://docs.datadoghq.com/database_monitoring/setup_postgres/"
+                    "troubleshooting#pg-stat-statement-not-created for more details",
                     self._config.dbname,
                 )
             else:

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -234,19 +234,23 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 isinstance(e, psycopg2.errors.ObjectNotInPrerequisiteState)
             ) and 'pg_stat_statements must be loaded' in str(e.pgerror):
                 error_tag = "error:database-{}-pg_stat_statements_not_loaded".format(type(e).__name__)
-                self._check.warning("Unable to collect statement metrics because pg_stat_statements extension is not "
-                                    "loaded in database '%s'. See https://docs.datadoghq.com/database_monitoring/"
-                                    "troubleshooting/?tab=postgres#query-metrics-are-missing for more details",
-                                    self._config.dbname)
+                self._check.warning(
+                    "Unable to collect statement metrics because pg_stat_statements extension is not "
+                    "loaded in database '%s'. See https://docs.datadoghq.com/database_monitoring/"
+                    "troubleshooting/?tab=postgres#query-metrics-are-missing for more details",
+                    self._config.dbname,
+                )
                 self._log.warning(
                     "Unable to collect statement metrics because pg_stat_statements shared library is not loaded"
                 )
             elif isinstance(e, psycopg2.errors.UndefinedTable) and 'pg_stat_statements' in str(e.pgerror):
                 error_tag = "error:database-{}-pg_stat_statements_not_created".format(type(e).__name__)
-                self._check.warning("Unable to collect statement metrics because pg_stat_statements is not created "
-                                    "in database '%s'. See See https://docs.datadoghq.com/database_monitoring/"
-                                    "troubleshooting/?tab=postgres#query-metrics-are-missing for more details",
-                                    self._config.dbname)
+                self._check.warning(
+                    "Unable to collect statement metrics because pg_stat_statements is not created "
+                    "in database '%s'. See See https://docs.datadoghq.com/database_monitoring/"
+                    "troubleshooting/?tab=postgres#query-metrics-are-missing for more details",
+                    self._config.dbname,
+                )
             else:
                 self._log.warning("Unable to collect statement metrics because of an error running queries: %s", e)
 

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -185,6 +185,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 'postgres_rows': rows,
                 'postgres_version': self._payload_pg_version(),
                 'ddagentversion': datadog_agent.get_version(),
+                "ddagenthostname": self._check.agent_hostname,
             }
             self._check.database_monitoring_query_metrics(json.dumps(payload, default=default_json_event_encoding))
         except Exception:

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import string
+from enum import Enum
 from typing import Any, List, Tuple
 
 from datadog_checks.base import AgentCheck
@@ -22,22 +23,18 @@ class PartialFormatter(string.Formatter):
             return string.Formatter.get_value(self, key, args, kwargs)
 
 
-class DatabaseConfigurationWarning(object):
-    """DatabaseConfigurationWarning formalizes the format of database configuration warning messages."""
+class DatabaseConfigurationError(Enum):
+    """
+    Denotes the possible database configuration errors
+    """
 
-    def __init__(self, metadata, message, *args):
-        if metadata is None:
-            metadata = {}
-        if args:
-            message = message % args
-        self._message = message
-        self._metadata = metadata
+    pg_stat_statement_not_created = 'pg-stat-statement-not-created'
+    pg_stat_statement_not_loaded = 'pg-stat-statement-not-loaded'
+    undefined_explain_function = 'undefined-explain-function'
 
-    def __str__(self):
-        return '{msg}\n{key_values}'.format(
-            msg=self._message,
-            key_values=" ".join('{key}={value}'.format(key=k, value=v) for k, v in sorted(self._metadata.items())),
-        )
+
+def warning_tags(**kwargs):
+    return " ".join('{key}={value}'.format(key=k, value=v) for k, v in sorted(kwargs.items()))
 
 
 def milliseconds_to_nanoseconds(value):

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -33,8 +33,13 @@ class DatabaseConfigurationError(Enum):
     undefined_explain_function = 'undefined-explain-function'
 
 
-def warning_tags(**kwargs):
-    return " ".join('{key}={value}'.format(key=k, value=v) for k, v in sorted(kwargs.items()))
+def warning_with_tags(warning_message, *args, **kwargs):
+    if args:
+        warning_message = warning_message % args
+
+    return "{msg}\n{tags}".format(
+        msg=warning_message, tags=" ".join('{key}={value}'.format(key=k, value=v) for k, v in sorted(kwargs.items()))
+    )
 
 
 def milliseconds_to_nanoseconds(value):

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -22,6 +22,15 @@ class PartialFormatter(string.Formatter):
             return string.Formatter.get_value(self, key, args, kwargs)
 
 
+class DatabaseConfigurationError(Exception):
+    """Relating to a database configuration error"""
+
+    def __init__(self, message, reference_doc=""):
+        super(DatabaseConfigurationError, self).__init__(
+            '{message}. See {doc} for help'.format(message=message, doc=reference_doc)
+        )
+
+
 def milliseconds_to_nanoseconds(value):
     """Convert from ms to ns (used for pg_stat* conversion to metrics with units in ns)"""
     return value * 1000000

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -36,7 +36,7 @@ class DatabaseConfigurationWarning(object):
     def __str__(self):
         return '{msg}\n{key_values}'.format(
             msg=self._message,
-            key_values=" ".join('{key}={value}'.format(key=k, value=v) for k, v in self._metadata.items()),
+            key_values=" ".join('{key}={value}'.format(key=k, value=v) for k, v in sorted(self._metadata.items())),
         )
 
 

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -22,15 +22,6 @@ class PartialFormatter(string.Formatter):
             return string.Formatter.get_value(self, key, args, kwargs)
 
 
-class DatabaseConfigurationError(Exception):
-    """Relating to a database configuration error"""
-
-    def __init__(self, message, reference_doc=""):
-        super(DatabaseConfigurationError, self).__init__(
-            '{message}. See {doc}'.format(message=message, doc=reference_doc)
-        )
-
-
 def milliseconds_to_nanoseconds(value):
     """Convert from ms to ns (used for pg_stat* conversion to metrics with units in ns)"""
     return value * 1000000

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -30,9 +30,7 @@ class DatabaseConfigurationError(Enum):
 
     pg_stat_statements_not_created = 'pg-stat-statements-not-created'
     pg_stat_statements_not_loaded = 'pg-stat-statements-not-loaded'
-    pg_stat_statements_missing_columns = 'pg-stat-statements-missing-columns'
     undefined_explain_function = 'undefined-explain-function'
-    unable_to_collect_statement_metrics = 'unable-to-collect-statement-metrics'
 
 
 def warning_with_tags(warning_message, *args, **kwargs):

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -22,6 +22,24 @@ class PartialFormatter(string.Formatter):
             return string.Formatter.get_value(self, key, args, kwargs)
 
 
+class DatabaseConfigurationWarning(object):
+    """DatabaseConfigurationWarning formalizes the format of database configuration warning messages."""
+
+    def __init__(self, metadata, message, *args):
+        if metadata is None:
+            metadata = {}
+        if args:
+            message = message % args
+        self._message = message
+        self._metadata = metadata
+
+    def __str__(self):
+        return '{msg}\n{key_values}'.format(
+            msg=self._message,
+            key_values=" ".join('{key}={value}'.format(key=k, value=v) for k, v in self._metadata.items()),
+        )
+
+
 def milliseconds_to_nanoseconds(value):
     """Convert from ms to ns (used for pg_stat* conversion to metrics with units in ns)"""
     return value * 1000000

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -28,9 +28,11 @@ class DatabaseConfigurationError(Enum):
     Denotes the possible database configuration errors
     """
 
-    pg_stat_statement_not_created = 'pg-stat-statement-not-created'
-    pg_stat_statement_not_loaded = 'pg-stat-statement-not-loaded'
+    pg_stat_statements_not_created = 'pg-stat-statements-not-created'
+    pg_stat_statements_not_loaded = 'pg-stat-statements-not-loaded'
+    pg_stat_statements_missing_columns = 'pg-stat-statements-missing-columns'
     undefined_explain_function = 'undefined-explain-function'
+    unable_to_collect_statement_metrics = 'unable-to-collect-statement-metrics'
 
 
 def warning_with_tags(warning_message, *args, **kwargs):

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -27,7 +27,7 @@ class DatabaseConfigurationError(Exception):
 
     def __init__(self, message, reference_doc=""):
         super(DatabaseConfigurationError, self).__init__(
-            '{message}. See {doc} for help'.format(message=message, doc=reference_doc)
+            '{message}. See {doc}'.format(message=message, doc=reference_doc)
         )
 
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1217,7 +1217,7 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
             [
                 "Unable to collect statement metrics because of an error running queries in database 'datadog_test'. "
                 "See https://docs.datadoghq.com/database_monitoring/troubleshooting for help: cannot insert into view\n"
-                "code=unable-to-collect-statement-metrics dbname=datadog_test host=stubbed.hostname"
+                "dbname=datadog_test host=stubbed.hostname"
             ],
         ),
         (
@@ -1227,7 +1227,7 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
             [
                 "Unable to collect statement metrics because of an error running queries in database 'datadog_test'. "
                 'See https://docs.datadoghq.com/database_monitoring/troubleshooting for help: connection reset\n'
-                'code=unable-to-collect-statement-metrics dbname=datadog_test host=stubbed.hostname',
+                'dbname=datadog_test host=stubbed.hostname',
             ],
         ),
         (
@@ -1235,10 +1235,8 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
             [],
             'error:database-missing_pg_stat_statements_required_columns',
             [
-                'Unable to collect statement metrics because required fields are unavailable: calls, query, rows. '
-                'See https://docs.datadoghq.com/database_monitoring/'
-                'setup_postgres/troubleshooting#pg-stat-statements-missing-columns'
-                ' for help.\ncode=pg-stat-statements-missing-columns dbname=datadog_test host=stubbed.hostname',
+                'Unable to collect statement metrics because required fields are unavailable: calls, query, rows.\n'
+                'dbname=datadog_test host=stubbed.hostname',
             ],
         ),
     ],

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -404,9 +404,8 @@ def test_failed_explain_handling(
                 "'dogs_noschema'. This could be due to a missing 'datadog' schema in the "
                 'database. See '
                 'https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#explain-invalid-schema '
-                'for more details: InvalidSchemaName(\'schema "datadog" does not exist\\nLINE '
-                '1: SELECT datadog.explain_statement($stmt$SELECT * FROM '
-                "pg_stat...\\n               ^\\n')",
+                'for more details: schema "datadog" does not exist\nLINE 1: SELECT datadog.explain_statement('
+                '$stmt$SELECT * FROM pg_stat...\n               ^\n',
             ],
         ),
         (
@@ -421,12 +420,12 @@ def test_failed_explain_handling(
             [
                 'Unable to collect execution plans in dbname=dogs_nofunc. Check that the '
                 'function datadog.explain_statement exists in the database. See '
-                "https://docs.datadoghq.com/database_monitoring/setup_postgres/"
-                "troubleshooting#explain-undefined-function for more details: UndefinedFunction('function "
-                'datadog.explain_statement(unknown) does not exist\\nLINE 1: SELECT '
-                'datadog.explain_statement($stmt$SELECT * FROM pg_stat...\\n               '
-                '^\\nHINT:  No function matches the given name and argument types. You might '
-                "need to add explicit type casts.\\n')",
+                'https://docs.datadoghq.com/database_monitoring/setup_postgres/'
+                'troubleshooting#explain-undefined-function for more details: function '
+                'datadog.explain_statement(unknown) does not exist\nLINE 1: SELECT '
+                'datadog.explain_statement($stmt$SELECT * FROM pg_stat...\n               '
+                '^\nHINT:  No function matches the given name and argument types. You might need to add '
+                'explicit type casts.\n',
             ],
         ),
         (

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -415,13 +415,13 @@ def test_failed_explain_handling(
                 'Unable to collect execution plans in dbname=dogs_nofunc. Check that the '
                 'function datadog.explain_statement exists in the database. See '
                 'https://docs.datadoghq.com/database_monitoring/setup_postgres/'
-                'troubleshooting#explain-undefined-function for more details: function '
+                'troubleshooting#undefined-explain-function for more details: function '
                 'datadog.explain_statement(unknown) does not exist\nLINE 1: SELECT '
                 'datadog.explain_statement($stmt$SELECT * FROM pg_stat...\n               '
                 '^\nHINT:  No function matches the given name and argument types. You might need to add '
                 'explicit type casts.\n'
                 '\n'
-                'dbname=dogs_nofunc host=stubbed.hostname',
+                'code=undefined-explain-function dbname=dogs_nofunc host=stubbed.hostname',
             ],
         ),
         (
@@ -1190,7 +1190,7 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
                 'Unable to collect statement metrics because pg_stat_statements extension is '
                 "not loaded in database 'datadog_test'. See https://docs.datadoghq.com/database_monitoring/"
                 'setup_postgres/troubleshooting#pg-stat-statement-not-loaded'
-                ' for more details\ndbname=datadog_test host=stubbed.hostname',
+                ' for more details\ncode=pg-stat-statement-not-loaded dbname=datadog_test host=stubbed.hostname',
             ],
         ),
         (
@@ -1201,7 +1201,7 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
                 'Unable to collect statement metrics because pg_stat_statements is not '
                 "created in database 'datadog_test'. See https://docs.datadoghq.com/database_monitoring/"
                 'setup_postgres/troubleshooting#pg-stat-statement-not-created'
-                ' for more details\ndbname=datadog_test host=stubbed.hostname',
+                ' for more details\ncode=pg-stat-statement-not-created dbname=datadog_test host=stubbed.hostname',
             ],
         ),
         (

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1203,7 +1203,7 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
             'error:database-UndefinedTable-pg_stat_statements_not_created',
             [
                 'Unable to collect statement metrics because pg_stat_statements is not '
-                "created in database 'datadog_test'. See See "
+                "created in database 'datadog_test'. See "
                 'https://docs.datadoghq.com/database_monitoring/troubleshooting/?tab=postgres#query-metrics-are-missing'
                 ' for more details',
             ],

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -365,7 +365,8 @@ def test_failed_explain_handling(
 
 @pytest.mark.parametrize("pg_stat_activity_view", ["pg_stat_activity", "datadog.pg_stat_activity()"])
 @pytest.mark.parametrize(
-    "user,password,dbname,query,arg,expected_error_tag,expected_collection_errors,expected_statement_truncated,expected_warnings",
+    "user,password,dbname,query,arg,expected_error_tag,expected_collection_errors,expected_statement_truncated,"
+    "expected_warnings",
     [
         (
             "bob",
@@ -1192,8 +1193,8 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
             [
                 'Unable to collect statement metrics because pg_stat_statements extension is '
                 "not loaded in database 'datadog_test'. See "
-                'https://docs.datadoghq.com/database_monitoring/troubleshooting/?tab=postgres#query-metrics-are-missing '
-                'for more details',
+                'https://docs.datadoghq.com/database_monitoring/troubleshooting/?tab=postgres#query-metrics-are-missing'
+                ' for more details',
             ],
         ),
         (
@@ -1203,8 +1204,8 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
             [
                 'Unable to collect statement metrics because pg_stat_statements is not '
                 "created in database 'datadog_test'. See See "
-                'https://docs.datadoghq.com/database_monitoring/troubleshooting/?tab=postgres#query-metrics-are-missing '
-                'for more details',
+                'https://docs.datadoghq.com/database_monitoring/troubleshooting/?tab=postgres#query-metrics-are-missing'
+                ' for more details',
             ],
         ),
         (

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -146,6 +146,7 @@ def test_statement_metrics(
     assert event['timestamp'] > 0
     assert event['postgres_version'] == check.statement_metrics._payload_pg_version()
     assert event['ddagentversion'] == datadog_agent.get_version()
+    assert event['ddagenthostname'] == datadog_agent.get_hostname()
     assert event['min_collection_interval'] == dbm_instance['query_metrics']['collection_interval']
     expected_dbm_metrics_tags = {'foo:bar', 'port:{}'.format(PORT)}
     assert set(event['tags']) == expected_dbm_metrics_tags

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -420,7 +420,7 @@ def test_failed_explain_handling(
                 '^\nHINT:  No function matches the given name and argument types. You might need to add '
                 'explicit type casts.\n'
                 '\n'
-                'host=stubbed.hostname dbname=dogs_nofunc',
+                'dbname=dogs_nofunc host=stubbed.hostname',
             ],
         ),
         (
@@ -1189,7 +1189,7 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
                 'Unable to collect statement metrics because pg_stat_statements extension is '
                 "not loaded in database 'datadog_test'. See https://docs.datadoghq.com/database_monitoring/"
                 'setup_postgres/troubleshooting#pg-stat-statement-not-loaded'
-                ' for more details\nhost=stubbed.hostname dbname=datadog_test',
+                ' for more details\ndbname=datadog_test host=stubbed.hostname',
             ],
         ),
         (
@@ -1200,7 +1200,7 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
                 'Unable to collect statement metrics because pg_stat_statements is not '
                 "created in database 'datadog_test'. See https://docs.datadoghq.com/database_monitoring/"
                 'setup_postgres/troubleshooting#pg-stat-statement-not-created'
-                ' for more details\nhost=stubbed.hostname dbname=datadog_test',
+                ' for more details\ndbname=datadog_test host=stubbed.hostname',
             ],
         ),
         (

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -399,14 +399,7 @@ def test_failed_explain_handling(
             "error:explain-invalid_schema-<class 'psycopg2.errors.InvalidSchemaName'>",
             [{'code': 'invalid_schema', 'message': "<class 'psycopg2.errors.InvalidSchemaName'>"}],
             StatementTruncationState.not_truncated.value,
-            [
-                'Unable to collect execution plans due to invalid schema in database '
-                "'dogs_noschema'. This could be due to a missing 'datadog' schema in the "
-                'database. See '
-                'https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#explain-invalid-schema '
-                'for more details: schema "datadog" does not exist\nLINE 1: SELECT datadog.explain_statement('
-                '$stmt$SELECT * FROM pg_stat...\n               ^\n',
-            ],
+            [],
         ),
         (
             "dd_admin",
@@ -425,7 +418,9 @@ def test_failed_explain_handling(
                 'datadog.explain_statement(unknown) does not exist\nLINE 1: SELECT '
                 'datadog.explain_statement($stmt$SELECT * FROM pg_stat...\n               '
                 '^\nHINT:  No function matches the given name and argument types. You might need to add '
-                'explicit type casts.\n',
+                'explicit type casts.\n'
+                '\n'
+                'host=stubbed.hostname dbname=dogs_nofunc',
             ],
         ),
         (
@@ -1194,7 +1189,7 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
                 'Unable to collect statement metrics because pg_stat_statements extension is '
                 "not loaded in database 'datadog_test'. See https://docs.datadoghq.com/database_monitoring/"
                 'setup_postgres/troubleshooting#pg-stat-statement-not-loaded'
-                ' for more details',
+                ' for more details\nhost=stubbed.hostname dbname=datadog_test',
             ],
         ),
         (
@@ -1205,7 +1200,7 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
                 'Unable to collect statement metrics because pg_stat_statements is not '
                 "created in database 'datadog_test'. See https://docs.datadoghq.com/database_monitoring/"
                 'setup_postgres/troubleshooting#pg-stat-statement-not-created'
-                ' for more details',
+                ' for more details\nhost=stubbed.hostname dbname=datadog_test',
             ],
         ),
         (

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -403,7 +403,7 @@ def test_failed_explain_handling(
                 'Unable to collect execution plans due to invalid schema in database '
                 "'dogs_noschema'. This could be due to a missing 'datadog' schema in the "
                 'database. See '
-                'https://docs.datadoghq.com/database_monitoring/setup_postgres/selfhosted/?tab=postgres10 '
+                'https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#explain-invalid-schema '
                 'for more details: InvalidSchemaName(\'schema "datadog" does not exist\\nLINE '
                 '1: SELECT datadog.explain_statement($stmt$SELECT * FROM '
                 "pg_stat...\\n               ^\\n')",
@@ -421,7 +421,8 @@ def test_failed_explain_handling(
             [
                 'Unable to collect execution plans in dbname=dogs_nofunc. Check that the '
                 'function datadog.explain_statement exists in the database. See '
-                "https://datadoghq.com for more details: UndefinedFunction('function "
+                "https://docs.datadoghq.com/database_monitoring/setup_postgres/"
+                "troubleshooting#explain-undefined-function for more details: UndefinedFunction('function "
                 'datadog.explain_statement(unknown) does not exist\\nLINE 1: SELECT '
                 'datadog.explain_statement($stmt$SELECT * FROM pg_stat...\\n               '
                 '^\\nHINT:  No function matches the given name and argument types. You might '
@@ -1192,8 +1193,8 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
             'error:database-ObjectNotInPrerequisiteState-pg_stat_statements_not_loaded',
             [
                 'Unable to collect statement metrics because pg_stat_statements extension is '
-                "not loaded in database 'datadog_test'. See "
-                'https://docs.datadoghq.com/database_monitoring/troubleshooting/?tab=postgres#query-metrics-are-missing'
+                "not loaded in database 'datadog_test'. See https://docs.datadoghq.com/database_monitoring/"
+                'setup_postgres/troubleshooting#pg-stat-statement-not-loaded'
                 ' for more details',
             ],
         ),
@@ -1203,8 +1204,8 @@ class UndefinedTable(psycopg2.errors.UndefinedTable):
             'error:database-UndefinedTable-pg_stat_statements_not_created',
             [
                 'Unable to collect statement metrics because pg_stat_statements is not '
-                "created in database 'datadog_test'. See "
-                'https://docs.datadoghq.com/database_monitoring/troubleshooting/?tab=postgres#query-metrics-are-missing'
+                "created in database 'datadog_test'. See https://docs.datadoghq.com/database_monitoring/"
+                'setup_postgres/troubleshooting#pg-stat-statement-not-created'
                 ' for more details',
             ],
         ),


### PR DESCRIPTION
### What does this PR do?
This sends warnings in well-known database configuration errors to improve customers' visibility into issues due to missing or wrong database configuration required by the integration to work properly. Those warnings will appear in the agent status like this:

```
postgres (12.0.1)
    -----------------
      Instance ID: postgres:cc8c74ba7766a003 [WARNING]
      Configuration Source: file:/etc/datadog-agent/conf.d/postgres.d/conf.yaml
      Total Runs: 71
      Metric Samples: Last Run: 143, Total: 10,169
      Events: Last Run: 0, Total: 0
      Database Monitoring Activity Samples: Last Run: 1, Total: 102
      Service Checks: Last Run: 1, Total: 71
      Average Execution Time : 46ms
      Last Execution Date : 2022-01-25 17:40:09 UTC (1643132409000)
      Last Successful Execution Date : 2022-01-25 17:40:09 UTC (1643132409000)
      metadata:
        version.major: 12
        version.minor: 6
        version.patch: 0
        version.raw: 12.6 (Debian 12.6-1.pgdg100+1)
        version.scheme: semver

      Warning: Unable to collect statement metrics because pg_stat_statements is not created in database 'postgres'. See https://docs.datadoghq.com/database_monitoring/troubleshooting/?tab=postgres#query-metrics-are-missing for more details
host=postgrehost,dbname=postgres
```

As well as show up in the infrastructure views. 

### Motivation
Provide better ways for customers to identify database configuration errors and resolve them.

### Additional Notes
The links included in the warnings don't currently exist but will be created [as part of work planned ahead of the 7.35.0 release](https://datadoghq.atlassian.net/browse/DOCS-3075). We should make sure here that the links do make sense here even if the content doesn't already exist as we're aiming for stable permanent links. 

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
