### PR TITLE
Add recovery_model_desc tag for sqlserver database metrics

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -697,6 +697,7 @@ class SqlDatabaseStats(BaseSqlServerMetric):
     def fetch_metric(self, rows, columns):
         database_name = columns.index("name")
         db_state_desc_index = columns.index("state_desc")
+        db_recovery_model_desc_index = columns.index("recovery_model_desc")
         value_column_index = columns.index(self.column)
 
         for row in rows:
@@ -705,9 +706,11 @@ class SqlDatabaseStats(BaseSqlServerMetric):
 
             column_val = row[value_column_index]
             db_state_desc = row[db_state_desc_index]
+            db_recovery_model_desc = row[db_recovery_model_desc_index]
             metric_tags = [
                 'database:{}'.format(str(self.instance)),
                 'database_state_desc:{}'.format(str(db_state_desc)),
+                'database_recovery_model_desc:{}'.format(str(db_recovery_model_desc)),
             ]
             metric_tags.extend(self.tags)
             metric_name = '{}'.format(self.datadog_name)


### PR DESCRIPTION
### What does this PR do?
Fixes #11082 by adding a tag for the value of recovery_model_desc to database metrics.

### Motivation
Adding more useful tags to filter off of.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
