### PR TITLE
Detect and warn on potential typos in configuration options

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -34,6 +34,7 @@ gearman,PyPI,Apache-2.0,Matthew Tai
 immutables,PyPI,Apache-2.0,MagicStack Inc
 in-toto,PyPI,Apache-2.0,New York University: Secure Systems Lab
 ipaddress,PyPI,PSF,Philipp Hagemeister
+jellyfish,PyPI,BSD-3-Clause,
 kafka-python,PyPI,Apache-2.0,Dana Powers
 kazoo,PyPI,Apache-2.0,Kazoo team
 kubernetes,PyPI,Apache-2.0,Kubernetes

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -408,7 +408,6 @@ class AgentCheck(object):
         user_config = user_config or {}
         models_config = models_config or {}
         unknown_options = sorted(list(user_config.keys() - dict(models_config).keys()))
-
         for unknown_option in unknown_options:
             most_similar_known_option = (None, 0)
             for known_option in models_config:
@@ -416,10 +415,9 @@ class AgentCheck(object):
                 ratio = fuzz.ratio(unknown_option, known_option_name)
                 if ratio > most_similar_known_option[1]:
                     most_similar_known_option = (known_option_name, ratio)
-
             if most_similar_known_option[1] >= TYPO_SIMILARITY_THRESHOLD:
                 message = (
-                    "Detected potential typo in configuration option in {}/{} section: {}." "Did you mean `{}`?"
+                    "Detected potential typo in configuration option in {}/{} section: {}. Did you mean `{}`?"
                 ).format(self.name, level, unknown_option, most_similar_known_option[0])
                 self.log.warning(message)
 
@@ -428,7 +426,6 @@ class AgentCheck(object):
             # 'datadog_checks.<PACKAGE>.<MODULE>...'
             module_parts = self.__module__.split('.')
             package_path = '{}.config_models'.format('.'.join(module_parts[:2]))
-
         if self._config_model_shared is None:
             raw_shared_config = self._get_config_model_initialization_data()
             intg_shared_config = self._get_shared_config()

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -15,7 +15,6 @@ from os.path import basename
 from typing import TYPE_CHECKING, Any, AnyStr, Callable, Deque, Dict, List, Optional, Sequence, Tuple, Union
 
 import yaml
-from jellyfish import jaro_distance
 from six import PY2, binary_type, iteritems, raise_from, text_type
 
 from ..config import is_affirmative
@@ -405,6 +404,9 @@ class AgentCheck(object):
         return False
 
     def find_typos_in_options(self, user_config, models_config, level):
+        # only import it when running in python 3
+        from jellyfish import jaro_winkler_similarity
+
         user_config = user_config or {}
         models_config = models_config or {}
         typos = []  # type: List[str]
@@ -414,7 +416,7 @@ class AgentCheck(object):
         for unknown_option in unknown_options:
             most_similar_known_option = (None, 0)
             for known_option in known_options:
-                ratio = jaro_distance(unknown_option, known_option)
+                ratio = jaro_winkler_similarity(unknown_option, known_option)
                 if ratio > most_similar_known_option[1]:
                     most_similar_known_option = (known_option, ratio)
             if most_similar_known_option[1] >= TYPO_SIMILARITY_THRESHOLD:

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -423,7 +423,7 @@ class AgentCheck(object):
                     typos.add(unknown_option)
 
             if len(similar_known_options) > 0:
-                similar_known_options.sort(key=lambda option: option[1])
+                similar_known_options.sort(key=lambda option: option[1], reverse=True)
                 similar_known_options_names = [option[0] for option in similar_known_options]  # type: List[str]
                 message = (
                     'Detected potential typo in configuration option in {}/{} section: `{}`. Did you mean {}?'

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -405,7 +405,7 @@ class AgentCheck(object):
     def validate_unknown_options(self, user_config, models_config, level):
         user_config = user_config or {}
         models_config = models_config or {}
-        unknown_options = sorted(list(dict(user_config).keys() - dict(models_config).keys()))
+        unknown_options = sorted(list(user_config.keys() - dict(models_config).keys()))
         if unknown_options:
             message = "Detected undocumented or unknown configuration options in {}/{} section: {}".format(
                 self.name, level, ", ".join(unknown_options)

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -15,8 +15,8 @@ from os.path import basename
 from typing import TYPE_CHECKING, Any, AnyStr, Callable, Deque, Dict, List, Optional, Sequence, Tuple, Union
 
 import yaml
+from jellyfish import jaro_distance
 from six import PY2, binary_type, iteritems, raise_from, text_type
-from thefuzz import fuzz
 
 from ..config import is_affirmative
 from ..constants import ServiceCheck
@@ -75,7 +75,7 @@ if TYPE_CHECKING:
 
 # Metric types for which it's only useful to submit once per set of tags
 ONE_PER_CONTEXT_METRIC_TYPES = [aggregator.GAUGE, aggregator.RATE, aggregator.MONOTONIC_COUNT]
-TYPO_SIMILARITY_THRESHOLD = 90
+TYPO_SIMILARITY_THRESHOLD = 0.85
 
 
 @traced_class
@@ -414,7 +414,7 @@ class AgentCheck(object):
         for unknown_option in unknown_options:
             most_similar_known_option = (None, 0)
             for known_option in known_options:
-                ratio = fuzz.ratio(unknown_option, known_option)
+                ratio = jaro_distance(unknown_option, known_option)
                 if ratio > most_similar_known_option[1]:
                     most_similar_known_option = (known_option, ratio)
             if most_similar_known_option[1] >= TYPO_SIMILARITY_THRESHOLD:

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -403,6 +403,11 @@ class AgentCheck(object):
         return False
 
     def validate_unknown_options(self, user_config, models_config, level):
+        if not user_config:
+            user_config = {}
+
+        if not models_config:
+            models_config = {}
         unknown_options = sorted(list(dict(user_config).keys() - dict(models_config).keys()))
         if unknown_options:
             message = "Detected undocumented or unknown configuration options in {}/{} section: {}".format(

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -410,17 +410,27 @@ class AgentCheck(object):
 
         if self._config_model_shared is None:
             raw_shared_config = self._get_config_model_initialization_data()
-            raw_shared_config.update(self._get_shared_config())
+            intg_shared_config = self._get_shared_config()
+            raw_shared_config.update(intg_shared_config)
 
             shared_config = self.load_configuration_model(package_path, 'SharedConfig', raw_shared_config)
+            unknown_shared_options = list(set(intg_shared_config) - set(shared_config))
+            if unknown_shared_options:
+                message = "Detected unknown configuration options in {}: {}".format(self.name, unknown_shared_options)
+                self.log.warning(message)
             if shared_config is not None:
                 self._config_model_shared = shared_config
 
         if self._config_model_instance is None:
             raw_instance_config = self._get_config_model_initialization_data()
-            raw_instance_config.update(self._get_instance_config())
+            intg_instance_config = self._get_instance_config()
+            raw_instance_config.update(intg_instance_config)
 
             instance_config = self.load_configuration_model(package_path, 'InstanceConfig', raw_instance_config)
+            unknown_instance_options = list(set(intg_instance_config) - set(instance_config))
+            if unknown_instance_options:
+                message = "Detected unknown configuration options in {}: {}".format(self.name, unknown_instance_options)
+                self.log.warning(message)
             if instance_config is not None:
                 self._config_model_instance = instance_config
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -416,7 +416,9 @@ class AgentCheck(object):
             shared_config = self.load_configuration_model(package_path, 'SharedConfig', raw_shared_config)
             unknown_shared_options = list(set(intg_shared_config) - set(shared_config))
             if unknown_shared_options:
-                message = "Detected unknown configuration options in {}: {}".format(self.name, unknown_shared_options)
+                message = "Detected undocumented or unknown configuration options in {}: {}".format(
+                    self.name, unknown_shared_options
+                )
                 self.log.warning(message)
             if shared_config is not None:
                 self._config_model_shared = shared_config
@@ -429,7 +431,9 @@ class AgentCheck(object):
             instance_config = self.load_configuration_model(package_path, 'InstanceConfig', raw_instance_config)
             unknown_instance_options = list(set(intg_instance_config) - set(instance_config))
             if unknown_instance_options:
-                message = "Detected unknown configuration options in {}: {}".format(self.name, unknown_instance_options)
+                message = "Detected undocumented or unknown configuration options in {}: {}".format(
+                    self.name, unknown_instance_options
+                )
                 self.log.warning(message)
             if instance_config is not None:
                 self._config_model_instance = instance_config

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -402,6 +402,14 @@ class AgentCheck(object):
         self._log_deprecation('in_developer_mode')
         return False
 
+    def validate_unknown_options(self, user_config, models_config, level):
+        unknown_options = sorted(list(dict(user_config).keys() - dict(models_config).keys()))
+        if unknown_options:
+            message = "Detected undocumented or unknown configuration options in {}/{} section: {}".format(
+                self.name, level, ", ".join(unknown_options)
+            )
+            self.log.warning(message)
+
     def load_configuration_models(self, package_path=None):
         if package_path is None:
             # 'datadog_checks.<PACKAGE>.<MODULE>...'
@@ -414,12 +422,7 @@ class AgentCheck(object):
             raw_shared_config.update(intg_shared_config)
 
             shared_config = self.load_configuration_model(package_path, 'SharedConfig', raw_shared_config)
-            unknown_shared_options = list(set(intg_shared_config) - set(shared_config))
-            if unknown_shared_options:
-                message = "Detected undocumented or unknown configuration options in {}: {}".format(
-                    self.name, unknown_shared_options
-                )
-                self.log.warning(message)
+            self.validate_unknown_options(intg_shared_config, shared_config, 'init_config')
             if shared_config is not None:
                 self._config_model_shared = shared_config
 
@@ -429,12 +432,8 @@ class AgentCheck(object):
             raw_instance_config.update(intg_instance_config)
 
             instance_config = self.load_configuration_model(package_path, 'InstanceConfig', raw_instance_config)
-            unknown_instance_options = list(set(intg_instance_config) - set(instance_config))
-            if unknown_instance_options:
-                message = "Detected undocumented or unknown configuration options in {}: {}".format(
-                    self.name, unknown_instance_options
-                )
-                self.log.warning(message)
+            self.validate_unknown_options(intg_instance_config, instance_config, 'instances')
+
             if instance_config is not None:
                 self._config_model_instance = instance_config
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -403,11 +403,8 @@ class AgentCheck(object):
         return False
 
     def validate_unknown_options(self, user_config, models_config, level):
-        if not user_config:
-            user_config = {}
-
-        if not models_config:
-            models_config = {}
+        user_config = user_config or {}
+        models_config = models_config or {}
         unknown_options = sorted(list(dict(user_config).keys() - dict(models_config).keys()))
         if unknown_options:
             message = "Detected undocumented or unknown configuration options in {}/{} section: {}".format(

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -74,7 +74,7 @@ if TYPE_CHECKING:
 
 # Metric types for which it's only useful to submit once per set of tags
 ONE_PER_CONTEXT_METRIC_TYPES = [aggregator.GAUGE, aggregator.RATE, aggregator.MONOTONIC_COUNT]
-TYPO_SIMILARITY_THRESHOLD = 0.85
+TYPO_SIMILARITY_THRESHOLD = 0.95
 
 
 @traced_class
@@ -424,7 +424,7 @@ class AgentCheck(object):
 
             if len(similar_known_options) > 0:
                 message = (
-                    'Detected potential typo in configuration option in {}/{} section: {}. Did you mean `{}`?'
+                    'Detected potential typo in configuration option in {}/{} section: `{}`. Did you mean {}?'
                 ).format(self.name, level, unknown_option, ', or '.join(similar_known_options))
                 self.log.warning(message)
         return typos

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -91,6 +91,7 @@ simplejson==3.6.5
 six==1.16.0
 snowflake-connector-python==2.6.0; python_version > "3.0"
 supervisor==4.1.0
+thefuzz==0.19.0
 tuf==0.17.0; python_version < "3.0"
 tuf==0.19.0; python_version > "3.0"
 typing==3.7.4.1; python_version < "3.0"

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -91,7 +91,6 @@ simplejson==3.6.5
 six==1.16.0
 snowflake-connector-python==2.6.0; python_version > "3.0"
 supervisor==4.1.0
-jellyfish==0.6.1; python_version < '3.0'
 jellyfish==0.9.0; python_version > '3.0'
 tuf==0.17.0; python_version < "3.0"
 tuf==0.19.0; python_version > "3.0"

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -91,7 +91,8 @@ simplejson==3.6.5
 six==1.16.0
 snowflake-connector-python==2.6.0; python_version > "3.0"
 supervisor==4.1.0
-thefuzz==0.19.0
+jellyfish==0.6.1; python_version < '3.0'
+jellyfish==0.9.0; python_version > '3.0'
 tuf==0.17.0; python_version < "3.0"
 tuf==0.19.0; python_version > "3.0"
 typing==3.7.4.1; python_version < "3.0"

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -33,7 +33,6 @@ requests_toolbelt==0.9.1
 requests-unixsocket==0.2.0
 simplejson==3.6.5
 six==1.16.0
-jellyfish==0.6.1; python_version < '3.0'
 jellyfish==0.9.0; python_version > '3.0'
 typing==3.7.4.1; python_version < '3.0'
 uptime==3.0.1

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -33,6 +33,7 @@ requests_toolbelt==0.9.1
 requests-unixsocket==0.2.0
 simplejson==3.6.5
 six==1.16.0
+thefuzz==0.19.0
 typing==3.7.4.1; python_version < '3.0'
 uptime==3.0.1
 win-inet-pton==1.1.0; sys_platform == 'win32' and python_version < '3.0'

--- a/datadog_checks_base/requirements.in
+++ b/datadog_checks_base/requirements.in
@@ -33,7 +33,8 @@ requests_toolbelt==0.9.1
 requests-unixsocket==0.2.0
 simplejson==3.6.5
 six==1.16.0
-thefuzz==0.19.0
+jellyfish==0.6.1; python_version < '3.0'
+jellyfish==0.9.0; python_version > '3.0'
 typing==3.7.4.1; python_version < '3.0'
 uptime==3.0.1
 win-inet-pton==1.1.0; sys_platform == 'win32' and python_version < '3.0'

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_options.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_options.py
@@ -673,31 +673,6 @@ class TestShareLabels:
 
         aggregator.assert_all_metrics_covered()
 
-    def test_unknown_config(self, aggregator, dd_run_check, mock_http_response, caplog):
-        mock_http_response(
-            """
-            # HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
-            # TYPE go_memstats_gc_sys_bytes gauge
-            go_memstats_gc_sys_bytes{bar="foo"} 901120
-            # HELP go_memstats_free_bytes Number of bytes free and available for use.
-            # TYPE go_memstats_free_bytes gauge
-            go_memstats_free_bytes{bar="baz"} 6.396288e+06
-            # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
-            # TYPE go_memstats_alloc_bytes gauge
-            go_memstats_alloc_bytes{foo="bar"} 6.396288e+06
-            """
-        )
-        check = get_check(
-            {
-                'metrics': ['.+'],
-                'ollect_histogram_buckets': 'test',
-                'share_labels': {'go_memstats_alloc_bytes': True},
-                'cache_shared_labels': False,
-            }
-        )
-        dd_run_check(check)
-        assert "Detected potential typo in configuration option" in caplog.text
-
 
 class TestIgnoreTags:
     def test_simple_match(self, aggregator, dd_run_check, mock_http_response):

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_options.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_options.py
@@ -673,6 +673,31 @@ class TestShareLabels:
 
         aggregator.assert_all_metrics_covered()
 
+    def test_unknown_config(self, aggregator, dd_run_check, mock_http_response, caplog):
+        mock_http_response(
+            """
+            # HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+            # TYPE go_memstats_gc_sys_bytes gauge
+            go_memstats_gc_sys_bytes{bar="foo"} 901120
+            # HELP go_memstats_free_bytes Number of bytes free and available for use.
+            # TYPE go_memstats_free_bytes gauge
+            go_memstats_free_bytes{bar="baz"} 6.396288e+06
+            # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+            # TYPE go_memstats_alloc_bytes gauge
+            go_memstats_alloc_bytes{foo="bar"} 6.396288e+06
+            """
+        )
+        check = get_check(
+            {
+                'metrics': ['.+'],
+                'ollect_histogram_buckets': 'test',
+                'share_labels': {'go_memstats_alloc_bytes': True},
+                'cache_shared_labels': False,
+            }
+        )
+        dd_run_check(check)
+        assert "Detected potential typo in configuration option" in caplog.text
+
 
 class TestIgnoreTags:
     def test_simple_match(self, aggregator, dd_run_check, mock_http_response):

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -919,20 +919,18 @@ def test_load_configuration_models(dd_run_check, mocker):
 
 @requires_py3
 @pytest.mark.parametrize(
-    'check_instance_config, default_instance_config, log_lines, all_typos',
+    'check_instance_config, default_instance_config, log_lines',
     [
         pytest.param(
             {'endpoint': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
             {},
             None,
-            set(),
             id='empty default',
         ),
         pytest.param(
             {'endpoint': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
             {'endpoint': 'url'},
             None,
-            set(),
             id='no typo',
         ),
         pytest.param(
@@ -944,14 +942,12 @@ def test_load_configuration_models(dd_run_check, mocker):
                     'Did you mean endpoint?'
                 )
             ],
-            set({'endpoints'}),
             id='typo',
         ),
         pytest.param(
             {'endpoints': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
             {'endpoint': 'url', 'endpoints': 'url'},
             None,
-            set(),
             id='no typo similar option',
         ),
         pytest.param(
@@ -963,10 +959,9 @@ def test_load_configuration_models(dd_run_check, mocker):
                     'Did you mean endpoint, or endpoints?'
                 )
             ],
-            set({'endpont'}),
             id='typo two candidates',
         ),
-        pytest.param({'tag': 'test'}, {'tags': 'test'}, None, set(), id='short option cant catch'),
+        pytest.param({'tag': 'test'}, {'tags': 'test'}, None, id='short option cant catch'),
         pytest.param(
             {'testing_long_para': 'test'},
             {'testing_long_param': 'test', 'test_short_param': 'test'},
@@ -976,14 +971,12 @@ def test_load_configuration_models(dd_run_check, mocker):
                     'Did you mean testing_long_param?'
                 )
             ],
-            set({'testing_long_para'}),
             id='somewhat similar option',
         ),
         pytest.param(
             {'send_distribution_sums_as_monotonic': False, 'exclude_labels': True},
             {'send_distribution_counts_as_monotonic': True, 'include_labels': True},
             None,
-            set(),
             id='different options no typos',
         ),
         pytest.param(
@@ -1004,13 +997,12 @@ def test_load_configuration_models(dd_run_check, mocker):
                     'Did you mean exclude_labels?'
                 ),
             ],
-            set({'send_distribution_count_as_monotonic', 'exclude_label'}),
             id='different options typo',
         ),
     ],
 )
 def test_detect_typos_configuration_models(
-    dd_run_check, mocker, caplog, check_instance_config, default_instance_config, log_lines, all_typos
+    dd_run_check, mocker, caplog, check_instance_config, default_instance_config, log_lines
 ):
     caplog.clear()
     caplog.set_level(logging.WARNING)
@@ -1018,9 +1010,7 @@ def test_detect_typos_configuration_models(
     check = AgentCheck('test', empty_config, [check_instance_config])
     check.check_id = 'test:123'
 
-    found_typos = check.find_typos_in_options(check_instance_config, default_instance_config, 'instance')
-
-    assert found_typos == all_typos
+    check.log_typos_in_options(check_instance_config, default_instance_config, 'instance')
 
     if log_lines is not None:
         for log_line in log_lines:

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -894,8 +894,8 @@ def test_load_configuration_models(dd_run_check, mocker):
     assert check._config_model_instance is None
     assert check._config_model_shared is None
 
-    instance_config = object()
-    shared_config = object()
+    instance_config = {}
+    shared_config = {}
     package = mocker.MagicMock()
     package.InstanceConfig = mocker.MagicMock(return_value=instance_config)
     package.SharedConfig = mocker.MagicMock(return_value=shared_config)


### PR DESCRIPTION
### What does this PR do?
Adds the ability to detects and warn the user on typos in configuration options. We calculate the jaro distance of undocumented configuration options and each documented configuration option, and if they are similar enough, warn the user they could have made a typo. 
   
### Motivation
We want to give better feedback on typos in configuration options
It's following up and based on the work from https://github.com/DataDog/integrations-core/pull/10438/, yet only warning on typos, not all unknown options.

### Additional Notes
Logs will be in the form of:

```
2022-01-26 16:07:25 UTC | CORE | WARN | (pkg/collector/python/datadog_agent.go:124 in LogMessage) | openmetrics:openmetrics:4f4b8d8a05846ec | (base.py:425) | Detected potential typo in configuration option in openmetrics/instances section: prometheus_ur. Did you mean `prometheus_url`?
```

We've set the similarity threshold to 0.95 to avoid as many false positives and unhelpful hints as possible, such as `send_distribution_sums_as_monotonic` vs `send_distribution_counts_as_monotonic` and `include_labels` vs `exclude_labels`. False negatives are inevitable 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
