### PR TITLE
Standardize key and token options behaviour

### DIFF
--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -52,9 +52,6 @@ class SnowflakeCheck(AgentCheck):
         if self._config.password:
             self.register_secret(self._config.password)
 
-        if self._config.private_key_password:
-            self.register_secret(self._config.private_key_password)
-
         if self._config.role == 'ACCOUNTADMIN':
             self.log.info(
                 'Snowflake `role` is set as `ACCOUNTADMIN` which should be used cautiously, '

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -85,6 +85,8 @@ class SnowflakeCheck(AgentCheck):
             with open(self._config.token_path, 'rb', encoding="UTF-8") as f:
                 self._config.token = f.read()
 
+        return self._config.token
+
     def read_key(self):
         if self._config.private_key_path:
             self.log.debug("Reading Snowflake client key for key pair authentication")
@@ -148,8 +150,6 @@ class SnowflakeCheck(AgentCheck):
             self.proxy_port,
         )
 
-        self.read_token()
-
         try:
             conn = sf.connect(
                 user=self._config.user,
@@ -165,7 +165,7 @@ class SnowflakeCheck(AgentCheck):
                 login_timeout=self._config.login_timeout,
                 ocsp_response_cache_filename=self._config.ocsp_response_cache_filename,
                 authenticator=self._config.authenticator,
-                token=self._config.token,
+                token=self.read_token(),
                 private_key=self.read_key(),
                 client_session_keep_alive=self._config.client_keep_alive,
                 proxy_host=self.proxy_host,

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -51,6 +51,9 @@ class SnowflakeCheck(AgentCheck):
 
         if self._config.password:
             self.register_secret(self._config.password)
+        
+        if self._config.private_key_password:
+            self.register_secret(self._config.private_key_password)
 
         if self._config.role == 'ACCOUNTADMIN':
             self.log.info(

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -51,7 +51,7 @@ class SnowflakeCheck(AgentCheck):
 
         if self._config.password:
             self.register_secret(self._config.password)
-        
+
         if self._config.private_key_password:
             self.register_secret(self._config.private_key_password)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`read_token` now return the token value, so it has a similar behaviour as `read_key`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
