### PR TITLE
Collect value-only application tags

### DIFF
--- a/yarn/datadog_checks/yarn/yarn.py
+++ b/yarn/datadog_checks/yarn/yarn.py
@@ -273,8 +273,12 @@ class YarnCheck(AgentCheck):
         tags = []
         kv_pairs = [x.split(':') for x in application_tags.split(',')]
         try:
-            for tag_key, tag_value in kv_pairs:
-                tags.append('app_{tag}:{value}'.format(tag=tag_key, value=tag_value))
+            for tag_set in kv_pairs:
+                if len(tag_set) > 1:
+                    tag_key, tag_value = tag_set
+                    tags.append('app_{tag}:{value}'.format(tag=tag_key, value=tag_value))
+                else:
+                    tags.append('app_{}'.format(tag_set[0]))
         except ValueError:
             self.log.warning("Unable to split string %s with YARN application tags", application_tags)
             # Reverting to default behavior.

--- a/yarn/tests/test_unit.py
+++ b/yarn/tests/test_unit.py
@@ -13,11 +13,24 @@ from .common import YARN_CONFIG
     'tags, expected_tags',
     [
         pytest.param("test:example", ["app_test:example"], id='tag_key_value'),
-        pytest.param("test:example1,test:example2", ["app_test:example1,app_test:example2"], id='multiple_tag_key_value'),
+        pytest.param(
+            "test:example1,test:example2", ["app_test:example1,app_test:example2"], id='multiple_tag_key_value'
+        ),
         pytest.param("test1,testtag2,test2", ["app_test", "app_testag2", "app_test2"], id='multiple_tag_value_only'),
         pytest.param(
             "script_name:test_script,value_only_tag,user_email:test_email",
             ["app_script_name:test_script", "app_value_only_tag", "app_user_email:test_email"],
+            id='both_tag_key_and_value_only',
+        ),
+        pytest.param(
+            "script_name:test_script,value_only_tag1,user_email:test_email,value_only_tag2,test:env",
+            [
+                "app_script_name:test_script",
+                "app_value_only_tag1",
+                "app_user_email:test_email",
+                "app_value_only_tag2",
+                "app_test:env",
+            ],
             id='both_tag_key_and_value_only',
         ),
     ],

--- a/yarn/tests/test_unit.py
+++ b/yarn/tests/test_unit.py
@@ -15,8 +15,8 @@ from .common import YARN_CONFIG
         pytest.param("test:example", ["app_test:example"], id='tag_key_value'),
         pytest.param("test", ["app_test"], id='tag_value_only'),
         pytest.param(
-            "luigiscript_name:dash_monitor_edge,livy-batch-0-5hmfsykz,user_email:data-science-eng",
-            ["app_luigiscript_name:dash_monitor_edge", "app_livy-batch-0-5hmfsykz", "app_user_email:data-science-eng"],
+            "script_name:test_script,value_only_tag,user_email:test_email",
+            ["app_script_name:test_script", "app_value_only_tag", "app_user_email:test_email"],
             id='both_tag_key_and_value_only',
         ),
     ],

--- a/yarn/tests/test_unit.py
+++ b/yarn/tests/test_unit.py
@@ -16,7 +16,7 @@ from .common import YARN_CONFIG
         pytest.param(
             "test:example1,test:example2", ["app_test:example1,app_test:example2"], id='multiple_tag_key_value'
         ),
-        pytest.param("test1,testtag2,test2", ["app_test", "app_testag2", "app_test2"], id='multiple_tag_value_only'),
+        pytest.param("test1,testtag2,test2", ["app_test1", "app_testtag2", "app_test2"], id='multiple_tag_value_only'),
         pytest.param(
             "script_name:test_script,value_only_tag,user_email:test_email",
             ["app_script_name:test_script", "app_value_only_tag", "app_user_email:test_email"],

--- a/yarn/tests/test_unit.py
+++ b/yarn/tests/test_unit.py
@@ -13,7 +13,8 @@ from .common import YARN_CONFIG
     'tags, expected_tags',
     [
         pytest.param("test:example", ["app_test:example"], id='tag_key_value'),
-        pytest.param("test", ["app_test"], id='tag_value_only'),
+        pytest.param("test:example1,test:example2", ["app_test:example1,app_test:example2"], id='multiple_tag_key_value'),
+        pytest.param("test1,testtag2,test2", ["app_test", "app_testag2", "app_test2"], id='multiple_tag_value_only'),
         pytest.param(
             "script_name:test_script,value_only_tag,user_email:test_email",
             ["app_script_name:test_script", "app_value_only_tag", "app_user_email:test_email"],

--- a/yarn/tests/test_unit.py
+++ b/yarn/tests/test_unit.py
@@ -14,7 +14,7 @@ from .common import YARN_CONFIG
     [
         pytest.param("test:example", ["app_test:example"], id='tag_key_value'),
         pytest.param(
-            "test:example1,test:example2", ["app_test:example1,app_test:example2"], id='multiple_tag_key_value'
+            "test:example1,test:example2", ["app_test:example1", "app_test:example2"], id='multiple_tag_key_value'
         ),
         pytest.param("test1,testtag2,test2", ["app_test1", "app_testtag2", "app_test2"], id='multiple_tag_value_only'),
         pytest.param(

--- a/yarn/tests/test_unit.py
+++ b/yarn/tests/test_unit.py
@@ -1,0 +1,31 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+
+from datadog_checks.yarn import YarnCheck
+
+from .common import YARN_CONFIG
+
+
+@pytest.mark.parametrize(
+    'tags, expected_tags',
+    [
+        pytest.param("test:example", ["app_test:example"], id='tag_key_value'),
+        pytest.param("test", ["app_test"], id='tag_value_only'),
+        pytest.param(
+            "luigiscript_name:dash_monitor_edge,livy-batch-0-5hmfsykz,user_email:data-science-eng",
+            ["app_luigiscript_name:dash_monitor_edge", "app_livy-batch-0-5hmfsykz", "app_user_email:data-science-eng"],
+            id='both_tag_key_and_value_only',
+        ),
+    ],
+)
+def test_split_application_tag(tags, expected_tags):
+    instance = YARN_CONFIG['instances'][0]
+
+    # Instantiate YarnCheck
+    yarn = YarnCheck('yarn', {}, [instance])
+
+    split_tags = yarn._split_yarn_application_tags(tags, "job_tag")
+    assert split_tags == expected_tags

--- a/yarn/tests/test_yarn.py
+++ b/yarn/tests/test_yarn.py
@@ -218,7 +218,8 @@ def test_check_splits_yarn_application_tags(aggregator, mocked_request):
         tags=[
             'app_queue:default',
             'app_name:dead app',
-            'app_tags:tag1,tag2',
+            'app_tag1',
+            'app_tag2',
         ]
         + EXPECTED_TAGS,
     )
@@ -248,14 +249,14 @@ def test_disable_legacy_cluster_tag(aggregator, mocked_request):
         + expected_tags,
     )
 
-    # And check that the YARN application tags have not been split for other tags
     aggregator.assert_service_check(
         APPLICATION_STATUS_SERVICE_CHECK,
         status=YarnCheck.WARNING,
         tags=[
             'app_queue:default',
             'app_name:dead app',
-            'app_tags:tag1,tag2',
+            'app_tag1',
+            'app_tag2',
         ]
         + expected_tags,
     )


### PR DESCRIPTION
### What does this PR do?
Currently the yarn integration will skip parsing application tags if they're not in `key:value` form. 

### Motivation

Value tags are technically valid tags and should be collected: see [docs](https://docs.datadoghq.com/getting_started/tagging/)

Currently the logs are getting skipped and submitted as a long string
```
2022-01-26 16:02:51 UTC | CORE | WARN | (pkg/collector/python/datadog_agent.go:124 in LogMessage) | yarn:c21bd3c1c88284c2 | (yarn.py:279) | Unable to split string luigiscript_name:dash_monitor_edge,livy-batch-0-5hmfsykz,user_email:data-science-eng with YARN application tags
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
