### PR TITLE
Report known mysql database configuration errors as warnings

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -981,9 +981,9 @@ class MySql(AgentCheck):
         self._warnings_by_code[code] = message
 
     def _report_warnings(self):
-        messages = list(self._warnings_by_code.values())
-        # Clear the warnings for the next check run
-        self._warnings_by_code.clear()
+        messages = self._warnings_by_code.values()
+        # Reset the warnings for the next check run
+        self._warnings_by_code = {}
 
         for warning in messages:
             self.warning(warning)

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -977,7 +977,7 @@ class MySql(AgentCheck):
             self._qcache_not_cached = int(results['Qcache_not_cached'])
 
     def record_warning(self, code, message):
-        # type: (DatabaseConfigurationError, str) -> ()
+        # type: (DatabaseConfigurationError, str) -> None
         self._warnings_by_code[code] = message
 
     def _report_warnings(self):

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -981,7 +981,9 @@ class MySql(AgentCheck):
         self._warnings_by_code[code] = message
 
     def _report_warnings(self):
-        for warning in self._warnings_by_code.values():
-            self.warning(warning)
+        messages = list(self._warnings_by_code.values())
         # Clear the warnings for the next check run
-        self._warnings_by_code = {}
+        self._warnings_by_code.clear()
+
+        for warning in messages:
+            self.warning(warning)

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -883,16 +883,18 @@ class MySQLStatementSamples(DBMAsyncJob):
             return cursor.fetchone()[0]
         except pymysql.err.DatabaseError as e:
             if e.args[0] in PYMYSQL_MISSING_EXPLAIN_STATEMENT_PROC_ERRORS:
+                err_msg = e.args[1] if len(e.args) > 1 else ''
                 self._check.warning(
                     str(
                         DatabaseConfigurationWarning(
                             {'host': self._check.resolved_hostname, 'schema': schema},
                             "Unable to collect explain plans because the procedure '%s' is either undefined or not "
                             "granted access to in schema '%s'. See https://docs.datadoghq.com/database_monitoring/"
-                            'setup_mysql/troubleshooting#explain-plan-procedure-missing for more details: %s',
+                            'setup_mysql/troubleshooting#explain-plan-procedure-missing for more details: (%d) %s',
                             self._explain_procedure,
                             schema,
-                            str(e),
+                            e.args[0],
+                            str(err_msg),
                         )
                     )
                 )
@@ -909,15 +911,17 @@ class MySQLStatementSamples(DBMAsyncJob):
             return cursor.fetchone()[0]
         except pymysql.err.DatabaseError as e:
             if e.args[0] in PYMYSQL_MISSING_EXPLAIN_STATEMENT_PROC_ERRORS:
+                err_msg = e.args[1] if len(e.args) > 1 else ''
                 self._check.warning(
                     str(
                         DatabaseConfigurationWarning(
                             {'host': self._check.resolved_hostname},
                             "Unable to collect explain plans because the procedure '%s' is either undefined or "
                             'not granted access to. See https://docs.datadoghq.com/database_monitoring/setup_mysql/'
-                            'troubleshooting#explain-plan-fq-procedure for more details: %s',
+                            'troubleshooting#explain-plan-fq-procedure for more details: (%d) %s',
                             self._fully_qualified_explain_procedure,
-                            str(e),
+                            e.args[0],
+                            str(err_msg),
                         )
                     )
                 )

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -883,7 +883,6 @@ class MySQLStatementSamples(DBMAsyncJob):
         except pymysql.err.DatabaseError as e:
             if e.args[0] in PYMYSQL_MISSING_EXPLAIN_STATEMENT_PROC_ERRORS:
                 err_msg = e.args[1] if len(e.args) > 1 else ''
-                self._log.warning("Recording warning for code explain_plan_procedure_missing")
                 self._check.record_warning(
                     DatabaseConfigurationError.explain_plan_procedure_missing,
                     warning_with_tags(

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -17,7 +17,7 @@ from datadog_checks.base.utils.db.statement_metrics import StatementMetrics
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
 from datadog_checks.base.utils.serialization import json
 
-from .util import DatabaseConfigurationWarning
+from .util import DatabaseConfigurationError, warning_tags
 
 try:
     import datadog_agent
@@ -115,13 +115,13 @@ class MySQLStatementMetrics(DBMAsyncJob):
         # just returns no rows without errors if the performance schema is disabled
         if not self._check.performance_schema_enabled:
             self._check.warning(
-                str(
-                    DatabaseConfigurationWarning(
-                        {'host': self._check.resolved_hostname},
-                        'Unable to collect statement metrics because the performance schema is disabled. '
-                        'See https://docs.datadoghq.com/database_monitoring/setup_mysql/'
-                        'troubleshooting#performance-schema-not-enabled for more details',
-                    )
+                'Unable to collect statement metrics because the performance schema is disabled. '
+                'See https://docs.datadoghq.com/database_monitoring/setup_mysql/'
+                'troubleshooting#%s for more details',
+                DatabaseConfigurationError.performance_schema_not_enabled.value,
+                warning_tags(
+                    code=DatabaseConfigurationError.performance_schema_not_enabled.value,
+                    host=self._check.resolved_hostname,
                 ),
             )
             return

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -17,7 +17,7 @@ from datadog_checks.base.utils.db.statement_metrics import StatementMetrics
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
 from datadog_checks.base.utils.serialization import json
 
-from .util import DatabaseConfigurationError, warning_tags
+from .util import DatabaseConfigurationError, warning_with_tags
 
 try:
     import datadog_agent
@@ -114,12 +114,13 @@ class MySQLStatementMetrics(DBMAsyncJob):
         # Detect a database misconfiguration by checking if the performance schema is enabled since mysql
         # just returns no rows without errors if the performance schema is disabled
         if not self._check.performance_schema_enabled:
-            self._check.warning(
-                'Unable to collect statement metrics because the performance schema is disabled. '
-                'See https://docs.datadoghq.com/database_monitoring/setup_mysql/'
-                'troubleshooting#%s for more details',
-                DatabaseConfigurationError.performance_schema_not_enabled.value,
-                warning_tags(
+            self._check.record_warning(
+                DatabaseConfigurationError.performance_schema_not_enabled,
+                warning_with_tags(
+                    'Unable to collect statement metrics because the performance schema is disabled. '
+                    'See https://docs.datadoghq.com/database_monitoring/setup_mysql/'
+                    'troubleshooting#%s for more details',
+                    DatabaseConfigurationError.performance_schema_not_enabled.value,
                     code=DatabaseConfigurationError.performance_schema_not_enabled.value,
                     host=self._check.resolved_hostname,
                 ),

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -142,6 +142,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
             'timestamp': time.time() * 1000,
             'mysql_version': self._check.version.version + '+' + self._check.version.build,
             'mysql_flavor': self._check.version.flavor,
+            "ddagenthostname": self._check.agent_hostname,
             'ddagentversion': datadog_agent.get_version(),
             'min_collection_interval': self._metric_collection_interval,
             'tags': self._tags,

--- a/mysql/datadog_checks/mysql/util.py
+++ b/mysql/datadog_checks/mysql/util.py
@@ -1,0 +1,20 @@
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+
+class DatabaseConfigurationWarning(object):
+    """DatabaseConfigurationWarning formalizes the format of database configuration warning messages."""
+
+    def __init__(self, metadata, message, *args):
+        if metadata is None:
+            metadata = {}
+        if args:
+            message = message % args
+        self._message = message
+        self._metadata = metadata
+
+    def __str__(self):
+        return '{msg}\n{key_values}'.format(
+            msg=self._message,
+            key_values=" ".join('{key}={value}'.format(key=k, value=v) for k, v in sorted(self._metadata.items())),
+        )

--- a/mysql/datadog_checks/mysql/util.py
+++ b/mysql/datadog_checks/mysql/util.py
@@ -1,20 +1,17 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+from enum import Enum
 
 
-class DatabaseConfigurationWarning(object):
-    """DatabaseConfigurationWarning formalizes the format of database configuration warning messages."""
+class DatabaseConfigurationError(Enum):
+    """
+    Denotes the possible database configuration errors
+    """
 
-    def __init__(self, metadata, message, *args):
-        if metadata is None:
-            metadata = {}
-        if args:
-            message = message % args
-        self._message = message
-        self._metadata = metadata
+    explain_plan_procedure_missing = 'explain-plan-procedure-missing'
+    explain_plan_fq_procedure_missing = 'explain-plan-fq-procedure-missing'
+    performance_schema_not_enabled = 'performance-schema-not-enabled'
 
-    def __str__(self):
-        return '{msg}\n{key_values}'.format(
-            msg=self._message,
-            key_values=" ".join('{key}={value}'.format(key=k, value=v) for k, v in sorted(self._metadata.items())),
-        )
+
+def warning_tags(**kwargs):
+    return " ".join('{key}={value}'.format(key=k, value=v) for k, v in sorted(kwargs.items()))

--- a/mysql/datadog_checks/mysql/util.py
+++ b/mysql/datadog_checks/mysql/util.py
@@ -13,5 +13,10 @@ class DatabaseConfigurationError(Enum):
     performance_schema_not_enabled = 'performance-schema-not-enabled'
 
 
-def warning_tags(**kwargs):
-    return " ".join('{key}={value}'.format(key=k, value=v) for k, v in sorted(kwargs.items()))
+def warning_with_tags(warning_message, *args, **kwargs):
+    if args:
+        warning_message = warning_message % args
+
+    return "{msg}\n{tags}".format(
+        msg=warning_message, tags=" ".join('{key}={value}'.format(key=k, value=v) for k, v in sorted(kwargs.items()))
+    )

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -75,8 +75,8 @@ def dd_environment(config_e2e):
 def instance_basic():
     return {
         'host': common.HOST,
-        'user': common.USER,
-        'pass': common.PASS,
+        'username': common.USER,
+        'password': common.PASS,
         'port': common.PORT,
         'disable_generic_tags': 'true',
     }
@@ -86,8 +86,8 @@ def instance_basic():
 def instance_complex():
     return {
         'host': common.HOST,
-        'user': common.USER,
-        'pass': common.PASS,
+        'username': common.USER,
+        'password': common.PASS,
         'port': common.PORT,
         'disable_generic_tags': 'true',
         'options': {
@@ -119,8 +119,8 @@ def instance_complex():
 def instance_additional_status():
     return {
         'host': common.HOST,
-        'user': common.USER,
-        'pass': common.PASS,
+        'username': common.USER,
+        'password': common.PASS,
         'port': common.PORT,
         'tags': tags.METRIC_TAGS,
         'disable_generic_tags': 'true',
@@ -143,8 +143,8 @@ def instance_additional_status():
 def instance_additional_variable():
     return {
         'host': common.HOST,
-        'user': common.USER,
-        'pass': common.PASS,
+        'username': common.USER,
+        'password': common.PASS,
         'port': common.PORT,
         'tags': tags.METRIC_TAGS,
         'disable_generic_tags': 'true',
@@ -167,8 +167,8 @@ def instance_additional_variable():
 def instance_status_already_queried():
     return {
         'host': common.HOST,
-        'user': common.USER,
-        'pass': common.PASS,
+        'username': common.USER,
+        'password': common.PASS,
         'port': common.PORT,
         'tags': tags.METRIC_TAGS,
         'disable_generic_tags': 'true',
@@ -186,8 +186,8 @@ def instance_status_already_queried():
 def instance_var_already_queried():
     return {
         'host': common.HOST,
-        'user': common.USER,
-        'pass': common.PASS,
+        'username': common.USER,
+        'password': common.PASS,
         'port': common.PORT,
         'tags': tags.METRIC_TAGS,
         'disable_generic_tags': 'true',
@@ -205,8 +205,8 @@ def instance_var_already_queried():
 def instance_invalid_var():
     return {
         'host': common.HOST,
-        'user': common.USER,
-        'pass': common.PASS,
+        'username': common.USER,
+        'password': common.PASS,
         'port': common.PORT,
         'tags': tags.METRIC_TAGS,
         'disable_generic_tags': 'true',
@@ -229,8 +229,8 @@ def instance_invalid_var():
 def instance_custom_queries():
     return {
         'host': common.HOST,
-        'user': common.USER,
-        'pass': common.PASS,
+        'username': common.USER,
+        'password': common.PASS,
         'port': common.PORT,
         'tags': tags.METRIC_TAGS,
         'disable_generic_tags': 'true',
@@ -249,7 +249,7 @@ def instance_custom_queries():
 
 @pytest.fixture(scope='session')
 def instance_error():
-    return {'host': common.HOST, 'user': 'unknown', 'pass': common.PASS, 'disable_generic_tags': 'true'}
+    return {'host': common.HOST, 'username': 'unknown', 'password': common.PASS, 'disable_generic_tags': 'true'}
 
 
 @pytest.fixture(scope='session')

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -396,7 +396,7 @@ def test_statement_samples_collect(
                 "See https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting#"
                 "explain-plan-procedure-missing for more details: "
                 "(1044) Access denied for user 'dog'@'%' to database 'information_schema'\n"
-                "host=stubbed.hostname schema=information_schema",
+                "code=explain-plan-procedure-missing host=stubbed.hostname schema=information_schema",
             ],
         ),
         (
@@ -443,7 +443,7 @@ def test_performance_schema_disabled(dbm_instance):
         'Unable to collect statement metrics because the performance schema is disabled. See '
         'https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting#performance-schema-not-enabled '
         'for more details\n'
-        'host=stubbed.hostname'
+        'code=performance-schema-not-enabled host=stubbed.hostname'
     ]
 
 

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -394,7 +394,7 @@ def test_statement_samples_collect(
                 "either undefined or not granted access to in schema 'information_schema'. "
                 "See https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting#"
                 "explain-plan-procedure-missing for more details: "
-                "(1044, u\"Access denied for user 'dog'@'%' to database 'information_schema'\")\n"
+                "(1044) Access denied for user 'dog'@'%' to database 'information_schema'\n"
                 "host=stubbed.hostname schema=information_schema",
             ],
         ),

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -131,6 +131,7 @@ def test_statement_metrics(
 
     assert event['host'] == 'stubbed.hostname'
     assert event['ddagentversion'] == datadog_agent.get_version()
+    assert event['ddagenthostname'] == datadog_agent.get_hostname()
     assert event['mysql_version'] == mysql_check.version.version + '+' + mysql_check.version.build
     assert event['mysql_flavor'] == mysql_check.version.flavor
     assert event['timestamp'] > 0


### PR DESCRIPTION
### What does this PR do?
This sends warnings in well-known database configuration errors to improve customers' visibility into issues due to missing or wrong database configuration required by the integration to work properly. Those warnings will appear in the agent status like this:

```
mysql (8.0.2)
    -------------
      Instance ID: mysql:d790abe8c7b4512b [WARNING]
      Configuration Source: file:/etc/datadog-agent/conf.d/mysql.d/conf.yaml
      Total Runs: 22
      Metric Samples: Last Run: 135, Total: 2,495
      Events: Last Run: 0, Total: 0
      Database Monitoring Query Metrics: Last Run: 2, Total: 32
      Database Monitoring Query Samples: Last Run: 6, Total: 65
      Service Checks: Last Run: 3, Total: 66
      Average Execution Time : 138ms
      Last Execution Date : 2022-01-27 01:54:29 UTC (1643248469000)
      Last Successful Execution Date : 2022-01-27 01:54:29 UTC (1643248469000)
      metadata:
        flavor: MySQL
        version.build: log
        version.major: 5
        version.minor: 7
        version.patch: 37
        version.raw: 5.7.37+log
        version.scheme: semver

      Warning: Unable to collect explain plans because the procedure 'datadog.explain_statement' is either undefined or not granted access to. See https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting#explain-plan-fq-procedure for more details: (1370, "execute command denied to user 'datadog'@'%' for routine 'datadog.explain_statement'")
host=mysqldb
```

As well as show up in the infrastructure views. 

The database configuration errors covered here are:
* performance_schema not enabled
* Missing `datadog.explain_statement` procedure or missing grant to run it
* Missing schema-specific version of the `explain_statement` or missing grant to run it

### Motivation
Provide better ways for customers to identify database configuration errors and resolve them.

### Additional Notes
The links included in the warnings don't currently exist but will be created [as part of work planned ahead of the 7.35.0 release](https://datadoghq.atlassian.net/browse/DOCS-3075). We should make sure here that the links do make sense here even if the content doesn't already exist as we're aiming for stable permanent links. 

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
