### PR TITLE
Add ddagenthostname to dbm-metrics payloads

### DIFF
--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -24,6 +24,7 @@ parameters:
 jobs:
 - job: '${{ coalesce(parameters.job_name, parameters.check) }}_Windows'
   displayName: '${{ parameters.display }}'
+  timeoutInMinutes: 90
 
   services:
     ${{ if eq(parameters.ddtrace_flag, '--ddtrace') }}:

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -295,6 +295,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             'sqlserver_rows': [self._to_metrics_payload_row(r) for r in rows],
             'sqlserver_version': self.check.static_info_cache.get("version", ""),
             'ddagentversion': datadog_agent.get_version(),
+            'ddagenthostname': self._check.agent_hostname,
         }
 
     @tracked_method(agent_check_getter=agent_check_getter)

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -183,6 +183,7 @@ def test_statement_metrics_and_plans(
     disable_secondary_tags,
     match_pattern,
     caplog,
+    datadog_agent,
 ):
     caplog.set_level(logging.INFO)
     if disable_secondary_tags:
@@ -220,6 +221,7 @@ def test_statement_metrics_and_plans(
     # host metadata
     assert payload['sqlserver_version'].startswith("Microsoft SQL Server"), "invalid version"
     assert payload['host'] == "stubbed.hostname", "wrong hostname"
+    assert payload['ddagenthostname'] == datadog_agent.get_hostname()
     assert set(payload['tags']) == expected_instance_tags, "wrong instance tags for dbm-metrics event"
     assert type(payload['min_collection_interval']) in (float, int), "invalid min_collection_interval"
     # metrics rows


### PR DESCRIPTION
### What does this PR do?
Add `ddagenthostname` to the dbm-metrics payloads.

### Motivation
We already have the agent version sent as a field with metrics payloads but we'd like to have an easy way to know which agent is monitoring a database host. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
