### PR TITLE
Add snmp build-traps-db command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/__init__.py
@@ -4,12 +4,13 @@
 import click
 
 from ...console import CONTEXT_SETTINGS
+from .build_traps_db import build_traps_db
 from .generate_profile import generate_profile_from_mibs
 from .translate_profile import translate_profile
 from .validate_mib_filenames import validate_mib_filenames
 from .validate_snmp_profiles import validate_profile
 
-ALL_COMMANDS = [generate_profile_from_mibs, translate_profile, validate_mib_filenames, validate_profile]
+ALL_COMMANDS = [generate_profile_from_mibs, build_traps_db, translate_profile, validate_mib_filenames, validate_profile]
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, short_help='SNMP utilities')


### PR DESCRIPTION
### What does this PR do?
Add a new command to `ddev meta snmp` called `build-traps-db`.
This new command can create a json file containing traps definition from a list of MIBs. 


### Motivation
Supporting traps
