### PR TITLE
Add Security parameter

### DIFF
--- a/ibm_db2/assets/configuration/spec.yaml
+++ b/ibm_db2/assets/configuration/spec.yaml
@@ -40,6 +40,11 @@ files:
         value:
           type: integer
           example: 50000
+      - name: security
+        description: Set this parameter to `ssl` if you want to use the SSL protocol for a connection to the database server.
+        value:
+          type: string
+          example: none
       - name: tls_cert
         description: |
           The path to a SSL certificate to use, when connecting to a database in a secure fashion. It

--- a/ibm_db2/assets/configuration/spec.yaml
+++ b/ibm_db2/assets/configuration/spec.yaml
@@ -42,9 +42,8 @@ files:
           example: 50000
       - name: security
         description: |
-          Set this parameter to `ssl` if you want to use the SSL protocol for a connection to the database server.
-          SSL can be used without specifying a certificate for connections to Db2 on Cloud on IBM Cloud. 
-          For those services the required certificate is already a part of the driver package (ibm-db).
+          Set this parameter to `ssl` to use the SSL protocol for a connection to the database server using the default
+          certificate from the ibm-db driver package. Specifying `tls_cert` is not required when using this option.
         value:
           type: string
           example: none

--- a/ibm_db2/assets/configuration/spec.yaml
+++ b/ibm_db2/assets/configuration/spec.yaml
@@ -41,7 +41,10 @@ files:
           type: integer
           example: 50000
       - name: security
-        description: Set this parameter to `ssl` if you want to use the SSL protocol for a connection to the database server.
+        description: |
+          Set this parameter to `ssl` if you want to use the SSL protocol for a connection to the database server.
+          SSL can be used without specifying a certificate for connections to Db2 on Cloud on IBM Cloud. 
+          For those services the required certificate is already a part of the driver package (ibm-db).
         value:
           type: string
           example: none

--- a/ibm_db2/datadog_checks/ibm_db2/config_models/defaults.py
+++ b/ibm_db2/datadog_checks/ibm_db2/config_models/defaults.py
@@ -46,16 +46,16 @@ def instance_port(field, value):
     return 50000
 
 
+def instance_security(field, value):
+    return 'none'
+
+
 def instance_service(field, value):
     return get_default_field_value(field, value)
 
 
 def instance_tags(field, value):
     return get_default_field_value(field, value)
-
-
-def instance_security(field, value):
-    return 'none'
 
 
 def instance_tls_cert(field, value):

--- a/ibm_db2/datadog_checks/ibm_db2/config_models/defaults.py
+++ b/ibm_db2/datadog_checks/ibm_db2/config_models/defaults.py
@@ -54,6 +54,10 @@ def instance_tags(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_security(field, value):
+    return 'none'
+
+
 def instance_tls_cert(field, value):
     return get_default_field_value(field, value)
 

--- a/ibm_db2/datadog_checks/ibm_db2/config_models/instance.py
+++ b/ibm_db2/datadog_checks/ibm_db2/config_models/instance.py
@@ -44,6 +44,7 @@ class InstanceConfig(BaseModel):
     port: Optional[int]
     service: Optional[str]
     tags: Optional[Sequence[str]]
+    security: Optional[str]
     tls_cert: Optional[str]
     use_global_custom_queries: Optional[str]
     username: str

--- a/ibm_db2/datadog_checks/ibm_db2/config_models/instance.py
+++ b/ibm_db2/datadog_checks/ibm_db2/config_models/instance.py
@@ -42,9 +42,9 @@ class InstanceConfig(BaseModel):
     only_custom_queries: Optional[bool]
     password: str
     port: Optional[int]
+    security: Optional[str]
     service: Optional[str]
     tags: Optional[Sequence[str]]
-    security: Optional[str]
     tls_cert: Optional[str]
     use_global_custom_queries: Optional[str]
     username: str

--- a/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
+++ b/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
@@ -52,6 +52,8 @@ instances:
 
     ## @param security - string - optional - default: none
     ## Set this parameter to `ssl` if you want to use the SSL protocol for a connection to the database server.
+    ## SSL can be used without specifying a certificate for connections to Db2 on Cloud on IBM Cloud. 
+    ## For those services the required certificate is already a part of the driver package (ibm-db).
     #
     # security: none
 

--- a/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
+++ b/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
@@ -51,8 +51,8 @@ instances:
     # port: 50000
 
     ## @param security - string - optional
-    ## Set this parameter to `ssl` if you want to use the Secure Socket Layer (SSL) protocol is 
-    ## for a connection to the database server. 
+    ## Set this parameter to `ssl` if you want to use the Secure Socket Layer (SSL) protocol for a 
+    ## connection to the database server. 
     #
     # security: none
 

--- a/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
+++ b/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
@@ -50,6 +50,12 @@ instances:
     #
     # port: 50000
 
+    ## @param security - string - optional
+    ## Set this parameter to `ssl` if you want to use the Secure Socket Layer (SSL) protocol is 
+    ## for a connection to the database server. 
+    #
+    # security: none
+
     ## @param tls_cert - string - optional
     ## The path to a SSL certificate to use, when connecting to a database in a secure fashion. It
     ## has to be accessible and readable by the agent user.

--- a/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
+++ b/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
@@ -51,9 +51,8 @@ instances:
     # port: 50000
 
     ## @param security - string - optional - default: none
-    ## Set this parameter to `ssl` if you want to use the SSL protocol for a connection to the database server.
-    ## SSL can be used without specifying a certificate for connections to Db2 on Cloud on IBM Cloud. 
-    ## For those services the required certificate is already a part of the driver package (ibm-db).
+    ## Set this parameter to `ssl` to use the SSL protocol for a connection to the database server using the default
+    ## certificate from the ibm-db driver package. Specifying `tls_cert` is not required when using this option.
     #
     # security: none
 

--- a/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
+++ b/ibm_db2/datadog_checks/ibm_db2/data/conf.yaml.example
@@ -50,9 +50,8 @@ instances:
     #
     # port: 50000
 
-    ## @param security - string - optional
-    ## Set this parameter to `ssl` if you want to use the Secure Socket Layer (SSL) protocol for a 
-    ## connection to the database server. 
+    ## @param security - string - optional - default: none
+    ## Set this parameter to `ssl` if you want to use the SSL protocol for a connection to the database server.
     #
     # security: none
 

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -30,6 +30,7 @@ class IbmDb2Check(AgentCheck):
         self._host = self.instance.get('host', '')
         self._port = self.instance.get('port', 50000)
         self._tags = self.instance.get('tags', [])
+        self._security = self.instance.get('security', 'none')
         self._tls_cert = self.instance.get('tls_cert')
 
         # Add global database tag
@@ -554,7 +555,7 @@ class IbmDb2Check(AgentCheck):
 
     def get_connection(self):
         target, username, password = self.get_connection_data(
-            self._db, self._username, self._password, self._host, self._port, self._tls_cert
+            self._db, self._username, self._password, self._host, self._port, self._security, self._tls_cert
         )
 
         # Get column names in lower case

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -571,13 +571,15 @@ class IbmDb2Check(AgentCheck):
             return connection
 
     @classmethod
-    def get_connection_data(cls, db, username, password, host, port, tls_cert):
+    def get_connection_data(cls, db, username, password, host, port, security, tls_cert):
         if host:
             target = 'database={};hostname={};port={};protocol=tcpip;uid={};pwd={}'.format(
                 db, host, port, username, password
             )
             username = ''
             password = ''
+            if security == 'ssl':
+                target = '{};security=ssl;'.format(target)
             if tls_cert:
                 target = '{};security=ssl;sslservercertificate={}'.format(target, tls_cert)
         else:  # no cov

--- a/ibm_db2/tests/conftest.py
+++ b/ibm_db2/tests/conftest.py
@@ -15,7 +15,7 @@ from .common import COMPOSE_FILE, CONFIG, E2E_METADATA
 class DbManager(object):
     def __init__(self, config):
         self.target, self.username, self.password = IbmDb2Check.get_connection_data(
-            config['db'], config['username'], config['password'], config['host'], config['port'], None
+            config['db'], config['username'], config['password'], config['host'], config['port'], 'none', None
         )
         self.db_name = config['db']
         self.conn = None

--- a/ibm_db2/tests/test_unit.py
+++ b/ibm_db2/tests/test_unit.py
@@ -114,10 +114,10 @@ def test_get_connection_data(instance):
     check = IbmDb2Check('ibm_db2', {}, [instance])
 
     expected = 'database=db1;hostname=host1;port=1000;protocol=tcpip;uid=user1;pwd=pass1'
-    assert (expected, '', '') == check.get_connection_data('db1', 'user1', 'pass1', 'host1', 1000, None)
+    assert (expected, '', '') == check.get_connection_data('db1', 'user1', 'pass1', 'host1', 1000, 'none', None)
 
     expected = (
         'database=db1;hostname=host1;port=1000;protocol=tcpip;uid=user1;pwd=pass1;'
         'security=ssl;sslservercertificate=/path/cert'
     )
-    assert (expected, '', '') == check.get_connection_data('db1', 'user1', 'pass1', 'host1', 1000, '/path/cert')
+    assert (expected, '', '') == check.get_connection_data('db1', 'user1', 'pass1', 'host1', 1000, 'none', '/path/cert')


### PR DESCRIPTION
### What does this PR do?
This PR adds the parameter ```security``` to the Db2 integration.

### Motivation
Currently the integration only supports SSL when also a client-side certificate is defined. But Db2 also supports SSL without explicitely specifying a certificate (see https://www.ibm.com/docs/en/db2/11.5?topic=keywords-security for more information on that). Db2 on Cloud (IBM Cloud) only allows SSL-enabled connections (without the need to mention a certificate because it is already bundled into the driver package). Currently this is only possible by adding the ```Security``` paramater to one of the other options, e.g.:
```yaml
- db: <database name>
  username: <username>
  password: <password>
  host: <hostname>;Security=ssl
  port: <port>
```
This PR enables users to use the following:
```yaml
- db: <database name>
  username: <username>
  password: <password>
  host: <hostname>
  port: <port>
  security: ssl
```
This is an optional parameter, the default is set to ```none``` .

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
