### PR TITLE
Disable docker autodiscovery so docker metrics do not pollute tests a…

### DIFF
--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -18,7 +18,7 @@ E2E_METADATA = {
         'apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y docker.io',
     ],
     'docker_volumes': ['/var/run/docker.sock:/var/run/docker.sock'],
-    'DD_IGNORE_AUTOCONF': 'docker',
+    'env_vars': {'DD_IGNORE_AUTOCONF': 'docker'},
 }
 
 

--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -18,7 +18,7 @@ E2E_METADATA = {
         'apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y docker.io',
     ],
     'docker_volumes': ['/var/run/docker.sock:/var/run/docker.sock'],
-    'autoconfig_exclude_features': 'docker',
+    'DD_IGNORE_AUTOCONF': 'docker',
 }
 
 

--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -18,6 +18,7 @@ E2E_METADATA = {
         'apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y docker.io',
     ],
     'docker_volumes': ['/var/run/docker.sock:/var/run/docker.sock'],
+    'autoconfig_exclude_features': 'docker'
 }
 
 

--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -18,7 +18,7 @@ E2E_METADATA = {
         'apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y docker.io',
     ],
     'docker_volumes': ['/var/run/docker.sock:/var/run/docker.sock'],
-    'autoconfig_exclude_features': 'docker'
+    'autoconfig_exclude_features': 'docker',
 }
 
 


### PR DESCRIPTION
Cassandra nodetool e2e tests flake because it collects `docker.*` metrics

```
tests/test_e2e.py:44: in test_e2e
    aggregator.assert_all_metrics_covered()
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:419: in assert_all_metrics_covered
    assert condition, msg
E   AssertionError: Some metrics are missing:
E     Asserted Metrics:
E     	- cassandra.nodetool.status.load
E     	- cassandra.nodetool.status.owns
E     	- cassandra.nodetool.status.replication_availability
E     	- cassandra.nodetool.status.replication_factor
E     	- cassandra.nodetool.status.status
E     Missing Metrics:
E     	- docker.container.open_fds
E     	- docker.containers.running
E     	- docker.containers.running.total
E     	- docker.containers.stopped
E     	- docker.containers.stopped.total
E     	- docker.cpu.shares
E     	- docker.kmem.usage
E     	- docker.mem.cache
E     	- docker.mem.failed_count
E     	- docker.mem.rss
E   assert False
```

The reason is because during test set-up we install docker on the agent image and then it gets autodiscovered

