### PR TITLE
Bump tested versions

### DIFF
--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -18,7 +18,7 @@ E2E_METADATA = {
         'apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y docker.io',
     ],
     'docker_volumes': ['/var/run/docker.sock:/var/run/docker.sock'],
-    'DD_IGNORE_AUTOCONF': 'docker',
+    'env_vars': {'DD_IGNORE_AUTOCONF': 'docker'},
 }
 
 

--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -18,7 +18,7 @@ E2E_METADATA = {
         'apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y docker.io',
     ],
     'docker_volumes': ['/var/run/docker.sock:/var/run/docker.sock'],
-    'autoconfig_exclude_features': 'docker',
+    'DD_IGNORE_AUTOCONF': 'docker',
 }
 
 

--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -18,6 +18,7 @@ E2E_METADATA = {
         'apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y docker.io',
     ],
     'docker_volumes': ['/var/run/docker.sock:/var/run/docker.sock'],
+    'autoconfig_exclude_features': 'docker'
 }
 
 

--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -18,7 +18,7 @@ E2E_METADATA = {
         'apt-get install -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y docker.io',
     ],
     'docker_volumes': ['/var/run/docker.sock:/var/run/docker.sock'],
-    'autoconfig_exclude_features': 'docker'
+    'autoconfig_exclude_features': 'docker',
 }
 
 

--- a/cassandra_nodetool/tox.ini
+++ b/cassandra_nodetool/tox.ini
@@ -2,7 +2,7 @@
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{2.1,3.0}
+    py{27,38}-{3.11,4.0}
 
 [testenv]
 ensure_default_envdir = true
@@ -18,8 +18,8 @@ deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =
-    2.1: CASSANDRA_VERSION=2.1.14
-    3.0: CASSANDRA_VERSION=3.0.23
+    3.11: CASSANDRA_VERSION=3.11.11
+    4.0: CASSANDRA_VERSION=4.0.1
     CONTAINER_PORT=7199
 passenv =
     DOCKER*


### PR DESCRIPTION
Version 2.1 has been EOLEd since Nov 2016
3.0 will EOL in April 2022