### PR TITLE
Update Istio 1.5+ dashboard to use v2 metrics

### DIFF
--- a/istio/assets/dashboards/istio_1_5_overview.json
+++ b/istio/assets/dashboards/istio_1_5_overview.json
@@ -350,7 +350,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "top(avg:istio.grpc.server.msg_sent_total{$cluster}.as_count(), 10, 'mean', 'desc'), top(avg:istio.grpc.server.msg_received_total{$cluster}.as_count(), 10, 'mean', 'desc')",
+                        "q": "top(avg:istio.grpc.server.msg_sent.count{$cluster}.as_count(), 10, 'mean', 'desc'), top(avg:istio.grpc.server.msg_received.count{$cluster}.as_count(), 10, 'mean', 'desc')",
                         "display_type": "area",
                         "style": {
                             "palette": "cool",
@@ -462,7 +462,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:istio.pilot.xds.pushes{$cluster} by {type}",
+                        "q": "sum:istio.pilot.xds.pushes.count{$cluster} by {type}",
                         "display_type": "bars",
                         "style": {
                             "palette": "dog_classic",
@@ -691,7 +691,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "avg:istio.galley.validation.failed{$cluster}.as_count()",
+                        "q": "avg:istio.galley.validation.failed.count{$cluster}.as_count()",
                         "display_type": "line",
                         "style": {
                             "palette": "dog_classic",


### PR DESCRIPTION
### What does this PR do?
Update Istio 1.5+ dashboard to use v2 metrics

### Motivation
I am seeing empty charts in the Istio dashboard.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
