### PR TITLE
Add tls_protocols_allowed option documentation

### DIFF
--- a/activemq_xml/datadog_checks/activemq_xml/config_models/defaults.py
+++ b/activemq_xml/datadog_checks/activemq_xml/config_models/defaults.py
@@ -178,6 +178,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/activemq_xml/datadog_checks/activemq_xml/config_models/defaults.py
+++ b/activemq_xml/datadog_checks/activemq_xml/config_models/defaults.py
@@ -178,7 +178,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/activemq_xml/datadog_checks/activemq_xml/config_models/instance.py
+++ b/activemq_xml/datadog_checks/activemq_xml/config_models/instance.py
@@ -78,7 +78,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/activemq_xml/datadog_checks/activemq_xml/config_models/instance.py
+++ b/activemq_xml/datadog_checks/activemq_xml/config_models/instance.py
@@ -78,6 +78,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
+++ b/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
@@ -314,7 +314,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -323,7 +323,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
+++ b/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
@@ -314,6 +314,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
+++ b/activemq_xml/datadog_checks/activemq_xml/data/conf.yaml.example
@@ -316,7 +316,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/activemq_xml/setup.py
+++ b/activemq_xml/setup.py
@@ -29,7 +29,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.7.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-activemq_xml',

--- a/airflow/datadog_checks/airflow/config_models/defaults.py
+++ b/airflow/datadog_checks/airflow/config_models/defaults.py
@@ -162,7 +162,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/airflow/datadog_checks/airflow/config_models/defaults.py
+++ b/airflow/datadog_checks/airflow/config_models/defaults.py
@@ -162,6 +162,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/airflow/datadog_checks/airflow/config_models/instance.py
+++ b/airflow/datadog_checks/airflow/config_models/instance.py
@@ -74,6 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/airflow/datadog_checks/airflow/config_models/instance.py
+++ b/airflow/datadog_checks/airflow/config_models/instance.py
@@ -74,7 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -285,6 +285,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -285,7 +285,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -294,7 +294,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/airflow/datadog_checks/airflow/data/conf.yaml.example
+++ b/airflow/datadog_checks/airflow/data/conf.yaml.example
@@ -287,7 +287,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/airflow/setup.py
+++ b/airflow/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/amazon_msk/datadog_checks/amazon_msk/config_models/defaults.py
+++ b/amazon_msk/datadog_checks/amazon_msk/config_models/defaults.py
@@ -278,6 +278,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/amazon_msk/datadog_checks/amazon_msk/config_models/defaults.py
+++ b/amazon_msk/datadog_checks/amazon_msk/config_models/defaults.py
@@ -278,7 +278,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
+++ b/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
@@ -130,6 +130,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_latest_spec: Optional[bool]

--- a/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
+++ b/amazon_msk/datadog_checks/amazon_msk/config_models/instance.py
@@ -130,7 +130,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_latest_spec: Optional[bool]

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -551,6 +551,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -551,7 +551,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -560,7 +560,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -553,7 +553,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/amazon_msk/setup.py
+++ b/amazon_msk/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/ambari/datadog_checks/ambari/config_models/defaults.py
+++ b/ambari/datadog_checks/ambari/config_models/defaults.py
@@ -174,7 +174,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/ambari/datadog_checks/ambari/config_models/defaults.py
+++ b/ambari/datadog_checks/ambari/config_models/defaults.py
@@ -174,6 +174,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/ambari/datadog_checks/ambari/config_models/instance.py
+++ b/ambari/datadog_checks/ambari/config_models/instance.py
@@ -75,6 +75,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/ambari/datadog_checks/ambari/config_models/instance.py
+++ b/ambari/datadog_checks/ambari/config_models/instance.py
@@ -75,7 +75,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/ambari/datadog_checks/ambari/data/conf.yaml.example
+++ b/ambari/datadog_checks/ambari/data/conf.yaml.example
@@ -314,7 +314,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -323,7 +323,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/ambari/datadog_checks/ambari/data/conf.yaml.example
+++ b/ambari/datadog_checks/ambari/data/conf.yaml.example
@@ -314,6 +314,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/ambari/datadog_checks/ambari/data/conf.yaml.example
+++ b/ambari/datadog_checks/ambari/data/conf.yaml.example
@@ -316,7 +316,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/ambari/setup.py
+++ b/ambari/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/apache/datadog_checks/apache/config_models/defaults.py
+++ b/apache/datadog_checks/apache/config_models/defaults.py
@@ -162,7 +162,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/apache/datadog_checks/apache/config_models/defaults.py
+++ b/apache/datadog_checks/apache/config_models/defaults.py
@@ -162,6 +162,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/apache/datadog_checks/apache/config_models/instance.py
+++ b/apache/datadog_checks/apache/config_models/instance.py
@@ -75,7 +75,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/apache/datadog_checks/apache/config_models/instance.py
+++ b/apache/datadog_checks/apache/config_models/instance.py
@@ -75,6 +75,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -285,6 +285,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -285,7 +285,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -294,7 +294,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/apache/datadog_checks/apache/data/conf.yaml.example
+++ b/apache/datadog_checks/apache/data/conf.yaml.example
@@ -287,7 +287,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/apache/setup.py
+++ b/apache/setup.py
@@ -37,7 +37,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-apache',

--- a/avi_vantage/datadog_checks/avi_vantage/config_models/defaults.py
+++ b/avi_vantage/datadog_checks/avi_vantage/config_models/defaults.py
@@ -258,7 +258,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/avi_vantage/datadog_checks/avi_vantage/config_models/defaults.py
+++ b/avi_vantage/datadog_checks/avi_vantage/config_models/defaults.py
@@ -258,6 +258,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/avi_vantage/datadog_checks/avi_vantage/config_models/instance.py
+++ b/avi_vantage/datadog_checks/avi_vantage/config_models/instance.py
@@ -125,6 +125,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_latest_spec: Optional[bool]

--- a/avi_vantage/datadog_checks/avi_vantage/config_models/instance.py
+++ b/avi_vantage/datadog_checks/avi_vantage/config_models/instance.py
@@ -125,7 +125,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_latest_spec: Optional[bool]

--- a/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
+++ b/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
@@ -513,6 +513,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
+++ b/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
@@ -515,7 +515,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
+++ b/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example
@@ -513,7 +513,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -522,7 +522,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/avi_vantage/setup.py
+++ b/avi_vantage/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/defaults.py
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/defaults.py
@@ -246,6 +246,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/defaults.py
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/defaults.py
@@ -246,7 +246,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/instance.py
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/instance.py
@@ -120,6 +120,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/instance.py
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/instance.py
@@ -120,7 +120,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
@@ -422,7 +422,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
@@ -420,6 +420,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
@@ -420,7 +420,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -429,7 +429,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/azure_iot_edge/setup.py
+++ b/azure_iot_edge/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/cilium/datadog_checks/cilium/config_models/defaults.py
+++ b/cilium/datadog_checks/cilium/config_models/defaults.py
@@ -326,7 +326,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/cilium/datadog_checks/cilium/config_models/defaults.py
+++ b/cilium/datadog_checks/cilium/config_models/defaults.py
@@ -326,6 +326,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/cilium/datadog_checks/cilium/config_models/instance.py
+++ b/cilium/datadog_checks/cilium/config_models/instance.py
@@ -164,6 +164,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/cilium/datadog_checks/cilium/config_models/instance.py
+++ b/cilium/datadog_checks/cilium/config_models/instance.py
@@ -164,7 +164,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/cilium/datadog_checks/cilium/data/conf.yaml.example
+++ b/cilium/datadog_checks/cilium/data/conf.yaml.example
@@ -520,7 +520,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/cilium/datadog_checks/cilium/data/conf.yaml.example
+++ b/cilium/datadog_checks/cilium/data/conf.yaml.example
@@ -518,7 +518,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -527,7 +527,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/cilium/datadog_checks/cilium/data/conf.yaml.example
+++ b/cilium/datadog_checks/cilium/data/conf.yaml.example
@@ -518,6 +518,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/cilium/setup.py
+++ b/cilium/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/cisco_aci/datadog_checks/cisco_aci/config_models/defaults.py
+++ b/cisco_aci/datadog_checks/cisco_aci/config_models/defaults.py
@@ -198,6 +198,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/cisco_aci/datadog_checks/cisco_aci/config_models/defaults.py
+++ b/cisco_aci/datadog_checks/cisco_aci/config_models/defaults.py
@@ -198,7 +198,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/cisco_aci/datadog_checks/cisco_aci/config_models/instance.py
+++ b/cisco_aci/datadog_checks/cisco_aci/config_models/instance.py
@@ -83,6 +83,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/cisco_aci/datadog_checks/cisco_aci/config_models/instance.py
+++ b/cisco_aci/datadog_checks/cisco_aci/config_models/instance.py
@@ -83,7 +83,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
+++ b/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
@@ -229,7 +229,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -238,7 +238,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
+++ b/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
@@ -231,7 +231,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
+++ b/cisco_aci/datadog_checks/cisco_aci/data/conf.yaml.example
@@ -229,6 +229,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/cisco_aci/setup.py
+++ b/cisco_aci/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-cisco_aci',

--- a/citrix_hypervisor/datadog_checks/citrix_hypervisor/config_models/defaults.py
+++ b/citrix_hypervisor/datadog_checks/citrix_hypervisor/config_models/defaults.py
@@ -162,7 +162,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/citrix_hypervisor/datadog_checks/citrix_hypervisor/config_models/defaults.py
+++ b/citrix_hypervisor/datadog_checks/citrix_hypervisor/config_models/defaults.py
@@ -162,6 +162,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/citrix_hypervisor/datadog_checks/citrix_hypervisor/config_models/instance.py
+++ b/citrix_hypervisor/datadog_checks/citrix_hypervisor/config_models/instance.py
@@ -74,6 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/citrix_hypervisor/datadog_checks/citrix_hypervisor/config_models/instance.py
+++ b/citrix_hypervisor/datadog_checks/citrix_hypervisor/config_models/instance.py
@@ -74,7 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
+++ b/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
@@ -285,6 +285,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
+++ b/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
@@ -285,7 +285,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -294,7 +294,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
+++ b/citrix_hypervisor/datadog_checks/citrix_hypervisor/data/conf.yaml.example
@@ -287,7 +287,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/citrix_hypervisor/setup.py
+++ b/citrix_hypervisor/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=21.3.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/config_models/defaults.py
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/config_models/defaults.py
@@ -170,7 +170,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/config_models/defaults.py
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/config_models/defaults.py
@@ -170,6 +170,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/config_models/instance.py
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/config_models/instance.py
@@ -79,7 +79,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/config_models/instance.py
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/config_models/instance.py
@@ -79,6 +79,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/data/conf.yaml.example
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/data/conf.yaml.example
@@ -170,7 +170,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/data/conf.yaml.example
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/data/conf.yaml.example
@@ -168,7 +168,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -177,7 +177,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/cloud_foundry_api/datadog_checks/cloud_foundry_api/data/conf.yaml.example
+++ b/cloud_foundry_api/datadog_checks/cloud_foundry_api/data/conf.yaml.example
@@ -168,6 +168,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/cloud_foundry_api/setup.py
+++ b/cloud_foundry_api/setup.py
@@ -18,7 +18,7 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/cockroachdb/datadog_checks/cockroachdb/config_models/defaults.py
+++ b/cockroachdb/datadog_checks/cockroachdb/config_models/defaults.py
@@ -318,6 +318,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/cockroachdb/datadog_checks/cockroachdb/config_models/defaults.py
+++ b/cockroachdb/datadog_checks/cockroachdb/config_models/defaults.py
@@ -318,7 +318,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/cockroachdb/datadog_checks/cockroachdb/config_models/instance.py
+++ b/cockroachdb/datadog_checks/cockroachdb/config_models/instance.py
@@ -162,7 +162,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/cockroachdb/datadog_checks/cockroachdb/config_models/instance.py
+++ b/cockroachdb/datadog_checks/cockroachdb/config_models/instance.py
@@ -162,6 +162,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -505,7 +505,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -503,7 +503,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -512,7 +512,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -503,6 +503,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/cockroachdb/setup.py
+++ b/cockroachdb/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.4.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/consul/datadog_checks/consul/config_models/defaults.py
+++ b/consul/datadog_checks/consul/config_models/defaults.py
@@ -206,6 +206,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/consul/datadog_checks/consul/config_models/defaults.py
+++ b/consul/datadog_checks/consul/config_models/defaults.py
@@ -206,7 +206,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/consul/datadog_checks/consul/config_models/instance.py
+++ b/consul/datadog_checks/consul/config_models/instance.py
@@ -85,7 +85,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/consul/datadog_checks/consul/config_models/instance.py
+++ b/consul/datadog_checks/consul/config_models/instance.py
@@ -85,6 +85,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -368,7 +368,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -377,7 +377,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -370,7 +370,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -368,6 +368,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/consul/setup.py
+++ b/consul/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=22.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-consul',

--- a/coredns/datadog_checks/coredns/config_models/defaults.py
+++ b/coredns/datadog_checks/coredns/config_models/defaults.py
@@ -318,6 +318,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/coredns/datadog_checks/coredns/config_models/defaults.py
+++ b/coredns/datadog_checks/coredns/config_models/defaults.py
@@ -318,7 +318,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/coredns/datadog_checks/coredns/config_models/instance.py
+++ b/coredns/datadog_checks/coredns/config_models/instance.py
@@ -162,7 +162,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/coredns/datadog_checks/coredns/config_models/instance.py
+++ b/coredns/datadog_checks/coredns/config_models/instance.py
@@ -162,6 +162,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -528,7 +528,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -537,7 +537,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -530,7 +530,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -528,6 +528,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/coredns/setup.py
+++ b/coredns/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/couch/datadog_checks/couch/config_models/defaults.py
+++ b/couch/datadog_checks/couch/config_models/defaults.py
@@ -182,6 +182,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/couch/datadog_checks/couch/config_models/defaults.py
+++ b/couch/datadog_checks/couch/config_models/defaults.py
@@ -182,7 +182,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/couch/datadog_checks/couch/config_models/instance.py
+++ b/couch/datadog_checks/couch/config_models/instance.py
@@ -80,6 +80,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/couch/datadog_checks/couch/config_models/instance.py
+++ b/couch/datadog_checks/couch/config_models/instance.py
@@ -80,7 +80,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/couch/datadog_checks/couch/data/conf.yaml.example
+++ b/couch/datadog_checks/couch/data/conf.yaml.example
@@ -350,6 +350,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/couch/datadog_checks/couch/data/conf.yaml.example
+++ b/couch/datadog_checks/couch/data/conf.yaml.example
@@ -350,7 +350,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -359,7 +359,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/couch/datadog_checks/couch/data/conf.yaml.example
+++ b/couch/datadog_checks/couch/data/conf.yaml.example
@@ -352,7 +352,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/couch/setup.py
+++ b/couch/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=22.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-couch',

--- a/couchbase/datadog_checks/couchbase/config_models/defaults.py
+++ b/couchbase/datadog_checks/couchbase/config_models/defaults.py
@@ -174,7 +174,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/couchbase/datadog_checks/couchbase/config_models/defaults.py
+++ b/couchbase/datadog_checks/couchbase/config_models/defaults.py
@@ -174,6 +174,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/couchbase/datadog_checks/couchbase/config_models/instance.py
+++ b/couchbase/datadog_checks/couchbase/config_models/instance.py
@@ -78,7 +78,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/couchbase/datadog_checks/couchbase/config_models/instance.py
+++ b/couchbase/datadog_checks/couchbase/config_models/instance.py
@@ -78,6 +78,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/couchbase/datadog_checks/couchbase/data/conf.yaml.example
+++ b/couchbase/datadog_checks/couchbase/data/conf.yaml.example
@@ -303,7 +303,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -312,7 +312,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/couchbase/datadog_checks/couchbase/data/conf.yaml.example
+++ b/couchbase/datadog_checks/couchbase/data/conf.yaml.example
@@ -303,6 +303,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/couchbase/datadog_checks/couchbase/data/conf.yaml.example
+++ b/couchbase/datadog_checks/couchbase/data/conf.yaml.example
@@ -305,7 +305,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/couchbase/setup.py
+++ b/couchbase/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=22.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-couchbase',

--- a/crio/datadog_checks/crio/config_models/defaults.py
+++ b/crio/datadog_checks/crio/config_models/defaults.py
@@ -242,7 +242,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/crio/datadog_checks/crio/config_models/defaults.py
+++ b/crio/datadog_checks/crio/config_models/defaults.py
@@ -242,6 +242,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/crio/datadog_checks/crio/config_models/instance.py
+++ b/crio/datadog_checks/crio/config_models/instance.py
@@ -118,6 +118,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/crio/datadog_checks/crio/config_models/instance.py
+++ b/crio/datadog_checks/crio/config_models/instance.py
@@ -118,7 +118,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/crio/datadog_checks/crio/data/conf.yaml.example
+++ b/crio/datadog_checks/crio/data/conf.yaml.example
@@ -415,7 +415,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -424,7 +424,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/crio/datadog_checks/crio/data/conf.yaml.example
+++ b/crio/datadog_checks/crio/data/conf.yaml.example
@@ -417,7 +417,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/crio/datadog_checks/crio/data/conf.yaml.example
+++ b/crio/datadog_checks/crio/data/conf.yaml.example
@@ -415,6 +415,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/crio/setup.py
+++ b/crio/setup.py
@@ -24,7 +24,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
@@ -263,7 +263,7 @@
     containing several CA certificates in PEM format. If a directory, the directory
     must have been processed using the c_rehash utility supplied with OpenSSL. See:
     https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
-- name: tls_protocol
+- name: tls_protocols_allowed
   value:
     example:
     - 'SSLv3'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
@@ -274,7 +274,7 @@
       type: string
   description: |
     The expected versions of TLS/SSL when fetching intermediate certificates.
-    The supported versions and values are:
+    Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
       SSLv3
       TLSv1
       TLSv1.1

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/http.yaml
@@ -263,6 +263,23 @@
     containing several CA certificates in PEM format. If a directory, the directory
     must have been processed using the c_rehash utility supplied with OpenSSL. See:
     https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+- name: tls_protocol
+  value:
+    example:
+    - 'SSLv3'
+    - 'TLSv1.2'
+    - 'TLSv1.3'
+    type: array
+    items:
+      type: string
+  description: |
+    The expected versions of TLS/SSL when fetching intermediate certificates.
+    The supported versions and values are:
+      SSLv3
+      TLSv1
+      TLSv1.1
+      TLSv1.2
+      TLSv1.3
 - name: headers
   value:
     example:

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -2857,6 +2857,7 @@ def test_template_array():
         'tls_cert',
         'tls_private_key',
         'tls_ca_cert',
+        'tls_protocols_allowed',
         'headers',
         'extra_headers',
         'timeout',

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/defaults.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/defaults.py
@@ -242,7 +242,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/defaults.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/defaults.py
@@ -242,6 +242,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/instance.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/instance.py
@@ -118,6 +118,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/instance.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/instance.py
@@ -118,7 +118,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
@@ -423,7 +423,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -432,7 +432,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
@@ -423,6 +423,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
@@ -425,7 +425,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
@@ -415,7 +415,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -424,7 +424,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
@@ -417,7 +417,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
@@ -415,6 +415,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/datadog_cluster_agent/setup.py
+++ b/datadog_cluster_agent/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/druid/datadog_checks/druid/config_models/defaults.py
+++ b/druid/datadog_checks/druid/config_models/defaults.py
@@ -162,7 +162,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/druid/datadog_checks/druid/config_models/defaults.py
+++ b/druid/datadog_checks/druid/config_models/defaults.py
@@ -162,6 +162,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/druid/datadog_checks/druid/config_models/instance.py
+++ b/druid/datadog_checks/druid/config_models/instance.py
@@ -74,6 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/druid/datadog_checks/druid/config_models/instance.py
+++ b/druid/datadog_checks/druid/config_models/instance.py
@@ -74,7 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/druid/datadog_checks/druid/data/conf.yaml.example
+++ b/druid/datadog_checks/druid/data/conf.yaml.example
@@ -285,6 +285,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/druid/datadog_checks/druid/data/conf.yaml.example
+++ b/druid/datadog_checks/druid/data/conf.yaml.example
@@ -285,7 +285,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -294,7 +294,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/druid/datadog_checks/druid/data/conf.yaml.example
+++ b/druid/datadog_checks/druid/data/conf.yaml.example
@@ -287,7 +287,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/druid/setup.py
+++ b/druid/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/ecs_fargate/datadog_checks/ecs_fargate/config_models/defaults.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/config_models/defaults.py
@@ -162,7 +162,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/ecs_fargate/datadog_checks/ecs_fargate/config_models/defaults.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/config_models/defaults.py
@@ -162,6 +162,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/ecs_fargate/datadog_checks/ecs_fargate/config_models/instance.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/config_models/instance.py
@@ -74,7 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/ecs_fargate/datadog_checks/ecs_fargate/config_models/instance.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/config_models/instance.py
@@ -74,6 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
+++ b/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
@@ -281,6 +281,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
+++ b/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
@@ -281,7 +281,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -290,7 +290,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
+++ b/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
@@ -283,7 +283,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/ecs_fargate/setup.py
+++ b/ecs_fargate/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=22.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-ecs_fargate',

--- a/eks_fargate/datadog_checks/eks_fargate/config_models/defaults.py
+++ b/eks_fargate/datadog_checks/eks_fargate/config_models/defaults.py
@@ -162,7 +162,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/eks_fargate/datadog_checks/eks_fargate/config_models/defaults.py
+++ b/eks_fargate/datadog_checks/eks_fargate/config_models/defaults.py
@@ -162,6 +162,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/eks_fargate/datadog_checks/eks_fargate/config_models/instance.py
+++ b/eks_fargate/datadog_checks/eks_fargate/config_models/instance.py
@@ -74,7 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/eks_fargate/datadog_checks/eks_fargate/config_models/instance.py
+++ b/eks_fargate/datadog_checks/eks_fargate/config_models/instance.py
@@ -74,6 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
+++ b/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
@@ -281,6 +281,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
+++ b/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
@@ -281,7 +281,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -290,7 +290,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
+++ b/eks_fargate/datadog_checks/eks_fargate/data/conf.yaml.example
@@ -283,7 +283,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/eks_fargate/setup.py
+++ b/eks_fargate/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=17.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/elastic/datadog_checks/elastic/config_models/defaults.py
+++ b/elastic/datadog_checks/elastic/config_models/defaults.py
@@ -214,7 +214,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/elastic/datadog_checks/elastic/config_models/defaults.py
+++ b/elastic/datadog_checks/elastic/config_models/defaults.py
@@ -214,6 +214,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/elastic/datadog_checks/elastic/config_models/instance.py
+++ b/elastic/datadog_checks/elastic/config_models/instance.py
@@ -107,7 +107,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/elastic/datadog_checks/elastic/config_models/instance.py
+++ b/elastic/datadog_checks/elastic/config_models/instance.py
@@ -107,6 +107,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -446,6 +446,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -446,7 +446,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -455,7 +455,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -448,7 +448,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/elastic/setup.py
+++ b/elastic/setup.py
@@ -29,7 +29,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=18.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-elastic',

--- a/envoy/datadog_checks/envoy/config_models/defaults.py
+++ b/envoy/datadog_checks/envoy/config_models/defaults.py
@@ -282,6 +282,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/envoy/datadog_checks/envoy/config_models/defaults.py
+++ b/envoy/datadog_checks/envoy/config_models/defaults.py
@@ -282,7 +282,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/envoy/datadog_checks/envoy/config_models/instance.py
+++ b/envoy/datadog_checks/envoy/config_models/instance.py
@@ -130,6 +130,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_latest_spec: Optional[bool]

--- a/envoy/datadog_checks/envoy/config_models/instance.py
+++ b/envoy/datadog_checks/envoy/config_models/instance.py
@@ -130,7 +130,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_latest_spec: Optional[bool]

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -516,7 +516,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -514,6 +514,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/envoy/datadog_checks/envoy/data/conf.yaml.example
+++ b/envoy/datadog_checks/envoy/data/conf.yaml.example
@@ -514,7 +514,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -523,7 +523,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/envoy/setup.py
+++ b/envoy/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.4.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-envoy',

--- a/etcd/datadog_checks/etcd/config_models/defaults.py
+++ b/etcd/datadog_checks/etcd/config_models/defaults.py
@@ -246,6 +246,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/etcd/datadog_checks/etcd/config_models/defaults.py
+++ b/etcd/datadog_checks/etcd/config_models/defaults.py
@@ -246,7 +246,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/etcd/datadog_checks/etcd/config_models/instance.py
+++ b/etcd/datadog_checks/etcd/config_models/instance.py
@@ -119,6 +119,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/etcd/datadog_checks/etcd/config_models/instance.py
+++ b/etcd/datadog_checks/etcd/config_models/instance.py
@@ -119,7 +119,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -421,6 +421,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -423,7 +423,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -421,7 +421,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -430,7 +430,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/etcd/setup.py
+++ b/etcd/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-etcd',

--- a/external_dns/datadog_checks/external_dns/config_models/defaults.py
+++ b/external_dns/datadog_checks/external_dns/config_models/defaults.py
@@ -242,7 +242,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/external_dns/datadog_checks/external_dns/config_models/defaults.py
+++ b/external_dns/datadog_checks/external_dns/config_models/defaults.py
@@ -242,6 +242,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/external_dns/datadog_checks/external_dns/config_models/instance.py
+++ b/external_dns/datadog_checks/external_dns/config_models/instance.py
@@ -118,6 +118,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/external_dns/datadog_checks/external_dns/config_models/instance.py
+++ b/external_dns/datadog_checks/external_dns/config_models/instance.py
@@ -118,7 +118,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/external_dns/datadog_checks/external_dns/data/conf.yaml.example
+++ b/external_dns/datadog_checks/external_dns/data/conf.yaml.example
@@ -415,7 +415,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -424,7 +424,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/external_dns/datadog_checks/external_dns/data/conf.yaml.example
+++ b/external_dns/datadog_checks/external_dns/data/conf.yaml.example
@@ -417,7 +417,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/external_dns/datadog_checks/external_dns/data/conf.yaml.example
+++ b/external_dns/datadog_checks/external_dns/data/conf.yaml.example
@@ -415,6 +415,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/external_dns/setup.py
+++ b/external_dns/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-external_dns',

--- a/fluentd/datadog_checks/fluentd/config_models/defaults.py
+++ b/fluentd/datadog_checks/fluentd/config_models/defaults.py
@@ -178,6 +178,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/fluentd/datadog_checks/fluentd/config_models/defaults.py
+++ b/fluentd/datadog_checks/fluentd/config_models/defaults.py
@@ -178,7 +178,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/fluentd/datadog_checks/fluentd/config_models/instance.py
+++ b/fluentd/datadog_checks/fluentd/config_models/instance.py
@@ -78,7 +78,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/fluentd/datadog_checks/fluentd/config_models/instance.py
+++ b/fluentd/datadog_checks/fluentd/config_models/instance.py
@@ -78,6 +78,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/fluentd/datadog_checks/fluentd/data/conf.yaml.example
+++ b/fluentd/datadog_checks/fluentd/data/conf.yaml.example
@@ -340,7 +340,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/fluentd/datadog_checks/fluentd/data/conf.yaml.example
+++ b/fluentd/datadog_checks/fluentd/data/conf.yaml.example
@@ -338,6 +338,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/fluentd/datadog_checks/fluentd/data/conf.yaml.example
+++ b/fluentd/datadog_checks/fluentd/data/conf.yaml.example
@@ -338,7 +338,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -347,7 +347,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/fluentd/setup.py
+++ b/fluentd/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-fluentd',

--- a/gitlab/datadog_checks/gitlab/config_models/defaults.py
+++ b/gitlab/datadog_checks/gitlab/config_models/defaults.py
@@ -254,6 +254,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/gitlab/datadog_checks/gitlab/config_models/defaults.py
+++ b/gitlab/datadog_checks/gitlab/config_models/defaults.py
@@ -254,7 +254,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/gitlab/datadog_checks/gitlab/config_models/instance.py
+++ b/gitlab/datadog_checks/gitlab/config_models/instance.py
@@ -120,6 +120,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/gitlab/datadog_checks/gitlab/config_models/instance.py
+++ b/gitlab/datadog_checks/gitlab/config_models/instance.py
@@ -120,7 +120,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -386,6 +386,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -388,7 +388,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -386,7 +386,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -395,7 +395,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/gitlab/setup.py
+++ b/gitlab/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-gitlab',

--- a/gitlab_runner/datadog_checks/gitlab_runner/config_models/defaults.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/config_models/defaults.py
@@ -242,7 +242,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/gitlab_runner/datadog_checks/gitlab_runner/config_models/defaults.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/config_models/defaults.py
@@ -242,6 +242,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/gitlab_runner/datadog_checks/gitlab_runner/config_models/instance.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/config_models/instance.py
@@ -120,6 +120,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/gitlab_runner/datadog_checks/gitlab_runner/config_models/instance.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/config_models/instance.py
@@ -120,7 +120,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -471,7 +471,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -469,6 +469,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -469,7 +469,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -478,7 +478,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/gitlab_runner/setup.py
+++ b/gitlab_runner/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-gitlab_runner',

--- a/go_expvar/datadog_checks/go_expvar/config_models/defaults.py
+++ b/go_expvar/datadog_checks/go_expvar/config_models/defaults.py
@@ -170,7 +170,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/go_expvar/datadog_checks/go_expvar/config_models/defaults.py
+++ b/go_expvar/datadog_checks/go_expvar/config_models/defaults.py
@@ -170,6 +170,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/go_expvar/datadog_checks/go_expvar/config_models/instance.py
+++ b/go_expvar/datadog_checks/go_expvar/config_models/instance.py
@@ -87,6 +87,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/go_expvar/datadog_checks/go_expvar/config_models/instance.py
+++ b/go_expvar/datadog_checks/go_expvar/config_models/instance.py
@@ -87,7 +87,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
+++ b/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
@@ -324,6 +324,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
+++ b/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
@@ -326,7 +326,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
+++ b/go_expvar/datadog_checks/go_expvar/data/conf.yaml.example
@@ -324,7 +324,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -333,7 +333,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/go_expvar/setup.py
+++ b/go_expvar/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-go_expvar',

--- a/haproxy/datadog_checks/haproxy/config_models/defaults.py
+++ b/haproxy/datadog_checks/haproxy/config_models/defaults.py
@@ -302,7 +302,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/haproxy/datadog_checks/haproxy/config_models/defaults.py
+++ b/haproxy/datadog_checks/haproxy/config_models/defaults.py
@@ -302,6 +302,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/haproxy/datadog_checks/haproxy/config_models/instance.py
+++ b/haproxy/datadog_checks/haproxy/config_models/instance.py
@@ -132,7 +132,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/haproxy/datadog_checks/haproxy/config_models/instance.py
+++ b/haproxy/datadog_checks/haproxy/config_models/instance.py
@@ -132,6 +132,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -562,7 +562,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -571,7 +571,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -562,6 +562,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/haproxy/datadog_checks/haproxy/data/conf.yaml.example
+++ b/haproxy/datadog_checks/haproxy/data/conf.yaml.example
@@ -564,7 +564,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/haproxy/setup.py
+++ b/haproxy/setup.py
@@ -25,7 +25,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-haproxy',

--- a/harbor/datadog_checks/harbor/config_models/defaults.py
+++ b/harbor/datadog_checks/harbor/config_models/defaults.py
@@ -158,6 +158,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/harbor/datadog_checks/harbor/config_models/defaults.py
+++ b/harbor/datadog_checks/harbor/config_models/defaults.py
@@ -158,7 +158,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/harbor/datadog_checks/harbor/config_models/instance.py
+++ b/harbor/datadog_checks/harbor/config_models/instance.py
@@ -74,6 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/harbor/datadog_checks/harbor/config_models/instance.py
+++ b/harbor/datadog_checks/harbor/config_models/instance.py
@@ -74,7 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/harbor/datadog_checks/harbor/data/conf.yaml.example
+++ b/harbor/datadog_checks/harbor/data/conf.yaml.example
@@ -289,7 +289,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/harbor/datadog_checks/harbor/data/conf.yaml.example
+++ b/harbor/datadog_checks/harbor/data/conf.yaml.example
@@ -287,7 +287,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -296,7 +296,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/harbor/datadog_checks/harbor/data/conf.yaml.example
+++ b/harbor/datadog_checks/harbor/data/conf.yaml.example
@@ -287,6 +287,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/harbor/setup.py
+++ b/harbor/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/hazelcast/datadog_checks/hazelcast/config_models/defaults.py
+++ b/hazelcast/datadog_checks/hazelcast/config_models/defaults.py
@@ -246,6 +246,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/hazelcast/datadog_checks/hazelcast/config_models/defaults.py
+++ b/hazelcast/datadog_checks/hazelcast/config_models/defaults.py
@@ -246,7 +246,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/hazelcast/datadog_checks/hazelcast/config_models/instance.py
+++ b/hazelcast/datadog_checks/hazelcast/config_models/instance.py
@@ -90,7 +90,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     tools_jar_path: Optional[str]

--- a/hazelcast/datadog_checks/hazelcast/config_models/instance.py
+++ b/hazelcast/datadog_checks/hazelcast/config_models/instance.py
@@ -90,6 +90,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     tools_jar_path: Optional[str]

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -462,7 +462,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -471,7 +471,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -464,7 +464,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
+++ b/hazelcast/datadog_checks/hazelcast/data/conf.yaml.example
@@ -462,6 +462,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/hazelcast/setup.py
+++ b/hazelcast/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/config_models/defaults.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/config_models/defaults.py
@@ -162,7 +162,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/config_models/defaults.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/config_models/defaults.py
@@ -162,6 +162,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/config_models/instance.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/config_models/instance.py
@@ -75,7 +75,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/config_models/instance.py
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/config_models/instance.py
@@ -75,6 +75,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
@@ -291,6 +291,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
@@ -293,7 +293,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
+++ b/hdfs_datanode/datadog_checks/hdfs_datanode/data/conf.yaml.example
@@ -291,7 +291,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -300,7 +300,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/hdfs_datanode/setup.py
+++ b/hdfs_datanode/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.7.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-hdfs_datanode',

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/config_models/defaults.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/config_models/defaults.py
@@ -162,7 +162,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/config_models/defaults.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/config_models/defaults.py
@@ -162,6 +162,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/config_models/instance.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/config_models/instance.py
@@ -75,7 +75,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/config_models/instance.py
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/config_models/instance.py
@@ -75,6 +75,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
@@ -291,6 +291,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
@@ -293,7 +293,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
+++ b/hdfs_namenode/datadog_checks/hdfs_namenode/data/conf.yaml.example
@@ -291,7 +291,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -300,7 +300,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/hdfs_namenode/setup.py
+++ b/hdfs_namenode/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-hdfs_namenode',

--- a/http_check/datadog_checks/http_check/config_models/defaults.py
+++ b/http_check/datadog_checks/http_check/config_models/defaults.py
@@ -226,6 +226,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/http_check/datadog_checks/http_check/config_models/defaults.py
+++ b/http_check/datadog_checks/http_check/config_models/defaults.py
@@ -226,7 +226,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/http_check/datadog_checks/http_check/config_models/instance.py
+++ b/http_check/datadog_checks/http_check/config_models/instance.py
@@ -91,7 +91,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/http_check/datadog_checks/http_check/config_models/instance.py
+++ b/http_check/datadog_checks/http_check/config_models/instance.py
@@ -91,6 +91,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -446,6 +446,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -446,7 +446,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -455,7 +455,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -448,7 +448,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/http_check/setup.py
+++ b/http_check/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=22.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-http_check',

--- a/ibm_was/datadog_checks/ibm_was/config_models/defaults.py
+++ b/ibm_was/datadog_checks/ibm_was/config_models/defaults.py
@@ -174,7 +174,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/ibm_was/datadog_checks/ibm_was/config_models/defaults.py
+++ b/ibm_was/datadog_checks/ibm_was/config_models/defaults.py
@@ -174,6 +174,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/ibm_was/datadog_checks/ibm_was/config_models/instance.py
+++ b/ibm_was/datadog_checks/ibm_was/config_models/instance.py
@@ -87,6 +87,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_global_custom_queries: Optional[str]

--- a/ibm_was/datadog_checks/ibm_was/config_models/instance.py
+++ b/ibm_was/datadog_checks/ibm_was/config_models/instance.py
@@ -87,7 +87,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_global_custom_queries: Optional[str]

--- a/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
+++ b/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
@@ -288,7 +288,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
+++ b/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
@@ -286,6 +286,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
+++ b/ibm_was/datadog_checks/ibm_was/data/conf.yaml.example
@@ -286,7 +286,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -295,7 +295,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/ibm_was/setup.py
+++ b/ibm_was/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.1.2'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/istio/datadog_checks/istio/config_models/defaults.py
+++ b/istio/datadog_checks/istio/config_models/defaults.py
@@ -326,7 +326,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/istio/datadog_checks/istio/config_models/defaults.py
+++ b/istio/datadog_checks/istio/config_models/defaults.py
@@ -326,6 +326,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/istio/datadog_checks/istio/config_models/instance.py
+++ b/istio/datadog_checks/istio/config_models/instance.py
@@ -164,6 +164,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/istio/datadog_checks/istio/config_models/instance.py
+++ b/istio/datadog_checks/istio/config_models/instance.py
@@ -164,7 +164,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -520,6 +520,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -520,7 +520,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -529,7 +529,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -522,7 +522,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/istio/setup.py
+++ b/istio/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/kong/datadog_checks/kong/config_models/defaults.py
+++ b/kong/datadog_checks/kong/config_models/defaults.py
@@ -258,7 +258,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/kong/datadog_checks/kong/config_models/defaults.py
+++ b/kong/datadog_checks/kong/config_models/defaults.py
@@ -258,6 +258,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/kong/datadog_checks/kong/config_models/instance.py
+++ b/kong/datadog_checks/kong/config_models/instance.py
@@ -124,6 +124,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_latest_spec: Optional[bool]

--- a/kong/datadog_checks/kong/config_models/instance.py
+++ b/kong/datadog_checks/kong/config_models/instance.py
@@ -124,7 +124,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_latest_spec: Optional[bool]

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -513,6 +513,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -515,7 +515,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/kong/datadog_checks/kong/data/conf.yaml.example
+++ b/kong/datadog_checks/kong/data/conf.yaml.example
@@ -513,7 +513,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -522,7 +522,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/kong/setup.py
+++ b/kong/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-kong',

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/defaults.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/defaults.py
@@ -246,6 +246,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/defaults.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/defaults.py
@@ -246,7 +246,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/instance.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/instance.py
@@ -119,6 +119,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/instance.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/instance.py
@@ -119,7 +119,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -424,7 +424,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -422,6 +422,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -422,7 +422,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -431,7 +431,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/kube_apiserver_metrics/setup.py
+++ b/kube_apiserver_metrics/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
@@ -457,7 +457,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -466,7 +466,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
@@ -459,7 +459,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
@@ -457,6 +457,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/kube_controller_manager/setup.py
+++ b/kube_controller_manager/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=16.5.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
+++ b/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
@@ -415,7 +415,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -424,7 +424,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
+++ b/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
@@ -417,7 +417,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
+++ b/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
@@ -415,6 +415,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/kube_dns/setup.py
+++ b/kube_dns/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-kube_dns',

--- a/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
@@ -424,7 +424,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
@@ -422,6 +422,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
@@ -422,7 +422,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -431,7 +431,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/kube_metrics_server/setup.py
+++ b/kube_metrics_server/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.8.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
+++ b/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
@@ -415,7 +415,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -424,7 +424,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
+++ b/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
@@ -417,7 +417,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
+++ b/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
@@ -415,6 +415,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/kube_proxy/setup.py
+++ b/kube_proxy/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-kube-proxy',

--- a/kube_scheduler/datadog_checks/kube_scheduler/config_models/defaults.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/config_models/defaults.py
@@ -254,6 +254,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/kube_scheduler/datadog_checks/kube_scheduler/config_models/defaults.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/config_models/defaults.py
@@ -254,7 +254,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/kube_scheduler/datadog_checks/kube_scheduler/config_models/instance.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/config_models/instance.py
@@ -121,6 +121,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/kube_scheduler/datadog_checks/kube_scheduler/config_models/instance.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/config_models/instance.py
@@ -121,7 +121,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -436,7 +436,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -445,7 +445,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -436,6 +436,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -438,7 +438,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/kube_scheduler/setup.py
+++ b/kube_scheduler/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/kyototycoon/datadog_checks/kyototycoon/config_models/defaults.py
+++ b/kyototycoon/datadog_checks/kyototycoon/config_models/defaults.py
@@ -166,7 +166,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/kyototycoon/datadog_checks/kyototycoon/config_models/defaults.py
+++ b/kyototycoon/datadog_checks/kyototycoon/config_models/defaults.py
@@ -166,6 +166,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/kyototycoon/datadog_checks/kyototycoon/config_models/instance.py
+++ b/kyototycoon/datadog_checks/kyototycoon/config_models/instance.py
@@ -76,6 +76,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/kyototycoon/datadog_checks/kyototycoon/config_models/instance.py
+++ b/kyototycoon/datadog_checks/kyototycoon/config_models/instance.py
@@ -76,7 +76,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
+++ b/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
@@ -290,7 +290,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -299,7 +299,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
+++ b/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
@@ -290,6 +290,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
+++ b/kyototycoon/datadog_checks/kyototycoon/data/conf.yaml.example
@@ -292,7 +292,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/kyototycoon/setup.py
+++ b/kyototycoon/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-kyototycoon',

--- a/lighttpd/datadog_checks/lighttpd/config_models/defaults.py
+++ b/lighttpd/datadog_checks/lighttpd/config_models/defaults.py
@@ -162,7 +162,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/lighttpd/datadog_checks/lighttpd/config_models/defaults.py
+++ b/lighttpd/datadog_checks/lighttpd/config_models/defaults.py
@@ -162,6 +162,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/lighttpd/datadog_checks/lighttpd/config_models/instance.py
+++ b/lighttpd/datadog_checks/lighttpd/config_models/instance.py
@@ -75,7 +75,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/lighttpd/datadog_checks/lighttpd/config_models/instance.py
+++ b/lighttpd/datadog_checks/lighttpd/config_models/instance.py
@@ -75,6 +75,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
+++ b/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
@@ -285,6 +285,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
+++ b/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
@@ -285,7 +285,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -294,7 +294,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
+++ b/lighttpd/datadog_checks/lighttpd/data/conf.yaml.example
@@ -287,7 +287,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/lighttpd/setup.py
+++ b/lighttpd/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-lighttpd',

--- a/linkerd/datadog_checks/linkerd/config_models/defaults.py
+++ b/linkerd/datadog_checks/linkerd/config_models/defaults.py
@@ -318,6 +318,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/linkerd/datadog_checks/linkerd/config_models/defaults.py
+++ b/linkerd/datadog_checks/linkerd/config_models/defaults.py
@@ -318,7 +318,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/linkerd/datadog_checks/linkerd/config_models/instance.py
+++ b/linkerd/datadog_checks/linkerd/config_models/instance.py
@@ -162,7 +162,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/linkerd/datadog_checks/linkerd/config_models/instance.py
+++ b/linkerd/datadog_checks/linkerd/config_models/instance.py
@@ -162,6 +162,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/linkerd/datadog_checks/linkerd/data/conf.yaml.example
+++ b/linkerd/datadog_checks/linkerd/data/conf.yaml.example
@@ -505,7 +505,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/linkerd/datadog_checks/linkerd/data/conf.yaml.example
+++ b/linkerd/datadog_checks/linkerd/data/conf.yaml.example
@@ -503,7 +503,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -512,7 +512,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/linkerd/datadog_checks/linkerd/data/conf.yaml.example
+++ b/linkerd/datadog_checks/linkerd/data/conf.yaml.example
@@ -503,6 +503,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/linkerd/setup.py
+++ b/linkerd/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-linkerd',

--- a/mapreduce/datadog_checks/mapreduce/config_models/defaults.py
+++ b/mapreduce/datadog_checks/mapreduce/config_models/defaults.py
@@ -174,7 +174,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/mapreduce/datadog_checks/mapreduce/config_models/defaults.py
+++ b/mapreduce/datadog_checks/mapreduce/config_models/defaults.py
@@ -174,6 +174,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/mapreduce/datadog_checks/mapreduce/config_models/instance.py
+++ b/mapreduce/datadog_checks/mapreduce/config_models/instance.py
@@ -77,7 +77,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/mapreduce/datadog_checks/mapreduce/config_models/instance.py
+++ b/mapreduce/datadog_checks/mapreduce/config_models/instance.py
@@ -77,6 +77,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
+++ b/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
@@ -347,7 +347,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -356,7 +356,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
+++ b/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
@@ -347,6 +347,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
+++ b/mapreduce/datadog_checks/mapreduce/data/conf.yaml.example
@@ -349,7 +349,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/mapreduce/setup.py
+++ b/mapreduce/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.7.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-mapreduce',

--- a/marathon/datadog_checks/marathon/config_models/defaults.py
+++ b/marathon/datadog_checks/marathon/config_models/defaults.py
@@ -174,7 +174,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/marathon/datadog_checks/marathon/config_models/defaults.py
+++ b/marathon/datadog_checks/marathon/config_models/defaults.py
@@ -174,6 +174,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/marathon/datadog_checks/marathon/config_models/instance.py
+++ b/marathon/datadog_checks/marathon/config_models/instance.py
@@ -77,7 +77,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/marathon/datadog_checks/marathon/config_models/instance.py
+++ b/marathon/datadog_checks/marathon/config_models/instance.py
@@ -77,6 +77,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/marathon/datadog_checks/marathon/data/conf.yaml.example
+++ b/marathon/datadog_checks/marathon/data/conf.yaml.example
@@ -338,7 +338,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/marathon/datadog_checks/marathon/data/conf.yaml.example
+++ b/marathon/datadog_checks/marathon/data/conf.yaml.example
@@ -336,7 +336,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -345,7 +345,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/marathon/datadog_checks/marathon/data/conf.yaml.example
+++ b/marathon/datadog_checks/marathon/data/conf.yaml.example
@@ -336,6 +336,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/marathon/setup.py
+++ b/marathon/setup.py
@@ -25,7 +25,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=22.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-marathon',

--- a/marklogic/datadog_checks/marklogic/config_models/defaults.py
+++ b/marklogic/datadog_checks/marklogic/config_models/defaults.py
@@ -170,7 +170,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/marklogic/datadog_checks/marklogic/config_models/defaults.py
+++ b/marklogic/datadog_checks/marklogic/config_models/defaults.py
@@ -170,6 +170,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/marklogic/datadog_checks/marklogic/config_models/instance.py
+++ b/marklogic/datadog_checks/marklogic/config_models/instance.py
@@ -76,6 +76,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/marklogic/datadog_checks/marklogic/config_models/instance.py
+++ b/marklogic/datadog_checks/marklogic/config_models/instance.py
@@ -76,7 +76,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/marklogic/datadog_checks/marklogic/data/conf.yaml.example
+++ b/marklogic/datadog_checks/marklogic/data/conf.yaml.example
@@ -311,7 +311,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/marklogic/datadog_checks/marklogic/data/conf.yaml.example
+++ b/marklogic/datadog_checks/marklogic/data/conf.yaml.example
@@ -309,7 +309,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -318,7 +318,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/marklogic/datadog_checks/marklogic/data/conf.yaml.example
+++ b/marklogic/datadog_checks/marklogic/data/conf.yaml.example
@@ -309,6 +309,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/marklogic/setup.py
+++ b/marklogic/setup.py
@@ -18,7 +18,7 @@ with open(path.join(HERE, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.7.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/mesos_master/datadog_checks/mesos_master/config_models/defaults.py
+++ b/mesos_master/datadog_checks/mesos_master/config_models/defaults.py
@@ -162,7 +162,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/mesos_master/datadog_checks/mesos_master/config_models/defaults.py
+++ b/mesos_master/datadog_checks/mesos_master/config_models/defaults.py
@@ -162,6 +162,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/mesos_master/datadog_checks/mesos_master/config_models/instance.py
+++ b/mesos_master/datadog_checks/mesos_master/config_models/instance.py
@@ -74,6 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/mesos_master/datadog_checks/mesos_master/config_models/instance.py
+++ b/mesos_master/datadog_checks/mesos_master/config_models/instance.py
@@ -74,7 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
+++ b/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
@@ -291,6 +291,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
+++ b/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
@@ -293,7 +293,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
+++ b/mesos_master/datadog_checks/mesos_master/data/conf.yaml.example
@@ -291,7 +291,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -300,7 +300,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/mesos_master/setup.py
+++ b/mesos_master/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.3.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-mesos_master',

--- a/mesos_slave/datadog_checks/mesos_slave/config_models/defaults.py
+++ b/mesos_slave/datadog_checks/mesos_slave/config_models/defaults.py
@@ -174,7 +174,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/mesos_slave/datadog_checks/mesos_slave/config_models/defaults.py
+++ b/mesos_slave/datadog_checks/mesos_slave/config_models/defaults.py
@@ -174,6 +174,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/mesos_slave/datadog_checks/mesos_slave/config_models/instance.py
+++ b/mesos_slave/datadog_checks/mesos_slave/config_models/instance.py
@@ -77,7 +77,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/mesos_slave/datadog_checks/mesos_slave/config_models/instance.py
+++ b/mesos_slave/datadog_checks/mesos_slave/config_models/instance.py
@@ -77,6 +77,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
+++ b/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
@@ -308,6 +308,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
+++ b/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
@@ -308,7 +308,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -317,7 +317,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
+++ b/mesos_slave/datadog_checks/mesos_slave/data/conf.yaml.example
@@ -310,7 +310,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/mesos_slave/setup.py
+++ b/mesos_slave/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.3.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-mesos_slave',

--- a/nginx/datadog_checks/nginx/config_models/defaults.py
+++ b/nginx/datadog_checks/nginx/config_models/defaults.py
@@ -170,7 +170,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/nginx/datadog_checks/nginx/config_models/defaults.py
+++ b/nginx/datadog_checks/nginx/config_models/defaults.py
@@ -170,6 +170,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/nginx/datadog_checks/nginx/config_models/instance.py
+++ b/nginx/datadog_checks/nginx/config_models/instance.py
@@ -77,7 +77,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/nginx/datadog_checks/nginx/config_models/instance.py
+++ b/nginx/datadog_checks/nginx/config_models/instance.py
@@ -77,6 +77,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/nginx/datadog_checks/nginx/data/conf.yaml.example
+++ b/nginx/datadog_checks/nginx/data/conf.yaml.example
@@ -329,7 +329,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -338,7 +338,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/nginx/datadog_checks/nginx/data/conf.yaml.example
+++ b/nginx/datadog_checks/nginx/data/conf.yaml.example
@@ -331,7 +331,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/nginx/datadog_checks/nginx/data/conf.yaml.example
+++ b/nginx/datadog_checks/nginx/data/conf.yaml.example
@@ -329,6 +329,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/nginx/setup.py
+++ b/nginx/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.1.2'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-nginx',

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/defaults.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/defaults.py
@@ -246,6 +246,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/defaults.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/defaults.py
@@ -246,7 +246,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/instance.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/instance.py
@@ -119,6 +119,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/instance.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/instance.py
@@ -119,7 +119,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -423,7 +423,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -432,7 +432,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -423,6 +423,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -425,7 +425,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/nginx_ingress_controller/setup.py
+++ b/nginx_ingress_controller/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/openmetrics/datadog_checks/openmetrics/config_models/defaults.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/defaults.py
@@ -314,7 +314,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/openmetrics/datadog_checks/openmetrics/config_models/defaults.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/defaults.py
@@ -314,6 +314,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/openmetrics/datadog_checks/openmetrics/config_models/instance.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/instance.py
@@ -162,7 +162,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/openmetrics/datadog_checks/openmetrics/config_models/instance.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/instance.py
@@ -162,6 +162,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -549,6 +549,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -551,7 +551,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -549,7 +549,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -558,7 +558,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/openmetrics/setup.py
+++ b/openmetrics/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-openmetrics',

--- a/openstack_controller/datadog_checks/openstack_controller/data/conf.yaml.example
+++ b/openstack_controller/datadog_checks/openstack_controller/data/conf.yaml.example
@@ -307,7 +307,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/openstack_controller/datadog_checks/openstack_controller/data/conf.yaml.example
+++ b/openstack_controller/datadog_checks/openstack_controller/data/conf.yaml.example
@@ -305,7 +305,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -314,7 +314,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/openstack_controller/datadog_checks/openstack_controller/data/conf.yaml.example
+++ b/openstack_controller/datadog_checks/openstack_controller/data/conf.yaml.example
@@ -305,6 +305,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/openstack_controller/setup.py
+++ b/openstack_controller/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/php_fpm/datadog_checks/php_fpm/config_models/defaults.py
+++ b/php_fpm/datadog_checks/php_fpm/config_models/defaults.py
@@ -178,6 +178,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/php_fpm/datadog_checks/php_fpm/config_models/defaults.py
+++ b/php_fpm/datadog_checks/php_fpm/config_models/defaults.py
@@ -178,7 +178,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/php_fpm/datadog_checks/php_fpm/config_models/instance.py
+++ b/php_fpm/datadog_checks/php_fpm/config_models/instance.py
@@ -78,6 +78,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_fastcgi: Optional[bool]

--- a/php_fpm/datadog_checks/php_fpm/config_models/instance.py
+++ b/php_fpm/datadog_checks/php_fpm/config_models/instance.py
@@ -78,7 +78,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_fastcgi: Optional[bool]

--- a/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
+++ b/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
@@ -323,7 +323,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
+++ b/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
@@ -321,6 +321,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
+++ b/php_fpm/datadog_checks/php_fpm/data/conf.yaml.example
@@ -321,7 +321,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -330,7 +330,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/php_fpm/setup.py
+++ b/php_fpm/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=22.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-php_fpm',

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/config_models/defaults.py
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/config_models/defaults.py
@@ -162,7 +162,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/config_models/defaults.py
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/config_models/defaults.py
@@ -162,6 +162,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/config_models/instance.py
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/config_models/instance.py
@@ -77,7 +77,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/config_models/instance.py
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/config_models/instance.py
@@ -77,6 +77,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
@@ -310,7 +310,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -319,7 +319,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
@@ -310,6 +310,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
+++ b/powerdns_recursor/datadog_checks/powerdns_recursor/data/conf.yaml.example
@@ -312,7 +312,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/powerdns_recursor/setup.py
+++ b/powerdns_recursor/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.8.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-powerdns_recursor',

--- a/rabbitmq/datadog_checks/rabbitmq/config_models/defaults.py
+++ b/rabbitmq/datadog_checks/rabbitmq/config_models/defaults.py
@@ -194,6 +194,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/rabbitmq/datadog_checks/rabbitmq/config_models/defaults.py
+++ b/rabbitmq/datadog_checks/rabbitmq/config_models/defaults.py
@@ -194,7 +194,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/rabbitmq/datadog_checks/rabbitmq/config_models/instance.py
+++ b/rabbitmq/datadog_checks/rabbitmq/config_models/instance.py
@@ -83,6 +83,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/rabbitmq/datadog_checks/rabbitmq/config_models/instance.py
+++ b/rabbitmq/datadog_checks/rabbitmq/config_models/instance.py
@@ -83,7 +83,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -377,7 +377,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -386,7 +386,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -377,6 +377,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -379,7 +379,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/rabbitmq/setup.py
+++ b/rabbitmq/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=22.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-rabbitmq',

--- a/riak/datadog_checks/riak/config_models/defaults.py
+++ b/riak/datadog_checks/riak/config_models/defaults.py
@@ -162,7 +162,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/riak/datadog_checks/riak/config_models/defaults.py
+++ b/riak/datadog_checks/riak/config_models/defaults.py
@@ -162,6 +162,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/riak/datadog_checks/riak/config_models/instance.py
+++ b/riak/datadog_checks/riak/config_models/instance.py
@@ -74,6 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/riak/datadog_checks/riak/config_models/instance.py
+++ b/riak/datadog_checks/riak/config_models/instance.py
@@ -74,7 +74,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/riak/datadog_checks/riak/data/conf.yaml.example
+++ b/riak/datadog_checks/riak/data/conf.yaml.example
@@ -285,6 +285,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/riak/datadog_checks/riak/data/conf.yaml.example
+++ b/riak/datadog_checks/riak/data/conf.yaml.example
@@ -285,7 +285,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -294,7 +294,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/riak/datadog_checks/riak/data/conf.yaml.example
+++ b/riak/datadog_checks/riak/data/conf.yaml.example
@@ -287,7 +287,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/riak/setup.py
+++ b/riak/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-riak',

--- a/scylla/datadog_checks/scylla/config_models/defaults.py
+++ b/scylla/datadog_checks/scylla/config_models/defaults.py
@@ -246,6 +246,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/scylla/datadog_checks/scylla/config_models/defaults.py
+++ b/scylla/datadog_checks/scylla/config_models/defaults.py
@@ -246,7 +246,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/scylla/datadog_checks/scylla/config_models/instance.py
+++ b/scylla/datadog_checks/scylla/config_models/instance.py
@@ -119,6 +119,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/scylla/datadog_checks/scylla/config_models/instance.py
+++ b/scylla/datadog_checks/scylla/config_models/instance.py
@@ -119,7 +119,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -432,7 +432,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -441,7 +441,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -432,6 +432,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -434,7 +434,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/scylla/setup.py
+++ b/scylla/setup.py
@@ -32,7 +32,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.2.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
+++ b/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
@@ -254,6 +254,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
+++ b/sonarqube/datadog_checks/sonarqube/config_models/defaults.py
@@ -254,7 +254,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/sonarqube/datadog_checks/sonarqube/config_models/instance.py
+++ b/sonarqube/datadog_checks/sonarqube/config_models/instance.py
@@ -101,7 +101,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     tools_jar_path: Optional[str]

--- a/sonarqube/datadog_checks/sonarqube/config_models/instance.py
+++ b/sonarqube/datadog_checks/sonarqube/config_models/instance.py
@@ -101,6 +101,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     tools_jar_path: Optional[str]

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -377,7 +377,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -375,6 +375,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -375,7 +375,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -384,7 +384,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/sonarqube/setup.py
+++ b/sonarqube/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/spark/datadog_checks/spark/config_models/defaults.py
+++ b/spark/datadog_checks/spark/config_models/defaults.py
@@ -198,6 +198,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/spark/datadog_checks/spark/config_models/defaults.py
+++ b/spark/datadog_checks/spark/config_models/defaults.py
@@ -198,7 +198,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/spark/datadog_checks/spark/config_models/instance.py
+++ b/spark/datadog_checks/spark/config_models/instance.py
@@ -85,6 +85,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/spark/datadog_checks/spark/config_models/instance.py
+++ b/spark/datadog_checks/spark/config_models/instance.py
@@ -85,7 +85,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -386,6 +386,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -388,7 +388,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/spark/datadog_checks/spark/data/conf.yaml.example
+++ b/spark/datadog_checks/spark/data/conf.yaml.example
@@ -386,7 +386,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -395,7 +395,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/spark/setup.py
+++ b/spark/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=15.3.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-spark',

--- a/squid/datadog_checks/squid/config_models/defaults.py
+++ b/squid/datadog_checks/squid/config_models/defaults.py
@@ -170,7 +170,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/squid/datadog_checks/squid/config_models/defaults.py
+++ b/squid/datadog_checks/squid/config_models/defaults.py
@@ -170,6 +170,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/squid/datadog_checks/squid/config_models/instance.py
+++ b/squid/datadog_checks/squid/config_models/instance.py
@@ -77,7 +77,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/squid/datadog_checks/squid/config_models/instance.py
+++ b/squid/datadog_checks/squid/config_models/instance.py
@@ -77,6 +77,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/squid/datadog_checks/squid/data/conf.yaml.example
+++ b/squid/datadog_checks/squid/data/conf.yaml.example
@@ -324,6 +324,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/squid/datadog_checks/squid/data/conf.yaml.example
+++ b/squid/datadog_checks/squid/data/conf.yaml.example
@@ -326,7 +326,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/squid/datadog_checks/squid/data/conf.yaml.example
+++ b/squid/datadog_checks/squid/data/conf.yaml.example
@@ -324,7 +324,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -333,7 +333,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/squid/setup.py
+++ b/squid/setup.py
@@ -28,7 +28,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=22.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-squid',

--- a/teamcity/datadog_checks/teamcity/config_models/defaults.py
+++ b/teamcity/datadog_checks/teamcity/config_models/defaults.py
@@ -174,7 +174,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/teamcity/datadog_checks/teamcity/config_models/defaults.py
+++ b/teamcity/datadog_checks/teamcity/config_models/defaults.py
@@ -174,6 +174,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/teamcity/datadog_checks/teamcity/config_models/instance.py
+++ b/teamcity/datadog_checks/teamcity/config_models/instance.py
@@ -80,6 +80,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/teamcity/datadog_checks/teamcity/config_models/instance.py
+++ b/teamcity/datadog_checks/teamcity/config_models/instance.py
@@ -80,7 +80,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/teamcity/datadog_checks/teamcity/data/conf.yaml.example
+++ b/teamcity/datadog_checks/teamcity/data/conf.yaml.example
@@ -318,6 +318,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/teamcity/datadog_checks/teamcity/data/conf.yaml.example
+++ b/teamcity/datadog_checks/teamcity/data/conf.yaml.example
@@ -320,7 +320,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/teamcity/datadog_checks/teamcity/data/conf.yaml.example
+++ b/teamcity/datadog_checks/teamcity/data/conf.yaml.example
@@ -318,7 +318,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -327,7 +327,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/teamcity/setup.py
+++ b/teamcity/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=22.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-teamcity',

--- a/twistlock/datadog_checks/twistlock/config_models/defaults.py
+++ b/twistlock/datadog_checks/twistlock/config_models/defaults.py
@@ -166,7 +166,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/twistlock/datadog_checks/twistlock/config_models/defaults.py
+++ b/twistlock/datadog_checks/twistlock/config_models/defaults.py
@@ -166,6 +166,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/twistlock/datadog_checks/twistlock/config_models/instance.py
+++ b/twistlock/datadog_checks/twistlock/config_models/instance.py
@@ -75,6 +75,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/twistlock/datadog_checks/twistlock/config_models/instance.py
+++ b/twistlock/datadog_checks/twistlock/config_models/instance.py
@@ -75,7 +75,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/twistlock/datadog_checks/twistlock/data/conf.yaml.example
+++ b/twistlock/datadog_checks/twistlock/data/conf.yaml.example
@@ -291,6 +291,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/twistlock/datadog_checks/twistlock/data/conf.yaml.example
+++ b/twistlock/datadog_checks/twistlock/data/conf.yaml.example
@@ -293,7 +293,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/twistlock/datadog_checks/twistlock/data/conf.yaml.example
+++ b/twistlock/datadog_checks/twistlock/data/conf.yaml.example
@@ -291,7 +291,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -300,7 +300,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/twistlock/setup.py
+++ b/twistlock/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=22.0.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/vault/datadog_checks/vault/config_models/defaults.py
+++ b/vault/datadog_checks/vault/config_models/defaults.py
@@ -182,6 +182,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/vault/datadog_checks/vault/config_models/defaults.py
+++ b/vault/datadog_checks/vault/config_models/defaults.py
@@ -182,7 +182,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/vault/datadog_checks/vault/config_models/instance.py
+++ b/vault/datadog_checks/vault/config_models/instance.py
@@ -80,6 +80,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/vault/datadog_checks/vault/config_models/instance.py
+++ b/vault/datadog_checks/vault/config_models/instance.py
@@ -80,7 +80,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/vault/datadog_checks/vault/data/conf.yaml.example
+++ b/vault/datadog_checks/vault/data/conf.yaml.example
@@ -313,7 +313,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/vault/datadog_checks/vault/data/conf.yaml.example
+++ b/vault/datadog_checks/vault/data/conf.yaml.example
@@ -311,6 +311,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/vault/datadog_checks/vault/data/conf.yaml.example
+++ b/vault/datadog_checks/vault/data/conf.yaml.example
@@ -311,7 +311,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -320,7 +320,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/vault/setup.py
+++ b/vault/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=16.5.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-vault',

--- a/voltdb/datadog_checks/voltdb/config_models/defaults.py
+++ b/voltdb/datadog_checks/voltdb/config_models/defaults.py
@@ -178,6 +178,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/voltdb/datadog_checks/voltdb/config_models/defaults.py
+++ b/voltdb/datadog_checks/voltdb/config_models/defaults.py
@@ -178,7 +178,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/voltdb/datadog_checks/voltdb/config_models/instance.py
+++ b/voltdb/datadog_checks/voltdb/config_models/instance.py
@@ -87,6 +87,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/voltdb/datadog_checks/voltdb/config_models/instance.py
+++ b/voltdb/datadog_checks/voltdb/config_models/instance.py
@@ -87,7 +87,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     url: str

--- a/voltdb/datadog_checks/voltdb/data/conf.yaml.example
+++ b/voltdb/datadog_checks/voltdb/data/conf.yaml.example
@@ -186,7 +186,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -195,7 +195,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/voltdb/datadog_checks/voltdb/data/conf.yaml.example
+++ b/voltdb/datadog_checks/voltdb/data/conf.yaml.example
@@ -188,7 +188,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/voltdb/datadog_checks/voltdb/data/conf.yaml.example
+++ b/voltdb/datadog_checks/voltdb/data/conf.yaml.example
@@ -186,6 +186,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/voltdb/setup.py
+++ b/voltdb/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.1.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 
 setup(

--- a/vsphere/datadog_checks/vsphere/config_models/instance.py
+++ b/vsphere/datadog_checks/vsphere/config_models/instance.py
@@ -100,7 +100,7 @@ class RestApiOptions(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/vsphere/datadog_checks/vsphere/config_models/instance.py
+++ b/vsphere/datadog_checks/vsphere/config_models/instance.py
@@ -100,6 +100,7 @@ class RestApiOptions(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -622,7 +622,7 @@ instances:
         #
         # tls_ca_cert: <CA_CERT_PATH>
 
-        ## @param tls_protocol - list of strings - optional
+        ## @param tls_protocols_allowed - list of strings - optional
         ## The expected versions of TLS/SSL when fetching intermediate certificates.
         ## The supported versions and values are:
         ##   SSLv3
@@ -631,7 +631,7 @@ instances:
         ##   TLSv1.2
         ##   TLSv1.3
         #
-        # tls_protocol:
+        # tls_protocols_allowed:
         #   - SSLv3
         #   - TLSv1.2
         #   - TLSv1.3

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -624,7 +624,7 @@ instances:
 
         ## @param tls_protocols_allowed - list of strings - optional
         ## The expected versions of TLS/SSL when fetching intermediate certificates.
-        ## The supported versions and values are:
+        ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
         ##   SSLv3
         ##   TLSv1
         ##   TLSv1.1

--- a/vsphere/datadog_checks/vsphere/data/conf.yaml.example
+++ b/vsphere/datadog_checks/vsphere/data/conf.yaml.example
@@ -622,6 +622,20 @@ instances:
         #
         # tls_ca_cert: <CA_CERT_PATH>
 
+        ## @param tls_protocol - list of strings - optional
+        ## The expected versions of TLS/SSL when fetching intermediate certificates.
+        ## The supported versions and values are:
+        ##   SSLv3
+        ##   TLSv1
+        ##   TLSv1.1
+        ##   TLSv1.2
+        ##   TLSv1.3
+        #
+        # tls_protocol:
+        #   - SSLv3
+        #   - TLSv1.2
+        #   - TLSv1.3
+
         ## @param headers - mapping - optional
         ## The headers parameter allows you to send specific headers with every request.
         ## You can use it for explicitly specifying the host header or adding headers for

--- a/vsphere/setup.py
+++ b/vsphere/setup.py
@@ -27,7 +27,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.9.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-vsphere',

--- a/yarn/datadog_checks/yarn/config_models/defaults.py
+++ b/yarn/datadog_checks/yarn/config_models/defaults.py
@@ -198,6 +198,10 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_protocol(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_use_host_header(field, value):
     return False
 

--- a/yarn/datadog_checks/yarn/config_models/defaults.py
+++ b/yarn/datadog_checks/yarn/config_models/defaults.py
@@ -198,7 +198,7 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_tls_protocol(field, value):
+def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 

--- a/yarn/datadog_checks/yarn/config_models/instance.py
+++ b/yarn/datadog_checks/yarn/config_models/instance.py
@@ -83,6 +83,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_protocol: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/yarn/datadog_checks/yarn/config_models/instance.py
+++ b/yarn/datadog_checks/yarn/config_models/instance.py
@@ -83,7 +83,7 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
-    tls_protocol: Optional[Sequence[str]]
+    tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]

--- a/yarn/datadog_checks/yarn/data/conf.yaml.example
+++ b/yarn/datadog_checks/yarn/data/conf.yaml.example
@@ -367,7 +367,7 @@ instances:
 
     ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
-    ## The supported versions and values are:
+    ## Only `SSLv3`, `TLSv1.2`, `TLSv1.3` are allowed by default. The possible values are:
     ##   SSLv3
     ##   TLSv1
     ##   TLSv1.1

--- a/yarn/datadog_checks/yarn/data/conf.yaml.example
+++ b/yarn/datadog_checks/yarn/data/conf.yaml.example
@@ -365,6 +365,20 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
+    ## @param tls_protocol - list of strings - optional
+    ## The expected versions of TLS/SSL when fetching intermediate certificates.
+    ## The supported versions and values are:
+    ##   SSLv3
+    ##   TLSv1
+    ##   TLSv1.1
+    ##   TLSv1.2
+    ##   TLSv1.3
+    #
+    # tls_protocol:
+    #   - SSLv3
+    #   - TLSv1.2
+    #   - TLSv1.3
+
     ## @param headers - mapping - optional
     ## The headers parameter allows you to send specific headers with every request.
     ## You can use it for explicitly specifying the host header or adding headers for

--- a/yarn/datadog_checks/yarn/data/conf.yaml.example
+++ b/yarn/datadog_checks/yarn/data/conf.yaml.example
@@ -365,7 +365,7 @@ instances:
     #
     # tls_ca_cert: <CA_CERT_PATH>
 
-    ## @param tls_protocol - list of strings - optional
+    ## @param tls_protocols_allowed - list of strings - optional
     ## The expected versions of TLS/SSL when fetching intermediate certificates.
     ## The supported versions and values are:
     ##   SSLv3
@@ -374,7 +374,7 @@ instances:
     ##   TLSv1.2
     ##   TLSv1.3
     #
-    # tls_protocol:
+    # tls_protocols_allowed:
     #   - SSLv3
     #   - TLSv1.2
     #   - TLSv1.3

--- a/yarn/setup.py
+++ b/yarn/setup.py
@@ -30,7 +30,7 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.8.0'
+CHECKS_BASE_REQ = 'datadog-checks-base>=24.0.0'
 
 setup(
     name='datadog-yarn',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add `tls_protocols_allowed` configuration documentation

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Needs #11237 

This is a breaking change since TLSv1 and TLSv1.1 are not allowed anymore by default. To go back to the old behaviour, use:
```
instances:
- arg1: val1
  ...
  tls_protocols_allowed:
  - SSLv3
  - TLSv1
  - TLSv1.1
  - TLSv1.2
  - TLSv1.3
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
