### PR TITLE
Change order ibm_mq tests are run

### DIFF
--- a/ibm_mq/tox.ini
+++ b/ibm_mq/tox.ini
@@ -25,7 +25,7 @@ dd_mypy_args =
 dd_mypy_deps =
     types-mock==0.1.5
 platform =
-    linux|win32
+    linux|darwin
     py38-9: linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]

--- a/ibm_mq/tox.ini
+++ b/ibm_mq/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py{27,38}-{9,8,9cluster}
+    py{38,27}-{9,8,9cluster}
 
 [testenv]
 ensure_default_envdir = true

--- a/ibm_mq/tox.ini
+++ b/ibm_mq/tox.ini
@@ -3,7 +3,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py{27,38}-{8,9,9cluster}
+    py{27,38}-{9,8,9cluster}
 
 [testenv]
 ensure_default_envdir = true
@@ -25,7 +25,7 @@ dd_mypy_args =
 dd_mypy_deps =
     types-mock==0.1.5
 platform =
-    linux|darwin
+    linux|win32
     py38-9: linux|darwin|win32
 deps =
     -e../datadog_checks_base[deps]


### PR DESCRIPTION
### What does this PR do?
Changes the order in which `ibm_mq` tests are run

### Motivation

Our tooling does not support testing only some environments specifically in [test.py](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py), we exit the program in [start.py](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py#L366) if the platform is not supported, which stops the execution of the other environments. This is a temporary workaround to run ibm_mq tests on windows

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
