### PR TITLE
Add `weblogic.servlet_runtime.exec_time_total`

### DIFF
--- a/weblogic/datadog_checks/weblogic/data/metrics.yaml
+++ b/weblogic/datadog_checks/weblogic/data/metrics.yaml
@@ -120,6 +120,7 @@ jmx_metrics:
           metric_type: monotonic_count
           alias: weblogic.servlet_runtime.exec_time_high
         ExecutionTimeTotal:
+          metric_type: monotonic_count
           alias: weblogic.servlet_runtime.exec_time_total
         ExecutionTimeLow:
           alias: weblogic.servlet_runtime.exec_time_low

--- a/weblogic/datadog_checks/weblogic/data/metrics.yaml
+++ b/weblogic/datadog_checks/weblogic/data/metrics.yaml
@@ -119,6 +119,8 @@ jmx_metrics:
         ExecutionTimeHigh:
           metric_type: monotonic_count
           alias: weblogic.servlet_runtime.exec_time_high
+        ExecutionTimeTotal:
+          alias: weblogic.servlet_runtime.exec_time_total
         ExecutionTimeLow:
           alias: weblogic.servlet_runtime.exec_time_low
         ReloadTotalCount:

--- a/weblogic/tests/metrics.py
+++ b/weblogic/tests/metrics.py
@@ -40,6 +40,7 @@ METRICS = [
     "weblogic.work_manager_runtime.threads_stuck",
     "weblogic.servlet_runtime.exec_time_high",
     "weblogic.servlet_runtime.exec_time_low",
+    "weblogic.servlet_runtime.exec_time_total",
     "weblogic.servlet_runtime.reloads_total",
     "weblogic.servlet_runtime.pool_max_capacity",
     "weblogic.webapp_component_runtime.sessions_current",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`weblogic.servlet_runtime.exec_time_total` is [found](https://github.com/DataDog/integrations-core/blob/master/weblogic/metadata.csv#L37) in `metadata.csv` but is missing in `metrics.yaml`.

### Motivation
<!-- What inspired you to submit this pull request? -->
QA 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
