### PR TITLE
sqlserver: Filter queries without text

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -245,6 +245,8 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         normalized_rows = []
         for row in rows:
             try:
+                if not row['text']:
+                    continue
                 statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             except Exception as e:
                 # obfuscation errors are relatively common so only log them during debugging


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
There is a bug where we try to truncate query text of type `None`. 
```
packages/datadog_checks/sqlserver/statements.py", line 286, in _to_metrics_payload_row
    row['text'] = row['text'][0:200]
TypeError: 'NoneType' object is not subscriptable
```
In 7.33, this wouldn't have happened because it would've been caught in the exception handler for attempting to obfuscate a `None` value. However, the new obfuscator wrapper gracefully handles `None` values by returning a valid object `{'query': None, 'metadata': {}}` which results in a row without text to slip through.

This change filters out queries without text **before** obfuscation which results in
1. Preventing errors like the above ^
2. Reduce log noise from what previously would've logged `Failed to obfuscate query 'None': argument 1 must be str, not None`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
