### PR TITLE
Add k8s-dns-kube-dns as default AD identifier

### DIFF
--- a/kube_dns/assets/configuration/spec.yaml
+++ b/kube_dns/assets/configuration/spec.yaml
@@ -25,6 +25,7 @@ files:
       value.example:
       - kubedns-amd64
       - k8s-dns-kube-dns-amd64
+      - k8s-dns-kube-dns
   - template: init_config
     options: []
   - template: instances

--- a/kube_dns/datadog_checks/kube_dns/data/auto_conf.yaml
+++ b/kube_dns/datadog_checks/kube_dns/data/auto_conf.yaml
@@ -6,6 +6,7 @@
 ad_identifiers:
   - kubedns-amd64
   - k8s-dns-kube-dns-amd64
+  - k8s-dns-kube-dns
 
 ## All options defined here are available to all instances.
 #


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds `k8s-dns-kube-dns` to the default `ad_identifiers` list for `kube_dns`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Recent GKE clusters use the `k8s-dns-kube-dns` image.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This is a customer feature request

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
