### PR TITLE
More specific config validation error message

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -124,7 +124,7 @@ def config(ctx, check, sync, verbose):
                             write_file(example_file_path, contents)
                         else:
                             files_failed[example_file_path] = True
-                            message = f'File `{example_file}` is not in sync, run "ddev validate config -s"'
+                            message = f'File `{example_file}` is not in sync, run "ddev validate config {check} -s"'
                             if file_exists(example_file_path):
                                 example_file = read_file(example_file_path)
                                 for diff_line in difflib.context_diff(


### PR DESCRIPTION
### What does this PR do?

A recent validation error returned this message to the user: `File `conf.yaml.example` is not in sync, run "ddev validate config -s"`

When the user followed the suggestion, several other files outside their specific PR got changed as well, causing cascading validation failures due to other issues in those checks.

This PR adjusts the error message to just the check that's being validated to better target remediation actions.

### Motivation
Better user experience.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
