### PR TITLE
Validate all `curated_metric` rows and properly validate empty `metadata.csv` files

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -488,7 +488,7 @@ def metadata(check, check_duplicates, show_warnings):
                     display_queue.append(
                         (
                             echo_failure,
-                            f"{current_check}:{line} `{row['metric_name']}` contains duplicate metric types.",
+                            f"{current_check}:{line} `{row['metric_name']}` contains duplicate curated_metric types.",
                         )
                     )
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -483,7 +483,7 @@ def metadata(check, check_duplicates, show_warnings):
 
             if 'curated_metric' in row and row['curated_metric']:
                 metric_types = row['curated_metric'].split('|')
-                if len(set(metric_types)) == len(metric_types):
+                if len(set(metric_types)) != len(metric_types):
                     errors = True
                     display_queue.append(
                         (

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -482,13 +482,24 @@ def metadata(check, check_duplicates, show_warnings):
                 )
 
             if 'curated_metric' in row and row['curated_metric']:
-                for curated_metric_type in row['curated_metric'].split('|'):
+                metric_types = row['curated_metric'].split('|')
+                if len(set(metric_types)) == len(metric_types):
+                    errors = True
+                    display_queue.append(
+                        (
+                            echo_failure,
+                            f"{current_check}:{line} `{row['metric_name']}` contains duplicate metric types.",
+                        )
+                    )
+
+                for curated_metric_type in metric_types:
                     if curated_metric_type not in VALID_CURATED_METRIC_TYPES:
                         errors = True
                         display_queue.append(
                             (
                                 echo_failure,
-                                f"{current_check}:{line} `{row['metric_name']}` contains invalid curated metric type.",
+                                f"{current_check}:{line} `{row['metric_name']}` contains invalid "
+                                f"curated metric type: {curated_metric_type}",
                             )
                         )
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -481,20 +481,20 @@ def metadata(check, check_duplicates, show_warnings):
                     (echo_failure, f"{current_check}:{line} interval should be an int, found '{row['interval']}'.")
                 )
 
+            if 'curated_metric' in row and row['curated_metric']:
+                for curated_metric_type in row['curated_metric'].split('|'):
+                    if curated_metric_type not in VALID_CURATED_METRIC_TYPES:
+                        errors = True
+                        display_queue.append(
+                            (
+                                echo_failure,
+                                f"{current_check}:{line} `{row['metric_name']}` contains invalid curated metric type.",
+                            )
+                        )
+
         for header, count in empty_count.items():
             errors = True
             display_queue.append((echo_failure, f'{current_check}: {header} is empty in {count} rows.'))
-
-        if 'curated_metric' in row and row['curated_metric']:
-            for curated_metric_type in row['curated_metric'].split('|'):
-                if curated_metric_type not in VALID_CURATED_METRIC_TYPES:
-                    errors = True
-                    display_queue.append(
-                        (
-                            echo_failure,
-                            f"{current_check}:{line} `{row['metric_name']}` contains invalid curated metric type.",
-                        )
-                    )
 
         for prefix, count in metric_prefix_count.items():
             display_queue.append(


### PR DESCRIPTION
### What does this PR do?
Followup for this [pr](https://github.com/DataDog/integrations-core/pull/11168/files), the 'curated_metric' check in `validate/metadata.py` needs to be moved inside of the read_metadata_rows for loop to prevent an `UnboundLocalError`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
