### PR TITLE
Fix `curated_metric` validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -481,20 +481,22 @@ def metadata(check, check_duplicates, show_warnings):
                     (echo_failure, f"{current_check}:{line} interval should be an int, found '{row['interval']}'.")
                 )
 
+            # check if curated_metric is valid
+            if row['curated_metric']:
+                for curated_metric_type in row['curated_metric'].split('|'):
+                    if curated_metric_type not in VALID_CURATED_METRIC_TYPES:
+                        errors = True
+                        display_queue.append(
+                            (
+                                echo_failure,
+                                f"{current_check}:{line} `{row['metric_name']}` contains invalid curated metric type.",
+                            )
+                        )
+
         for header, count in empty_count.items():
             errors = True
             display_queue.append((echo_failure, f'{current_check}: {header} is empty in {count} rows.'))
 
-        if 'curated_metric' in row and row['curated_metric']:
-            for curated_metric_type in row['curated_metric'].split('|'):
-                if curated_metric_type not in VALID_CURATED_METRIC_TYPES:
-                    errors = True
-                    display_queue.append(
-                        (
-                            echo_failure,
-                            f"{current_check}:{line} `{row['metric_name']}` contains invalid curated metric type.",
-                        )
-                    )
 
         for prefix, count in metric_prefix_count.items():
             display_queue.append(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Move validation of `curated_metric` into where `row` is initialized.
### Motivation
<!-- What inspired you to submit this pull request? -->
Validation is currently failing for https://github.com/DataDog/integrations-core/pull/11035 because `row` is being referenced outside of scope:

```
Run ddev validate metadata changed
##[debug]/usr/bin/bash -e /home/runner/work/_temp/612a0a7d-4d2b-4ca9-8ccb-5ae18d72a248.sh
Validating metadata for 1 checks ...
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.12/x64/bin/ddev", line 33, in <module>
    sys.exit(load_entry_point('datadog-checks-dev', 'console_scripts', 'ddev')())
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/home/runner/work/integrations-core/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py", line 488, in metadata
    if 'curated_metric' in row and row['curated_metric']:
UnboundLocalError: local variable 'row' referenced before assignment
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
