### PR TITLE
datadog_checks_base: Update obfuscator wrapper to return empty string 

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -183,7 +183,7 @@ def default_json_event_encoding(o):
 
 def obfuscate_sql_with_metadata(query, options=None):
     if not query:
-        return {'query': None, 'metadata': {}}
+        return {'query': '', 'metadata': {}}
 
     def _load_metadata(statement):
         try:

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -159,9 +159,9 @@ def test_obfuscate_sql_with_metadata(obfuscator_return_value, expected_value, re
         )
         assert statement == expected_value
 
-    # Check that it can handle null values
+    # Check that it can handle None values
     statement = obfuscate_sql_with_metadata(None)
-    assert statement['query'] is None
+    assert statement['query'] == ''
     assert statement['metadata'] == {}
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
There is a bug in SQL Server where we try to truncate query text of type `None`.
```
packages/datadog_checks/sqlserver/statements.py", line 286, in _to_metrics_payload_row
    row['text'] = row['text'][0:200]
TypeError: 'NoneType' object is not subscriptable
```
The root cause of this error occurs upstream and is caused by SQL Server potentially returning query metrics for a query without text. This causes the wrapper in this PR to return `None`, causing this particular error above. We decided to not filter queries like this out because the behavior we are seeking is to continue sending metrics even in the case of no query text. This will give us more control over how we handle a scenario like this in our back-end.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
