### PR TITLE
Fail gracefully when scraping OpenMetrics endpoints

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -57,7 +57,10 @@ class OpenMetricsBaseCheckV2(AgentCheck):
             self.log.info('Scraping OpenMetrics endpoint: %s', endpoint)
 
             with self.adopt_namespace(scraper.namespace):
-                scraper.scrape()
+                try:
+                    scraper.scrape()
+                except Exception as e:
+                    self.log.error("There was an error scraping endpoint %s: %s", endpoint, str(e))
 
     def configure_scrapers(self):
         """

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -10,6 +10,7 @@ from ....errors import ConfigurationError
 from ....utils.tracing import traced_class
 from ... import AgentCheck
 from .scraper import OpenMetricsScraper
+from requests.exceptions import HTTPError
 
 
 class OpenMetricsBaseCheckV2(AgentCheck):
@@ -59,7 +60,7 @@ class OpenMetricsBaseCheckV2(AgentCheck):
             with self.adopt_namespace(scraper.namespace):
                 try:
                     scraper.scrape()
-                except Exception as e:
+                except (ConnectionError, HTTPError) as e:
                     self.log.error("There was an error scraping endpoint %s: %s", endpoint, str(e))
 
     def configure_scrapers(self):

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -6,11 +6,12 @@
 from collections import ChainMap
 from contextlib import contextmanager
 
+from requests.exceptions import HTTPError
+
 from ....errors import ConfigurationError
 from ....utils.tracing import traced_class
 from ... import AgentCheck
 from .scraper import OpenMetricsScraper
-from requests.exceptions import HTTPError
 
 
 class OpenMetricsBaseCheckV2(AgentCheck):

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -6,7 +6,7 @@
 from collections import ChainMap
 from contextlib import contextmanager
 
-from requests.exceptions import HTTPError
+from requests.exceptions import RequestException
 
 from ....errors import ConfigurationError
 from ....utils.tracing import traced_class
@@ -61,7 +61,7 @@ class OpenMetricsBaseCheckV2(AgentCheck):
             with self.adopt_namespace(scraper.namespace):
                 try:
                     scraper.scrape()
-                except (ConnectionError, HTTPError) as e:
+                except (ConnectionError, RequestException) as e:
                     self.log.error("There was an error scraping endpoint %s: %s", endpoint, str(e))
 
     def configure_scrapers(self):

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_options.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_options.py
@@ -2,10 +2,10 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
+from mock import Mock
 
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.testing import requires_py3
-from mock import mock, Mock
 
 from .utils import get_check
 


### PR DESCRIPTION
When scraping an endpoint, if its not available the check submits a critical service check but still propagates the exception, causing a big stacktrace to appear on the logs. In this change the exception is captured and logged as a single line.

Sample exception trace:
```
Traceback (most recent call last):
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 1033, in run
E               self.check(instance)
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/v2/base.py", line 60, in check
E               scraper.scrape()
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 238, in scrape
E               for metric in self.consume_metrics(runtime_data):
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 258, in consume_metrics
E               for metric in metric_parser:
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 276, in parse_metrics
E               for metric in self.parse_metric_families(line_streamer):
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/prometheus_client/parser.py", line 174, in text_fd_to_metric_families
E               for line in fd:
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 337, in stream_connection_lines
E               with self.get_connection() as connection:
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 358, in get_connection
E               response = self.send_request()
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 385, in send_request
E               return self.http.get(self.endpoint, **kwargs)
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/utils/http.py", line 341, in get
E               return self._request('get', url, options)
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/utils/http.py", line 405, in _request
E               response = self.make_request_aia_chasing(request_method, method, url, new_options, persist)
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/utils/http.py", line 411, in make_request_aia_chasing
E               response = request_method(url, **new_options)
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/requests/api.py", line 76, in get
E               return request('get', url, params=params, **kwargs)
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/requests/api.py", line 61, in request
E               return session.request(method=method, url=url, **kwargs)
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/requests/sessions.py", line 542, in request
E               resp = self.send(prep, **send_kwargs)
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/requests/sessions.py", line 655, in send
E               r = adapter.send(request, **kwargs)
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/requests/adapters.py", line 516, in send
E               raise ConnectionError(e, request=request)
E           requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=9090): Max retries exceeded with url: /metrics (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fac419ab9a0>: Failed to establish a new connection: [Errno 111] Connection refused'))
E           
E           Message: HTTPConnectionPool(host='localhost', port=6942): Max retries exceeded with url: /metrics (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fac58133580>: Failed to establish a new connection: [Errno 111] Connection refused'))
E           Traceback (most recent call last):
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/urllib3/connection.py", line 174, in _new_conn
E               conn = connection.create_connection(
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/urllib3/util/connection.py", line 95, in create_connection
E               raise err
E             File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/urllib3/util/connection.py", line 85, in create_connection
E               sock.connect(sa)
E           ConnectionRefusedError: [Errno 111] Connection refused
```