### PR TITLE
Safely check the dashboards key exists before trying to write to it

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_utils.py
@@ -73,6 +73,9 @@ class ManifestV1:
         self.version = V1
 
     def add_dashboard(self, title, file_name):
+        # Default manifest dashboards to an empty dictionary in the event the key isn't already in the manifest
+        if not self._manifest_json['assets'].get('dashboards'):
+            self._manifest_json['assets']['dashboards'] = dict()
         self._manifest_json['assets']['dashboards'][title] = f'assets/dashboards/{file_name}'
 
     def get_path(self, path):
@@ -125,6 +128,9 @@ class ManifestV2:
         self.version = V2
 
     def add_dashboard(self, title, file_name):
+        # Default manifest dashboards to an empty dictionary in the event the key isn't already in the manifest
+        if not self._manifest_json['assets'].get('dashboards'):
+            self._manifest_json['assets']['dashboards'] = dict()
         self._manifest_json['assets']['dashboards'][title] = f'assets/dashboards/{file_name}'
 
     def get_path(self, path):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the `add_dashboard` helper utility to safely initialize an empty dictionary if the key does not yet exist in the manifest when you try to add to it

### Motivation
<!-- What inspired you to submit this pull request? -->
There are some cases in the migration to Manifest V2 where you do not yet have a `dashboards` key under the `assets` section of a manifest. This is OK as not all integrations will have `dashboards`. 

Though currently, if you migrate to Manifest V2 and try to later add a dashboard through the `ddev meta dash export` command, it'd fail since the `dashboards` key does not yet exist. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
