### PR TITLE
Add support for OpenMetrics v2

### DIFF
--- a/vault/assets/configuration/spec.yaml
+++ b/vault/assets/configuration/spec.yaml
@@ -4,15 +4,30 @@ files:
   options:
   - template: init_config
     options:
-    - template: init_config/http
-    - template: init_config/default
+    - template: init_config/openmetrics
   - template: instances
     options:
+    - name: use_openmetrics
+      description: |
+        Use the latest OpenMetrics implementation for more features, better performance,
+        and more appropriate metric types by default. If running on Agent v6, you must
+        set the `python_version` option in `datadog.yaml` to `"3"`.
+
+        In a future release, this option will be set to `true` by default.
+
+        Note: To see the configuration options for the legacy implementation (Agent 7.34 or older),
+        https://github.com/DataDog/integrations-core/blob/7.34.x/vault/datadog_checks/vault/data/conf.yaml.example
+      enabled: true
+      value:
+        display_default: false
+        example: true
+        type: boolean
     - name: api_url
       required: true
       description: URL of the Vault to query.
       value:
         example: http://localhost:8200/v1
+        pattern: \w+
         type: string
     - name: detect_leader
       description: Whether or not this instance should report cluster leader change events.
@@ -36,15 +51,12 @@ files:
       value:
         example: false
         type: boolean
-    - name: disable_legacy_cluster_tag
-      description: Enable to stop submitting the tag `cluster_name`, which has been renamed to `vault_cluster`.
-      value:
-        type: boolean
-        display_default: false
-        example: true
       enabled: true
-    - template: instances/http
-    - template: instances/default
+    - template: instances/openmetrics
+      overrides:
+        openmetrics_endpoint.required: false
+        openmetrics_endpoint.hidden: true
+        auth_token.hidden: true
   - template: logs
     example:
     - type: file

--- a/vault/datadog_checks/vault/check.py
+++ b/vault/datadog_checks/vault/check.py
@@ -1,0 +1,271 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from copy import deepcopy
+
+from datadog_checks.base import OpenMetricsBaseCheckV2, is_affirmative
+from datadog_checks.base.checks.openmetrics.v2.transform import NATIVE_TRANSFORMERS
+from datadog_checks.base.utils.time import get_timestamp
+
+from .common import API_METHODS, DEFAULT_API_VERSION, SYS_HEALTH_DEFAULT_CODES, SYS_LEADER_DEFAULT_CODES, Api, Leader
+from .config_models import ConfigMixin
+from .metrics import METRIC_MAP, ROUTE_METRICS_TO_TRANSFORM, construct_metrics_config
+
+
+class VaultCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
+    __NAMESPACE__ = 'vault'
+
+    DEFAULT_METRIC_LIMIT = 0
+
+    EVENT_LEADER_CHANGE = 'leader_change'
+    SERVICE_CHECK_CONNECT = 'can_connect'
+    SERVICE_CHECK_UNSEALED = 'unsealed'
+    SERVICE_CHECK_INITIALIZED = 'initialized'
+
+    def __init__(self, name, init_config, instances):
+        super().__init__(name, init_config, instances)
+
+        self._api_url = ''
+        self._metrics_url = ''
+        self._tags = ()
+
+        # Determine the appropriate methods later
+        self._api = None
+
+        # Keep track of the previous cluster leader to detect changes
+        self._previous_leader = None
+
+        # Detect if Vault is in replication mode
+        self._replication_dr_secondary_mode = False
+
+        # Might not be configured for metric collection
+        self.scraper_configs.clear()
+
+        # Before scrapers are configured
+        self.check_initializations.insert(-1, self.parse_config)
+
+        self.check_initializations.append(self.configure_additional_transformers)
+
+    @property
+    def metric_collection_enabled(self):
+        return self.config.no_token or self.config.client_token_path or self.config.client_token
+
+    def check(self, _):
+        submission_queue = []
+        dynamic_tags = []
+
+        # Useful data comes from multiple endpoints so we collect the
+        # tags and then submit everything with access to all tags
+        try:
+            self._api.check_leader(submission_queue, dynamic_tags)
+            self._api.check_health(submission_queue, dynamic_tags)
+        finally:
+            tags = list(self._tags)
+            tags.extend(dynamic_tags)
+            for submit_function in submission_queue:
+                submit_function(tags=tags)
+
+        if self.metric_collection_enabled and not self._replication_dr_secondary_mode:
+            self.set_dynamic_tags(*dynamic_tags)
+            super().check(_)
+
+        self.service_check(self.SERVICE_CHECK_CONNECT, self.OK, tags=self._tags)
+
+    def check_leader_v1(self, submission_queue, dynamic_tags):
+        url = self._api_url + '/sys/leader'
+        leader_data = self.access_api(url, ignore_status_codes=SYS_LEADER_DEFAULT_CODES)
+        errors = leader_data.get('errors')
+        if errors:
+            error_msg = ';'.join(errors)
+            self.log.error('Unable to fetch leader data from Vault. Reason: %s', error_msg)
+            return
+
+        is_leader = is_affirmative(leader_data.get('is_self'))
+        dynamic_tags.append(f'is_leader:{str(is_leader).lower()}')
+
+        submission_queue.append(lambda tags: self.gauge('is_leader', int(is_leader), tags=tags))
+
+        current_leader = Leader(leader_data.get('leader_address'), leader_data.get('leader_cluster_address'))
+        has_leader = any(current_leader)  # At least one address is set
+
+        if self.config.detect_leader and has_leader:
+            if self._previous_leader is None:
+                # First check run, let's set the previous leader variable.
+                self._previous_leader = current_leader
+                return
+            if self._previous_leader == current_leader:
+                # Leader hasn't changed
+                return
+            if not is_leader:
+                # Leader has changed but the monitored vault node is not the leader. Because the agent monitors
+                # each vault node in the cluster, let's use this condition to submit a single event.
+                self._previous_leader = current_leader
+                self.log.debug(
+                    'Leader changed from %s to %s but not reporting an event as the current node is not the leader.',
+                    self._previous_leader,
+                    current_leader,
+                )
+                return
+
+            if current_leader.leader_addr != self._previous_leader.leader_addr:
+                # The main leader address has changed
+                event_message = (
+                    f'Leader address changed from `{self._previous_leader.leader_addr}` to '
+                    f'`{current_leader.leader_addr}`.'
+                )
+            else:
+                # The leader_cluster_addr changed (usually happen when the leader address points to a load balancer
+                event_message = (
+                    f'Leader cluster address changed from `{self._previous_leader.leader_cluster_addr}` to '
+                    f'`{current_leader.leader_cluster_addr}`.'
+                )
+
+            self.log.debug('Leader changed from %s to %s, sending the event.', self._previous_leader, current_leader)
+            submission_queue.append(
+                lambda tags: self.event(
+                    {
+                        'timestamp': get_timestamp(),
+                        'event_type': self.EVENT_LEADER_CHANGE,
+                        'msg_title': 'Leader change',
+                        'msg_text': event_message,
+                        'alert_type': 'info',
+                        'host': self.hostname,
+                        'tags': tags,
+                    }
+                )
+            )
+            # Update _previous_leader for the next run
+            self._previous_leader = current_leader
+
+    def check_health_v1(self, submission_queue, dynamic_tags):
+        url = self._api_url + '/sys/health'
+        health_data = self.access_api(url, ignore_status_codes=SYS_HEALTH_DEFAULT_CODES)
+        cluster_name = health_data.get('cluster_name')
+        if cluster_name:
+            dynamic_tags.append(f'vault_cluster:{cluster_name}')
+
+        replication_mode = health_data.get('replication_dr_mode', '').lower()
+        if replication_mode == 'secondary':
+            self._replication_dr_secondary_mode = True
+            self.log.debug('Detected vault in replication DR secondary mode, skipping Prometheus metric collection.')
+        else:
+            self._replication_dr_secondary_mode = False
+
+        vault_version = health_data.get('version')
+        if vault_version:
+            dynamic_tags.append(f'vault_version:{vault_version}')
+            self.set_metadata('version', vault_version)
+
+        unsealed = not is_affirmative(health_data.get('sealed'))
+        if unsealed:
+            submission_queue.append(lambda tags: self.service_check(self.SERVICE_CHECK_UNSEALED, self.OK, tags=tags))
+        else:
+            submission_queue.append(
+                lambda tags: self.service_check(self.SERVICE_CHECK_UNSEALED, self.CRITICAL, tags=tags)
+            )
+
+        initialized = is_affirmative(health_data.get('initialized'))
+        if initialized:
+            submission_queue.append(lambda tags: self.service_check(self.SERVICE_CHECK_INITIALIZED, self.OK, tags=tags))
+        else:
+            submission_queue.append(
+                lambda tags: self.service_check(self.SERVICE_CHECK_INITIALIZED, self.CRITICAL, tags=tags)
+            )
+
+    def access_api(self, url, ignore_status_codes=None):
+        if ignore_status_codes is None:
+            ignore_status_codes = []
+
+        try:
+            response = self.http.get(url)
+            if response.status_code not in ignore_status_codes:
+                response.raise_for_status()
+
+            return response.json()
+        except Exception as e:
+            self.service_check(self.SERVICE_CHECK_CONNECT, self.CRITICAL, message=str(e), tags=self._tags)
+            raise
+
+    def parse_config(self):
+        self._api_url = self.config.api_url
+        api_version = self._api_url[-1]
+        if api_version not in ('1',):
+            self.log.warning('Unknown Vault API version `%s`, using version `%s`', api_version, DEFAULT_API_VERSION)
+            api_version = DEFAULT_API_VERSION
+            self._api_url = self._api_url[:-1] + api_version
+
+        self._metrics_url = f'{self._api_url}/sys/metrics?format=prometheus'
+
+        methods = {method: getattr(self, f'{method}_v{api_version}') for method in API_METHODS}
+        self._api = Api(**methods)
+
+        tags = [f'api_url:{self._api_url}']
+        tags.extend(self.config.tags)
+        self._tags = tuple(tags)
+
+    def configure_scrapers(self):
+        if self.metric_collection_enabled:
+            config = deepcopy(self.instance)
+
+            config['openmetrics_endpoint'] = self._metrics_url
+            config['tags'] = list(self._tags)
+
+            if not self.config.no_token:
+                if self.config.client_token_path:
+                    self.HTTP_CONFIG_REMAPPER = {
+                        'auth_token': {
+                            'name': 'auth_token',
+                            'default': {
+                                'reader': {'type': 'file', 'path': self.config.client_token_path},
+                                'writer': {'type': 'header', 'name': 'X-Vault-Token'},
+                            },
+                        }
+                    }
+                else:
+                    self.http.options['headers']['X-Vault-Token'] = self.config.client_token
+
+            self.scraper_configs.clear()
+            self.scraper_configs.append(config)
+
+        # https://www.vaultproject.io/api/overview#the-x-vault-request-header
+        #
+        # Do this here so any HTTP_CONFIG_REMAPPER changes come first
+        self.http.options['headers']['X-Vault-Request'] = 'true'
+
+        super().configure_scrapers()
+
+    def get_default_config(self):
+        return {'metrics': construct_metrics_config(METRIC_MAP, {})}
+
+    def configure_transformer_route_metrics(self):
+        cached_metric_data = {}
+
+        def route_metrics_transformer(metric, sample_data, runtime_data):
+            if metric.name in cached_metric_data:
+                transformer, metric_name, mount_tag = cached_metric_data[metric.name]
+            else:
+                parts = metric.name.rstrip('_').split('_')
+                metric_name = '.'.join(parts[:3])
+                mount_tag = f'mountpoint:{"_".join(parts[3:])}'
+                transformer = NATIVE_TRANSFORMERS[metric.type](self, metric_name, {}, {})
+                cached_metric_data[metric.name] = transformer, metric_name, mount_tag
+
+            new_sample_data = []
+            for sample, tags, hostname in sample_data:
+                tags.append(mount_tag)
+                new_sample_data.append((sample, tags, hostname))
+
+            transformer(metric, new_sample_data, runtime_data)
+
+        return route_metrics_transformer
+
+    def configure_additional_transformers(self):
+        if not self.scrapers:
+            return
+
+        metric_transformer = self.scrapers[self._metrics_url].metric_transformer
+        metric_transformer.add_custom_transformer(
+            '|'.join(f'{prefix}.+' for prefix in ROUTE_METRICS_TO_TRANSFORM),
+            self.configure_transformer_route_metrics(),
+            pattern=True,
+        )

--- a/vault/datadog_checks/vault/common.py
+++ b/vault/datadog_checks/vault/common.py
@@ -1,0 +1,25 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from collections import namedtuple
+
+DEFAULT_API_VERSION = '1'
+API_METHODS = ('check_health', 'check_leader')
+
+# Expected HTTP Error codes for /sys/health endpoint
+# https://www.vaultproject.io/api/system/health.html
+SYS_HEALTH_DEFAULT_CODES = {
+    200,  # initialized, unsealed, and active
+    429,  # unsealed and standby
+    472,  # data recovery mode replication secondary and active
+    473,  # performance standby
+    501,  # not initialized
+    503,  # sealed
+}
+
+SYS_LEADER_DEFAULT_CODES = {
+    503,  # sealed
+}
+
+Api = namedtuple('Api', ('check_health', 'check_leader'))
+Leader = namedtuple('Leader', ('leader_addr', 'leader_cluster_addr'))

--- a/vault/datadog_checks/vault/config_models/defaults.py
+++ b/vault/datadog_checks/vault/config_models/defaults.py
@@ -50,12 +50,28 @@ def instance_aws_service(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_cache_metric_wildcards(field, value):
+    return True
+
+
+def instance_cache_shared_labels(field, value):
+    return True
+
+
 def instance_client_token(field, value):
     return get_default_field_value(field, value)
 
 
 def instance_client_token_path(field, value):
     return get_default_field_value(field, value)
+
+
+def instance_collect_counters_with_distributions(field, value):
+    return False
+
+
+def instance_collect_histogram_buckets(field, value):
+    return True
 
 
 def instance_connect_timeout(field, value):
@@ -70,19 +86,55 @@ def instance_disable_generic_tags(field, value):
     return False
 
 
-def instance_disable_legacy_cluster_tag(field, value):
-    return False
-
-
 def instance_empty_default_hostname(field, value):
     return False
+
+
+def instance_enable_health_service_check(field, value):
+    return True
+
+
+def instance_exclude_labels(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_exclude_metrics(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_exclude_metrics_by_labels(field, value):
+    return get_default_field_value(field, value)
 
 
 def instance_extra_headers(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_extra_metrics(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_headers(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_histogram_buckets_as_distributions(field, value):
+    return False
+
+
+def instance_hostname_format(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_hostname_label(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_ignore_tags(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_include_labels(field, value):
     return get_default_field_value(field, value)
 
 
@@ -118,15 +170,31 @@ def instance_log_requests(field, value):
     return False
 
 
+def instance_metrics(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_min_collection_interval(field, value):
     return 15
+
+
+def instance_namespace(field, value):
+    return get_default_field_value(field, value)
 
 
 def instance_no_token(field, value):
     return False
 
 
+def instance_non_cumulative_histogram_buckets(field, value):
+    return False
+
+
 def instance_ntlm_domain(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_openmetrics_endpoint(field, value):
     return get_default_field_value(field, value)
 
 
@@ -142,7 +210,19 @@ def instance_proxy(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_raw_line_filters(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_raw_metric_prefix(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_read_timeout(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_rename_labels(field, value):
     return get_default_field_value(field, value)
 
 
@@ -154,12 +234,20 @@ def instance_service(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_share_labels(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_skip_proxy(field, value):
     return False
 
 
 def instance_tags(field, value):
     return get_default_field_value(field, value)
+
+
+def instance_telemetry(field, value):
+    return False
 
 
 def instance_timeout(field, value):
@@ -190,8 +278,20 @@ def instance_tls_verify(field, value):
     return True
 
 
+def instance_use_latest_spec(field, value):
+    return False
+
+
 def instance_use_legacy_auth_encoding(field, value):
     return True
+
+
+def instance_use_openmetrics(field, value):
+    return False
+
+
+def instance_use_process_start_time(field, value):
+    return False
 
 
 def instance_username(field, value):

--- a/vault/datadog_checks/vault/config_models/instance.py
+++ b/vault/datadog_checks/vault/config_models/instance.py
@@ -9,9 +9,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence, Union
 
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, Extra, Field, root_validator, validator
 
 from datadog_checks.base.utils.functions import identity
 from datadog_checks.base.utils.models import validation
@@ -27,6 +27,24 @@ class AuthToken(BaseModel):
     writer: Optional[Mapping[str, Any]]
 
 
+class ExtraMetric(BaseModel):
+    class Config:
+        extra = Extra.allow
+        allow_mutation = False
+
+    name: Optional[str]
+    type: Optional[str]
+
+
+class Metric(BaseModel):
+    class Config:
+        extra = Extra.allow
+        allow_mutation = False
+
+    name: Optional[str]
+    type: Optional[str]
+
+
 class Proxy(BaseModel):
     class Config:
         allow_mutation = False
@@ -36,26 +54,47 @@ class Proxy(BaseModel):
     no_proxy: Optional[Sequence[str]]
 
 
+class ShareLabel(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    labels: Optional[Sequence[str]]
+    match: Optional[Sequence[str]]
+
+
 class InstanceConfig(BaseModel):
     class Config:
         allow_mutation = False
 
     allow_redirects: Optional[bool]
-    api_url: str
+    api_url: str = Field(..., regex='\\w+')
     auth_token: Optional[AuthToken]
     auth_type: Optional[str]
     aws_host: Optional[str]
     aws_region: Optional[str]
     aws_service: Optional[str]
+    cache_metric_wildcards: Optional[bool]
+    cache_shared_labels: Optional[bool]
     client_token: Optional[str]
     client_token_path: Optional[str]
+    collect_counters_with_distributions: Optional[bool]
+    collect_histogram_buckets: Optional[bool]
     connect_timeout: Optional[float]
     detect_leader: Optional[bool]
     disable_generic_tags: Optional[bool]
-    disable_legacy_cluster_tag: Optional[bool]
     empty_default_hostname: Optional[bool]
+    enable_health_service_check: Optional[bool]
+    exclude_labels: Optional[Sequence[str]]
+    exclude_metrics: Optional[Sequence[str]]
+    exclude_metrics_by_labels: Optional[Mapping[str, Union[bool, Sequence[str]]]]
     extra_headers: Optional[Mapping[str, Any]]
+    extra_metrics: Optional[Sequence[Union[str, Mapping[str, Union[str, ExtraMetric]]]]]
     headers: Optional[Mapping[str, Any]]
+    histogram_buckets_as_distributions: Optional[bool]
+    hostname_format: Optional[str]
+    hostname_label: Optional[str]
+    ignore_tags: Optional[Sequence[str]]
+    include_labels: Optional[Sequence[str]]
     kerberos_auth: Optional[str]
     kerberos_cache: Optional[str]
     kerberos_delegate: Optional[bool]
@@ -64,17 +103,26 @@ class InstanceConfig(BaseModel):
     kerberos_keytab: Optional[str]
     kerberos_principal: Optional[str]
     log_requests: Optional[bool]
+    metrics: Optional[Sequence[Union[str, Mapping[str, Union[str, Metric]]]]]
     min_collection_interval: Optional[float]
+    namespace: Optional[str] = Field(None, regex='\\w*')
     no_token: Optional[bool]
+    non_cumulative_histogram_buckets: Optional[bool]
     ntlm_domain: Optional[str]
+    openmetrics_endpoint: Optional[str]
     password: Optional[str]
     persist_connections: Optional[bool]
     proxy: Optional[Proxy]
+    raw_line_filters: Optional[Sequence[str]]
+    raw_metric_prefix: Optional[str]
     read_timeout: Optional[float]
+    rename_labels: Optional[Mapping[str, Any]]
     request_size: Optional[float]
     service: Optional[str]
+    share_labels: Optional[Mapping[str, Union[bool, ShareLabel]]]
     skip_proxy: Optional[bool]
     tags: Optional[Sequence[str]]
+    telemetry: Optional[bool]
     timeout: Optional[float]
     tls_ca_cert: Optional[str]
     tls_cert: Optional[str]
@@ -82,7 +130,10 @@ class InstanceConfig(BaseModel):
     tls_private_key: Optional[str]
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
+    use_latest_spec: Optional[bool]
     use_legacy_auth_encoding: Optional[bool]
+    use_openmetrics: Optional[bool]
+    use_process_start_time: Optional[bool]
     username: Optional[str]
 
     @root_validator(pre=True)

--- a/vault/datadog_checks/vault/data/conf.yaml.example
+++ b/vault/datadog_checks/vault/data/conf.yaml.example
@@ -45,10 +45,22 @@ init_config:
 #
 instances:
 
+    ## @param use_openmetrics - boolean - optional - default: false
+    ## Use the latest OpenMetrics implementation for more features, better performance,
+    ## and more appropriate metric types by default. If running on Agent v6, you must
+    ## set the `python_version` option in `datadog.yaml` to `"3"`.
+    ##
+    ## In a future release, this option will be set to `true` by default.
+    ##
+    ## Note: To see the configuration options for the legacy implementation (Agent 7.34 or older),
+    ## https://github.com/DataDog/integrations-core/blob/7.34.x/vault/datadog_checks/vault/data/conf.yaml.example
+    #
+  - use_openmetrics: true
+
     ## @param api_url - string - required
     ## URL of the Vault to query.
     #
-  - api_url: http://localhost:8200/v1
+    api_url: http://localhost:8200/v1
 
     ## @param detect_leader - boolean - optional - default: false
     ## Whether or not this instance should report cluster leader change events.
@@ -69,12 +81,224 @@ instances:
     ## @param no_token - boolean - optional - default: false
     ## Attempt metric collection without a token.
     #
-    # no_token: false
+    no_token: false
 
-    ## @param disable_legacy_cluster_tag - boolean - optional - default: false
-    ## Enable to stop submitting the tag `cluster_name`, which has been renamed to `vault_cluster`.
+    ## @param raw_metric_prefix - string - optional
+    ## A prefix that will be removed from all exposed metric names, if present.
+    ## All configuration options will use the prefix-less name.
     #
-    disable_legacy_cluster_tag: true
+    # raw_metric_prefix: <PREFIX>_
+
+    ## @param extra_metrics - (list of string or mapping) - optional
+    ## This list defines metrics to collect from the `openmetrics_endpoint`, in addition to
+    ## what the check collects by default. If the check already collects a metric, then
+    ## metric definitions here take precedence. Metrics may be defined in 3 ways:
+    ##
+    ## 1. If the item is a string, then it represents the exposed metric name, and
+    ##    the sent metric name will be identical. For example:
+    ##
+    ##      metrics:
+    ##      - <METRIC_1>
+    ##      - <METRIC_2>
+    ## 2. If the item is a mapping, then the keys represent the exposed metric names.
+    ##
+    ##      a. If a value is a string, then it represents the sent metric name. For example:
+    ##
+    ##           metrics:
+    ##           - <EXPOSED_METRIC_1>: <SENT_METRIC_1>
+    ##           - <EXPOSED_METRIC_2>: <SENT_METRIC_2>
+    ##      b. If a value is a mapping, then it must have a `name` and/or `type` key.
+    ##         The `name` represents the sent metric name, and the `type` represents how
+    ##         the metric should be handled, overriding any type information the endpoint
+    ##         may provide. For example:
+    ##
+    ##           metrics:
+    ##           - <EXPOSED_METRIC_1>:
+    ##               name: <SENT_METRIC_1>
+    ##               type: <METRIC_TYPE_1>
+    ##           - <EXPOSED_METRIC_2>:
+    ##               name: <SENT_METRIC_2>
+    ##               type: <METRIC_TYPE_2>
+    ##
+    ##         The supported native types are `gauge`, `counter`, `histogram`, and `summary`.
+    ##
+    ## Regular expressions may be used to match the exposed metric names, for example:
+    ##
+    ##   metrics:
+    ##   - ^network_(ingress|egress)_.+
+    ##   - .+:
+    ##       type: gauge
+    #
+    # extra_metrics: []
+
+    ## @param exclude_metrics - list of strings - optional
+    ## A list of metrics to exclude, with each entry being either
+    ## the exact metric name or a regular expression.
+    ## In order to exclude all metrics but the ones matching a specific filter,
+    ## you can use a negative lookahead regex like:
+    ##   - ^(?!foo).*$
+    #
+    # exclude_metrics: []
+
+    ## @param exclude_metrics_by_labels - mapping - optional
+    ## A mapping of labels where metrics with matching label name and values are ignored. To match
+    ## all values of a label, set it to `true`.
+    ##
+    ## Note: Labels filtering happens before `rename_labels`.
+    ##
+    ## For example, the following configuration instructs the check to exclude all metrics with
+    ## a label `worker` or a label `pid` with the value of either `23` or `42`.
+    ##
+    ##   exclude_metrics_by_labels:
+    ##     worker: true
+    ##     pid:
+    ##     - '23'
+    ##     - '42'
+    #
+    # exclude_metrics_by_labels: {}
+
+    ## @param exclude_labels - list of strings - optional
+    ## A list of labels to exclude, useful for high cardinality values like timestamps or UUIDs.
+    ## May be used in conjunction with `include_labels`.
+    ## Labels defined in `excluded labels` will take precedence in case of overlap.
+    ##
+    ## Note: Labels filtering happens before `rename_labels`.
+    #
+    # exclude_labels: []
+
+    ## @param include_labels - list of strings - optional
+    ## A list of labels to include. May be used in conjunction with `exclude_labels`.
+    ## Labels defined in `excluded labels` will take precedence in case of overlap.
+    ##
+    ## Note: Labels filtering happens before `rename_labels`.
+    #
+    # include_labels: []
+
+    ## @param rename_labels - mapping - optional
+    ## A mapping of label names to how they should be renamed.
+    #
+    # rename_labels:
+    #   <LABEL_NAME_1>: <NEW_LABEL_NAME_1>
+    #   <LABEL_NAME_2>: <NEW_LABEL_NAME_2>
+
+    ## @param enable_health_service_check - boolean - optional - default: true
+    ## Whether or not to send a service check named `<NAMESPACE>.openmetrics.health` which reports
+    ## the health of the `openmetrics_endpoint`.
+    #
+    # enable_health_service_check: true
+
+    ## @param hostname_label - string - optional
+    ## Override the hostname for every metric submission with the value of one of its labels.
+    #
+    # hostname_label: <HOSTNAME_LABEL>
+
+    ## @param hostname_format - string - optional
+    ## When `hostname_label` is set, this instructs the check how to format the values. The string
+    ## `<HOSTNAME>` will be replaced by the value of the label defined by `hostname_label`.
+    #
+    # hostname_format: <HOSTNAME>
+
+    ## @param collect_histogram_buckets - boolean - optional - default: true
+    ## Whether or not to send histogram buckets.
+    #
+    # collect_histogram_buckets: true
+
+    ## @param non_cumulative_histogram_buckets - boolean - optional - default: false
+    ## Whether or not histogram buckets should be non-cumulative and to come with a `lower_bound` tag.
+    #
+    # non_cumulative_histogram_buckets: false
+
+    ## @param histogram_buckets_as_distributions - boolean - optional - default: false
+    ## Whether or not to send histogram buckets as Datadog distribution metrics. This implicitly
+    ## enables the `collect_histogram_buckets` and `non_cumulative_histogram_buckets` options.
+    ##
+    ## Learn more about distribution metrics:
+    ## https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#metric-types
+    #
+    # histogram_buckets_as_distributions: false
+
+    ## @param collect_counters_with_distributions - boolean - optional - default: false
+    ## Whether or not to also collect the observation counter metrics ending in `.sum` and `.count`
+    ## when sending histogram buckets as Datadog distribution metrics. This implicitly enables the
+    ## `histogram_buckets_as_distributions` option.
+    #
+    # collect_counters_with_distributions: false
+
+    ## @param use_process_start_time - boolean - optional - default: false
+    ## Whether to enable a heuristic for reporting counter values on the first scrape. When true,
+    ## the first time an endpoint is scraped, check `process_start_time_seconds` to decide whether zero
+    ## initial value can be assumed for counters. This requires keeping metrics in memory until the entire
+    ## response is received.
+    #
+    # use_process_start_time: false
+
+    ## @param share_labels - mapping - optional
+    ## This mapping allows for the sharing of labels across multiple metrics. The keys represent the
+    ## exposed metrics from which to share labels, and the values are mappings that configure the
+    ## sharing behavior. Each mapping must have at least one of the following keys:
+    ##
+    ##   labels - This is a list of labels to share. All labels are shared if this is not set.
+    ##   match - This is a list of labels to match on other metrics as a condition for sharing.
+    ##   values - This is a list of allowed values as a condition for sharing.
+    ##
+    ## To unconditionally share all labels of a metric, set it to `true`.
+    ##
+    ## For example, the following configuration instructs the check to apply all labels from `metric_a`
+    ## to all other metrics, the `node` label from `metric_b` to only those metrics that have a `pod`
+    ## label value that matches the `pod` label value of `metric_b`, and all labels from `metric_c`
+    ## to all other metrics if its value is equal to `23` or `42`.
+    ##
+    ##   share_labels:
+    ##     metric_a: true
+    ##     metric_b:
+    ##       labels:
+    ##       - node
+    ##       match:
+    ##       - pod
+    ##     metric_c:
+    ##       values:
+    ##       - 23
+    ##       - 42
+    #
+    # share_labels: {}
+
+    ## @param cache_shared_labels - boolean - optional - default: true
+    ## When `share_labels` is set, it instructs the check to cache labels collected from the first payload
+    ## for increased performance.
+    ##
+    ## Set this to `false` to compute label sharing for every payload at the risk of potentially increased memory usage.
+    #
+    # cache_shared_labels: true
+
+    ## @param raw_line_filters - list of strings - optional
+    ## A list of regular expressions used to exclude lines read from the `openmetrics_endpoint`
+    ## from being parsed.
+    #
+    # raw_line_filters: []
+
+    ## @param cache_metric_wildcards - boolean - optional - default: true
+    ## Whether or not to cache data from metrics that are defined by regular expressions rather
+    ## than the full metric name.
+    #
+    # cache_metric_wildcards: true
+
+    ## @param use_latest_spec - boolean - optional - default: false
+    ## Whether or not the parser will strictly adhere to the latest version of the OpenMetrics specification.
+    #
+    # use_latest_spec: false
+
+    ## @param telemetry - boolean - optional - default: false
+    ## Whether or not to submit metrics prefixed by `<NAMESPACE>.telemetry.` for debugging purposes.
+    #
+    # telemetry: false
+
+    ## @param ignore_tags - list of strings - optional
+    ## A list of regular expressions used to ignore tags added by autodiscovery and entries in the `tags` option.
+    #
+    # ignore_tags:
+    #   - <FULL:TAG>
+    #   - <TAG_PREFIX:.*>
+    #   - <TAG_SUFFIX$>
 
     ## @param proxy - mapping - optional
     ## This overrides the `proxy` setting in `init_config`.
@@ -213,34 +437,6 @@ instances:
     ## Set the path to your Kerberos key tab file.
     #
     # kerberos_keytab: <KEYTAB_FILE_PATH>
-
-    ## @param auth_token - mapping - optional
-    ## This allows for the use of authentication information from dynamic sources.
-    ## Both a reader and writer must be configured.
-    ##
-    ## The available readers are:
-    ##
-    ##   - type: file
-    ##     path (required): The absolute path for the file to read from.
-    ##     pattern: A regular expression pattern with a single capture group used to find the
-    ##              token rather than using the entire file, for example: Your secret is (.+)
-    ##
-    ## The available writers are:
-    ##
-    ##   - type: header
-    ##     name (required): The name of the field, for example: Authorization
-    ##     value: The template value, for example `Bearer <TOKEN>`. The default is: <TOKEN>
-    ##     placeholder: The substring in `value` to replace by the token, defaults to: <TOKEN>
-    #
-    # auth_token:
-    #   reader:
-    #     type: <READER_TYPE>
-    #     <OPTION_1>: <VALUE_1>
-    #     <OPTION_2>: <VALUE_2>
-    #   writer:
-    #     type: <WRITER_TYPE>
-    #     <OPTION_1>: <VALUE_1>
-    #     <OPTION_2>: <VALUE_2>
 
     ## @param aws_region - string - optional
     ## If your services require AWS Signature Version 4 signing, set the region.

--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -2,13 +2,13 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import time
-from collections import namedtuple
 
 import requests
 from six import PY2
 
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck, is_affirmative
 
+from .common import API_METHODS, DEFAULT_API_VERSION, SYS_HEALTH_DEFAULT_CODES, SYS_LEADER_DEFAULT_CODES, Api, Leader
 from .errors import ApiUnreachable
 from .metrics import METRIC_MAP, METRIC_ROLLBACK_COMPAT_MAP, ROUTE_METRICS_TO_TRANSFORM
 
@@ -16,9 +16,6 @@ try:
     from json import JSONDecodeError
 except ImportError:
     from simplejson import JSONDecodeError
-
-Api = namedtuple('Api', ('check_health', 'check_leader'))
-Leader = namedtuple('Leader', ('leader_addr', 'leader_cluster_addr'))
 
 
 class Vault(OpenMetricsBaseCheck):
@@ -29,7 +26,6 @@ class Vault(OpenMetricsBaseCheck):
     SERVICE_CHECK_CONNECT = 'vault.can_connect'
     SERVICE_CHECK_UNSEALED = 'vault.unsealed'
     SERVICE_CHECK_INITIALIZED = 'vault.initialized'
-    API_METHODS = ('check_health', 'check_leader')
 
     HTTP_CONFIG_REMAPPER = {
         'ssl_verify': {'name': 'tls_verify'},
@@ -39,18 +35,22 @@ class Vault(OpenMetricsBaseCheck):
         'ssl_ignore_warning': {'name': 'tls_ignore_warning'},
     }
 
-    # Expected HTTP Error codes for /sys/health endpoint
-    # https://www.vaultproject.io/api/system/health.html
-    SYS_HEALTH_DEFAULT_CODES = {
-        200,  # initialized, unsealed, and active
-        429,  # unsealed and standby
-        472,  # data recovery mode replication secondary and active
-        473,  # performance standby
-        501,  # not initialized
-        503,  # sealed
-    }
+    def __new__(cls, name, init_config, instances):
+        instance = instances[0]
 
-    SYS_LEADER_DEFAULT_CODES = {503}  # sealed
+        if is_affirmative(instance.get('use_openmetrics', False)):
+            if PY2:
+                raise ConfigurationError(
+                    'This version of the integration is only available when using Python 3. '
+                    'Check https://docs.datadoghq.com/agent/guide/agent-v6-python-3/ '
+                    'for more information or use the older style config.'
+                )
+            # TODO: when we drop Python 2 move this import up top
+            from .check import VaultCheckV2
+
+            return VaultCheckV2(name, init_config, instances)
+        else:
+            return super(Vault, cls).__new__(cls)
 
     def __init__(self, name, init_config, instances):
         super(Vault, self).__init__(
@@ -140,7 +140,7 @@ class Vault(OpenMetricsBaseCheck):
 
     def check_leader_v1(self, submission_queue, dynamic_tags):
         url = self._api_url + '/sys/leader'
-        leader_data = self.access_api(url, ignore_status_codes=self.SYS_LEADER_DEFAULT_CODES)
+        leader_data = self.access_api(url, ignore_status_codes=SYS_LEADER_DEFAULT_CODES)
         errors = leader_data.get('errors')
         if errors:
             error_msg = ';'.join(errors)
@@ -205,7 +205,7 @@ class Vault(OpenMetricsBaseCheck):
 
     def check_health_v1(self, submission_queue, dynamic_tags):
         url = self._api_url + '/sys/health'
-        health_data = self.access_api(url, ignore_status_codes=self.SYS_HEALTH_DEFAULT_CODES)
+        health_data = self.access_api(url, ignore_status_codes=SYS_HEALTH_DEFAULT_CODES)
         cluster_name = health_data.get('cluster_name')
         if cluster_name:
             dynamic_tags.append('vault_cluster:{}'.format(cluster_name))
@@ -273,13 +273,11 @@ class Vault(OpenMetricsBaseCheck):
 
         api_version = self._api_url[-1]
         if api_version not in ('1',):
-            self.log.warning(
-                'Unknown Vault API version `%s`, using version `%s`', api_version, self.DEFAULT_API_VERSION
-            )
-            api_version = self.DEFAULT_API_VERSION
+            self.log.warning('Unknown Vault API version `%s`, using version `%s`', api_version, DEFAULT_API_VERSION)
+            api_version = DEFAULT_API_VERSION
             self._api_url = self._api_url[:-1] + api_version
 
-        methods = {method: getattr(self, '{}_v{}'.format(method, api_version)) for method in self.API_METHODS}
+        methods = {method: getattr(self, '{}_v{}'.format(method, api_version)) for method in API_METHODS}
         self._api = Api(**methods)
 
         if self._client_token_path or self._client_token or self._no_token:

--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -21,7 +21,6 @@ except ImportError:
 class Vault(OpenMetricsBaseCheck):
     DEFAULT_METRIC_LIMIT = 0
     CHECK_NAME = 'vault'
-    DEFAULT_API_VERSION = '1'
     EVENT_LEADER_CHANGE = 'vault.leader_change'
     SERVICE_CHECK_CONNECT = 'vault.can_connect'
     SERVICE_CHECK_UNSEALED = 'vault.unsealed'

--- a/vault/tests/conftest.py
+++ b/vault/tests/conftest.py
@@ -7,6 +7,7 @@ import time
 
 import pytest
 import requests
+from six import PY2
 
 from datadog_checks.dev import LazyFunction, TempDir, docker_run, run_command
 from datadog_checks.dev.ci import running_on_ci
@@ -16,6 +17,14 @@ from datadog_checks.dev.utils import ON_WINDOWS
 from datadog_checks.vault import Vault
 
 from .common import COMPOSE_FILE, HEALTH_ENDPOINT, INSTANCES, VAULT_VERSION, get_vault_server_config_file
+
+
+@pytest.fixture
+def use_openmetrics(request):
+    if request.param and PY2:
+        pytest.skip('This version of the integration is only available when using Python 3.')
+
+    return request.param
 
 
 @pytest.fixture(scope='session')

--- a/vault/tests/metrics.py
+++ b/vault/tests/metrics.py
@@ -91,6 +91,9 @@ METRICS_OPTIONAL = {
     'vault.rollback.attempt.cubbyhole',
     'vault.rollback.attempt.identity',
     'vault.rollback.attempt.sys',
+    'vault.route.create',
+    'vault.route.read',
+    'vault.route.rollback',
     'vault.route.rollback.auth.jwt',
     'vault.route.rollback.auth.token',
     'vault.route.rollback.cubbyhole',
@@ -100,5 +103,16 @@ METRICS_OPTIONAL = {
     'vault.runtime.total.gc.pause_ns',
     'vault.token.count.by_policy',
     'vault.token.create',
+    'vault.token.creation',
+}
+
+KNOWN_COUNTERS = {
+    'vault.audit.log.request.failure',
+    'vault.audit.log.response.failure',
+    'vault.cache.delete',
+    'vault.cache.hit',
+    'vault.cache.miss',
+    'vault.cache.write',
+    'vault.identity.entity.creation',
     'vault.token.creation',
 }

--- a/vault/tests/test_integration.py
+++ b/vault/tests/test_integration.py
@@ -10,39 +10,47 @@ from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.vault import Vault
 
 from .common import auth_required, noauth_required
-from .metrics import METRICS, METRICS_OPTIONAL
+from .metrics import KNOWN_COUNTERS, METRICS, METRICS_OPTIONAL
 
 
 @auth_required
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_integration(aggregator, dd_run_check, check, instance, global_tags):
-    instance = instance()
+@pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+def test_integration(aggregator, dd_run_check, check, instance, global_tags, use_openmetrics):
+    instance = dict(instance())
+    instance['use_openmetrics'] = use_openmetrics
     check = check(instance)
     dd_run_check(check)
 
-    assert_collection(aggregator, global_tags)
+    assert_collection(aggregator, global_tags, use_openmetrics)
 
 
 @noauth_required
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
-def test_integration_noauth(aggregator, dd_run_check, check, no_token_instance, global_tags):
-    check = check(no_token_instance)
+@pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+def test_integration_noauth(aggregator, dd_run_check, check, no_token_instance, global_tags, use_openmetrics):
+    instance = dict(no_token_instance)
+    instance['use_openmetrics'] = use_openmetrics
+    check = check(instance)
     dd_run_check(check)
 
-    assert_collection(aggregator, global_tags)
+    assert_collection(aggregator, global_tags, use_openmetrics)
 
 
 @auth_required
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, e2e_instance, global_tags):
-    aggregator = dd_agent_check(e2e_instance, rate=True)
+@pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+def test_e2e(dd_agent_check, e2e_instance, global_tags, use_openmetrics):
+    instance = dict(e2e_instance)
+    instance['use_openmetrics'] = use_openmetrics
+    aggregator = dd_agent_check(instance, rate=True)
 
-    assert_collection(aggregator, global_tags, runs=2)
+    assert_collection(aggregator, global_tags, use_openmetrics, runs=2)
 
 
-def assert_collection(aggregator, tags, runs=1):
+def assert_collection(aggregator, tags, use_openmetrics, runs=1):
     metrics = set(METRICS)
     metrics.update(METRICS_OPTIONAL)
     metrics.add('is_leader')
@@ -76,6 +84,17 @@ def assert_collection(aggregator, tags, runs=1):
         metrics.remove(metric)
         metrics.update({'{}.count'.format(metric), '{}.quantile'.format(metric), '{}.sum'.format(metric)})
 
+    if use_openmetrics:
+        for metric in list(metrics):
+            if metric.endswith('.total'):
+                metrics.discard(metric)
+                metrics.add('{}.count'.format(metric[:-6]))
+            elif metric in KNOWN_COUNTERS:
+                metrics.discard(metric)
+                metrics.add('{}.count'.format(metric))
+            elif metric.startswith('vault.route.rollback.') and not metric.endswith(('.count', '.quantile', '.sum')):
+                metrics.discard(metric)
+
     missing_summaries = defaultdict(set)
     for metric in sorted(metrics):
         at_least = 1
@@ -96,15 +115,19 @@ def assert_collection(aggregator, tags, runs=1):
             else:
                 aggregator.assert_metric_has_tag_prefix(metric, 'is_leader:', at_least=at_least)
                 aggregator.assert_metric_has_tag_prefix(metric, 'vault_cluster:', at_least=at_least)
-                aggregator.assert_metric_has_tag_prefix(metric, 'cluster_name:', at_least=at_least)
                 aggregator.assert_metric_has_tag_prefix(metric, 'vault_version:', at_least=at_least)
+                if not use_openmetrics:
+                    aggregator.assert_metric_has_tag_prefix(metric, 'cluster_name:', at_least=at_least)
 
     for _, summaries in sorted(missing_summaries.items()):
         if len(summaries) > 2:
             raise AssertionError('Missing: {}'.format(' | '.join(sorted(summaries))))
 
     aggregator.assert_all_metrics_covered()
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+
+    # TODO: Flip condition and modify `metadata.csv` when the new implementation is the default
+    if not use_openmetrics:
+        aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
     aggregator.assert_service_check(Vault.SERVICE_CHECK_CONNECT, Vault.OK, count=runs)
     aggregator.assert_service_check(Vault.SERVICE_CHECK_UNSEALED, Vault.OK, count=runs)

--- a/vault/tests/test_vault.py
+++ b/vault/tests/test_vault.py
@@ -28,8 +28,10 @@ class TestVault:
 
         aggregator.assert_service_check(Vault.SERVICE_CHECK_CONNECT, count=0)
 
-    def test_unsupported_api_version_fallback(self, aggregator, dd_run_check):
-        instance = INSTANCES['unsupported_api']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_unsupported_api_version_fallback(self, aggregator, dd_run_check, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['unsupported_api'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
 
         assert not instance['api_url'].endswith(Vault.DEFAULT_API_VERSION)
@@ -38,15 +40,19 @@ class TestVault:
 
         aggregator.assert_service_check(Vault.SERVICE_CHECK_CONNECT, status=Vault.OK, count=1)
 
-    def test_service_check_connect_ok(self, aggregator, dd_run_check):
-        instance = INSTANCES['main']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_service_check_connect_ok(self, aggregator, dd_run_check, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
         dd_run_check(c, dd_run_check)
 
         aggregator.assert_service_check(Vault.SERVICE_CHECK_CONNECT, status=Vault.OK, count=1)
 
-    def test_service_check_connect_ok_all_tags(self, aggregator, dd_run_check, global_tags):
-        instance = INSTANCES['main']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_service_check_connect_ok_all_tags(self, aggregator, dd_run_check, global_tags, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
 
         # Keep a reference for use during mock
@@ -114,15 +120,19 @@ class TestVault:
         with pytest.raises(ApiUnreachable, match=r"Error accessing Vault endpoint.*"):
             c.access_api("http://foo.bar", ignore_status_codes=None)
 
-    def test_service_check_unsealed_ok(self, aggregator, dd_run_check):
-        instance = INSTANCES['main']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_service_check_unsealed_ok(self, aggregator, dd_run_check, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
         dd_run_check(c)
 
         aggregator.assert_service_check(Vault.SERVICE_CHECK_UNSEALED, status=Vault.OK, count=1)
 
-    def test_service_check_unsealed_ok_all_tags(self, aggregator, dd_run_check, global_tags):
-        instance = INSTANCES['main']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_service_check_unsealed_ok_all_tags(self, aggregator, dd_run_check, global_tags, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
 
         # Keep a reference for use during mock
@@ -154,15 +164,18 @@ class TestVault:
 
         expected_tags = [
             'is_leader:true',
-            'cluster_name:vault-cluster-f5f44063',
             'vault_cluster:vault-cluster-f5f44063',
             'vault_version:0.10.2',
         ]
+        if not use_openmetrics:
+            expected_tags.append('cluster_name:vault-cluster-f5f44063')
         expected_tags.extend(global_tags)
         aggregator.assert_service_check(Vault.SERVICE_CHECK_UNSEALED, status=Vault.OK, tags=expected_tags, count=1)
 
-    def test_service_check_unsealed_fail(self, aggregator, dd_run_check):
-        instance = INSTANCES['main']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_service_check_unsealed_fail(self, aggregator, dd_run_check, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
 
         # Keep a reference for use during mock
@@ -191,15 +204,19 @@ class TestVault:
 
         aggregator.assert_service_check(Vault.SERVICE_CHECK_UNSEALED, status=Vault.CRITICAL, count=1)
 
-    def test_service_check_initialized_ok(self, aggregator, dd_run_check):
-        instance = INSTANCES['main']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_service_check_initialized_ok(self, aggregator, dd_run_check, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
         dd_run_check(c)
 
         aggregator.assert_service_check(Vault.SERVICE_CHECK_INITIALIZED, status=Vault.OK, count=1)
 
-    def test_service_check_initialized_ok_all_tags(self, aggregator, dd_run_check, global_tags):
-        instance = INSTANCES['main']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_service_check_initialized_ok_all_tags(self, aggregator, dd_run_check, global_tags, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
 
         # Keep a reference for use during mock
@@ -231,15 +248,18 @@ class TestVault:
 
         expected_tags = [
             'is_leader:true',
-            'cluster_name:vault-cluster-f5f44063',
             'vault_cluster:vault-cluster-f5f44063',
             'vault_version:0.10.2',
         ]
+        if not use_openmetrics:
+            expected_tags.append('cluster_name:vault-cluster-f5f44063')
         expected_tags.extend(global_tags)
         aggregator.assert_service_check(Vault.SERVICE_CHECK_INITIALIZED, status=Vault.OK, tags=expected_tags, count=1)
 
-    def test_service_check_initialized_fail(self, aggregator, dd_run_check):
-        instance = INSTANCES['main']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_service_check_initialized_fail(self, aggregator, dd_run_check, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
 
         # Keep a reference for use during mock
@@ -308,8 +328,10 @@ class TestVault:
         expected_tags.extend(global_tags)
         aggregator.assert_service_check(Vault.SERVICE_CHECK_INITIALIZED, status=Vault.OK, tags=expected_tags, count=1)
 
-    def test_replication_dr_mode(self, aggregator, dd_run_check):
-        instance = INSTANCES['main']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_replication_dr_mode(self, aggregator, dd_run_check, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
         c.log.debug = mock.MagicMock()
         # Keep a reference for use during mock
@@ -343,8 +365,10 @@ class TestVault:
         aggregator.assert_service_check(Vault.SERVICE_CHECK_CONNECT, status=Vault.OK, count=1)
         assert_all_metrics(aggregator)
 
-    def test_replication_dr_mode_changed(self, aggregator, dd_run_check):
-        instance = INSTANCES['main']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_replication_dr_mode_changed(self, aggregator, dd_run_check, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
         c.log.debug = mock.MagicMock()
         # Keep a reference for use during mock
@@ -437,9 +461,11 @@ class TestVault:
         assert 'is_leader:true' in event['tags']
         assert c._previous_leader == next_leader
 
-    def test_leader_change_not_self(self, aggregator, dd_run_check):
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_leader_change_not_self(self, aggregator, dd_run_check, use_openmetrics):
         """The agent should only submit a leader change event when the monitored vault is the leader."""
-        instance = INSTANCES['main']
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
         c._previous_leader = Leader('foo', '')
 
@@ -463,8 +489,10 @@ class TestVault:
 
         assert len(aggregator.events) == 0
 
-    def test_is_leader_metric_true(self, aggregator, dd_run_check):
-        instance = INSTANCES['main']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_is_leader_metric_true(self, aggregator, dd_run_check, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
 
         # Keep a reference for use during mock
@@ -487,8 +515,10 @@ class TestVault:
 
         aggregator.assert_metric('vault.is_leader', 1)
 
-    def test_is_leader_metric_false(self, aggregator, dd_run_check):
-        instance = INSTANCES['main']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_is_leader_metric_false(self, aggregator, dd_run_check, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
 
         # Keep a reference for use during mock
@@ -544,8 +574,10 @@ class TestVault:
         aggregator.assert_metric('vault.is_leader', 1)
         assert_all_metrics(aggregator)
 
-    def test_sys_leader_non_standard_status_codes(self, aggregator, dd_run_check):
-        instance = INSTANCES['main']
+    @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+    def test_sys_leader_non_standard_status_codes(self, aggregator, dd_run_check, use_openmetrics):
+        instance = {'use_openmetrics': use_openmetrics}
+        instance.update(INSTANCES['main'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
 
         # Keep a reference for use during mock

--- a/vault/tests/test_vault.py
+++ b/vault/tests/test_vault.py
@@ -10,6 +10,7 @@ import requests
 from datadog_checks.dev.http import MockResponse
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.vault import Vault
+from datadog_checks.vault.common import DEFAULT_API_VERSION
 from datadog_checks.vault.errors import ApiUnreachable
 from datadog_checks.vault.vault import Leader
 
@@ -34,9 +35,9 @@ class TestVault:
         instance.update(INSTANCES['unsupported_api'])
         c = Vault(Vault.CHECK_NAME, {}, [instance])
 
-        assert not instance['api_url'].endswith(Vault.DEFAULT_API_VERSION)
+        assert not instance['api_url'].endswith(DEFAULT_API_VERSION)
         dd_run_check(c)
-        assert c._api_url.endswith(Vault.DEFAULT_API_VERSION)
+        assert c._api_url.endswith(DEFAULT_API_VERSION)
 
         aggregator.assert_service_check(Vault.SERVICE_CHECK_CONNECT, status=Vault.OK, count=1)
 


### PR DESCRIPTION
### Additional Notes

Also took the liberty of not supporting legacy behavior when enabled:

- `disable_legacy_cluster_tag` option
- `vault.route.<API>.<MOUNTPOINT>` metrics (new is `vault.route.<API>` with `mountpoint:<MOUNTPOINT>` tag)
- `ssl_*` options