### PR TITLE
Remove `pysmi` from required dependencies

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_traps_db.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_traps_db.py
@@ -8,12 +8,6 @@ from functools import lru_cache
 
 import click
 import yaml
-from pysmi.codegen import JsonCodeGen
-from pysmi.compiler import MibCompiler
-from pysmi.parser import SmiV1CompatParser
-from pysmi.reader import getReadersFromUrls
-from pysmi.searcher import AnyFileSearcher
-from pysmi.writer import FileWriter
 
 from datadog_checks.dev import TempDir
 
@@ -69,7 +63,16 @@ def generate_traps_db(mib_sources, output_dir, output_file, output_format, no_de
     1- Identify a type of device that is sending traps that Datadog does not already recognize.\n
     2- Fetch all the MIBs that Datadog does not support.\n
     3- Run `ddev meta snmp generate-traps-db -o ./output_dir/ /path/to/my/mib1 /path/to/my/mib2`\n
+
+    You'll need to install pysmi manually beforehand.
     """
+    from pysmi.codegen import JsonCodeGen
+    from pysmi.compiler import MibCompiler
+    from pysmi.parser import SmiV1CompatParser
+    from pysmi.reader import getReadersFromUrls
+    from pysmi.searcher import AnyFileSearcher
+    from pysmi.writer import FileWriter
+
     if debug:
         set_debug()
         from pysmi import debug

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -88,7 +88,6 @@ setup(
             'pip-tools',
             'platformdirs>=2.0.0a3',
             'pyperclip>=1.7.0',
-            'pysmi>=0.3.4',
             'semver',
             'tabulate>=0.8.9',
             'toml>=0.9.4, <1.0.0',

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -88,6 +88,7 @@ setup(
             'pip-tools',
             'platformdirs>=2.0.0a3',
             'pyperclip>=1.7.0',
+            'pysmi>=0.3.4',
             'semver',
             'tabulate>=0.8.9',
             'toml>=0.9.4, <1.0.0',


### PR DESCRIPTION
### Motivation

I noticed `ddev` started failing imports for me after pulling https://github.com/DataDog/integrations-core/pull/11235

The `meta` commands provide no stability guarantees (https://datadoghq.dev/integrations-core/ddev/cli/#ddev-meta) and should not define dependencies but rather lazily import and require manual installation if necessary, see:

- https://github.com/DataDog/integrations-core/blob/9cb47fde4b8dce2521e7712125800d12aad84428/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/translate_profile.py#L51-L56
- https://github.com/DataDog/integrations-core/blob/9cb47fde4b8dce2521e7712125800d12aad84428/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/windows/pdh.py#L98-L101
- https://github.com/DataDog/integrations-core/blob/9cb47fde4b8dce2521e7712125800d12aad84428/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/jmx.py#L20-L22