### PR TITLE
Fix style check environment for Python checks defined by a `pyproject.toml` file

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -137,8 +137,8 @@ def add_style_checker(config, sections, make_envconfig, reader):
 
     commands = [
         'flake8 --config=../.flake8 .',
-        'black --check --diff .',
-        'isort --check-only --diff .',
+        'black --config ../pyproject.toml --check --diff .',
+        'isort --settings-path ../pyproject.toml --check-only --diff .',
     ]
 
     if sections['testenv'].get(TYPES_FLAG, 'false').lower() == 'true':


### PR DESCRIPTION
### What does this PR do?

Part of https://github.com/DataDog/integrations-core/pull/11233

### Motivation

The new file would take precedence by default