### PR TITLE
Add `pyproject.toml` file

### DIFF
--- a/datadog_checks_dev/MANIFEST.in
+++ b/datadog_checks_dev/MANIFEST.in
@@ -1,7 +1,0 @@
-graft datadog_checks
-graft tests
-
-include MANIFEST.in
-include README.md
-
-global-exclude *.py[cod] __pycache__

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -71,7 +71,7 @@ cli = [
     "pip-tools",
     "platformdirs>=2.0.0a3",
     "pyperclip>=1.7.0",
-    "pysmi",
+    "pysmi>=0.3.4",
     "semver",
     "tabulate>=0.8.9",
     "toml>=0.9.4, <1.0.0",

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -1,0 +1,116 @@
+[build-system]
+requires = [
+    "hatchling>=0.11.2",
+]
+build-backend = "hatchling.build"
+
+[project]
+name = "datadog-checks-dev"
+description = "The Datadog Checks Developer Tool"
+readme = "README.md"
+license = "BSD-3-Clause"
+keywords = [
+    "datadog",
+    "datadog agent",
+    "datadog check",
+    "dev tool",
+    "tests",
+]
+authors = [
+    { name = "Datadog", email = "packages@datadoghq.com" },
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: BSD License",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.8",
+]
+dependencies = [
+    "contextlib2; python_version < '3.0'",
+    "coverage>=5.0.3",
+    "flaky",
+    "mock",
+    "psutil",
+    "pytest",
+    "pytest-benchmark[histogram]>=3.2.1",
+    "pytest-cov>=2.6.1",
+    "pytest-mock",
+    "pyyaml==5.4.1",
+    "requests>=2.22.0",
+    "shutilwhich==1.1.0; python_version < '3.0'",
+    "six",
+    "subprocess32==3.5.4; python_version < '3.0'",
+    "tenacity",
+]
+dynamic = [
+    "version",
+]
+
+[project.optional-dependencies]
+cli = [
+    "aiohttp",
+    "aiomultiprocess",
+    "atomicwrites",
+    "beautifulsoup4>=4.9.3",
+    "build>=0.7.0",
+    "click~=8.0",
+    "codespell",
+    "colorama",
+    "datamodel-code-generator~=0.11.4",
+    "docker-compose>=1.25",
+    "in-toto>=0.4.2",
+    "jsonschema",
+    "markdown",
+    "orjson",
+    "packaging",
+    "pip-tools",
+    "platformdirs>=2.0.0a3",
+    "pyperclip>=1.7.0",
+    "pysmi",
+    "semver",
+    "tabulate>=0.8.9",
+    "toml>=0.9.4, <1.0.0",
+    "tomli>=1.1.0",
+    "tomli-w>=1.0.0",
+    "tox>=3.12.1",
+    "twine>=1.11.0",
+    "virtualenv>=20.5.0",
+    # TODO: Remove once every check has a pyproject.toml
+    "setuptools>=38.6.0",
+    "wheel>=0.31.0",
+]
+
+[project.scripts]
+ddev = "datadog_checks.dev.tooling.cli:ddev"
+
+[project.entry-points.pytest11]
+datadog_checks = "datadog_checks.dev.plugin.pytest"
+
+[project.entry-points.tox]
+datadog_checks = "datadog_checks.dev.plugin.tox"
+
+[project.urls]
+Source = "https://github.com/DataDog/integrations-core"
+
+[tool.hatch.version]
+path = "datadog_checks/dev/__about__.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/datadog_checks",
+    "/tests",
+    "/requirements-dev.txt",
+    "/tox.ini",
+]
+
+[tool.hatch.build.targets.wheel]
+include = [
+    "/datadog_checks",
+]
+dev-mode-dirs = [
+    ".",
+]

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
+    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_dev/setup.py
+++ b/datadog_checks_dev/setup.py
@@ -21,23 +21,19 @@ with open(path.join(HERE, 'README.md'), 'r', encoding='utf-8') as f:
     README = f.read()
 
 
-REQUIRES = [
-    "contextlib2; python_version < '3.0'",
-    'coverage>=5.0.3',
-    'flaky',
-    'mock',
-    'psutil',
-    'PyYAML==5.4.1',
-    'pytest',
-    'pytest-benchmark[histogram]>=3.2.1',
-    'pytest-cov>=2.6.1',
-    'pytest-mock',
-    'requests>=2.22.0',
-    'six',
-    "shutilwhich==1.1.0; python_version < '3.0'",
-    "subprocess32==3.5.4; python_version < '3.0'",
-    'tenacity',
-]
+def parse_pyproject_array(name):
+    import os
+    import re
+    from ast import literal_eval
+
+    pattern = r'^{} = (\[.+?\])$'.format(name)
+
+    with open(os.path.join(HERE, 'pyproject.toml'), 'r', encoding='utf-8') as f:
+        # Windows \r\n prevents match
+        contents = '\n'.join(line.rstrip() for line in f.readlines())
+
+    array = re.search(pattern, contents, flags=re.MULTILINE | re.DOTALL).group(1)
+    return literal_eval(array)
 
 
 setup(
@@ -64,44 +60,11 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     packages=['datadog_checks', 'datadog_checks.dev'],
-    install_requires=REQUIRES,
+    install_requires=parse_pyproject_array('dependencies'),
     # TODO: Uncomment when we fully drop Python 2
     # python_requires='>=3.7',
     include_package_data=True,
-    extras_require={
-        'cli': [
-            'aiohttp',
-            'aiomultiprocess',
-            'atomicwrites',
-            'beautifulsoup4>=4.9.3',
-            'build>=0.7.0',
-            'click~=8.0',
-            'codespell',
-            'colorama',
-            'datamodel-code-generator~=0.11.4',
-            'docker-compose>=1.25',
-            'in-toto>=0.4.2',
-            'jsonschema',
-            'markdown',
-            'orjson',
-            'packaging',
-            'pip-tools',
-            'platformdirs>=2.0.0a3',
-            'pyperclip>=1.7.0',
-            'pysmi>=0.3.4',
-            'semver',
-            'tabulate>=0.8.9',
-            'toml>=0.9.4, <1.0.0',
-            'tomli>=1.1.0',
-            'tomli-w>=1.0.0',
-            'tox>=3.12.1',
-            'twine>=1.11.0',
-            'virtualenv>=20.5.0',
-            # TODO: Remove once every check has a pyproject.toml
-            'setuptools>=38.6.0',
-            'wheel>=0.31.0',
-        ]
-    },
+    extras_require={'cli': parse_pyproject_array('cli')},
     entry_points={
         'pytest11': ['datadog_checks = datadog_checks.dev.plugin.pytest'],
         'tox': ['datadog_checks = datadog_checks.dev.plugin.tox'],


### PR DESCRIPTION
### Motivation

Modernize packaging, continues https://github.com/DataDog/integrations-core/pull/11233

### Additional Notes

The `setup.py` file will be removed when we drop Python 2 since new-style editable installations require versions of `pip` that are Python 3-only