### PR TITLE
Final fix for dependency tooling

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -56,7 +56,7 @@ AGENT_V5_ONLY = {'agent_metrics', 'docker_daemon', 'go-metro', 'kubernetes', 'nt
 
 BETA_PACKAGES = {}
 
-NOT_CHECKS = {'datadog_checks_dev'}
+NOT_CHECKS = {'datadog_checks_dev', 'datadog_checks_tests_helper'}
 
 # Some integrations do not have an associated tile, mostly system integrations
 NOT_TILES = [
@@ -138,7 +138,7 @@ integration_type_links = {
 
 # If a file changes in a PR with any of these file extensions,
 # a test will run against the check containing the file
-TESTABLE_FILE_PATTERNS = ('*.py', '*.ini', '*.in', '*.txt', '*.yml', '*.yaml', '**/tests/*')
+TESTABLE_FILE_PATTERNS = ('*.py', '*.ini', '*.in', '*.txt', '*.yml', '*.yaml', '**/tests/*', '**/pyproject.toml')
 NON_TESTABLE_FILES = ('auto_conf.yaml', 'agent_requirements.in')
 
 REQUIREMENTS_IN = 'requirements.in'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 from packaging.requirements import InvalidRequirement, Requirement
 
 from ..fs import stream_file_lines
-from .constants import get_agent_requirements, get_root
+from .constants import NOT_CHECKS, get_agent_requirements, get_root
 from .utils import (
     get_project_file,
     get_valid_checks,
@@ -132,6 +132,9 @@ def read_check_dependencies(check=None):
         checks = sorted(get_valid_checks()) if check is None else [check]
 
     for check_name in checks:
+        if check_name in NOT_CHECKS:
+            continue
+
         if has_project_file(check_name):
             load_dependency_data_from_metadata(check_name, dependencies, errors)
         else:
@@ -152,7 +155,7 @@ def read_check_base_dependencies(check=None):
         checks = sorted(get_valid_checks()) if check is None else [check]
 
     for check_name in checks:
-        if check_name.startswith('datadog_checks_'):
+        if check_name in NOT_CHECKS or check_name == 'datadog_checks_base':
             continue
 
         if has_project_file(check_name):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/dependencies.py
@@ -154,8 +154,10 @@ def read_check_base_dependencies(check=None):
     else:
         checks = sorted(get_valid_checks()) if check is None else [check]
 
+    not_required = {'datadog_checks_base', 'datadog_checks_downloader'}
+    not_required.update(NOT_CHECKS)
     for check_name in checks:
-        if check_name in NOT_CHECKS or check_name == 'datadog_checks_base':
+        if check_name in not_required:
             continue
 
         if has_project_file(check_name):


### PR DESCRIPTION
### What does this PR do?

1. Run tests for `pyproject.toml` changes
2. Skip dependency validation for non-checks (this was always broken by only looking for a `requirements.in`)

### Motivation

Fix CI for https://github.com/DataDog/integrations-core/pull/11303