### PR TITLE
Allows to disable querying an exporter

### DIFF
--- a/amazon_msk/assets/configuration/spec.yaml
+++ b/amazon_msk/assets/configuration/spec.yaml
@@ -36,12 +36,16 @@ files:
       value:
         type: string
     - name: jmx_exporter_port
-      description: The port on which the JMX Exporter serves metrics.
+      description: |
+        The port on which the JMX Exporter serves metrics.
+        Set the port to 0 to disable.
       value:
         type: integer
         example: 11001
     - name: node_exporter_port
-      description: The port on which the Node Exporter serves metrics.
+      description: |
+        The port on which the Node Exporter serves metrics.
+        Set the port to 0 to disable.
       value:
         type: integer
         example: 11002

--- a/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
+++ b/amazon_msk/datadog_checks/amazon_msk/amazon_msk.py
@@ -117,13 +117,14 @@ class AmazonMskCheck(OpenMetricsBaseCheck):
 
             for endpoint in broker_info['Endpoints']:
                 for (port, metrics_mapper, type_overrides) in self._exporter_data:
-                    self._scraper_config['prometheus_url'] = '{}://{}:{}{}'.format(
-                        self._endpoint_prefix, endpoint, port, self._prometheus_metrics_path
-                    )
-                    self._scraper_config['metrics_mapper'] = metrics_mapper
-                    self._scraper_config['type_overrides'] = type_overrides
+                    if port:
+                        self._scraper_config['prometheus_url'] = '{}://{}:{}{}'.format(
+                            self._endpoint_prefix, endpoint, port, self._prometheus_metrics_path
+                        )
+                        self._scraper_config['metrics_mapper'] = metrics_mapper
+                        self._scraper_config['type_overrides'] = type_overrides
 
-                    self.process(self._scraper_config)
+                        self.process(self._scraper_config)
 
     def parse_config(self):
         cluster_arn = self.instance.get('cluster_arn')

--- a/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
+++ b/amazon_msk/datadog_checks/amazon_msk/data/conf.yaml.example
@@ -72,11 +72,13 @@ instances:
 
     ## @param jmx_exporter_port - integer - optional - default: 11001
     ## The port on which the JMX Exporter serves metrics.
+    ## Set the port to 0 to disable.
     #
     # jmx_exporter_port: 11001
 
     ## @param node_exporter_port - integer - optional - default: 11002
     ## The port on which the Node Exporter serves metrics.
+    ## Set the port to 0 to disable.
     #
     # node_exporter_port: 11002
 


### PR DESCRIPTION
### What does this PR do?
Allows to disable querying an exporter by setting the port to 0

### Motivation
- AGENT-7470

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
