### PR TITLE
update service_checks.json to point out service checks

### DIFF
--- a/disk/assets/service_checks.json
+++ b/disk/assets/service_checks.json
@@ -12,6 +12,6 @@
             "device"
         ],
         "name": "Disk read_write",
-        "description": "Returns `CRITICAL` if filesystem is in read-only mode."
+        "description": "Returns `CRITICAL` if filesystem is in read-only mode. **Note**: This service check is not enabled by default and must be enabled under `service_check_rw` in the [disk.d/conf.yaml][3] config file."
     }
 ]

--- a/disk/assets/service_checks.json
+++ b/disk/assets/service_checks.json
@@ -12,6 +12,6 @@
             "device"
         ],
         "name": "Disk read_write",
-        "description": "Returns `CRITICAL` if filesystem is in read-only mode. **Note**: This service check is not enabled by default and must be enabled under `service_check_rw` in the [disk.d/conf.yaml][3] config file."
+        "description": "Returns `CRITICAL` if filesystem is in read-only mode. **Note**: This service check is not enabled by default and must be enabled under `service_check_rw` in the disk check's conf.yaml config file."
     }
 ]


### PR DESCRIPTION

### What does this PR do?
Service check for `disk.read_write` is not enabled by default. This updates the `service_checks.json` file to mention this more explicitly.

### Motivation
Docs didn't mention that this attribute wasn't enabled by default. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
