### PR TITLE
Add `pyproject.toml` file

### DIFF
--- a/solr/MANIFEST.in
+++ b/solr/MANIFEST.in
@@ -1,3 +1,0 @@
-include README.md
-include manifest.json
-graft datadog_checks

--- a/solr/pyproject.toml
+++ b/solr/pyproject.toml
@@ -1,0 +1,62 @@
+[build-system]
+requires = [
+    "hatchling>=0.11.2",
+    "setuptools; python_version < '3.0'",
+]
+build-backend = "hatchling.build"
+
+[project]
+name = "datadog-solr"
+description = "The Solr check"
+readme = "README.md"
+license = "BSD-3-Clause"
+keywords = [
+    "datadog",
+    "datadog agent",
+    "datadog check",
+    "solr",
+]
+authors = [
+    { name = "Datadog", email = "packages@datadoghq.com" },
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.8",
+    "Topic :: System :: Monitoring",
+]
+dependencies = [
+    "datadog-checks-base>=23.6.0",
+]
+dynamic = [
+    "version",
+]
+
+[project.optional-dependencies]
+deps = []
+
+[project.urls]
+Source = "https://github.com/DataDog/integrations-core"
+
+[tool.hatch.version]
+path = "datadog_checks/solr/__about__.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/datadog_checks",
+    "/tests",
+    "/manifest.json",
+    "/requirements-dev.txt",
+    "/tox.ini",
+]
+
+[tool.hatch.build.targets.wheel]
+include = [
+    "/datadog_checks",
+]
+dev-mode-dirs = [
+    ".",
+]

--- a/solr/setup.py
+++ b/solr/setup.py
@@ -27,7 +27,22 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=23.6.0'
+def parse_pyproject_array(name):
+    import os
+    import re
+    from ast import literal_eval
+
+    pattern = r'^{} = (\[.*?\])$'.format(name)
+
+    with open(os.path.join(HERE, 'pyproject.toml'), 'r', encoding='utf-8') as f:
+        # Windows \r\n prevents match
+        contents = '\n'.join(line.rstrip() for line in f.readlines())
+
+    array = re.search(pattern, contents, flags=re.MULTILINE | re.DOTALL).group(1)
+    return literal_eval(array)
+
+
+CHECKS_BASE_REQ = parse_pyproject_array('dependencies')[0]
 
 
 setup(
@@ -60,7 +75,7 @@ setup(
     packages=['datadog_checks.solr'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
-    extras_require={'deps': get_dependencies()},
+    extras_require={'deps': parse_pyproject_array('deps')},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )

--- a/solr/tox.ini
+++ b/solr/tox.ini
@@ -14,6 +14,7 @@ description =
 usedevelop = true
 dd_check_style = true
 platform = linux|darwin|win32
+extras = deps
 deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt


### PR DESCRIPTION
### Motivation

Modernize packaging, continues https://github.com/DataDog/integrations-core/pull/11233

### Additional Notes

The `setup.py` file will be removed when we drop Python 2 since new-style editable installations require versions of `pip` that are Python 3-only