### PR TITLE
Remove unused `metric_prefix` in init_config

### DIFF
--- a/clickhouse/assets/configuration/spec.yaml
+++ b/clickhouse/assets/configuration/spec.yaml
@@ -7,8 +7,7 @@ files:
     - template: init_config/db
       overrides:
         global_custom_queries.value.example:
-          - metric_prefix: clickhouse
-            query: <QUERY>
+          - query: <QUERY>
             columns: <COLUMNS>
             tags: <TAGS>
     - template: init_config/default

--- a/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
+++ b/clickhouse/datadog_checks/clickhouse/data/conf.yaml.example
@@ -9,8 +9,7 @@ init_config:
     ## `use_global_custom_queries` setting at the instance level.
     #
     # global_custom_queries:
-    #   - metric_prefix: clickhouse
-    #     query: <QUERY>
+    #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
 

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -7,8 +7,7 @@ files:
           - template: init_config/db
             overrides:
               global_custom_queries.value.example:
-                - metric_prefix: mysql
-                  query: <QUERY>
+                - query: <QUERY>
                   columns: <COLUMNS>
                   tags: <TAGS>
           - template: init_config/default

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -9,8 +9,7 @@ init_config:
     ## `use_global_custom_queries` setting at the instance level.
     #
     # global_custom_queries:
-    #   - metric_prefix: mysql
-    #     query: <QUERY>
+    #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
 

--- a/vertica/assets/configuration/spec.yaml
+++ b/vertica/assets/configuration/spec.yaml
@@ -8,8 +8,7 @@ files:
           - template: init_config/db
             overrides:
               global_custom_queries.value.example:
-                - metric_prefix: vertica
-                  query: <QUERY>
+                - query: <QUERY>
                   columns: <COLUMNS>
                   tags: <TAGS>
           - template: init_config/default

--- a/vertica/datadog_checks/vertica/data/conf.yaml.example
+++ b/vertica/datadog_checks/vertica/data/conf.yaml.example
@@ -9,8 +9,7 @@ init_config:
     ## `use_global_custom_queries` setting at the instance level.
     #
     # global_custom_queries:
-    #   - metric_prefix: vertica
-    #     query: <QUERY>
+    #   - query: <QUERY>
     #     columns: <COLUMNS>
     #     tags: <TAGS>
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
https://github.com/DataDog/integrations-core/pull/7583 removed the default `metric_prefix` in init_config since it was deprecated, but some db integrations that didn't previously implement `metric_prefix` still have the option. This is causing confusing since the option is not used in those integrations.

This PR removes the `metric_prefix` option in init_config/db for mysql, clickhouse, and vertica since those integrations don't use `metric_prefix`.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/integrations-core/issues/11030
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
