### PR TITLE
Fix indent in istio doc

### DIFF
--- a/istio/README.md
+++ b/istio/README.md
@@ -29,29 +29,29 @@ Edit the `istio.d/conf.yaml` file (in the `conf.d/` folder at the root of your [
 #### Metric collection
 To monitor the `istiod` deployment and `istio-proxy` in Istio `v1.5+`, use the following configuration:
     
-    ```yaml
-    init_config:
-    
-    instances:
-      - use_openmetrics: true  # Enables Openmetrics V2 version of the integration
-        istiod_endpoint: http://istiod.istio-system:15014/metrics
-        istio_mesh_endpoint: http://istio-proxy.istio-system:15090/stats/prometheus
-        exclude_labels:
-         - source_version
-         - destination_version
-         - source_canonical_revision
-         - destination_canonical_revision
-         - source_principal
-         - destination_principal
-         - source_cluster
-         - destination_cluster
-         - source_canonical_service
-         - destination_canonical_service
-         - source_workload_namespace
-         - destination_workload_namespace
-         - request_protocol
-         - connection_security_policy
-    ```
+```yaml
+init_config:
+
+instances:
+  - use_openmetrics: true  # Enables Openmetrics V2 version of the integration
+    istiod_endpoint: http://istiod.istio-system:15014/metrics
+    istio_mesh_endpoint: http://istio-proxy.istio-system:15090/stats/prometheus
+    exclude_labels:
+      - source_version
+      - destination_version
+      - source_canonical_revision
+      - destination_canonical_revision
+      - source_principal
+      - destination_principal
+      - source_cluster
+      - destination_cluster
+      - source_canonical_service
+      - destination_canonical_service
+      - source_workload_namespace
+      - destination_workload_namespace
+      - request_protocol
+      - connection_security_policy
+```
    
 **Note**: The `connectionID` Prometheus label is excluded. The [sample istio.d/conf.yaml][8] also has a list of suggested labels to exclude.
 
@@ -131,10 +131,10 @@ See [service_checks.json][16] for a list of service checks provided by this inte
 ### Invalid chunk length error
 If you see the following error on OpenMetricsBaseCheck (V1) implementation of Istio (Istio integration version `3.13.0` or older):
 
-    ```python
-      Error: ("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)", 
-      InvalidChunkLength(got length b'', 0 bytes read))
-    ```
+```python
+  Error: ("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)", 
+  InvalidChunkLength(got length b'', 0 bytes read))
+```
 
 You can use the Openmetrics V2 implementation of the Istio integration to resolve this error.
 


### PR DESCRIPTION
### What does this PR do?

Fix indent in istio doc.

### Motivation

There are broken indents in this doc.

https://docs.datadoghq.com/integrations/istio/#metric-collection

![Istio 2022-02-08 at 10 11 46 AM](https://user-images.githubusercontent.com/41987730/152899089-0e340472-54c6-41b8-aac4-1973a52bbc2b.jpg)

https://docs.datadoghq.com/integrations/istio/#invalid-chunk-length-error

![Istio 2022-02-08 at 10 11 34 AM](https://user-images.githubusercontent.com/41987730/152899116-b4a7cc37-8808-4a94-9f61-1f71ae4a4c4f.jpg)


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
