### PR TITLE
Fix E2E for new base package versions

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -141,8 +141,6 @@ integration_type_links = {
 TESTABLE_FILE_PATTERNS = ('*.py', '*.ini', '*.in', '*.txt', '*.yml', '*.yaml', '**/tests/*', '**/pyproject.toml')
 NON_TESTABLE_FILES = ('auto_conf.yaml', 'agent_requirements.in')
 
-REQUIREMENTS_IN = 'requirements.in'
-
 ROOT = ''
 
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -276,8 +276,7 @@ class DockerInterface(object):
     def update_base_package(self):
         command = ['docker', 'exec', self.container_name]
         command.extend(get_pip_exe(self.python_version, platform=self.container_platform))
-        command.extend(('install', '-e', self.base_mount_dir))
-        command.extend(('-r', f'{self.base_mount_dir}/{REQUIREMENTS_IN}'))
+        command.extend(('install', '-e', f'{self.base_mount_dir}[db,deps,http,json,kube]'))
         run_command(command, capture=True, check=True)
 
     def update_agent(self):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -9,7 +9,7 @@ from ...errors import SubprocessError
 from ...subprocess import run_command
 from ...utils import ON_WINDOWS, file_exists, find_free_port, get_ip, path_join
 from ..commands.console import echo_debug, echo_warning
-from ..constants import REQUIREMENTS_IN, get_root
+from ..constants import get_root
 from .agent import (
     DEFAULT_AGENT_VERSION,
     DEFAULT_DOGSTATSD_PORT,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -204,8 +204,7 @@ class LocalAgentInterface(object):
 
     def update_base_package(self):
         command = get_pip_exe(self.python_version, self.platform)
-        command.extend(('install', '-e', self.base_package))
-        command.extend(('-r', path_join(self.base_package, REQUIREMENTS_IN)))
+        command.extend(('install', '-e', f'{self.base_package}[db,deps,http,json,kube]'))
         return run_command(command, capture=True, check=True)
 
     def update_agent(self):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -9,7 +9,7 @@ from shutil import copyfile, move
 from ...structures import EnvVars
 from ...subprocess import run_command
 from ...utils import ON_LINUX, ON_MACOS, ON_WINDOWS, file_exists, path_join
-from ..constants import REQUIREMENTS_IN, get_root
+from ..constants import get_root
 from .agent import (
     DEFAULT_AGENT_VERSION,
     DEFAULT_PYTHON_VERSION,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -96,7 +96,14 @@ def update_link_metadata(checks, core_workflow=True):
     products = []
     for check in checks:
         products.append(path_join(check, 'datadog_checks'))
-        products.append(path_join(check, 'setup.py'))
+
+        setup_file = path_join(check, 'setup.py')
+        if file_exists(setup_file):
+            products.append(setup_file)
+
+        project_file = path_join(check, 'pyproject.toml')
+        if file_exists(project_file):
+            products.append(project_file)
 
         dep_file = path_join(check, 'requirements.in')
         if file_exists(dep_file):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -96,14 +96,7 @@ def update_link_metadata(checks, core_workflow=True):
     products = []
     for check in checks:
         products.append(path_join(check, 'datadog_checks'))
-
-        setup_file = path_join(check, 'setup.py')
-        if file_exists(setup_file):
-            products.append(setup_file)
-
-        project_file = path_join(check, 'pyproject.toml')
-        if file_exists(project_file):
-            products.append(project_file)
+        products.append(path_join(check, 'setup.py'))
 
         dep_file = path_join(check, 'requirements.in')
         if file_exists(dep_file):

--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -88,7 +88,7 @@ def find_check_root(depth=0):
 
     root = get_parent_dir(frame.f_code.co_filename)
     while True:
-        if file_exists(path_join(root, 'setup.py')):
+        if file_exists(path_join(root, 'pyproject.toml')) or file_exists(path_join(root, 'setup.py')):
             break
 
         new_root = os.path.dirname(root)


### PR DESCRIPTION
### Motivation

```
datadog_checks.dev.errors.SubprocessError: Command: ['docker', 'exec', 'dd_activemq_xml_py38', '/opt/datadog-agent/embedded/bin/pip3', 'install', '-e', '/home/datadog_checks_base', '-r', '/home/datadog_checks_base/requirements.in']

Captured Output: ERROR: Could not open requirements file: [Errno 2] No such file or directory: '/home/datadog_checks_base/requirements.in'
```