### PR TITLE
Fix `pytest` and `tox` plugins for checks with only a `pyproject.toml`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -148,7 +148,7 @@ def dd_agent_check(request, aggregator, datadog_agent):
     def run_check(config=None, **kwargs):
         root = os.path.dirname(request.module.__file__)
         while True:
-            if os.path.isfile(os.path.join(root, 'setup.py')):
+            if os.path.isfile(os.path.join(root, 'pyproject.toml')) or os.path.isfile(os.path.join(root, 'setup.py')):
                 check = os.path.basename(root)
                 break
 

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -121,6 +121,13 @@ def tox_configure(config):
         for env in config.envlist:
             config.envconfigs[env].commands.insert(0, command)
 
+    # This will inherit the configuration of `[testenv]` and if it doesn't support the platform then for some reason
+    # running a user defined environment and a generated environment at the same time (e.g. `tox -e py38,style`) will
+    # attempt to use the Python executable in the `.package` environment but will fail because the environment has
+    # not been created due to the platform mismatch.
+    if '.package' in config.envconfigs:
+        config.envconfigs['.package'].platform = 'linux|darwin|win32'
+
 
 def add_style_checker(config, sections, make_envconfig, reader):
     # testenv:style


### PR DESCRIPTION
### Motivation

Fix CI for https://github.com/DataDog/integrations-core/pull/11459