### PR TITLE
Properly create list of known options when detecting typos

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -407,12 +407,12 @@ class AgentCheck(object):
         # only import it when running in python 3
         from jellyfish import jaro_winkler_similarity
 
-        user_config = user_config or {}
+        user_configs = user_config or {}  # type: Dict[str, Any]
         models_config = models_config or {}
         typos = set()  # type: Set[str]
 
-        known_options = [k for k, _ in models_config]  # type List[str]
-        unknown_options = sorted(list(user_config.keys() - known_options))
+        known_options = [k for k, _ in models_config]  # type: List[str]
+        unknown_options = [option for option in user_configs.keys() if option not in known_options]  # type: List[str]
 
         for unknown_option in unknown_options:
             similar_known_options = []  # type: List[Tuple[str, int]]

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -411,7 +411,7 @@ class AgentCheck(object):
         models_config = models_config or {}
         typos = set()  # type: Set[str]
 
-        known_options = dict(models_config).keys()
+        known_options = [k for k, _ in models_config]  # type List[str]
         unknown_options = sorted(list(user_config.keys() - known_options))
 
         for unknown_option in unknown_options:

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -919,85 +919,107 @@ def test_load_configuration_models(dd_run_check, mocker):
 
 @requires_py3
 @pytest.mark.parametrize(
-    'check_instance_config, default_instance_config, log_lines',
+    "check_instance_config, default_instance_config, log_lines",
     [
         pytest.param(
-            {'endpoint': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
-            {},
-            None,
-            id='empty default',
-        ),
-        pytest.param(
-            {'endpoint': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
-            {'endpoint': 'url'},
-            None,
-            id='no typo',
-        ),
-        pytest.param(
-            {'endpoints': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
-            {'endpoint': 'url'},
-            [
-                (
-                    'Detected potential typo in configuration option in test/instance section: `endpoints`. '
-                    'Did you mean endpoint?'
-                )
-            ],
-            id='typo',
-        ),
-        pytest.param(
-            {'endpoints': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
-            {'endpoint': 'url', 'endpoints': 'url'},
-            None,
-            id='no typo similar option',
-        ),
-        pytest.param(
-            {'endpont': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
-            {'endpoint': 'url', 'endpoints': 'url'},
-            [
-                (
-                    'Detected potential typo in configuration option in test/instance section: `endpont`. '
-                    'Did you mean endpoint, or endpoints?'
-                )
-            ],
-            id='typo two candidates',
-        ),
-        pytest.param({'tag': 'test'}, {'tags': 'test'}, None, id='short option cant catch'),
-        pytest.param(
-            {'testing_long_para': 'test'},
-            {'testing_long_param': 'test', 'test_short_param': 'test'},
-            [
-                (
-                    'Detected potential typo in configuration option in test/instance section: `testing_long_para`. '
-                    'Did you mean testing_long_param?'
-                )
-            ],
-            id='somewhat similar option',
-        ),
-        pytest.param(
-            {'send_distribution_sums_as_monotonic': False, 'exclude_labels': True},
-            {'send_distribution_counts_as_monotonic': True, 'include_labels': True},
-            None,
-            id='different options no typos',
-        ),
-        pytest.param(
-            {'send_distribution_count_as_monotonic': True, 'exclude_label': True},
             {
-                'send_distribution_sums_as_monotonic': False,
-                'send_distribution_counts_as_monotonic': True,
-                'exclude_labels': False,
-                'include_labels': True,
+                "endpoint": "url",
+                "tags": ["foo:bar"],
+                "proxy": {"http": "http://1.2.3.4:9000"},
             },
+            [],
+            None,
+            id="empty default",
+        ),
+        pytest.param(
+            {
+                "endpoint": "url",
+                "tags": ["foo:bar"],
+                "proxy": {"http": "http://1.2.3.4:9000"},
+            },
+            [("endpoint", "url")],
+            None,
+            id="no typo",
+        ),
+        pytest.param(
+            {
+                "endpoints": "url",
+                "tags": ["foo:bar"],
+                "proxy": {"http": "http://1.2.3.4:9000"},
+            },
+            [("endpoint", "url")],
             [
                 (
-                    'Detected potential typo in configuration option in test/instance section: '
-                    '`send_distribution_count_as_monotonic`. Did you mean send_distribution_counts_as_monotonic?'
+                    "Detected potential typo in configuration option in test/instance section: `endpoints`. "
+                    "Did you mean endpoint?"
+                )
+            ],
+            id="typo",
+        ),
+        pytest.param(
+            {
+                "endpoints": "url",
+                "tags": ["foo:bar"],
+                "proxy": {"http": "http://1.2.3.4:9000"},
+            },
+            [("endpoint", "url"), ("endpoints", "url")],
+            None,
+            id="no typo similar option",
+        ),
+        pytest.param(
+            {
+                "endpont": "url",
+                "tags": ["foo:bar"],
+                "proxy": {"http": "http://1.2.3.4:9000"},
+            },
+            [("endpoint", "url"), ("endpoints", "url")],
+            [
+                (
+                    "Detected potential typo in configuration option in test/instance section: `endpont`. "
+                    "Did you mean endpoint, or endpoints?"
+                )
+            ],
+            id="typo two candidates",
+        ),
+        pytest.param(
+            {"tag": "test"}, [("tags", "test")], None, id="short option cant catch"
+        ),
+        pytest.param(
+            {"testing_long_para": "test"},
+            [("testing_long_param", "test"), ("test_short_param", "test")],
+            [
+                (
+                    "Detected potential typo in configuration option in test/instance section: `testing_long_para`. "
+                    "Did you mean testing_long_param?"
+                )
+            ],
+            id="somewhat similar option",
+        ),
+        pytest.param(
+            {"send_distribution_sums_as_monotonic": False, "exclude_labels": True},
+            [("send_distribution_counts_as_monotonic", True), ("include_labels", True)],
+            None,
+            id="different options no typos",
+        ),
+        pytest.param(
+            {"send_distribution_count_as_monotonic": True, "exclude_label": True},
+            [
+                ("send_distribution_sums_as_monotonic", False),
+                ("send_distribution_counts_as_monotonic", True),
+                ("exclude_labels", False),
+                ("include_labels", True),
+            ],
+            [
+                (
+                    "Detected potential typo in configuration option in test/instance section: "
+                    "`send_distribution_count_as_monotonic`. Did you mean send_distribution_counts_as_monotonic?"
                 ),
                 (
-                    'Detected potential typo in configuration option in test/instance section: `exclude_label`. '
-                    'Did you mean exclude_labels?'
+                    "Detected potential typo in configuration option in test/instance section: `exclude_label`. "
+                    "Did you mean exclude_labels?"
                 ),
             ],
-            id='different options typo',
+            id="different options typo",
         ),
     ],
 )

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -981,9 +981,7 @@ def test_load_configuration_models(dd_run_check, mocker):
             ],
             id="typo two candidates",
         ),
-        pytest.param(
-            {"tag": "test"}, [("tags", "test")], None, id="short option cant catch"
-        ),
+        pytest.param({"tag": "test"}, [("tags", "test")], None, id="short option cant catch"),
         pytest.param(
             {"testing_long_para": "test"},
             [("testing_long_param", "test"), ("test_short_param", "test")],

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -919,105 +919,85 @@ def test_load_configuration_models(dd_run_check, mocker):
 
 @requires_py3
 @pytest.mark.parametrize(
-    "check_instance_config, default_instance_config, log_lines",
+    'check_instance_config, default_instance_config, log_lines',
     [
         pytest.param(
-            {
-                "endpoint": "url",
-                "tags": ["foo:bar"],
-                "proxy": {"http": "http://1.2.3.4:9000"},
-            },
+            {'endpoint': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
             [],
             None,
-            id="empty default",
+            id='empty default',
         ),
         pytest.param(
-            {
-                "endpoint": "url",
-                "tags": ["foo:bar"],
-                "proxy": {"http": "http://1.2.3.4:9000"},
-            },
-            [("endpoint", "url")],
+            {'endpoint': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
+            [('endpoint', 'url')],
             None,
-            id="no typo",
+            id='no typo',
         ),
         pytest.param(
-            {
-                "endpoints": "url",
-                "tags": ["foo:bar"],
-                "proxy": {"http": "http://1.2.3.4:9000"},
-            },
-            [("endpoint", "url")],
+            {'endpoints': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
+            [('endpoint', 'url')],
             [
                 (
-                    "Detected potential typo in configuration option in test/instance section: `endpoints`. "
-                    "Did you mean endpoint?"
+                    'Detected potential typo in configuration option in test/instance section: `endpoints`. '
+                    'Did you mean endpoint?'
                 )
             ],
-            id="typo",
+            id='typo',
         ),
         pytest.param(
-            {
-                "endpoints": "url",
-                "tags": ["foo:bar"],
-                "proxy": {"http": "http://1.2.3.4:9000"},
-            },
-            [("endpoint", "url"), ("endpoints", "url")],
+            {'endpoints': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
+            [('endpoint', 'url'), ('endpoints', 'url')],
             None,
-            id="no typo similar option",
+            id='no typo similar option',
         ),
         pytest.param(
-            {
-                "endpont": "url",
-                "tags": ["foo:bar"],
-                "proxy": {"http": "http://1.2.3.4:9000"},
-            },
-            [("endpoint", "url"), ("endpoints", "url")],
+            {'endpont': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
+            [('endpoint', 'url'), ('endpoints', 'url')],
             [
                 (
-                    "Detected potential typo in configuration option in test/instance section: `endpont`. "
-                    "Did you mean endpoint, or endpoints?"
+                    'Detected potential typo in configuration option in test/instance section: `endpont`. '
+                    'Did you mean endpoint, or endpoints?'
                 )
             ],
-            id="typo two candidates",
+            id='typo two candidates',
         ),
-        pytest.param({"tag": "test"}, [("tags", "test")], None, id="short option cant catch"),
+        pytest.param({'tag': 'test'}, [('tags', 'test')], None, id='short option cant catch'),
         pytest.param(
-            {"testing_long_para": "test"},
-            [("testing_long_param", "test"), ("test_short_param", "test")],
+            {'testing_long_para': 'test'},
+            [('testing_long_param', 'test'), ('test_short_param', 'test')],
             [
                 (
-                    "Detected potential typo in configuration option in test/instance section: `testing_long_para`. "
-                    "Did you mean testing_long_param?"
+                    'Detected potential typo in configuration option in test/instance section: `testing_long_para`. '
+                    'Did you mean testing_long_param?'
                 )
             ],
-            id="somewhat similar option",
+            id='somewhat similar option',
         ),
         pytest.param(
-            {"send_distribution_sums_as_monotonic": False, "exclude_labels": True},
-            [("send_distribution_counts_as_monotonic", True), ("include_labels", True)],
+            {'send_distribution_sums_as_monotonic': False, 'exclude_labels': True},
+            [('send_distribution_counts_as_monotonic', True), ('include_labels', True)],
             None,
-            id="different options no typos",
+            id='different options no typos',
         ),
         pytest.param(
-            {"send_distribution_count_as_monotonic": True, "exclude_label": True},
+            {'send_distribution_count_as_monotonic': True, 'exclude_label': True},
             [
-                ("send_distribution_sums_as_monotonic", False),
-                ("send_distribution_counts_as_monotonic", True),
-                ("exclude_labels", False),
-                ("include_labels", True),
+                ('send_distribution_sums_as_monotonic', False),
+                ('send_distribution_counts_as_monotonic', True),
+                ('exclude_labels', False),
+                ('include_labels', True),
             ],
             [
                 (
-                    "Detected potential typo in configuration option in test/instance section: "
-                    "`send_distribution_count_as_monotonic`. Did you mean send_distribution_counts_as_monotonic?"
+                    'Detected potential typo in configuration option in test/instance section: '
+                    '`send_distribution_count_as_monotonic`. Did you mean send_distribution_counts_as_monotonic?'
                 ),
                 (
-                    "Detected potential typo in configuration option in test/instance section: `exclude_label`. "
-                    "Did you mean exclude_labels?"
+                    'Detected potential typo in configuration option in test/instance section: `exclude_label`. '
+                    'Did you mean exclude_labels?'
                 ),
             ],
-            id="different options typo",
+            id='different options typo',
         ),
     ],
 )
@@ -1027,10 +1007,13 @@ def test_detect_typos_configuration_models(
     caplog.clear()
     caplog.set_level(logging.WARNING)
     empty_config = {}
+    default_instance = mocker.MagicMock()
+    default_instance.__iter__ = mocker.MagicMock(return_value=iter(default_instance_config))
+
     check = AgentCheck('test', empty_config, [check_instance_config])
     check.check_id = 'test:123'
 
-    check.log_typos_in_options(check_instance_config, default_instance_config, 'instance')
+    check.log_typos_in_options(check_instance_config, default_instance, 'instance')
 
     if log_lines is not None:
         for log_line in log_lines:


### PR DESCRIPTION
### What does this PR do?
Properly create list of known options when validating typos
Fixes: https://github.com/DataDog/integrations-core/pull/11211

### Motivation
Redis tests were failing with:
```
tests/test_slowlog.py:56: in test_custom_slowlog
    dd_run_check(redis_check)
../datadog_checks_dev/datadog_checks/dev/plugin/pytest.py:219: in run_check
    raise Exception('\n'.join(exc_lines))
E   Exception: 
E   Traceback (most recent call last):
E     File "/home/vsts/work/1/s/datadog_checks_base/datadog_checks/base/checks/base.py", line 1041, in run
E       initialization()
E     File "/home/vsts/work/1/s/datadog_checks_base/datadog_checks/base/utils/tracing.py", line 77, in wrapper
E       return f(self, *args, **kwargs)
E     File "/home/vsts/work/1/s/datadog_checks_base/datadog_checks/base/checks/base.py", line 455, in load_configuration_models
E       self.log_typos_in_options(intg_instance_config, instance_config, 'instances')
E     File "/home/vsts/work/1/s/datadog_checks_base/datadog_checks/base/utils/tracing.py", line 77, in wrapper
E       return f(self, *args, **kwargs)
E     File "/home/vsts/work/1/s/datadog_checks_base/datadog_checks/base/checks/base.py", line 414, in log_typos_in_options
E       known_options = dict(models_config).keys()
E   TypeError: attribute of type 'tuple' is not callable
```

This was happening because redis had a config option named `keys`
 
### Additional Notes
Also updated the tests to input classes instead of dictionaries to mirror the actual input better, as well as added more type hints in the function.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
