### PR TITLE
disable modified rowcounts in result sets for all connections

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -193,11 +193,6 @@ class Connection(object):
         with rawconn.cursor() as cursor:
             # ensure that by default, the agent's reads can never block updates to any tables it's reading from
             cursor.execute("SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED")
-            # Neither pyodbc nor adodbapi are able to read results of a query if the number of rows affected
-            # statement are returned as part of the result set, so we disable for the entire connection
-            # this is important mostly for custom_queries or the stored_procedure feature
-            # https://docs.microsoft.com/en-us/sql/t-sql/statements/set-nocount-transact-sql
-            cursor.execute("SET NOCOUNT ON")
 
     def close_db_connections(self, db_key, db_name=None, key_prefix=None):
         """

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -193,6 +193,11 @@ class Connection(object):
         with rawconn.cursor() as cursor:
             # ensure that by default, the agent's reads can never block updates to any tables it's reading from
             cursor.execute("SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED")
+            # Neither pyodbc nor adodbapi are able to read results of a query if the number of rows affected
+            # statement are returned as part of the result set, so we disable for the entire connection
+            # this is important mostly for custom_queries or the stored_procedure feature
+            # https://docs.microsoft.com/en-us/sql/t-sql/statements/set-nocount-transact-sql
+            cursor.execute("SET NOCOUNT ON")
 
     def close_db_connections(self, db_key, db_name=None, key_prefix=None):
         """

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -77,18 +77,6 @@ EXPECTED_AO_METRICS_PRIMARY = [m[0] for m in AO_METRICS_PRIMARY]
 EXPECTED_AO_METRICS_SECONDARY = [m[0] for m in AO_METRICS_SECONDARY]
 EXPECTED_AO_METRICS_COMMON = [m[0] for m in AO_METRICS]
 
-CUSTOM_QUERY_A = {
-    'query': "SELECT letter, num FROM (VALUES (97, 'a'), (98, 'b'), (99, 'c')) AS t (num,letter)",
-    'columns': [{'name': 'customtag', 'type': 'tag'}, {'name': 'num', 'type': 'gauge'}],
-    'tags': ['query:custom'],
-}
-
-CUSTOM_QUERY_B = {
-    'query': "SELECT letter, num FROM (VALUES (97, 'a'), (98, 'b'), (99, 'c')) AS t (num,letter)",
-    'columns': [{'name': 'customtag', 'type': 'tag'}, {'name': 'num', 'type': 'gauge'}],
-    'tags': ['query:another_custom_one'],
-}
-
 INSTANCE_SQL_DEFAULTS = {
     'host': DOCKER_SERVER,
     'username': 'sa',

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -59,6 +59,18 @@ END;
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
 
+CREATE PROCEDURE exampleProcWithoutNocount
+AS
+BEGIN
+    CREATE TABLE #Hello
+    (
+        [value] int not null,
+    )
+    INSERT INTO #Hello VALUES (1)
+    select * from #Hello;
+END;
+GRANT EXECUTE on exampleProcWithoutNocount to datadog;
+
 -----------------------------------
 -- AGOG setup
 

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -59,8 +59,7 @@ END;
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
 
-CREATE PROCEDURE exampleProcWithoutNocount
-AS
+CREATE PROCEDURE exampleProcWithoutNocount AS
 BEGIN
     CREATE TABLE #Hello
     (
@@ -69,6 +68,7 @@ BEGIN
     INSERT INTO #Hello VALUES (1)
     select * from #Hello;
 END;
+GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
 
 -----------------------------------

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -58,6 +58,7 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
+GO
 
 CREATE PROCEDURE exampleProcWithoutNocount AS
 BEGIN
@@ -70,6 +71,7 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
+GO
 
 -----------------------------------
 -- AGOG setup

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -36,6 +36,7 @@ CREATE PROCEDURE pyStoredProc
     END;
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
+GO
 
 CREATE PROCEDURE exampleProcWithoutNocount AS
 BEGIN
@@ -48,6 +49,7 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
+GO
 
 -- Create test database for integration tests.
 -- Only bob and fred have read/write access to this database.

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -37,8 +37,7 @@ CREATE PROCEDURE pyStoredProc
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
 
-CREATE PROCEDURE exampleProcWithoutNocount
-AS
+CREATE PROCEDURE exampleProcWithoutNocount AS
 BEGIN
     CREATE TABLE #Hello
     (
@@ -47,6 +46,7 @@ BEGIN
     INSERT INTO #Hello VALUES (1)
     select * from #Hello;
 END;
+GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
 
 -- Create test database for integration tests.

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -37,6 +37,18 @@ CREATE PROCEDURE pyStoredProc
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
 
+CREATE PROCEDURE exampleProcWithoutNocount
+AS
+BEGIN
+    CREATE TABLE #Hello
+    (
+        [value] int not null,
+    )
+    INSERT INTO #Hello VALUES (1)
+    select * from #Hello;
+END;
+GRANT EXECUTE on exampleProcWithoutNocount to datadog;
+
 -- Create test database for integration tests.
 -- Only bob and fred have read/write access to this database.
 CREATE DATABASE datadog_test;

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -36,6 +36,7 @@ CREATE PROCEDURE pyStoredProc
     END;
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
+GO
 
 CREATE PROCEDURE exampleProcWithoutNocount AS
 BEGIN
@@ -48,6 +49,7 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
+GO
 
 -- Create test database for integration tests.
 -- Only bob and fred have read/write access to this database.

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -37,8 +37,7 @@ CREATE PROCEDURE pyStoredProc
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
 
-CREATE PROCEDURE exampleProcWithoutNocount
-AS
+CREATE PROCEDURE exampleProcWithoutNocount AS
 BEGIN
     CREATE TABLE #Hello
     (
@@ -47,6 +46,7 @@ BEGIN
     INSERT INTO #Hello VALUES (1)
     select * from #Hello;
 END;
+GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
 
 -- Create test database for integration tests.

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -37,6 +37,18 @@ CREATE PROCEDURE pyStoredProc
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
 
+CREATE PROCEDURE exampleProcWithoutNocount
+AS
+BEGIN
+    CREATE TABLE #Hello
+    (
+        [value] int not null,
+    )
+    INSERT INTO #Hello VALUES (1)
+    select * from #Hello;
+END;
+GRANT EXECUTE on exampleProcWithoutNocount to datadog;
+
 -- Create test database for integration tests.
 -- Only bob and fred have read/write access to this database.
 CREATE DATABASE datadog_test;

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -53,9 +53,9 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
+GO
 
-CREATE PROCEDURE exampleProcWithoutNocount
-AS
+CREATE PROCEDURE exampleProcWithoutNocount AS
 BEGIN
     CREATE TABLE #Hello
     (
@@ -64,4 +64,6 @@ BEGIN
     INSERT INTO #Hello VALUES (1)
     select * from #Hello;
 END;
+GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
+GO

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -53,3 +53,15 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
+
+CREATE PROCEDURE exampleProcWithoutNocount
+AS
+BEGIN
+    CREATE TABLE #Hello
+    (
+        [value] int not null,
+    )
+    INSERT INTO #Hello VALUES (1)
+    select * from #Hello;
+END;
+GRANT EXECUTE on exampleProcWithoutNocount to datadog;

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -54,6 +54,7 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
+GO
 
 CREATE PROCEDURE exampleProcWithoutNocount AS
 BEGIN
@@ -66,3 +67,4 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
+GO

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -55,8 +55,7 @@ END;
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
 
-CREATE PROCEDURE exampleProcWithoutNocount
-AS
+CREATE PROCEDURE exampleProcWithoutNocount AS
 BEGIN
     CREATE TABLE #Hello
     (
@@ -65,4 +64,5 @@ BEGIN
     INSERT INTO #Hello VALUES (1)
     select * from #Hello;
 END;
+GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -54,3 +54,15 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
+
+CREATE PROCEDURE exampleProcWithoutNocount
+AS
+BEGIN
+    CREATE TABLE #Hello
+    (
+        [value] int not null,
+    )
+    INSERT INTO #Hello VALUES (1)
+    select * from #Hello;
+END;
+GRANT EXECUTE on exampleProcWithoutNocount to datadog;


### PR DESCRIPTION
### What does this PR do?

If a stored procedure uses a temporary table then it will, by default, return the number of rows affected as part of the result set. If such a procedure is called (i.e. as part of `custom_queries`) then the query will fail because neither the `pyodbc` nor `adodbapi` libraries are able to deal with this correctly.

For example, adodbapi throws the following error: `fetch() on closed connection or empty query set`

If the procedure sets `SET NOCOUNT ON` internally then the query will succeed. To ensure the agent is able to call all procedures regardless of whether this has been set in the procedure or not, we'll now set `SET NOCOUNT ON` when we're running custom queries.

### Motivation

Fix failed `custom_queries` when calling stored procedures that use temporary tables.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
