### PR TITLE
Add attempts

### DIFF
--- a/confluent_platform/tests/conftest.py
+++ b/confluent_platform/tests/conftest.py
@@ -62,5 +62,6 @@ def dd_environment():
             WaitFor(create_connectors),
             CheckDockerLogs('connect', 'flushing 0 outstanding messages for offset commit'),
         ],
+        attempts=2
     ):
         yield CHECK_CONFIG, {'use_jmx': True}

--- a/confluent_platform/tests/conftest.py
+++ b/confluent_platform/tests/conftest.py
@@ -62,6 +62,6 @@ def dd_environment():
             WaitFor(create_connectors),
             CheckDockerLogs('connect', 'flushing 0 outstanding messages for offset commit'),
         ],
-        attempts=2
+        attempts=2,
     ):
         yield CHECK_CONFIG, {'use_jmx': True}


### PR DESCRIPTION
Confluent platform environment fails to start (kafka throws exceptions) so let's add a retry