### PR TITLE
Add ability to collect blocking pids for queries run on postgres dbs

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -54,7 +54,7 @@ PG_STAT_ACTIVITY_QUERY = re.sub(
     r'\s+',
     ' ',
     """
-    SELECT * FROM {pg_stat_activity_view}
+    SELECT *, pg_blocking_pids(pid) as blocking_pids FROM {pg_stat_activity_view}
     WHERE coalesce(TRIM(query), '') != ''
     AND query_start IS NOT NULL
     {extra_filters}

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -49,12 +49,36 @@ pg_stat_activity_sample_exclude_keys = {
     'client_port',
 }
 
+# enumeration of the columns we collect
+PG_STAT_ACTIVITY_COLS = [
+    "datid",
+    "datname",
+    "pid",
+    "usesysid",
+    "usename",
+    "application_name",
+    "client_addr",
+    "client_hostname",
+    "client_port",
+    "backend_start",
+    "xact_start",
+    "query_start",
+    "state_change",
+    "wait_event_type",
+    "wait_event",
+    "state",
+    "backend_xid",
+    "backend_xmin",
+    "query",
+    "backend_type",
+]
+
 #
 PG_STAT_ACTIVITY_QUERY = re.sub(
     r'\s+',
     ' ',
     """
-    SELECT *, pg_blocking_pids(pid) as blocking_pids FROM {pg_stat_activity_view}
+    SELECT {pg_stat_activity_cols}, pg_blocking_pids(pid) as blocking_pids FROM {pg_stat_activity_view}
     WHERE coalesce(TRIM(query), '') != ''
     AND query_start IS NOT NULL
     {extra_filters}
@@ -206,11 +230,13 @@ class PostgresStatementSamples(DBMAsyncJob):
         self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)
         return [dict(row) for row in rows]
 
-    def _get_new_pg_stat_activity(self):
+    def _get_new_pg_stat_activity(self, available_activity_columns):
         start_time = time.time()
         extra_filters, params = self._get_extra_filters_and_params(filter_stale_idle_conn=True)
         query = PG_STAT_ACTIVITY_QUERY.format(
-            pg_stat_activity_view=self._config.pg_stat_activity_view, extra_filters=extra_filters
+            pg_stat_activity_cols=', '.join(available_activity_columns),
+            pg_stat_activity_view=self._config.pg_stat_activity_view,
+            extra_filters=extra_filters,
         )
         with self._check._get_db(self._config.dbname).cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
             self._log.debug("Running query [%s] %s", query, params)
@@ -219,6 +245,21 @@ class PostgresStatementSamples(DBMAsyncJob):
         self._report_check_hist_metrics(start_time, len(rows), "get_new_pg_stat_activity")
         self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)
         return rows
+
+    def _get_available_activity_columns(self, all_expected_columns):
+        with self._check._get_db(self._config.dbname).cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
+            cursor.execute(
+                "select * from {pg_stat_activity_view} LIMIT 0".format(
+                    pg_stat_activity_view=self._config.pg_stat_activity_view
+                )
+            )
+            all_columns = set([i[0] for i in cursor.description])
+            available_columns = [c for c in all_expected_columns if c in all_columns]
+            missing_columns = set(all_expected_columns) - set(available_columns)
+            if missing_columns:
+                self._log.debug("missing the following expected columns from pg_stat_activity: %s", missing_columns)
+            self._log.debug("found available pg_stat_activity columns: %s", available_columns)
+        return available_columns
 
     def _filter_and_normalize_statement_rows(self, rows):
         insufficient_privilege_count = 0
@@ -306,7 +347,8 @@ class PostgresStatementSamples(DBMAsyncJob):
 
     def _collect_statement_samples(self):
         start_time = time.time()
-        rows = self._get_new_pg_stat_activity()
+        pg_activity_cols = self._get_available_activity_columns(PG_STAT_ACTIVITY_COLS)
+        rows = self._get_new_pg_stat_activity(pg_activity_cols)
         rows = self._filter_and_normalize_statement_rows(rows)
         event_samples = self._collect_plans(rows)
         submitted_count = 0

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -237,7 +237,8 @@ class PostgresStatementSamples(DBMAsyncJob):
         extra_filters, params = self._get_extra_filters_and_params(filter_stale_idle_conn=True)
         blocking_func = ""
         # minimum version for pg_blocking_pids function is v9.6
-        if self._check.version >= V9_6:
+        # only call pg_blocking_pids as often as we collect activity snapshots
+        if self._check.version >= V9_6 and self._report_activity_event():
             blocking_func = PG_BLOCKING_PIDS_FUNC
         query = PG_STAT_ACTIVITY_QUERY.format(
             pg_stat_activity_cols=', '.join(available_activity_columns),

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -704,6 +704,8 @@ def test_activity_snapshot_collection(
             # pg v < 10 does not have a backend_type column
             # so we shouldn't see this key in our activity rows
             expected_keys.remove('backend_type')
+            if POSTGRES_VERSION == '9.5':
+                expected_keys.remove('blocking_pids')
         for val in expected_keys:
             assert val in bobs_query
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -635,7 +635,7 @@ def test_statement_metadata(
                 'query_signature': 'd9193c18a6f372d8',
                 'statement': "SELECT city FROM pg_sleep(3), persons WHERE city = 'hello'",
             },
-            ["xact_start", "query_start", "pid", "client_port", "client_addr"],
+            ["xact_start", "query_start", "pid", "client_port", "client_addr", "blocking_pids"],
             {
                 'usename': 'bob',
                 'state': 'idle in transaction',

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -635,7 +635,7 @@ def test_statement_metadata(
                 'query_signature': 'd9193c18a6f372d8',
                 'statement': "SELECT city FROM pg_sleep(3), persons WHERE city = 'hello'",
             },
-            ["xact_start", "query_start", "pid", "client_port", "client_addr", "blocking_pids"],
+            ["xact_start", "query_start", "pid", "client_port", "client_addr", "backend_type", "blocking_pids"],
             {
                 'usename': 'bob',
                 'state': 'idle in transaction',
@@ -700,6 +700,10 @@ def test_activity_snapshot_collection(
 
         for key in expected_out:
             assert expected_out[key] == bobs_query[key]
+        if POSTGRES_VERSION.split('.')[0] == "9":
+            # pg v < 10 does not have a backend_type column
+            # so we shouldn't see this key in our activity rows
+            expected_keys.remove('backend_type')
         for val in expected_keys:
             assert val in bobs_query
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Updates the pg_stat_activity query that the agent runs to also collect the blocking pids for a query. Will be an empty `{}` set if there are no pids blocking the query. 

More documentation on this function [exists here](https://pgpedia.info/p/pg_blocking_pids.html#:~:text=pg_blocking_pids()%20is%20a%20system,was%20added%20in%20PostgreSQL%209.6.)

From the docs:
```
Note the following caveats:

1. For parallel queries, the session PID where the query was executed is listed, not that of the parallel worker, meaning there may be duplicate PIDs
2. When a prepared transaction holds a conflicting lock, it will be represented by PID 0

Note that execution of pg_blocking_pids() requires exclusive access to the lock manager's shared state for a short period, which may have performance implications, particularly if frequently called.
```

☝️ Due to this, this change will undergo performance testing in our integration environment to test whether it is safe. 

### Motivation
<!-- What inspired you to submit this pull request? -->

This change allows us to ingest the block pids per query, which we will use to support our new activity view for postgres in the DBM UI. The idea here being, we can show the customer what the query is waiting on and why. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
