### PR TITLE
Update cpu utilization query in default dashboard

### DIFF
--- a/databricks/assets/dashboards/databricks_overview.json
+++ b/databricks/assets/dashboards/databricks_overview.json
@@ -290,7 +290,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:system.cpu.system{$spark_node,$databricks_cluster_name,$app_name}"
+                                            "query": "avg:system.cpu.system{$spark_node,$databricks_cluster_name,$app_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",


### PR DESCRIPTION
### What does this PR do?
Update databricks dashboard widget to display the average of CPU percent Utilization, not the sum

### Motivation
The widget is currently reporting unreasonable values

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
