### PR TITLE
Fix only_custom_queries configuration not honored

### DIFF
--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -40,6 +40,7 @@ class MySQLConfig(object):
         self.statement_samples_config = instance.get('query_samples', instance.get('statement_samples', {})) or {}
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}
         self.min_collection_interval = instance.get('min_collection_interval', 15)
+        self.only_custom_queries = is_affirmative(instance.get('only_custom_queries', False))
         obfuscator_options_config = instance.get('obfuscator_options', {}) or {}
         self.obfuscator_options = {
             # Valid values for this can be found at

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -93,7 +93,6 @@ class MySql(AgentCheck):
         self._agent_hostname = None
         self._is_aurora = None
         self._config = MySQLConfig(self.instance)
-        self._only_custom_queries = is_affirmative(self.instance.get('only_custom_queries', False))
 
         # Create a new connection on every check run
         self._conn = None
@@ -179,7 +178,7 @@ class MySql(AgentCheck):
                 self.check_performance_schema_enabled(db)
 
                 # Metric collection
-                if not self._only_custom_queries:
+                if not self._config.only_custom_queries:
                     self._collect_metrics(db, tags=tags)
                     self._collect_system_metrics(self._config.host, db, tags)
 

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -93,6 +93,7 @@ class MySql(AgentCheck):
         self._agent_hostname = None
         self._is_aurora = None
         self._config = MySQLConfig(self.instance)
+        self._only_custom_queries = is_affirmative(self.instance.get('only_custom_queries', False))
 
         # Create a new connection on every check run
         self._conn = None
@@ -166,8 +167,10 @@ class MySql(AgentCheck):
                     tags = tags + self._get_runtime_aurora_tags(db)
 
                 # Metric collection
-                self._collect_metrics(db, tags=tags)
-                self._collect_system_metrics(self._config.host, db, tags)
+                if not self._only_custom_queries:
+                    self._collect_metrics(db, tags=tags)
+                    self._collect_system_metrics(self._config.host, db, tags)
+
                 if self._config.dbm_enabled:
                     dbm_tags = list(set(self.service_check_tags) | set(tags))
                     self._statement_metrics.run_job_loop(dbm_tags)

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -102,6 +102,7 @@ class MySql(AgentCheck):
         self.check_initializations.append(self._query_manager.compile_queries)
         self.innodb_stats = InnoDBMetrics()
         self.check_initializations.append(self._config.configuration_checks)
+        self.performance_schema_enabled = None
         self._warnings_by_code = {}
         self._statement_metrics = MySQLStatementMetrics(self, self._config, self._get_connection_args())
         self._statement_samples = MySQLStatementSamples(self, self._config, self._get_connection_args())
@@ -135,6 +136,15 @@ class MySql(AgentCheck):
             self._agent_hostname = datadog_agent.get_hostname()
         return self._agent_hostname
 
+    def check_performance_schema_enabled(self, db):
+        if self.performance_schema_enabled is None:
+            with closing(db.cursor()) as cursor:
+                cursor.execute("SHOW VARIABLES LIKE 'performance_schema'")
+                results = dict(cursor.fetchall())
+                self.performance_schema_enabled = self._get_variable_enabled(results, 'performance_schema')
+
+        return self.performance_schema_enabled
+
     def resolve_db_host(self):
         return agent_host_resolver(self._config.host)
 
@@ -165,6 +175,8 @@ class MySql(AgentCheck):
                 self.is_mariadb = self.version.flavor == "MariaDB"
                 if self._get_is_aurora(db):
                     tags = tags + self._get_runtime_aurora_tags(db)
+
+                self.check_performance_schema_enabled(db)
 
                 # Metric collection
                 if not self._only_custom_queries:
@@ -329,7 +341,6 @@ class MySql(AgentCheck):
             self.log.debug("Collecting Galera Metrics.")
             metrics.update(GALERA_VARS)
 
-        self.performance_schema_enabled = self._get_variable_enabled(results, 'performance_schema')
         above_560 = self.version.version_compatible((5, 6, 0))
         if (
             is_affirmative(self._config.options.get('extra_performance_metrics', False))

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -12,6 +12,20 @@ from pkg_resources import parse_version
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.mysql import MySql
+from datadog_checks.mysql.const import (
+    BINLOG_VARS,
+    GALERA_VARS,
+    GROUP_REPLICATION_VARS,
+    INNODB_VARS,
+    OPTIONAL_STATUS_VARS,
+    OPTIONAL_STATUS_VARS_5_6_6,
+    PERFORMANCE_VARS,
+    REPLICA_VARS,
+    SCHEMA_VARS,
+    STATUS_VARS,
+    SYNTHETIC_VARS,
+    VARIABLES_VARS,
+)
 
 from . import common, tags, variables
 from .common import HOST, MYSQL_REPLICATION, MYSQL_VERSION_PARSED, PORT, requires_static_version
@@ -329,6 +343,36 @@ def test_custom_queries(aggregator, instance_custom_queries, dd_run_check):
 
     aggregator.assert_metric('alice.age', value=25, tags=tags.METRIC_TAGS)
     aggregator.assert_metric('bob.age', value=20, tags=tags.METRIC_TAGS)
+
+
+@pytest.mark.usefixtures('dd_environment')
+def test_only_custom_queries(aggregator, dd_run_check, instance_custom_queries):
+    instance_custom_queries['only_custom_queries'] = True
+    check = MySql(common.CHECK_NAME, {}, [instance_custom_queries])
+    dd_run_check(check)
+
+    standard_metric_sets = [
+        STATUS_VARS,
+        VARIABLES_VARS,
+        INNODB_VARS,
+        BINLOG_VARS,
+        OPTIONAL_STATUS_VARS,
+        OPTIONAL_STATUS_VARS_5_6_6,
+        GALERA_VARS,
+        PERFORMANCE_VARS,
+        SCHEMA_VARS,
+        SYNTHETIC_VARS,
+        REPLICA_VARS,
+        GROUP_REPLICATION_VARS,
+    ]
+    for metric_set in standard_metric_sets:
+        for metric_def in metric_set.values():
+            metric = metric_def[0]
+            aggregator.assert_metric(metric, count=0)
+
+    aggregator.assert_metric('alice.age', value=25, tags=tags.METRIC_TAGS)
+    aggregator.assert_metric('bob.age', value=20, tags=tags.METRIC_TAGS)
+    aggregator.assert_all_metrics_covered()
 
 
 @pytest.mark.integration

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -370,6 +370,11 @@ def test_only_custom_queries(aggregator, dd_run_check, instance_custom_queries):
             metric = metric_def[0]
             aggregator.assert_metric(metric, count=0)
 
+    # Internal check metrics are still allowed even if only_custom_queries is enabled
+    internal_metrics = [m for m in aggregator.metric_names if m.startswith('dd.')]
+    for m in internal_metrics:
+        aggregator.assert_metric(m, at_least=0)
+
     aggregator.assert_metric('alice.age', value=25, tags=tags.METRIC_TAGS)
     aggregator.assert_metric('bob.age', value=20, tags=tags.METRIC_TAGS)
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
This fixes support for the [only_custom_queries](https://github.com/DataDog/integrations-core/blob/master/mysql/datadog_checks/mysql/data/conf.yaml.example#L95). Prior to this change, all core mysql metrics were still emitted even with `only_custom_queries` set to `true`.

### Motivation
A customer report.

### Additional Notes
`performance_schema` is being used by the statement metrics job loop when dbm is enabled. Previously, this was gathered with other global status variables in the main metric collection but this had to be extracted now to always be initialized regardless of whether the core integration metrics were collected or not. 

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
