### PR TITLE
Add `metric_patterns` options to filter all metric submission with a list of regexes

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -294,14 +294,18 @@ class AgentCheck(object):
         filters = metric_filters.get(option_name, [])
 
         if not isinstance(filters, list):
-            raise ConfigurationError('Setting `{}` must be an array'.format(option_name))
+            raise ConfigurationError('Setting `{}` of `metric_filters` must be an array'.format(option_name))
 
         metrics_patterns = []
         for i, entry in enumerate(filters, 1):
             if not isinstance(entry, str):
-                raise ConfigurationError('Entry #{} of setting `{}` must be a string'.format(i, option_name))
+                raise ConfigurationError(
+                    'Entry #{} of setting `{}` of `metric_filters` must be a string'.format(i, option_name)
+                )
             if not entry:
-                self.log.debug('Entry #%s of setting `%s` must not be empty, ignoring', i, option_name)
+                self.log.debug(
+                    'Entry #%s of setting `%s` of `metric_filters` must not be empty, ignoring', i, option_name
+                )
                 continue
 
             metrics_patterns.append(entry)

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -291,7 +291,6 @@ class AgentCheck(object):
         if not isinstance(filters, list):
             raise ConfigurationError('Setting `{}` must be an array'.format(option_name))
 
-        metrics_pattern = None
         metrics_patterns = []
         for i, entry in enumerate(filters, 1):
             if not isinstance(entry, str):
@@ -303,8 +302,9 @@ class AgentCheck(object):
             metrics_patterns.append(entry)
 
         if metrics_patterns:
-            metrics_pattern = re.compile('|'.join(metrics_patterns))
-        return metrics_pattern
+            return re.compile('|'.join(metrics_patterns))
+
+        return None
 
     def _get_metric_limiter(self, name, instance=None):
         # type: (str, InstanceType) -> Optional[Limiter]

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -210,10 +210,10 @@ class AgentCheck(object):
         if self.global_metrics_filter is not None:
             try:
                 self.global_metrics_filter = re.compile(self.global_metrics_filter)
-            except re.error:
+            except Exception:
                 raise ConfigurationError(
                     'The pattern `{}` in `global_metrics_filter` must be a valid regex'.format(
-                        self.global_metrics_filter.pattern
+                        self.global_metrics_filter
                     )
                 )
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -204,7 +204,6 @@ class AgentCheck(object):
         self.disable_generic_tags = (
             is_affirmative(self.instance.get('disable_generic_tags', False)) if instance else False
         )
-
         self.debug_metrics = {}
         if self.init_config is not None:
             self.debug_metrics.update(self.init_config.get('debug_metrics', {}))

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -216,12 +216,12 @@ class AgentCheck(object):
         logger = logging.getLogger('{}.{}'.format(__name__, self.name))
         self.log = CheckLoggingAdapter(logger, self)
 
-        metric_filters = self.instance.get('metric_filters', {}) if instance else {}
-        if not isinstance(metric_filters, dict):
-            raise ConfigurationError('Setting `metric_filters` must be a mapping')
+        metric_patterns = self.instance.get('metric_patterns', {}) if instance else {}
+        if not isinstance(metric_patterns, dict):
+            raise ConfigurationError('Setting `metric_patterns` must be a mapping')
 
-        self.exclude_metrics_pattern = self._create_metrics_pattern(metric_filters, 'exclude')
-        self.include_metrics_pattern = self._create_metrics_pattern(metric_filters, 'include')
+        self.exclude_metrics_pattern = self._create_metrics_pattern(metric_patterns, 'exclude')
+        self.include_metrics_pattern = self._create_metrics_pattern(metric_patterns, 'include')
 
         # TODO: Remove with Agent 5
         # Set proxy settings
@@ -290,21 +290,21 @@ class AgentCheck(object):
         if not PY2:
             self.check_initializations.append(self.load_configuration_models)
 
-    def _create_metrics_pattern(self, metric_filters, option_name):
-        filters = metric_filters.get(option_name, [])
+    def _create_metrics_pattern(self, metric_patterns, option_name):
+        all_patterns = metric_patterns.get(option_name, [])
 
-        if not isinstance(filters, list):
-            raise ConfigurationError('Setting `{}` of `metric_filters` must be an array'.format(option_name))
+        if not isinstance(all_patterns, list):
+            raise ConfigurationError('Setting `{}` of `metric_patterns` must be an array'.format(option_name))
 
         metrics_patterns = []
-        for i, entry in enumerate(filters, 1):
+        for i, entry in enumerate(all_patterns, 1):
             if not isinstance(entry, str):
                 raise ConfigurationError(
-                    'Entry #{} of setting `{}` of `metric_filters` must be a string'.format(i, option_name)
+                    'Entry #{} of setting `{}` of `metric_patterns` must be a string'.format(i, option_name)
                 )
             if not entry:
                 self.log.debug(
-                    'Entry #%s of setting `%s` of `metric_filters` must not be empty, ignoring', i, option_name
+                    'Entry #%s of setting `%s` of `metric_patterns` must not be empty, ignoring', i, option_name
                 )
                 continue
 

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -205,6 +205,18 @@ class AgentCheck(object):
             is_affirmative(self.instance.get('disable_generic_tags', False)) if instance else False
         )
 
+        self.debug_metrics = {}
+        if self.init_config is not None:
+            self.debug_metrics.update(self.init_config.get('debug_metrics', {}))
+        if self.instance is not None:
+            self.debug_metrics.update(self.instance.get('debug_metrics', {}))
+
+        # `self.hostname` is deprecated, use `datadog_agent.get_hostname()` instead
+        self.hostname = datadog_agent.get_hostname()  # type: str
+
+        logger = logging.getLogger('{}.{}'.format(__name__, self.name))
+        self.log = CheckLoggingAdapter(logger, self)
+
         exclude_metrics_filters = self.instance.get('exclude_metrics_filters', []) if instance else []
 
         if not isinstance(exclude_metrics_filters, list):
@@ -253,18 +265,6 @@ class AgentCheck(object):
 
         if include_metrics_patterns:
             self.include_metrics_pattern = re.compile('|'.join(include_metrics_patterns))
-
-        self.debug_metrics = {}
-        if self.init_config is not None:
-            self.debug_metrics.update(self.init_config.get('debug_metrics', {}))
-        if self.instance is not None:
-            self.debug_metrics.update(self.instance.get('debug_metrics', {}))
-
-        # `self.hostname` is deprecated, use `datadog_agent.get_hostname()` instead
-        self.hostname = datadog_agent.get_hostname()  # type: str
-
-        logger = logging.getLogger('{}.{}'.format(__name__, self.name))
-        self.log = CheckLoggingAdapter(logger, self)
 
         # TODO: Remove with Agent 5
         # Set proxy settings

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -204,6 +204,8 @@ class AgentCheck(object):
         self.disable_generic_tags = (
             is_affirmative(self.instance.get('disable_generic_tags', False)) if instance else False
         )
+
+        self.global_metrics_filter = self.instance.get('global_metrics_filter') if instance else None
         self.debug_metrics = {}
         if self.init_config is not None:
             self.debug_metrics.update(self.init_config.get('debug_metrics', {}))
@@ -617,6 +619,11 @@ class AgentCheck(object):
                 context = self._context_uid(mtype, name, tags, hostname)
                 if self.metric_limiter.is_reached(context):
                     return
+
+        if self.global_metrics_filter is not None:
+            collect_metric = re.match(self.global_metrics_filter, name)
+            if not collect_metric:
+                return
 
         try:
             value = float(value)

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -609,6 +609,11 @@ class AgentCheck(object):
         if hostname is None:
             hostname = ''
 
+        if self.global_metrics_filter is not None:
+            collect_metric = re.match(self.global_metrics_filter, name)
+            if not collect_metric:
+                return
+
         if self.metric_limiter:
             if mtype in ONE_PER_CONTEXT_METRIC_TYPES:
                 # Fast path for gauges, rates, monotonic counters, assume one set of tags per call
@@ -619,11 +624,6 @@ class AgentCheck(object):
                 context = self._context_uid(mtype, name, tags, hostname)
                 if self.metric_limiter.is_reached(context):
                     return
-
-        if self.global_metrics_filter is not None:
-            collect_metric = re.match(self.global_metrics_filter, name)
-            if not collect_metric:
-                return
 
         try:
             value = float(value)

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -749,13 +749,6 @@ class TestTags:
                 'Entry #1 of setting `include_metrics_filters` must not be empty, ignoring',
                 id='empty include',
             ),
-            pytest.param(
-                ['metric_one'],
-                ['metric_one'],
-                'Metric `metric_one` is set in both `exclude_metrics_filters` and'
-                ' `include_metrics_filters`. Excluding metric.',
-                id='duplicate',
-            ),
         ],
     )
     def test_metrics_filter_warnings(self, caplog, exclude_metrics_filters, include_metrics_filters, expected_log):

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -665,6 +665,12 @@ class TestTags:
             pytest.param([], [r'^my_(me|test)tric*'], ['my_metric', 'my_metric_count'], id='include multiple matches'),
             pytest.param([r'my_metric_count'], [r'my_metric*'], ['my_metric', 'test.my_metric1'], id='match both'),
             pytest.param([r'my_metric_count'], [r'my_metric_count'], [], id='duplicate'),
+            pytest.param(
+                [],
+                ['metric'],
+                ['my_metric', 'my_metric_count', 'test.my_metric1'],
+                id='include multiple matches inside',
+            ),
             pytest.param(['my_metric_count'], ['hello'], ['hello'], id='include exclude'),
             pytest.param(
                 [r'testing'], [r'.*'], ['my_metric', 'my_metric_count', 'hello', 'test.my_metric1'], id='include all'

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -673,6 +673,13 @@ class TestTags:
             aggregator.assert_metric(metric_name, count=0)
         aggregator.assert_service_check('test.can_check', status=AgentCheck.OK)
 
+    def test_global_metrics_filter_invalid(self, aggregator):
+        instance = {'global_metrics_filter': r'['}
+        with pytest.raises(Exception) as conf_error:
+            AgentCheck('myintegration', {}, [instance])
+
+        assert 'The pattern `[` in `global_metrics_filter` must be a valid regex' in str(conf_error)
+
 
 class LimitedCheck(AgentCheck):
     DEFAULT_METRIC_LIMIT = 10

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -683,8 +683,20 @@ class TestTags:
     @pytest.mark.parametrize(
         "exclude_metrics_filters, include_metrics_filters, expected_error",
         [
-            pytest.param('hello', [], r'^Setting `exclude_metrics_filters` must be an array', id='exclude not list'),
-            pytest.param([], 'hello', r'^Setting `include_metrics_filters` must be an array', id='include not list'),
+            pytest.param('metric', [], r'^Setting `exclude_metrics_filters` must be an array', id='exclude not list'),
+            pytest.param([], 'metric', r'^Setting `include_metrics_filters` must be an array', id='include not list'),
+            pytest.param(
+                ['metric_one', 1000],
+                [],
+                r'^Entry #2 of setting `exclude_metrics_filters` must be a string',
+                id='exclude bad element',
+            ),
+            pytest.param(
+                [],
+                [10, 'metric_one'],
+                r'^Entry #1 of setting `include_metrics_filters` must be a string',
+                id='include bad element',
+            ),
         ],
     )
     def test_metrics_filter_invalid(self, aggregator, exclude_metrics_filters, include_metrics_filters, expected_error):

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -712,18 +712,22 @@ class TestTags:
     @pytest.mark.parametrize(
         "exclude_metrics_filters, include_metrics_filters, expected_error",
         [
-            pytest.param('metric', [], r'^Setting `exclude_metrics_filters` must be an array', id='exclude not list'),
-            pytest.param([], 'metric', r'^Setting `include_metrics_filters` must be an array', id='include not list'),
+            pytest.param(
+                'metric', [], r'^Setting `exclude` of `metric_filters` must be an array', id='exclude not list'
+            ),
+            pytest.param(
+                [], 'metric', r'^Setting `include` of `metric_filters` must be an array', id='include not list'
+            ),
             pytest.param(
                 ['metric_one', 1000],
                 [],
-                r'^Entry #2 of setting `exclude_metrics_filters` must be a string',
+                r'^Entry #2 of setting `exclude` of `metric_filters` must be a string',
                 id='exclude bad element',
             ),
             pytest.param(
                 [],
                 [10, 'metric_one'],
-                r'^Entry #1 of setting `include_metrics_filters` must be a string',
+                r'^Entry #1 of setting `include` of `metric_filters` must be a string',
                 id='include bad element',
             ),
         ],
@@ -744,13 +748,13 @@ class TestTags:
             pytest.param(
                 [''],
                 [],
-                'Entry #1 of setting `exclude_metrics_filters` must not be empty, ignoring',
+                'Entry #1 of setting `exclude` of `metric_filters` must not be empty, ignoring',
                 id='empty exclude',
             ),
             pytest.param(
                 [],
                 [''],
-                'Entry #1 of setting `include_metrics_filters` must not be empty, ignoring',
+                'Entry #1 of setting `include` of `metric_filters` must not be empty, ignoring',
                 id='empty include',
             ),
         ],

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -691,8 +691,10 @@ class TestTags:
     )
     def test_metrics_filters(self, exclude_metrics_filters, include_metrics_filters, expected_metrics, aggregator):
         instance = {
-            'exclude_metrics_filters': exclude_metrics_filters,
-            'include_metrics_filters': include_metrics_filters,
+            'metric_filters': {
+                'exclude': exclude_metrics_filters,
+                'include': include_metrics_filters,
+            }
         }
         check = AgentCheck('myintegration', {}, [instance])
         check.gauge('my_metric', 0)
@@ -728,8 +730,10 @@ class TestTags:
     )
     def test_metrics_filter_invalid(self, aggregator, exclude_metrics_filters, include_metrics_filters, expected_error):
         instance = {
-            'exclude_metrics_filters': exclude_metrics_filters,
-            'include_metrics_filters': include_metrics_filters,
+            'metric_filters': {
+                'exclude': exclude_metrics_filters,
+                'include': include_metrics_filters,
+            }
         }
         with pytest.raises(Exception, match=expected_error):
             AgentCheck('myintegration', {}, [instance])
@@ -753,8 +757,10 @@ class TestTags:
     )
     def test_metrics_filter_warnings(self, caplog, exclude_metrics_filters, include_metrics_filters, expected_log):
         instance = {
-            'exclude_metrics_filters': exclude_metrics_filters,
-            'include_metrics_filters': include_metrics_filters,
+            'metric_filters': {
+                'exclude': exclude_metrics_filters,
+                'include': include_metrics_filters,
+            }
         }
         caplog.clear()
         caplog.set_level(logging.DEBUG)

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -691,7 +691,7 @@ class TestTags:
     )
     def test_metrics_filters(self, exclude_metrics_filters, include_metrics_filters, expected_metrics, aggregator):
         instance = {
-            'metric_filters': {
+            'metric_patterns': {
                 'exclude': exclude_metrics_filters,
                 'include': include_metrics_filters,
             }
@@ -713,28 +713,28 @@ class TestTags:
         "exclude_metrics_filters, include_metrics_filters, expected_error",
         [
             pytest.param(
-                'metric', [], r'^Setting `exclude` of `metric_filters` must be an array', id='exclude not list'
+                'metric', [], r'^Setting `exclude` of `metric_patterns` must be an array', id='exclude not list'
             ),
             pytest.param(
-                [], 'metric', r'^Setting `include` of `metric_filters` must be an array', id='include not list'
+                [], 'metric', r'^Setting `include` of `metric_patterns` must be an array', id='include not list'
             ),
             pytest.param(
                 ['metric_one', 1000],
                 [],
-                r'^Entry #2 of setting `exclude` of `metric_filters` must be a string',
+                r'^Entry #2 of setting `exclude` of `metric_patterns` must be a string',
                 id='exclude bad element',
             ),
             pytest.param(
                 [],
                 [10, 'metric_one'],
-                r'^Entry #1 of setting `include` of `metric_filters` must be a string',
+                r'^Entry #1 of setting `include` of `metric_patterns` must be a string',
                 id='include bad element',
             ),
         ],
     )
     def test_metrics_filter_invalid(self, aggregator, exclude_metrics_filters, include_metrics_filters, expected_error):
         instance = {
-            'metric_filters': {
+            'metric_patterns': {
                 'exclude': exclude_metrics_filters,
                 'include': include_metrics_filters,
             }
@@ -748,20 +748,20 @@ class TestTags:
             pytest.param(
                 [''],
                 [],
-                'Entry #1 of setting `exclude` of `metric_filters` must not be empty, ignoring',
+                'Entry #1 of setting `exclude` of `metric_patterns` must not be empty, ignoring',
                 id='empty exclude',
             ),
             pytest.param(
                 [],
                 [''],
-                'Entry #1 of setting `include` of `metric_filters` must not be empty, ignoring',
+                'Entry #1 of setting `include` of `metric_patterns` must not be empty, ignoring',
                 id='empty include',
             ),
         ],
     )
     def test_metrics_filter_warnings(self, caplog, exclude_metrics_filters, include_metrics_filters, expected_log):
         instance = {
-            'metric_filters': {
+            'metric_patterns': {
                 'exclude': exclude_metrics_filters,
                 'include': include_metrics_filters,
             }

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -652,7 +652,13 @@ class TestTags:
         "exclude_metrics_filters, include_metrics_filters, expected_metrics",
         [
             pytest.param(['hello'], [], ['my_metric', 'my_metric_count', 'test.my_metric1'], id='exclude string'),
-            pytest.param([r'my_metric_*'], [], ['hello'], id='exclude multiple matches'),
+            pytest.param([r'my_metric_*'], [], ['hello'], id='exclude multiple matches glob'),
+            pytest.param(
+                [],
+                [r'my_metricw*'],
+                ['my_metric', 'my_metric_count', 'test.my_metric1'],
+                id='include multiple matches glob',
+            ),
             pytest.param(
                 [r'my_metrics'],
                 [],


### PR DESCRIPTION
### What does this PR do?
Adds instance-level options to the base check to filter all metric submission with a regex. The main option is `metric_patterns` with two sub-options are `exclude` and `include`. 

### Motivation
Allow users to have more control over what metrics are submitted for each integration

### Additional Notes
- These behave very similarly to `exclude_labels` and `include_labels`, where `exclude` takes precedence over `include`  
- These can either be strings or regexes.
- They also use the same regex construction as `exclude_metrics`
- The namespace is included in the regex
- I could add a debug log line if a metric is skipped, but that would be noisy

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
