### PR TITLE
Add more error handling when detecting typos

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -442,7 +442,10 @@ class AgentCheck(object):
             raw_shared_config.update(intg_shared_config)
 
             shared_config = self.load_configuration_model(package_path, 'SharedConfig', raw_shared_config)
-            self.log_typos_in_options(intg_shared_config, shared_config, 'init_config')
+            try:
+                self.log_typos_in_options(intg_shared_config, shared_config, 'init_config')
+            except Exception as e:
+                self.log.debug("Failed to detect typos in `init_config` section: %s", e)
             if shared_config is not None:
                 self._config_model_shared = shared_config
 
@@ -452,8 +455,10 @@ class AgentCheck(object):
             raw_instance_config.update(intg_instance_config)
 
             instance_config = self.load_configuration_model(package_path, 'InstanceConfig', raw_instance_config)
-            self.log_typos_in_options(intg_instance_config, instance_config, 'instances')
-
+            try:
+                self.log_typos_in_options(intg_instance_config, instance_config, 'instances')
+            except Exception as e:
+                self.log.debug("Failed to detect typos in `instances` section: %s", e)
             if instance_config is not None:
                 self._config_model_instance = instance_config
 


### PR DESCRIPTION
### What does this PR do?
Add more error handling when detecting typos

### Motivation
Avoid issues like https://github.com/DataDog/integrations-core/pull/11482 addressed where checks can't properly load when detecting typos. Since the function is only logging a warning it's not essential and ok to swallow the exception

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
