### PR TITLE
remove aggregation by SQL text from query stats query

### DIFF
--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -295,7 +295,6 @@ def test_statement_metadata(
     query = '''
     -- Test comment
     select * from sys.databases'''
-    query_signature = '6d1d070f9b6c5647'
 
     def _run_query():
         bob_conn.execute_with_retries(query)
@@ -314,7 +313,9 @@ def test_statement_metadata(
     dbm_samples = aggregator.get_event_platform_events("dbm-samples")
     assert dbm_samples, "should have collected at least one sample"
 
-    matching = [s for s in dbm_samples if s['db']['query_signature'] == query_signature and s['dbm_type'] == 'plan']
+    matching = [
+        s for s in dbm_samples if 'select * from sys.databases' in s['db']['statement'] and s['dbm_type'] == 'plan'
+    ]
     assert len(matching) == 1
 
     sample = matching[0]
@@ -325,7 +326,7 @@ def test_statement_metadata(
     dbm_metrics = aggregator.get_event_platform_events("dbm-metrics")
     assert len(dbm_metrics) == 1
     metric = dbm_metrics[0]
-    matching_metrics = [m for m in metric['sqlserver_rows'] if m['query_signature'] == query_signature]
+    matching_metrics = [m for m in metric['sqlserver_rows'] if 'select * from sys.databases' in m['text']]
     assert len(matching_metrics) == 1
     metric = matching_metrics[0]
     assert metric['dd_tables'] == expected_metadata_payload['tables']


### PR DESCRIPTION
### What does this PR do?

In some situations there can be many unique query texts per `query_hash, query_plan_hash, ...`. They often differ only by their parameters (i.e. `select * from foo where id=1` and `select *f rom foo where id=2`) so there is no reason to be aggregating by text when in the agent code we'll be normalizing the text and aggregating it together anyway. Not only is this unnecessary but it can also be very expensive, causing the latency of the query to increase by several times when there are many unique query texts.

Now we update to first do the aggregation only by `query_hash, query_plan_hash` (and optionally `user` and `database`) and then look up the sql text by `plan_handle`.

### Motivation

Improve query performance. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
