### PR TITLE
Fix passing in username and password as options

### DIFF
--- a/mongo/datadog_checks/mongo/utils.py
+++ b/mongo/datadog_checks/mongo/utils.py
@@ -27,7 +27,13 @@ def build_connection_string(hosts, scheme, username=None, password=None, databas
         netloc = host
 
     path_params = ""
-    query = urlencode(options or {})
+    url_options = dict(options)
+    if "username" in url_options:
+        url_options.pop("username")
+    if "password" in url_options:
+        url_options.pop("password")
+
+    query = urlencode(url_options or {})
     fragment = ""
 
     return urlunparse([scheme, netloc, path, path_params, query, fragment])

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -500,3 +500,17 @@ def test_standalone(instance_integration, aggregator, check, dd_run_check):
         check_submission_type=True,
     )
     assert len(aggregator._events) == 0
+
+
+def test_user_pass_options(check, instance_user, dd_run_check):
+    instance_user['options'] = {
+        'authSource': '$external',
+        'authMechanism': 'PLAIN',
+        'username': instance_user['username'],
+        'password': instance_user['password'],
+    }
+    check = check(instance_user)
+
+    with mock_pymongo("standalone"):
+        # ensure we don't get a pymongo exception saying `Unknown option username`
+        dd_run_check(check, extract_message=True)


### PR DESCRIPTION
### What does this PR do?
Allow passing in username and password as options 

### Motivation
Some authentication methods require a username and/or password when initializing the client in pymongo.
https://github.com/mongodb/mongo-python-driver/blob/master/pymongo/auth.py#L105

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
