### PR TITLE
Update documented library version to install

### DIFF
--- a/ibm_db2/README.md
+++ b/ibm_db2/README.md
@@ -30,7 +30,7 @@ For Agent versions <= 6.11:
 "C:\Program Files\Datadog\Datadog Agent\embedded\python.exe" -m pip install ibm_db==3.0.1
 ```
 
-For Agent versions >= 6.12:
+For Agent versions >= 6.12 and < 7.0:
 
 ```text
 "C:\Program Files\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe" -m pip install ibm_db==3.0.1

--- a/ibm_db2/README.md
+++ b/ibm_db2/README.md
@@ -36,6 +36,12 @@ For Agent versions >= 6.12:
 "C:\Program Files\Datadog\Datadog Agent\embedded<PYTHON_MAJOR_VERSION>\python.exe" -m pip install ibm_db==3.0.1
 ```
 
+For Agent versions >= 7.0:
+
+```text
+"C:\Program Files\Datadog\Datadog Agent\embedded3\python.exe" -m pip install ibm_db==3.1.0
+```
+
 On Linux there may be need for XML functionality. If you encounter errors during
 the build process, install `libxslt-dev` (or `libxslt-devel` for RPM).
 


### PR DESCRIPTION
### What does this PR do?
Updates the docs to instruct users to install `ibm_db` version `3.1.0` for  python3 

### Motivation
Follow up to https://github.com/DataDog/integrations-core/pull/10331, `ibm_db` `3.0.1` is not compatible with python3. We are now using version `3.0.1` in our testing environment.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
