### PR TITLE
Update disabling sidecar injection instructions

### DIFF
--- a/istio/README.md
+++ b/istio/README.md
@@ -76,7 +76,30 @@ Set the `use_openmetrics` configuration option to `false` to use the OpenMetrics
 
 If you are installing the [Datadog Agent in a container][10], Datadog recommends that you first disable Istio's sidecar injection.
 
-Add the `sidecar.istio.io/inject: "false"` annotation to the `datadog-agent` DaemonSet:
+_Istio versions >= 1.10:_
+
+Add the `sidecar.istio.io/inject: "false"` _label_ to the `datadog-agent` DaemonSet:
+
+```yaml
+...
+spec:
+   ...
+  template:
+    metadata:
+      labels:
+        sidecar.istio.io/inject: "false"
+     ...
+```
+
+This can also be done with the `kubectl patch` command.
+
+```text
+kubectl patch daemonset datadog-agent -p '{"spec":{"template":{"metadata":{"labels":{"sidecar.istio.io/inject":"false"}}}}}'
+```
+
+_Istio versions <= 1.9:_ 
+
+Add the `sidecar.istio.io/inject: "false"` _annotation_ to the `datadog-agent` DaemonSet:
 
 ```yaml
 ...
@@ -89,7 +112,7 @@ spec:
      ...
 ```
 
-This can also be done with the `kubectl patch` command.
+Using the `kubectl patch` command:
 
 ```text
 kubectl patch daemonset datadog-agent -p '{"spec":{"template":{"metadata":{"annotations":{"sidecar.istio.io/inject":"false"}}}}}'


### PR DESCRIPTION
### What does this PR do?
Adds updated configuration instructions for disabling sidecar injection in Istio versions 1.10+. Since Istio version 1.10, `sidecar.istio.io/inject` should be configured as a label, not an annotation. 

It is still supported as an [annotation](https://istio.io/latest/docs/reference/config/annotations/), but the behavior has changed:

https://istio.io/latest/news/releases/1.10.x/announcing-1.10/upgrade-notes/#sidecar-injector-changes

### Motivation
https://github.com/DataDog/integrations-core/issues/11501

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
