### PR TITLE
Fix fallback case in trello card assignment algorithm

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector_team.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector_team.py
@@ -35,10 +35,10 @@ class TesterSelectorTeam:
         exclude_testers.add(author)
 
         # find a tester who is neither the author nor a reviewer
-        tester = self.__select_testers(lambda t: t in exclude_testers)
+        tester = self.__select_testers(user_excluded_fct=lambda t: t in exclude_testers)
         if tester is None:
             # find a tester who is not the author
-            tester = self.__select_testers(lambda t: t == author)
+            tester = self.__select_testers(user_excluded_fct=lambda t: t == author)
 
         if tester is not None:
             self.__prs_by_tester[tester].append(pr_num)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector_team.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector_team.py
@@ -38,7 +38,7 @@ class TesterSelectorTeam:
         tester = self.__select_testers(lambda t: t in exclude_testers)
         if tester is None:
             # find a tester who is not the author
-            tester = self.__select_testers(lambda t: t != author)
+            tester = self.__select_testers(lambda t: t == author)
 
         if tester is not None:
             self.__prs_by_tester[tester].append(pr_num)


### PR DESCRIPTION
### What does this PR do?

This PR fixes the fallback case in the trello card assignment algorithm.
The function passed to `__select_testers` is an exclusion filter and we used to pass a function that excluded everyone except the author.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
