### PR TITLE
Handle the case in models sync where a file does not have a license header

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/models.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/models.py
@@ -37,6 +37,8 @@ from ..console import (
     echo_success,
 )
 
+LICENSE_HEADER = "(C) Datadog, Inc."
+
 
 def standardize_new_lines(lines):
     # If a new line is at the start or end of a line, remove it and add it to the list
@@ -176,7 +178,8 @@ def models(ctx, check, sync, verbose):
                 expected_model_file_lines.extend(generated_model_file_lines)
 
             # If we're re-generating a file, we should ensure we do not change the license date
-            if len(current_model_file_lines) > 0:
+            # We also want to handle the case where there is no license header
+            if len(current_model_file_lines) > 0 and LICENSE_HEADER in current_model_file_lines[0]:
                 expected_model_file_lines[0] = current_model_file_lines[0]
 
             if not current_model_file_lines or not content_matches(current_model_file_lines, expected_model_file_lines):


### PR DESCRIPTION
### What does this PR do?
In `ddev validate models -s`, handle the case where a generated file does not have a license file

### Motivation
We saw this happen with foundationdb
 
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
