### PR TITLE
Updates Broken Doc Link in Win 32 event log

### DIFF
--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -218,4 +218,4 @@ Need help? Contact [Datadog support][7].
 [10]: https://www.datadoghq.com/blog/collect-windows-server-2012-metrics
 [11]: https://www.datadoghq.com/blog/windows-server-monitoring
 [12]: https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile
-[13]: https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc722404(v=ws.11)
+[13]: https://docs.microsoft.com/en-us/windows/win32/eventlog/event-logging


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fixes 404 URL (https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/cc722404(v=ws.11) to https://docs.microsoft.com/en-us/windows/win32/eventlog/event-logging.

### Motivation
<!-- What inspired you to submit this pull request? -->

Slack

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
