### PR TITLE
Don't ignore the last character of lines when validating ASCII

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/readmes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/readmes.py
@@ -141,9 +141,6 @@ def validate_readme(integration, repo, display_queue, files_failed, readme_count
 def get_ascii_enforcement_error_lines(contents):
     errors_lines = []
     for i, line in enumerate(contents.splitlines()):
-        # Ignore new line
-        line = line[:-1]
-
         invalid_code_unit_indices = []
         indicator_code_units = []
         for code_unit in line:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/readmes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/readmes.py
@@ -141,6 +141,8 @@ def validate_readme(integration, repo, display_queue, files_failed, readme_count
 def get_ascii_enforcement_error_lines(contents):
     errors_lines = []
     for i, line in enumerate(contents.splitlines()):
+        # Don't print newlines
+        line = line.rstrip('\n')
         invalid_code_unit_indices = []
         indicator_code_units = []
         for code_unit in line:


### PR DESCRIPTION
### What does this PR do?
Don't ignore the last character of lines when validating ASCII

### Motivation
QA week

### Additional Notes
Before it didn't catch ascii characters at the end of the line, and removing this line doesn't cause false positives with new lines
 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
