### PR TITLE
Ignore errors from unmet Python version requirements

### DIFF
--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -87,7 +87,16 @@ def download(package, version=None, root_layout_type='core'):
     if version:
         cmd.extend(['--version', version])
     cmd.append(package)
-    out = subprocess.check_output(cmd)
+
+    try:
+        out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        if b'datadog_checks.downloader.exceptions.PythonVersionMismatch' in e.output:
+            log.debug('unmet Python version requirements')
+            return
+        else:
+            raise
+
     log.debug(' '.join(cmd))
     log.debug(out)
     log.debug('')


### PR DESCRIPTION
### Motivation

Expected situation now that we properly indicate Python constraints: https://github.com/DataDog/integrations-core/blob/9027bd465978ddd437e093feaeaaa4095605bbef/avi_vantage/pyproject.toml#L13