### PR TITLE
Apply namespace exclusion rules in cadvisor and summary metrics

### DIFF
--- a/kubelet/datadog_checks/kubelet/cadvisor.py
+++ b/kubelet/datadog_checks/kubelet/cadvisor.py
@@ -141,6 +141,10 @@ class CadvisorScraper(object):
         if pod is not None and is_static_pending_pod(pod):
             in_static_pod = True
 
+        namespace = pod.get('metadata', {}).get('namespace')
+        if pod_list_utils.is_namespace_excluded(namespace):
+            return
+
         # Let's see who we have here
         if is_pod:
             tags = tags_for_pod(pod_uid, tagger.HIGH)

--- a/kubelet/datadog_checks/kubelet/summary.py
+++ b/kubelet/datadog_checks/kubelet/summary.py
@@ -32,6 +32,9 @@ class SummaryScraperMixin(object):
                 self.log.warning("Got incomplete results from '/stats/summary', missing data for POD: %s", pod)
                 continue
 
+            if pod_list_utils.is_namespace_excluded(pod_namespace):
+                continue
+
             self._report_pod_stats(
                 pod_namespace, pod_name, pod_uid, pod, pod_list_utils, instance_tags, main_stats_source
             )

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -1054,6 +1054,19 @@ def test_process_stats_summary_as_source(monkeypatch, aggregator, tagger):
     )
 
 
+def test_process_stats_summary_as_source_filtering_by_namespace(monkeypatch):
+    check = KubeletCheck('kubelet', {}, [{}])
+    monkeypatch.setattr(check, 'gauge', mock.Mock())
+    monkeypatch.setattr(check, 'rate', mock.Mock())
+    pod_list_utils = PodListUtils(json.loads(mock_from_file('pods_windows.json')))
+    stats = json.loads(mock_from_file('stats_summary_windows.json'))
+
+    # Namespace is excluded, so it shouldn't report any metrics
+    monkeypatch.setattr(pod_list_utils, 'is_namespace_excluded', mock.Mock(return_value=True))
+    check.process_stats_summary(pod_list_utils, stats, [], True)
+    assert len(check.gauge.mock_calls) == 0 and len(check.rate.mock_calls) == 0
+
+
 def test_kubelet_check_disable_summary_rates(monkeypatch, aggregator):
     check = KubeletCheck('kubelet', {}, [{'enabled_rates': ['*unsupported_regex*']}])
     pod_list_utils = PodListUtils(json.loads(mock_from_file('pods_windows.json')))


### PR DESCRIPTION
### What does this PR do?

This PR filters kubelet metrics according to the `DD_CONTAINER_EXCLUDE` option.

This is similar to my previous PR https://github.com/DataDog/integrations-core/pull/11512

In this PR, we make sure that metrics coming from the cadvisor and the summary endpoint are also correctly filtered when `DD_CONTAINER_EXCLUDE` references a kubernetes namespace.

Using the default configuration, `kubernetes.ephemental.storage.usage`, `kubernetes.filesystem.usage`, and `kubernetes.filesystem.usage_pct` were not correctly filtered. With this change, they should be.

After this change, the only metrics not filtered according to `DD_CONTAINER_EXCLUDE` should be the ones about containers/pods running, stopped, etc. As mentioned in [the docs](https://docs.datadoghq.com/agent/docker/?tab=standard#ignore-containers).

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
