### PR TITLE
Fix service check failures on auto discovered dbs failing full check execution

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -187,7 +187,9 @@ class Connection(object):
 
             self.service_check_handler(AgentCheck.CRITICAL, host, database, message, is_default=is_default)
 
-            raise_from(SQLConnectionError(message), None)
+            # Only raise exception on the default instance database
+            if is_default:
+                raise_from(SQLConnectionError(message), None)
 
     def _setup_new_connection(self, rawconn):
         with rawconn.cursor() as cursor:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -582,7 +582,12 @@ class SQLServer(AgentCheck):
             if self.autodiscovery and self.autodiscovery_db_service_check:
                 for db_name in self.databases:
                     if db_name != self.connection.DEFAULT_DATABASE:
-                        self.connection.check_database_conns(db_name)
+                        try:
+                            self.connection.check_database_conns(db_name)
+                        except Exception as e:
+                            # service_check errors on auto discovered databases should not abort the check
+                            self.log.warning("failed service check for auto discovered database: %s", e)
+
             if self.dbm_enabled:
                 self.statement_metrics.run_job_loop(self.tags)
                 self.activity.run_job_loop(self.tags)

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -23,6 +23,12 @@ GO
 CREATE DATABASE datadog_test;
 GO
 
+-- create an offline database to have an unavailable database to test with
+CREATE DATABASE unavailable_db;
+GO
+ALTER DATABASE unavailable_db SET OFFLINE;
+GO
+
 -- Create test database for integration tests
 -- only bob and fred have read/write access to this database
 USE datadog_test;

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -69,6 +69,12 @@ EXEC sp_addrolemember 'db_datawriter', 'bob'
 EXEC sp_addrolemember 'db_datareader', 'fred'
 GO
 
+-- create an offline database to have an unavailable database to test with
+CREATE DATABASE unavailable_db;
+GO
+ALTER DATABASE unavailable_db SET OFFLINE;
+GO
+
 -- This table is pronounced "things" except we've replaced "th" with the greek lower case "theta" to ensure we
 -- correctly support unicode throughout the integration.
 CREATE TABLE datadog_test.dbo.ϑings (id int, name varchar(255));

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -69,6 +69,12 @@ EXEC sp_addrolemember 'db_datawriter', 'bob'
 EXEC sp_addrolemember 'db_datareader', 'fred'
 GO
 
+-- create an offline database to have an unavailable database to test with
+CREATE DATABASE unavailable_db;
+GO
+ALTER DATABASE unavailable_db SET OFFLINE;
+GO
+
 -- This table is pronounced "things" except we've replaced "th" with the greek lower case "theta" to ensure we
 -- correctly support unicode throughout the integration.
 CREATE TABLE datadog_test.dbo.ϑings (id int, name varchar(255));

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -32,6 +32,12 @@ EXEC sp_addrolemember 'db_datareader', 'fred'
 EXEC sp_addrolemember 'db_datawriter', 'bob'
 GO
 
+-- create an offline database to have an unavailable database to test with
+CREATE DATABASE unavailable_db;
+GO
+ALTER DATABASE unavailable_db SET OFFLINE;
+GO
+
 -- create test procedure for metrics loading feature
 USE master;
 GO

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -33,6 +33,12 @@ EXEC sp_addrolemember 'db_datareader', 'fred'
 EXEC sp_addrolemember 'db_datawriter', 'bob'
 GO
 
+-- create an offline database to have an unavailable database to test with
+CREATE DATABASE unavailable_db;
+GO
+ALTER DATABASE unavailable_db SET OFFLINE;
+GO
+
 -- create test procedure for metrics loading feature
 USE master;
 GO

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -155,7 +155,7 @@ def test_autodiscovery_database_metrics(aggregator, dd_run_check, instance_autod
 def test_autodiscovery_db_service_checks(
     aggregator, dd_run_check, instance_autodiscovery, service_check_enabled, default_count, extra_count
 ):
-    instance_autodiscovery['autodiscovery_include'] = ['master', 'msdb']
+    instance_autodiscovery['autodiscovery_include'] = ['master', 'msdb', 'unavailable_db']
     instance_autodiscovery['autodiscovery_db_service_check'] = service_check_enabled
     check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
     dd_run_check(check)
@@ -179,6 +179,14 @@ def test_autodiscovery_db_service_checks(
         count=extra_count,
         tags=['db:msdb', 'optional:tag1', 'sqlserver_host:localhost,1433'],
         status=SQLServer.OK,
+    )
+    # unavailable_db is an 'offline' database which prevents connections so we expect this service check to be
+    # critical but not cause a failure of the check
+    aggregator.assert_service_check(
+        'sqlserver.database.can_connect',
+        count=extra_count,
+        tags=['db:unavailable_db', 'optional:tag1', 'sqlserver_host:localhost,1433'],
+        status=SQLServer.CRITICAL,
     )
 
 


### PR DESCRIPTION
### What does this PR do?
When we added the execution of the service check on auto discovered databases (https://github.com/DataDog/integrations-core/pull/9900), we opened the door to the integration check failing when one of the auto discovered databases couldn't be connected to. A more sensible behavior is to report a auto discovered database's service check status correctly but still proceed with the metrics collection and the rest of the check's execution.

Before this change, the integration would fail with:
```
______________________________________________________________________ test_autodiscovery_db_service_checks[True-4-1] ______________________________________________________________________
tests/test_integration.py:161: in test_autodiscovery_db_service_checks
    dd_run_check(check)
../datadog_checks_dev/datadog_checks/dev/plugin/pytest.py:219: in run_check
    raise Exception('\n'.join(exc_lines))
E   Exception:
E   Traceback (most recent call last):
E     File "/Users/alex.normand/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/checks/base.py", line 1071, in run
E       self.check(instance)
E     File "/Users/alex.normand/go/src/github.com/DataDog/integrations-core/sqlserver/datadog_checks/sqlserver/sqlserver.py", line 585, in check
E       self.connection.check_database_conns(db_name)
E     File "/Users/alex.normand/go/src/github.com/DataDog/integrations-core/sqlserver/datadog_checks/sqlserver/connection.py", line 118, in check_database_conns
E       self.open_db_connections(None, db_name=db_name, is_default=False)
E     File "/Users/alex.normand/go/src/github.com/DataDog/integrations-core/sqlserver/datadog_checks/sqlserver/connection.py", line 190, in open_db_connections
E       raise_from(SQLConnectionError(message), None)
E     File "<string>", line 3, in raise_from
E   datadog_checks.sqlserver.connection.SQLConnectionError: Unable to connect to Database: unavailable_db for instance localhost,1433: ProgrammingError('42000', "[42000] [FreeTDS][SQL Server]Login failed for user 'datadog'. (18456) (SQLDriverConnect)")
```

And now the check runs to completion while reporting a status of `Critical` on a db that the datadog user fails to connect to (`unavailable_db` in the example above).

### Motivation
Customer report of the integration breaking

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
