### PR TITLE
Properly raise scraper error in OpenMetrics v2

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -5,9 +5,9 @@
 # type: ignore
 from collections import ChainMap
 from contextlib import contextmanager
-from six import raise_from
 
 from requests.exceptions import RequestException
+from six import raise_from
 
 from ....errors import ConfigurationError
 from ....utils.tracing import traced_class
@@ -63,9 +63,8 @@ class OpenMetricsBaseCheckV2(AgentCheck):
                 try:
                     scraper.scrape()
                 except (ConnectionError, RequestException) as e:
-                    msg = "There was an error scraping endpoint "
-                    self.log.error(msg + "%s: %s", endpoint, str(e))
-                    raise_from(ConnectionError((msg + endpoint), e), None)
+                    self.log.error("There was an error scraping endpoint %s: %s", endpoint, str(e))
+                    raise_from(ConnectionError(("There was an error scraping endpoint " + endpoint), e), None)
 
     def configure_scrapers(self):
         """

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -64,7 +64,7 @@ class OpenMetricsBaseCheckV2(AgentCheck):
                     scraper.scrape()
                 except (ConnectionError, RequestException) as e:
                     self.log.error("There was an error scraping endpoint %s: %s", endpoint, str(e))
-                    raise_from(type(e)("There was an error scraping endpoint {}: {}".format(endpoint, e), None))
+                    raise_from(type(e)("There was an error scraping endpoint {}: {}".format(endpoint, e)), None)
 
     def configure_scrapers(self):
         """

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -5,6 +5,7 @@
 # type: ignore
 from collections import ChainMap
 from contextlib import contextmanager
+from six import raise_from
 
 from requests.exceptions import RequestException
 
@@ -62,7 +63,9 @@ class OpenMetricsBaseCheckV2(AgentCheck):
                 try:
                     scraper.scrape()
                 except (ConnectionError, RequestException) as e:
-                    self.log.error("There was an error scraping endpoint %s: %s", endpoint, str(e))
+                    msg = "There was an error scraping endpoint "
+                    self.log.error(msg + "%s: %s", endpoint, str(e))
+                    raise_from(ConnectionError((msg + endpoint), e), None)
 
     def configure_scrapers(self):
         """

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py
@@ -64,7 +64,7 @@ class OpenMetricsBaseCheckV2(AgentCheck):
                     scraper.scrape()
                 except (ConnectionError, RequestException) as e:
                     self.log.error("There was an error scraping endpoint %s: %s", endpoint, str(e))
-                    raise_from(ConnectionError(("There was an error scraping endpoint " + endpoint), e), None)
+                    raise_from(type(e)("There was an error scraping endpoint {}: {}".format(endpoint, e), None))
 
     def configure_scrapers(self):
         """

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_options.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_options.py
@@ -75,7 +75,8 @@ class TestEnableHealthServiceCheck:
             status_code=401,
         )
         check = get_check({'metrics': ['.+'], 'tags': ['foo:bar']})
-        dd_run_check(check)
+        with pytest.raises(Exception):
+            dd_run_check(check)
 
         aggregator.assert_service_check(
             'test.openmetrics.health', ServiceCheck.CRITICAL, tags=['endpoint:test', 'foo:bar']
@@ -91,7 +92,8 @@ class TestEnableHealthServiceCheck:
             status_code=401,
         )
         check = get_check({'metrics': ['.+'], 'enable_health_service_check': False})
-        dd_run_check(check)
+        with pytest.raises(Exception):
+            dd_run_check(check)
 
         assert not aggregator.service_check_names
 


### PR DESCRIPTION
### What does this PR do?
This [fix](https://github.com/DataDog/integrations-core/pull/11281) added an improvement to the error logging. The scraper error was logged and the service check was submitted as CRITICAL, however, the agent status was still reporting the check as OK:

```
error: openmetrics:openmetrics:a601c57cd02b9742 | (base.py:65) | There was an error scraping endpoint http://localhost:9099/metrics: HTTPConnectionPool(host='localhost', port=9099): Max retries exceeded with url: /metrics (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f0dd442dd90>: Failed to establish a new connection: [Errno 111] Connection refused'))
=== Service Checks ===
[
  {
    "check": "openmetrics.openmetrics.health",
    "host_name": "docker-desktop",
    "timestamp": 1645656011,
    "status": 2,
    "message": "HTTPConnectionPool(host='localhost', port=9099): Max retries exceeded with url: /metrics (Caused by NewConnectionError('\u003curllib3.connection.HTTPConnection object at 0x7f0dd442dd90\u003e: Failed to establish a new connection: [Errno 111] Connection refused'))",
    "tags": [
      "endpoint:http://localhost:9099/metrics"
    ]
  }
]
=========
Collector
=========

  Running Checks
  ==============

    openmetrics (2.0.0)
    -------------------
      Instance ID: openmetrics:openmetrics:a601c57cd02b9742 [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/openmetrics.d/openmetrics.yaml
      Total Runs: 1
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 11ms
      Last Execution Date : 2022-02-23 22:40:11 UTC (1645656011000)
      Last Successful Execution Date : 2022-02-23 22:40:11 UTC (1645656011000)
```

This change raises the error to the agent so that the status is properly reported in the agent status:

```
error: openmetrics:openmetrics:a601c57cd02b9742 | (base.py:66) | There was an error scraping endpoint http://localhost:9099/metrics: HTTPConnectionPool(host='localhost', port=9099): Max retries exceeded with url: /metrics (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f3090383cd0>: Failed to establish a new connection: [Errno 111] Connection refused'))
=== Service Checks ===
[
  {
    "check": "openmetrics.openmetrics.health",
    "host_name": "docker-desktop",
    "timestamp": 1645715486,
    "status": 2,
    "message": "HTTPConnectionPool(host='localhost', port=9099): Max retries exceeded with url: /metrics (Caused by NewConnectionError('\u003curllib3.connection.HTTPConnection object at 0x7f3090383cd0\u003e: Failed to establish a new connection: [Errno 111] Connection refused'))",
    "tags": [
      "endpoint:http://localhost:9099/metrics"
    ]
  }
]
=========
Collector
=========

  Running Checks
  ==============

    openmetrics (2.0.0)
    -------------------
      Instance ID: openmetrics:openmetrics:a601c57cd02b9742 [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/openmetrics.d/openmetrics.yaml
      Total Runs: 1
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 22ms
      Last Execution Date : 2022-02-24 15:11:26 UTC (1645715486000)
      Last Successful Execution Date : Never
      Error: There was an error scraping endpoint http://localhost:9099/metrics: HTTPConnectionPool(host='localhost', port=9099): Max retries exceeded with url: /metrics (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f3090383cd0>: Failed to establish a new connection: [Errno 111] Connection refused'))
      Traceback (most recent call last):
        File "/home/datadog_checks_base/datadog_checks/base/checks/base.py", line 1071, in run
          self.check(instance)
        File "/home/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py", line 67, in check
          raise_from(type(e)("There was an error scraping endpoint {}: {}".format(endpoint, e)), None)
        File "<string>", line 3, in raise_from
      requests.exceptions.ConnectionError: There was an error scraping endpoint http://localhost:9099/metrics: HTTPConnectionPool(host='localhost', port=9099): Max retries exceeded with url: /metrics (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f3090383cd0>: Failed to establish a new connection: [Errno 111] Connection refused'))
```

### Motivation
QA for https://github.com/DataDog/integrations-core/pull/11281

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
