### PR TITLE
Ensure check still loads if agent fails to connect to possible prometheus urls

### DIFF
--- a/openmetrics/datadog_checks/openmetrics/config_models/validators.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/validators.py
@@ -7,13 +7,20 @@ from six import PY2
 def initialize_instance(values, **kwargs):
     v2_endpoint = values.get('openmetrics_endpoint')
     v1_endpoint = values.get('prometheus_url')
+    v1_possible_urls = values.get('possible_prometheus_urls')
     if PY2 and v2_endpoint:
         raise ValueError('`openmetrics_endpoint` cannot be used if the agent is running Python 2')
     if v1_endpoint and v2_endpoint:
         raise ValueError('`prometheus_url` cannot be used along `openmetrics_endpoint`')
+    if v1_endpoint and v1_possible_urls:
+        raise ValueError('Only one of `prometheus_url` or `possible_prometheus_urls` may be used.')
+    if v2_endpoint and v1_possible_urls:
+        raise ValueError('`openmetrics_endpoint` cannot be used along `possible_prometheus_urls`')
     if not v1_endpoint and not v2_endpoint:
         if PY2:
             raise ValueError('`prometheus_url` is required')
+        elif not v1_possible_urls:
+            raise ValueError('`openmetrics_endpoint` is required')
         else:
             raise ValueError('`openmetrics_endpoint` is required')
     return values


### PR DESCRIPTION
### What does this PR do?
If the agent fails to connect to any `possible_prometheus_urls`, the check fails as expected, but it also causes a check loading error:

```
      etcd (3.0.0)
      ------------

      instance 0:

        could not invoke 'etcd' python check constructor. New constructor API returned:
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/etcd/etcd.py", line 87, in __init__
    super(Etcd, self).__init__(
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/base_check.py", line 126, in __init__
    raise CheckException(
datadog_checks.base.errors.CheckException: The agent could not connect to any of the following URLs: ['https://192.168.143.206:2379/metrics', 'http://192.168.143.206:2379/metrics'].
Deprecated constructor API returned:
__init__() got an unexpected keyword argument 'agentConfig'
  Loading Errors
  ==============
    etcd
    ----
      Core Check Loader:
        Check etcd not found in Catalog

      JMX Check Loader:
        check is not a jmx check, or unable to determine if it's so

      Python Check Loader:
        could not configure check instance for python check etcd: could not invoke 'etcd' python check constructor. New constructor API returned:
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/etcd/etcd.py", line 87, in __init__
    super(Etcd, self).__init__(
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/base_check.py", line 126, in __init__
    raise CheckException(
datadog_checks.base.errors.CheckException: The agent could not connect to any of the following URLs: ['https://192.168.143.206:2379/metrics', 'http://192.168.143.206:2379/metrics'].
Deprecated constructor API returned:
__init__() got an unexpected keyword argument 'agentConfig'
```

This change handles the failure more gracefully and also ensures the check still loads. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
Adds additional config validations. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
