### PR TITLE
Add logs section to pulsar readme

### DIFF
--- a/pulsar/README.md
+++ b/pulsar/README.md
@@ -39,7 +39,7 @@ See [metadata.csv][7] for a list of metrics provided by this check.
    logs_enabled: true
    ```
 
-3. Uncomment and edit the logs configuration block in your `pulsar.d/conf.yaml` file. Change the path and service parameter values based on your environment. See the [sample pulsar.d/conf.yaml][4]] for all available configuration options.
+3. Uncomment and edit the logs configuration block in your `pulsar.d/conf.yaml` file. Change the path and service parameter values based on your environment. See the [sample pulsar.d/conf.yaml][4] for all available configuration options.
    ```yaml
     logs:
       - type: file

--- a/pulsar/README.md
+++ b/pulsar/README.md
@@ -39,7 +39,7 @@ See [metadata.csv][7] for a list of metrics provided by this check.
    logs_enabled: true
    ```
 
-3. Uncomment and edit the logs configuration block in your `pulsar.d/conf.yaml` file. Change the path and service parameter values based on your environment. See the [sample pulsar.d/conf.yaml][4] for all available configuration options.
+3. Uncomment and edit the logs configuration block in your `pulsar.d/conf.yaml` file. Change the path parameter value based on your environment. See the [sample pulsar.d/conf.yaml][4] for all available configuration options.
    ```yaml
     logs:
       - type: file

--- a/pulsar/README.md
+++ b/pulsar/README.md
@@ -29,6 +29,25 @@ No additional installation is needed on your server.
 
 See [metadata.csv][7] for a list of metrics provided by this check.
 
+
+### Log collection
+
+1. The Pulsar log integration supports Pulsar's [default log format][10]. Clone and edit the [integration pipeline][11] if you have a different format.
+
+2. Collecting logs is disabled by default in the Datadog Agent. Enable it in your `datadog.yaml` file:
+   ```yaml
+   logs_enabled: true
+   ```
+
+3. Uncomment and edit the logs configuration block in your `pulsar.d/conf.yaml` file. Change the path and service parameter values based on your environment. See the [sample pulsar.d/conf.yaml][4]] for all available configuration options.
+   ```yaml
+    logs:
+      - type: file
+        path: /pulsar/logs/pulsar.log
+        source: pulsar
+   ```
+4. [Restart the Agent][5]
+
 ### Events
 
 The Pulsar integration does not include any events.
@@ -51,3 +70,5 @@ Need help? Contact [Datadog support][9].
 [7]: https://github.com/DataDog/integrations-core/blob/master/pulsar/metadata.csv
 [8]: https://github.com/DataDog/integrations-core/blob/master/pulsar/assets/service_checks.json
 [9]: https://docs.datadoghq.com/help/
+[10]: https://pulsar.apache.org/docs/en/reference-configuration/#log4j
+[11]: https://docs.datadoghq.com/logs/processing/#integration-pipelines


### PR DESCRIPTION
### What does this PR do?
Adds a logs section to the pulsar readme 

### Motivation
It has a logs integration but it is not documented.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
