### PR TITLE
Update system state log line wording 

### DIFF
--- a/silk/datadog_checks/silk/check.py
+++ b/silk/datadog_checks/silk/check.py
@@ -96,7 +96,11 @@ class SilkCheck(AgentCheck):
                 self._submit_version_metadata(data.get('system_version'))
                 self.service_check(self.STATE_SERVICE_CHECK, STATE_MAP[state], tags=self._tags)
             else:
-                msg = "Could not access system state, got response: {}".format(code)
+                msg = (
+                    "Could not access system state and version info, got response code `{}` from endpoint `{}`".format(
+                        code, STATE_ENDPOINT
+                    )
+                )
                 self.log.debug(msg)
         return system_tags
 

--- a/silk/tests/test_silk.py
+++ b/silk/tests/test_silk.py
@@ -56,7 +56,6 @@ def test_submit_system_state(instance, datadog_agent):
 def test_submit_system_state_error(aggregator, instance, caplog):
     caplog.set_level(logging.DEBUG)
     check = SilkCheck('silk', {}, [instance])
-    check.check_id = 'test:123'
 
     check._get_data = mock.MagicMock(side_effect=[(None, 404)])
     check.submit_system_state()


### PR DESCRIPTION
### What does this PR do?
- Update the wording of a log line regarding failure to collect system state.
- Also adds a test for this scenario, as well as updates the other system state test to assert the tags returned

### Motivation
More clear instructions to users, QA

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
