### PR TITLE
Remove unsupported schema properties

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/constants.py
@@ -30,7 +30,7 @@ OPENAPI_SCHEMA_PROPERTIES = {
     'maximum',
     'minItems',
     'minLength',
-    'minProperties',
+    # 'minProperties',  Not supported https://github.com/samuelcolvin/pydantic/issues/1277
     'minimum',
     'multipleOf',
     'not',
@@ -40,5 +40,5 @@ OPENAPI_SCHEMA_PROPERTIES = {
     'required',
     'title',
     'type',
-    'uniqueItems',
+    # 'uniqueItems',      Not supported https://github.com/koxudaxi/datamodel-code-generator/issues/719
 }

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/constants.py
@@ -30,7 +30,6 @@ OPENAPI_SCHEMA_PROPERTIES = {
     'maximum',
     'minItems',
     'minLength',
-    # 'minProperties',  Not supported https://github.com/samuelcolvin/pydantic/issues/1277
     'minimum',
     'multipleOf',
     'not',
@@ -40,5 +39,4 @@ OPENAPI_SCHEMA_PROPERTIES = {
     'required',
     'title',
     'type',
-    # 'uniqueItems',      Not supported https://github.com/koxudaxi/datamodel-code-generator/issues/719
 }


### PR DESCRIPTION
### What does this PR do?

* `uniqueItems` for constrained lists are not currently supported in `datamodel-code-generator`: https://github.com/koxudaxi/datamodel-code-generator/issues/719

* `condict` and `minProperties` are not currently supported in pydantic: https://github.com/samuelcolvin/pydantic/issues/1277#issuecomment-939633650. Suggestion is to use validators.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
