### PR TITLE
Add debug logging for unknown server statuses

### DIFF
--- a/silk/assets/service_checks.json
+++ b/silk/assets/service_checks.json
@@ -13,7 +13,7 @@
             "warning"
         ],
         "name": "Silk system state",
-        "description": "Returns `WARNING` if the check cannot access the system state but connects to endpoint, and `CRITICAL` if endpoint is inaccessible. Returns `OK` if ONLINE, `UNKNOWN` if endpoint is unaccessible."
+        "description": "Returns `WARNING` if the check cannot access the system state but connects to endpoint, and `CRITICAL` if endpoint is inaccessible. Returns `OK` if ONLINE, `UNKNOWN` if endpoint is inaccessible or returns a non-OK status."
     },
     {
         "agent_version": "7.35.0",
@@ -29,7 +29,7 @@
             "warning"
         ],
         "name": "Silk servers state",
-        "description": "Returns `WARNING` if the check cannot access the system's server state but connects to endpoint, and `CRITICAL` if endpoint is inaccessible. Returns `OK` if ONLINE, `UNKNOWN` if endpoint is unaccessible. Tagged by `server_name`."
+        "description": "Returns `WARNING` if the check cannot access the system's server state but connects to endpoint, and `CRITICAL` if endpoint is inaccessible. Returns `OK` if ONLINE, `UNKNOWN` if endpoint is inaccessible or returns a non-OK status. Tagged by `server_name`."
     },
     {
       "agent_version": "7.35.0",

--- a/silk/assets/service_checks.json
+++ b/silk/assets/service_checks.json
@@ -13,7 +13,7 @@
             "warning"
         ],
         "name": "Silk system state",
-        "description": "Returns `WARNING` if the check cannot access the system state but connects to endpoint, and `CRITICAL` if endpoint is inaccessible. Returns `OK` if ONLINE, `UNKNOWN` if endpoint is inaccessible or returns a non-OK status."
+        "description": "Returns `CRITICAL` if the system is degraded, `WARNING` if the system is offline. Returns `OK` if ONLINE, `UNKNOWN` if the endpoint is is inaccessible."
     },
     {
         "agent_version": "7.35.0",
@@ -24,12 +24,10 @@
         "check": "silk.server.state",
         "statuses": [
             "ok",
-            "critical",
-            "unknown",
-            "warning"
+            "unknown"
         ],
         "name": "Silk servers state",
-        "description": "Returns `WARNING` if the check cannot access the system's server state but connects to endpoint, and `CRITICAL` if endpoint is inaccessible. Returns `OK` if ONLINE, `UNKNOWN` if endpoint is inaccessible or returns a non-OK status. Tagged by `server_name`."
+        "description": "Returns `OK` if the server is ONLINE, `UNKNOWN` if the endpoint is inaccessible or returns a non-OK status. Tagged by `server_name`."
     },
     {
       "agent_version": "7.35.0",
@@ -40,9 +38,10 @@
       "check": "silk.can_connect",
       "statuses": [
           "ok",
-          "critical"
+          "critical",
+          "warning"
       ],
       "name": "Can connect",
-      "description": "Returns `CRITICAL` if check cannot access stats endpoints. Returns `OK` otherwise."
+      "description": "Returns `CRITICAL` if check cannot access stats endpoints, `WARNING` if an error response is encountered. Returns `OK` otherwise."
   }
 ]

--- a/silk/datadog_checks/silk/check.py
+++ b/silk/datadog_checks/silk/check.py
@@ -115,8 +115,9 @@ class SilkCheck(AgentCheck):
         else:
             if server_data:
                 for server in server_data:
+                    server_name = server.get('name')
                     tags = deepcopy(self._tags) + [
-                        'server_name:{}'.format(server.get('name')),
+                        'server_name:{}'.format(server_name),
                     ]
                     state = server.get('status').lower()
 
@@ -125,6 +126,7 @@ class SilkCheck(AgentCheck):
                     else:
                         # Other states are not documented
                         self.service_check(self.SERVERS_SERVICE_CHECK, AgentCheck.UNKNOWN, tags=tags)
+                        self.log.debug("Server %s reporting status of `%s`.", server_name, state)
             else:
                 msg = "Could not access server state, got response: {}".format(code)
                 self.log.debug(msg)

--- a/silk/datadog_checks/silk/check.py
+++ b/silk/datadog_checks/silk/check.py
@@ -126,7 +126,7 @@ class SilkCheck(AgentCheck):
                     else:
                         # Other states are not documented
                         self.service_check(self.SERVERS_SERVICE_CHECK, AgentCheck.UNKNOWN, tags=tags)
-                    self.log.debug("Server %s reporting status of `%s`.", server_name, state)
+                        self.log.debug("Server %s is reporting unknown status of `%s`.", server_name, state)
             else:
                 msg = "Could not access server state, got response: {}".format(code)
                 self.log.debug(msg)

--- a/silk/datadog_checks/silk/check.py
+++ b/silk/datadog_checks/silk/check.py
@@ -126,7 +126,7 @@ class SilkCheck(AgentCheck):
                     else:
                         # Other states are not documented
                         self.service_check(self.SERVERS_SERVICE_CHECK, AgentCheck.UNKNOWN, tags=tags)
-                        self.log.debug("Server %s reporting status of `%s`.", server_name, state)
+                    self.log.debug("Server %s reporting status of `%s`.", server_name, state)
             else:
                 msg = "Could not access server state, got response: {}".format(code)
                 self.log.debug(msg)


### PR DESCRIPTION
### What does this PR do?
Add debug logging for unknown server statuses reported from the servers endpoint `system/servers`. Non-`ok` statuses are not currently documented. If a user encounters any UNKNOWN `server.state` service check status, they may want to check the debug logs for the returned status. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
