### PR TITLE
Enable SQL metadata collection by default

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -406,11 +406,11 @@ files:
             example: false
         - name: collect_metadata
           description: |
-            Set to `true` to enable the collection of metadata in your SQL statements.
+            Set to `false` to disable the collection of metadata in your SQL statements.
             Metadata includes things such as tables, commands, and comments.
           value:
             type: boolean
-            example: false
+            example: true
         - name: collect_tables
           description: |
             Set to `false` to disable the collection of tables in your SQL statements.

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -95,9 +95,11 @@ class PostgresConfig:
             # Valid values for this can be found at
             # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#connection-level-attributes
             'dbms': 'postgresql',
-            'replace_digits': is_affirmative(obfuscator_options_config.get(
-                'replace_digits', is_affirmative(obfuscator_options_config.get('quantize_sql_tables', False))
-            )),
+            'replace_digits': is_affirmative(
+                obfuscator_options_config.get(
+                    'replace_digits', is_affirmative(obfuscator_options_config.get('quantize_sql_tables', False))
+                )
+            ),
             'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
             'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),
             'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -97,7 +97,7 @@ class PostgresConfig:
             'dbms': 'postgresql',
             'replace_digits': is_affirmative(
                 obfuscator_options_config.get(
-                    'replace_digits', is_affirmative(obfuscator_options_config.get('quantize_sql_tables', False))
+                    'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
                 )
             ),
             'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -95,13 +95,13 @@ class PostgresConfig:
             # Valid values for this can be found at
             # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#connection-level-attributes
             'dbms': 'postgresql',
-            'replace_digits': obfuscator_options_config.get(
-                'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
-            ),
-            'return_json_metadata': obfuscator_options_config.get('collect_metadata', False),
-            'table_names': obfuscator_options_config.get('collect_tables', True),
-            'collect_commands': obfuscator_options_config.get('collect_commands', True),
-            'collect_comments': obfuscator_options_config.get('collect_comments', True),
+            'replace_digits': is_affirmative(obfuscator_options_config.get(
+                'replace_digits', is_affirmative(obfuscator_options_config.get('quantize_sql_tables', False))
+            )),
+            'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
+            'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),
+            'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),
+            'collect_comments': is_affirmative(obfuscator_options_config.get('collect_comments', True)),
         }
 
     def _build_tags(self, custom_tags):

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -342,11 +342,11 @@ instances:
         #
         # replace_digits: false
 
-        ## @param collect_metadata - boolean - optional - default: false
-        ## Set to `true` to enable the collection of metadata in your SQL statements.
+        ## @param collect_metadata - boolean - optional - default: true
+        ## Set to `false` to disable the collection of metadata in your SQL statements.
         ## Metadata includes things such as tables, commands, and comments.
         #
-        # collect_metadata: false
+        # collect_metadata: true
 
         ## @param collect_tables - boolean - optional - default: true
         ## Set to `false` to disable the collection of tables in your SQL statements.

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -555,7 +555,6 @@ def test_statement_metadata(
     expected_metadata_payload,
 ):
     """Tests for metadata in both samples and metrics"""
-    dbm_instance['obfuscator_options'] = {'collect_metadata': True}
     dbm_instance['pg_stat_statements_view'] = pg_stat_statements_view
     dbm_instance['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
     dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Enables the collection of SQL metadata by default for Postgres.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
