### PR TITLE
Enable SQL metadata collection by default

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -450,11 +450,11 @@ files:
                   example: false
               - name: collect_metadata
                 description: |
-                  Set to `true` to enable the collection of metadata in your SQL statements.
+                  Set to `false` to disable the collection of metadata in your SQL statements.
                   Metadata includes things such as tables, commands, and comments.
                 value:
                   type: boolean
-                  example: false
+                  example: true
               - name: collect_tables
                 description: |
                   Set to `false` to disable the collection of tables in your SQL statements.

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -48,7 +48,7 @@ class MySQLConfig(object):
             'dbms': 'mysql',
             'replace_digits': is_affirmative(
                 obfuscator_options_config.get(
-                    'replace_digits', is_affirmative(obfuscator_options_config.get('quantize_sql_tables', False))
+                    'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
                 )
             ),
             'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -46,13 +46,15 @@ class MySQLConfig(object):
             # Valid values for this can be found at
             # https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#connection-level-attributes
             'dbms': 'mysql',
-            'replace_digits': obfuscator_options_config.get(
-                'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
+            'replace_digits': is_affirmative(
+                obfuscator_options_config.get(
+                    'replace_digits', is_affirmative(obfuscator_options_config.get('quantize_sql_tables', False))
+                )
             ),
-            'return_json_metadata': obfuscator_options_config.get('collect_metadata', False),
-            'table_names': obfuscator_options_config.get('collect_tables', True),
-            'collect_commands': obfuscator_options_config.get('collect_commands', True),
-            'collect_comments': obfuscator_options_config.get('collect_comments', True),
+            'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
+            'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),
+            'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),
+            'collect_comments': is_affirmative(obfuscator_options_config.get('collect_comments', True)),
         }
         self.configuration_checks()
 

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -412,11 +412,11 @@ instances:
         #
         # replace_digits: false
 
-        ## @param collect_metadata - boolean - optional - default: false
-        ## Set to `true` to enable the collection of metadata in your SQL statements.
+        ## @param collect_metadata - boolean - optional - default: true
+        ## Set to `false` to disable the collection of metadata in your SQL statements.
         ## Metadata includes things such as tables, commands, and comments.
         #
-        # collect_metadata: false
+        # collect_metadata: true
 
         ## @param collect_tables - boolean - optional - default: true
         ## Set to `false` to disable the collection of tables in your SQL statements.

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -474,7 +474,6 @@ def test_performance_schema_disabled(dbm_instance, dd_run_check):
     ],
 )
 def test_statement_metadata(aggregator, dd_run_check, dbm_instance, datadog_agent, metadata, expected_metadata_payload):
-    dbm_instance['obfuscator_options'] = {'collect_metadata': True}
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
     test_query = '''


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Enables the collection of SQL metadata by default for MySQL.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
