### PR TITLE
Prevent tags for unreleased integrations

### DIFF
--- a/.gitlab/tagger/tag-release.sh
+++ b/.gitlab/tagger/tag-release.sh
@@ -14,7 +14,7 @@ git config --global user.email "$TAGGER_EMAIL"
 git config --global user.name "$TAGGER_NAME"
 
 set +e
-ddev release tag all
+ddev release tag all --skip-prerelease
 status=$?
 set -e
 

--- a/.gitlab/tagger/tag-release.sh
+++ b/.gitlab/tagger/tag-release.sh
@@ -14,7 +14,7 @@ git config --global user.email "$TAGGER_EMAIL"
 git config --global user.name "$TAGGER_NAME"
 
 set +e
-ddev release tag all --skip-prerelease
+ddev release tag all
 status=$?
 set -e
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
@@ -8,7 +8,8 @@ from ...release import get_release_tag_string
 from ...utils import complete_valid_checks, get_valid_checks, get_version_string
 from ..console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waiting, echo_warning
 
-# This should be the initial version generated from the integration template
+# 0.0.1 is the initial pre-release version that is generated from the integrations template.
+# Updating to any version > 0.0.1 would require a tag.*.link file to be updated.
 PRERELEASE = '0.0.1'
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Tag the git repo with the current release of a check')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
@@ -8,13 +8,16 @@ from ...release import get_release_tag_string
 from ...utils import complete_valid_checks, get_valid_checks, get_version_string
 from ..console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waiting, echo_warning
 
+# This should be the initial version generated from the integration template
+PRERELEASE = '0.0.1'
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Tag the git repo with the current release of a check')
 @click.argument('check', autocompletion=complete_valid_checks)
 @click.argument('version', required=False)
 @click.option('--push/--no-push', default=True)
 @click.option('--dry-run', '-n', is_flag=True)
-def tag(check, version, push, dry_run):
+@click.option('--skip-prerelease', is_flag=True)
+def tag(check, version, push, dry_run, skip_prerelease):
     """Tag the HEAD of the git repo with the current release number for a
     specific check. The tag is pushed to origin by default.
 
@@ -48,8 +51,8 @@ def tag(check, version, push, dry_run):
         if not version:
             version = get_version_string(check)
 
-        if version == '0.0.1':
-            echo_warning('skipping since not released yet')
+        if skip_prerelease and version == PRERELEASE:
+            echo_warning('skipping prerelease version')
             continue
 
         # get the tag name

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
@@ -48,6 +48,10 @@ def tag(check, version, push, dry_run):
         if not version:
             version = get_version_string(check)
 
+        if version == '0.0.1':
+            echo_warning('skipping since not released yet')
+            continue
+
         # get the tag name
         release_tag = get_release_tag_string(check, version)
         echo_waiting(f'Tagging HEAD with {release_tag}... ', indent=True, nl=False)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
@@ -9,7 +9,7 @@ from ...utils import complete_valid_checks, get_valid_checks, get_version_string
 from ..console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waiting, echo_warning
 
 # 0.0.1 is the initial pre-release version that is generated from the integrations template.
-# Updating to any version > 0.0.1 would require a tag.*.link file to be updated.
+# Releasing any version > 0.0.1 for a core integration requires a tag.*.link file to be updated in the PR
 PRERELEASE = '0.0.1'
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Tag the git repo with the current release of a check')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
@@ -8,7 +8,7 @@ from ...release import get_release_tag_string
 from ...utils import complete_valid_checks, get_valid_checks, get_version_string
 from ..console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_waiting, echo_warning
 
-# 0.0.1 is the initial pre-release version that is generated from the integrations template.
+# 0.0.1 is the initial pre-release version that is generated from the integration's template.
 # Releasing any version > 0.0.1 for a core integration requires a tag.*.link file to be updated in the PR
 PRERELEASE = '0.0.1'
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
New integrations cause CI to trigger the release pipeline, which shouldn't occur until integrations are officially signed and released.

This PR skips tagging v0.0.1 integrations to prevent the release pipeline from running.

https://github.com/DataDog/integrations-core/pull/11610 adds the flag the shell script.

### Motivation
<!-- What inspired you to submit this pull request? -->
CI pipeline bug - CI looks for most recent .tag file, but since the integration isn't released yet the file is incorrect.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
