### PR TITLE
Use sum by in datadog_cluster_agent external metrics by namespace graph

### DIFF
--- a/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
+++ b/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
@@ -1354,12 +1354,12 @@
                             {
                                 "data_source": "metrics",
                                 "name": "query1",
-                                "query": "avg:datadog.cluster_agent.external_metrics{$namespace,$cluster,$leader} by {valid,kube_namespace}"
+                                "query": "sum:datadog.cluster_agent.external_metrics{$namespace,$cluster,$leader} by {valid,kube_namespace}"
                             },
                             {
                                 "data_source": "metrics",
                                 "name": "query2",
-                                "query": "avg:datadog.cluster_agent.external_metrics.datadog_metrics{$namespace,$cluster,$leader} by {valid,kube_namespace}"
+                                "query": "sum:datadog.cluster_agent.external_metrics.datadog_metrics{$namespace,$cluster,$leader} by {valid,kube_namespace}"
                             }
                         ],
                         "response_format": "timeseries",


### PR DESCRIPTION
### What does this PR do?
Use `sum by` instead of `avg by` to show the total number of external metrics per namespace

### Motivation
Total count is more meaningful than an avg value in this case

### Additional Notes
Staging link: [External metrics by namespace](https://dd.datad0g.com/dash/integration/30706/datadog-cluster-agent-overview) graph under `Autoscaling`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
