### PR TITLE
Postgres: Prioritize collection of size metrics on larger tables

### DIFF
--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -110,7 +110,8 @@ LEFT JOIN pg_namespace N ON (N.oid = C.relnamespace)
 WHERE nspname NOT IN ('pg_catalog', 'information_schema') AND
   nspname !~ '^pg_toast' AND
   relkind = 'r' AND
-  {relations}""",
+  {relations}
+ORDER BY pg_total_relation_size(C.oid) DESC""",
 }
 
 # The pg_statio_all_tables view will contain one row for each table in the current database,


### PR DESCRIPTION
I can work on the "Review checklist" items if someone agrees that this PR is a good idea.

### What does this PR do?

The `max_relations` parameter (https://github.com/DataDog/integrations-core/blob/cf923f4aa3e63d/postgres/datadog_checks/postgres/data/conf.yaml.example#L160-L163) limits the number of relations that metrics are collected on.  Previously, no order was specified, which meant that the metrics that were reported depedended on the vagaries of Postgres. This change orders the query by total table size because people are more likely to care about size-related metrics for larger tables than for smaller ones.  There are exceptions, but even so, collecting metrics for the largest N tables seems more useful than collecting metrics for an unspecified subset of N tables.

### Motivation

I was going to make a feature request, but I thought a PR would be more likely to be noticed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached