### PR TITLE
Remove duplicate beans

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/jmx_metrics.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/jmx_metrics.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from ast import literal_eval
 from collections import defaultdict
 
 import click
@@ -60,6 +61,17 @@ def validate_jmx_metrics(check_name, saved_errors, verbose):
     if not metrics_file_exists:
         saved_errors[(check_name, None)].append(f'{jmx_metrics_file} does not exist')
         return
+    try:
+        # Load yaml config with custom constructor. The default loader overwrites duplicate keys:
+        # https://github.com/yaml/pyyaml/issues/165
+        yaml.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, no_duplicates_constructor)
+        yaml.load(read_file(jmx_metrics_file), Loader=yaml.FullLoader).get('jmx_metrics')
+    except Exception as errors:
+        saved_errors[(check_name, jmx_metrics_file)].append("The config contains the following duplicates keys:")
+        # Convert Exception -> String -> List
+        errors = literal_eval(str(errors))
+        for e in errors:
+            saved_errors[(check_name, jmx_metrics_file)].append(f"{e[0]} on line {e[-1]}")
 
     jmx_metrics_data = yaml.safe_load(read_file(jmx_metrics_file)).get('jmx_metrics')
     if jmx_metrics_data is None:
@@ -83,6 +95,7 @@ def validate_jmx_metrics(check_name, saved_errors, verbose):
             saved_errors[(check_name, jmx_metrics_file)].append(
                 f"domain or bean attribute is missing for rule: {include_str}"
             )
+
     duplicates = duplicate_bean_check(jmx_metrics_data)
     if duplicates:
         saved_errors[(check_name, jmx_metrics_file)].append(
@@ -144,3 +157,21 @@ def truncate_message(s, verbose):
     if not verbose:
         s = (s[:100] + '...') if len(s) > 100 else s
     return s
+
+
+# Modified version of:
+# https://gist.github.com/pypt/94d747fe5180851196eb
+def no_duplicates_constructor(loader, node, deep=False):
+    """Check for duplicate keys."""
+
+    mapping = {}
+    errors = []
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        value = loader.construct_object(value_node, deep=deep)
+        if key in mapping:
+            errors.append([key, key_node.start_mark.line])
+        mapping[key] = value
+    if len(errors) > 0:
+        raise Exception(errors)
+    return loader.construct_mapping(node, deep)

--- a/hive/tests/test_check.py
+++ b/hive/tests/test_check.py
@@ -28,8 +28,32 @@ def test(dd_agent_check):
         "hive.metastore.partition.init",
         "hive.metastore.api.get_all_databases.active_call",
         "hive.metastore.api.init.active_call",
+        "hive.server.memory.heap.usage",
+        "jvm.buffer_pool.direct.capacity",
+        "jvm.buffer_pool.direct.count",
+        "jvm.buffer_pool.direct.used",
+        "jvm.buffer_pool.mapped.capacity",
+        "jvm.buffer_pool.mapped.count",
+        "jvm.buffer_pool.mapped.used",
+        "jvm.cpu_load.process",
+        "jvm.cpu_load.system",
+        "jvm.gc.eden_size",
+        "jvm.gc.metaspace_size",
+        "jvm.gc.old_gen_size",
+        "jvm.gc.survivor_size",
+        "jvm.heap_memory",
+        "jvm.heap_memory_committed",
+        "jvm.heap_memory_init",
+        "jvm.heap_memory_max",
+        "jvm.loaded_classes",
+        "jvm.non_heap_memory",
+        "jvm.non_heap_memory_committed",
+        "jvm.non_heap_memory_init",
+        "jvm.non_heap_memory_max",
+        "jvm.os.open_file_descriptors",
+        "jvm.thread_count",
     ]
     for metric in metrics:
         aggregator.assert_metric(metric)
-    
+
     aggregator.assert_all_metrics_covered()

--- a/hive/tests/test_check.py
+++ b/hive/tests/test_check.py
@@ -31,3 +31,5 @@ def test(dd_agent_check):
     ]
     for metric in metrics:
         aggregator.assert_metric(metric)
+    
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
This PR is to remove some duplicate beans from the Hive integration

### Motivation
Duplicate beans don't get collected. JMXFetch will only collect the bean from the first set if duplicate exists

### Additional Notes
I added a few more metrics in the e2e test. I initially asserted that those were all the metrics that we collected using `assert_all_metrics_covered` but I removed it because I was afraid it might cause flaky-ness later on should this env be updated.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
