### PR TITLE
[kubernetes_state] Adding kube-state-metrics V2 horizontalpodautoscaler metrics

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -225,6 +225,11 @@ class KubernetesState(OpenMetricsBaseCheck):
                         'kube_hpa_status_desired_replicas': 'hpa.desired_replicas',
                         'kube_hpa_status_current_replicas': 'hpa.current_replicas',
                         'kube_hpa_status_condition': 'hpa.condition',
+                        'kube_horizontalpodautoscaler_spec_min_replicas': 'hpa.min_replicas',
+                        'kube_horizontalpodautoscaler_spec_max_replicas': 'hpa.max_replicas',
+                        'kube_horizontalpodautoscaler_status_desired_replicas': 'hpa.desired_replicas',
+                        'kube_horizontalpodautoscaler_status_current_replicas': 'hpa.current_replicas',
+                        'kube_horizontalpodautoscaler_status_condition': 'hpa.condition',
                         'kube_node_info': 'node.count',
                         'kube_pod_info': 'pod.count',
                         'kube_node_status_allocatable_cpu_cores': 'node.cpu_allocatable',
@@ -329,6 +334,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                     'kube_replicationcontroller_status_observed_generation',
                     'kube_statefulset_metadata_generation',
                     'kube_hpa_metadata_generation',
+                    'kube_horizontalpodautoscaler_metadata_generation'
                     # kube_node_status_phase has no use case as a service check
                     'kube_node_status_phase',
                     # These CronJob and Job metrics need use cases to determine how do implement
@@ -364,6 +370,7 @@ class KubernetesState(OpenMetricsBaseCheck):
 
         experimental_metrics_mapping = {
             'kube_hpa_spec_target_metric': 'hpa.spec_target_metric',
+            'kube_horizontalpodautoscaler_spec_target_metric': 'hpa.spec_target_metric',
             'kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_minallowed': (
                 'vpa.spec_container_minallowed'
             ),

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -13,6 +13,21 @@ kube_hpa_status_current_replicas{hpa="hpa1",namespace="ns1"} 2
 # HELP kube_hpa_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
 # TYPE kube_hpa_status_desired_replicas gauge
 kube_hpa_status_desired_replicas{hpa="hpa1",namespace="ns1"} 2
+# HELP kube_horizontalpodautoscaler_metadata_generation The generation observed by the HorizontalPodAutoscaler controller.
+# TYPE kube_horizontalpodautoscaler_metadata_generation gauge
+kube_horizontalpodautoscaler_metadata_generation{horizontalpodautoscaler="horizontalpodautoscaler1",namespace="ns1"} 2
+# HELP kube_horizontalpodautoscaler_spec_max_replicas Upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.
+# TYPE kube_horizontalpodautoscaler_spec_max_replicas gauge
+kube_horizontalpodautoscaler_spec_max_replicas{horizontalpodautoscaler="horizontalpodautoscaler1",namespace="ns1"} 4
+# HELP kube_horizontalpodautoscaler_spec_min_replicas Lower limit for the number of pods that can be set by the autoscaler, default 1.
+# TYPE kube_horizontalpodautoscaler_spec_min_replicas gauge
+kube_horizontalpodautoscaler_spec_min_replicas{horizontalpodautoscaler="horizontalpodautoscaler1",namespace="ns1"} 2
+# HELP kube_horizontalpodautoscaler_status_current_replicas Current number of replicas of pods managed by this autoscaler.
+# TYPE kube_horizontalpodautoscaler_status_current_replicas gauge
+kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler="horizontalpodautoscaler1",namespace="ns1"} 2
+# HELP kube_horizontalpodautoscaler_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
+# TYPE kube_horizontalpodautoscaler_status_desired_replicas gauge
+kube_horizontalpodautoscaler_status_desired_replicas{hpa="hpa1",namespace="ns1"} 2
 # HELP kube_cronjob_created Unix creation timestamp
 # TYPE kube_cronjob_created gauge
 kube_cronjob_created{cronjob="hello",namespace="default"} 1.509978394e+09

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -889,9 +889,9 @@ def test_telemetry(aggregator, instance):
 
     for _ in range(2):
         check.check(instance)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=94499.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=1004.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1336.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=96036.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=1014.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1346.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.blacklist.count', tags=['optional:tag1'], value=24.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=332.0)
     aggregator.assert_metric(


### PR DESCRIPTION
### What does this PR do?
Adds V2 versions of the horizontalpodautoscaler metrics to the kuberentes_state metrics gathering.

### Motivation
horizontalpodautoscaler metrics don't get collected by DataDog when upgrading to the latest version of kube_state_metrics.

### Additional Notes
Issue has been raised here https://github.com/DataDog/integrations-core/issues/8244

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
