### PR TITLE
[DOCS] Update URL steps to reference webserver base_url

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -31,7 +31,7 @@ There are two forms of the Airflow integration. There is the Datadog Agent integ
 
 Configure the Airflow check included in the [Datadog Agent][4] package to collect health metrics and service checks. This can be done by editing the `url` within the `airflow.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory, to start collecting your Airflow service checks. See the [sample airflow.d/conf.yaml][5] for all available configuration options.
 
-The `url` should match the URL used to connect to the Airflow Instance, the [webserver base_url][20].
+Ensure that `url` matches your Airflow [webserver `base_url`][20], the URL used to connect to your Airflow instance.
 
 ##### Connect Airflow to DogStatsD
 
@@ -277,7 +277,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][8]
 | `<INIT_CONFIG>`      | blank or `{}`         |
 | `<INSTANCE_CONFIG>`  | `{"url": "http://%%host%%:8080"}` |
 
-The `url` should match the URL used to connect to the Airflow Instance, the [webserver base_url][20]. With the Template Variable `%%host%%` replacing `localhost`.
+Ensure that `url` matches your Airflow [webserver `base_url`][20], the URL used to connect to your Airflow instance. Replace `localhost` with the template variable `%%host%%`.
 
 ##### Connect Airflow to DogStatsD
 

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -31,6 +31,8 @@ There are two forms of the Airflow integration. There is the Datadog Agent integ
 
 Configure the Airflow check included in the [Datadog Agent][4] package to collect health metrics and service checks. This can be done by editing the `url` within the `airflow.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory, to start collecting your Airflow service checks. See the [sample airflow.d/conf.yaml][5] for all available configuration options.
 
+The `url` should match the URL used to connect to the Airflow Instance, the [webserver base_url][20].
+
 ##### Connect Airflow to DogStatsD
 
 Connect Airflow to DogStatsD (included in the Datadog Agent) by using the Airflow `statsd` feature to collect metrics. For more information about the metrics reported by the Airflow version used and the additional configuration options, see the Airflow documentation below:
@@ -273,7 +275,9 @@ For containerized environments, see the [Autodiscovery Integration Templates][8]
 |----------------------|-----------------------|
 | `<INTEGRATION_NAME>` | `airflow`             |
 | `<INIT_CONFIG>`      | blank or `{}`         |
-| `<INSTANCE_CONFIG>`  | `{"url": "http://%%host%%"}` |
+| `<INSTANCE_CONFIG>`  | `{"url": "http://%%host%%:8080"}` |
+
+The `url` should match the URL used to connect to the Airflow Instance, the [webserver base_url][20]. With the Template Variable `%%host%%` replacing `localhost`.
 
 ##### Connect Airflow to DogStatsD
 
@@ -376,3 +380,4 @@ Need help? Contact [Datadog support][11].
 [17]: https://airflow.apache.org/docs/apache-airflow-providers-datadog/stable/_modules/airflow/providers/datadog/hooks/datadog.html
 [18]: https://github.com/DataDog/integrations-core/blob/master/airflow/metadata.csv
 [19]: https://github.com/DataDog/integrations-core/blob/master/airflow/assets/service_checks.json
+[20]: https://airflow.apache.org/docs/apache-airflow/stable/configurations-ref.html#base-url


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add a sentence describing what the `url` should be, referencing the Airflow docs for webserver/base_url. If this is changed from the default `http://localhost:8080` to something like `http://localhost:80/server` the Agent's URL needs to be updated accordingly.

### Motivation
<!-- What inspired you to submit this pull request? -->
Clear up steps and support cases, ex: CONS-4574

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
