### PR TITLE
Adding secondary link

### DIFF
--- a/etcd/README.md
+++ b/etcd/README.md
@@ -104,6 +104,7 @@ Need help? Contact [Datadog support][11].
 
 ## Further Reading
 
+- [Kubernetes Control Plane Monitoring][13]
 - [Monitor etcd performance to ensure consistent Docker configuration][12]
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/etcd/images/etcd_dashboard.png
@@ -118,3 +119,4 @@ Need help? Contact [Datadog support][11].
 [10]: https://github.com/DataDog/integrations-core/blob/master/etcd/assets/service_checks.json
 [11]: https://docs.datadoghq.com/help/
 [12]: https://www.datadoghq.com/blog/monitor-etcd-performance
+[13]: https://docs.datadoghq.com/agent/kubernetes/control_plane/?tab=helm


### PR DESCRIPTION
Adding a secondary reference to Further Reading in case the user is deploying etcd on a Kubernetes cluster.

### What does this PR do?
Adding a secondary reference to Further Reading in case the user is deploying etcd on a Kubernetes cluster.

### Motivation
Multiple hours of trying to figure out why the etcd integration was running into internal certificate issues on a standard kubernetes cluster. Ultimately, found the solution on this secondary page. Pages should be linked.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
