### PR TITLE
Remove outdated config description

### DIFF
--- a/http_check/assets/configuration/spec.yaml
+++ b/http_check/assets/configuration/spec.yaml
@@ -105,8 +105,6 @@ files:
         that configuration parameters expressed in seconds take precedence over
         the corresponding ones expressed in days.
 
-        The SSL certificate will always be validated for this additional
-        service check regardless of the value of `tls_verify`.
         By default, for the expiration check, the Agent validates the SSL certificate
         hostname against the host of the provided url.
       value:

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -416,10 +416,6 @@ instances:
     ## @param tls_ignore_warning - boolean - optional - default: false
     ## If `tls_verify` is disabled, security warnings are logged by the check.
     ## Disable those by setting `tls_ignore_warning` to true.
-    ##
-    ## Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration.
-    ## If enabled for multiple instances, spurious warnings might still appear even if `tls_ignore_warning` is set
-    ## to true.
     #
     # tls_ignore_warning: false
 

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -129,8 +129,6 @@ instances:
     ## that configuration parameters expressed in seconds take precedence over
     ## the corresponding ones expressed in days.
     ##
-    ## The SSL certificate will always be validated for this additional
-    ## service check regardless of the value of `tls_verify`.
     ## By default, for the expiration check, the Agent validates the SSL certificate
     ## hostname against the host of the provided url.
     #
@@ -418,6 +416,10 @@ instances:
     ## @param tls_ignore_warning - boolean - optional - default: false
     ## If `tls_verify` is disabled, security warnings are logged by the check.
     ## Disable those by setting `tls_ignore_warning` to true.
+    ##
+    ## Note: `tls_ignore_warning` set to true is currently only reliable if used by one instance of one integration.
+    ## If enabled for multiple instances, spurious warnings might still appear even if `tls_ignore_warning` is set
+    ## to true.
     #
     # tls_ignore_warning: false
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
After adding TLSContextWrapper support in https://github.com/DataDog/integrations-core/pull/8268, the value of `context.verify_mode` is affected by `tls_verify` rather than hardcoded to `ssl.CERT_REQUIRED`. 

This PR removes references to the hardcoded `ssl.CERT_REQUIRED` value from the config description.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
