### PR TITLE
Use remote hostname on all metrics when DBM is enabled

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -42,7 +42,10 @@ class BaseSqlServerMetric(object):
         self.datadog_name = cfg_instance['name']
         self.sql_name = cfg_instance.get('counter_name', '')
         self.base_name = base_name
-        self.report_function = partial(report_function, raw=True)
+        partial_kwargs = {}
+        if 'hostname' in cfg_instance:
+            partial_kwargs['hostname'] = cfg_instance['hostname']
+        self.report_function = partial(report_function, raw=True, **partial_kwargs)
         self.instance = cfg_instance.get('instance_name', '')
         self.object_name = cfg_instance.get('object_name', '')
         self.tags = cfg_instance.get('tags', [])

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -363,8 +363,7 @@ class SQLServer(AgentCheck):
 
         # Load database files
         for name, column, metric_type in DATABASE_FILES_IO:
-            cfg = {'name': name, 'column': column, 'tags': tags}
-
+            cfg = {'name': name, 'column': column, 'tags': tags, 'hostname': self.resolved_hostname}
             metrics_to_collect.append(SqlFileStats(cfg, None, getattr(self, metric_type), column, self.log))
 
         # Load AlwaysOn metrics
@@ -574,6 +573,8 @@ class SQLServer(AgentCheck):
             # Lookup metrics classes by their associated table
             metric_type_str, cls = metrics.TABLE_MAPPING[table]
             metric_type = getattr(self, metric_type_str)
+
+        cfg_inst['hostname'] = self.resolved_hostname
 
         return cls(cfg_inst, base_name, metric_type, column, self.log)
 

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -159,7 +159,7 @@ INIT_CONFIG_ALT_TABLES = {
 }
 
 
-def assert_metrics(aggregator, expected_tags, dbm_enabled=False):
+def assert_metrics(aggregator, expected_tags, dbm_enabled=False, hostname=None):
     """
     Boilerplate asserting all the expected metrics and service checks.
     Make sure ALL custom metric is tagged by database.
@@ -170,7 +170,8 @@ def assert_metrics(aggregator, expected_tags, dbm_enabled=False):
         dbm_excluded_metrics = [m[0] for m in DBM_MIGRATED_METRICS]
         expected_metrics = [m for m in EXPECTED_METRICS if m not in dbm_excluded_metrics]
     for mname in expected_metrics:
-        aggregator.assert_metric(mname)
+        assert hostname is not None, "hostname must be explicitly specified for all metrics"
+        aggregator.assert_metric(mname, hostname=hostname)
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK, tags=expected_tags)
     aggregator.assert_all_metrics_covered()
     aggregator.assert_no_duplicate_metrics()

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -44,7 +44,7 @@ def test_check_docker(aggregator, dd_run_check, init_config, instance_docker):
         'sqlserver_host:{}'.format(instance_docker.get('host')),
         'db:master',
     ]
-    assert_metrics(aggregator, expected_tags)
+    assert_metrics(aggregator, expected_tags, hostname=sqlserver_check.resolved_hostname)
 
 
 @pytest.mark.integration

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -232,4 +232,4 @@ def test_check_local(aggregator, dd_run_check, init_config, instance_docker):
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
     expected_tags = instance_docker.get('tags', []) + ['sqlserver_host:{}'.format(DOCKER_SERVER), 'db:master']
-    assert_metrics(aggregator, expected_tags)
+    assert_metrics(aggregator, expected_tags, hostname=sqlserver_check.resolved_hostname)


### PR DESCRIPTION
### What does this PR do?

When DBM is enabled we want all telemetry, both standard metrics as well as DBM events, to have the hostname set to the resolved hostname. This ensures that when an agent is monitoring a remote host (i.e. RDS or Azure managed) all SQL Server telemetry is tagged with the hostname of the remote host and not the agent's hostname.

### Motivation

Fix inconsistent hostname tagging when using DBM. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
