### PR TITLE
Add missing wait_resource column for activity collections

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -69,6 +69,7 @@ DM_EXEC_REQUESTS_COLS = [
     "wait_type",
     "wait_time",
     "last_wait_type",
+    "wait_resource",
     "open_transaction_count",
     "transaction_id",
     "percent_complete",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

SQLServer [dm_exec_requests](https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-exec-requests-transact-sql?view=sql-server-ver15) table has a `wait_resource` column, which we should show when we display blocking query trees

### Motivation
<!-- What inspired you to submit this pull request? -->

Follow up from https://github.com/DataDog/integrations-core/pull/11629

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
