### PR TITLE
Convert private key password into string instead of byte

### DIFF
--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -53,7 +53,9 @@ class SnowflakeCheck(AgentCheck):
             self.register_secret(self._config.password)
 
         if self._config.private_key_password:
-            self.register_secret(self._config.private_key_password)
+            # private_key_password is of type bytes so it can be loaded for the pem private key
+            # but this needs to converted to string to be registered as a secret for filtering
+            self.register_secret(str(self._config.private_key_password))
 
         if self._config.role == 'ACCOUNTADMIN':
             self.log.info(

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -9,6 +9,7 @@ from cryptography.hazmat.primitives import serialization
 
 from datadog_checks.base import AgentCheck, ConfigurationError, to_native_string
 from datadog_checks.base.utils.db import QueryManager
+from datadog_checks.base.utils.common import ensure_unicode
 
 from . import queries
 from .config import Config
@@ -55,7 +56,7 @@ class SnowflakeCheck(AgentCheck):
         if self._config.private_key_password:
             # private_key_password is of type bytes so it can be loaded for the pem private key
             # but this needs to converted to string to be registered as a secret for filtering
-            self.register_secret(str(self._config.private_key_password))
+            self.register_secret(ensure_unicode(self._config.private_key_password))
 
         if self._config.role == 'ACCOUNTADMIN':
             self.log.info(

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -53,8 +53,6 @@ class SnowflakeCheck(AgentCheck):
             self.register_secret(self._config.password)
 
         if self._config.private_key_password:
-            # private_key_password is of type bytes so it can be loaded for the pem private key
-            # but this needs to converted to string to be registered as a secret for filtering
             self.register_secret(self._config.private_key_password)
 
         if self._config.role == 'ACCOUNTADMIN':

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -7,7 +7,7 @@ import snowflake.connector as sf
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
-from datadog_checks.base import AgentCheck, ConfigurationError, to_native_string, ensure_bytes
+from datadog_checks.base import AgentCheck, ConfigurationError, ensure_bytes, to_native_string
 from datadog_checks.base.utils.db import QueryManager
 
 from . import queries

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from typing import List, Optional
 
-from datadog_checks.base import ConfigurationError, ensure_bytes, is_affirmative
+from datadog_checks.base import ConfigurationError, is_affirmative
 
 
 class Config(object):
@@ -42,7 +42,7 @@ class Config(object):
         token = instance.get('token', None)
         token_path = instance.get('token_path', None)
         private_key_path = instance.get('private_key_path', None)
-        private_key_password = ensure_bytes(instance.get('private_key_password', None))
+        private_key_password = instance.get('private_key_password', None)
         client_keep_alive = instance.get('client_session_keep_alive', False)
         aggregate_last_24_hours = instance.get('aggregate_last_24_hours', False)
         custom_queries_defined = len(instance.get('custom_queries', [])) > 0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR changes Snowflake's `private_key_password` to a string instead of a byte, and casts it as a byte once it is used for loading the PEM key.

### Motivation
<!-- What inspired you to submit this pull request? -->
Support and QA

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
