### PR TITLE
Add duration field for SQLServer samples

### DIFF
--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -256,6 +256,9 @@ def test_statement_metrics_and_plans(
     assert plan_events, "should have collected some plans"
 
     for event in plan_events:
+        assert event['duration'], "missing duration"
+        assert event['duration'] > 0, \
+            "unable to calc duration, missing total_elapsed_time or execution_count columns in qstats"
         assert event['db']['plan']['definition'], "event plan definition missing"
         parsed_plan = ET.fromstring(event['db']['plan']['definition'])
         assert parsed_plan.tag.endswith("ShowPlanXML"), "plan does not match expected structure"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds `duration` field to Query Sample events for SQLServer, which is calculated by dividing `total_elapsed_time` by `execution_count`, which should give us the avg duration of the query. 

Column values are detailed [in this doc](https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-exec-query-stats-transact-sql?view=sql-server-ver15)

### Motivation
<!-- What inspired you to submit this pull request? -->

Currently we are not adding this field to the sample events, and so customers see empty `Duration` columns in the Samples UI. This was reported by one of our Sales engineers as being confusing.

Example of current UI:

![Screen Shot 2022-03-11 at 12 11 35 PM](https://user-images.githubusercontent.com/14317240/157953079-4d2e53b9-7717-4c36-9d85-d56123fb3d15.png)


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
