### PR TITLE
[doc] corrected link for Kafka_consumer check

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -156,7 +156,7 @@ See [service_checks.json][15] for a list of service checks provided by this inte
 
 [1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/kafka/images/kafka_dashboard.png
 [2]: https://docs.datadoghq.com/integrations/java/
-[3]: https://docs.datadoghq.com/integrations/kafka/#agent-check-kafka-consumer
+[3]: https://docs.datadoghq.com/integrations/kafka/?tab=host#kafka-consumer-integration
 [4]: https://app.datadoghq.com/account/settings#agent
 [5]: https://github.com/DataDog/jmxfetch
 [6]: https://docs.datadoghq.com/integrations/amazon_msk/#pagetitle


### PR DESCRIPTION
### What does this PR do?
It corrects the link to the kafka_consumer check set up, previously, it would render the same exact page (https://docs.datadoghq.com/integrations/kafka/?tab=host#agent-check-kafka-consumer)

### Motivation
I am investigating on a ticket and found out that the link was not relevant

### Additional Notes
I hope this is accurate!

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
