### PR TITLE
Convert byte to string when sanitizing secrets

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/secrets.py
+++ b/datadog_checks_base/datadog_checks/base/utils/secrets.py
@@ -1,4 +1,5 @@
 from typing import Set
+from ..utils.common import ensure_unicode
 
 
 class SecretsSanitizer:
@@ -14,6 +15,9 @@ class SecretsSanitizer:
 
     def register(self, secret):
         # type: (str) -> None
+        if not isinstance(secret, str):
+            secret = ensure_unicode(secret)
+
         self.patterns.add(secret)
 
     def sanitize(self, text):

--- a/datadog_checks_base/tests/base/utils/test_utils.py
+++ b/datadog_checks_base/tests/base/utils/test_utils.py
@@ -251,3 +251,11 @@ class TestSecretsSanitizer:
         sanitized = sanitizer.sanitize(message)
         assert pwd1 not in sanitized
         assert pwd2 not in sanitized
+
+    def test_sanitize_type(self):
+        # test: () -> None
+        byte_secret = str.encode("s3cr3t")  # byte type
+        sanitizer = SecretsSanitizer()
+        sanitizer.register(byte_secret)
+        message = "s3cr3t"  # string type
+        assert all(letter == '*' for letter in sanitizer.sanitize(message))


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR converts any secrets that are byte types into strings in the base class.
### Motivation
<!-- What inspired you to submit this pull request? -->
Snowflake originally added its `private_key_password` as a byte (this changed in https://github.com/DataDog/integrations-core/pull/11648), which caused the [`replace()`](https://github.com/DataDog/integrations-core/blob/cb1538f36d221e698db8118e83cb968d99ad1614/datadog_checks_base/datadog_checks/base/utils/secrets.py#L22) function to fail. 
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
