### PR TITLE
Add a log line when activity limit is reached

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -162,6 +162,11 @@ class SqlserverActivity(DBMAsyncJob):
             if estimated_size > max_bytes_limit:
                 # query results are pre-sorted
                 # so once we hit the max bytes limit, return
+                self.log.warn(
+                    "Exceeded the limit of activity rows captured ({0} of {1} rows included). Database load may be under-reported as a result.".format(
+                        len(normalized_rows), len(rows)
+                    )
+                )
                 return normalized_rows
             normalized_rows.append(row)
         return normalized_rows

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -163,9 +163,8 @@ class SqlserverActivity(DBMAsyncJob):
                 # query results are pre-sorted
                 # so once we hit the max bytes limit, return
                 self.log.warn(
-                    "Exceeded the limit of activity rows captured ({0} of {1} rows included). Database load may be under-reported as a result.".format(
-                        len(normalized_rows), len(rows)
-                    )
+                    "Exceeded the limit of activity rows captured ({0} of {1} rows included). "
+                    "Database load may be under-reported as a result.".format(len(normalized_rows), len(rows))
                 )
                 return normalized_rows
             normalized_rows.append(row)


### PR DESCRIPTION
### What does this PR do?

This change adds a log line when an activity payload exceeds the current limit of 19MB. This should be a very rare occurrence, so a warning seems appropriate, since it can lead to under-reporting.

### Motivation


### Additional Notes

 In a future update, we will ideally handle this case better, but at a minimum we should know when this happens today.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
