### PR TITLE
Add image for OpenShift Service Mesh Proxy to ad_identifiers

### DIFF
--- a/istio/datadog_checks/istio/data/auto_conf.yaml
+++ b/istio/datadog_checks/istio/data/auto_conf.yaml
@@ -1,5 +1,6 @@
 ad_identifiers:
   - proxyv2
+  - proxyv2-rhel8
 
 ## All options defined here are available to all instances.
 #


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add the image `proxyv2-rhel8` to the list of `ad_identifiers` of the `istio/auto_conf.yaml`. In OpenShift Service Mesh it utilizes a custom Istio container image named `proxyv2-rhel8` instead of just `proxyv2`. So adding in this extra image to account for that. 

The actual integration will still run the same way, this is just to trigger on those Istio sidecar containers too.

### Motivation
<!-- What inspired you to submit this pull request? -->
Allow this portion of the integration to get setup automatically for OpenShift Service Mesh. This can be covered by a custom `istio.d/conf.yaml` configuration as a workaround, but this would just simplify that step.

[CONS-4516](https://datadoghq.atlassian.net/browse/CONS-4516)

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Redhat registry for this image:
- https://catalog.redhat.com/software/containers/openshift-service-mesh/proxyv2-rhel8/5d2cda455a134672890f640a

About Openshift Service Mesh:
- https://docs.openshift.com/container-platform/4.6/service_mesh/v2x/ossm-about.html

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
