### PR TITLE
Require private_key_password when using key pair auth

### DIFF
--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -100,7 +100,7 @@ files:
           Authenticator for Snowflake. Supported methods are:
           * `snowflake`, the default value, uses the internal Snowflake authenticator. It needs `password` or 
             `private_key_path` option.
-          * `snowflake_jwt`, uses key pair authentication. It needs `private_key_path` option.
+          * `snowflake_jwt`, uses key pair authentication. It needs `private_key_path` and `private_key_password` options.
           * `oauth`, to authenticate with OAuth method. It needs `token` or `token_path` option.
         value:
           type: string

--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -120,7 +120,7 @@ files:
       - name: private_key_path
         description: |
           The path to the file that contains the private key used to connect to Snowflake.
-          The key is re-read at every check run.
+          The key is re-read at every check run. This private key must be encrypted.
         value:
           type: string
           display_default: null

--- a/snowflake/datadog_checks/snowflake/config_models/validators.py
+++ b/snowflake/datadog_checks/snowflake/config_models/validators.py
@@ -23,6 +23,11 @@ def initialize_instance(values, **kwargs):
             '`only_custom_queries` prevents `metric_groups` to be collected.'
         )
 
+    if values.get('private_key_path', False) and not values.get('private_key_password', False):
+        raise ConfigurationError(
+            'Option `private_key_path` requires `private_key_password` entry.'
+        )
+
     return values
 
 

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -108,7 +108,7 @@ instances:
     ## Authenticator for Snowflake. Supported methods are:
     ## * `snowflake`, the default value, uses the internal Snowflake authenticator. It needs `password` or 
     ##   `private_key_path` option.
-    ## * `snowflake_jwt`, uses key pair authentication. It needs `private_key_path` option.
+    ## * `snowflake_jwt`, uses key pair authentication. It needs `private_key_path` and `private_key_password` options.
     ## * `oauth`, to authenticate with OAuth method. It needs `token` or `token_path` option.
     #
     # authenticator: <AUTHENTICATOR>

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -127,7 +127,7 @@ instances:
 
     ## @param private_key_path - string - optional
     ## The path to the file that contains the private key used to connect to Snowflake.
-    ## The key is re-read at every check run.
+    ## The key is re-read at every check run. This private key must be encrypted.
     #
     # private_key_path: /path/to/private_key
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR makes it required to use `private_key_password` when using `private_key_path`.

### Motivation
<!-- What inspired you to submit this pull request? -->
SnowSQL (which is used by the Snowflake Connector) [requires encrypted private keys](https://docs.snowflake.com/en/user-guide/snowsql-start.html#using-key-pair-authentication-key-pair-rotation).
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
