### PR TITLE
Fix flakey sqlserver activity test

### DIFF
--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -85,7 +85,9 @@ def test_collect_load_activity(aggregator, instance_docker, dd_run_check, dbm_in
         print("blocking query finished, waiting for fred's query to complete")
         time.sleep(1)
     # clean up fred's connection
+    # and shutdown executor
     fred_conn.close()
+    executor.shutdown(wait=True)
 
     expected_instance_tags = set(dbm_instance.get('tags', []))
 

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -72,6 +72,8 @@ def test_collect_load_activity(aggregator, instance_docker, dd_run_check, dbm_in
     executor = concurrent.futures.ThreadPoolExecutor(1)
     f_q = executor.submit(run_test_query, fred_conn, query)
     while not f_q.running():
+        if f_q.done():
+            break
         print("waiting on fred's query to execute")
         time.sleep(1)
 

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -64,19 +64,27 @@ def test_collect_load_activity(aggregator, instance_docker, dd_run_check, dbm_in
         cur.execute("USE {}".format("datadog_test"))
         cur.execute(q)
 
-    # bob's query blocks until the tx is completed,
-    # so it needs to be run asynchronously
-    executor = concurrent.futures.ThreadPoolExecutor(1)
-    executor.submit(run_test_query, bob_conn, blocking_query)
-    time.sleep(3)  # sleep for 3 seconds
+    # bob's query blocks until the tx is completed
+    run_test_query(bob_conn, blocking_query)
+
     # fred's query will get blocked by bob, so it needs
     # to be run asynchronously
-    executor.submit(run_test_query, fred_conn, query)
-    # run the check
+    executor = concurrent.futures.ThreadPoolExecutor(1)
+    f_q = executor.submit(run_test_query, fred_conn, query)
+    while not f_q.running():
+        print("waiting on fred's query to execute")
+        time.sleep(1)
+
+    # both queries were kicked off, so run the check
     dd_run_check(check)
-    # commit and close both transactions
+    # commit and close bob's transaction
     bob_conn.commit()
     bob_conn.close()
+
+    while not f_q.done():
+        print("blocking query finished, waiting for fred's query to complete")
+        time.sleep(1)
+    # clean up fred's connection
     fred_conn.close()
 
     expected_instance_tags = set(dbm_instance.get('tags', []))


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Attempt to fix these errors:
```3221225477 is 0xC0000005 which is NTSTATUS STATUS_ACCESS_VIOLATION; the corresponsing error message is The instruction at 0x%08lx referenced memory at 0x%08lx. The memory could not be %s..```

we are seeing intermittently in the test runs on windows machines

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
