### PR TITLE
Add more allowed recommended monitor types

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -23,7 +23,16 @@ from ..console import (
 
 REQUIRED_ATTRIBUTES = {'name', 'type', 'query', 'message', 'tags', 'options', 'recommended_monitor_metadata'}
 EXTRA_NOT_ALLOWED_FIELDS = ['id']
-ALLOWED_MONITOR_TYPES = ['query alert', 'event alert', 'service check']
+ALLOWED_MONITOR_TYPES = [
+    'audit alert',
+    'event alert',
+    'event-v2 alert',
+    'log alert',
+    'query alert',
+    'rum alert',
+    'service check',
+    'trace-analytics alert',
+]
 
 
 @click.command(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add more allowed monitors to the "recommended monitors" validation. Monitor types can be validated here - https://docs.datadoghq.com/api/latest/monitors/#create-a-monitor

### Motivation
<!-- What inspired you to submit this pull request? -->
These monitor types are now supported with recommended monitors

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
