### PR TITLE
Ensure PCFExecute disconnects

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -48,6 +48,7 @@ class ChannelMetricCollector(object):
 
     def get_pcf_channel_metrics(self, queue_manager):
         args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ensure_bytes('*')}
+        pcf = None
         try:
             pcf = pymqi.PCFExecute(
                 queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
@@ -72,6 +73,9 @@ class ChannelMetricCollector(object):
                 self._submit_metrics_from_properties(
                     channel_info, channel_name, metrics.channel_metrics(), channel_tags
                 )
+        finally:
+            if pcf is not None:
+                pcf.disconnect()
 
         # Check specific channels
         # If a channel is not discoverable, a user may want to check it specifically.
@@ -93,6 +97,7 @@ class ChannelMetricCollector(object):
         """
         channels_to_skip = channels_to_skip or []
         search_channel_tags = tags + ["channel:{}".format(search_channel_name)]
+        pcf = None
         try:
             args = {pymqi.CMQCFC.MQCACH_CHANNEL_NAME: pymqi.ensure_bytes(search_channel_name)}
             pcf = pymqi.PCFExecute(
@@ -132,6 +137,9 @@ class ChannelMetricCollector(object):
                 channel_status = channel_info[pymqi.CMQCFC.MQIACH_CHANNEL_STATUS]
                 self._submit_channel_count(channel_name, channel_status, channel_tags)
                 self._submit_status_check(channel_name, channel_status, channel_tags)
+        finally:
+            if pcf is not None:
+                pcf.disconnect()
 
     def _submit_metrics_from_properties(self, channel_info, channel_name, metrics_map, tags):
         # type: (Dict, str, Dict[str, int], List[str] ) -> None

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/metadata_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/metadata_collector.py
@@ -31,7 +31,7 @@ class MetadataCollector(object):
             queue_manager, response_wait_interval=self.config.timeout, convert=self.config.convert_endianness
         )
         resp = pcf.MQCMD_INQUIRE_Q_MGR({pymqi.CMQCFC.MQIACF_Q_MGR_ATTRS: [pymqi.CMQC.MQCA_VERSION]})
-
+        pcf.disconnect()
         try:
             version = to_native_string(resp[0][pymqi.CMQC.MQCA_VERSION])
             self.log.debug("IBM MQ version from response: %s", version)

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
@@ -37,14 +37,12 @@ class StatsCollector(object):
         """
         self.log.debug("Collecting stats newer than %s", self.config.instance_creation_datetime)
         queue = Queue(queue_manager, STATISTICS_QUEUE_NAME)
-        pcf = None
         try:
             # It's expected for the loop to stop when pymqi.MQMIError is raised with reason MQRC_NO_MSG_AVAILABLE.
-            pcf = pymqi.PCFExecute()
             while True:
                 bin_message = queue.get()
                 self.log.trace('Stats binary message: %s', bin_message)
-                message, header = pcf.unpack(bin_message)
+                message, header = pymqi.PCFExecute.unpack(bin_message)
                 self.log.trace('Stats unpacked message: %s, Stats unpacked header: %s', message, header)
 
                 stats = self._get_stats(message, header)
@@ -73,8 +71,6 @@ class StatsCollector(object):
             else:
                 raise
         finally:
-            if pcf is not None:
-                pcf.disconnect()
             try:
                 queue.close()
             except pymqi.PYIFError as e:

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/stats_collector.py
@@ -37,11 +37,13 @@ class StatsCollector(object):
         """
         self.log.debug("Collecting stats newer than %s", self.config.instance_creation_datetime)
         queue = Queue(queue_manager, STATISTICS_QUEUE_NAME)
+
         try:
             # It's expected for the loop to stop when pymqi.MQMIError is raised with reason MQRC_NO_MSG_AVAILABLE.
             while True:
                 bin_message = queue.get()
                 self.log.trace('Stats binary message: %s', bin_message)
+
                 message, header = pymqi.PCFExecute.unpack(bin_message)
                 self.log.trace('Stats unpacked message: %s, Stats unpacked header: %s', message, header)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds [`disconnect()`](https://github.com/dsuch/pymqi/blob/v1.12.0/code/pymqi/__init__.py#L2894) to all `PCFExecute` initializations to ensure that they are closed.
### Motivation
<!-- What inspired you to submit this pull request? -->
Reduce memory leak possibility.
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
