### PR TITLE
Add `auto_discover_channels` option

### DIFF
--- a/ibm_mq/assets/configuration/spec.yaml
+++ b/ibm_mq/assets/configuration/spec.yaml
@@ -105,6 +105,12 @@ files:
           type: array
           items:
             type: string
+      - name: auto_discover_channels
+        description: |
+          Autodiscover channels to monitor. This will discover all discoverable channels.
+        value:
+          example: true
+          type: boolean
       - name: channel_status_mapping
         description: |
           Custom channel status mapping for service check `ibm_mq.channel.status`.

--- a/ibm_mq/assets/configuration/spec.yaml
+++ b/ibm_mq/assets/configuration/spec.yaml
@@ -107,7 +107,10 @@ files:
             type: string
       - name: auto_discover_channels
         description: |
-          Autodiscover channels to monitor. This will discover all discoverable channels.
+          Autodiscover channels to monitor. This finds all discoverable channels.
+
+          Note: autodiscovered channels are in addition to the ones provided in `channels`,
+          and these channels will only report their statuses but not property metrics.
         value:
           example: true
           type: boolean

--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -81,7 +81,8 @@ class ChannelMetricCollector(object):
             self._submit_channel_status(queue_manager, channel, self.config.tags_no_channel)
 
         # Grab all the discoverable channels
-        self._submit_channel_status(queue_manager, '*', self.config.tags_no_channel)
+        if self.config.auto_discover_channels:
+            self._submit_channel_status(queue_manager, '*', self.config.tags_no_channel)
 
     def _submit_channel_status(self, queue_manager, search_channel_name, tags, channels_to_skip=None):
         """Submit channel status

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -100,6 +100,7 @@ class IBMMQConfig:
 
         self.convert_endianness = instance.get('convert_endianness', False)  # type: bool
         self.qm_timezone = instance.get('queue_manager_timezone', 'UTC')  # type: str
+        self.auto_discover_channels = instance.get('auto_discover_channels', True)  # type: bool
 
         custom_tags = instance.get('tags', [])  # type: List[str]
         tags = [

--- a/ibm_mq/datadog_checks/ibm_mq/config_models/defaults.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config_models/defaults.py
@@ -14,6 +14,10 @@ def shared_service(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_auto_discover_channels(field, value):
+    return True
+
+
 def instance_auto_discover_queues(field, value):
     return False
 

--- a/ibm_mq/datadog_checks/ibm_mq/config_models/instance.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config_models/instance.py
@@ -23,6 +23,7 @@ class InstanceConfig(BaseModel):
     class Config:
         allow_mutation = False
 
+    auto_discover_channels: Optional[bool]
     auto_discover_queues: Optional[bool]
     channel: str = Field(..., min_length=1)
     channel_status_mapping: Optional[Mapping[str, Any]]

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -95,7 +95,7 @@ instances:
     #   - <CHANNEL_NAME>
 
     ## @param auto_discover_channels - boolean - optional - default: true
-    ## Autodiscover channels to monitor. This will discover all discoverable channels.
+    ## Autodiscover channels to monitor. This finds all discoverable channels.
     #
     # auto_discover_channels: true
 

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -96,6 +96,9 @@ instances:
 
     ## @param auto_discover_channels - boolean - optional - default: true
     ## Autodiscover channels to monitor. This finds all discoverable channels.
+    ##
+    ## Note: autodiscovered channels are in addition to the ones provided in `channels`,
+    ## and these channels will only report their statuses but not property metrics.
     #
     # auto_discover_channels: true
 

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -94,6 +94,11 @@ instances:
     # channels:
     #   - <CHANNEL_NAME>
 
+    ## @param auto_discover_channels - boolean - optional - default: true
+    ## Autodiscover channels to monitor. This will discover all discoverable channels.
+    #
+    # auto_discover_channels: true
+
     ## @param channel_status_mapping - mapping - optional
     ## Custom channel status mapping for service check `ibm_mq.channel.status`.
     ##


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds a new `auto_discover_channels` option to disable automatically submitting channel status for `'*'` channels.

### Motivation
<!-- What inspired you to submit this pull request? -->
Reduce memory leak possibility

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
