### PR TITLE
Revert "[Cilium] Fix containerised configuration doc"

### DIFF
--- a/cilium/README.md
+++ b/cilium/README.md
@@ -114,40 +114,24 @@ Cilium contains two types of logs: `cilium-agent` and `cilium-operator`.
 
 For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.
 
-Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes Log Collection][7].
-
-##### To collect `cilium-agent` metrics and logs: 
-
-- Metric collection
+##### Metric collection
 
 | Parameter            | Value                                                      |
 |----------------------|------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `"cilium"`                                                 |
+| `<INTEGRATION_NAME>` | `cilium`                                                   |
 | `<INIT_CONFIG>`      | blank or `{}`                                              |
-| `<INSTANCE_CONFIG>`  | `{"agent_endpoint": "http://%%host%%:9090/metrics", "use_openmetrics": "true"}` |
+| `<INSTANCE_CONFIG>`  | `{"agent_endpoint": "http://%%host%%:9090/metrics", "use_openmetrics": True}`       |
 
-- Log collection
+##### Log collection
+
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes Log Collection][7].
 
 | Parameter      | Value                                     |
 |----------------|-------------------------------------------|
 | `<LOG_CONFIG>` | `{"source": "cilium-agent", "service": "cilium-agent"}` |
 
-##### To collect `cilium-operator` metrics and logs: 
-
-- Metric collection
-
-| Parameter            | Value                                                      |
-|----------------------|------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `"cilium"`                                                 |
-| `<INIT_CONFIG>`      | blank or `{}`                                              |
-| `<INSTANCE_CONFIG>`  | `{"operator_endpoint": "http://%%host%%:6942/metrics", "use_openmetrics": "true"}` |
-
-- Log collection
-
-| Parameter      | Value                                     |
-|----------------|-------------------------------------------|
-| `<LOG_CONFIG>` | `{"source": "cilium-operator", "service": "cilium-operator"}` |
-
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 ### Validation
 


### PR DESCRIPTION
Reverts DataDog/integrations-core#11656 - broke the docs build. Will add it back when I figure out why