### PR TITLE
REDO: [Cilium] Fix containerised configuration doc

### DIFF
--- a/cilium/README.md
+++ b/cilium/README.md
@@ -114,24 +114,40 @@ Cilium contains two types of logs: `cilium-agent` and `cilium-operator`.
 
 For containerized environments, see the [Autodiscovery Integration Templates][2] for guidance on applying the parameters below.
 
-##### Metric collection
+Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes Log Collection][7].
+
+##### To collect `cilium-agent` metrics and logs: 
+
+- Metric collection
 
 | Parameter            | Value                                                      |
 |----------------------|------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `cilium`                                                   |
+| `<INTEGRATION_NAME>` | `"cilium"`                                                 |
 | `<INIT_CONFIG>`      | blank or `{}`                                              |
-| `<INSTANCE_CONFIG>`  | `{"agent_endpoint": "http://%%host%%:9090/metrics", "use_openmetrics": True}`       |
+| `<INSTANCE_CONFIG>`  | `{"agent_endpoint": "http://%%host%%:9090/metrics", "use_openmetrics": "true"}` |
 
-##### Log collection
-
-Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes Log Collection][7].
+- Log collection
 
 | Parameter      | Value                                     |
 |----------------|-------------------------------------------|
 | `<LOG_CONFIG>` | `{"source": "cilium-agent", "service": "cilium-agent"}` |
 
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
+##### To collect `cilium-operator` metrics and logs: 
+
+- Metric collection
+
+| Parameter            | Value                                                      |
+|----------------------|------------------------------------------------------------|
+| `<INTEGRATION_NAME>` | `"cilium"`                                                 |
+| `<INIT_CONFIG>`      | blank or `{}`                                              |
+| `<INSTANCE_CONFIG>`  | `{"operator_endpoint": "http://%%host%%:6942/metrics", "use_openmetrics": "true"}` |
+
+- Log collection
+
+| Parameter      | Value                                     |
+|----------------|-------------------------------------------|
+| `<LOG_CONFIG>` | `{"source": "cilium-operator", "service": "cilium-operator"}` |
+
 
 ### Validation
 

--- a/cilium/README.md
+++ b/cilium/README.md
@@ -148,6 +148,8 @@ Collecting logs is disabled by default in the Datadog Agent. To enable it, see [
 |----------------|-------------------------------------------|
 | `<LOG_CONFIG>` | `{"source": "cilium-operator", "service": "cilium-operator"}` |
 
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
 
 ### Validation
 


### PR DESCRIPTION
Original PR #11656 broke the documentation build. Retrying (do not merge until we're sure this works)

FIxing the `instance_config` definition should be string instead of Boolean:
  `"use_openmetrics": "true"`

Also added separate metrics/logs collection for Agent and Operator containerised

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
