### PR TITLE
Default to matching all conntrack metrics

### DIFF
--- a/network/datadog_checks/network/data/conf.yaml.default
+++ b/network/datadog_checks/network/data/conf.yaml.default
@@ -82,12 +82,12 @@ instances:
     #
     # use_sudo_conntrack: true
 
-    ## @param whitelist_conntrack_metrics - list of strings - optional - default: ['max', 'count']
+    ## @param whitelist_conntrack_metrics - list of strings - optional - default: ['.*']
     ## Linux only.
     ## Names of the conntrack metrics to whitelist for monitoring. The metric value is in the file
     ## /${proc}/sys/net/netfilter/nf_conntrack_${metric_name}.
-    ## By default the agent collects only max and count.
-    ## Regex expressions for the project names are supported.
+    ## By default the agent collects all reported metrics.
+    ## Project names are matched using regex, which means that metrics which contain the substring will match.
     ## Blacklist takes precedence over whitelist in case of overlap.
     #
     # whitelist_conntrack_metrics:
@@ -99,7 +99,7 @@ instances:
     ## Names of the conntrack metrics to blacklist for monitoring. The metric value is in the file
     ## /${proc}/sys/net/netfilter/nf_conntrack_${metric_name}.
     ## If set, whitelist default value is reset to [].
-    ## Regex expressions for the project names are supported.
+    ## Project names are matched using regex, which means that metrics which contain the substring will match.
     ## Blacklist takes precedence over whitelist in case of overlap.
     #
     # blacklist_conntrack_metrics:

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -551,12 +551,12 @@ class Network(AgentCheck):
 
         # Get the rest of the metric by reading the files. Metrics available since kernel 3.6
         conntrack_files_location = os.path.join(proc_location, 'sys', 'net', 'netfilter')
-        # By default, only max and count are reported. However if the blacklist is set,
+        # By default, all conntrack metrics are reported. However if the blacklist is set,
         # the whitelist is losing its default value
         blacklisted_files = instance.get('blacklist_conntrack_metrics')
         whitelisted_files = instance.get('whitelist_conntrack_metrics')
         if blacklisted_files is None and whitelisted_files is None:
-            whitelisted_files = ['max', 'count']
+            whitelisted_files = ['.*']
 
         available_files = []
 


### PR DESCRIPTION
### What does this PR do?
Default to matching all conntrack metrics when no whitelist or blacklist is configured. 

This PR also updates the documentation comments in the network module's configuration file to indicate that the matcher uses regex matching, which means that supplied whitelist/blacklist configuration might match more than what's expected. 
For example: Supplying `max` in the whitelist will match `tcp_max_retrans` (and this corroborates observed behavior). 

### Motivation
See Case #: 711411 for full context. 

The default behavior feels a bit unintuitive. I would expect that not providing a white/black list would, by default, send all metrics. 

Similarly, overriding the default behavior leads to permanent management overhead. Examples: 
* If a kernel upgrade exposes additional metrics, these would have to be similarly configured and managed). 
* If the whitelist/blacklist behavior changed, we'd have to update configuration

### Additional Notes
I don't understand why the default behavior was to limit the metrics sent back, so there could very well be a good reason for it. As mentioned on the Support Ticket I filed, my slight preference is to send all metrics back by default rather than default to a filter being applied due to the ongoing need to manage the configuration overrides. I'm open to a discussion regarding this change in default behavior. 

Also note that in my local environment the unit tests failed without any changes. Similarly, the integration tests don't currently test the default behavior (my read is that they do test the filtering logic when a white/blacklist is applied), so I don't believe this needs a test update. Let me know if you don't agree and I can add tests. 

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
