### PR TITLE
Add ag listener ip state metric for SQL Server

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -80,8 +80,11 @@ INSTANCE_METRICS_TOTAL = [
 
 # AlwaysOn metrics
 # datadog metric name, sql table, column name, tag
+# Listener IP State enum:
+#   0 = Offline, 1 = Online, 2 = Online Pending, 3 = Failed
 AO_METRICS = [
     ('sqlserver.ao.ag_sync_health', 'sys.dm_hadr_availability_group_states', 'synchronization_health'),
+    ('sqlserver.ao.ag_listener_ip_state', 'availability_group_listener_ip_addresses', 'state'),
     ('sqlserver.ao.replica_sync_state', 'sys.dm_hadr_database_replica_states', 'synchronization_state'),
     ('sqlserver.ao.replica_failover_mode', 'sys.availability_replicas', 'failover_mode'),
     ('sqlserver.ao.replica_failover_readiness', 'sys.availability_replicas', 'is_failover_ready'),

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -84,7 +84,7 @@ INSTANCE_METRICS_TOTAL = [
 #   0 = Offline, 1 = Online, 2 = Online Pending, 3 = Failed
 AO_METRICS = [
     ('sqlserver.ao.ag_sync_health', 'sys.dm_hadr_availability_group_states', 'synchronization_health'),
-    ('sqlserver.ao.ag_listener_ip_state', 'availability_group_listener_ip_addresses', 'state'),
+    ('sqlserver.ao.ag_listener_ip_state', 'sys.availability_group_listener_ip_addresses', 'state'),
     ('sqlserver.ao.replica_sync_state', 'sys.dm_hadr_database_replica_states', 'synchronization_state'),
     ('sqlserver.ao.replica_failover_mode', 'sys.availability_replicas', 'failover_mode'),
     ('sqlserver.ao.replica_failover_readiness', 'sys.availability_replicas', 'is_failover_ready'),

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -974,6 +974,7 @@ class SqlAvailabilityGroups(BaseSqlServerMetric):
 
             self.report_function(metric_name, column_val, tags=metric_tags)
 
+
 # sys.availability_group_listener_ip_addresses
 # Returns a row for each listener IP address that is assigned to an availability group's listener.
 # Each row displays the states that define the state of a given listener IP.
@@ -982,11 +983,11 @@ class SqlAvailabilityGroups(BaseSqlServerMetric):
 class SqlAvailabilityGroupListenerIps(BaseSqlServerMetric):
     TABLE = 'sys.availability_group_listener_ip_addresses'
     DEFAULT_METRIC_TYPE = 'gauge'
-    QUERY_BASE = """select ag.resource_group_id, ag.name,agl.dns_name, aglia.* 
+    QUERY_BASE = """select ag.resource_group_id, ag.name,agl.dns_name, aglia.*
                     from {table} as aglia
-                    inner join sys.availability_group_listeners as agl 
+                    inner join sys.availability_group_listeners as agl
                     on agl.listener_id = aglia.listener_id
-                    inner join sys.availability_groups as ag 
+                    inner join sys.availability_groups as ag
                     on ag.group_id = agl.group_id""".format(
         table=TABLE
     )

--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -1,6 +1,7 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 sqlserver.access.page_splits,gauge,,operation,second,The number of page splits per second.,-1,sql_server,page splits,
 sqlserver.ao.ag_sync_health,gauge,,,,"Availability group synchronization health: 0 = Not healthy, 1 = Partially healthy, 2 = Healthy",0,sql_server,ag sync health,
+sqlserver.ao.ag_listener_ip_state,gauge,,,,"Availability group listener IP state: 0 = Offline, 1 = Online, 2 = Online Pending, 3 = Failed",0,sql_server,ag listener ip state,
 sqlserver.ao.replica_sync_state,gauge,,,,"Replica synchronization state: 0 = Not synchronizing, 1 = Synchronizing, 2 = Synchronized, 3 = Reverting, 4 = Initializing",0,sql_server,replica sync state,
 sqlserver.ao.replica_failover_mode,gauge,,,,"Replica failover mode: 0 = Automatic failover, 1 = Manual failover",0,sql_server,replica failover mode,
 sqlserver.ao.replica_failover_readiness,gauge,,,,"Replica failover readiness: 0 = Not ready for failover, 1 = Ready for failover",0,sql_server,replica failover readiness,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds metrics to get the state of SQL Server availability group listener IP addresses via DMVs.

I think it makes sense to add it as a new class, but am happy to insert it into an existing one as well.

### Motivation
<!-- What inspired you to submit this pull request? -->
This is a DMV that Microsoft lists to use to monitor availability group listeners in their [documentation](https://docs.microsoft.com/en-us/sql/database-engine/availability-groups/windows/monitor-availability-groups-transact-sql?view=sql-server-ver15#AGlisteners). It is also featured in other SQL Server monitoring tools, like [Foglight for Databases](https://support.quest.com/kb/337242/what-rules-are-available-for-sql-server-availability-groups). 

We are currently working to transition alerting from Foglight to Datadog for SQL Server and this is one that we can't yet migrate without this new metric.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e) - _Existing tests should be sufficient as far as I can tell_
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
