### PR TITLE
Add SQL metadata to SQL Server activity events

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -192,7 +192,11 @@ class SqlserverActivity(DBMAsyncJob):
         if 'text' not in row:
             return row
         try:
-            obfuscated_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)['query']
+            statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
+            obfuscated_statement = statement['query']
+            metadata = statement['metadata']
+            row['dd_tables'] = metadata.get('tables', None)
+            row['dd_commands'] = metadata.get('commands', None)
             row['query_signature'] = compute_sql_signature(obfuscated_statement)
         except Exception as e:
             # obfuscation errors are relatively common so only log them during debugging

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -195,8 +195,9 @@ class SqlserverActivity(DBMAsyncJob):
             statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             obfuscated_statement = statement['query']
             metadata = statement['metadata']
-            row['dd_tables'] = metadata.get('tables', None)
             row['dd_commands'] = metadata.get('commands', None)
+            row['dd_tables'] = metadata.get('tables', None)
+            row['dd_comments'] = metadata.get('comments', None)
             row['query_signature'] = compute_sql_signature(obfuscated_statement)
         except Exception as e:
             # obfuscation errors are relatively common so only log them during debugging

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -288,9 +288,7 @@ def test_statement_metrics_and_plans(
         ),
     ],
 )
-def test_statement_metadata(
-    aggregator, dd_run_check, dbm_instance, datadog_agent, metadata, expected_metadata_payload
-):
+def test_statement_metadata(aggregator, dd_run_check, dbm_instance, datadog_agent, metadata, expected_metadata_payload):
     # Enable activity for this test to check for metadata
     dbm_instance['query_activity'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
 

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -357,7 +357,7 @@ def test_statement_metadata(
     assert metric['dd_tables'] == expected_metadata_payload['tables']
     assert metric['dd_commands'] == expected_metadata_payload['commands']
 
-    # Setup activity for testing
+    # Setup activity for metadata testing
     blocking_query = "INSERT INTO ϑings WITH (TABLOCK, HOLDLOCK) (name) VALUES ('puppy')"
     fred_conn = _get_conn_for_user('fred')
 
@@ -391,6 +391,7 @@ def test_statement_metadata(
     activity = matching_activity[0]
     assert activity['dd_tables'] == expected_metadata_payload['tables']
     assert activity['dd_commands'] == expected_metadata_payload['commands']
+    assert activity['dd_comments'] == expected_metadata_payload['comments']
 
 
 @pytest.mark.integration

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -294,7 +294,7 @@ def test_statement_metrics_and_plans(
     ],
 )
 def test_statement_metadata(
-    aggregator, instance_docker, dd_run_check, datadog_conn_docker, dbm_instance, datadog_agent, metadata, expected_metadata_payload
+    aggregator, instance_docker, dd_run_check, dbm_instance, datadog_agent, metadata, expected_metadata_payload
 ):
     def _get_conn_for_user(user):
         conn_str = 'DRIVER={};Server={};Database=master;UID={};PWD={};'.format(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds SQL metadata to SQL Server activity.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
