### PR TITLE
Properly report a critical service check status if connection to database fails using the Oracle client

### DIFF
--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -158,8 +158,12 @@ class Oracle(AgentCheck):
             if self.can_use_oracle_client():
                 dsn = self._get_dsn()
                 self.log.debug("Connecting via Oracle Instant Client with DSN: %s", dsn)
-                self._cached_connection = cx_Oracle.connect(user=self._user, password=self._password, dsn=dsn)
-                self.log.debug("Connected to Oracle DB using Oracle Instant Client")
+                try:
+                    self._cached_connection = cx_Oracle.connect(user=self._user, password=self._password, dsn=dsn)
+                    self.log.debug("Connected to Oracle DB using Oracle Instant Client")
+                except cx_Oracle.DatabaseError as e:
+                    self._connection_errors += 1
+                    self.log.error("Failed to connect to Oracle DB using Oracle Instant Client, error: %s", str(e))
             elif JDBC_IMPORT_ERROR:
                 self._connection_errors += 1
                 self.log.error(

--- a/oracle/tests/conftest.py
+++ b/oracle/tests/conftest.py
@@ -138,6 +138,17 @@ def dd_environment():
         yield instance, e2e_metadata
 
 
+@pytest.fixture
+def bad_instance():
+    return {
+        "password": "badpassword",
+        "protocol": "TCP",
+        "server": "localhost:1521",
+        "service_name": "InfraDB.us.oracle.com",
+        "username": "datadog",
+    }
+
+
 def create_user():
     output = run_docker_command(
         [

--- a/oracle/tests/test_e2e.py
+++ b/oracle/tests/test_e2e.py
@@ -4,6 +4,8 @@
 
 import pytest
 
+from datadog_checks.oracle import Oracle
+
 METRICS = [
     'oracle.tablespace.used',
     # ProcessMetrics
@@ -43,6 +45,14 @@ METRICS = [
 ]
 SERVICE_CHECKS = ['oracle.can_connect', 'oracle.can_query']
 
+bad_instance = {
+    "password": "badpassword",
+    "protocol": "TCP",
+    "server": "localhost:1521",
+    "service_name": "InfraDB.us.oracle.com",
+    "username": "datadog",
+}
+
 
 @pytest.mark.e2e
 def test_check(dd_agent_check):
@@ -53,3 +63,9 @@ def test_check(dd_agent_check):
     for service_check in SERVICE_CHECKS:
         aggregator.assert_service_check(service_check)
     aggregator.assert_all_metrics_covered()
+
+
+@pytest.mark.e2e
+def test_bad_service_check(dd_agent_check, bad_instance):
+    aggregator = dd_agent_check(bad_instance)
+    aggregator.assert_service_check("oracle.can_connect", Oracle.CRITICAL)

--- a/oracle/tests/test_e2e.py
+++ b/oracle/tests/test_e2e.py
@@ -45,14 +45,6 @@ METRICS = [
 ]
 SERVICE_CHECKS = ['oracle.can_connect', 'oracle.can_query']
 
-bad_instance = {
-    "password": "badpassword",
-    "protocol": "TCP",
-    "server": "localhost:1521",
-    "service_name": "InfraDB.us.oracle.com",
-    "username": "datadog",
-}
-
 
 @pytest.mark.e2e
 def test_check(dd_agent_check):


### PR DESCRIPTION
### What does this PR do?
Added logic to submit a critical status for the service check if the connection being made using the instance client fails. Currently when using the instant client the service check will only return critical if there's a parsing issue in creating the dsn, but the service check will return `OK` regardless if we're able to connect or not.

The check at the current state will continue running even if the connection fails. Is it better to raise an exception if the connection fails? 

### Motivation
Support case


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
