### PR TITLE
Add `metric_patterns` to base template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/default.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/default.yaml
@@ -8,3 +8,24 @@
     display_default: false
     example: true
   hidden: true
+- name: metric_patterns
+  description: |
+    A mapping of metrics to include or exclude, with each entry being a regular expression.
+
+    Metrics defined in `exclude` will take precedence in case of overlap.
+  value:
+    example:
+      include:
+        - <INCLUDE_REGEX>
+      exclude:
+        - <EXCLUDE_REGEX>
+    type: object
+    properties:
+      - name: include
+        type: array
+        items:
+          type: string
+      - name: exclude
+        type: array
+        items:
+          type: string

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=11.2.0",
+    "datadog-checks-base>=25.1.0",
 ]
 dynamic = [
     "version",

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -1099,6 +1099,17 @@ def test_template_recursion():
             ## This is useful for cluster-level checks.
             #
             # empty_default_hostname: false
+
+            ## @param metric_patterns - mapping - optional
+            ## A mapping of metrics to include or exclude, with each entry being a regular expression.
+            ##
+            ## Metrics defined in `exclude` will take precedence in case of overlap.
+            #
+            # metric_patterns:
+            #   include:
+            #   - <INCLUDE_REGEX>
+            #   exclude:
+            #   - <EXCLUDE_REGEX>
         """
     )
 


### PR DESCRIPTION
### What does this PR do?
Adds `metric_patterns` to the base template

### Motivation
https://github.com/DataDog/integrations-core/pull/11508

### Additional Notes
Will fail validation until https://github.com/DataDog/integrations-core/pull/11695 is merged
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
