### PR TITLE
Add note about special characters in property name

### DIFF
--- a/windows_service/README.md
+++ b/windows_service/README.md
@@ -16,7 +16,7 @@ The Windows Service check is included in the [Datadog Agent][1] package, so you 
 
 2. Provide service names as they appear in the `services.msc` properties field, **NOT** the display names. For names with spaces, enclose the whole name in double quotation marks, for example: `"Windows Service"`. **Note**: Spaces are replaced by underscores in Datadog. 
   
-- If your service name includes a special character *i.g.* `MSSQL$CRMAWS` you will need to [escape the special character](https://docs.datadoghq.com/real_user_monitoring/explorer/search_syntax/#escape-special-characters) with a "\\". The service name should look like `MSSQL\$CRMAWS` in the configuration.
+- If your service name includes a special character (for example: `MSSQL$CRMAWS`) you must [escape the special character](https://docs.datadoghq.com/real_user_monitoring/explorer/search_syntax/#escape-special-characters) with a `\`. The service name should look like `MSSQL\$CRMAWS` in the configuration.
 
 3. [Restart the Agent][4].
 

--- a/windows_service/README.md
+++ b/windows_service/README.md
@@ -14,7 +14,7 @@ The Windows Service check is included in the [Datadog Agent][1] package, so you 
 
 1. Edit the `windows_service.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample windows_service.d/conf.yaml][3] for all available configuration options.
 
-2. Provide service names as they appear in the `services.msc` properties field **NOT** the display name. For names with spaces, enclose the whole name in double quotation marks, for example: `"Windows Service"`. **Note**: Spaces are replaced by underscores in Datadog. 
+2. Provide service names as they appear in the `services.msc` properties field, **NOT** the display names. For names with spaces, enclose the whole name in double quotation marks, for example: `"Windows Service"`. **Note**: Spaces are replaced by underscores in Datadog. 
   
 - If your service name includes a special character *i.g.* `MSSQL$CRMAWS` you will need to [escape the special character](https://docs.datadoghq.com/real_user_monitoring/explorer/search_syntax/#escape-special-characters) with a "\\". The service name should look like `MSSQL\$CRMAWS` in the configuration.
 

--- a/windows_service/README.md
+++ b/windows_service/README.md
@@ -16,7 +16,7 @@ The Windows Service check is included in the [Datadog Agent][1] package, so you 
 
 2. Provide service names as they appear in the `services.msc` properties field, **NOT** the display names. For names with spaces, enclose the whole name in double quotation marks, for example: `"Windows Service"`. **Note**: Spaces are replaced by underscores in Datadog. 
   
-- If your service name includes a special character (for example: `MSSQL$CRMAWS`) you must [escape the special character](https://docs.datadoghq.com/real_user_monitoring/explorer/search_syntax/#escape-special-characters) with a `\`. The service name should look like `MSSQL\$CRMAWS` in the configuration.
+- If your service name includes a special character (for example: `MSSQL$CRMAWS`) you must [escape the special character][13] with a `\`. The service name should look like `MSSQL\$CRMAWS` in the configuration.
 
 3. [Restart the Agent][4].
 
@@ -64,3 +64,4 @@ Need help? Contact [Datadog support][9].
 [10]: https://www.datadoghq.com/blog/monitoring-windows-server-2012
 [11]: https://www.datadoghq.com/blog/collect-windows-server-2012-metrics
 [12]: https://www.datadoghq.com/blog/windows-server-monitoring
+[13]: https://docs.datadoghq.com/real_user_monitoring/explorer/search_syntax/#escape-special-characters

--- a/windows_service/README.md
+++ b/windows_service/README.md
@@ -14,7 +14,9 @@ The Windows Service check is included in the [Datadog Agent][1] package, so you 
 
 1. Edit the `windows_service.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. See the [sample windows_service.d/conf.yaml][3] for all available configuration options.
 
-2. Provide service names as they appear in the `services.msc` properties field **NOT** the display name. For names with spaces, enclose the whole name in double quotation marks, for example: `"Windows Service"`. **Note**: Spaces are replaced by underscores in Datadog.
+2. Provide service names as they appear in the `services.msc` properties field **NOT** the display name. For names with spaces, enclose the whole name in double quotation marks, for example: `"Windows Service"`. **Note**: Spaces are replaced by underscores in Datadog. 
+  
+- If your service name includes a special character *i.g.* `MSSQL$CRMAWS` you will need to [escape the special character](https://docs.datadoghq.com/real_user_monitoring/explorer/search_syntax/#escape-special-characters) with a "\\". The service name should look like `MSSQL\$CRMAWS` in the configuration.
 
 3. [Restart the Agent][4].
 


### PR DESCRIPTION
Some users will find that the service name includes a special character - MSSQL$CRMAWS - in this instance when they enter this into the configuration file just as it is, the windows service check will return unknown. What's happening is that the $ gets turned into an underscore and the agent can't find it since that isn't its name. They need to escape special characters like this - MSSQL\$CRMAWS for the service name to be properly found. Since this isn't mentioned anywhere in this doc, there only option is to ask support why its messed up.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
