### PR TITLE
Add request_status in sqlserver activity query

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -46,6 +46,7 @@ SELECT
     sess.session_id as id,
     DB_NAME(sess.database_id) as database_name,
     sess.status as session_status,
+    req.status as request_status,
     text.text as text,
     c.client_tcp_port as client_port,
     c.client_net_address as client_address,

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -111,6 +111,7 @@ def test_collect_load_activity(aggregator, instance_docker, dd_run_check, dbm_in
     # assert the data that was collected is correct
     assert blocked_row['user_name'] == "fred", "incorrect user_name"
     assert blocked_row['session_status'] == "running", "incorrect session_status"
+    assert blocked_row['request_status'] == "suspended", "incorrect request_status"
     assert blocked_row['blocking_session_id'], "missing blocking_session_id"
     assert blocked_row['text'] == query, "incorrect blocked query"
     assert blocked_row['database_name'] == "datadog_test", "incorrect database_name"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Right now we only send the status from the `dm_exec_sessions` dmv table, which can be different than the status in the `dm_exec_requests` view.

### Motivation
<!-- What inspired you to submit this pull request? -->

This information is important for customers to be able to distinguish between queries that are active, but blocked and queries that are active and executing 

more information documented here https://www.sqlshack.com/monitoring-sql-server-with-dynamic-management-objects-requests/

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
