### PR TITLE
Add CloudFormation example and document newer env var options

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -163,18 +163,20 @@ For environment variables available with the Docker Agent container, see the [Do
 | Environment Variable               | Description                                    |
 |------------------------------------|------------------------------------------------|
 | `DD_DOCKER_LABELS_AS_TAGS`         | Extract docker container labels                |
+| `DD_CONTAINER_LABELS_AS_TAGS`      | Extract container labels                       |
 | `DD_DOCKER_ENV_AS_TAGS`            | Extract docker container environment variables |
+| `DD_CONTAINER_ENV_AS_TAGS`         | Extract container environment variables        |
 | `DD_KUBERNETES_POD_LABELS_AS_TAGS` | Extract pod labels                             |
 | `DD_CHECKS_TAG_CARDINALITY`        | Add tags to check metrics                      |
 | `DD_DOGSTATSD_TAG_CARDINALITY`     | Add tags to custom metrics                     |
 
-For global tagging, it is recommended to use `DD_DOCKER_LABELS_AS_TAGS`. With this method, the Agent pulls in tags from your Docker container labels. This requires you to add the appropriate labels to your other Docker containers. Labels can be added directly in the [task definition][19].
+For global tagging, it is recommended to use `DD_CONTAINER_LABELS_AS_TAGS`. With this method, the Agent pulls in tags from your container labels. This requires you to add the appropriate labels to your other containers. Labels can be added directly in the [task definition][19].
 
 Format for the Agent container:
 
 ```json
 {
-  "name": "DD_DOCKER_LABELS_AS_TAGS",
+  "name": "DD_CONTAINER_LABELS_AS_TAGS",
   "value": "{\"<LABEL_NAME_TO_COLLECT>\":\"<TAG_KEY_FOR_DATADOG>\"}"
 }
 ```
@@ -183,9 +185,19 @@ Example for the Agent container:
 
 ```json
 {
-  "name": "DD_DOCKER_LABELS_AS_TAGS",
+  "name": "DD_CONTAINER_LABELS_AS_TAGS",
   "value": "{\"com.docker.compose.service\":\"service_name\"}"
 }
+```
+
+CloudFormation example (YAML):
+
+```yaml
+      ContainerDefinitions:
+        - 
+          Environment:
+            - Name: DD_CONTAINER_LABELS_AS_TAGS
+              Value: "{\"com.docker.compose.service\":\"service_name\"}"
 ```
 
 **Note**: You should not use `DD_HOSTNAME` since there is no concept of a host to the user in Fargate. `DD_TAGS` is traditionally used to assign host tags, but as of Datadog Agent version 6.13.0 you can also use the environment variable to set global tags on your integration metrics.


### PR DESCRIPTION
### What does this PR do?
* Documents newer env vars `DD_CONTAINER_ENV/LABELS_AS_TAGS` introduced in Agent v7.32/33
* Adds a YAML CloudFormation example for `DD_DOCKER/CONTAINER_LABELS_AS_TAGS`

### Motivation
Github issue in which a user requested a CloudFormation example for `DD_DOCKER_LABELS_AS_TAGS`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
