### PR TITLE
Corrects link to Tracing Docker Applications

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -347,7 +347,7 @@ Required environment variables on the Agent container:
 | `<DD_APM_ENABLED>`      | true                                                              |
 | `<DD_APM_NON_LOCAL_TRAFFIC>`  | true |
 
-See [Tracing Docker Applications][12] for a complete list of available environment variables and configuration.
+See [Tracing Docker Applications][27] for a complete list of available environment variables and configuration.
 
 Then, [instrument your application container that makes requests to Postgres][11] and set `DD_AGENT_HOST` to the [EC2 private IP address][17].
 
@@ -421,3 +421,4 @@ Additional helpful documentation, links, and articles:
 [24]: https://www.datadoghq.com/blog/postgresql-monitoring
 [25]: https://www.datadoghq.com/blog/postgresql-monitoring-tools
 [26]: https://www.datadoghq.com/blog/collect-postgresql-data-with-datadog
+[27]: https://docs.datadoghq.com/agent/docker/apm/


### PR DESCRIPTION
### What does this PR do?
Corrects a link to Tracing Docker Applications in the README. It previously referenced link 12, about ECS tracing.

### Motivation
I was surprised that the link for Tracing Docker Applications took me to a page about ECS tracing.

### Additional Notes
Link 12 is still valid; it is referenced correctly elsewhere in the page

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
