### PR TITLE
[kubernetes_state] re-add missing params in conf.yaml.example

### DIFF
--- a/kubernetes_state/assets/configuration/spec.yaml
+++ b/kubernetes_state/assets/configuration/spec.yaml
@@ -14,6 +14,27 @@ files:
       value:
         type: string
         example: http://example.com:8080/metrics
+    - name: join_standard_tags
+      description: |
+        To enable joining standard tags from labels, you must set this parameter to true.
+        It will join standard tags found in these labels coming from info Kube State metrics (*_labels).
+          tags.datadoghq.com/env     => env
+          tags.datadoghq.com/service => service
+          tags.datadoghq.com/version => version
+        
+        Resources enabled for join_standard_tags include:
+        Pod, Deployment, ReplicaSet, DaemonSet, StatefulSet, Job, CronJob
+      value:
+        type: boolean
+        example: false
+    - name: hostname_override
+      description: |
+        By default the hostname for metrics containing the node label is
+        overridden by the value of the label, this can be deactivated (all metrics
+        will be attached to the host running KSM)
+      value:
+        type: boolean
+        example: true
     - template: instances/openmetrics_legacy
       overrides:
         prometheus_url.required: false

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -50,6 +50,25 @@ instances:
     #
   - kube_state_url: http://example.com:8080/metrics
 
+    ## @param join_standard_tags - boolean - optional - default: false
+    ## To enable joining standard tags from labels, you must set this parameter to true.
+    ## It will join standard tags found in these labels coming from info Kube State metrics (*_labels).
+    ##   tags.datadoghq.com/env     => env
+    ##   tags.datadoghq.com/service => service
+    ##   tags.datadoghq.com/version => version
+    ##
+    ## Resources enabled for join_standard_tags include:
+    ## Pod, Deployment, ReplicaSet, DaemonSet, StatefulSet, Job, CronJob
+    #
+    # join_standard_tags: false
+
+    ## @param hostname_override - boolean - optional - default: true
+    ## By default the hostname for metrics containing the node label is
+    ## overridden by the value of the label, this can be deactivated (all metrics
+    ## will be attached to the host running KSM)
+    #
+    # hostname_override: true
+
     ## @param health_service_check - boolean - optional - default: true
     ## Send a service check reporting about the health of the Prometheus endpoint.
     ## The service check is named <NAMESPACE>.prometheus.health


### PR DESCRIPTION
### What does this PR do?
Add back params that were inadvertently removed from the Kubernetes State conf.yaml.example file in https://github.com/DataDog/integrations-core/pull/11515

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
