### PR TITLE
Remap `check_hostname` to `tls_validate_hostname`

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -45,6 +45,10 @@ class HTTPCheck(AgentCheck):
         'ca_certs': {'name': 'tls_ca_cert'},
     }
 
+    TLS_CONFIG_REMAPPER = {
+        'check_hostname': {'name': 'tls_validate_hostname'},
+    }
+
     def __init__(self, name, init_config, instances):
         super(HTTPCheck, self).__init__(name, init_config, instances)
 

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -390,3 +390,48 @@ def test_expected_headers(dd_run_check, instance, expected_headers):
 
     dd_run_check(check)
     assert expected_headers == check.http.options['headers']
+
+
+@pytest.mark.parametrize(
+    'instance, check_hostname',
+    [
+        pytest.param(
+            {
+                'url': 'https://valid.mock',
+                'name': 'UpService',
+                'tls_verify': True,
+                'check_hostname': False,
+            },
+            False,
+            id='check_hostname disabled',
+        ),
+        pytest.param(
+            {
+                'url': 'https://valid.mock',
+                'name': 'UpService',
+                'tls_verify': True,
+                'check_hostname': True,
+            },
+            True,
+            id='check_hostname enabled',
+        ),
+        pytest.param(
+            {
+                'url': 'https://valid.mock',
+                'name': 'UpService',
+                'tls_verify': False,
+                'check_hostname': True,
+            },
+            False,
+            id='tls not verify',
+        ),
+    ],
+)
+def test_tls_config_ok(dd_run_check, instance, check_hostname):
+    check = HTTPCheck(
+        'http_check',
+        {'ca_certs': mock_get_ca_certs_path()},
+        [instance],
+    )
+    tls_context = check.get_tls_context()
+    assert tls_context.check_hostname is check_hostname


### PR DESCRIPTION
### What does this PR do?
Remaps `check_hostname` to `tls_validate_hostname`

### Motivation
The `check_hostname` parameter does not do anything now, since the HTTP check was refactored to use the TLS Wrapper: https://github.com/DataDog/integrations-core/pull/8268/s

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
