### PR TITLE
Fix `enabled` for parent options

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
@@ -183,7 +183,11 @@ def write_option(option, writer, indent='', start_list=False):
             multiple = option['multiple']
             multiple_instances_defined = option.get('multiple_instances_defined')
 
-            writer.write(indent, option_name, ':', '\n')
+            if not option_enabled(option):
+                writer.write(indent, '# ', option_name, ':', '\n')
+            else:
+                writer.write(indent, option_name, ':', '\n')
+
             if multiple and multiple_instances_defined:
                 for instance in option['options']:
                     write_sub_option(instance, writer, indent, multiple, include_top_description=True)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/init_config.yaml
@@ -1,3 +1,4 @@
 name: init_config
+enabled: true
 description: |
   All options defined here are available to all instances.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances.yaml
@@ -1,4 +1,5 @@
 name: instances
 multiple: true
+enabled: true
 description: |
   Every instance is scheduled independent of the others.


### PR DESCRIPTION
### What does this PR do?
Fixes the `enabled` option for parent config options. Previously, `enabled: false` was not getting taken into account. 

### Motivation
Bug

### Additional Notes
The `enabled` option value does not propagate to the nested options. `enabled` would still need to be configured for the nested options, if applicable.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
