### PR TITLE
gracefully handle inaccessible database for `sqlserver.files.*`

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -643,18 +643,21 @@ class SqlFileStats(BaseSqlServerMetric):
 
             for db in databases:
                 # use statements need to be executed separate from select queries
-                ctx = construct_use_statement(db)
-                logger.debug("%s: changing cursor context via use statement: %s", cls.__name__, ctx)
-                cursor.execute(ctx)
-                logger.debug("%s: fetch_all executing query: %s", cls.__name__, query)
-                cursor.execute(query)
-                data = cursor.fetchall()
-
-                columns = [i[0] for i in cursor.description]
-                for r in data:
-                    rows.append(r)
-
-                logger.debug("%s: received %d rows and %d columns for db %s", cls.__name__, len(data), len(columns), db)
+                try:
+                    ctx = construct_use_statement(db)
+                    logger.debug("%s: changing cursor context via use statement: %s", cls.__name__, ctx)
+                    cursor.execute(ctx)
+                    logger.debug("%s: fetch_all executing query: %s", cls.__name__, query)
+                    cursor.execute(query)
+                    data = cursor.fetchall()
+                    columns = [i[0] for i in cursor.description]
+                    for r in data:
+                        rows.append(r)
+                    logger.debug(
+                        "%s: received %d rows and %d columns for db %s", cls.__name__, len(data), len(columns), db
+                    )
+                except Exception as e:
+                    logger.warning("failed to fetch SQLFileStats from db %s due to Error: %s", db, e)
 
             # reset back to previous db
             logger.debug("%s: reverting cursor context via use statement to %s", cls.__name__, current_db)

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -159,7 +159,7 @@ INIT_CONFIG_ALT_TABLES = {
 }
 
 
-def assert_metrics(aggregator, expected_tags, dbm_enabled=False, hostname=None):
+def assert_metrics(aggregator, expected_tags, dbm_enabled=False, hostname=None, database_autodiscovery=False):
     """
     Boilerplate asserting all the expected metrics and service checks.
     Make sure ALL custom metric is tagged by database.
@@ -174,4 +174,6 @@ def assert_metrics(aggregator, expected_tags, dbm_enabled=False, hostname=None):
         aggregator.assert_metric(mname, hostname=hostname)
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK, tags=expected_tags)
     aggregator.assert_all_metrics_covered()
-    aggregator.assert_no_duplicate_metrics()
+    if not database_autodiscovery:
+        # if we're autodiscovering other databases then there will be duplicate metrics, one per database
+        aggregator.assert_no_duplicate_metrics()

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -29,6 +29,13 @@ GO
 ALTER DATABASE unavailable_db SET OFFLINE;
 GO
 
+-- create a a restricted database to ensure the agent gracefully handles not being able to connect
+-- to it
+CREATE DATABASE restricted_db;
+GO
+ALTER DATABASE restricted_db SET RESTRICTED_USER
+GO
+
 -- Create test database for integration tests
 -- only bob and fred have read/write access to this database
 USE datadog_test;

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -75,6 +75,13 @@ GO
 ALTER DATABASE unavailable_db SET OFFLINE;
 GO
 
+-- create a a restricted database to ensure the agent gracefully handles not being able to connect
+-- to it
+CREATE DATABASE restricted_db;
+GO
+ALTER DATABASE restricted_db SET RESTRICTED_USER
+GO
+
 -- This table is pronounced "things" except we've replaced "th" with the greek lower case "theta" to ensure we
 -- correctly support unicode throughout the integration.
 CREATE TABLE datadog_test.dbo.ϑings (id int, name varchar(255));

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -75,6 +75,13 @@ GO
 ALTER DATABASE unavailable_db SET OFFLINE;
 GO
 
+-- create a a restricted database to ensure the agent gracefully handles not being able to connect
+-- to it
+CREATE DATABASE restricted_db;
+GO
+ALTER DATABASE restricted_db SET RESTRICTED_USER
+GO
+
 -- This table is pronounced "things" except we've replaced "th" with the greek lower case "theta" to ensure we
 -- correctly support unicode throughout the integration.
 CREATE TABLE datadog_test.dbo.ϑings (id int, name varchar(255));

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -38,6 +38,13 @@ GO
 ALTER DATABASE unavailable_db SET OFFLINE;
 GO
 
+-- create a a restricted database to ensure the agent gracefully handles not being able to connect
+-- to it
+CREATE DATABASE restricted_db;
+GO
+ALTER DATABASE restricted_db SET RESTRICTED_USER
+GO
+
 -- create test procedure for metrics loading feature
 USE master;
 GO

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -39,6 +39,13 @@ GO
 ALTER DATABASE unavailable_db SET OFFLINE;
 GO
 
+-- create a a restricted database to ensure the agent gracefully handles not being able to connect
+-- to it
+CREATE DATABASE restricted_db;
+GO
+ALTER DATABASE restricted_db SET RESTRICTED_USER
+GO
+
 -- create test procedure for metrics loading feature
 USE master;
 GO

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -37,14 +37,21 @@ def test_check_invalid_password(aggregator, dd_run_check, init_config, instance_
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_check_docker(aggregator, dd_run_check, init_config, instance_docker):
+@pytest.mark.parametrize('database_autodiscovery', [True, False])
+def test_check_docker(aggregator, dd_run_check, init_config, instance_docker, database_autodiscovery):
+    instance_docker['database_autodiscovery'] = database_autodiscovery
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
     expected_tags = instance_docker.get('tags', []) + [
         'sqlserver_host:{}'.format(instance_docker.get('host')),
         'db:master',
     ]
-    assert_metrics(aggregator, expected_tags, hostname=sqlserver_check.resolved_hostname)
+    assert_metrics(
+        aggregator,
+        expected_tags,
+        hostname=sqlserver_check.resolved_hostname,
+        database_autodiscovery=database_autodiscovery,
+    )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### What does this PR do?

Gracefully handle an inaccessible database when loading `sqlserver.files.*` metrics.

### Motivation

Prior to this change if any of the databases were inaccessible then all of `SqlFileStats` would fail and we would lose `sqlserver.files.*` metrics for all databases. Example log:

```
(sqlserver.py:623) | Error running `fetch_all` for metrics SqlFileStats - skipping.  Error: ('42000', '[42000] [FreeTDS][SQL Server]The server principal "datadog" is not able to access the database "model" under the current security context. (916) (SQLExecDirectW)')
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
