### PR TITLE
Add new README for Tile-only integrations

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -121,10 +121,16 @@ def create_template_files(template_name, new_root, config, read=False):
     for root, _, template_files in os.walk(template_root):
         for template_file in template_files:
             if not template_file.endswith(('.pyc', '.pyo')):
-                # Use a special README for the marketplace/partner support_type integrations
-                if template_file == 'README.md' and config.get('support_type') == 'partner':
-                    template_path = path_join(TEMPLATES_DIR, 'marketplace/', 'README.md')
-                    file_path = path_join("/", config.get('check_name'), "README.md")
+                if template_file == 'README.md':
+                    # Custom README for the marketplace/partner support_type integrations
+                    if config.get('support_type') == 'partner':
+                        template_path = path_join(TEMPLATES_DIR, 'marketplace/', 'README.md')
+                        file_path = path_join("/", config.get('check_name'), "README.md")
+
+                    # Custom README for tile apps
+                    elif config.get('support_type') == 'contrib' and config.get('manifest_v2'):
+                        template_path = path_join(TEMPLATES_DIR, 'tile_v2/', 'README.md')
+                        file_path = path_join("/", config.get('check_name'), "README.md")
 
                 # Use a special readme file for media carousel information
                 # .gitkeep currently only used for images, but double check anyway

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/marketplace/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/marketplace/README.md
@@ -1,8 +1,9 @@
 # {integration_name}
 
 ## Overview
-High level overview of what this integration does
-Usually includes a screenshot
+High level overview of what this integration does.
+
+Screenshots should be absent for this section, instead put them in the media carousel with captions.
 
 All `###` headers are optional to showcase what this integration includes
 
@@ -16,6 +17,8 @@ All `###` headers are optional to showcase what this integration includes
 
 ## Setup
 Specific step-by-step configuration instructions for this integration.
+
+Screenshots are okay for this section, if they help demonstrate configuration steps.
 
 ## Support
 Information about how and where to go for support for this integration

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile_v2/README.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile_v2/README.md
@@ -1,0 +1,29 @@
+# {integration_name}
+ 
+## Overview
+ 
+< Provide some background information on your software, along with specifics about what is being offered in your Datadog app >
+ 
+## Setup
+ 
+### Installation
+ 
+1. On any Datadog dashboard, click the "Add Widgets" button
+2. Select "Apps" in the widget menu
+3. Drag the {integration_name} widget onto your dashboard
+ 
+### Configuration
+ 
+< Add any extra configuration steps for your app, including any options or settings that the user has to configure before the app is able to function >
+ 
+### Validation
+ 
+< Steps to validate that the app is functioning as expected. If no validation steps are needed, delete this section >
+ 
+## Troubleshooting
+ 
+< Add any links to relevant documentation regarding your Datadog app >
+ 
+Need help? Contact [Datadog support][1].
+ 
+[1]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?
Adds a slightly different README.md template for Tile-only Manifest V2 apps.  This can be triggered via the following command:

`ddev -e create -t tile foo_tile -v2`

This will create a Tile integration with Manifest V2 inside the `integrations-extras` repo.

### Motivation
Better help partners with their documentation first steps.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
