### PR TITLE
Document TLS options

### DIFF
--- a/http_check/assets/configuration/spec.yaml
+++ b/http_check/assets/configuration/spec.yaml
@@ -130,11 +130,6 @@ files:
         the critical threshold for the HTTP check in second
       value:
         type: integer
-    - name: check_hostname
-      description: Set check_hostname to false to disable the verification check for matching hostnames.
-      value:
-        type: boolean
-        example: true
     - name: ssl_server_name
       description: |
         If necessary and check_hostname is set to true,
@@ -160,3 +155,9 @@ files:
     - template: instances/http
       overrides:
         tls_verify.value.example: false
+    - template: instances/tls
+      overrides:
+        tls_verify.hidden: true
+        tls_cert.hidden: true
+        tls_ca_cert.hidden: true
+        tls_private_key.hidden: true

--- a/http_check/datadog_checks/http_check/config_models/defaults.py
+++ b/http_check/datadog_checks/http_check/config_models/defaults.py
@@ -54,10 +54,6 @@ def instance_check_certificate_expiration(field, value):
     return True
 
 
-def instance_check_hostname(field, value):
-    return True
-
-
 def instance_collect_response_time(field, value):
     return True
 
@@ -230,12 +226,20 @@ def instance_tls_private_key(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_tls_private_key_password(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tls_protocols_allowed(field, value):
     return get_default_field_value(field, value)
 
 
 def instance_tls_use_host_header(field, value):
     return False
+
+
+def instance_tls_validate_hostname(field, value):
+    return True
 
 
 def instance_tls_verify(field, value):

--- a/http_check/datadog_checks/http_check/config_models/instance.py
+++ b/http_check/datadog_checks/http_check/config_models/instance.py
@@ -55,7 +55,6 @@ class InstanceConfig(BaseModel):
     aws_region: Optional[str]
     aws_service: Optional[str]
     check_certificate_expiration: Optional[bool]
-    check_hostname: Optional[bool]
     collect_response_time: Optional[bool]
     connect_timeout: Optional[float]
     content_match: Optional[str]
@@ -100,8 +99,10 @@ class InstanceConfig(BaseModel):
     tls_cert: Optional[str]
     tls_ignore_warning: Optional[bool]
     tls_private_key: Optional[str]
+    tls_private_key_password: Optional[str]
     tls_protocols_allowed: Optional[Sequence[str]]
     tls_use_host_header: Optional[bool]
+    tls_validate_hostname: Optional[bool]
     tls_verify: Optional[bool]
     url: str
     use_legacy_auth_encoding: Optional[bool]

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -156,11 +156,6 @@ instances:
     #
     # seconds_critical: <SECONDS_CRITICAL>
 
-    ## @param check_hostname - boolean - optional - default: true
-    ## Set check_hostname to false to disable the verification check for matching hostnames.
-    #
-    # check_hostname: true
-
     ## @param ssl_server_name - string - optional
     ## If necessary and check_hostname is set to true,
     ## override the hostname to match with ssl_server_name.
@@ -519,3 +514,15 @@ instances:
     ## Whether or not to allow URL redirection.
     #
     # allow_redirects: true
+
+    ## @param tls_private_key_password - string - optional
+    ## Optional password to decrypt tls_private_key.
+    ##
+    ## Setting this implicitly sets `tls_verify` to true.
+    #
+    # tls_private_key_password: <PRIVATE_KEY_PASSWORD>
+
+    ## @param tls_validate_hostname - boolean - optional - default: true
+    ## Verifies that the server's cert hostname matches the one requested.
+    #
+    # tls_validate_hostname: true


### PR DESCRIPTION
### What does this PR do?
Adds the TLS Wrapper config spec to http_check to document all options

### Motivation
https://github.com/DataDog/integrations-core/pull/11706 and we currently aren't documenting all options

### Additional Notes
Note: the http spec and tls spec share  some common options now. Their documentation is currently similar enough that it is fine to keep one (http) and hide the tls options
 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
