### PR TITLE
[kubernetes] Add missing 'job.complete' service check

### DIFF
--- a/kubernetes_state/assets/service_checks.json
+++ b/kubernetes_state/assets/service_checks.json
@@ -97,7 +97,7 @@
         "description": "Returns `CRITICAL` if a cron job scheduled time is in the past. Returns `UNKNOWN` if the scheduled time is unknown. Returns `OK` otherwise."
     },
     {
-        "agent_version": "5.6.0",
+        "agent_version": "7.22.0",
         "integration": "Kubernetes",
         "check": "kubernetes_state.job.complete",
         "statuses": [

--- a/kubernetes_state/assets/service_checks.json
+++ b/kubernetes_state/assets/service_checks.json
@@ -89,8 +89,9 @@
             "critical"
         ],
         "groups": [
-            "host",
-            "node"
+           "kube_cluster_name",
+           "kube_namespace",
+           "kube_cronjob"
         ],
         "name": "CronJob next schedule",
         "description": "Returns `CRITICAL` if a cron job scheduled time is in the past. Returns `UNKNOWN` if the scheduled time is unknown. Returns `OK` otherwise."
@@ -104,8 +105,10 @@
             "critical"
         ],
         "groups": [
-            "host",
-            "node"
+           "kube_cluster_name",
+           "kube_namespace",
+           "kube_cronjob",
+           "kube_job"
         ],
         "name": "Job completion status",
         "description": " Returns `CRITICAL` if a job failed. Returns `OK` otherwise."

--- a/kubernetes_state/assets/service_checks.json
+++ b/kubernetes_state/assets/service_checks.json
@@ -94,5 +94,20 @@
         ],
         "name": "CronJob next schedule",
         "description": "Returns `CRITICAL` if a cron job scheduled time is in the past. Returns `UNKNOWN` if the scheduled time is unknown. Returns `OK` otherwise."
+    },
+    {
+        "agent_version": "5.6.0",
+        "integration": "Kubernetes",
+        "check": "kubernetes_state.job.complete",
+        "statuses": [
+            "ok",
+            "critical"
+        ],
+        "groups": [
+            "host",
+            "node"
+        ],
+        "name": "Job completion status",
+        "description": " Returns `CRITICAL` if a job failed. Returns `OK` otherwise."
     }
 ]


### PR DESCRIPTION
### What does this PR do?

Add missing `kubernetes_state.job.complete` service check to the `kubernetes` integration.

### Motivation

the `kubernetes_state.job.complete` [service check](https://docs.datadoghq.com/integrations/kubernetes_state_core/?tab=helm#service-checks) was missing from the `kubernetes` integration


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
