### PR TITLE
Refactor dependency tooling

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -9,20 +9,22 @@ import click
 import orjson
 from aiohttp import request
 from aiomultiprocess import Pool
-from packaging.markers import InvalidMarker, Marker
+from packaging.markers import Marker
+from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
+from packaging.version import parse as parse_version
 
-from ...fs import basepath, read_file_lines, write_file_lines
 from ..constants import get_agent_requirements
 from ..dependencies import (
+    get_dependency_set,
     read_agent_dependencies,
     read_check_dependencies,
+    update_agent_dependencies,
     update_check_dependencies,
-    update_check_dependencies_at,
+    update_project_dependency,
 )
-from ..utils import get_check_req_file, get_valid_checks, has_project_file
+from ..utils import get_normalized_dependency, normalize_project_name
 from .console import CONTEXT_SETTINGS, abort, echo_failure, echo_info
-from .validate.licenses import extract_classifier_value
 
 # Dependencies to ignore when update dependencies
 IGNORED_DEPS = {
@@ -45,23 +47,9 @@ def dep():
 
 
 @dep.command(context_settings=CONTEXT_SETTINGS, short_help='Pin a dependency for all checks that require it')
-@click.argument('package')
-@click.argument('version')
-@click.option('--marker', '-m', help='Environment marker to use')
-def pin(package, version, marker):
-    """Pin a dependency for all checks that require it. This can
-    also resolve transient dependencies.
-
-    Setting the version to `none` will remove the package. You can
-    specify an unlimited number of additional checks to apply the
-    pin for via arguments.
-    """
-    if marker is not None:
-        try:
-            marker = Marker(marker)
-        except InvalidMarker as e:
-            abort(f'Invalid marker: {e}')
-
+@click.argument('definition')
+def pin(definition):
+    """Pin a dependency for all checks that require it."""
     dependencies, errors = read_check_dependencies()
 
     if errors:
@@ -70,45 +58,21 @@ def pin(package, version, marker):
 
         abort()
 
-    package = package.lower()
+    requirement = Requirement(definition)
+    package = normalize_project_name(requirement.name)
     if package not in dependencies:
         abort(f'Unknown package: {package}')
 
-    files_to_update = defaultdict(list)
-    files_updated = 0
-
-    versions = dependencies[package]
-    for dependency_definitions in versions.values():
-        for dependency_definition in dependency_definitions:
-            files_to_update[dependency_definition.file_path].append(dependency_definition)
-
-    for file_path, dependency_definitions in sorted(files_to_update.items()):
-        for dependency_definition in dependency_definitions:
-            requirement = dependency_definition.requirement
-            if marker != requirement.marker:
-                continue
-
-            requirement.specifier = SpecifierSet(f'=={version}')
-
-        if basepath(file_path) == 'pyproject.toml':
-            if update_check_dependencies_at(file_path, dependency_definitions):
-                files_updated += 1
-        else:
-            old_lines = read_file_lines(file_path)
-
-            new_lines = old_lines.copy()
-
-            for dependency_definition in dependency_definitions:
-                new_lines[dependency_definition.line_number] = f'{dependency_definition.requirement}\n'
-
-            if new_lines != old_lines:
-                files_updated += 1
-                write_file_lines(file_path, new_lines)
-
-    if not files_updated:
+    new_dependencies = copy.deepcopy(dependencies)
+    python_versions = new_dependencies[package]
+    checks = update_project_dependency(python_versions, definition)
+    if new_dependencies == dependencies:
         abort('No dependency definitions to update')
 
-    echo_info(f'Files updated: {files_updated}')
+    for check_name in sorted(checks):
+        update_check_dependencies(check_name, new_dependencies)
+
+    echo_info(f'Files updated: {len(checks)}')
 
 
 @dep.command(
@@ -124,22 +88,8 @@ def freeze():
 
         abort()
 
-    static_file = get_agent_requirements()
-
-    echo_info(f'Static file: {static_file}')
-
-    data = sorted(
-        (
-            (dependency_definition.name, str(dependency_definition.requirement).lower())
-            for versions in dependencies.values()
-            for dependency_definitions in versions.values()
-            for dependency_definition in dependency_definitions
-        ),
-        key=lambda d: d[0],
-    )
-    lines = sorted(set(f'{d[1]}\n' for d in data))
-
-    write_file_lines(static_file, lines)
+    echo_info(f'Static file: {get_agent_requirements()}')
+    update_agent_dependencies(dependencies)
 
 
 @dep.command(
@@ -147,184 +97,150 @@ def freeze():
     short_help="Update integrations' dependencies so that they match the Agent's static environment",
 )
 def sync():
-    all_agent_dependencies, errors = read_agent_dependencies()
+    agent_dependencies, errors = read_agent_dependencies()
 
     if errors:
         for error in errors:
             echo_failure(error)
         abort()
 
-    files_updated = 0
-    checks = sorted(get_valid_checks())
-    for check_name in checks:
-        check_dependencies, check_errors = read_check_dependencies(check=check_name)
+    check_dependencies, check_errors = read_check_dependencies()
 
-        if check_errors:
-            for error in check_errors:
-                echo_failure(error)
-            abort()
+    if check_errors:
+        for error in check_errors:
+            echo_failure(error)
+        abort()
 
-        deps_to_update = {
-            check_dependency_definition: agent_dep_version
-            for check_dependency_name, check_dependency_definitions in check_dependencies.items()
-            for version, dependency_definitions in check_dependency_definitions.items()
-            for check_dependency_definition in dependency_definitions
-            for agent_dep_version, agent_dependency_definitions in all_agent_dependencies[check_dependency_name].items()
-            for agent_dependency_definition in agent_dependency_definitions
-            # look for the dependency with the same marker and name since the version can be different
-            if check_dependency_definition.same_name_marker(agent_dependency_definition)
-            and version != agent_dep_version
-        }
+    updated_checks = set()
+    for name, python_versions in check_dependencies.items():
+        check_dependency_definitions = get_dependency_set(python_versions)
+        agent_dependency_definitions = get_dependency_set(agent_dependencies[name])
 
-        if deps_to_update:
-            files_updated += 1
-            for dependency_definition, new_version in deps_to_update.items():
-                dependency_definition.requirement.specifier = new_version
+        if check_dependency_definitions != agent_dependency_definitions:
+            for dependency_definition in agent_dependency_definitions:
+                updated_checks.update(update_project_dependency(python_versions, dependency_definition))
 
-            if has_project_file(check_name):
-                update_check_dependencies(check_name, list(deps_to_update))
-            else:
-                check_req_file = get_check_req_file(check_name)
-                old_lines = read_file_lines(check_req_file)
-                new_lines = old_lines.copy()
-
-                for dependency_definition, new_version in deps_to_update.items():
-                    dependency_definition.requirement.specifier = new_version
-                    new_lines[dependency_definition.line_number] = f'{dependency_definition.requirement}\n'
-
-                write_file_lines(check_req_file, new_lines)
-
-    if not files_updated:
+    if not updated_checks:
         echo_info('All dependencies synced.')
+        return
 
-    echo_info(f'Files updated: {files_updated}')
+    for check_name in sorted(updated_checks):
+        update_check_dependencies(check_name, check_dependencies)
+
+    echo_info(f'Files updated: {len(updated_checks)}')
 
 
 async def get_version_data(url):
     async with request('GET', url) as response:
         try:
-            info = orjson.loads(await response.read())['info']
+            data = orjson.loads(await response.read())
         except Exception as e:
             raise type(e)(f'Error processing URL {url}: {e}')
         else:
-            return (
-                info['name'],
-                info['version'],
-                {
-                    extract_classifier_value(c)
-                    for c in info['classifiers']
-                    if c.startswith('Programming Language :: Python ::')
-                },
-            )
+            return data['info']['name'], data['releases']
 
 
 async def scrape_version_data(urls):
-    package_data = defaultdict(lambda: {'version': '', 'classifiers': set()})
+    package_data = {}
 
     async with Pool() as pool:
-        async for package_name, package_version, version_classifiers in pool.map(get_version_data, urls):
-            data = package_data[package_name]
-            if package_version:
-                data['version'] = package_version
+        async for package_name, releases in pool.map(get_version_data, urls):
+            latest_py2 = None
+            latest_py3 = None
 
-            data['classifiers'].update(version_classifiers)
+            versions = []
+            for version, artifacts in reversed(sorted(releases.items(), key=lambda item: parse_version(item[0]))):
+                versions.append(version)
+
+                for artifact in artifacts:
+                    python_version = artifact['python_version']
+
+                    if latest_py2 is None and ('py2' in python_version or 'cp2' in python_version):
+                        latest_py2 = version
+                    if latest_py3 is None and ('py3' in python_version or 'cp3' in python_version):
+                        latest_py3 = version
+
+                if latest_py2 is not None and latest_py3 is not None:
+                    break
+            else:
+                # Package only released source distributions
+                if latest_py2 is None and latest_py3 is None:
+                    latest_py2 = latest_py3 = versions[0]
+
+            package_data[package_name] = {'py2': latest_py2, 'py3': latest_py3}
 
     return package_data
 
 
-def is_version_compatible(marker, supported_versions):
-    """
-    Determines if any of the given versions are compatible with the given marker
-    """
-    os_markers = ['darwin', 'win32', 'linux', 'aix']
-    is_compatible = False
-
-    if marker is None:
-        # manually set marker since if there's none the dependency should work on all environments
-        marker = Marker('python_version > "2.0"')
-
-    if len(supported_versions) == 0:
-        # if there are no classifiers then assume it works on all Python versions
-        is_compatible = True
-
-    for python_version in supported_versions:
-        has_match = False
-
-        for os in os_markers:
-            env = {'python_version': python_version, 'sys_platform': os}
-            # override system python version and sys platform to evaluate whether the version is compatible
-            has_match = marker.evaluate(environment=env)
-            is_compatible = is_compatible or has_match
-
-    return is_compatible
-
-
 @dep.command(context_settings=CONTEXT_SETTINGS, short_help='Automatically check for dependency updates')
-@click.option('--sync', '-s', is_flag=True, help='Update the `agent_requirements.in` file')
-@click.option(
-    '--check-python-classifiers',
-    '-c',
-    is_flag=True,
-    help="""Only flag a dependency as needing an update if the newest version has python classifiers matching the marker.
-    NOTE: Some packages may not have proper classifiers.""",
-)
+@click.option('--sync', '-s', 'sync_dependencies', is_flag=True, help='Update the dependency definitions')
 @click.option('--include-security-deps', '-i', is_flag=True, help="Attempt to update security dependencies")
 @click.option('--batch-size', '-b', type=int, help='The maximum number of dependencies to upgrade if syncing')
-def updates(sync, check_python_classifiers, include_security_deps, batch_size):
-
-    ignore_deps = copy.deepcopy(IGNORED_DEPS)
+@click.pass_context
+def updates(ctx, sync_dependencies, include_security_deps, batch_size):
+    ignore_deps = set(IGNORED_DEPS)
     if not include_security_deps:
-        sec_deps = copy.deepcopy(SECURITY_DEPS)
-        ignore_deps = ignore_deps.union(sec_deps)
+        ignore_deps.update(SECURITY_DEPS)
+    ignore_deps = {normalize_project_name(d) for d in ignore_deps}
 
-    all_agent_dependencies, errors = read_agent_dependencies()
+    dependencies, errors = read_agent_dependencies()
 
-    api_urls = []
-    for package in all_agent_dependencies.keys():
-        api_urls.append(f'https://pypi.org/pypi/{package}/json')
+    if errors:
+        for error in errors:
+            echo_failure(error)
+        abort()
 
+    api_urls = [f'https://pypi.org/pypi/{package}/json' for package in dependencies]
     package_data = asyncio.run(scrape_version_data(api_urls))
-    package_data = {
-        package_name.lower().replace('_', '-'): package_info for package_name, package_info in package_data.items()
-    }
+    package_data = {normalize_project_name(package_name): versions for package_name, versions in package_data.items()}
 
-    deps_to_update = {
-        agent_dependency_definition: package_data[package]['version']
-        for package, package_dependency_definitions in all_agent_dependencies.items()
-        if package not in ignore_deps
-        for agent_dep_version, agent_dependency_definitions in package_dependency_definitions.items()
-        for agent_dependency_definition in agent_dependency_definitions
-        if str(agent_dep_version)[2:] != package_data[package]['version']
-        and (
-            not check_python_classifiers
-            or is_version_compatible(
-                agent_dependency_definition.requirement.marker,
-                package_data[package]['classifiers'],
-            )
-        )
-    }
+    new_dependencies = copy.deepcopy(dependencies)
+    version_updates = defaultdict(lambda: defaultdict(set))
+    updated_packages = set()
+    for name, python_versions in sorted(new_dependencies.items()):
+        if name in ignore_deps:
+            continue
+        elif batch_size is not None and len(updated_packages) >= batch_size:
+            break
 
-    if sync:
-        static_file = get_agent_requirements()
-        if deps_to_update:
-            deps_updated = 0
-            old_lines = read_file_lines(static_file)
-            new_lines = old_lines.copy()
+        new_python_versions = package_data[name]
+        dropped_py2 = len(set(new_python_versions.values())) > 1
+        for python_version, package_version in new_python_versions.items():
+            dependency_definitions = python_versions[python_version]
+            if not dependency_definitions:
+                continue
+            dependency_definition, checks = dependency_definitions.popitem()
 
-            for dependency_definition, new_version in deps_to_update.items():
-                dependency_definition.requirement.specifier = f'=={new_version}'
-                new_lines[dependency_definition.line_number] = f'{dependency_definition.requirement}\n'
+            requirement = Requirement(dependency_definition)
+            requirement.specifier = SpecifierSet(f'=={package_version}')
+            if dropped_py2 and 'python_version' not in dependency_definition:
+                python_marker = f'python_version {"<" if python_version == "py2" else ">"} "3.0"'
+                if not requirement.marker:
+                    requirement.marker = Marker(python_marker)
+                else:
+                    requirement.marker = Marker(f'{requirement.marker} and {python_marker}')
 
-                deps_updated += 1
-                if batch_size is not None and deps_updated >= batch_size:
-                    break
+            new_dependency_definition = get_normalized_dependency(requirement)
 
-            write_file_lines(static_file, new_lines)
-            echo_info(f'Updated {deps_updated} dependencies in `agent_requirements.in`')
+            dependency_definitions[new_dependency_definition] = checks
+            if dependency_definition != new_dependency_definition:
+                version_updates[name][package_version].add(python_version)
+                updated_packages.add(name)
+
+    if sync_dependencies:
+        if updated_packages:
+            update_agent_dependencies(new_dependencies)
+            ctx.invoke(sync)
+            echo_info(f'Updated {len(updated_packages)} dependencies')
     else:
-        if deps_to_update:
-            echo_failure(f"{len(deps_to_update.keys())} Dependencies are out of sync:")
-            for dependency_definition, version in deps_to_update.items():
-                echo_failure(f"Dependency {dependency_definition.requirement} can be updated to version {version}")
+        if updated_packages:
+            echo_failure(f"{len(updated_packages)} dependencies are out of sync:")
+            for name, versions in version_updates.items():
+                for package_version, python_versions in versions.items():
+                    echo_failure(
+                        f'{name} can be updated to version {package_version} '
+                        f'on {" and ".join(sorted(python_versions))}'
+                    )
+            abort()
         else:
             echo_info('All dependencies are up to date')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dep.py
@@ -4,10 +4,16 @@
 import os
 
 import click
+from packaging.requirements import Requirement
 
 from ....utils import get_next
 from ...constants import get_agent_requirements, get_root
-from ...dependencies import read_agent_dependencies, read_check_base_dependencies, read_check_dependencies
+from ...dependencies import (
+    get_dependency_set,
+    read_agent_dependencies,
+    read_check_base_dependencies,
+    read_check_dependencies,
+)
 from ...testing import process_checks_option
 from ...utils import complete_valid_checks, get_project_file, has_project_file
 from ..console import CONTEXT_SETTINGS, abort, annotate_error, annotate_errors, echo_failure
@@ -25,6 +31,7 @@ def format_check_usage(checks, default=None):
     if not checks:
         return default
 
+    checks = sorted(checks)
     num_checks = len(checks)
     if num_checks == 1:
         return checks[0]
@@ -36,7 +43,7 @@ def format_check_usage(checks, default=None):
         return f'{checks[0]}, {checks[1]}, and {remaining} other{plurality}'
 
 
-def verify_base_dependency(source, name, base_versions, force_pinned=True, min_base_version=None):
+def verify_base_dependency(source, check_name, dependency, force_pinned=True, min_base_version=None):
     """Minimal dependency verification for `datadog-checks-base` dependencies.
 
     Ensures that the version isn't specifically pinned since that will limit check installations.
@@ -44,102 +51,90 @@ def verify_base_dependency(source, name, base_versions, force_pinned=True, min_b
     Optionally validate a specific version satisfies the base requirement spec.
     """
     failed = False
-    for specifier_set, dependency_definitions in base_versions.items():
-        checks = sorted(dep.check_name for dep in dependency_definitions)
-        files = []
-        for check_name in checks:
-            if has_project_file(check_name):
-                files.append(get_project_file(check_name))
-            else:
-                files.append(os.path.join(get_root(), check_name, 'setup.py'))
-        file = ','.join(files)
-        if not specifier_set and force_pinned:
-            message = f'Unspecified version found for dependency `{name}`: {format_check_usage(checks, source)}'
-            echo_failure(message)
-            annotate_error(file, message)
-            failed = True
-        elif len(specifier_set) > 1:
+    name = 'datadog-checks-base'
+    checks = [check_name]
+    requirement = Requirement(dependency)
+    specifier_set = requirement.specifier
+    if has_project_file(check_name):
+        file = get_project_file(check_name)
+    else:
+        file = os.path.join(get_root(), check_name, 'setup.py')
+
+    if not specifier_set and force_pinned:
+        message = f'Unspecified version found for dependency `{name}`: {format_check_usage(checks, source)}'
+        echo_failure(message)
+        annotate_error(file, message)
+        failed = True
+    elif len(specifier_set) > 1:
+        message = (
+            f'Multiple unstable version pins `{specifier_set}` found for dependency `{name}`: '
+            f'{format_check_usage(checks, source)}'
+        )
+        echo_failure(message)
+        annotate_error(file, message)
+        failed = True
+    elif specifier_set:
+        specifier = get_next(specifier_set)
+
+        if specifier.operator != '>=':
             message = (
-                f'Multiple unstable version pins `{specifier_set}` found for dependency `{name}`: '
-                f'{format_check_usage(checks, source)}'
+                f'Forced version pin `{specifier}` found for dependency `{name}` '
+                f'(use >= explicitly for base dependency): {format_check_usage(checks, source)}'
             )
             echo_failure(message)
             annotate_error(file, message)
             failed = True
-        elif specifier_set:
-            specifier = get_next(specifier_set)
 
-            if specifier.operator != '>=':
-                message = (
-                    f'Forced version pin `{specifier}` found for dependency `{name}` '
-                    f'(use >= explicitly for base dependency): {format_check_usage(checks, source)}'
-                )
-                echo_failure(message)
-                annotate_error(file, message)
-                failed = True
-
-            if min_base_version is not None and min_base_version not in specifier:
-                message = (
-                    f'Minimum datadog_checks_base version `{min_base_version}` not satisfied by dependency specifier'
-                    f'`{specifier}`: {format_check_usage(checks, source)}'
-                )
-                echo_failure(message)
-                annotate_error(file, message)
-                failed = True
+        if min_base_version is not None and min_base_version not in specifier:
+            message = (
+                f'Minimum datadog_checks_base version `{min_base_version}` not satisfied by dependency specifier'
+                f'`{specifier}`: {format_check_usage(checks, source)}'
+            )
+            echo_failure(message)
+            annotate_error(file, message)
+            failed = True
 
     return not failed
 
 
-def verify_dependency(source, name, versions, file):
-    markers = {}
-    for specifier_set, dependency_definitions in versions.items():
-        checks = set()
-
-        for dependency_definition in dependency_definitions:
-            check_name = dependency_definition.check_name
-            if check_name is not None:
-                checks.add(check_name)
-
-            marker = get_marker_string(dependency_definition)
-            if marker in markers:
-                existing_check_name, existing_specifier_set = markers[marker]
-                if existing_specifier_set != specifier_set:
-                    message = (
-                        f'Multiple version specifiers found for marker `{marker}` of dependency `{name}`:'
-                        f'    {specifier_set} from: {check_name or source}'
-                        f'    {existing_specifier_set} from: {existing_check_name or source}'
-                    )
-                    echo_failure(message)
-                    annotate_error(file, message)
-                    return False
-            else:
-                markers[marker] = (check_name, specifier_set)
-
-        checks = sorted(checks)
-
-        if not specifier_set:
-            message = f'Unpinned version found for dependency `{name}`: {format_check_usage(checks, source)}'
-            echo_failure(message)
-            annotate_error(file, message)
-            return False
-        elif len(specifier_set) > 1:
-            message = (
-                f'Multiple unstable version pins `{specifier_set}` found for dependency `{name}` '
-                f'(use a single == explicitly): {format_check_usage(checks, source)}'
-            )
+def verify_dependency(source, name, python_versions, file):
+    for dependency_definitions in python_versions.values():
+        if len(dependency_definitions) > 1:
+            message = f'Multiple dependency definitions found for dependency `{name}`:\n'
+            for dependency_definition, checks in dependency_definitions.items():
+                message += f'    {dependency_definition} from: {format_check_usage([checks])}\n'
+            message = message.rstrip()
             echo_failure(message)
             annotate_error(file, message)
             return False
 
-        specifier = get_next(specifier_set)
-        if specifier.operator != '==':
-            message = (
-                f'Unstable version pin `{specifier}` found for dependency `{name}` '
-                f'(use == explicitly): {format_check_usage(checks, source)}'
-            )
-            echo_failure(message)
-            annotate_error(file, message)
-            return False
+        for dependency_definition, checks in dependency_definitions.items():
+            requirement = Requirement(dependency_definition)
+            specifier_set = requirement.specifier
+
+            if not specifier_set:
+                message = f'Unpinned version found for dependency `{name}`: {format_check_usage(checks, source)}'
+                echo_failure(message)
+                annotate_error(file, message)
+                return False
+            elif len(specifier_set) > 1:
+                message = (
+                    f'Multiple unstable version pins `{specifier_set}` found for dependency `{name}` '
+                    f'(use a single == explicitly): {format_check_usage(checks, source)}'
+                )
+                echo_failure(message)
+                annotate_error(file, message)
+                return False
+
+            specifier = get_next(specifier_set)
+            if specifier.operator != '==':
+                message = (
+                    f'Unstable version pin `{specifier}` found for dependency `{name}` '
+                    f'(use == explicitly): {format_check_usage(checks, source)}'
+                )
+                echo_failure(message)
+                annotate_error(file, message)
+                return False
 
     return True
 
@@ -210,9 +205,9 @@ def dep(check, require_base_check_version, min_base_check_version):
     check_base_dependencies, check_base_errors = read_check_base_dependencies(checks)
     check_dependencies, check_errors = read_check_dependencies(checks)
 
-    for name, versions in sorted(check_base_dependencies.items()):
+    for name, dependency in sorted(check_base_dependencies.items()):
         if not verify_base_dependency(
-            'Base Checks', name, versions, require_base_check_version, min_base_check_version
+            'Base Checks', name, dependency, require_base_check_version, min_base_check_version
         ):
             failed = True
 
@@ -220,8 +215,8 @@ def dep(check, require_base_check_version, min_base_check_version):
     if check is not None:
         agent_dependencies = {}
 
-    for name, versions in sorted(agent_dependencies.items()):
-        if not verify_dependency('Agent', name, versions, agent_dependencies_file):
+    for name, python_versions in sorted(agent_dependencies.items()):
+        if not verify_dependency('Agent', name, python_versions, agent_dependencies_file):
             failed = True
 
         if name not in check_dependencies:  # Looks like this fails because of the per check run....
@@ -231,40 +226,19 @@ def dep(check, require_base_check_version, min_base_check_version):
             annotate_error(agent_dependencies_file, message)
             continue
 
-        agent_versions = sorted(versions, key=lambda v: str(v))
-        check_versions = sorted(check_dependencies[name], key=lambda v: str(v))
+        agent_dependency_definitions = get_dependency_set(python_versions)
+        check_dependency_definitions = get_dependency_set(check_dependencies[name])
 
-        if agent_versions != check_versions:
+        if agent_dependency_definitions != check_dependency_definitions:
             failed = True
             message = (
-                f'Version mismatch for dependency `{name}`:'
-                f'    Agent: {" | ".join(map(str, agent_versions))}'
-                f'    Checks: {" | ".join(map(str, check_versions))}'
+                f'Mismatch for dependency `{name}`:\n'
+                f'    Agent: {" | ".join(sorted(agent_dependency_definitions))}\n'
+                f'    Checks: {" | ".join(sorted(check_dependency_definitions))}'
             )
             echo_failure(message)
             annotate_error(agent_dependencies_file, message)
             continue
-
-        for specifier_set in agent_versions:
-            agent_dependency_definitions = versions[specifier_set]
-            check_dependency_definitions = check_dependencies[name][specifier_set]
-
-            agent_markers = sorted(
-                set(get_marker_string(dependency_definition) for dependency_definition in agent_dependency_definitions)
-            )
-            check_markers = sorted(
-                set(get_marker_string(dependency_definition) for dependency_definition in check_dependency_definitions)
-            )
-
-            if agent_markers != check_markers:
-                failed = True
-                message = (
-                    f'Marker mismatch for dependency `{name}`:'
-                    f'    Agent: {" | ".join(agent_markers)}'
-                    f'    Checks: {" | ".join(check_markers)}'
-                )
-                echo_failure(message)
-                annotate_error(agent_dependencies_file, message)
 
         if failed:
             abort()


### PR DESCRIPTION
### What does this PR do?

Simplified dependency logic to act upon the full definition + supported Python version, changing the allowed arguments for the `dep pin` command

### Motivation

The `dep updates` and `dep sync` commands could not properly handle different versions per Python version