### PR TITLE
Update metric_to_check to `cilium.endpoint.state`

### DIFF
--- a/cilium/manifest.json
+++ b/cilium/manifest.json
@@ -4,7 +4,7 @@
   "manifest_version": "1.0.0",
   "name": "cilium",
   "metric_prefix": "cilium.",
-  "metric_to_check": "cilium.endpoint.count",
+  "metric_to_check": "cilium.endpoint.state",
   "creates_events": false,
   "short_description": "Collect per pod agent metrics and cluster-wide operator metrics",
   "guid": "1d9db288-4678-4ede-9ba0-8b04a8ae31c2",


### PR DESCRIPTION


### What does this PR do?
Changes the metric_to_check from `cilium.endpoint.count` to `cilium.endpoint.state`

Former longer exists in Cilium 1.10.x.
 - https://docs.cilium.io/en/v1.10/operations/metrics/#endpoint

`endpoint_state` appears to be common one

### Motivation
- AGENT-7673

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
