### PR TITLE
Pin Jinja2 version to 3.0.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,8 @@ deps =
     -e./datadog_checks_dev[cli]
     ; for CLI auto-documentation of ddev
     mkdocs-click~=0.4
+    jinja2==3.0.3
+    ; pin version until this fix is merged https://github.com/mkdocs/mkdocs/pull/2795
 setenv =
     ; Use a set timestamp for reproducible builds.
     ; See https://reproducible-builds.org/specs/source-date-epoch/


### PR DESCRIPTION
### What does this PR do?
jinja2 v3.1.0 was released today and included the removal of some deprecated code: https://jinja.palletsprojects.com/en/3.1.x/changes/#version-3-1-0

### Motivation
Fix CI

### Additional Notes
mkdocs fix is in the works: https://github.com/mkdocs/mkdocs/pull/2795

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
