### PR TITLE
Add `kube_namespace` tag to object count metrics

### DIFF
--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -372,22 +372,22 @@ def test_update_kube_state_metrics(aggregator, instance, check):
     # services count
     aggregator.assert_metric(
         NAMESPACE + '.service.count',
-        tags=['namespace:default', 'type:clusterip', 'optional:tag1'],
+        tags=['kube_namespace:default', 'namespace:default', 'type:clusterip', 'optional:tag1'],
         value=3,
     )
     aggregator.assert_metric(
         NAMESPACE + '.service.count',
-        tags=['namespace:default', 'type:loadbalancer', 'optional:tag1'],
+        tags=['kube_namespace:default', 'namespace:default', 'type:loadbalancer', 'optional:tag1'],
         value=2,
     )
     aggregator.assert_metric(
         NAMESPACE + '.service.count',
-        tags=['namespace:kube-system', 'type:clusterip', 'optional:tag1'],
+        tags=['kube_namespace:kube-system', 'namespace:kube-system', 'type:clusterip', 'optional:tag1'],
         value=4,
     )
     aggregator.assert_metric(
         NAMESPACE + '.service.count',
-        tags=['namespace:kube-system', 'type:nodeport', 'optional:tag1'],
+        tags=['kube_namespace:kube-system', 'namespace:kube-system', 'type:nodeport', 'optional:tag1'],
         value=1,
     )
 
@@ -406,53 +406,77 @@ def test_update_kube_state_metrics(aggregator, instance, check):
     # replicasets count
     aggregator.assert_metric(
         NAMESPACE + '.replicaset.count',
-        tags=['namespace:kube-system', 'owner_kind:deployment', 'owner_name:l7-default-backend', 'optional:tag1'],
+        tags=[
+            'kube_namespace:kube-system',
+            'namespace:kube-system',
+            'owner_kind:deployment',
+            'owner_name:l7-default-backend',
+            'optional:tag1',
+        ],
         value=1,
     )
     aggregator.assert_metric(
         NAMESPACE + '.replicaset.count',
-        tags=['namespace:kube-system', 'owner_kind:deployment', 'owner_name:metrics-server-v0.3.6', 'optional:tag1'],
+        tags=[
+            'kube_namespace:kube-system',
+            'namespace:kube-system',
+            'owner_kind:deployment',
+            'owner_name:metrics-server-v0.3.6',
+            'optional:tag1',
+        ],
         value=1,
     )
     aggregator.assert_metric(
         NAMESPACE + '.replicaset.count',
-        tags=['namespace:kube-system', 'owner_kind:deployment', 'owner_name:kube-dns-autoscaler', 'optional:tag1'],
+        tags=[
+            'kube_namespace:kube-system',
+            'namespace:kube-system',
+            'owner_kind:deployment',
+            'owner_name:kube-dns-autoscaler',
+            'optional:tag1',
+        ],
         value=1,
     )
 
     # jobs count
     aggregator.assert_metric(
         NAMESPACE + '.job.count',
-        tags=['namespace:default', 'owner_kind:cronjob', 'owner_name:a-cronjob', 'optional:tag1'],
+        tags=[
+            'kube_namespace:default',
+            'namespace:default',
+            'owner_kind:cronjob',
+            'owner_name:a-cronjob',
+            'optional:tag1',
+        ],
         value=1,
     )
     aggregator.assert_metric(
         NAMESPACE + '.job.count',
-        tags=['namespace:default', 'owner_kind:<none>', 'owner_name:<none>', 'optional:tag1'],
+        tags=['kube_namespace:default', 'namespace:default', 'owner_kind:<none>', 'owner_name:<none>', 'optional:tag1'],
         value=1,
     )
 
     # deployments count
     aggregator.assert_metric(
         NAMESPACE + '.deployment.count',
-        tags=['namespace:default', 'optional:tag1'],
+        tags=['kube_namespace:default', 'namespace:default', 'optional:tag1'],
         value=2,
     )
     aggregator.assert_metric(
         NAMESPACE + '.deployment.count',
-        tags=['namespace:kube-system', 'optional:tag1'],
+        tags=['kube_namespace:kube-system', 'namespace:kube-system', 'optional:tag1'],
         value=2,
     )
 
     # statefulset count
     aggregator.assert_metric(
         NAMESPACE + '.statefulset.count',
-        tags=['namespace:default', 'optional:tag1'],
+        tags=['kube_namespace:default', 'namespace:default', 'optional:tag1'],
         value=2,
     )
     aggregator.assert_metric(
         NAMESPACE + '.statefulset.count',
-        tags=['namespace:kube-system', 'optional:tag1'],
+        tags=['kube_namespace:kube-system', 'namespace:kube-system', 'optional:tag1'],
         value=2,
     )
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

`<object>.count` metrics do not use the default `kube_labels_mapper` as opposed to the other metrics, it's why the `kube_namespace` tag was missing. This PR fixes this.

### Motivation
<!-- What inspired you to submit this pull request? -->

Bug fix.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

The label mapper override is inspired by what we do in the ksm core check https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go#L717-L729

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
