### PR TITLE
Properly tag all integration versions 

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/tag.py
@@ -55,6 +55,7 @@ def tag(check, version, push, dry_run, skip_prerelease):
 
         if skip_prerelease and version == PRERELEASE:
             echo_warning('skipping prerelease version')
+            version = None
             continue
 
         # get the tag name


### PR DESCRIPTION
### What does this PR do?
Properly tag all integration versions

### Motivation
Before, we would stop checking for new integration versions to tag once any pre-release integration was found. This is because we have a `None` check for version in the loop, but if we discover a pre-release integration, we didn't reset version to `None` so version will be `0.0.1` for the rest of the loop https://github.com/DataDog/integrations-core/pull/11736/files#diff-f0591d2ad7a83220593faa96c6a481a295b0e0d45af286c0ad5d07832bd1b502L53

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
