### PR TITLE
Report critical queue manager service check when connection fails

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
+++ b/ibm_mq/datadog_checks/ibm_mq/ibm_mq.py
@@ -58,6 +58,12 @@ class IbmMqCheck(AgentCheck):
             self.service_check(
                 self.SERVICE_CHECK, AgentCheck.CRITICAL, self._config.tags, hostname=self._config.hostname
             )
+            self.service_check(
+                QueueMetricCollector.QUEUE_MANAGER_SERVICE_CHECK,
+                AgentCheck.CRITICAL,
+                self._config.tags,
+                hostname=self._config.hostname,
+            )
             raise
 
         self._collect_metadata(queue_manager)

--- a/ibm_mq/tests/test_ibm_mq_int.py
+++ b/ibm_mq/tests/test_ibm_mq_int.py
@@ -12,6 +12,7 @@ from six import iteritems
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.time import ensure_aware_datetime
 from datadog_checks.dev.utils import get_metadata_metrics
+from datadog_checks.ibm_mq import IbmMqCheck
 from datadog_checks.ibm_mq.collectors import ChannelMetricCollector, QueueMetricCollector
 
 from . import common
@@ -67,6 +68,26 @@ def test_unknown_service_check(aggregator, get_check, instance, caplog, dd_run_c
         for channel in channels:
             channel_tags = tags + ['channel:{}'.format(channel)]
             aggregator.assert_service_check('ibm_mq.channel', check.UNKNOWN, tags=channel_tags, count=1)
+
+
+def test_check_cant_connect(aggregator, get_check, instance, dd_run_check):
+    instance['queue_manager'] = "not_real"
+    check = get_check(instance)
+    dd_run_check(check)
+
+    tags = [
+        'connection_name:{}({})'.format(common.HOST, common.PORT),
+        'foo:bar',
+        'port:{}'.format(common.PORT),
+        'queue_manager:not_real',
+        'channel:{}'.format(common.CHANNEL),
+    ]
+    hostname = common.HOST
+
+    aggregator.assert_service_check(IbmMqCheck.SERVICE_CHECK, check.CRITICAL, tags=tags, count=1, hostname=hostname)
+    aggregator.assert_service_check(
+        ChannelMetricCollector.CHANNEL_SERVICE_CHECK, check.CRITICAL, tags=tags, count=1, hostname=hostname
+    )
 
 
 def test_errors_are_logged(get_check, instance, caplog, dd_run_check):

--- a/ibm_mq/tests/test_ibm_mq_int.py
+++ b/ibm_mq/tests/test_ibm_mq_int.py
@@ -72,22 +72,24 @@ def test_unknown_service_check(aggregator, get_check, instance, caplog, dd_run_c
 
 def test_check_cant_connect(aggregator, get_check, instance, dd_run_check):
     instance['queue_manager'] = "not_real"
-    check = get_check(instance)
-    dd_run_check(check)
 
-    tags = [
-        'connection_name:{}({})'.format(common.HOST, common.PORT),
-        'foo:bar',
-        'port:{}'.format(common.PORT),
-        'queue_manager:not_real',
-        'channel:{}'.format(common.CHANNEL),
-    ]
-    hostname = common.HOST
+    with pytest.raises(Exception, match=r'MQI Error'):
+        check = get_check(instance)
+        dd_run_check(check)
 
-    aggregator.assert_service_check(IbmMqCheck.SERVICE_CHECK, check.CRITICAL, tags=tags, count=1, hostname=hostname)
-    aggregator.assert_service_check(
-        ChannelMetricCollector.CHANNEL_SERVICE_CHECK, check.CRITICAL, tags=tags, count=1, hostname=hostname
-    )
+        tags = [
+            'connection_name:{}({})'.format(common.HOST, common.PORT),
+            'foo:bar',
+            'port:{}'.format(common.PORT),
+            'queue_manager:not_real',
+            'channel:{}'.format(common.CHANNEL),
+        ]
+        hostname = common.HOST
+
+        aggregator.assert_service_check(IbmMqCheck.SERVICE_CHECK, check.CRITICAL, tags=tags, count=1, hostname=hostname)
+        aggregator.assert_service_check(
+            ChannelMetricCollector.CHANNEL_SERVICE_CHECK, check.CRITICAL, tags=tags, count=1, hostname=hostname
+        )
 
 
 def test_errors_are_logged(get_check, instance, caplog, dd_run_check):


### PR DESCRIPTION
### What does this PR do?
Report critical queue manager check when connection fails 

### Motivation
More service check coverage

### Additional Notes
TODO: also report when connection succeeds but other operations do not

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
