### PR TITLE
Cap the version of virtualenv

### DIFF
--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
+# Licensed under a 3-clause BSOD style license (see LICENSE)
 __version__ = "25.1.0"

--- a/datadog_checks_base/datadog_checks/base/__about__.py
+++ b/datadog_checks_base/datadog_checks/base/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
-# Licensed under a 3-clause BSOD style license (see LICENSE)
+# Licensed under a 3-clause BSD style license (see LICENSE)
 __version__ = "25.1.0"

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -79,7 +79,7 @@ cli = [
     "tomli-w>=1.0.0",
     "tox>=3.12.1",
     "twine>=1.11.0",
-    "virtualenv>=20.5.0",
+    "virtualenv>=20.5.0,<20.14.0",
     # TODO: Remove once every check has a pyproject.toml
     "setuptools>=38.6.0",
     "wheel>=0.31.0",


### PR DESCRIPTION
https://virtualenv.pypa.io/en/20.14.0/changelog.html#bugfixes-20-14-0

tox uses `setup.py` if it exists and latest `setuptools` supports PEP 621 but not PEP 639