### PR TITLE
Pin click dependency

### DIFF
--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -58,7 +58,7 @@ cli = [
     "atomicwrites",
     "beautifulsoup4>=4.9.3",
     "build>=0.7.0",
-    "click~=8.0",
+    "click==8.0",
     "codespell",
     "colorama",
     "datamodel-code-generator~=0.11.4",


### PR DESCRIPTION
### What does this PR do?

The `click` library changed their support for autocompletion, raising errors when trying to run any `ddev` commands: [changelog here](https://click.palletsprojects.com/en/8.1.x/changes/)

This PR pins the version to `8.0` instead, until the proper support gets added.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
