### PR TITLE
Update error message in recommended monitor validation to include more context

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/recommended_monitors.py
@@ -130,8 +130,15 @@ def recommended_monitors(check):
                 monitor_name = decoded.get('name').lower()
                 if not (check_name in monitor_name or display_name in monitor_name):
                     file_failed = True
+                    if check_name == display_name:
+                        error_msg = f":{check_name}"
+                    else:
+                        error_msg = f". Either: {check_name} or {display_name}"
                     display_queue.append(
-                        (echo_failure, f"    {monitor_filename} name must contain the integration name"),
+                        (
+                            echo_failure,
+                            f"    {monitor_filename} `name` field must contain the integration name{error_msg}",
+                        ),
                     )
 
             if file_failed:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds more information to the error message presented to a user when the integration name is not present in the recommended monitor `name` field. 

### Motivation
<!-- What inspired you to submit this pull request? -->
Help users be able to resolve this issue more clearly when its hit

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
