### PR TITLE
Fix broken latency metric collection

### DIFF
--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -444,6 +444,9 @@ class AerospikeCheck(AgentCheck):
             if line.startswith("error-"):
                 continue
 
+            if not data:
+                break
+
             timestamp = re.match(r'(\d+:\d+:\d+)', line)
             if timestamp:
                 metric_values = line.split(",")[1:]

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -444,9 +444,6 @@ class AerospikeCheck(AgentCheck):
             if line.startswith("error-"):
                 continue
 
-            if not data:
-                break
-
             timestamp = re.match(r'(\d+:\d+:\d+)', line)
             if timestamp:
                 metric_values = line.split(",")[1:]
@@ -482,7 +479,6 @@ class AerospikeCheck(AgentCheck):
                     self.send(NAMESPACE_LATENCY_METRIC_TYPE, metric_names[i], metric_values[i], namespace_tags)
             else:
                 self.log.debug("Got unexpected latency buckets: %s", ns_latencies)
-
 
     def collect_throughput(self, namespaces):
         """

--- a/aerospike/datadog_checks/aerospike/aerospike.py
+++ b/aerospike/datadog_checks/aerospike/aerospike.py
@@ -394,9 +394,6 @@ class AerospikeCheck(AgentCheck):
         while data:
             line = data.pop(0)
 
-            if not data:
-                break
-
             ns, metric_name = self.get_metric_name(line)
             if metric_name is None:
                 return
@@ -447,9 +444,6 @@ class AerospikeCheck(AgentCheck):
             if line.startswith("error-"):
                 continue
 
-            if not data:
-                break
-
             timestamp = re.match(r'(\d+:\d+:\d+)', line)
             if timestamp:
                 metric_values = line.split(",")[1:]
@@ -483,6 +477,9 @@ class AerospikeCheck(AgentCheck):
             if len(metric_names) == len(metric_values):
                 for i in range(len(metric_names)):
                     self.send(NAMESPACE_LATENCY_METRIC_TYPE, metric_names[i], metric_values[i], namespace_tags)
+            else:
+                self.log.debug("Got unexpected latency buckets: %s", ns_latencies)
+
 
     def collect_throughput(self, namespaces):
         """

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -108,12 +108,16 @@ def test_collect_latency_parser(aggregator):
             '11:53:57,0.0,0.00,0.00,0.00',
             '{ns-1}-write:11:53:47-GMT,ops/sec,>1ms,>8ms,>64ms',
             '11:53:57,0.0,0.00,0.00,0.00',
+            '{ns-1}-query:11:53:47-GMT,ops/sec,>1ms,>8ms,>64ms',
+            '11:53:57,0.0,0.00,0.00,0.00',
             '{ns-2_foo}-read:11:53:47-GMT,ops/sec,>1ms,>8ms,>64ms',
             '11:53:57,0.0,0.00,0.00,0.00',
             '{ns-2_foo}-write:11:53:47-GMT,ops/sec,>1ms,>8ms,>64ms',
             '11:53:57,0.0,0.00,0.00,0.00',
             'error-no-data-yet-or-back-too-small',
             'error-no-data-yet-or-back-too-small',
+            '{ns-2_foo}-query:11:53:47-GMT,ops/sec,>1ms,>8ms,>64ms',
+            '11:53:57,0.0,0.00,0.00,0.00',
         ]
     )
     check.collect_latency(None)

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -98,7 +98,7 @@ def test_connection_uses_tls():
 
 
 @pytest.mark.parametrize(
-    "data, calls",
+    "data, calls_count",
     [
         pytest.param(
             [


### PR DESCRIPTION
### What does this PR do?
Fixes broken latency and latencies metric connection. Previously, the `collect_latency` and `collect_latencies` methods exited before the last row of output could be processed due to an unneeded `break` statement. The existing tests did not catch this because the mocked data returned either no data or empty data as the last row. This PR removes the unneeded break statements and adds additional test cases.

### Motivation
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
