### PR TITLE
Specify ECS Fargate platform-version 1.4.0 in run-task command

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -125,7 +125,7 @@ Run the task as a service for your cluster:
 aws ecs run-task --cluster <CLUSTER_NAME> \
 --network-configuration "awsvpcConfiguration={subnets=["<PRIVATE_SUBNET>"],securityGroups=["<SECURITY_GROUP>"]}" \
 --task-definition arn:aws:ecs:us-east-1:<AWS_ACCOUNT_NUMBER>:task-definition/<TASK_NAME>:1 \
---region <AWS_REGION> --launch-type FARGATE --platform-version 1.1.0
+--region <AWS_REGION> --launch-type FARGATE --platform-version 1.4.0
 ```
 
 ##### Web UI


### PR DESCRIPTION
ECS Fargate platform version 1.4.0 has been out since Nov 2020, so specify 1.4.0 as the platform version in your run-task example.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
In `aws ecs run-task ...` command specify v1.4.0 instead of v1.1.0.

### Motivation
<!-- What inspired you to submit this pull request? -->
Help customers who copy/paste the example `aws ecs run-task ...` command to use the current version of Fargate.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
