### PR TITLE
Update GitLab Runner documentation URL

### DIFF
--- a/gitlab_runner/README.md
+++ b/gitlab_runner/README.md
@@ -78,7 +78,7 @@ The Gitlab Runner check provides a service check to ensure that the Runner can t
 
 Need help? Contact [Datadog support][10].
 
-[1]: https://docs.gitlab.com/runner/monitoring/README.html
+[1]: https://docs.gitlab.com/runner/monitoring/
 [2]: https://docs.datadoghq.com/agent/kubernetes/integrations/
 [3]: https://app.datadoghq.com/account/settings#agent
 [4]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory


### PR DESCRIPTION
### What does this PR do?
Update the GitLab Runner documentation URL.

### Motivation
The old url is broken.

### Additional Notes
```
# Old URL
$ curl -I https://docs.gitlab.com/runner/monitoring/README.html
HTTP/2 404

# New URL
$ curl -I https://docs.gitlab.com/runner/monitoring/
HTTP/2 200
```
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
