### PR TITLE
Bug fix: fix postgres activity inflated query durations

### DIFF
--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -11,6 +11,7 @@ from concurrent.futures.thread import ThreadPoolExecutor
 import mock
 import psycopg2
 import pytest
+from dateutil import parser
 from semver import VersionInfo
 from six import string_types
 
@@ -644,7 +645,7 @@ def test_statement_metadata(
                 'query_signature': '9382c42e92099c04',
                 'statement': "BEGIN TRANSACTION; SELECT city FROM persons WHERE city = 'hello';",
             },
-            ["xact_start", "query_start", "pid", "client_port", "client_addr", "backend_type", "blocking_pids"],
+            ["now", "xact_start", "query_start", "pid", "client_port", "client_addr", "backend_type", "blocking_pids"],
             {
                 'usename': 'bob',
                 'state': 'active',
@@ -734,6 +735,9 @@ def test_activity_snapshot_collection(
                 expected_keys.remove('blocking_pids')
         for val in expected_keys:
             assert val in bobs_query
+
+        # assert that the current timestamp is being collected as an ISO timestamp with TZ info
+        assert parser.isoparse(bobs_query['now']).tzinfo, "current timestamp not formatted correctly"
 
         if 'blocking_pids' in expected_keys:
             # if we are collecting pg blocking information, then


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds a new column to activity queries for postgres, `now`, which is collected by calling the `clock_timestamp()` function. This will allow us to ingest the current time as seen by the database itself, and use that for our duration calculations for active queries in the backend. 

### Motivation
<!-- What inspired you to submit this pull request? -->

For the postgres integration, we're setting duration as `payloadTimestamp - query_start`, but payloadTimestamp is now() as calculated by the agent. It should instead be clock_timestamp() as reported by the database when the activity query is made.

This is likely adding 10-20 ms to our Postgres activity query durations. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
