### PR TITLE
[github/codeowners] Assign helm to container-integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,6 +43,9 @@ assets/               @DataDog/agent-integrations
 /eks_fargate/                             @DataDog/container-integrations @DataDog/agent-integrations
 /eks_fargate/*.md                         @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /eks_fargate/manifest.json                @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/helm/                                    @DataDog/container-integrations @DataDog/agent-integrations
+/helm/*.md                                @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/helm/manifest.json                       @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /kube_apiserver_metrics/                  @DataDog/container-integrations @DataDog/agent-integrations
 /kube_apiserver_metrics/*.md              @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /kube_apiserver_metrics/manifest.json     @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation


### PR DESCRIPTION
### What does this PR do?
 Assigns `helm` to container-integrations in `.github/codeowners`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
