### PR TITLE
Update metadata.csv to require curated_metric column

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/prometheus.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/prometheus.py
@@ -16,7 +16,8 @@ from ..console import CONTEXT_SETTINGS, abort, echo_info, echo_success, echo_wai
 METRIC_SEPARATORS = ('.', '_')
 TYPE_MAP = {'gauge': 'gauge', 'counter': 'count', 'rate': 'gauge', 'histogram': 'gauge', 'summary': 'gauge'}
 METADATA_CSV_HEADER = (
-    'metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name'
+    'metric_name,metric_type,interval,unit_name,per_unit_name,description,'
+    'orientation,integration,short_name,curated_metric'
 )
 
 
@@ -228,7 +229,7 @@ def parse(ctx, endpoint, check, here):
             metric_description = f'"{metric_description}"'
 
         output_lines.append(
-            '{check}.{metric_name},{metric_type},,,,{metric_description},0,{check},\n'.format(
+            '{check}.{metric_name},{metric_type},,,,{metric_description},0,{check},,\n'.format(
                 check=check, metric_name=metric_name, metric_type=metric_type, metric_description=metric_description
             )
         )

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/metrics2md.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/metrics2md.py
@@ -20,6 +20,7 @@ VALID_FIELDS = {
     'orientation',
     'integration',
     'short_name',
+    'curated_metric',
 }
 
 DEFAULT_FIELDS = ('metric_name', 'description', 'metric_type', 'unit_name')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -21,13 +21,9 @@ from ..console import (
     echo_warning,
 )
 
-REQUIRED_VALUE_HEADERS = {'metric_name', 'metric_type', 'orientation', 'integration'}
+REQUIRED_HEADERS = {'metric_name', 'metric_type', 'orientation', 'integration'}
 
-OPTIONAL_VALUE_HEADERS = {'description', 'interval', 'unit_name', 'per_unit_name', 'short_name'}
-
-REQUIRED_HEADERS = REQUIRED_VALUE_HEADERS | OPTIONAL_VALUE_HEADERS
-
-OPTIONAL_HEADERS = {'curated_metric'}
+OPTIONAL_HEADERS = {'description', 'interval', 'unit_name', 'per_unit_name', 'short_name', 'curated_metric'}
 
 ALL_HEADERS = REQUIRED_HEADERS | OPTIONAL_HEADERS
 
@@ -353,7 +349,7 @@ def metadata(check, check_duplicates, show_warnings):
                     errors = True
                     display_queue.append((echo_failure, f'{current_check}:{line} Invalid column {invalid_headers}'))
 
-                missing_headers = REQUIRED_HEADERS.difference(all_keys)
+                missing_headers = ALL_HEADERS.difference(all_keys)
                 if missing_headers:
                     errors = True
                     display_queue.append(echo_failure(f'{current_check}:{line} Missing columns {missing_headers}'))
@@ -446,7 +442,7 @@ def metadata(check, check_duplicates, show_warnings):
                 )
 
             # empty required fields
-            for header in REQUIRED_VALUE_HEADERS:
+            for header in REQUIRED_HEADERS:
                 if not row[header]:
                     empty_count[header] += 1
 
@@ -481,7 +477,7 @@ def metadata(check, check_duplicates, show_warnings):
                     (echo_failure, f"{current_check}:{line} interval should be an int, found '{row['interval']}'.")
                 )
 
-            if 'curated_metric' in row and row['curated_metric']:
+            if row['curated_metric']:
                 metric_types = row['curated_metric'].split('|')
                 if len(set(metric_types)) != len(metric_types):
                     errors = True

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/metadata.csv
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/metadata.csv
@@ -1,1 +1,1 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/metadata.csv
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/metadata.csv
@@ -1,1 +1,1 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/metadata.csv
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/metadata.csv
@@ -1,1 +1,1 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/metadata.csv
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/metadata.csv
@@ -1,1 +1,1 @@
-metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name
+metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric

--- a/openshift/gen_clusterquota_metadata.py
+++ b/openshift/gen_clusterquota_metadata.py
@@ -57,7 +57,7 @@ def gen_clusterquota_line(resource, count_type, applied=False):
     else:
         description += " for all namespaces"
 
-    print("{},gauge,,{},,{},{},openshift".format(
+    print("{},gauge,,{},,{},{},openshift,".format(
         metric_name,
         UNITS_PER_RESOURCE.get(resource, ""),
         description,
@@ -65,7 +65,7 @@ def gen_clusterquota_line(resource, count_type, applied=False):
     ))
 
 
-print("metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name")
+print("metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric")
 
 for res in RESOURCES:
     gen_clusterquota_line(res, "used", False)


### PR DESCRIPTION
### What does this PR do?
This pr is the last step of migrating all metadata.csv files in all repos to add the new `curated_metric` column. In this step we are requiring `curated_metric` to be a column (though can be empty) now that all new metadata.csv files generated should include this column.

Previous pr that allowed `curated_metric` to be optional - https://github.com/DataDog/integrations-core/pull/11168

### Motivation
We want to allow defining metrics for a given integration as a 'curated' metric. A metric selected here can be given a type (starting with 'cpu' or 'memory') to group metrics by when users are investigating issues based on that type. We will give these metrics more emphasis in the UI of our products (Live Processes to start) relative to other metrics.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
