### PR TITLE
Fix logic for loading minimum base package dependency for tests

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -10,7 +10,7 @@ from ..._env import DDTRACE_OPTIONS_LIST, E2E_PARENT_PYTHON, SKIP_ENVIRONMENT
 from ...ci import get_ci_env_vars, running_on_ci
 from ...fs import chdir, file_exists, remove_path
 from ...subprocess import run_command
-from ...utils import ON_WINDOWS, get_next
+from ...utils import ON_WINDOWS
 from ..constants import get_root
 from ..dependencies import read_check_base_dependencies
 from ..testing import construct_pytest_options, fix_coverage_report, get_tox_envs, pytest_coverage_sources
@@ -246,22 +246,12 @@ def test(
                 if errors:
                     abort(f'\nError collecting base package dependencies: {errors}')
 
-                ##Test Start
                 spec = check_base_dependencies[check]
                 if spec is None:
                     abort(f'\nFailed to determine minimum version of package `datadog_checks_base`: {spec}')
-                    
+
                 version = spec.split('>=')[-1]
-                ##Test End
-                ##Ori Start
-                # spec_set = list(check_base_dependencies['datadog-checks-base'].keys())[0]
 
-                # spec = get_next(spec_set) if spec_set else None
-                # if spec is None or spec.operator != '>=':
-                #     abort(f'\nFailed to determine minimum version of package `datadog_checks_base`: {spec}')
-
-                # version = spec.version
-                ##Ori End
                 env['TOX_FORCE_INSTALL'] = f"datadog_checks_base[deps]=={version}"
             elif force_base_unpinned and not base_or_dev:
                 env['TOX_FORCE_UNPINNED'] = "datadog_checks_base"

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -246,13 +246,22 @@ def test(
                 if errors:
                     abort(f'\nError collecting base package dependencies: {errors}')
 
-                spec_set = list(check_base_dependencies['datadog-checks-base'].keys())[0]
-
-                spec = get_next(spec_set) if spec_set else None
-                if spec is None or spec.operator != '>=':
+                ##Test Start
+                spec = check_base_dependencies[check]
+                if spec is None:
                     abort(f'\nFailed to determine minimum version of package `datadog_checks_base`: {spec}')
+                    
+                version = spec.split('>=')[-1]
+                ##Test End
+                ##Ori Start
+                # spec_set = list(check_base_dependencies['datadog-checks-base'].keys())[0]
 
-                version = spec.version
+                # spec = get_next(spec_set) if spec_set else None
+                # if spec is None or spec.operator != '>=':
+                #     abort(f'\nFailed to determine minimum version of package `datadog_checks_base`: {spec}')
+
+                # version = spec.version
+                ##Ori End
                 env['TOX_FORCE_INSTALL'] = f"datadog_checks_base[deps]=={version}"
             elif force_base_unpinned and not base_or_dev:
                 env['TOX_FORCE_UNPINNED'] = "datadog_checks_base"


### PR DESCRIPTION
### What does this PR do?
Fix logic used to determine the minimum version of the base check needed for testing. 

### Motivation
Base package CI was failing with:

```
spec_set = list(check_base_dependencies['datadog-checks-base'].keys())[0]
KeyError: 'datadog-checks-base'
```

`check_base_dependencies` returns a simple dictionary structure now. I.e.:
`{'amazon_msk': 'datadog-checks-base>=25.1.0'}`


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
