### PR TITLE
Lower reserved CPU units for datadog-agent in Cloudformation example of Fargate documentation

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -87,7 +87,7 @@ Resources:
       ContainerDefinitions:
         - Name: datadog-agent
           Image: 'gcr.io/datadoghq/agent:latest'
-          Cpu: 100
+          Cpu: 10
           Memory: 256MB
 ```
 


### PR DESCRIPTION
### What does this PR do?
Lower reserved CPU units for `datadog-agent` in the Cloudformation example of the Fargate documentation.

### Motivation
The [Web UI part](https://docs.datadoghq.com/integrations/ecs_fargate/?tab=fluentbitandfirelens#web-ui) of the documentation specifies 10 CPU units for the `datadog-agent`. Since the discrepancy is tenfold, I reckoned it was a mistake. In any case they should probably be the same, be it 10 or 100.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
The [AWS CLI part](https://docs.datadoghq.com/integrations/ecs_fargate/?tab=fluentbitandfirelens#aws-cli) of the examples does not include any reservations at all in the container definitions. Should this be added as well?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
