### PR TITLE
Fix glob pattern for gitlab changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -214,7 +214,7 @@ reminder-image-builder:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:18.03.1
   only:
     changes:
-      - .gitlab/reminder/**
+      - .gitlab/reminder/**/*
     refs:
       - master
   script:
@@ -229,8 +229,8 @@ tagger-image-builder:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:18.03.1
   only:
     changes:
-      - .gitlab/tagger/**
-      - datadog_checks_dev/**
+      - .gitlab/tagger/**/*
+      - datadog_checks_dev/**/*
     refs:
       - master
   script:
@@ -245,7 +245,7 @@ validate-log-intgs-builder:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:18.03.1
   only:
     changes:
-      - .gitlab/validate-logs-intgs/**
+      - .gitlab/validate-logs-intgs/**/*
     refs:
       - master
   script:
@@ -260,7 +260,7 @@ validate-agent-build-builder:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:18.03.1
   only:
     changes:
-      - .gitlab/validate-agent-build/**
+      - .gitlab/validate-agent-build/**/*
     refs:
       - master
   script:


### PR DESCRIPTION
### What does this PR do?
Fix the gitlab jobs to trigger on changes in all subdirectories of the given directories.

### Motivation
We noticed the tagger job did not run on every change to `datadog_checks_dev`, and realized it was an issue with the pattern for `only` `changes`. This PR is updating all stages in the pipeline to trigger on changes to any subdirectories. 

### Additional Notes
https://gitlab.com/gitlab-org/gitlab-foss/-/issues/59540

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
