### PR TITLE
[snmp] add memory and cpu abstract metrics

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/_aruba-switch-cpu-memory.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_aruba-switch-cpu-memory.yaml
@@ -13,10 +13,6 @@ metrics:
         # core check only
         name: cpu.usage
     metric_tags:
-      - tag: processor_index
-        column:
-          OID: 1.3.6.1.4.1.14823.2.2.1.2.1.13.1.1
-          name: sysExtProcessorID
       - tag: cpu
         index: 1
 
@@ -37,9 +33,5 @@ metrics:
         name: memory.used
         scale_factor: 1000
     metric_tags:
-      - tag: memory_index
-        column:
-          OID: 1.3.6.1.4.1.14823.2.2.1.2.1.15.1.1
-          name: sysExtMemoryIndex
       - tag: mem
         index: 1

--- a/snmp/datadog_checks/snmp/data/profiles/_aruba-switch-cpu-memory.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_aruba-switch-cpu-memory.yaml
@@ -1,0 +1,45 @@
+# CPU and memory metrics for Aruba switch
+metrics:
+  ### Processor
+
+  - # The table of processors contained by the controller.
+    MIB: WLSX-SYSTEMEXT-MIB
+    table:
+      OID: 1.3.6.1.4.1.14823.2.2.1.2.1.13
+      name: wlsxSysExtProcessorTable
+    symbols:
+      # The average, over the last minute, of the percentage of time that this processor was not idle.
+      - OID: 1.3.6.1.4.1.14823.2.2.1.2.1.13.1.3
+        # core check only
+        name: cpu.usage
+    metric_tags:
+      - tag: processor_index
+        column:
+          OID: 1.3.6.1.4.1.14823.2.2.1.2.1.13.1.1
+          name: sysExtProcessorID
+      - tag: cpu
+        index: 1
+
+  ### Memory
+
+  - # The memory status of the controller. All memory values measured in KB.
+    MIB: WLSX-SYSTEMEXT-MIB
+    table:
+      OID: 1.3.6.1.4.1.14823.2.2.1.2.1.15.1
+      name: wlsxSysExtMemoryTable
+    symbols:
+      - OID: 1.3.6.1.4.1.14823.2.2.1.2.1.15.1.2
+        # core check only
+        name: memory.total
+        scale_factor: 1000
+      - OID: 1.3.6.1.4.1.14823.2.2.1.2.1.15.1.3
+        # core check only
+        name: memory.used
+        scale_factor: 1000
+    metric_tags:
+      - tag: memory_index
+        column:
+          OID: 1.3.6.1.4.1.14823.2.2.1.2.1.15.1.1
+          name: sysExtMemoryIndex
+      - tag: mem
+        index: 1

--- a/snmp/datadog_checks/snmp/data/profiles/_checkpoint-firewall-cpu-memory.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_checkpoint-firewall-cpu-memory.yaml
@@ -1,0 +1,32 @@
+# CPU and memory metrics for Checkpoint Firewall devices
+
+metrics:
+    # CPU
+  - MIB: CHECKPOINT-MIB
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.2620.1.6.7.5.1.1
+          name: multiProcIndex
+        tag: cpu_core
+      - tag: cpu
+        index: 1
+    symbols:
+      - OID: 1.3.6.1.4.1.2620.1.6.7.5.1.5
+        # core check only
+        name: cpu.usage
+    table:
+      OID: 1.3.6.1.4.1.2620.1.6.7.5
+      name: multiProcTable
+    # Memory
+  - MIB: CHECKPOINT-MIB
+    forced_type: gauge
+    symbol:
+      OID: 1.3.6.1.4.1.2620.1.6.7.4.3.0
+        # core check only
+      name: memory.total
+  - MIB: CHECKPOINT-MIB
+    forced_type: gauge
+    symbol:
+      OID: 1.3.6.1.4.1.2620.1.6.7.4.4.0
+        # core check only
+      name: memory.used

--- a/snmp/datadog_checks/snmp/data/profiles/_cisco-cpu-memory.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_cisco-cpu-memory.yaml
@@ -25,9 +25,5 @@ metrics:
         # core check only
         name: memory.free
     metric_tags:
-      - column:
-          OID: 1.3.6.1.4.1.9.9.48.1.1.1.2
-          name: ciscoMemoryPoolName
-        tag: mem_pool_name
       - tag: mem
         index: 1

--- a/snmp/datadog_checks/snmp/data/profiles/_cisco-cpu-memory.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_cisco-cpu-memory.yaml
@@ -1,0 +1,33 @@
+# CPU and memory metrics for Cisco devices.
+
+metrics:
+  - MIB: CISCO-PROCESS-MIB
+    table:
+      OID: 1.3.6.1.4.1.9.9.109.1.1.1
+      name: cpmCPUTotalTable
+    symbols:
+      - OID: 1.3.6.1.4.1.9.9.109.1.1.1.1.7
+        # core check only
+        name: cpu.usage
+    metric_tags:
+      - index: 1
+        tag: cpu
+
+  - MIB: CISCO-MEMORY-POOL-MIB
+    table:
+      OID: 1.3.6.1.4.1.9.9.48.1.1
+      name: ciscoMemoryPoolTable
+    symbols:
+      - OID: 1.3.6.1.4.1.9.9.48.1.1.1.5
+        # core check only
+        name: memory.used
+      - OID: 1.3.6.1.4.1.9.9.48.1.1.1.6
+        # core check only
+        name: memory.free
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.9.9.48.1.1.1.2
+          name: ciscoMemoryPoolName
+        tag: mem_pool_name
+      - tag: mem
+        index: 1

--- a/snmp/datadog_checks/snmp/data/profiles/_cisco-generic.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_cisco-generic.yaml
@@ -7,6 +7,7 @@ extends:
   - _generic-ospf.yaml
   - _generic-bgp4.yaml
   - _generic-ip.yaml
+  - _cisco-cpu-memory.yaml
 
 metadata:
   device:

--- a/snmp/datadog_checks/snmp/data/profiles/_f5-big-ip-cpu-memory.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_f5-big-ip-cpu-memory.yaml
@@ -1,0 +1,30 @@
+# CPU and memory metrics for F5 BIG-IP devices
+
+metrics:
+  # Memory stats
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    forced_type: gauge
+    symbol:
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.44.0
+        # core check only
+      name: memory.total
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    forced_type: gauge
+    symbol:
+      OID: 1.3.6.1.4.1.3375.2.1.1.2.1.45.0
+        # core check only
+      name: memory.used
+  # CPU
+  - MIB: F5-BIGIP-SYSTEM-MIB
+    table:
+      OID: 1.3.6.1.4.1.3375.2.1.7.5.2
+      name: sysMultiHostCpuTable
+    forced_type: gauge
+    symbols:
+      - OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.27
+        name: cpu.usage # sysMultiHostCpuUsageRatio1m
+    metric_tags:
+      - column:
+          OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.3
+          name: sysMultiHostCpuId
+        tag: cpu

--- a/snmp/datadog_checks/snmp/data/profiles/_fortinet-fortigate-cpu-memory.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_fortinet-fortigate-cpu-memory.yaml
@@ -1,0 +1,19 @@
+# CPU and memory metrics for Fortinet FortiGate devices
+metrics:
+
+  ### CPU
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      # Current CPU usage (percentage).
+      OID: 1.3.6.1.4.1.12356.101.4.1.3.0
+        # core check only
+      name: cpu.usage
+
+
+  ### Memory
+  - MIB: FORTINET-FORTIGATE-MIB
+    symbol:
+      # Current memory utilization (percentage).
+      OID: 1.3.6.1.4.1.12356.101.4.1.4.0
+      # core check only
+      name: memory.usage

--- a/snmp/datadog_checks/snmp/data/profiles/_generic-host-cpu-memory.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-host-cpu-memory.yaml
@@ -1,0 +1,47 @@
+# CPU and memory metrics for devices
+
+metrics:
+  #
+  # Memory
+  #
+  - MIB: HOST-RESOURCES-MIB
+    table:
+      OID: 1.3.6.1.2.1.25.2.3
+      name: hrStorageTable
+    symbols:
+      - OID: 1.3.6.1.2.1.25.2.3.1.5
+        # core check only
+        name: memory.total
+      - OID: 1.3.6.1.2.1.25.2.3.1.6
+        # core check only
+        name: memory.used
+    metric_tags:
+      - tag: storagedesc
+        column:
+          OID: 1.3.6.1.2.1.25.2.3.1.3
+          name: hrStorageDescr
+      - tag: storagetype
+        column:
+          OID: 1.3.6.1.2.1.25.2.3.1.2
+          name: hrStorageType
+      - tag: mem
+        index: 1
+
+  #
+  # Processor Load
+  #
+  - MIB: HOST-RESOURCES-MIB
+    table:
+      OID: 1.3.6.1.2.1.25.3.3
+      name: hrProcessorTable
+    symbols:
+      - OID: 1.3.6.1.2.1.25.3.3.1.2
+        # core check only
+        name: cpu.usage
+    metric_tags:
+      - tag: processorid
+        column:
+          OID: 1.3.6.1.2.1.25.3.3.1.1
+          name: hrProcessorFrwID
+      - tag: cpu
+        index: 1

--- a/snmp/datadog_checks/snmp/data/profiles/_generic-host-cpu-memory.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-host-cpu-memory.yaml
@@ -16,14 +16,6 @@ metrics:
         # core check only
         name: memory.used
     metric_tags:
-      - tag: storagedesc
-        column:
-          OID: 1.3.6.1.2.1.25.2.3.1.3
-          name: hrStorageDescr
-      - tag: storagetype
-        column:
-          OID: 1.3.6.1.2.1.25.2.3.1.2
-          name: hrStorageType
       - tag: mem
         index: 1
 
@@ -39,9 +31,5 @@ metrics:
         # core check only
         name: cpu.usage
     metric_tags:
-      - tag: processorid
-        column:
-          OID: 1.3.6.1.2.1.25.3.3.1.1
-          name: hrProcessorFrwID
       - tag: cpu
         index: 1

--- a/snmp/datadog_checks/snmp/data/profiles/_generic-host-resources.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_generic-host-resources.yaml
@@ -2,6 +2,8 @@
 
 # Currently covers basic uptime and system process count along with storage stats
 # TODO: add device table
+extends:
+  - _generic-host-cpu-memory.yaml
 
 metrics:
   #

--- a/snmp/datadog_checks/snmp/data/profiles/aruba-switch.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/aruba-switch.yaml
@@ -17,6 +17,7 @@ extends:
   - _aruba-base.yaml
   - _generic-if.yaml
   - _generic-ospf.yaml
+  - _aruba-switch-cpu-memory.yaml
 
 # All Switch Products (switchProducts/1.3.6.1.4.1.14823.1.1) from ARUBA-MIB
 sysobjectid: 1.3.6.1.4.1.14823.1.1.*

--- a/snmp/datadog_checks/snmp/data/profiles/checkpoint-firewall.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/checkpoint-firewall.yaml
@@ -11,6 +11,7 @@ extends:
   - _generic-tcp.yaml
   - _generic-udp.yaml
   - _generic-ip.yaml
+  - _checkpoint-firewall-cpu-memory.yaml
 
 device:
   vendor: "checkpoint"

--- a/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/f5-big-ip.yaml
@@ -13,6 +13,7 @@ extends:
   - _generic-tcp.yaml
   - _generic-udp.yaml
   - _generic-ip.yaml
+  - _f5-big-ip-cpu-memory.yaml
 
 device:
   vendor: "f5"

--- a/snmp/datadog_checks/snmp/data/profiles/fortinet-fortigate.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/fortinet-fortigate.yaml
@@ -5,6 +5,7 @@
 extends:
   - _base.yaml
   - _generic-if.yaml
+  - _fortinet-fortigate-cpu-memory.yaml
 
 device:
   vendor: "fortinet"

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -24,6 +24,16 @@ ASSERT_VALUE_METRICS = [
     'datadog.snmp.submitted_metrics',
 ]
 
+# Profiles may contain symbols declared twice with different names and the same OID
+# Python check does handles one single metric name per OID symbol
+SKIPPED_CORE_ONLY_METRICS = [
+    'snmp.memory.total',
+    'snmp.memory.used',
+    'snmp.memory.free',
+    'snmp.memory.usage',
+    'snmp.cpu.usage',
+]
+
 SKIPPED_TAGS = ['loader']
 
 CORE_ONLY_TAGS = ['device_namespace:default']
@@ -47,7 +57,15 @@ def test_e2e_v3_version_autodetection(dd_agent_check):
             'community_string': '',
         }
     )
-    assert_python_vs_core(dd_agent_check, config, expected_total_count=515 + 5)
+    assert_value_metrics = [
+        'snmp.devices_monitored',
+    ]
+    assert_python_vs_core(
+        dd_agent_check,
+        config,
+        metrics_to_skip=SKIPPED_CORE_ONLY_METRICS,
+        assert_value_metrics=assert_value_metrics,
+    )
 
 
 def test_e2e_v3_explicit_version(dd_agent_check):
@@ -64,7 +82,15 @@ def test_e2e_v3_explicit_version(dd_agent_check):
             'community_string': '',
         }
     )
-    assert_python_vs_core(dd_agent_check, config, expected_total_count=515 + 5)
+    assert_value_metrics = [
+        'snmp.devices_monitored',
+    ]
+    assert_python_vs_core(
+        dd_agent_check,
+        config,
+        metrics_to_skip=SKIPPED_CORE_ONLY_METRICS,
+        assert_value_metrics=assert_value_metrics,
+    )
 
 
 def test_e2e_v3_md5_aes(dd_agent_check):
@@ -81,7 +107,16 @@ def test_e2e_v3_md5_aes(dd_agent_check):
             'community_string': '',
         }
     )
-    assert_python_vs_core(dd_agent_check, config)
+    metrics_to_skip = SKIPPED_CORE_ONLY_METRICS
+    assert_value_metrics = [
+        'snmp.devices_monitored',
+    ]
+    assert_python_vs_core(
+        dd_agent_check,
+        config,
+        metrics_to_skip=metrics_to_skip,
+        assert_value_metrics=assert_value_metrics,
+    )
 
 
 def test_e2e_v3_md5_aes256_blumenthal(dd_agent_check):
@@ -98,7 +133,16 @@ def test_e2e_v3_md5_aes256_blumenthal(dd_agent_check):
             'community_string': '',
         }
     )
-    assert_python_vs_core(dd_agent_check, config)
+    metrics_to_skip = SKIPPED_CORE_ONLY_METRICS
+    assert_value_metrics = [
+        'snmp.devices_monitored',
+    ]
+    assert_python_vs_core(
+        dd_agent_check,
+        config,
+        metrics_to_skip=metrics_to_skip,
+        assert_value_metrics=assert_value_metrics,
+    )
 
 
 def test_e2e_v3_md5_aes256_reeder(dd_agent_check):
@@ -119,7 +163,16 @@ def test_e2e_v3_md5_aes256_reeder(dd_agent_check):
             'community_string': '',
         }
     )
-    assert_python_vs_core(dd_agent_check, config)
+    metrics_to_skip = SKIPPED_CORE_ONLY_METRICS
+    assert_value_metrics = [
+        'snmp.devices_monitored',
+    ]
+    assert_python_vs_core(
+        dd_agent_check,
+        config,
+        metrics_to_skip=metrics_to_skip,
+        assert_value_metrics=assert_value_metrics,
+    )
 
 
 def test_e2e_regex_match(dd_agent_check):
@@ -252,8 +305,18 @@ def test_e2e_profile_arista(dd_agent_check):
 
 
 def test_e2e_profile_aruba(dd_agent_check):
-    config = common.generate_container_profile_config('aruba')
-    assert_python_vs_core(dd_agent_check, config, expected_total_count=67 + 5)
+    config = common.generate_container_profile_config("aruba")
+    metrics_to_skip = SKIPPED_CORE_ONLY_METRICS
+    assert_value_metrics = [
+        'snmp.devices_monitored',
+    ]
+    assert_python_vs_core(
+        dd_agent_check,
+        config,
+        expected_total_count=67 + 5,
+        metrics_to_skip=metrics_to_skip,
+        assert_value_metrics=assert_value_metrics,
+    )
 
 
 def test_e2e_profile_chatsworth_pdu(dd_agent_check):
@@ -262,23 +325,61 @@ def test_e2e_profile_chatsworth_pdu(dd_agent_check):
 
 
 def test_e2e_profile_checkpoint_firewall(dd_agent_check):
-    config = common.generate_container_profile_config('checkpoint-firewall')
-    assert_python_vs_core(dd_agent_check, config, expected_total_count=301 + 5)
+    config = common.generate_container_profile_config("checkpoint-firewall")
+    metrics_to_skip = SKIPPED_CORE_ONLY_METRICS
+    assert_value_metrics = [
+        'snmp.devices_monitored',
+    ]
+    assert_python_vs_core(
+        dd_agent_check,
+        config,
+        expected_total_count=301 + 5,
+        metrics_to_skip=metrics_to_skip,
+        assert_value_metrics=assert_value_metrics,
+    )
 
 
 def test_e2e_profile_cisco_3850(dd_agent_check):
-    config = common.generate_container_profile_config('cisco-3850')
-    assert_python_vs_core(dd_agent_check, config, expected_total_count=5108 + 5)
+    config = common.generate_container_profile_config("cisco-3850")
+    metrics_to_skip = SKIPPED_CORE_ONLY_METRICS
+    assert_value_metrics = [
+        'snmp.devices_monitored',
+    ]
+    assert_python_vs_core(
+        dd_agent_check,
+        config,
+        expected_total_count=5108 + 5,
+        metrics_to_skip=metrics_to_skip,
+        assert_value_metrics=assert_value_metrics,
+    )
 
 
 def test_e2e_profile_cisco_asa(dd_agent_check):
-    config = common.generate_container_profile_config('cisco-asa')
-    assert_python_vs_core(dd_agent_check, config)
+    config = common.generate_container_profile_config("cisco-asa")
+    metrics_to_skip = SKIPPED_CORE_ONLY_METRICS
+    assert_value_metrics = [
+        'snmp.devices_monitored',
+    ]
+    assert_python_vs_core(
+        dd_agent_check,
+        config,
+        metrics_to_skip=metrics_to_skip,
+        assert_value_metrics=assert_value_metrics,
+    )
 
 
 def test_e2e_profile_cisco_asa_5525(dd_agent_check):
-    config = common.generate_container_profile_config('cisco-asa-5525')
-    assert_python_vs_core(dd_agent_check, config)
+    config = common.generate_container_profile_config("cisco-asa-5525")
+    metrics_to_skip = SKIPPED_CORE_ONLY_METRICS
+    assert_value_metrics = [
+        'snmp.devices_monitored',
+    ]
+    assert_python_vs_core(
+        dd_agent_check,
+        config,
+        metrics_to_skip=metrics_to_skip,
+        assert_value_metrics=assert_value_metrics,
+    )
 
 
 def test_e2e_profile_cisco_catalyst(dd_agent_check):
@@ -292,8 +393,17 @@ def test_e2e_profile_cisco_csr1000v(dd_agent_check):
 
 
 def test_e2e_profile_cisco_nexus(dd_agent_check):
-    config = common.generate_container_profile_config('cisco-nexus')
-    assert_python_vs_core(dd_agent_check, config)
+    config = common.generate_container_profile_config("cisco-nexus")
+    metrics_to_skip = SKIPPED_CORE_ONLY_METRICS
+    assert_value_metrics = [
+        'snmp.devices_monitored',
+    ]
+    assert_python_vs_core(
+        dd_agent_check,
+        config,
+        metrics_to_skip=metrics_to_skip,
+        assert_value_metrics=assert_value_metrics,
+    )
 
 
 def test_e2e_profile_cisco_icm(dd_agent_check):
@@ -320,13 +430,31 @@ def test_e2e_profile_dell_poweredge(dd_agent_check):
 
 
 def test_e2e_profile_f5_big_ip(dd_agent_check):
-    config = common.generate_container_profile_config('f5-big-ip')
-    assert_python_vs_core(dd_agent_check, config)
+    config = common.generate_container_profile_config("f5-big-ip")
+    metrics_to_skip = SKIPPED_CORE_ONLY_METRICS
+    assert_value_metrics = [
+        'snmp.devices_monitored',
+    ]
+    assert_python_vs_core(
+        dd_agent_check,
+        config,
+        metrics_to_skip=metrics_to_skip,
+        assert_value_metrics=assert_value_metrics,
+    )
 
 
 def test_e2e_profile_fortinet_fortigate(dd_agent_check):
-    config = common.generate_container_profile_config('fortinet-fortigate')
-    assert_python_vs_core(dd_agent_check, config)
+    config = common.generate_container_profile_config("fortinet-fortigate")
+    metrics_to_skip = SKIPPED_CORE_ONLY_METRICS
+    assert_value_metrics = [
+        'snmp.devices_monitored',
+    ]
+    assert_python_vs_core(
+        dd_agent_check,
+        config,
+        metrics_to_skip=metrics_to_skip,
+        assert_value_metrics=assert_value_metrics,
+    )
 
 
 def test_e2e_profile_generic_router(dd_agent_check):

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -299,9 +299,7 @@ def test_f5(aggregator):
         'sysMultiHostCpuSoftirq',
         'sysMultiHostCpuIowait',
     ]
-    cpu_gauges = [
-        'sysMultiHostCpuUsageRatio',
-    ]
+    cpu_gauges = ['sysMultiHostCpuUsageRatio', 'cpu.usage']
 
     interfaces = [
         ('1.0', 'desc2'),


### PR DESCRIPTION
### What does this PR do?

Add abstract memory and cpu usage metrics to snmp profiles, with `scale_factor` when needed. `scale_factor` is implemented only in `core` check in PR https://github.com/DataDog/datadog-agent/pull/11438. As `scale_factor` is not supported as of today, I will add a dedicated test in a follow up PR once https://github.com/DataDog/datadog-agent/pull/11438 is merged.

When part of a table, cpu metrics are tagged by `cpu` and memory metrics are tagged by `mem`.

I added an e2e test based on a profile that is exposing cpu and memory usage metrics for core check.

### Motivation

We are adding support for cross-profile metrics: we want to provide with generic information about devices, as we are doing for interface level metrics. While interface metrics have a standard across vendors, cpu and memory are exposed in vendor / profile specific OIDs. This PR abstract from the vendor definition to expose comparable metrics using same names.

### Additional Notes
`pycheck` does not support multiple snmp symbols with the same OID, it overrides with the last found symbol name. Thus I had to skip some metrics in the e2e python vs core test.

### QA instructions

* Ensure tests pass locally using `ddev env test snmp py38`
* Ensure `aruba-switch`, `cisco`, `checkpoint-firewall`, `f5-big-ip` and `fortinet-fortigate` profiles submit `memory` and `cpu.usage` metrics


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
