### PR TITLE
[mysql] fix documentation: change mysql.innodb.buffer_pool_* from pages to bytes

### DIFF
--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -3,9 +3,9 @@ mysql.info.schema.size,gauge,,mebibyte,,"Size of schemas in MiB",0,mysql,mysql s
 mysql.info.table.index_size,gauge,,mebibyte,,"Size of tables index in MiB",0,mysql,mysql index table size,
 mysql.info.table.data_size,gauge,,mebibyte,,"Size of tables data in MiB",0,mysql,mysql data table size,memory
 mysql.galera.wsrep_cluster_size,gauge,,node,,The current number of nodes in the Galera cluster.,0,mysql,galera cluster size,
-mysql.innodb.buffer_pool_free,gauge,,page,,The number of free pages in the InnoDB Buffer Pool.,1,mysql,innodb buf pool free,
-mysql.innodb.buffer_pool_total,gauge,,page,,The total number of pages in the InnoDB Buffer Pool.,0,mysql,innodb buf pool total,
-mysql.innodb.buffer_pool_used,gauge,,page,,The number of used pages in the InnoDB Buffer Pool.,-1,mysql,innodb buf pool used,memory
+mysql.innodb.buffer_pool_free,gauge,,byte,,The number of free bytes in the InnoDB Buffer Pool.,1,mysql,innodb buf pool free,
+mysql.innodb.buffer_pool_total,gauge,,byte,,The total number of bytes in the InnoDB Buffer Pool.,0,mysql,innodb buf pool total,
+mysql.innodb.buffer_pool_used,gauge,,byte,,The number of used bytes in the InnoDB Buffer Pool.,-1,mysql,innodb buf pool used,memory
 mysql.innodb.buffer_pool_utilization,gauge,,fraction,,The utilization of the InnoDB Buffer Pool.,-1,mysql,innodb buf pool usage,memory
 mysql.innodb.current_row_locks,gauge,,lock,,The number of current row locks.,-1,mysql,current row locks,
 mysql.innodb.data_reads,gauge,,read,second,The rate of data reads.,0,mysql,data reads,


### PR DESCRIPTION
### What does this PR do?

The unit of the following three metrics is pages, but bytes is correct.

- mysql.innodb.buffer_pool_free
- mysql.innodb.buffer_pool_total
- mysql.innodb.buffer_pool_used

So in this PR, change unit from pages to bytes.

The following setting confirms that these metrics are in bytes:

https://github.com/DataDog/integrations-core/blob/70701cd978356fa8c8110df945dfe8120ab5ad9a/mysql/datadog_checks/mysql/const.py#L89-L91

### Motivation

Documentation is incorrect.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
