### PR TITLE
Fix race condition in test for async jobs

### DIFF
--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -236,13 +236,14 @@ def test_dbm_async_job_run_sync(aggregator):
 def test_dbm_async_job_rate_limit(aggregator):
     # test the main collection loop rate limit
     rate_limit = 10
+    limit_time = 1.0
     sleep_time = 0.9  # just below what the rate limit should hit to buffer before cancelling the loop
 
     job = TestJob(AgentCheck(), rate_limit=rate_limit)
     job.run_job_loop([])
 
     time.sleep(sleep_time)
-    max_collections = int(rate_limit * sleep_time) + 1
+    max_collections = int(rate_limit * limit_time) + 1
     job.cancel()
 
     metrics = aggregator.metrics("dbm.async_job_test.run_job")


### PR DESCRIPTION
### What does this PR do?

A previous PR attempted to fix this race condition: https://github.com/DataDog/integrations-core/pull/10563

While the theory of the fix was valid, the implementation missed an important change: the sleep time should have been decreased but the rate limit time should have remained at 1s. This change should properly fix the race.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
