### PR TITLE
Improve service check message when cert is not found

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -314,7 +314,7 @@ class HTTPCheck(AgentCheck):
             cert = ssl_sock.getpeercert()
             exp_date = datetime.strptime(cert['notAfter'], "%b %d %H:%M:%S %Y %Z")
         except Exception as e:
-            msg = str(e)
+            msg = repr(e)
             if any(word in msg for word in ['expired', 'expiration']):
                 self.log.debug("error: %s. Cert might be expired.", e)
                 return AgentCheck.CRITICAL, 0, 0, msg


### PR DESCRIPTION
### What does this PR do?
Improves the service check message when a cert is not found such as when `tls_verify` is false. Currently the error is just `'notAfter'` which is confusing. Now it returns `'KeyError(\'notAfter\')'` which is slightly better, this could be improved more.

### Motivation
QA for https://github.com/DataDog/integrations-core/pull/11615
### Additional Notes
Alternative approaches are to make a better error message for this specific case

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
