### PR TITLE
Fix `metric_patterns` option to support namespaces

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -655,12 +655,13 @@ class AgentCheck(object):
             # ignore metric sample
             return
 
+        name = self._format_namespace(name, raw)
+        if not self.should_send_metric(name):
+            return
+
         tags = self._normalize_tags_type(tags or [], device_name, name)
         if hostname is None:
             hostname = ''
-
-        if not self.should_send_metric(name):
-            return
 
         if self.metric_limiter:
             if mtype in ONE_PER_CONTEXT_METRIC_TYPES:
@@ -684,9 +685,7 @@ class AgentCheck(object):
             self.warning(err_msg)
             return
 
-        aggregator.submit_metric(
-            self, self.check_id, mtype, self._format_namespace(name, raw), value, tags, hostname, flush_first_value
-        )
+        aggregator.submit_metric(self, self.check_id, mtype, name, value, tags, hostname, flush_first_value)
 
     def gauge(self, name, value, tags=None, hostname=None, device_name=None, raw=False):
         # type: (str, float, Sequence[str], str, str, bool) -> None

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -668,7 +668,9 @@ class TestTags:
             pytest.param([r'.*'], [], [], id='exclude everything'),
             pytest.param([r'.*'], ['hello'], [], id='exclude everything one include'),
             pytest.param([], ['hello'], ['hello'], id='include string'),
-            pytest.param([], [r'^ns\.my_(me|test)tric*'], ['my_metric', 'my_metric_count'], id='include multiple matches'),
+            pytest.param(
+                [], [r'^ns\.my_(me|test)tric*'], ['my_metric', 'my_metric_count'], id='include multiple matches'
+            ),
             pytest.param([r'my_metric_count'], [r'my_metric*'], ['my_metric', 'test.my_metric1'], id='match both'),
             pytest.param([r'my_metric_count'], [r'my_metric_count'], [], id='duplicate'),
             pytest.param(

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -668,7 +668,7 @@ class TestTags:
             pytest.param([r'.*'], [], [], id='exclude everything'),
             pytest.param([r'.*'], ['hello'], [], id='exclude everything one include'),
             pytest.param([], ['hello'], ['hello'], id='include string'),
-            pytest.param([], [r'^my_(me|test)tric*'], ['my_metric', 'my_metric_count'], id='include multiple matches'),
+            pytest.param([], [r'^ns\.my_(me|test)tric*'], ['my_metric', 'my_metric_count'], id='include multiple matches'),
             pytest.param([r'my_metric_count'], [r'my_metric*'], ['my_metric', 'test.my_metric1'], id='match both'),
             pytest.param([r'my_metric_count'], [r'my_metric_count'], [], id='duplicate'),
             pytest.param(
@@ -697,6 +697,7 @@ class TestTags:
             }
         }
         check = AgentCheck('myintegration', {}, [instance])
+        check.__NAMESPACE__ = 'ns'
         check.gauge('my_metric', 0)
         check.count('my_metric_count', 0)
         check.count('test.my_metric1', 1)
@@ -704,9 +705,9 @@ class TestTags:
         check.service_check('test.can_check', status=AgentCheck.OK)
 
         for metric_name in expected_metrics:
-            aggregator.assert_metric(metric_name, count=1)
+            aggregator.assert_metric('ns.{}'.format(metric_name), count=1)
 
-        aggregator.assert_service_check('test.can_check', status=AgentCheck.OK)
+        aggregator.assert_service_check('ns.test.can_check', status=AgentCheck.OK)
         aggregator.assert_all_metrics_covered()
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/integrations-core/pull/11508

### Additional Notes

Also put filtering before tag logic for performance