### PR TITLE
Add conf.yaml.default as a default config example_name

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/spec.py
@@ -73,7 +73,7 @@ def files_validator(files, loader) -> None:
         else:
             file_names_origin[file_name] = file_index
 
-        if file_name == 'auto_conf.yaml':
+        if file_name == 'auto_conf.yaml' or file_name == 'conf.yaml.default':
             if 'example_name' in config_file and config_file['example_name'] != file_name:
                 loader.errors.append(
                     '{}, file #{}: Example file name `{}` should be `{}`'.format(

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -248,6 +248,21 @@ def test_example_file_name_autodiscovery_incorrect():
     assert 'test, file #1: Example file name `test.yaml.example` should be `auto_conf.yaml`' in spec.errors
 
 
+def test_example_file_name_core_check_incorrect():
+    spec = get_spec(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: conf.yaml.default
+          example_name: test.yaml.example
+        """
+    )
+    spec.load()
+
+    assert 'test, file #1: Example file name `test.yaml.example` should be `conf.yaml.default`' in spec.errors
+
+
 def test_example_file_name_standard_default():
     spec = get_spec(
         """
@@ -274,6 +289,20 @@ def test_example_file_name_autodiscovery_default():
     spec.load()
 
     assert spec.data['files'][0]['example_name'] == 'auto_conf.yaml'
+
+
+def test_example_file_name_core_check_default():
+    spec = get_spec(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: conf.yaml.default
+        """
+    )
+    spec.load()
+
+    assert spec.data['files'][0]['example_name'] == 'conf.yaml.default'
 
 
 def test_no_options():

--- a/docs/developer/meta/config-specs.md
+++ b/docs/developer/meta/config-specs.md
@@ -141,6 +141,8 @@ It also respects a few extra fields under the `value` attribute of each option:
 
 Use the `--sync` flag of the [config validation command](../ddev/cli.md#ddev-validate-config) to render the example configuration files.
 
+**Note:** Python-based core checks contain a `conf.yaml.default` file that do not use the configuration specification files. These files must be updated manually.
+
 ## Data model consumer
 
 The [model consumer][config-spec-model-consumer] uses each spec to render the [pydantic](https://github.com/samuelcolvin/pydantic) models

--- a/docs/developer/meta/config-specs.md
+++ b/docs/developer/meta/config-specs.md
@@ -142,7 +142,6 @@ It also respects a few extra fields under the `value` attribute of each option:
 
 Use the `--sync` flag of the [config validation command](../ddev/cli.md#ddev-validate-config) to render the example configuration files.
 
-
 ## Data model consumer
 
 The [model consumer][config-spec-model-consumer] uses each spec to render the [pydantic](https://github.com/samuelcolvin/pydantic) models

--- a/docs/developer/meta/config-specs.md
+++ b/docs/developer/meta/config-specs.md
@@ -38,8 +38,9 @@ Every file has 3 possible attributes:
 
 - `name` - This is the name of the file the Agent will look for (**REQUIRED**)
 - `example_name` - This is the name of the example file the Agent will ship. If none is provided, the
-  default will be `conf.yaml.example`. The exception is auto-discovery files, which are also named
-  `auto_conf.yaml`.
+  default will be `conf.yaml.example`. The exceptions are:
+  - Auto-discovery files, which are named `auto_conf.yaml`
+  - Python-based core check default files, which are named `conf.yaml.default`
 - `options` - A list of [options](#options) (**REQUIRED**)
 
 ### Options
@@ -141,7 +142,6 @@ It also respects a few extra fields under the `value` attribute of each option:
 
 Use the `--sync` flag of the [config validation command](../ddev/cli.md#ddev-validate-config) to render the example configuration files.
 
-**Note:** Python-based core checks contain a `conf.yaml.default` file that do not use the configuration specification files. These files must be updated manually.
 
 ## Data model consumer
 

--- a/docs/developer/meta/config-specs.md
+++ b/docs/developer/meta/config-specs.md
@@ -38,7 +38,7 @@ Every file has 3 possible attributes:
 
 - `name` - This is the name of the file the Agent will look for (**REQUIRED**)
 - `example_name` - This is the name of the example file the Agent will ship. If none is provided, the
-  default will be `conf.yaml.example`. The exceptions are:
+  default will be `conf.yaml.example`. The exceptions are as follows:
   - Auto-discovery files, which are named `auto_conf.yaml`
   - Python-based core check default files, which are named `conf.yaml.default`
 - `options` - A list of [options](#options) (**REQUIRED**)


### PR DESCRIPTION
### What does this PR do?
Add note in the config spec docs about `conf.yaml.default` files. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
