### PR TITLE
[doc]jonathan.mcintyre-update-metadata.csv

### DIFF
--- a/disk/metadata.csv
+++ b/disk/metadata.csv
@@ -1,6 +1,6 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 system.disk.free,gauge,,byte,,The amount of disk space that is free.,1,system,disk free,
-system.disk.in_use,gauge,,fraction,,The amount of disk space in use as a fraction of the total.,-1,system,disk in use,
+system.disk.in_use,gauge,,percent,,The amount of disk space in use as a percent of the total.,-1,system,disk in use,
 system.disk.read_time,count,,millisecond,,The time in ms spent reading per device,0,system,disk read time,
 system.disk.read_time_pct,gauge,,percent,,Percent of time spent reading from disk.,0,system,disk read time pct,
 system.disk.total,gauge,,byte,,The total amount of disk space.,0,system,disk total,


### PR DESCRIPTION

### What does this PR do?
Updates metadata.csv to change the disk metric 'system.disk.in_use' to a percent instead of a fraction.

[Disk Documentation](https://docs.datadoghq.com/integrations/disk/#pagetitle)

### Motivation
I noticed that the metric 'system.disk.in_use'  is displayed as a percent in the DD UI instead of a fraction.  See UI screenshot below.

[UI Screenshot](https://a.cl.ly/5zuLr7YB)


### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
