### PR TITLE
Add option to select which queries to run

### DIFF
--- a/ibm_i/assets/configuration/spec.yaml
+++ b/ibm_i/assets/configuration/spec.yaml
@@ -72,4 +72,26 @@ files:
         minimum: 0
         exclusiveMinimum: true
         example: 30
+    - name: queries
+      description: |
+         List of queries to be run against the IBM i system. By default, all queries are run.
+      value:
+        type: array
+        items: 
+          type: object
+          required: [name]
+          properties:
+            - name: name
+              type: string
+        example: &queries_default
+          - name: "disk_usage"
+          - name: "cpu_usage"
+          - name: "jobq_job_status"
+          - name: "active_job_status"
+          - name: "job_memory_usage"
+          - name: "memory_info"
+          - name: "subsystem"
+          - name: "job_queue"
+          - name: "message_queue_info"
+        default: *queries_default
     - template: instances/default

--- a/ibm_i/datadog_checks/ibm_i/config_models/defaults.py
+++ b/ibm_i/datadog_checks/ibm_i/config_models/defaults.py
@@ -50,6 +50,20 @@ def instance_password(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_queries(field, value):
+    return [
+        {'name': 'disk_usage'},
+        {'name': 'cpu_usage'},
+        {'name': 'jobq_job_status'},
+        {'name': 'active_job_status'},
+        {'name': 'job_memory_usage'},
+        {'name': 'memory_info'},
+        {'name': 'subsystem'},
+        {'name': 'job_queue'},
+        {'name': 'message_queue_info'},
+    ]
+
+
 def instance_query_timeout(field, value):
     return 30
 

--- a/ibm_i/datadog_checks/ibm_i/config_models/instance.py
+++ b/ibm_i/datadog_checks/ibm_i/config_models/instance.py
@@ -27,6 +27,13 @@ class MetricPatterns(BaseModel):
     include: Optional[Sequence[str]]
 
 
+class Query(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    name: str
+
+
 class InstanceConfig(BaseModel):
     class Config:
         allow_mutation = False
@@ -40,6 +47,7 @@ class InstanceConfig(BaseModel):
     metric_patterns: Optional[MetricPatterns]
     min_collection_interval: Optional[float]
     password: Optional[str]
+    queries: Optional[Sequence[Query]]
     query_timeout: Optional[int] = Field(None, gt=0.0)
     service: Optional[str]
     severity_threshold: Optional[int] = Field(None, ge=0.0, le=99.0)

--- a/ibm_i/datadog_checks/ibm_i/data/conf.yaml.example
+++ b/ibm_i/datadog_checks/ibm_i/data/conf.yaml.example
@@ -64,6 +64,20 @@ instances:
     #
     # query_timeout: 30
 
+    ## @param queries - list of mappings - optional
+    ## List of queries to be run against the IBM i system. By default, all queries are run.
+    #
+    # queries:
+    #   - name: disk_usage
+    #   - name: cpu_usage
+    #   - name: jobq_job_status
+    #   - name: active_job_status
+    #   - name: job_memory_usage
+    #   - name: memory_info
+    #   - name: subsystem
+    #   - name: job_queue
+    #   - name: message_queue_info
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/ibm_i/datadog_checks/ibm_i/queries.py
+++ b/ibm_i/datadog_checks/ibm_i/queries.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from .config_models import InstanceConfig
 
 
 def get_base_disk_usage_72(timeout):
@@ -272,4 +273,19 @@ def get_message_queue_info(timeout, sev):
             {'name': 'ibm_i.message_queue.size', 'type': 'gauge'},
             {'name': 'ibm_i.message_queue.critical_size', 'type': 'gauge'},
         ],
+    }
+
+
+def query_map(config: InstanceConfig):
+    """Build a query map from query names to queries."""
+
+    # subsystem and disk_usage queries are not here since they are handled in a special way
+    return {
+        "cpu_usage": get_cpu_usage(config.query_timeout),
+        "jobq_job_status": get_jobq_job_status(config.job_query_timeout),
+        "active_job_status": get_active_job_status(config.job_query_timeout),
+        "job_memory_usage": get_job_memory_usage(config.job_query_timeout),
+        "memory_info": get_memory_info(config.query_timeout),
+        "job_queue": get_job_queue_info(config.query_timeout),
+        "message_queue_info": get_message_queue_info(config.system_mq_query_timeout, config.severity_threshold),
     }

--- a/ibm_i/tests/test_ibm_i.py
+++ b/ibm_i/tests/test_ibm_i.py
@@ -236,6 +236,56 @@ def test_set_up_query_manager_7_4_hostname(instance):
     assert len(check._query_manager.queries) == 10
 
 
+def test_set_up_query_manager_7_4_queries_list(instance):
+    instance = {
+        **instance,
+        **{
+            'queries': [
+                {'name': 'disk_usage'},
+                {'name': 'cpu_usage'},
+                {'name': 'job_memory_usage'},
+                {'name': 'memory_info'},
+                {'name': 'subsystem'},
+                {'name': 'job_queue'},
+                {'name': 'message_queue_info'},
+            ]
+        },
+    }
+    check = IbmICheck('ibm_i', {}, [instance])
+    check.log = mock.MagicMock()
+    check.load_configuration_models()
+    with mock.patch('datadog_checks.ibm_i.IbmICheck.fetch_system_info', return_value=SystemInfo("host", 7, 4)):
+        check.set_up_query_manager()
+    assert check._query_manager is not None
+    # disk usage counts like 2, the rest (6 queries) count as 1
+    assert len(check._query_manager.queries) == 6 + 2
+
+
+def test_set_up_query_manager_7_2_queries_list(instance):
+    instance = {
+        **instance,
+        **{
+            'queries': [
+                {'name': 'disk_usage'},
+                {'name': 'cpu_usage'},
+                {'name': 'job_memory_usage'},
+                {'name': 'memory_info'},
+                {'name': 'subsystem'},
+                {'name': 'job_queue'},
+                {'name': 'message_queue_info'},
+            ]
+        },
+    }
+    check = IbmICheck('ibm_i', {}, [instance])
+    check.log = mock.MagicMock()
+    check.load_configuration_models()
+    with mock.patch('datadog_checks.ibm_i.IbmICheck.fetch_system_info', return_value=SystemInfo("host", 7, 2)):
+        check.set_up_query_manager()
+    assert check._query_manager is not None
+    # disk_usage counts like 1, subsystem like 0 (not available on 7.2), the rest (5 queries) count as 1
+    assert len(check._query_manager.queries) == 5 + 0 + 1
+
+
 def test_check_no_query_manager(aggregator, instance):
     check = IbmICheck('ibm_i', {}, [instance])
     check.log = mock.MagicMock()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add `queries` option to be able to declare which queries are run against the IBM i machine.
Each query has a `name` field for now, so that we can introduce further properties in the future.

### Motivation
<!-- What inspired you to submit this pull request? -->

Customer request

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Same as #11805, but against master branch

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
