### PR TITLE
Handle probe metrics when the endpoint is not available (k8s < 1.15)

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -333,9 +333,14 @@ class KubeletCheck(
             'kubelet_metrics_endpoint', urljoin(endpoint, KUBELET_METRICS_PATH)
         )
 
-        self.probes_scraper_config['prometheus_url'] = instance.get(
-            'probes_metrics_endpoint', urljoin(endpoint, PROBES_METRICS_PATH)
-        )
+        probes_metrics_endpoint = urljoin(endpoint, PROBES_METRICS_PATH)
+        if self.detect_probes(probes_metrics_endpoint):
+            self.probes_scraper_config['prometheus_url'] = instance.get(
+                'probes_metrics_endpoint', probes_metrics_endpoint
+            )
+        else:
+            # Disable probe metrics collection (k8s 1.15+ required)
+            self.probes_scraper_config['prometheus_url'] = ''
 
         # Kubelet credentials handling
         self.kubelet_credentials.configure_scraper(self.cadvisor_scraper_config)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a detection check before collecting probe metrics introduced in https://github.com/DataDog/integrations-core/pull/11682

### Motivation
<!-- What inspired you to submit this pull request? -->

Avoid this

```
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://<ip>:10250/metrics/probes
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
