### PR TITLE
add a new metric on backends count and status for proxysql

### DIFF
--- a/proxysql/assets/configuration/spec.yaml
+++ b/proxysql/assets/configuration/spec.yaml
@@ -68,5 +68,6 @@ files:
           - connection_pool_metrics
           - users_metrics
           - memory_metrics
+          - backends_metrics
           - query_rules_metrics
     - template: instances/default

--- a/proxysql/datadog_checks/proxysql/data/conf.yaml.example
+++ b/proxysql/datadog_checks/proxysql/data/conf.yaml.example
@@ -73,6 +73,7 @@ instances:
     #   - connection_pool_metrics
     #   - users_metrics
     #   - memory_metrics
+    #   - backends_metrics
     #   - query_rules_metrics
 
     ## @param tags - list of strings - optional

--- a/proxysql/datadog_checks/proxysql/proxysql.py
+++ b/proxysql/datadog_checks/proxysql/proxysql.py
@@ -12,6 +12,7 @@ from datadog_checks.base.utils.db import QueryManager
 from .queries import (
     STATS_COMMAND_COUNTERS,
     STATS_MEMORY_METRICS,
+    STATS_MYSQL_BACKENDS,
     STATS_MYSQL_CONNECTION_POOL,
     STATS_MYSQL_GLOBAL,
     STATS_MYSQL_QUERY_RULES,
@@ -25,6 +26,7 @@ ADDITIONAL_METRICS_MAPPING = {
     'connection_pool_metrics': STATS_MYSQL_CONNECTION_POOL,
     'users_metrics': STATS_MYSQL_USERS,
     'memory_metrics': STATS_MEMORY_METRICS,
+    'backends_metrics': STATS_MYSQL_BACKENDS,
     'query_rules_metrics': STATS_MYSQL_QUERY_RULES,
 }
 

--- a/proxysql/datadog_checks/proxysql/queries.py
+++ b/proxysql/datadog_checks/proxysql/queries.py
@@ -234,6 +234,16 @@ STATS_MEMORY_METRICS = {
     ],
 }
 
+STATS_MYSQL_BACKENDS = {
+    'name': 'stats_mysql_backends',
+    'query': 'SELECT  hostgroup_id, status, COUNT(*) FROM runtime_mysql_servers GROUP BY hostgroup_id, status',
+    'columns': [
+        {'name': 'hostgroup_id', 'type': 'tag'},
+        {'name': 'status', 'type': 'tag'},
+        {'name': 'backends.count', 'type': 'gauge'},
+    ],
+}
+
 STATS_MYSQL_QUERY_RULES = {
     'name': 'stats_mysql_query_rules',
     'query': 'SELECT rule_id, hits FROM stats_mysql_query_rules',

--- a/proxysql/metadata.csv
+++ b/proxysql/metadata.csv
@@ -72,3 +72,4 @@ proxysql.memory.stack_memory_cluster_threads,gauge,,byte,,Memory used by the sta
 proxysql.frontend.user_connections,gauge,,connection,,Current number of frontend connections by user.,0,proxysql,current_frontend_connections_by_user,
 proxysql.frontend.user_max_connections,gauge,,connection,,Max number of frontend connections the user can create (as defined in mysql_users.max_connections).,0,proxysql,max_frontend_connections_by_user,
 proxysql.query_rules.rule_hits,gauge,,hit,second,The number of times query rules matched traffic.,0,proxysql,query_rules_hits,
+proxysql.backends.count,gauge,,node,,Number of mysql servers connected.,0,proxysql,mysql_backends_connected_count,

--- a/proxysql/tests/common.py
+++ b/proxysql/tests/common.py
@@ -95,6 +95,8 @@ MEMORY_METRICS = (
     'proxysql.memory.stack_memory_cluster_threads',
 )
 
+BACKENDS_METRICS = ('proxysql.backends.count',)
+
 QUERY_RULES_TAGS_METRICS = ('proxysql.query_rules.rule_hits',)
 
 

--- a/proxysql/tests/test_integration.py
+++ b/proxysql/tests/test_integration.py
@@ -6,6 +6,7 @@ import pytest
 from datadog_checks.base import AgentCheck
 
 from .common import (
+    BACKENDS_METRICS,
     COMMANDS_COUNTERS_METRICS,
     CONNECTION_POOL_METRICS,
     GLOBAL_METRICS,
@@ -66,13 +67,14 @@ def test_server_down(aggregator, instance_basic, dd_run_check):
         (['connection_pool_metrics'], CONNECTION_POOL_METRICS, ['hostgroup', 'srv_host', 'srv_port']),
         (['users_metrics'], USER_TAGS_METRICS, ['username']),
         (['memory_metrics'], MEMORY_METRICS, []),
+        (['backends_metrics'], BACKENDS_METRICS, ['hostgroup_id', 'status']),
         (
             ['query_rules_metrics'],
             QUERY_RULES_TAGS_METRICS,
             ['rule_id'],
         ),
     ),
-    ids=('global', 'command_counters', 'connection_pool', 'users', 'memory', 'query_rules'),
+    ids=('global', 'command_counters', 'connection_pool', 'users', 'memory', 'backends', 'query_rules'),
 )
 def test_metric(aggregator, instance_basic, dd_run_check, additional_metrics, expected_metrics, tag_prefixes):
     instance_basic['additional_metrics'] = additional_metrics


### PR DESCRIPTION
### What does this PR do?
This PR add a new additional metric to know the numbers of mysql backends and their status (as tags of the metric)

### Motivation
Currently there is a service check on backend status but no metrics.
The service check does not meet our needs as it does not allow to customize queries (ex: no custom time range evaluation)

### Additional Notes
Despite there is already a service check `proxysql.backend.status`. This PR seems the only way to correctly monitor and alert on mysql backends count/status  

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
