### PR TITLE
Fix obfuscate_sql_with_metadata wrapper memory usage

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -193,10 +193,9 @@ def obfuscate_sql_with_metadata(query, options=None):
     statement = to_native_string(statement.strip())
 
     # Older agents may not have the new metadata API which returns a JSON string, so we must support cases where
-    # newer integrations are running on an older agent. In the past, we used to attempt JSON deserialization
-    # and used exceptions here as a way to control the flow. We found that this increased memory usage due to the
-    # amount of exceptions being thrown. Now, we use this "shortcut" to determine if we've received a JSON string
-    # to avoid throwing excessive amounts of exceptions.
+    # newer integrations are running on an older agent. We use this "shortcut" to determine if we've received
+    # a JSON string to avoid throwing excessive exceptions because we found that orjson leaks memory.
+    # Note, this condition is only relevant for integrations running on agent versions < 7.34
     if not statement.startswith('{'):
         return {'query': statement, 'metadata': {}}
 

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -15,11 +15,12 @@ from typing import Any, Callable, Dict, List, Tuple
 
 from cachetools import TTLCache
 
-from ..common import to_native_string
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.log import get_check_logger
 from datadog_checks.base.utils.db.types import Transformer
 from datadog_checks.base.utils.serialization import json
+
+from ..common import to_native_string
 
 try:
     import datadog_agent

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -191,6 +191,12 @@ def obfuscate_sql_with_metadata(query, options=None):
     # The `obfuscate_sql` testing stub returns bytes, so we have to handle that here.
     # The actual `obfuscate_sql` method in the agent's Go code returns a JSON string.
     statement = to_native_string(statement.strip())
+
+    # Older agents may not have the new metadata API which returns a JSON string, so we must support cases where
+    # newer integrations are running on an older agent. In the past, we used to attempt JSON deserialization
+    # and used exceptions here as a way to control the flow. We found that this increased memory usage due to the
+    # amount of exceptions being thrown. Now, we use this "shortcut" to determine if we've received a JSON string
+    # to avoid throwing excessive amounts of exceptions.
     if not statement.startswith('{'):
         return {'query': statement, 'metadata': {}}
 

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -186,9 +186,7 @@ def obfuscate_sql_with_metadata(query, options=None):
         return {'query': '', 'metadata': {}}
 
     statement = datadog_agent.obfuscate_sql(query, options)
-    if isinstance(statement, str) and not statement.startswith('{'):
-        return {'query': statement, 'metadata': {}}
-    elif isinstance(statement, bytes) and not statement.startswith(b'{'):
+    if not statement.startswith('{'):
         return {'query': statement, 'metadata': {}}
 
     statement_with_metadata = json.loads(statement)

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -187,9 +187,9 @@ def obfuscate_sql_with_metadata(query, options=None):
         return {'query': '', 'metadata': {}}
 
     statement = datadog_agent.obfuscate_sql(query, options)
-    statement = to_native_string(statement.strip())
     # The `obfuscate_sql` testing stub returns bytes, so we have to handle that here.
     # The actual `obfuscate_sql` method in the agent's Go code returns a JSON string.
+    statement = to_native_string(statement.strip())
     if not statement.startswith('{'):
         return {'query': statement, 'metadata': {}}
 

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -15,6 +15,7 @@ from typing import Any, Callable, Dict, List, Tuple
 
 from cachetools import TTLCache
 
+from ..common import to_native_string
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.log import get_check_logger
 from datadog_checks.base.utils.db.types import Transformer
@@ -186,12 +187,10 @@ def obfuscate_sql_with_metadata(query, options=None):
         return {'query': '', 'metadata': {}}
 
     statement = datadog_agent.obfuscate_sql(query, options)
-
-    # The `obfuscate_sql` testing stub returns bytes from the encoder, so we have to handle that here.
+    statement = to_native_string(statement.strip())
+    # The `obfuscate_sql` testing stub returns bytes, so we have to handle that here.
     # The actual `obfuscate_sql` method in the agent's Go code returns a JSON string.
-    if isinstance(statement, str) and not statement.startswith('{'):
-        return {'query': statement, 'metadata': {}}
-    if isinstance(statement, bytes) and not statement.startswith(b'{'):
+    if not statement.startswith('{'):
         return {'query': statement, 'metadata': {}}
 
     statement_with_metadata = json.loads(statement)

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -186,7 +186,12 @@ def obfuscate_sql_with_metadata(query, options=None):
         return {'query': '', 'metadata': {}}
 
     statement = datadog_agent.obfuscate_sql(query, options)
-    if not statement.startswith('{'):
+
+    # The `obfuscate_sql` testing stub returns bytes from the encoder, so we have to handle that here.
+    # The actual `obfuscate_sql` method in the agent's Go code returns a JSON string.
+    if isinstance(statement, str) and not statement.startswith('{'):
+        return {'query': statement, 'metadata': {}}
+    if isinstance(statement, bytes) and not statement.startswith(b'{'):
         return {'query': statement, 'metadata': {}}
 
     statement_with_metadata = json.loads(statement)

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -194,8 +194,9 @@ def obfuscate_sql_with_metadata(query, options=None):
 
     # Older agents may not have the new metadata API which returns a JSON string, so we must support cases where
     # newer integrations are running on an older agent. We use this "shortcut" to determine if we've received
-    # a JSON string to avoid throwing excessive exceptions because we found that orjson leaks memory.
-    # Note, this condition is only relevant for integrations running on agent versions < 7.34
+    # a JSON string to avoid throwing excessive exceptions. We found that orjson leaks memory when failing
+    # to parse these strings which are not valid json. Note, this condition is only relevant for integrations
+    # running on agent versions < 7.34
     if not statement.startswith('{'):
         return {'query': statement, 'metadata': {}}
 

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -17,7 +17,6 @@ from datadog_checks.base.utils.db.utils import (
     obfuscate_sql_with_metadata,
     resolve_db_host,
 )
-from datadog_checks.base.utils.serialization import json
 
 
 @pytest.mark.parametrize(
@@ -81,28 +80,17 @@ class TestDBExcepption(BaseException):
     "obfuscator_return_value,expected_value",
     [
         (
-            json.dumps(
-                {
-                    'query': 'SELECT * FROM datadog',
-                    'metadata': {'tables_csv': 'datadog,', 'commands': ['SELECT'], 'comments': None},
-                }
-            ),
+            "{\"query\":\"SELECT * FROM datadog\",\"metadata\":{\"tables_csv\":\"datadog\",\"commands\":[\"SELECT\"],"
+            "\"comments\":null}}",
             {
                 'query': 'SELECT * FROM datadog',
                 'metadata': {'commands': ['SELECT'], 'comments': None, 'tables': ['datadog']},
             },
         ),
         (
-            json.dumps(
-                {
-                    'query': 'SELECT * FROM datadog WHERE age = (SELECT AVG(age) FROM datadog2)',
-                    'metadata': {
-                        'tables_csv': '    datadog,  datadog2      ',
-                        'commands': ['SELECT', 'SELECT'],
-                        'comments': ['-- Test comment'],
-                    },
-                }
-            ),
+            "{\"query\":\"SELECT * FROM datadog WHERE age = (SELECT AVG(age) FROM datadog2)\",\"metadata\":{"
+            "\"tables_csv\":\"    datadog,  datadog2      \",\"commands\":[\"SELECT\",\"SELECT\"],\"comments\":[\"-- "
+            "Test comment\"]}}",
             {
                 'query': 'SELECT * FROM datadog WHERE age = (SELECT AVG(age) FROM datadog2)',
                 'metadata': {
@@ -113,12 +101,7 @@ class TestDBExcepption(BaseException):
             },
         ),
         (
-            json.dumps(
-                {
-                    'query': 'COMMIT',
-                    'metadata': {'tables_csv': '', 'commands': ['COMMIT'], 'comments': None},
-                }
-            ),
+            "{\"query\":\"COMMIT\",\"metadata\":{\"tables_csv\":\"\",\"commands\":[\"COMMIT\"],\"comments\":null}}",
             {
                 'query': 'COMMIT',
                 'metadata': {'commands': ['COMMIT'], 'comments': None, 'tables': None},

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -17,6 +17,7 @@ from datadog_checks.base.utils.db.utils import (
     obfuscate_sql_with_metadata,
     resolve_db_host,
 )
+from datadog_checks.base.utils.serialization import json
 
 
 @pytest.mark.parametrize(
@@ -80,14 +81,19 @@ class TestDBExcepption(BaseException):
     "obfuscator_return_value,expected_value",
     [
         (
-            "{\"query\":\"SELECT * FROM datadog\",\"metadata\":{\"tables_csv\":\"datadog\",\"commands\":[\"SELECT\"],"
-            "\"comments\":null}}",
+            json.dumps(
+                {
+                    'query': 'SELECT * FROM datadog',
+                    'metadata': {'tables_csv': 'datadog,', 'commands': ['SELECT'], 'comments': None},
+                }
+            ),
             {
                 'query': 'SELECT * FROM datadog',
                 'metadata': {'commands': ['SELECT'], 'comments': None, 'tables': ['datadog']},
             },
         ),
         (
+            # Whitespace test
             "  {\"query\":\"SELECT * FROM datadog\",\"metadata\":{\"tables_csv\":\"datadog\",\"commands\":[\"SELECT\"],"
             "\"comments\":null}}          ",
             {
@@ -96,9 +102,16 @@ class TestDBExcepption(BaseException):
             },
         ),
         (
-            "{\"query\":\"SELECT * FROM datadog WHERE age = (SELECT AVG(age) FROM datadog2)\",\"metadata\":{"
-            "\"tables_csv\":\"    datadog,  datadog2      \",\"commands\":[\"SELECT\",\"SELECT\"],\"comments\":[\"-- "
-            "Test comment\"]}}",
+            json.dumps(
+                {
+                    'query': 'SELECT * FROM datadog WHERE age = (SELECT AVG(age) FROM datadog2)',
+                    'metadata': {
+                        'tables_csv': '    datadog,  datadog2      ',
+                        'commands': ['SELECT', 'SELECT'],
+                        'comments': ['-- Test comment'],
+                    },
+                }
+            ),
             {
                 'query': 'SELECT * FROM datadog WHERE age = (SELECT AVG(age) FROM datadog2)',
                 'metadata': {
@@ -109,7 +122,12 @@ class TestDBExcepption(BaseException):
             },
         ),
         (
-            "{\"query\":\"COMMIT\",\"metadata\":{\"tables_csv\":\"\",\"commands\":[\"COMMIT\"],\"comments\":null}}",
+            json.dumps(
+                {
+                    'query': 'COMMIT',
+                    'metadata': {'tables_csv': '', 'commands': ['COMMIT'], 'comments': None},
+                }
+            ),
             {
                 'query': 'COMMIT',
                 'metadata': {'commands': ['COMMIT'], 'comments': None, 'tables': None},

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -78,7 +78,7 @@ class TestDBExcepption(BaseException):
 
 
 @pytest.mark.parametrize(
-    "obfuscator_return_value,expected_value,return_json_metadata",
+    "obfuscator_return_value,expected_value",
     [
         (
             json.dumps(
@@ -91,7 +91,6 @@ class TestDBExcepption(BaseException):
                 'query': 'SELECT * FROM datadog',
                 'metadata': {'commands': ['SELECT'], 'comments': None, 'tables': ['datadog']},
             },
-            True,
         ),
         (
             json.dumps(
@@ -112,7 +111,6 @@ class TestDBExcepption(BaseException):
                     'tables': ['datadog', 'datadog2'],
                 },
             },
-            True,
         ),
         (
             json.dumps(
@@ -125,7 +123,6 @@ class TestDBExcepption(BaseException):
                 'query': 'COMMIT',
                 'metadata': {'commands': ['COMMIT'], 'comments': None, 'tables': None},
             },
-            True,
         ),
         (
             'SELECT * FROM datadog',
@@ -133,10 +130,6 @@ class TestDBExcepption(BaseException):
                 'query': 'SELECT * FROM datadog',
                 'metadata': {},
             },
-            # This test ensures that we handle the failed json decoder when requesting for metadata.
-            # This scenario could happen when newer integrations run against older agents which might not have the
-            # metadata API.
-            True,
         ),
         (
             'SELECT * FROM datadog',
@@ -144,19 +137,16 @@ class TestDBExcepption(BaseException):
                 'query': 'SELECT * FROM datadog',
                 'metadata': {},
             },
-            False,
         ),
     ],
 )
-def test_obfuscate_sql_with_metadata(obfuscator_return_value, expected_value, return_json_metadata):
+def test_obfuscate_sql_with_metadata(obfuscator_return_value, expected_value):
     def _mock_obfuscate_sql(query, options=None):
         return obfuscator_return_value
 
     with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
         mock_agent.side_effect = _mock_obfuscate_sql
-        statement = obfuscate_sql_with_metadata(
-            'query here does not matter', json.dumps({'return_json_metadata': return_json_metadata})
-        )
+        statement = obfuscate_sql_with_metadata('query here does not matter', None)
         assert statement == expected_value
 
     # Check that it can handle None values

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -88,6 +88,14 @@ class TestDBExcepption(BaseException):
             },
         ),
         (
+            "  {\"query\":\"SELECT * FROM datadog\",\"metadata\":{\"tables_csv\":\"datadog\",\"commands\":[\"SELECT\"],"
+            "\"comments\":null}}          ",
+            {
+                'query': 'SELECT * FROM datadog',
+                'metadata': {'commands': ['SELECT'], 'comments': None, 'tables': ['datadog']},
+            },
+        ),
+        (
             "{\"query\":\"SELECT * FROM datadog WHERE age = (SELECT AVG(age) FROM datadog2)\",\"metadata\":{"
             "\"tables_csv\":\"    datadog,  datadog2      \",\"commands\":[\"SELECT\",\"SELECT\"],\"comments\":[\"-- "
             "Test comment\"]}}",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates the `obfuscate_sql_with_metadata` wrapper to prevent unnecessarily throwing exceptions from decoding attempts. We found that `orjson` leaks memory when failing to parse these strings which are not valid json.

Note, this change is only relevant when integrations are running on an agent before 7.34.

Relevant PR: https://github.com/DataDog/datadog-agent/pull/10042

### Motivation
<!-- What inspired you to submit this pull request? -->
Before
![Screen Shot 2022-04-11 at 5 24 31 PM](https://user-images.githubusercontent.com/30381624/162836223-8afb7fdd-2ffc-44fe-8f12-024e20deb5b0.png)

After
![Screen Shot 2022-04-11 at 5 24 54 PM](https://user-images.githubusercontent.com/30381624/162836254-561033c8-89c5-4a0e-bdba-038a6873dbc1.png)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
