### PR TITLE
Remove http patch requests per second metric

### DIFF
--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -21,7 +21,6 @@ DEFAULT_COUNTERS = [
     ["Web Service", None, "Post Requests/sec", "iis.httpd_request_method.post", "gauge"],
     ["Web Service", None, "Head Requests/sec", "iis.httpd_request_method.head", "gauge"],
     ["Web Service", None, "Put Requests/sec", "iis.httpd_request_method.put", "gauge"],
-    ["Web Service", None, "Patch Requests/sec", "iis.httpd_request_method.patch", "gauge"],
     ["Web Service", None, "Delete Requests/sec", "iis.httpd_request_method.delete", "gauge"],
     ["Web Service", None, "Options Requests/sec", "iis.httpd_request_method.options", "gauge"],
     ["Web Service", None, "Trace Requests/sec", "iis.httpd_request_method.trace", "gauge"],

--- a/iis/datadog_checks/iis/metrics.py
+++ b/iis/datadog_checks/iis/metrics.py
@@ -31,7 +31,6 @@ METRICS_CONFIG = {
                 'Post Requests/sec': {'metric_name': 'httpd_request_method.post'},
                 'Head Requests/sec': {'metric_name': 'httpd_request_method.head'},
                 'Put Requests/sec': {'metric_name': 'httpd_request_method.put'},
-                'Patch Requests/sec': {'metric_name': 'httpd_request_method.patch'},
                 'Delete Requests/sec': {'metric_name': 'httpd_request_method.delete'},
                 'Options Requests/sec': {'metric_name': 'httpd_request_method.options'},
                 'Trace Requests/sec': {'metric_name': 'httpd_request_method.trace'},

--- a/iis/metadata.csv
+++ b/iis/metadata.csv
@@ -12,7 +12,6 @@ iis.httpd_request_method.get,gauge,,request,second,The number of GET requests pe
 iis.httpd_request_method.post,gauge,,request,second,The number of POST requests per second,0,iis,requests http post,
 iis.httpd_request_method.head,gauge,,request,second,The number of HEAD requests per second,0,iis,requests http head,
 iis.httpd_request_method.put,gauge,,request,second,The number of PUT requests per second,0,iis,requests http put,
-iis.httpd_request_method.patch,gauge,,request,second,The number of PATCH requests per second,0,iis,requests http patch,
 iis.httpd_request_method.delete,gauge,,request,second,The number of DELETE requests per second,0,iis,requests http delete,
 iis.httpd_request_method.options,gauge,,request,second,The number of OPTIONS requests per second,0,iis,requests http options,
 iis.httpd_request_method.trace,gauge,,request,second,The number of TRACE requests per second,0,iis,requests http trace,

--- a/iis/tests/common.py
+++ b/iis/tests/common.py
@@ -45,10 +45,6 @@ DEFAULT_APP_POOLS = [
 SITE_METRICS = [counter_data[3] for counter_data in DEFAULT_COUNTERS if counter_data[0] == 'Web Service']
 APP_POOL_METRICS = [counter_data[3] for counter_data in DEFAULT_COUNTERS if counter_data[0] == 'APP_POOL_WAS']
 
-# Skip test for legacy implementation since those giant fixtures are difficult to update
-for metric in ('iis.httpd_request_method.patch',):
-    SITE_METRICS.remove(metric)
-
 PERFORMANCE_OBJECTS = {}
 for object_name, instances in (('APP_POOL_WAS', ['foo-pool', 'bar-pool']), ('Web Service', ['foo.site', 'bar.site'])):
     PERFORMANCE_OBJECTS[object_name] = (


### PR DESCRIPTION
### What does this PR do?
The counter for this metric doesn't exist and has been causing a lot of logs from being generated.

### Motivation
Support cases.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
