### PR TITLE
[helm] Set "creates_events" to true

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -36,10 +36,10 @@ See [metadata.csv][4] for a list of metrics provided by this check.
 This check emits events when the `collect_events` option is set to `true`. The default is `false`.
 
 When the option is enabled, the check emits events when:
-- A new release has been deployed.
-- A release has been deleted.
-- A release has been upgraded (new revision).
-- There's a status change (from "deployed" to "superseded"), etc.
+- A new release is deployed.
+- A release is deleted.
+- A release is upgraded (new revision).
+- There's a status change, for example from deployed to superseded.
 
 ### Service Checks
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -33,8 +33,7 @@ See [metadata.csv][4] for a list of metrics provided by this check.
 
 ### Events
 
-This check emits events when the `collect_events` option is set to true (it's
-disabled by default).
+This check emits events when the `collect_events` option is set to `true`. The default is `false`.
 
 When the option is enabled, the check emits events when:
 - A new release has been deployed.

--- a/helm/README.md
+++ b/helm/README.md
@@ -33,7 +33,14 @@ See [metadata.csv][4] for a list of metrics provided by this check.
 
 ### Events
 
-The Helm integration does not include any events.
+This check emits events when the `collect_events` option is set to true (it's
+disabled by default).
+
+When the option is enabled, the check emits events when:
+- A new release has been deployed.
+- A release has been deleted.
+- A release has been upgraded (new revision).
+- There's a status change (from "deployed" to "superseded"), etc.
 
 ### Service Checks
 

--- a/helm/manifest.json
+++ b/helm/manifest.json
@@ -5,7 +5,7 @@
   "name": "helm",
   "metric_prefix": "helm.",
   "metric_to_check": "helm.release",
-  "creates_events": false,
+  "creates_events": true,
   "short_description": "Track your Helm deployments with Datadog",
   "guid": "7f57a1f2-6dc6-4029-ae9c-426238ea2f86",
   "support": "core",


### PR DESCRIPTION
### What does this PR do?

Set "creates_events" to true in the Helm integration.

The integration didn't create events in the first release, but it does starting from agent v7.36.0.

Merge after agent 7.36.0 is released.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
