### PR TITLE
Fix the elasticsearch guide URL in the `cluster_health` service check

### DIFF
--- a/elastic/assets/service_checks.json
+++ b/elastic/assets/service_checks.json
@@ -14,7 +14,7 @@
             "server"
         ],
         "name": "Cluster Health",
-        "description": "Returns the `status` from the Elasticsearch [Cluster Health API](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-health.html). Additional information about shard status at the time of collection is included in the check message."
+        "description": "Returns the `status` from the Elasticsearch [Cluster Health API](https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-health.html). Additional information about shard status at the time of collection is included in the check message."
     },
     {
         "agent_version": "5.1.0",


### PR DESCRIPTION
### What does this PR do?

Fix an external link to the Elasticsearch Cluster Health API section of the official guide in the cluster health service check description from the Elasticsearch integration.

### Motivation

External doc link to the Elasticsearch website was outdated.

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
