### PR TITLE
Add troubleshooting notes and script

### DIFF
--- a/cisco_aci/README.md
+++ b/cisco_aci/README.md
@@ -99,7 +99,7 @@ If you are missing `cisco_aci.tenant.*` metrics, you can run the `test/cisco_aci
 
 Modify the `apic_url`, `apic_username`, and `apic_password` to your configuration information, and input the `api_url` for the tenant URL.
 
-You can verify that the output you get from cURLing the endpoint matches any of the metrics collected in `datadog_checks/cisco_aci/aci_metrics.py`.
+You can verify that the output you get from cURLing the endpoint matches any of the metrics collected in `datadog_checks/cisco_aci/aci_metrics.py`. If none of the statistics match, this means that the endpoint is not emitting any statistics that the integration can collect.
 
 
 Need help? Contact [Datadog support][9].

--- a/cisco_aci/README.md
+++ b/cisco_aci/README.md
@@ -97,9 +97,9 @@ See [service_checks.json][8] for a list of service checks provided by this integ
 ### Missing `cisco_aci.tenant.*` metrics
 If you are missing `cisco_aci.tenant.*` metrics, you can run the `test/cisco_aci_query.py` script to manually query the tenant endpoint.
 
-Modify the `apic_url`, `apic_username`, and `apic_password` to your configuration information, and input the `api_url` for the tenant URL.
+Modify the `apic_url`, `apic_username`, and `apic_password` to your configuration information, and input the tenant URL for the `apic_url`.
 
-You can verify that the output you get from cURLing the endpoint matches any of the metrics collected in `datadog_checks/cisco_aci/aci_metrics.py`. If none of the statistics match, this means that the endpoint is not emitting any statistics that the integration can collect.
+Verify that the output you get from cURLing the endpoint matches any of the metrics collected in `datadog_checks/cisco_aci/aci_metrics.py`. If none of the statistics match, this means that the endpoint is not emitting any statistics that the integration can collect.
 
 
 Need help? Contact [Datadog support][9].

--- a/cisco_aci/README.md
+++ b/cisco_aci/README.md
@@ -94,6 +94,14 @@ See [service_checks.json][8] for a list of service checks provided by this integ
 
 ## Troubleshooting
 
+### Missing `cisco_aci.tenant.*` metrics
+If you are missing `cisco_aci.tenant.*` metrics, you can run the `test/cisco_aci_query.py` script to manually query the tenant endpoint.
+
+Modify the `apic_url`, `apic_username`, and `apic_password` to your configuration information, and input the `api_url` for the tenant URL.
+
+You can verify that the output you get from cURLing the endpoint matches any of the metrics collected in `datadog_checks/cisco_aci/aci_metrics.py`.
+
+
 Need help? Contact [Datadog support][9].
 
 [1]: https://app.datadoghq.com/account/settings#agent

--- a/cisco_aci/tests/cisco_aci_query.py
+++ b/cisco_aci/tests/cisco_aci_query.py
@@ -5,7 +5,7 @@ import requests
 # tenant metric endpoint and includes the login and logout requests.
 # You can change the parameters below for your configuration and tenant to query.
 
-# Edit this section
+# Edit this section. Below is a sample config using the public sandbox:
 apic_url = 'sandboxapicdc.cisco.com'
 apic_username = 'admin'
 apic_password = '!v3G@!4@Y'

--- a/cisco_aci/tests/cisco_aci_query.py
+++ b/cisco_aci/tests/cisco_aci_query.py
@@ -1,11 +1,16 @@
 import json
 import requests
 
+# This is a python script that you can use to query a specific
+# tenant metric endpoint and includes the login and logout requests.
+# You can change the parameters below for your configuration and tenant to query.
+
 # Edit this section
-apic_url = 'URL.com'
-apic_username = 'USERNAME'
-apic_password = 'PASSWORD'
-api_path = '/api/mo/uni/tn-infra.json?rsp-subtree-include=stats,no-scoped'  # This queries the `infra` tenant
+apic_url = 'sandboxapicdc.cisco.com'
+apic_username = 'admin'
+apic_password = '!v3G@!4@Y'
+tenant = 'infra'
+api_path = str.format('/api/mo/uni/tn-{}.json?rsp-subtree-include=stats,no-scoped', tenant)
 
 
 def apic_login(apic, username, password):
@@ -47,4 +52,4 @@ logout_response = apic_logout(apic=apic_url, cookie=apic_cookie)
 
 response_json = json.loads(response.text)
 
-print(response_json)
+print(json.dumps(response_json, indent=2, sort_keys=True))

--- a/cisco_aci/tests/cisco_aci_query.py
+++ b/cisco_aci/tests/cisco_aci_query.py
@@ -1,0 +1,50 @@
+import json
+import requests
+
+# Edit this section
+apic_url = 'URL.com'
+apic_username = 'USERNAME'
+apic_password = 'PASSWORD'
+api_path = '/api/mo/uni/tn-infra.json?rsp-subtree-include=stats,no-scoped'  # This queries the `infra` tenant
+
+
+def apic_login(apic, username, password):
+    """ APIC login and return session cookie """
+    apic_cookie = {}
+    credentials = {'aaaUser': {'attributes': {'name': username, 'pwd': password}}}
+    json_credentials = json.dumps(credentials)
+    base_url = 'https://' + apic + '/api/aaaLogin.json'
+
+    login_response = requests.post(base_url, data=json_credentials, verify=False)
+
+    login_response_json = json.loads(login_response.text)
+    token = login_response_json['imdata'][0]['aaaLogin']['attributes']['token']
+    apic_cookie['APIC-Cookie'] = token
+    return apic_cookie
+
+
+def apic_query(apic, path, cookie):
+    """ APIC 'GET' query and return response """
+    base_url = 'https://' + apic + path
+
+    get_response = requests.get(base_url, cookies=cookie, verify=False)
+
+    return get_response
+
+
+def apic_logout(apic, cookie):
+    """ APIC logout and return response """
+    base_url = 'https://' + apic + '/api/aaaLogout.json'
+
+    post_response = requests.post(base_url, cookies=cookie, verify=False)
+
+    return post_response
+
+
+apic_cookie = apic_login(apic=apic_url, username=apic_username, password=apic_password)
+response = apic_query(apic=apic_url, path=api_path, cookie=apic_cookie)
+logout_response = apic_logout(apic=apic_url, cookie=apic_cookie)
+
+response_json = json.loads(response.text)
+
+print(response_json)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds a troubleshooting section in the README of `cisco_aci` for missing `tenant` metrics. This also adds a script that `curl`s the tenant endpoint to verify if there are tenant metrics to collect.

### Motivation
<!-- What inspired you to submit this pull request? -->
Many support cases.


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
