### PR TITLE
updating snmp check documentation for timeout and retries

### DIFF
--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -178,16 +178,16 @@ files:
           example: 2
       - name: timeout
         description: |
-          Amount of second before timing out.
+          Amount of second before timing out. Default of 5 for Python version of this check.
         value:
           type: integer
-          example: 5
+          example: 2
       - name: retries
         description: |
-          Amount of retries before failure.
+          Amount of retries before failure. Default of 5 for Python version of this check.
         value:
           type: integer
-          example: 5
+          example: 3
       - name: loader
         enabled: true
         description: |

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -149,15 +149,15 @@ instances:
     #
     # snmp_version: 2
 
-    ## @param timeout - integer - optional - default: 5
-    ## Amount of second before timing out.
+    ## @param timeout - integer - optional - default: 2
+    ## Amount of second before timing out. Default of 5 for Python version of this check.
     #
-    # timeout: 5
+    # timeout: 2
 
-    ## @param retries - integer - optional - default: 5
-    ## Amount of retries before failure.
+    ## @param retries - integer - optional - default: 3
+    ## Amount of retries before failure. Default of 5 for Python version of this check.
     #
-    # retries: 5
+    # retries: 3
 
     ## @param loader - string - optional - default: python
     ## Check loader to use. Available loaders:


### PR DESCRIPTION
### What does this PR do?
Updating comments for parameters timeout and retries to accurately reflect what our go corecheck sets defaults to. The default value of timeout is 2 and the default value of retries is 3 according to [config.go](https://github.com/DataDog/datadog-agent/blob/main/pkg/collector/corechecks/snmp/internal/checkconfig/config.go)

### Motivation
Keeping our documentation up to date so customers don't get confused here

### Additional Notes
N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
