### PR TITLE
Do not collect table metrics by default

### DIFF
--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -148,8 +148,8 @@ files:
 
             - snowflake.query (enabled by default)
             - snowflake.billing (enabled by default)
-            - snowflake.storage (enabled by default)
-            - snowflake.storage.database
+            - snowflake.storage
+            - snowflake.storage.database (enabled by default)
             - snowflake.storage.table
             - snowflake.logins (enabled by default)
             - snowflake.data_transfer
@@ -163,7 +163,7 @@ files:
           example:
             - snowflake.query
             - snowflake.billing
-            - snowflake.storage
+            - snowflake.storage.database
             - snowflake.logins
       - name: aggregate_last_24_hours
         description: |

--- a/snowflake/datadog_checks/snowflake/config.py
+++ b/snowflake/datadog_checks/snowflake/config.py
@@ -15,7 +15,7 @@ class Config(object):
     DEFAULT_METRIC_GROUP = [
         'snowflake.query',
         'snowflake.billing',
-        'snowflake.storage',
+        'snowflake.storage.database',
         'snowflake.logins',
     ]
 

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -151,8 +151,8 @@ instances:
     ##
     ##   - snowflake.query (enabled by default)
     ##   - snowflake.billing (enabled by default)
-    ##   - snowflake.storage (enabled by default)
-    ##   - snowflake.storage.database
+    ##   - snowflake.storage
+    ##   - snowflake.storage.database (enabled by default)
     ##   - snowflake.storage.table
     ##   - snowflake.logins (enabled by default)
     ##   - snowflake.data_transfer
@@ -163,7 +163,7 @@ instances:
     # metric_groups:
     #   - snowflake.query
     #   - snowflake.billing
-    #   - snowflake.storage
+    #   - snowflake.storage.database
     #   - snowflake.logins
 
     ## @param aggregate_last_24_hours - boolean - optional - default: false

--- a/snowflake/tests/test_unit.py
+++ b/snowflake/tests/test_unit.py
@@ -214,7 +214,7 @@ def test_default_metric_groups(instance):
     assert check._config.metric_groups == [
         'snowflake.query',
         'snowflake.billing',
-        'snowflake.storage',
+        'snowflake.storage.database',
         'snowflake.logins',
     ]
 


### PR DESCRIPTION
Table metrics can cause a context explosion so they should not be enabled by default