### PR TITLE
Manually update `datadog_checks_base` changelog for `23.7.7`

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -41,6 +41,10 @@
 * [Added] Upgrade psutil to 5.9.0. See [#11139](https://github.com/DataDog/integrations-core/pull/11139).
 * [Changed] Add tls_protocols_allowed configuration option. See [#11237](https://github.com/DataDog/integrations-core/pull/11237).
 
+## 23.7.7 / 2022-04-12
+
+* [Fixed] Fix obfuscate_sql_with_metadata wrapper memory usage. See [#11815](https://github.com/DataDog/integrations-core/pull/11815).
+
 ## 23.7.6 / 2022-02-03 / Agent 7.34.0
 
 * [Fixed] Update obfuscator wrapper to return empty string. See [#11277](https://github.com/DataDog/integrations-core/pull/11277).


### PR DESCRIPTION
### What does this PR do?

Follow-up to https://github.com/DataDog/integrations-core/pull/11815. Changelog must be manually updated in case of a patch release for an older version.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
