### PR TITLE
remove extra : in the value field for `<INSTANCE_CONFIG>`

### DIFF
--- a/kong/README.md
+++ b/kong/README.md
@@ -84,7 +84,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][5]
 | -------------------- | ----------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `kong`                                                |
 | `<INIT_CONFIG>`      | blank or `{}`                                         |
-| `<INSTANCE_CONFIG>`  | `{"openmetrics_endpoint:": "http://%%host%%:8001/metrics"}` |
+| `<INSTANCE_CONFIG>`  | `{"openmetrics_endpoint": "http://%%host%%:8001/metrics"}` |
 
 ##### Log collection
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
I worked with a customer recently who copied the value in the instance config section. He then followed the auto-discovery integration template [5] to find how he should setup the config file. The extra : that he had copied was causing his configuration not to function. After removing the : he stopped receiving errors. I'm not sure if removing the : is the best approach to avoid any confusion like this but wanted to bring it your attention just to get the ball rolling.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://datadog.zendesk.com/agent/tickets/783413

### Additional Notes
<!-- Anything else we should know when reviewing? -->
I'm open to suggestions regarding how to approach this. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
