### PR TITLE
sqlserver: Fix activity and plan host reporting

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -237,7 +237,7 @@ class SqlserverActivity(DBMAsyncJob):
 
     def _create_activity_event(self, active_sessions, active_connections):
         event = {
-            "host": self._db_hostname,
+            "host": self.check.resolved_hostname,
             "ddagentversion": datadog_agent.get_version(),
             "ddsource": "sqlserver",
             "dbm_type": "activity",

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -113,7 +113,6 @@ class SqlserverActivity(DBMAsyncJob):
             enabled=is_affirmative(check.activity_config.get('enabled', True)),
             expected_db_exceptions=(),
             min_collection_interval=check.min_collection_interval,
-            config_host=check.resolved_hostname,
             dbms="sqlserver",
             rate_limit=1 / float(collection_interval),
             job_name="query-activity",

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -419,7 +419,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                 if 'database_name' in row:
                     tags += ["db:{}".format(row['database_name'])]
                 yield {
-                    "host": self._db_hostname,
+                    "host": self.check.resolved_hostname,
                     "ddagentversion": datadog_agent.get_version(),
                     "ddsource": "sqlserver",
                     "ddtags": ",".join(tags),

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -156,7 +156,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             enabled=is_affirmative(check.statement_metrics_config.get('enabled', True)),
             expected_db_exceptions=(),
             min_collection_interval=check.min_collection_interval,
-            config_host=check.resolved_hostname,
             dbms="sqlserver",
             rate_limit=1 / float(collection_interval),
             job_name="query-metrics",

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -146,7 +146,7 @@ def test_collect_load_activity(aggregator, instance_docker, dd_run_check, dbm_in
     aggregator.assert_metric(
         "dd.sqlserver.operation.time",
         tags=['agent_hostname:stubbed.hostname', 'operation:collect_activity']
-             + _expected_dbm_instance_tags(dbm_instance),
+        + _expected_dbm_instance_tags(dbm_instance),
     )
 
 
@@ -253,8 +253,7 @@ def test_activity_reported_hostname(
 
     dbm_activity = aggregator.get_event_platform_events("dbm-activity")
     assert dbm_activity, "should have at least one activity"
-    event = dbm_activity[0]
-    assert event['host'] == expected_hostname
+    assert dbm_activity[0]['host'] == expected_hostname
 
 
 def new_time():

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -205,7 +205,7 @@ def test_activity_metadata(
 @pytest.mark.parametrize(
     "set_reported_hostname,expected_reported_hostname",
     [
-        (True, 'fred_hostname_override'),
+        (True, 'override.hostname'),
         (False, 'stubbed.hostname'),
     ],
 )

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -244,8 +244,7 @@ def test_activity_metadata(
 def test_activity_reported_hostname(
     aggregator, instance_docker, dd_run_check, dbm_instance, reported_hostname, expected_hostname
 ):
-    if expected_hostname:
-        dbm_instance['reported_hostname'] = expected_hostname
+    dbm_instance['reported_hostname'] = reported_hostname
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
     dd_run_check(check)

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -341,17 +341,17 @@ def test_statement_metadata(
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
-    "set_reported_hostname,expected_reported_hostname",
+    "reported_hostname,expected_hostname",
     [
-        (True, 'override.hostname'),
-        (False, 'stubbed.hostname'),
+        (None, 'stubbed.hostname'),
+        ('override.hostname', 'override.hostname'),
     ],
 )
 def test_statement_reported_hostname(
-    aggregator, dd_run_check, dbm_instance, bob_conn, datadog_agent, set_reported_hostname, expected_reported_hostname
+    aggregator, dd_run_check, dbm_instance, bob_conn, datadog_agent, reported_hostname, expected_hostname
 ):
-    if set_reported_hostname:
-        dbm_instance['reported_hostname'] = expected_reported_hostname
+    if reported_hostname:
+        dbm_instance['reported_hostname'] = expected_hostname
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
     query = "select * from sys.databases"
@@ -377,17 +377,17 @@ def test_statement_reported_hostname(
     matching_samples = [s for s in samples if s['db']['query_signature'] == query_signature and s['dbm_type'] == 'plan']
     assert len(matching_samples) == 1
     sample = matching_samples[0]
-    assert sample['host'] == expected_reported_hostname
+    assert sample['host'] == expected_hostname
 
     matching_fqt = [s for s in samples if s.get('dbm_type') == 'fqt' and s['db']['query_signature'] == query_signature]
     assert len(matching_fqt) == 1
     fqt = matching_fqt[0]
-    assert fqt['host'] == expected_reported_hostname
+    assert fqt['host'] == expected_hostname
 
     metrics = aggregator.get_event_platform_events("dbm-metrics")
     assert metrics, "should have collected metrics"
     metric = metrics[0]
-    assert metric['host'] == expected_reported_hostname
+    assert metric['host'] == expected_hostname
 
 
 @pytest.mark.integration

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -350,8 +350,7 @@ def test_statement_metadata(
 def test_statement_reported_hostname(
     aggregator, dd_run_check, dbm_instance, bob_conn, datadog_agent, reported_hostname, expected_hostname
 ):
-    if reported_hostname:
-        dbm_instance['reported_hostname'] = expected_hostname
+    dbm_instance['reported_hostname'] = reported_hostname
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
     dd_run_check(check)

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -348,7 +348,7 @@ def test_statement_metadata(
     ],
 )
 def test_statement_reported_hostname(
-    aggregator, dd_run_check, dbm_instance, bob_conn, datadog_agent, set_reported_hostname, expected_reported_hostname
+    aggregator, dd_run_check, dbm_instance, bob_conn, set_reported_hostname, expected_reported_hostname
 ):
     if set_reported_hostname:
         dbm_instance['reported_hostname'] = expected_reported_hostname


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes the `host` reported on the activity and plan payloads for SQL Server.

### Motivation
<!-- What inspired you to submit this pull request? -->
If a user configures the integration's `reported_hostname` option, these payloads will not contain the configured hostname.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
