### PR TITLE
mysql: Fix activity host reporting

### DIFF
--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -234,7 +234,7 @@ class MySQLActivity(DBMAsyncJob):
     def _create_activity_event(self, active_sessions, active_connections):
         # type: (List[Dict[str]], List[Dict[str]]) -> Dict[str]
         return {
-            "host": self._db_hostname,
+            "host": self._check.resolved_hostname,
             "ddagentversion": datadog_agent.get_version(),
             "ddsource": "mysql",
             "dbm_type": "activity",

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -117,7 +117,7 @@ class MySQLActivity(DBMAsyncJob):
             enabled=is_affirmative(config.activity_config.get("enabled", True)),
             expected_db_exceptions=(pymysql.err.OperationalError, pymysql.err.InternalError),
             min_collection_interval=config.min_collection_interval,
-            config_host=config.host,
+            config_host=check.resolved_hostname,
             dbms="mysql",
             rate_limit=1 / float(self.collection_interval),
             job_name="query-activity",

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -117,7 +117,6 @@ class MySQLActivity(DBMAsyncJob):
             enabled=is_affirmative(config.activity_config.get("enabled", True)),
             expected_db_exceptions=(pymysql.err.OperationalError, pymysql.err.InternalError),
             min_collection_interval=config.min_collection_interval,
-            config_host=check.resolved_hostname,
             dbms="mysql",
             rate_limit=1 / float(self.collection_interval),
             job_name="query-activity",

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -264,7 +264,6 @@ class MySQLStatementSamples(DBMAsyncJob):
             run_sync=is_affirmative(config.statement_samples_config.get('run_sync', False)),
             enabled=is_affirmative(config.statement_samples_config.get('enabled', True)),
             min_collection_interval=config.min_collection_interval,
-            config_host=check.resolved_hostname,
             dbms="mysql",
             expected_db_exceptions=(pymysql.err.DatabaseError,),
             job_name="statement-samples",

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -264,7 +264,7 @@ class MySQLStatementSamples(DBMAsyncJob):
             run_sync=is_affirmative(config.statement_samples_config.get('run_sync', False)),
             enabled=is_affirmative(config.statement_samples_config.get('enabled', True)),
             min_collection_interval=config.min_collection_interval,
-            config_host=config.host,
+            config_host=check.resolved_hostname,
             dbms="mysql",
             expected_db_exceptions=(pymysql.err.DatabaseError,),
             job_name="statement-samples",

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -70,7 +70,6 @@ class MySQLStatementMetrics(DBMAsyncJob):
             enabled=is_affirmative(config.statement_metrics_config.get('enabled', True)),
             expected_db_exceptions=(pymysql.err.DatabaseError,),
             min_collection_interval=config.min_collection_interval,
-            config_host=check.resolved_hostname,
             dbms="mysql",
             job_name="statement-metrics",
             shutdown_callback=self._close_db_conn,

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -70,7 +70,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
             enabled=is_affirmative(config.statement_metrics_config.get('enabled', True)),
             expected_db_exceptions=(pymysql.err.DatabaseError,),
             min_collection_interval=config.min_collection_interval,
-            config_host=config.host,
+            config_host=check.resolved_hostname,
             dbms="mysql",
             job_name="statement-metrics",
             shutdown_callback=self._close_db_conn,

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -277,9 +277,9 @@ def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, agg
     instance_basic['dbm'] = dbm_enabled
     instance_basic['disable_generic_tags'] = False  # This flag also affects the hostname
     instance_basic['reported_hostname'] = reported_hostname
-    mysql_check = MySql(common.CHECK_NAME, {}, [instance_basic])
 
     with mock.patch('datadog_checks.mysql.MySql.resolve_db_host', return_value='resolved.hostname') as resolve_db_host:
+        mysql_check = MySql(common.CHECK_NAME, {}, [instance_basic])
         dd_run_check(mysql_check)
         if reported_hostname:
             assert resolve_db_host.called is False, 'Expected resolve_db_host.called to be False'

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -277,9 +277,9 @@ def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, agg
     instance_basic['dbm'] = dbm_enabled
     instance_basic['disable_generic_tags'] = False  # This flag also affects the hostname
     instance_basic['reported_hostname'] = reported_hostname
+    mysql_check = MySql(common.CHECK_NAME, {}, [instance_basic])
 
     with mock.patch('datadog_checks.mysql.MySql.resolve_db_host', return_value='resolved.hostname') as resolve_db_host:
-        mysql_check = MySql(common.CHECK_NAME, {}, [instance_basic])
         dd_run_check(mysql_check)
         if reported_hostname:
             assert resolve_db_host.called is False, 'Expected resolve_db_host.called to be False'

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -128,8 +128,7 @@ def test_collect_activity(aggregator, dbm_instance, dd_run_check):
     ],
 )
 def test_activity_reported_hostname(aggregator, dbm_instance, dd_run_check, reported_hostname, expected_hostname):
-    if reported_hostname:
-        dbm_instance['reported_hostname'] = expected_hostname
+    dbm_instance['reported_hostname'] = reported_hostname
     check = MySql(CHECK_NAME, {}, [dbm_instance])
 
     dd_run_check(check)

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -47,9 +47,29 @@ def test_collect_activity(aggregator, dbm_instance, dd_run_check):
 
     query = 'SELECT id, name FROM testdb.users FOR UPDATE'
     query_signature = 'aca1be410fbadb61'
-    blocking_query = 'SELECT id FROM testdb.users FOR UPDATE'
 
-    _run_blocking_simulation(query, blocking_query, check, dd_run_check)
+    def _run_query(conn, _query):
+        conn.cursor().execute(_query)
+
+    def _run_blocking(conn):
+        conn.begin()
+        conn.cursor().execute("SELECT id FROM testdb.users FOR UPDATE")
+
+    bob_conn = _get_conn_for_user('bob')
+    fred_conn = _get_conn_for_user('fred')
+
+    executor = concurrent.futures.thread.ThreadPoolExecutor(1)
+    # bob's query will block until the TX is completed
+    executor.submit(_run_blocking, bob_conn)
+    # fred's query will get blocked by bob's TX
+    executor.submit(_run_query, fred_conn, query)
+
+    dd_run_check(check)
+    bob_conn.commit()
+    bob_conn.close()
+    fred_conn.close()
+
+    executor.shutdown()
 
     dbm_activity = aggregator.get_event_platform_events("dbm-activity")
     assert len(dbm_activity) == 1, "should have collected exactly one activity payload"
@@ -101,29 +121,25 @@ def test_collect_activity(aggregator, dbm_instance, dd_run_check):
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
-    "set_reported_hostname,expected_reported_hostname",
+    "reported_hostname,expected_hostname",
     [
-        (True, 'fred_hostname_override'),
-        (False, 'stubbed.hostname'),
+        (None, 'stubbed.hostname'),
+        ('override.hostname', 'override.hostname'),
     ],
 )
 def test_activity_reported_hostname(
-    aggregator, dbm_instance, dd_run_check, set_reported_hostname, expected_reported_hostname
+    aggregator, dbm_instance, dd_run_check, reported_hostname, expected_hostname
 ):
-    if set_reported_hostname:
-        dbm_instance['reported_hostname'] = expected_reported_hostname
+    if reported_hostname:
+        dbm_instance['reported_hostname'] = expected_hostname
     check = MySql(CHECK_NAME, {}, [dbm_instance])
 
-    query = 'SELECT id, name FROM testdb.users FOR UPDATE'
-    blocking_query = "SELECT id FROM testdb.users FOR UPDATE"
-
-    _run_blocking_simulation(query, blocking_query, check, dd_run_check)
+    dd_run_check(check)
+    dd_run_check(check)
 
     dbm_activity = aggregator.get_event_platform_events("dbm-activity")
-    assert len(dbm_activity) == 1, "should have collected exactly one activity payload"
-
-    activity = dbm_activity[0]
-    assert activity['host'] == expected_reported_hostname
+    assert dbm_activity, "should have at least one activity sample"
+    assert dbm_activity[0]['host'] == expected_hostname
 
 
 @pytest.mark.integration
@@ -210,31 +226,6 @@ def test_get_estimated_row_size_bytes(dbm_instance, file):
     for a in test_activity:
         computed_size += check._query_activity._get_estimated_row_size_bytes(a)
     assert abs((actual_size - computed_size) / float(actual_size)) <= 0.10
-
-
-def _run_blocking_simulation(query, blocking_query, check, dd_run_check):
-    def _run_query(conn, _query):
-        conn.cursor().execute(_query)
-
-    def _run_blocking(conn):
-        conn.begin()
-        conn.cursor().execute(blocking_query)
-
-    bob_conn = _get_conn_for_user('bob')
-    fred_conn = _get_conn_for_user('fred')
-
-    executor = concurrent.futures.thread.ThreadPoolExecutor(1)
-    # bob's query will block until the TX is completed
-    executor.submit(_run_blocking, bob_conn)
-    # fred's query will get blocked by bob's TX
-    executor.submit(_run_query, fred_conn, query)
-
-    dd_run_check(check)
-    bob_conn.commit()
-    bob_conn.close()
-    fred_conn.close()
-
-    executor.shutdown()
 
 
 def _new_time():

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -127,9 +127,7 @@ def test_collect_activity(aggregator, dbm_instance, dd_run_check):
         ('override.hostname', 'override.hostname'),
     ],
 )
-def test_activity_reported_hostname(
-    aggregator, dbm_instance, dd_run_check, reported_hostname, expected_hostname
-):
+def test_activity_reported_hostname(aggregator, dbm_instance, dd_run_check, reported_hostname, expected_hostname):
     if reported_hostname:
         dbm_instance['reported_hostname'] = expected_hostname
     check = MySql(CHECK_NAME, {}, [dbm_instance])

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -541,8 +541,7 @@ def test_statement_metadata(aggregator, dd_run_check, dbm_instance, datadog_agen
 def test_statement_reported_hostname(
     aggregator, dd_run_check, dbm_instance, datadog_agent, reported_hostname, expected_hostname
 ):
-    if reported_hostname:
-        dbm_instance['reported_hostname'] = expected_hostname
+    dbm_instance['reported_hostname'] = reported_hostname
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
     dd_run_check(mysql_check)

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -546,7 +546,7 @@ def test_statement_reported_hostname(
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
     test_query = 'select * from information_schema.processlist where state in (\'starting\')'
-    query_signature = 'ad8e9c25d71690f7'
+    query_signature = '82cab8a2f6c362d7'
 
     def run_query(q):
         with mysql_check._connect() as db:
@@ -564,7 +564,6 @@ def test_statement_reported_hostname(
     ]
     assert len(matching_samples) == 1
     sample = matching_samples[0]
-
     assert sample['host'] == expected_reported_hostname
 
     matching_fqt = [s for s in samples if s['db']['query_signature'] == query_signature and s.get('dbm_type') == 'fqt']

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -461,6 +461,7 @@ def test_performance_schema_disabled(dbm_instance, dd_run_check):
         'code=performance-schema-not-enabled host=stubbed.hostname'
     ]
 
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
@@ -558,7 +559,9 @@ def test_statement_reported_hostname(
     dd_run_check(mysql_check)
 
     samples = aggregator.get_event_platform_events("dbm-samples")
-    matching_samples = [s for s in samples if s['db']['query_signature'] == query_signature and s.get('dbm_type') != 'fqt']
+    matching_samples = [
+        s for s in samples if s['db']['query_signature'] == query_signature and s.get('dbm_type') != 'fqt'
+    ]
     assert len(matching_samples) == 1
     sample = matching_samples[0]
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes the `host` reported on the activity payloads for MySQL.

### Motivation
<!-- What inspired you to submit this pull request? -->
If a user configures the integration's `reported_hostname` option, the activity payload will not contain the configured hostname.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
