### PR TITLE
postgres: Fix activity and sample host reporting

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -159,7 +159,7 @@ class PostgresStatementSamples(DBMAsyncJob):
             enabled=is_affirmative(config.statement_samples_config.get('enabled', True)),
             dbms="postgres",
             min_collection_interval=config.min_collection_interval,
-            config_host=config.host,
+            config_host=check.resolved_hostname,
             expected_db_exceptions=(psycopg2.errors.DatabaseError,),
             job_name="query-samples",
             shutdown_callback=shutdown_callback,
@@ -607,7 +607,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         statement_plan_sig = (row['query_signature'], plan_signature)
         if self._seen_samples_ratelimiter.acquire(statement_plan_sig):
             event = {
-                "host": self._db_hostname,
+                "host": self._check.resolved_hostname,
                 "ddagentversion": datadog_agent.get_version(),
                 "ddsource": "postgres",
                 "ddtags": ",".join(self._dbtags(row['datname'])),
@@ -687,7 +687,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         if len(active_sessions) > self._activity_max_rows:
             active_sessions = self._truncate_activity_rows(active_sessions, self._activity_max_rows)
         event = {
-            "host": self._db_hostname,
+            "host": self._check.resolved_hostname,
             "ddagentversion": datadog_agent.get_version(),
             "ddsource": "postgres",
             "dbm_type": "activity",

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -107,7 +107,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             enabled=is_affirmative(config.statement_metrics_config.get('enabled', True)),
             expected_db_exceptions=(psycopg2.errors.DatabaseError,),
             min_collection_interval=config.min_collection_interval,
-            config_host=config.host,
+            config_host=check.resolved_hostname,
             dbms="postgres",
             rate_limit=1 / float(collection_interval),
             job_name="query-metrics",

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -627,6 +627,69 @@ def test_statement_metadata(
     assert metric['dd_commands'] == expected_metadata_payload['commands']
 
 
+@pytest.mark.parametrize("pg_stat_statements_view", ["pg_stat_statements", "datadog.pg_stat_statements()"])
+@pytest.mark.parametrize(
+    "set_reported_hostname,expected_reported_hostname",
+    [
+        (True, 'fred_hostname_override'),
+        (False, 'stubbed.hostname'),
+    ],
+)
+def test_statement_reported_hostname(
+        aggregator,
+        integration_check,
+        dbm_instance,
+        datadog_agent,
+        pg_stat_statements_view,
+        set_reported_hostname,
+        expected_reported_hostname
+):
+    dbm_instance['pg_stat_statements_view'] = pg_stat_statements_view
+    dbm_instance['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    if set_reported_hostname:
+        dbm_instance['reported_hostname'] = expected_reported_hostname
+
+    # If the query changes, the query_signatures for both will need to be updated as well.
+    query = "SELECT city FROM persons WHERE city = 'hello'"
+    # Samples will match to the non normalized query signature
+    query_signature = 'd69a53d89c75f135'
+    normalized_query_signature = 'ce10a2b41983551c'
+
+    check = integration_check(dbm_instance)
+    check._connect()
+    conn = psycopg2.connect(host=HOST, dbname="datadog_test", user="bob", password="bob")
+    cursor = conn.cursor()
+
+    cursor.execute(query,)
+    check.check(dbm_instance)
+    cursor.execute(query,)
+    check.check(dbm_instance)
+
+    samples = aggregator.get_event_platform_events("dbm-samples")
+    matching_samples = [s for s in samples if s['db']['query_signature'] == query_signature]
+    assert len(matching_samples) == 1
+    sample = matching_samples[0]
+    assert sample['host'] == expected_reported_hostname
+
+    if POSTGRES_VERSION.split('.')[0] == "9" and pg_stat_statements_view == "pg_stat_statements":
+        # cannot catch any queries from other users
+        # only can see own queries
+        return False
+
+    fqt_samples = [
+        s for s in samples if s.get('dbm_type') == 'fqt' and s['db']['query_signature'] == normalized_query_signature
+    ]
+    assert len(fqt_samples) == 1
+    fqt = fqt_samples[0]
+    assert fqt['host'] == expected_reported_hostname
+
+    metrics = aggregator.get_event_platform_events("dbm-metrics")
+    assert len(metrics) == 1
+    metric = metrics[0]
+    assert metric['host'] == expected_reported_hostname
+
+
 @pytest.mark.parametrize("pg_stat_activity_view", ["pg_stat_activity", "datadog.pg_stat_activity()"])
 @pytest.mark.parametrize(
     "user,password,dbname,query,blocking_query,arg,expected_out,expected_keys,expected_conn_out",
@@ -788,6 +851,77 @@ def test_activity_snapshot_collection(
         # state should be idle now that it's no longer blocked
         assert bobs_query['state'] == "idle in transaction"
 
+    finally:
+        conn.close()
+        blocking_conn.close()
+
+
+@pytest.mark.parametrize("pg_stat_activity_view", ["pg_stat_activity", "datadog.pg_stat_activity()"])
+@pytest.mark.parametrize(
+    "set_reported_hostname,expected_reported_hostname",
+    [
+        (True, 'fred_hostname_override'),
+        (False, 'stubbed.hostname'),
+    ],
+)
+def test_activity_reported_hostname(
+        aggregator,
+        integration_check,
+        dbm_instance,
+        datadog_agent,
+        pg_stat_activity_view,
+        set_reported_hostname,
+        expected_reported_hostname
+):
+    dbm_instance['pg_stat_activity_view'] = pg_stat_activity_view
+    if set_reported_hostname:
+        dbm_instance['reported_hostname'] = expected_reported_hostname
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    query = "BEGIN TRANSACTION; SELECT city FROM persons WHERE city = %s"
+    blocking_query = "LOCK TABLE persons IN ACCESS EXCLUSIVE MODE"
+
+    user = "bob"
+    password = "bob"
+    dbname = "datadog_test"
+    conn = psycopg2.connect(host=HOST, dbname=dbname, user=user, password=password, async_=1)
+    blocking_conn = psycopg2.connect(host=HOST, dbname=dbname, user="blocking_bob", password=password)
+
+    def wait(conn):
+        while True:
+            state = conn.poll()
+            if state == psycopg2.extensions.POLL_OK:
+                break
+            elif state == psycopg2.extensions.POLL_WRITE:
+                select.select([], [conn.fileno()], [])
+            elif state == psycopg2.extensions.POLL_READ:
+                select.select([conn.fileno()], [], [])
+            else:
+                raise psycopg2.OperationalError("poll() returned %s" % state)
+
+    # we are able to see the full query (including the raw parameters) in pg_stat_activity because psycopg2 uses
+    # the simple query protocol, sending the whole query as a plain string to postgres.
+    # if a client is using the extended query protocol with prepare then the query would appear as
+    # leave connection open until after the check has run to ensure we're able to see the query in
+    # pg_stat_activity
+    try:
+        # first lock the table, which will cause the test query to be blocked
+        blocking_conn.autocommit = False
+        blocking_conn.cursor().execute(blocking_query)
+        # ... now execute the test query
+        wait(conn)
+        conn.cursor().execute(query,)
+        check.check(dbm_instance)
+        dbm_activity_event = aggregator.get_event_platform_events("dbm-activity")
+
+        if POSTGRES_VERSION.split('.')[0] == "9" and pg_stat_activity_view == "pg_stat_activity":
+            # cannot catch any queries from other users
+            # only can see own queries
+            return
+
+        event = dbm_activity_event[0]
+        assert event['host'] == expected_reported_hostname
     finally:
         conn.close()
         blocking_conn.close()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes the `host` reported on the activity and sample payloads for Postgres.

### Motivation
<!-- What inspired you to submit this pull request? -->
If a user configures the integration's `reported_hostname` option, these payloads will not contain the configured hostname.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
