### PR TITLE
Add more default metrics

### DIFF
--- a/traffic_server/assets/configuration/spec.yaml
+++ b/traffic_server/assets/configuration/spec.yaml
@@ -20,9 +20,9 @@ files:
           include:
               - traffic_server.node.*
               - traffic_server.process.http.code.*
-              - traffic_server.process.http.*current
-              - traffic_server.process.http.*_requests
-              - traffic_server.process.http.*_connections
+              - traffic_server.process.http(s|2)?.*current
+              - traffic_server.process.http(s|2)?.*_requests
+              - traffic_server.process.http(s|2)?.*_connections
               - traffic_server.process.http.transaction_.*
               - traffic_server.process.hostdb.*
               - traffic_server.process.dns.*

--- a/traffic_server/datadog_checks/traffic_server/data/conf.yaml.example
+++ b/traffic_server/datadog_checks/traffic_server/data/conf.yaml.example
@@ -36,9 +36,9 @@ instances:
       include:
       - traffic_server.node.*
       - traffic_server.process.http.code.*
-      - traffic_server.process.http.*current
-      - traffic_server.process.http.*_requests
-      - traffic_server.process.http.*_connections
+      - traffic_server.process.http(s|2)?.*current
+      - traffic_server.process.http(s|2)?.*_requests
+      - traffic_server.process.http(s|2)?.*_connections
       - traffic_server.process.http.transaction_.*
       - traffic_server.process.hostdb.*
       - traffic_server.process.dns.*


### PR DESCRIPTION
### What does this PR do?
Add more traffic_server metrics to be collected by default 

### Motivation
Traffic Server differentiates some of the same metrics by http2/http and http/https, and we want to collect all these metrics in the default config file.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
