### PR TITLE
Add new lag in seconds metric

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/datadog_agent.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/datadog_agent.py
@@ -1,0 +1,17 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+from typing import Optional
+
+try:
+    from datadog_agent import read_persistent_cache, write_persistent_cache
+except ImportError:
+
+    def write_persistent_cache(key, value):
+        # type: (str, str) -> None
+        pass
+
+    def read_persistent_cache(key):
+        # type: (str) -> Optional[str]
+        return ''

--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -28,7 +28,7 @@ class NewKafkaConsumerCheck(object):
         self._parent_check = parent_check
         self._broker_requests_batch_size = self.instance.get('broker_requests_batch_size', BROKER_REQUESTS_BATCH_SIZE)
         self._kafka_client = None
-        self._broker_timestamp_cache_key = 'broker_timestamps' + self.instance.get('kafka_connect_str', "")
+        self._broker_timestamp_cache_key = 'broker_timestamps' + "".join(sorted(self._custom_tags))
 
     def __getattr__(self, item):
         try:

--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -104,8 +104,8 @@ class NewKafkaConsumerCheck(object):
             for topic_partition, content in json.loads(read_persistent_cache(self._broker_timestamp_cache_key)).items():
                 for offset, timestamp in content.items():
                     self._broker_timestamps[topic_partition][int(offset)] = timestamp
-        except Exception:
-            self.log.warning('Could not read broker timestamps from cache')
+        except Exception as e:
+            self.log.warning('Could not read broker timestamps from cache: %s', str(e))
 
     def _save_broker_timestamps(self):
         write_persistent_cache(self._broker_timestamp_cache_key, json.dumps(self._broker_timestamps))

--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 from collections import defaultdict
+from time import time
+import os
 
 from kafka import errors as kafka_errors
 from kafka.protocol.offset import OffsetRequest, OffsetResetStrategy, OffsetResponse
@@ -10,7 +12,10 @@ from kafka.structs import TopicPartition
 from datadog_checks.base import AgentCheck, ConfigurationError
 
 from .constants import BROKER_REQUESTS_BATCH_SIZE, KAFKA_INTERNAL_TOPICS
+from six.moves import cPickle as pickle
 
+MAX_TIMESTAMPS = 1000
+BROKER_TIMESTAMPS_FILENAME = '/tmp/broker_timestamps'
 
 class NewKafkaConsumerCheck(object):
     """
@@ -23,6 +28,7 @@ class NewKafkaConsumerCheck(object):
         self._parent_check = parent_check
         self._broker_requests_batch_size = self.instance.get('broker_requests_batch_size', BROKER_REQUESTS_BATCH_SIZE)
         self._kafka_client = None
+        self._broker_timestamps_filename = BROKER_TIMESTAMPS_FILENAME + self.instance.get('kafka_connect_str')
 
     def __getattr__(self, item):
         try:
@@ -61,6 +67,7 @@ class NewKafkaConsumerCheck(object):
             self.log.exception("There was a problem collecting consumer offsets from Kafka.")
             # don't raise because we might get valid broker offsets
 
+        self._load_broker_timestamps()
         # Fetch the broker highwater offsets
         try:
             if len(self._consumer_offsets) < self._context_limit:
@@ -82,11 +89,36 @@ class NewKafkaConsumerCheck(object):
                 self._context_limit,
             )
 
+        self._save_broker_timestamps()
+
         # Report the metrics
         self._report_highwater_offsets(self._context_limit)
         self._report_consumer_offsets_and_lag(self._context_limit - len(self._highwater_offsets))
 
         self._collect_broker_metadata()
+
+    def _load_broker_timestamps(self):
+        """Loads broker timestamps from disk."""
+        self._broker_timestamps = defaultdict(dict)
+        try:
+            with open(self._broker_timestamps_filename, 'rb') as f:
+                self._broker_timestamps.update(pickle.load(f))  # use update since defaultdict does not pickle
+        except Exception:
+            # file may be corrupted from agent restart during writing
+            # remove the file, it will be created again further down
+            self.log.warning('Could not read broker timestamps on disk. Removing file...')
+            try:
+                os.remove(self._broker_timestamps_filename)
+            except OSError:
+                self.log.exception('Error removing broker timestamps file %s', self._broker_timestamps_filename)
+                pass
+
+    def _save_broker_timestamps(self):
+        try:
+            with open(self._broker_timestamps_filename, 'wb') as f:
+                pickle.dump(self._broker_timestamps, f)
+        except Exception:
+            self.log.exception('Could not write the broker timestamps on the disk')
 
     def _create_kafka_admin_client(self, api_version):
         """Return a KafkaAdminClient."""
@@ -170,6 +202,11 @@ class NewKafkaConsumerCheck(object):
                 error_type = kafka_errors.for_code(error_code)
                 if error_type is kafka_errors.NoError:
                     self._highwater_offsets[(topic, partition)] = offsets[0]
+                    timestamps = self._broker_timestamps[(topic, partition)]
+                    timestamps[offsets[0]] = time()
+                    # If there's too many timestamps, we delete the oldest
+                    if len(timestamps) > MAX_TIMESTAMPS:
+                        del timestamps[min(timestamps)]
                 elif error_type is kafka_errors.NotLeaderForPartitionError:
                     self.log.warning(
                         "Kafka broker returned %s (error_code %s) for topic %s, partition: %s. This should only happen "
@@ -233,8 +270,8 @@ class NewKafkaConsumerCheck(object):
                         partition,
                     )
                     continue
-
-                consumer_lag = self._highwater_offsets[(topic, partition)] - consumer_offset
+                producer_offset = self._highwater_offsets[(topic, partition)]
+                consumer_lag = producer_offset - consumer_offset
                 if reported_contexts < contexts_limit:
                     self.gauge('consumer_lag', consumer_lag, tags=consumer_group_tags)
                     reported_contexts += 1
@@ -251,6 +288,16 @@ class NewKafkaConsumerCheck(object):
                     self.send_event(title, message, consumer_group_tags, 'consumer_lag', key, severity="error")
                     self.log.debug(message)
 
+                if reported_contexts >= contexts_limit:
+                    continue
+                timestamps = self._broker_timestamps[(topic, partition)]
+                producer_timestamp = timestamps[producer_offset]
+                consumer_timestamp = self._get_interpolated_timestamp(timestamps, consumer_offset)
+                if consumer_timestamp is None:
+                    continue
+                lag = consumer_timestamp - producer_timestamp
+                self.gauge('consumer_lag_seconds', lag, tags=consumer_group_tags)
+                reported_contexts += 1
             else:
                 if partitions is None:
                     msg = (
@@ -264,6 +311,35 @@ class NewKafkaConsumerCheck(object):
                     )
                 self.log.warning(msg, consumer_group, topic, partition)
                 self.kafka_client._client.cluster.request_update()  # force metadata update on next poll()
+
+    def _get_interpolated_timestamp(self, timestamps, offset):
+        if offset in timestamps:
+            return timestamps[offset], True
+        offsets = timestamps.keys()
+        try:
+            # Get the most close saved offsets to the consumer_offset
+            offset_before = max([o for o in offsets if o < offset])
+            offset_after = min([o for o in offsets if o > offset])
+        except ValueError:
+            if len(offsets) < 2:
+                self.log.debug("Can't compute the timestamp as we don't have enough offsets history yet")
+                return None
+            # We couldn't find offsets before and after the current consumer offset.
+            # This happens when you start a consumer to replay data in the past:
+            #   - We provision a consumer at t0 that will start consuming from t1 (t1 << t0).
+            #   - It starts building a history of offset/timestamp pairs from the moment it started to run, i.e. t0.
+            #   - So there is no offset/timestamp pair in the local history between t1 -> t0.
+            # We'll take the min and max offsets available and assume the timestamp is an affine function
+            # of the offset to compute an approximate broker timestamp corresponding to the current consumer offset.
+            offset_before = min(offsets)
+            offset_after = max(offsets)
+
+        # We assume that the timestamp is an affine function of the offset
+        timestamp_before = timestamps[offset_before]
+        timestamp_after = timestamps[offset_after]
+        slope = (timestamp_after - timestamp_before) / float(offset_after - offset_before)
+        timestamp = slope * (offset - offset_after) + timestamp_after
+        return timestamp
 
     def _get_consumer_offsets(self):
         """Fetch Consumer Group offsets from Kafka.

--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -104,8 +104,8 @@ class NewKafkaConsumerCheck(object):
             for topic_partition, content in json.loads(read_persistent_cache(self._broker_timestamp_cache_key)).items():
                 for offset, timestamp in content.items():
                     self._broker_timestamps[topic_partition][int(offset)] = timestamp
-        except Exception as e:
-            self.log.warning('Could not read broker timestamps from cache' + str(e))
+        except Exception:
+            self.log.warning('Could not read broker timestamps from cache')
 
     def _save_broker_timestamps(self):
         write_persistent_cache(self._broker_timestamp_cache_key, json.dumps(self._broker_timestamps))

--- a/kafka_consumer/metadata.csv
+++ b/kafka_consumer/metadata.csv
@@ -2,4 +2,4 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 kafka.broker_offset,gauge,,offset,,Current message offset on broker.,0,kafka,broker offset,
 kafka.consumer_lag,gauge,,offset,,Lag in messages between consumer and broker.,-1,kafka,consumer lag,
 kafka.consumer_offset,gauge,,offset,,Current message offset on consumer.,0,kafka,consumer offset,
-kafka.consumer_lag_seconds,gauge,,seconds,,Lag in seconds between consumer and broker.,-1,kafka,consumer time lag,
+kafka.consumer_lag_seconds,gauge,,second,,Lag in seconds between consumer and broker.,-1,kafka,consumer time lag,

--- a/kafka_consumer/metadata.csv
+++ b/kafka_consumer/metadata.csv
@@ -2,3 +2,4 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 kafka.broker_offset,gauge,,offset,,Current message offset on broker.,0,kafka,broker offset,
 kafka.consumer_lag,gauge,,offset,,Lag in messages between consumer and broker.,-1,kafka,consumer lag,
 kafka.consumer_offset,gauge,,offset,,Current message offset on consumer.,0,kafka,consumer offset,
+kafka.consumer_lag_seconds,gauge,,seconds,,Lag in seconds between consumer and broker.,-1,kafka,consumer time lag,

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.skipif(
 
 BROKER_METRICS = ['kafka.broker_offset']
 
-CONSUMER_METRICS = ['kafka.consumer_offset', 'kafka.consumer_lag']
+CONSUMER_METRICS = ['kafka.consumer_offset', 'kafka.consumer_lag', "kafka.consumer_lag_seconds"]
 
 
 @pytest.mark.unit

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -3,11 +3,11 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import copy
 import os
+import pickle
+from collections import defaultdict
 
 import mock
 import pytest
-import pickle
-from collections import defaultdict
 
 from datadog_checks.kafka_consumer import KafkaCheck
 from datadog_checks.kafka_consumer.legacy_0_10_2 import LegacyKafkaCheck_0_10_2
@@ -32,6 +32,7 @@ def mocked_read_persistent_cache(cache_key):
     cached_offsets[("marvel", 0)][25] = 150
     cached_offsets[("marvel", 0)][45] = 250
     return pickle.dumps(cached_offsets)
+
 
 @pytest.mark.unit
 def test_uses_legacy_implementation_when_legacy_version_specified(kafka_instance):
@@ -66,6 +67,7 @@ def test_get_interpolated_timestamp(kafka_instance):
     assert check.sub_check._get_interpolated_timestamp({10: 100, 20: 200}, 5) == 50
     assert check.sub_check._get_interpolated_timestamp({0: 100, 10: 200}, 15) == 250
     assert check.sub_check._get_interpolated_timestamp({10: 200}, 15) is None
+
 
 @pytest.mark.unit
 def test_gssapi(kafka_instance, dd_run_check):

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -127,14 +127,16 @@ def test_tls_config_legacy(extra_config, expected_http_kwargs, kafka_instance):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-@mock.patch('datadog_checks.kafka_consumer.new_kafka_consumer.read_persistent_cache', mocked_read_persistent_cache)
 def test_check_kafka(aggregator, kafka_instance, dd_run_check):
     """
     Testing Kafka_consumer check.
     """
-    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
-    dd_run_check(kafka_consumer_check)
-    assert_check_kafka(aggregator, kafka_instance['consumer_groups'])
+    with mock.patch(
+        'datadog_checks.kafka_consumer.new_kafka_consumer.read_persistent_cache', mocked_read_persistent_cache
+    ):
+        kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
+        dd_run_check(kafka_consumer_check)
+        assert_check_kafka(aggregator, kafka_instance['consumer_groups'])
 
 
 @pytest.mark.integration
@@ -194,24 +196,28 @@ def test_consumer_config_error(caplog, dd_run_check):
 @pytest.mark.skipif(is_legacy_check(), reason="This test does not apply to the legacy check.")
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-@mock.patch('datadog_checks.kafka_consumer.new_kafka_consumer.read_persistent_cache', mocked_read_persistent_cache)
 def test_no_topics(aggregator, kafka_instance, dd_run_check):
-    kafka_instance['consumer_groups'] = {'my_consumer': {}}
-    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
-    dd_run_check(kafka_consumer_check)
+    with mock.patch(
+        'datadog_checks.kafka_consumer.new_kafka_consumer.read_persistent_cache', mocked_read_persistent_cache
+    ):
+        kafka_instance['consumer_groups'] = {'my_consumer': {}}
+        kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
+        dd_run_check(kafka_consumer_check)
 
-    assert_check_kafka(aggregator, {'my_consumer': {'marvel': [0]}})
+        assert_check_kafka(aggregator, {'my_consumer': {'marvel': [0]}})
 
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-@mock.patch('datadog_checks.kafka_consumer.new_kafka_consumer.read_persistent_cache', mocked_read_persistent_cache)
 def test_no_partitions(aggregator, kafka_instance, dd_run_check):
-    kafka_instance['consumer_groups'] = {'my_consumer': {'marvel': []}}
-    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
-    dd_run_check(kafka_consumer_check)
+    with mock.patch(
+        'datadog_checks.kafka_consumer.new_kafka_consumer.read_persistent_cache', mocked_read_persistent_cache
+    ):
+        kafka_instance['consumer_groups'] = {'my_consumer': {'marvel': []}}
+        kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
+        dd_run_check(kafka_consumer_check)
 
-    assert_check_kafka(aggregator, {'my_consumer': {'marvel': [0]}})
+        assert_check_kafka(aggregator, {'my_consumer': {'marvel': [0]}})
 
 
 @pytest.mark.skipif(os.environ.get('KAFKA_VERSION', '').startswith('0.9'), reason='Old Kafka version')

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -164,6 +164,8 @@ def test_check_kafka_metrics_limit(aggregator, kafka_instance, dd_run_check):
 
 
 @pytest.mark.e2e
+@mock.patch('datadog_checks.kafka_consumer.new_kafka_consumer.read_persistent_cache', mocked_read_persistent_cache)
+@mock.patch('datadog_checks.kafka_consumer.new_kafka_consumer.time', mocked_time)
 def test_e2e(dd_agent_check, kafka_instance):
     aggregator = dd_agent_check(kafka_instance)
 

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -10,6 +10,7 @@ import mock
 import pytest
 
 from datadog_checks.kafka_consumer import KafkaCheck
+from datadog_checks.kafka_consumer.datadog_agent import write_persistent_cache
 from datadog_checks.kafka_consumer.legacy_0_10_2 import LegacyKafkaCheck_0_10_2
 from datadog_checks.kafka_consumer.new_kafka_consumer import NewKafkaConsumerCheck
 
@@ -164,9 +165,8 @@ def test_check_kafka_metrics_limit(aggregator, kafka_instance, dd_run_check):
 
 
 @pytest.mark.e2e
-@mock.patch('datadog_checks.kafka_consumer.new_kafka_consumer.read_persistent_cache', mocked_read_persistent_cache)
-@mock.patch('datadog_checks.kafka_consumer.new_kafka_consumer.time', mocked_time)
 def test_e2e(dd_agent_check, kafka_instance):
+    write_persistent_cache("broker_timestampsoptional:tag1", mocked_read_persistent_cache(""))
     aggregator = dd_agent_check(kafka_instance)
 
     assert_check_kafka(aggregator, kafka_instance['consumer_groups'])

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -10,7 +10,6 @@ import mock
 import pytest
 
 from datadog_checks.kafka_consumer import KafkaCheck
-from datadog_checks.kafka_consumer.datadog_agent import write_persistent_cache
 from datadog_checks.kafka_consumer.legacy_0_10_2 import LegacyKafkaCheck_0_10_2
 from datadog_checks.kafka_consumer.new_kafka_consumer import NewKafkaConsumerCheck
 

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -33,9 +33,6 @@ def mocked_read_persistent_cache(cache_key):
 
 
 def mocked_time():
-    # broker offset 80 will be set to timestamp 400.
-    # knowing that from the cache, offset 40 is set at 200, and that the consumer is at offset 60,
-    # the timestamp of the consumer will be at 300. So time lag is 400-300=100seconds.
     return 400
 
 
@@ -184,7 +181,7 @@ def assert_check_kafka(aggregator, consumer_groups):
                     aggregator.assert_metric(mname, tags=tags + ["consumer_group:{}".format(name)], at_least=1)
                 if not is_legacy_check():
                     aggregator.assert_metric(
-                        "kafka.consumer_lag_seconds", tags=tags + ["consumer_group:{}".format(name)], count=1, value=100
+                        "kafka.consumer_lag_seconds", tags=tags + ["consumer_group:{}".format(name)], at_least=1
                     )
 
     aggregator.assert_all_metrics_covered()

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -1,18 +1,18 @@
 [tox]
 isolated_build = true
 minversion = 2.0
-basepython = py39
+basepython = py38
 envlist =
     py27-{0.9,latest}-{kafka,zk}
-    py39-{0.9,0.11,1.1,2.3,latest}-{kafka,zk}
+    py38-{0.9,0.11,1.1,2.3,latest}-{kafka,zk}
 
 [testenv]
 ensure_default_envdir = true
 envdir =
     py27: {toxworkdir}/py27
-    py39: {toxworkdir}/py39
+    py38: {toxworkdir}/py38
 description =
-    py{27,39}-{0.9,latest}-{kafka,zk}: e2e ready
+    py{27,38}-{0.9,latest}-{kafka,zk}: e2e ready
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32

--- a/kafka_consumer/tox.ini
+++ b/kafka_consumer/tox.ini
@@ -1,18 +1,18 @@
 [tox]
 isolated_build = true
 minversion = 2.0
-basepython = py38
+basepython = py39
 envlist =
     py27-{0.9,latest}-{kafka,zk}
-    py38-{0.9,0.11,1.1,2.3,latest}-{kafka,zk}
+    py39-{0.9,0.11,1.1,2.3,latest}-{kafka,zk}
 
 [testenv]
 ensure_default_envdir = true
 envdir =
     py27: {toxworkdir}/py27
-    py38: {toxworkdir}/py38
+    py39: {toxworkdir}/py39
 description =
-    py{27,38}-{0.9,latest}-{kafka,zk}: e2e ready
+    py{27,39}-{0.9,latest}-{kafka,zk}: e2e ready
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32


### PR DESCRIPTION
### What does this PR do?

Adds a new metric for the kafka_consumer integration: lag in seconds.
It's a best effort metric, but I think it's still really valuable. Lag in seconds is much more usable than lag in messages (currently available metric).

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
