### PR TITLE
Add `traffic_server_url` tag

### DIFF
--- a/traffic_server/assets/service_checks.json
+++ b/traffic_server/assets/service_checks.json
@@ -4,7 +4,8 @@
         "integration": "Traffic Server",
         "groups": [
             "host",
-            "instance"
+            "instance",
+            "traffic_server_url"
         ],
         "check": "traffic_server.can_connect",
         "statuses": [

--- a/traffic_server/datadog_checks/traffic_server/check.py
+++ b/traffic_server/datadog_checks/traffic_server/check.py
@@ -19,10 +19,11 @@ class TrafficServerCheck(AgentCheck):
         super(TrafficServerCheck, self).__init__(name, init_config, instances)
 
         self.traffic_server_url = self.instance.get("traffic_server_url")
-        self.tags = self.instance.get("tags", [])
-
         if self.traffic_server_url is None:
             raise ConfigurationError('Must specify a traffic_server_url')
+
+        self.tags = self.instance.get("tags", [])
+        self.tags.append("traffic_server_url:{}".format(self.traffic_server_url))
 
     def check(self, _):
         # type: (Any) -> None

--- a/traffic_server/tests/test_traffic_server.py
+++ b/traffic_server/tests/test_traffic_server.py
@@ -29,7 +29,7 @@ def test_check(aggregator, instance, dd_run_check):
         )
         for tag in traffic_server_tags:
             aggregator.assert_metric_has_tag(metric_name, tag)
-    aggregator.assert_service_check('traffic_server.can_connect', TrafficServerCheck.OK)
+    aggregator.assert_service_check('traffic_server.can_connect', TrafficServerCheck.OK, tags=traffic_server_tags)
     aggregator.assert_all_metrics_covered()
 
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
@@ -39,13 +39,14 @@ def test_check_cant_reach_url(aggregator, instance_bad_url, dd_run_check):
     # type: (AggregatorStub, Callable[[AgentCheck, bool], None], Dict[str, Any]) -> None
 
     check = TrafficServerCheck('traffic_server', {}, [instance_bad_url])
+    traffic_server_tags = instance_bad_url.get('tags')
 
     with pytest.raises(
         Exception, match='404 Client Error: Not Found on Accelerator for url: http://localhost:8080/_statss'
     ):
         dd_run_check(check)
 
-    aggregator.assert_service_check('traffic_server.can_connect', TrafficServerCheck.CRITICAL)
+    aggregator.assert_service_check('traffic_server.can_connect', TrafficServerCheck.CRITICAL, tags=traffic_server_tags)
     aggregator.assert_all_metrics_covered()
 
 


### PR DESCRIPTION
### What does this PR do?
Adds a traffic_server_url tag to all metrics and service checks

### Motivation
Most checks send a basic endpoint tag, and there are cases when a traffic server host can be monitored remotely.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
