### PR TITLE
Use sorted tags for expected metric in aggregator stub

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -351,7 +351,7 @@ class AggregatorStub(object):
 
             candidates.append(metric)
 
-        expected_metric = MetricStub(name, metric_type, value, tags, hostname, device, flush_first_value)
+        expected_metric = MetricStub(name, metric_type, value, expected_tags, hostname, device, flush_first_value)
 
         if value is not None and candidates and all(self.is_aggregate(m.type) for m in candidates):
             got = sum(m.value for m in candidates)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Use sorted tags for expected metric in aggregator stub

### Motivation
<!-- What inspired you to submit this pull request? -->

Having sorted expected metric tags makes it easier to compare when reading test assertion failures. 

For example in the example before, the actual metric contain `device_namespace:default` but it's not present in expected tags. When the tags are sorted, it's easier to spot that `device_namespace:default` is not present in expected metrics tag.

Before:

```
E   AssertionError: Needed at least 1 candidates for 'datadog.snmp.check_duration', got 0
E   Expected:
E           MetricStub(name='datadog.snmp.check_duration', type=0, value=None, tags=['snmp_profile:apc_ups', 'model:APC Smart-UPS 600', 'firmware_version:2.0.3-test', 'serial_num:test_serial', 'ups_name:testIdentName', 'device_vendor:apc', 'snmp_device:172.18.0.2', 'loader:core'], hostname=None, device=None, flush_first_value=None)
E   Similar submitted:
E   Score   Most similar
E   0.99    MetricStub(name='datadog.snmp.check_duration', type=0, value=0.1355018, tags=['device_namespace:default', 'device_vendor:apc', 'firmware_version:2.0.3-test', 'loader:core', 'model:APC Smart-UPS 600', 'serial_num:test_serial', 'snmp_device:172.18.0.2', 'snmp_profile:apc_ups', 'ups_name:testIdentName'], hostname='docker-desktop', device=None, flush_first_value=False)
```

After:

```
E   AssertionError: Needed at least 1 candidates for 'datadog.snmp.check_duration', got 0
E   Expected:
E           MetricStub(name='datadog.snmp.check_duration', type=0, value=None, tags=['device_vendor:apc', 'firmware_version:2.0.3-test', 'loader:core', 'model:APC Smart-UPS 600', 'serial_num:test_serial', 'snmp_device:172.18.0.2', 'snmp_profile:apc_ups', 'ups_name:testIdentName'], hostname=None, device=None, flush_first_value=None)
E   Similar submitted:
E   Score   Most similar
E   0.99    MetricStub(name='datadog.snmp.check_duration', type=0, value=0.12558, tags=['device_namespace:default', 'device_vendor:apc', 'firmware_version:2.0.3-test', 'loader:core', 'model:APC Smart-UPS 600', 'serial_num:test_serial', 'snmp_device:172.18.0.2', 'snmp_profile:apc_ups', 'ups_name:testIdentName'], hostname='docker-desktop', device=None, flush_first_value=False)
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
