### PR TITLE
Add change env to validations workflow

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -33,9 +33,14 @@ jobs:
         ddev config set repos.core .
         ddev config set repo core
 
+    - name: Set CHANGED
+      if: github.event_name == 'pull_request'
+      run: |
+          echo CHANGED=changed >> $GITHUB_ENV
+
     - name: Run agent requirements validation
       run: |
-        ddev validate agent-reqs changed
+        ddev validate agent-reqs ${{ env.CHANGED }}
 
     - name: Run CI validation
       run: |
@@ -43,11 +48,11 @@ jobs:
 
     - name: Run configuration validation
       run: |
-        ddev validate config changed
+        ddev validate config ${{ env.CHANGED }}
 
     - name: Run dashboard validation
       run: |
-        ddev validate dashboards changed
+        ddev validate dashboards ${{ env.CHANGED }}
 
     - name: Run dependency validation
       run: |
@@ -55,23 +60,23 @@ jobs:
 
     - name: Run HTTP wrapper validation
       run: |
-        ddev validate http changed
+        ddev validate http ${{ env.CHANGED }}
 
     - name: Run imports validation
       run: |
-        ddev validate imports changed
+        ddev validate imports ${{ env.CHANGED }}
 
     - name: Run integration style and best practices validation
       run: |
-        ddev validate integration-style changed --verbose
+        ddev validate integration-style ${{ env.CHANGED }} --verbose
 
     - name: Run JMX metrics validation
       run: |
-        ddev validate jmx-metrics changed
+        ddev validate jmx-metrics ${{ env.CHANGED }}
 
     - name: Run legacy signature validation
       run: |
-        ddev validate legacy-signature changed
+        ddev validate legacy-signature ${{ env.CHANGED }}
 
     - name: Run licenses validation
       run: |
@@ -79,35 +84,35 @@ jobs:
 
     - name: Run manifest validation
       run: |
-        ddev validate manifest changed
+        ddev validate manifest ${{ env.CHANGED }}
 
     - name: Run metadata validation
       run: |
-        ddev validate metadata changed
+        ddev validate metadata ${{ env.CHANGED }}
 
     - name: Run models validation
       run: |
-        ddev validate models changed
+        ddev validate models ${{ env.CHANGED }}
         
     - name: Run package validation
       run: |
-        ddev validate package changed
+        ddev validate package ${{ env.CHANGED }}
         
     - name: Run readmes validation
       run: |
-        ddev validate readmes changed
+        ddev validate readmes ${{ env.CHANGED }}
 
     - name: Run recommended monitors validation
       run: |
-        ddev validate recommended-monitors changed
+        ddev validate recommended-monitors ${{ env.CHANGED }}
 
     - name: Run saved views validation
       run: |
-        ddev validate saved-views changed
+        ddev validate saved-views ${{ env.CHANGED }}
 
     - name: Run service checks validation
       run: |
-        ddev validate service-checks changed
+        ddev validate service-checks ${{ env.CHANGED }}
 
     - name: Comment PR on failure
       if: ${{ failure() && github.event.pull_request.merged != true }}

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -8,6 +8,9 @@ on:
     branches:
     - master
 
+env:
+  CHANGED: ${{ github.event_name == 'pull_request' && 'changed' || '' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,14 +36,9 @@ jobs:
         ddev config set repos.core .
         ddev config set repo core
 
-    - name: Set CHANGED
-      if: github.event_name == 'pull_request'
-      run: |
-          echo CHANGED=changed >> $GITHUB_ENV
-
     - name: Run agent requirements validation
       run: |
-        ddev validate agent-reqs ${{ env.CHANGED }}
+        ddev validate agent-reqs $CHANGED
 
     - name: Run CI validation
       run: |
@@ -48,11 +46,11 @@ jobs:
 
     - name: Run configuration validation
       run: |
-        ddev validate config ${{ env.CHANGED }}
+        ddev validate config $CHANGED
 
     - name: Run dashboard validation
       run: |
-        ddev validate dashboards ${{ env.CHANGED }}
+        ddev validate dashboards $CHANGED
 
     - name: Run dependency validation
       run: |
@@ -60,23 +58,23 @@ jobs:
 
     - name: Run HTTP wrapper validation
       run: |
-        ddev validate http ${{ env.CHANGED }}
+        ddev validate http $CHANGED
 
     - name: Run imports validation
       run: |
-        ddev validate imports ${{ env.CHANGED }}
+        ddev validate imports $CHANGED
 
     - name: Run integration style and best practices validation
       run: |
-        ddev validate integration-style ${{ env.CHANGED }} --verbose
+        ddev validate integration-style $CHANGED --verbose
 
     - name: Run JMX metrics validation
       run: |
-        ddev validate jmx-metrics ${{ env.CHANGED }}
+        ddev validate jmx-metrics $CHANGED
 
     - name: Run legacy signature validation
       run: |
-        ddev validate legacy-signature ${{ env.CHANGED }}
+        ddev validate legacy-signature $CHANGED
 
     - name: Run licenses validation
       run: |
@@ -84,35 +82,35 @@ jobs:
 
     - name: Run manifest validation
       run: |
-        ddev validate manifest ${{ env.CHANGED }}
+        ddev validate manifest $CHANGED
 
     - name: Run metadata validation
       run: |
-        ddev validate metadata ${{ env.CHANGED }}
+        ddev validate metadata $CHANGED
 
     - name: Run models validation
       run: |
-        ddev validate models ${{ env.CHANGED }}
+        ddev validate models $CHANGED
         
     - name: Run package validation
       run: |
-        ddev validate package ${{ env.CHANGED }}
+        ddev validate package $CHANGED
         
     - name: Run readmes validation
       run: |
-        ddev validate readmes ${{ env.CHANGED }}
+        ddev validate readmes $CHANGED
 
     - name: Run recommended monitors validation
       run: |
-        ddev validate recommended-monitors ${{ env.CHANGED }}
+        ddev validate recommended-monitors $CHANGED
 
     - name: Run saved views validation
       run: |
-        ddev validate saved-views ${{ env.CHANGED }}
+        ddev validate saved-views $CHANGED
 
     - name: Run service checks validation
       run: |
-        ddev validate service-checks ${{ env.CHANGED }}
+        ddev validate service-checks $CHANGED
 
     - name: Comment PR on failure
       if: ${{ failure() && github.event.pull_request.merged != true }}

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -3,10 +3,10 @@ name: validations
 on:
   push:
     branches:
-    - master
+    - nathan.pezzotti/github-validations-push-master-env
   pull_request:
     branches:
-    - master
+    - nathan.pezzotti/github-validations-push-master-env
 
 env:
   CHANGED: ${{ github.event_name == 'pull_request' && 'changed' || '' }}

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -3,10 +3,10 @@ name: validations
 on:
   push:
     branches:
-    - nathan.pezzotti/github-validations-push-master-env
+    - master
   pull_request:
     branches:
-    - nathan.pezzotti/github-validations-push-master-env
+    - master
 
 env:
   CHANGED: ${{ github.event_name == 'pull_request' && 'changed' || '' }}

--- a/apache/README.md
+++ b/apache/README.md
@@ -6,6 +6,7 @@
 
 The Apache check tracks requests per second, bytes served, number of worker threads, service uptime, and more.
 
+Test change for github actions workflow
 ## Setup
 
 ### Installation

--- a/apache/README.md
+++ b/apache/README.md
@@ -6,7 +6,6 @@
 
 The Apache check tracks requests per second, bytes served, number of worker threads, service uptime, and more.
 
-Test change for github actions workflow
 ## Setup
 
 ### Installation


### PR DESCRIPTION
### What does this PR do?
Adds a step to set a `changed` env variable in the validations workflow in order to set format `ddev` command dynamically depending on github event.

### Motivation
Currently, `ddev validate` is not run on push to master, as the validations workflow has `ddev validate <COMMAND> changed` and no integrations are changed.

`AI-2263`

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
