### PR TITLE
Run validations on master

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -3,10 +3,10 @@ name: validations
 on:
   push:
     branches:
-    - nathan.pezzotti/github-validations-workflow-fix
+    - master
   pull_request:
     branches:
-    - nathan.pezzotti/github-validations-workflow-fix
+    - master
 
 env:
   CHANGED: ${{ github.event_name == 'pull_request' && 'changed' || '' }}

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -3,10 +3,13 @@ name: validations
 on:
   push:
     branches:
-    - master
+    - nathan.pezzotti/github-validations-workflow-fix
   pull_request:
     branches:
-    - master
+    - nathan.pezzotti/github-validations-workflow-fix
+
+env:
+  CHANGED: ${{ github.event_name == 'pull_request' && 'changed' || '' }}
 
 jobs:
   build:
@@ -35,7 +38,7 @@ jobs:
 
     - name: Run agent requirements validation
       run: |
-        ddev validate agent-reqs changed
+        ddev validate agent-reqs $CHANGED
 
     - name: Run CI validation
       run: |
@@ -43,11 +46,11 @@ jobs:
 
     - name: Run configuration validation
       run: |
-        ddev validate config changed
+        ddev validate config $CHANGED
 
     - name: Run dashboard validation
       run: |
-        ddev validate dashboards changed
+        ddev validate dashboards $CHANGED
 
     - name: Run dependency validation
       run: |
@@ -55,23 +58,23 @@ jobs:
 
     - name: Run HTTP wrapper validation
       run: |
-        ddev validate http changed
+        ddev validate http $CHANGED
 
     - name: Run imports validation
       run: |
-        ddev validate imports changed
+        ddev validate imports $CHANGED
 
     - name: Run integration style and best practices validation
       run: |
-        ddev validate integration-style changed --verbose
+        ddev validate integration-style $CHANGED --verbose
 
     - name: Run JMX metrics validation
       run: |
-        ddev validate jmx-metrics changed
+        ddev validate jmx-metrics $CHANGED
 
     - name: Run legacy signature validation
       run: |
-        ddev validate legacy-signature changed
+        ddev validate legacy-signature $CHANGED
 
     - name: Run licenses validation
       run: |
@@ -79,35 +82,35 @@ jobs:
 
     - name: Run manifest validation
       run: |
-        ddev validate manifest changed
+        ddev validate manifest $CHANGED
 
     - name: Run metadata validation
       run: |
-        ddev validate metadata changed
+        ddev validate metadata $CHANGED
 
     - name: Run models validation
       run: |
-        ddev validate models changed
+        ddev validate models $CHANGED
         
     - name: Run package validation
       run: |
-        ddev validate package changed
+        ddev validate package $CHANGED
         
     - name: Run readmes validation
       run: |
-        ddev validate readmes changed
+        ddev validate readmes $CHANGED
 
     - name: Run recommended monitors validation
       run: |
-        ddev validate recommended-monitors changed
+        ddev validate recommended-monitors $CHANGED
 
     - name: Run saved views validation
       run: |
-        ddev validate saved-views changed
+        ddev validate saved-views $CHANGED
 
     - name: Run service checks validation
       run: |
-        ddev validate service-checks changed
+        ddev validate service-checks $CHANGED
 
     - name: Comment PR on failure
       if: ${{ failure() && github.event.pull_request.merged != true }}

--- a/apache/README.md
+++ b/apache/README.md
@@ -5,7 +5,6 @@
 ## Overview
 
 The Apache check tracks requests per second, bytes served, number of worker threads, service uptime, and more.
-*Test change
 
 ## Setup
 

--- a/apache/README.md
+++ b/apache/README.md
@@ -5,6 +5,7 @@
 ## Overview
 
 The Apache check tracks requests per second, bytes served, number of worker threads, service uptime, and more.
+*Test change
 
 ## Setup
 


### PR DESCRIPTION
### What does this PR do?
Adds a step to set a `changed` env variable in the validations workflow in order to set format `ddev` command dynamically depending on github event.

### Motivation
Currently, `ddev validate` is not run on push to master, as the validations workflow has `ddev validate <COMMAND> changed` and no integrations are changed.

`AI-2263`

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
