### PR TITLE
Fix incorrect OpenMetrics V2 check exposition format HTTP header

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -217,12 +217,14 @@ class OpenMetricsScraper:
         if is_affirmative(config.get('use_latest_spec', False)):
             self.parse_metric_families = parse_metric_families_strict
             # https://github.com/prometheus/client_python/blob/v0.9.0/prometheus_client/openmetrics/exposition.py#L7
-            self.http.options['headers'].setdefault(
-                'Accept', 'application/openmetrics-text; version=0.0.1; charset=utf-8'
-            )
+            accept_header = 'application/openmetrics-text; version=0.0.1; charset=utf-8'
         else:
             self.parse_metric_families = parse_metric_families
-            self.http.options['headers'].setdefault('Accept', 'text/plain')
+            accept_header = 'text/plain'
+
+        # Request the appropriate exposition format
+        if self.http.options['headers'].get('Accept') == '*/*':
+            self.http.options['headers']['Accept'] = accept_header
 
         self.use_process_start_time = is_affirmative(config.get('use_process_start_time'))
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_config.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_config.py
@@ -414,3 +414,17 @@ class TestShareLabels:
             ),
         ):
             dd_run_check(check, extract_message=True)
+
+
+class TestUseLatestSpec:
+    def test_strict_latest_spec(self, dd_run_check):
+        check = get_check({'use_latest_spec': True})
+        check.configure_scrapers()
+        scraper = check.scrapers['test']
+        assert scraper.http.options['headers']['Accept'] == 'application/openmetrics-text; version=0.0.1; charset=utf-8'
+
+    def test_plain_text_spec(self, dd_run_check):
+        check = get_check({'use_latest_spec': False})
+        check.configure_scrapers()
+        scraper = check.scrapers['test']
+        assert scraper.http.options['headers']['Accept'] == 'text/plain'

--- a/openmetrics/tests/conftest.py
+++ b/openmetrics/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 
 import pytest
 from prometheus_client import CollectorRegistry, Counter, Gauge, generate_latest
+from prometheus_client.openmetrics.exposition import generate_latest as generate_latest_strict
 
 from datadog_checks.base import ensure_unicode
 from datadog_checks.dev import docker_run
@@ -35,3 +36,18 @@ def poll_mock(mock_http_response):
     g3.labels(matched_label="foobar", node="host2", timestamp="456").set(float('inf'))
 
     mock_http_response(ensure_unicode(generate_latest(registry)), normalize_content=False)
+
+
+@pytest.fixture
+def strict_poll_mock(mock_http_response):
+    registry = CollectorRegistry()
+    g1 = Gauge('metric1', 'processor usage', ['matched_label', 'node', 'flavor'], registry=registry)
+    g1.labels(matched_label="foobar", node="host1", flavor="test").set(99.9)
+    g2 = Gauge('metric2', 'memory usage', ['matched_label', 'node', 'timestamp'], registry=registry)
+    g2.labels(matched_label="foobar", node="host2", timestamp="123").set(12.2)
+    c1 = Counter('counter1', 'hits', ['node'], registry=registry)
+    c1.labels(node="host2").inc(42)
+    g3 = Gauge('metric3', 'memory usage', ['matched_label', 'node', 'timestamp'], registry=registry)
+    g3.labels(matched_label="foobar", node="host2", timestamp="456").set(float('inf'))
+
+    mock_http_response(ensure_unicode(generate_latest_strict(registry)), normalize_content=False)

--- a/openmetrics/tests/test_openmetrics_strict.py
+++ b/openmetrics/tests/test_openmetrics_strict.py
@@ -1,0 +1,43 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+from six import PY2
+
+from datadog_checks.openmetrics import OpenMetricsCheck
+
+from .common import CHECK_NAME
+
+pytestmark = pytest.mark.usefixtures("strict_poll_mock")
+
+instance_new_strict = {
+    'openmetrics_endpoint': 'http://localhost:10249/metrics',
+    'namespace': 'openmetrics',
+    'metrics': [{'metric1': 'renamed.metric1'}, 'metric2', 'counter1'],
+    'collect_histogram_buckets': True,
+    'use_latest_spec': True,
+}
+
+
+@pytest.mark.skipif(PY2, reason='Test only available on Python 3')
+def test_linkerd_v2_new_strict(aggregator, dd_run_check):
+    check = OpenMetricsCheck('openmetrics', {}, [instance_new_strict])
+    dd_run_check(check)
+
+    aggregator.assert_metric(
+        '{}.renamed.metric1'.format(CHECK_NAME),
+        tags=['endpoint:http://localhost:10249/metrics', 'node:host1', 'flavor:test', 'matched_label:foobar'],
+        metric_type=aggregator.GAUGE,
+    )
+    aggregator.assert_metric(
+        '{}.metric2'.format(CHECK_NAME),
+        tags=['endpoint:http://localhost:10249/metrics', 'timestamp:123', 'node:host2', 'matched_label:foobar'],
+        metric_type=aggregator.GAUGE,
+    )
+    aggregator.assert_metric(
+        '{}.counter1.count'.format(CHECK_NAME),
+        tags=['endpoint:http://localhost:10249/metrics', 'node:host2'],
+        metric_type=aggregator.MONOTONIC_COUNT,
+    )
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?

With this change, the openmetrics check should request the appropriate
exposition format fixing "Clashing name" errors.

### Motivation

The exposition format to request is set via the "Accept" header. Despite
the OpenMetricsScraper appearing to set the correct header when
`use_latest_spec` is enabled, it is actually a no-op due to the default
HTTP headers including `Accept: */*` and the use of `setdefault`.

### Additional Notes

Tests incoming. It appears that there were no existing tests of `use_latest_spec` or the new exposition format.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
