### PR TITLE
Remove log collection from docs

### DIFF
--- a/amazon_eks_blueprints/README.md
+++ b/amazon_eks_blueprints/README.md
@@ -79,33 +79,31 @@ new blueprints.EksBlueprint(app, { id: '<eks cluster name>', addOns}, props)
 | `version`               | Version of the Datadog Helm chart                   | "2.28.13"                     |
 | `release`               | Name of the Helm release                            | "datadog"                     |
 | `repository`            | Repository of the Helm chart                        | "https://helm.datadoghq.com"  |
-| `values`                | Configuration values passed to the chart. [See options][3]. | {}                            |
+| `values`                | Configuration values passed to the chart. [See options][2]. | {}                            |
 
 
-See the [Datadog Helm chart][3] for all Agent configuration options. You can then pass these values using the `values` option.
+See the [Datadog Helm chart][2] for all Agent configuration options. You can then pass these values using the `values` option.
 
 ### Metric collection
 
 Monitoring EKS requires that you set up one of the following Datadog integrations:
 
-- [Kubernetes][6]
-- [AWS][7]
-- [AWS EC2][8]
+- [Kubernetes][4]
+- [AWS][5]
+- [AWS EC2][6]
 
-Also set up the integrations for any other AWS services that you are running with EKS, such as [ELB][5].
+Also set up the integrations for any other AWS services that you are running with EKS, such as [ELB][3].
 
 ## Data Collected
 
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][2].
+Need help? Contact [Datadog support][1].
 
-[1]: https://docs.datadoghq.com/agent/kubernetes/log/?tab=daemonset
-[2]: https://docs.datadoghq.com/help/
-[3]: https://github.com/DataDog/helm-charts/tree/main/charts/datadog#all-configuration-options
-[4]: https://docs.datadoghq.com/integrations/amazon_eks/
-[5]: https://docs.datadoghq.com/integrations/amazon_elb/
-[6]: https://docs.datadoghq.com/integrations/kubernetes/
-[7]: https://docs.datadoghq.com/integrations/amazon_web_services/
-[8]: https://docs.datadoghq.com/integrations/amazon_ec2/
+[1]: https://docs.datadoghq.com/help/
+[2]: https://github.com/DataDog/helm-charts/tree/main/charts/datadog#all-configuration-options
+[3]: https://docs.datadoghq.com/integrations/amazon_elb/
+[4]: https://docs.datadoghq.com/integrations/kubernetes/
+[5]: https://docs.datadoghq.com/integrations/amazon_web_services/
+[6]: https://docs.datadoghq.com/integrations/amazon_ec2/

--- a/amazon_eks_blueprints/README.md
+++ b/amazon_eks_blueprints/README.md
@@ -96,11 +96,6 @@ Also set up the integrations for any other AWS services that you are running wit
 
 ## Data Collected
 
-### Log collection
-
-_Available for Agent versions >6.0_
-
-See [Kubernetes Log Collection][1].
 
 ## Troubleshooting
 

--- a/amazon_eks_blueprints/manifest.json
+++ b/amazon_eks_blueprints/manifest.json
@@ -18,8 +18,7 @@
   "categories": [
     "aws",
     "containers",
-    "orchestration",
-    "log collection"
+    "orchestration"
   ],
   "type": "check",
   "is_public": true,

--- a/oke/README.md
+++ b/oke/README.md
@@ -10,11 +10,6 @@ Because Datadog already integrates with Kubernetes, it is ready-made to monitor 
 
 Additionally, OKE node pools are supported.
 
-### Log collection
-
-_Available for Agent versions >6.0_
-
-[Set up log collection][1] for your containers.
 
 ## Troubleshooting
 

--- a/oke/README.md
+++ b/oke/README.md
@@ -13,12 +13,11 @@ Additionally, OKE node pools are supported.
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][2].
+Need help? Contact [Datadog support][1].
 
 ## Further Reading
 
-- [How to monitor OKE with Datadog][3]
+- [How to monitor OKE with Datadog][2]
 
-[1]: https://docs.datadoghq.com/agent/kubernetes/log
-[2]: https://docs.datadoghq.com/help/
-[3]: https://www.datadoghq.com/blog/monitor-oracle-kubernetes-engine/
+[1]: https://docs.datadoghq.com/help/
+[2]: https://www.datadoghq.com/blog/monitor-oracle-kubernetes-engine/

--- a/oke/manifest.json
+++ b/oke/manifest.json
@@ -18,8 +18,7 @@
   "categories": [
     "oracle",
     "containers",
-    "orchestration",
-    "log collection"
+    "orchestration"
   ],
   "type": "check",
   "is_public": true,


### PR DESCRIPTION
### What does this PR do?
Removes mention of log collection from the docs and removes the `log collection` category from manifest.json. 

### Motivation
There isn't a default logs pipeline for kubernetes logs and the presence of the `log collection` category causes the weekly integrations logs pipeline CI to fail. 

### Additional Notes
Other K8s orchestration integration tiles do not have the `log collection` category, such as [gke](https://github.com/DataDog/integrations-core/blob/ebb8e70be0d8301172a0432b6c8e6a354852f555/gke/manifest.json#L18-L21).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
