### PR TITLE
Do not raise exeptions on empty outout of varnishadm

### DIFF
--- a/varnish/datadog_checks/varnish/varnish.py
+++ b/varnish/datadog_checks/varnish/varnish.py
@@ -153,12 +153,13 @@ class Varnish(AgentCheck):
                     + ['-T', '{}:{}'.format(daemon_host, daemon_port), '-S', secretfile_path, 'backend.list', '-p']
                 )
 
+            err, output = None, None
             try:
-                output, err, _ = get_subprocess_output(cmd, self.log)
+                output, err, _ = get_subprocess_output(cmd, self.log, raise_on_empty_output=False)
             except OSError as e:
                 self.log.error("There was an error running varnishadm. Make sure 'sudo' is available. %s", e)
                 output = None
-            if err:
+            if err or not output:
                 self.log.error('Error getting service check from varnishadm: %s', err)
 
             if output:


### PR DESCRIPTION
Avoid getting this stacktrace:

```
Error: get_subprocess_output expected output but had none.
Traceback (most recent call last):
File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 1071, in run
self.check(instance)
File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/varnish/varnish.py", line 157, in check
output, err, _ = get_subprocess_output(cmd, self.log)
File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/utils/subprocess_output.py", line 56, in get_subprocess_output
out, err, returncode = subprocess_output(cmd_args, raise_on_empty_output, env=env)
_util.SubprocessOutputEmptyError: get_subprocess_output expected output but had none.
```