### PR TITLE
[HTTP Check] Add `status_code` to metric tags

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -100,6 +100,7 @@ class HTTPCheck(AgentCheck):
 
         # Store tags in a temporary list so that we don't modify the global tags data structure
         tags_list = list(tags)
+        tags_list.append('status_code:{}'.format(http_response_status_code))
         tags_list.append('url:{}'.format(addr))
         instance_name = self.normalize_tag(instance['name'])
         tags_list.append("instance:{}".format(instance_name))


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add `status_code` to http check tags.

### Motivation
<!-- What inspired you to submit this pull request? -->

Grouping http check metrics by `status_code` is good for troubleshooting like synthetics HTTP tests.
https://docs.datadoghq.com/synthetics/metrics/#http-tests 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
