### PR TITLE
Support dynamic bearer tokens (Bound Service Account Token Volume)

### DIFF
--- a/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/defaults.py
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_connect_timeout(field, value):
     return get_default_field_value(field, value)
 

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/instance.py
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/config_models/instance.py
@@ -79,6 +79,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]
     edge_agent_prometheus_url: str

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/data/conf.yaml.example
@@ -157,6 +157,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/cilium/datadog_checks/cilium/config_models/defaults.py
+++ b/cilium/datadog_checks/cilium/config_models/defaults.py
@@ -62,6 +62,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_cache_metric_wildcards(field, value):
     return True
 

--- a/cilium/datadog_checks/cilium/config_models/instance.py
+++ b/cilium/datadog_checks/cilium/config_models/instance.py
@@ -106,6 +106,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]
     collect_counters_with_distributions: Optional[bool]

--- a/cockroachdb/datadog_checks/cockroachdb/config_models/defaults.py
+++ b/cockroachdb/datadog_checks/cockroachdb/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_cache_metric_wildcards(field, value):
     return True
 

--- a/cockroachdb/datadog_checks/cockroachdb/config_models/instance.py
+++ b/cockroachdb/datadog_checks/cockroachdb/config_models/instance.py
@@ -105,6 +105,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]
     collect_counters_with_distributions: Optional[bool]

--- a/coredns/datadog_checks/coredns/config_models/defaults.py
+++ b/coredns/datadog_checks/coredns/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_cache_metric_wildcards(field, value):
     return True
 

--- a/coredns/datadog_checks/coredns/config_models/instance.py
+++ b/coredns/datadog_checks/coredns/config_models/instance.py
@@ -105,6 +105,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]
     collect_counters_with_distributions: Optional[bool]

--- a/crio/datadog_checks/crio/config_models/defaults.py
+++ b/crio/datadog_checks/crio/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_connect_timeout(field, value):
     return get_default_field_value(field, value)
 

--- a/crio/datadog_checks/crio/config_models/instance.py
+++ b/crio/datadog_checks/crio/config_models/instance.py
@@ -79,6 +79,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]

--- a/crio/datadog_checks/crio/data/conf.yaml.example
+++ b/crio/datadog_checks/crio/data/conf.yaml.example
@@ -152,6 +152,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_openmetrics.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_openmetrics.py
@@ -9,10 +9,12 @@ import logging
 import math
 import os
 import re
+import time
 
 import mock
 import pytest
 import requests
+from mock import patch
 from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily, HistogramMetricFamily, SummaryMetricFamily
 from prometheus_client.samples import Sample
 from six import iteritems
@@ -24,6 +26,7 @@ from datadog_checks.dev.http import MockResponse
 
 text_content_type = 'text/plain; version=0.0.4'
 FIXTURE_PATH = os.path.abspath(os.path.join(get_here(), '..', '..', '..', 'fixtures', 'prometheus'))
+TOKENS_PATH = os.path.abspath(os.path.join(get_here(), '..', '..', '..', 'fixtures', 'bearer_tokens'))
 
 FAKE_ENDPOINT = 'http://fake.endpoint:10055/metrics'
 
@@ -2988,3 +2991,23 @@ def test_use_process_start_time(
             )
 
         expect_first_flush = True
+
+
+def test_refresh_bearer_token(text_data, mocked_openmetrics_check_factory):
+    instance = {
+        'prometheus_url': 'https://fake.endpoint:10055/metrics',
+        'metrics': [{'process_virtual_memory_bytes': 'process.vm.bytes'}],
+        "namespace": "default_namespace",
+        "bearer_token_auth": True,
+        "bearer_token_refresh_interval": 1,
+    }
+
+    with patch.object(OpenMetricsBaseCheck, 'KUBERNETES_TOKEN_PATH', os.path.join(TOKENS_PATH, 'default_token')):
+        check = mocked_openmetrics_check_factory(instance)
+        check.poll = mock.MagicMock(return_value=MockResponse(text_data, headers={'Content-Type': text_content_type}))
+        instance = check.get_scraper_config(instance)
+        assert instance['_bearer_token'] == 'my default token'
+        time.sleep(1.5)
+        with patch.object(OpenMetricsBaseCheck, 'KUBERNETES_TOKEN_PATH', os.path.join(TOKENS_PATH, 'custom_token')):
+            check.check(instance)
+            assert instance['_bearer_token'] == 'my custom token'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy_base.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy_base.yaml
@@ -161,6 +161,12 @@
   value:
     example: <TOKEN_PATH>
     type: string
+- name: bearer_token_refresh_interval
+  description: |
+    The refresh interval to keep the bearer token up-to-date.
+  value:
+    example: 60
+    type: integer
 - name: ignore_metrics
   description: |
     A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/defaults.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_connect_timeout(field, value):
     return get_default_field_value(field, value)
 

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/instance.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/config_models/instance.py
@@ -79,6 +79,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/auto_conf.yaml
@@ -160,6 +160,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/data/conf.yaml.example
@@ -152,6 +152,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/etcd/datadog_checks/etcd/config_models/defaults.py
+++ b/etcd/datadog_checks/etcd/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_connect_timeout(field, value):
     return get_default_field_value(field, value)
 

--- a/etcd/datadog_checks/etcd/config_models/instance.py
+++ b/etcd/datadog_checks/etcd/config_models/instance.py
@@ -79,6 +79,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -158,6 +158,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/external_dns/datadog_checks/external_dns/config_models/defaults.py
+++ b/external_dns/datadog_checks/external_dns/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_connect_timeout(field, value):
     return get_default_field_value(field, value)
 

--- a/external_dns/datadog_checks/external_dns/config_models/instance.py
+++ b/external_dns/datadog_checks/external_dns/config_models/instance.py
@@ -79,6 +79,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]

--- a/external_dns/datadog_checks/external_dns/data/conf.yaml.example
+++ b/external_dns/datadog_checks/external_dns/data/conf.yaml.example
@@ -152,6 +152,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/gitlab/datadog_checks/gitlab/config_models/defaults.py
+++ b/gitlab/datadog_checks/gitlab/config_models/defaults.py
@@ -66,6 +66,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_connect_timeout(field, value):
     return get_default_field_value(field, value)
 

--- a/gitlab/datadog_checks/gitlab/config_models/instance.py
+++ b/gitlab/datadog_checks/gitlab/config_models/instance.py
@@ -80,6 +80,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -123,6 +123,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/gitlab_runner/datadog_checks/gitlab_runner/config_models/defaults.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_connect_timeout(field, value):
     return get_default_field_value(field, value)
 

--- a/gitlab_runner/datadog_checks/gitlab_runner/config_models/instance.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/config_models/instance.py
@@ -79,6 +79,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -206,6 +206,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/haproxy/datadog_checks/haproxy/config_models/defaults.py
+++ b/haproxy/datadog_checks/haproxy/config_models/defaults.py
@@ -62,6 +62,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_cache_metric_wildcards(field, value):
     return True
 

--- a/haproxy/datadog_checks/haproxy/config_models/instance.py
+++ b/haproxy/datadog_checks/haproxy/config_models/instance.py
@@ -106,6 +106,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]
     collate_status_tags_per_host: Optional[bool]

--- a/istio/datadog_checks/istio/config_models/defaults.py
+++ b/istio/datadog_checks/istio/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_cache_metric_wildcards(field, value):
     return True
 

--- a/istio/datadog_checks/istio/config_models/instance.py
+++ b/istio/datadog_checks/istio/config_models/instance.py
@@ -105,6 +105,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]
     collect_counters_with_distributions: Optional[bool]

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/defaults.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_connect_timeout(field, value):
     return get_default_field_value(field, value)
 

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/instance.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/config_models/instance.py
@@ -79,6 +79,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/data/conf.yaml.example
@@ -159,6 +159,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/data/conf.yaml.example
@@ -194,6 +194,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
+++ b/kube_dns/datadog_checks/kube_dns/data/conf.yaml.example
@@ -152,6 +152,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/data/conf.yaml.example
@@ -159,6 +159,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
+++ b/kube_proxy/datadog_checks/kube_proxy/data/conf.yaml.example
@@ -152,6 +152,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/kube_scheduler/datadog_checks/kube_scheduler/config_models/defaults.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_connect_timeout(field, value):
     return get_default_field_value(field, value)
 

--- a/kube_scheduler/datadog_checks/kube_scheduler/config_models/instance.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/config_models/instance.py
@@ -79,6 +79,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]

--- a/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
+++ b/kube_scheduler/datadog_checks/kube_scheduler/data/conf.yaml.example
@@ -173,6 +173,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/kubelet/datadog_checks/kubelet/data/conf.yaml.example
+++ b/kubelet/datadog_checks/kubelet/data/conf.yaml.example
@@ -180,6 +180,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
+++ b/kubernetes_state/datadog_checks/kubernetes_state/data/conf.yaml.example
@@ -166,6 +166,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/linkerd/datadog_checks/linkerd/config_models/defaults.py
+++ b/linkerd/datadog_checks/linkerd/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_cache_metric_wildcards(field, value):
     return True
 

--- a/linkerd/datadog_checks/linkerd/config_models/instance.py
+++ b/linkerd/datadog_checks/linkerd/config_models/instance.py
@@ -105,6 +105,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]
     collect_counters_with_distributions: Optional[bool]

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/defaults.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_collect_nginx_histograms(field, value):
     return False
 

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/instance.py
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/config_models/instance.py
@@ -79,6 +79,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     collect_nginx_histograms: Optional[bool]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]

--- a/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
+++ b/nginx_ingress_controller/datadog_checks/nginx_ingress_controller/data/conf.yaml.example
@@ -160,6 +160,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.

--- a/openmetrics/datadog_checks/openmetrics/config_models/defaults.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_cache_metric_wildcards(field, value):
     return True
 

--- a/openmetrics/datadog_checks/openmetrics/config_models/instance.py
+++ b/openmetrics/datadog_checks/openmetrics/config_models/instance.py
@@ -105,6 +105,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     cache_metric_wildcards: Optional[bool]
     cache_shared_labels: Optional[bool]
     collect_counters_with_distributions: Optional[bool]

--- a/scylla/datadog_checks/scylla/config_models/defaults.py
+++ b/scylla/datadog_checks/scylla/config_models/defaults.py
@@ -58,6 +58,10 @@ def instance_bearer_token_path(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_bearer_token_refresh_interval(field, value):
+    return 60
+
+
 def instance_connect_timeout(field, value):
     return get_default_field_value(field, value)
 

--- a/scylla/datadog_checks/scylla/config_models/instance.py
+++ b/scylla/datadog_checks/scylla/config_models/instance.py
@@ -79,6 +79,7 @@ class InstanceConfig(BaseModel):
     aws_service: Optional[str]
     bearer_token_auth: Optional[Union[bool, str]]
     bearer_token_path: Optional[str]
+    bearer_token_refresh_interval: Optional[int]
     connect_timeout: Optional[float]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]

--- a/scylla/datadog_checks/scylla/data/conf.yaml.example
+++ b/scylla/datadog_checks/scylla/data/conf.yaml.example
@@ -169,6 +169,11 @@ instances:
     #
     # bearer_token_path: <TOKEN_PATH>
 
+    ## @param bearer_token_refresh_interval - integer - optional - default: 60
+    ## The refresh interval to keep the bearer token up-to-date.
+    #
+    # bearer_token_refresh_interval: 60
+
     ## @param ignore_metrics - list of strings - optional
     ## A list of metrics to ignore, the "*" wildcard can be used to match multiple metric names.
     ## The wildcard matching is done via fnmatch, it locates a match anywhere in the string.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Support refreshing the service account's auth token needed for [Bound Service Account Token Volume](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume) (k8s v1.22+)

### Motivation
<!-- What inspired you to submit this pull request? -->

fixes https://github.com/DataDog/datadog-agent/issues/10604

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Similar fix in the Go code https://github.com/DataDog/datadog-agent/pull/11686

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
