### PR TITLE
Pin types-simplejson==3.17.5

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -32,7 +32,7 @@ TYPES_DEPS = [
     'types-python-dateutil==2.8.2',
     'types_requests==2.25.11',
     'types_six==1.16.2',
-    "types-simplejson==3.17.5",
+    'types-simplejson==3.17.5',
 ]
 PYDANTIC_DEP = 'pydantic==1.8.2'  # Keep in sync with: /datadog_checks_base/requirements.in
 

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -27,7 +27,13 @@ FLAKE8_LOGGING_FORMAT_DEP = 'flake8-logging-format==0.6.0'
 # TODO: remove extra when we drop Python 2
 MYPY_DEP = 'mypy[python2]==0.910'
 # TODO: when we drop Python 2 and replace with --install-types --non-interactive
-TYPES_DEPS = ['types-PyYAML==5.4.10', 'types-python-dateutil==2.8.2', 'types_requests==2.25.11', 'types_six==1.16.2', "types-simplejson==3.17.5"]
+TYPES_DEPS = [
+    'types-PyYAML==5.4.10',
+    'types-python-dateutil==2.8.2',
+    'types_requests==2.25.11',
+    'types_six==1.16.2',
+    "types-simplejson==3.17.5",
+]
 PYDANTIC_DEP = 'pydantic==1.8.2'  # Keep in sync with: /datadog_checks_base/requirements.in
 
 

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -27,7 +27,7 @@ FLAKE8_LOGGING_FORMAT_DEP = 'flake8-logging-format==0.6.0'
 # TODO: remove extra when we drop Python 2
 MYPY_DEP = 'mypy[python2]==0.910'
 # TODO: when we drop Python 2 and replace with --install-types --non-interactive
-TYPES_DEPS = ['types-PyYAML==5.4.10', 'types-python-dateutil==2.8.2', 'types_requests==2.25.11', 'types_six==1.16.2']
+TYPES_DEPS = ['types-PyYAML==5.4.10', 'types-python-dateutil==2.8.2', 'types_requests==2.25.11', 'types_six==1.16.2', "types-simplejson==3.17.5"]
 PYDANTIC_DEP = 'pydantic==1.8.2'  # Keep in sync with: /datadog_checks_base/requirements.in
 
 


### PR DESCRIPTION
Latest release 3.17.6, from April 27 causes the following error on glusterfs:

`datadog_checks/glusterfs/check.py:9:1: error: Library stubs not installed for "simplejson" (or incompatible with Python 2.7)`