### PR TITLE
Add `request_context` argument to `_new_pool` in weak ciphers adapter

### DIFF
--- a/http_check/datadog_checks/http_check/adapters.py
+++ b/http_check/datadog_checks/http_check/adapters.py
@@ -84,7 +84,7 @@ class WeakCiphersHTTPSConnectionPool(urllib3.connectionpool.HTTPSConnectionPool)
 
 
 class WeakCiphersPoolManager(urllib3.poolmanager.PoolManager):
-    def _new_pool(self, scheme, host, port):
+    def _new_pool(self, scheme, host, port, request_context=None):
         if scheme == 'https':
             return WeakCiphersHTTPSConnectionPool(host, port, **(self.connection_pool_kw))
         return super(WeakCiphersPoolManager, self)._new_pool(scheme, host, port)

--- a/http_check/tests/common.py
+++ b/http_check/tests/common.py
@@ -194,6 +194,8 @@ CONFIG_DONT_CHECK_EXP = {
     'instances': [{'name': 'simple_config', 'url': 'https://expired.mock', 'check_certificate_expiration': False}]
 }
 
+CONFIG_WEAK_CIPHERS = {'instances': [{'name': 'simple_config', 'weakciphers': True, 'url': 'https://valid.mock'}]}
+
 CONFIG_HTTP_NO_REDIRECTS = {
     'instances': [
         {

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -23,6 +23,7 @@ from .common import (
     CONFIG_HTTP_NO_REDIRECTS,
     CONFIG_SSL_ONLY,
     CONFIG_UNORMALIZED_INSTANCE_NAME,
+    CONFIG_WEAK_CIPHERS,
     FAKE_CERT,
     HERE,
 )
@@ -454,3 +455,16 @@ def test_tls_config_ok(dd_run_check, instance, check_hostname):
     )
     tls_context = check.get_tls_context()
     assert tls_context.check_hostname is check_hostname
+
+
+@pytest.mark.usefixtures("dd_environment")
+def test_weak_ciphers_adapter(aggregator, http_check, dd_run_check):
+
+    # ensure running the check with the adapter doesn't throw an exception
+    instance = CONFIG_WEAK_CIPHERS['instances'][0]
+    http_check.check(instance)
+
+    url_tag = ['url:{}'.format(instance.get('url'))]
+    instance_tag = ['instance:{}'.format(instance.get('name'))]
+
+    aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=HTTPCheck.OK, tags=url_tag + instance_tag, count=1)


### PR DESCRIPTION
### What does this PR do?
Fix WeakCipherAdapter code, also adds a test for this code path

### Motivation
currently (since https://github.com/urllib3/urllib3/commit/7c14966fc134146223650a8393e17e91a358ba6d) it errors as:
```
          conn = self.get_connection(request.url, proxies)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/requests/adapters.py", line 316, in get_connection
          conn = self.poolmanager.connection_from_url(url)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/urllib3/poolmanager.py", line 298, in connection_from_url
          return self.connection_from_host(
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/urllib3/poolmanager.py", line 245, in connection_from_host
          return self.connection_from_context(request_context)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/urllib3/poolmanager.py", line 260, in connection_from_context
          return self.connection_from_pool_key(pool_key, request_context=request_context)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/urllib3/poolmanager.py", line 281, in connection_from_pool_key
          pool = self._new_pool(scheme, host, port, request_context=request_context)
      TypeError: _new_pool() got an unexpected keyword argument 'request_context'
```
### Additional Notes
leaving the option as undocumented 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
