### PR TITLE
Fallback Kubernetes client version to 22.6 to avoid failures on non-standard POD conditions

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -39,7 +39,7 @@ jpype1==1.3.0; python_version > '3.0'
 kafka-python==2.0.2
 kazoo==2.8.0
 kubernetes==18.20.0; python_version < '3.0'
-kubernetes==23.3.0; python_version > '3.0'
+kubernetes==22.6.0; python_version > '3.0'
 ldap3==2.9.1
 lxml==4.8.0
 lz4==2.2.1; python_version < '3.0'

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -85,7 +85,7 @@ json = [
 ]
 kube = [
     "kubernetes==18.20.0; python_version < '3.0'",
-    "kubernetes==23.3.0; python_version > '3.0'",
+    "kubernetes==22.6.0; python_version > '3.0'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
In latest versions a check has been added on the values read from POD `status` sub-resource.
It can prevent some checks from running if a controller is setting non-standard conditions in status, with error like:

```
Error: Invalid value for `condition_type` (xxxx), must be one of ['ContainersReady', 'Initialized', 'PodScheduled', 'Ready']
```

### Motivation
Bugfix.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
