### PR TITLE
[helm] Add monitor for failed releases

### DIFF
--- a/helm/assets/monitors/monitor_failed_releases.json
+++ b/helm/assets/monitors/monitor_failed_releases.json
@@ -21,6 +21,6 @@
     "new_group_delay": 60
   },
   "recommended_monitor_metadata": {
-    "description": "Get notified when the latest revision of a Helm release is on \"failed\" state."
+    "description": "Get notified when the latest revision of a Helm release is in \"failed\" state."
   }
 }

--- a/helm/assets/monitors/monitor_failed_releases.json
+++ b/helm/assets/monitors/monitor_failed_releases.json
@@ -2,7 +2,7 @@
   "name": "Helm release {{helm_namespace.name}}/{{helm_release.name}} failed on {{kube_cluster_name.name}}",
   "type": "service check",
   "query": "\"helm.release_state\".over(\"*\").by(\"helm_namespace\",\"helm_release\",\"helm_storage\",\"kube_cluster_name\").last(6).count_by_status()",
-  "message": "The helm release deployment {{helm_namespace.name}}/{{helm_release.name}} (using storage {{helm_storage.name}}) has failed on {{kube_cluster_name.name}}.",
+  "message": "The Helm release deployment {{helm_namespace.name}}/{{helm_release.name}} (using storage {{helm_storage.name}}) has failed on {{kube_cluster_name.name}}.",
   "tags": [
     "integration:helm"
   ],

--- a/helm/assets/monitors/monitor_failed_releases.json
+++ b/helm/assets/monitors/monitor_failed_releases.json
@@ -1,0 +1,26 @@
+{
+  "name": "Helm release {{helm_namespace.name}}/{{helm_release.name}} failed on {{kube_cluster_name.name}}",
+  "type": "service check",
+  "query": "\"helm.release_state\".over(\"*\").by(\"helm_namespace\",\"helm_release\",\"helm_storage\",\"kube_cluster_name\").last(6).count_by_status()",
+  "message": "The helm release deployment {{helm_namespace.name}}/{{helm_release.name}} (using storage {{helm_storage.name}}) has failed on {{kube_cluster_name.name}}.",
+  "tags": [
+    "integration:helm"
+  ],
+  "options": {
+    "renotify_interval": 0,
+    "timeout_h": 0,
+    "thresholds": {
+      "ok": 1,
+      "warning": 1,
+      "critical": 5
+    },
+    "notify_no_data": false,
+    "no_data_timeframe": 2,
+    "notify_audit": false,
+    "escalation_message": "",
+    "new_group_delay": 60
+  },
+  "recommended_monitor_metadata": {
+    "description": "Get notified when the latest revision of a Helm release is on \"failed\" state."
+  }
+}

--- a/helm/manifest.json
+++ b/helm/manifest.json
@@ -26,7 +26,9 @@
     "dashboards": {
       "Helm - Overview": "assets/dashboards/overview.json"
     },
-    "monitors": {},
+    "monitors": {
+      "[helm] Monitor Helm failed releases": "assets/monitors/monitor_failed_releases.json"
+    },
     "saved_views": {},
     "service_checks": "assets/service_checks.json",
     "logs": {},


### PR DESCRIPTION
### What does this PR do?

Adds a monitor for the Helm integration. It's a monitor that triggers when there are Helm releases marked as "failed".
This monitor is based on the `helm.release_state` service check (ref: https://github.com/DataDog/integrations-core/pull/11766)

This needs to be merged after 7.36.0 is released.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
