### PR TITLE
Pin setuptools version and update license format

### DIFF
--- a/active_directory/pyproject.toml
+++ b/active_directory/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-active-directory"
 description = "The Active Directory check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/active_directory/pyproject.toml
+++ b/active_directory/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/activemq/pyproject.toml
+++ b/activemq/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-activemq"
 description = "The ActiveMQ check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/activemq/pyproject.toml
+++ b/activemq/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/activemq_xml/pyproject.toml
+++ b/activemq_xml/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-activemq-xml"
 description = "The ActiveMQ XML check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/activemq_xml/pyproject.toml
+++ b/activemq_xml/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/aerospike/pyproject.toml
+++ b/aerospike/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-aerospike"
 description = "The Aerospike check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/aerospike/pyproject.toml
+++ b/aerospike/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-airflow"
 description = "The Airflow check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/amazon_msk/pyproject.toml
+++ b/amazon_msk/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-amazon-msk"
 description = "The Amazon Kafka check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/amazon_msk/pyproject.toml
+++ b/amazon_msk/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ambari/pyproject.toml
+++ b/ambari/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-ambari"
 description = "The Ambari check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/ambari/pyproject.toml
+++ b/ambari/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/apache/pyproject.toml
+++ b/apache/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-apache"
 description = "The Apache check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/apache/pyproject.toml
+++ b/apache/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/arangodb/pyproject.toml
+++ b/arangodb/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 name = "datadog-arangodb"
 description = "The ArangoDB check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 requires-python = ">=3.8"
 keywords = [
     "datadog",

--- a/aspdotnet/pyproject.toml
+++ b/aspdotnet/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-aspdotnet"
 description = "The ASP.NET check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/aspdotnet/pyproject.toml
+++ b/aspdotnet/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/avi_vantage/pyproject.toml
+++ b/avi_vantage/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-avi-vantage"
 description = "The Avi Vantage check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 requires-python = ">=3.8"
 keywords = [
     "datadog",

--- a/avi_vantage/pyproject.toml
+++ b/avi_vantage/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/azure_iot_edge/pyproject.toml
+++ b/azure_iot_edge/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-azure-iot-edge"
 description = "The Azure IoT Edge check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/azure_iot_edge/pyproject.toml
+++ b/azure_iot_edge/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/btrfs/pyproject.toml
+++ b/btrfs/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-btrfs"
 description = "The Btrfs check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/btrfs/pyproject.toml
+++ b/btrfs/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cacti/pyproject.toml
+++ b/cacti/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-cacti"
 description = "The Cacti check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/cacti/pyproject.toml
+++ b/cacti/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/calico/pyproject.toml
+++ b/calico/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-calico"
 description = "The Calico check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/calico/pyproject.toml
+++ b/calico/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cassandra/pyproject.toml
+++ b/cassandra/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-cassandra"
 description = "The Cassandra check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/cassandra/pyproject.toml
+++ b/cassandra/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cassandra_nodetool/pyproject.toml
+++ b/cassandra_nodetool/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-cassandra-nodetool"
 description = "The Cassandra Nodetool check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/cassandra_nodetool/pyproject.toml
+++ b/cassandra_nodetool/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ceph/pyproject.toml
+++ b/ceph/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ceph/pyproject.toml
+++ b/ceph/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-ceph"
 description = "The Ceph check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/cilium/pyproject.toml
+++ b/cilium/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-cilium"
 description = "The Cilium check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/cilium/pyproject.toml
+++ b/cilium/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cisco_aci/pyproject.toml
+++ b/cisco_aci/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cisco_aci/pyproject.toml
+++ b/cisco_aci/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-cisco-aci"
 description = "The Cisco ACI check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/citrix_hypervisor/pyproject.toml
+++ b/citrix_hypervisor/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-citrix-hypervisor"
 description = "The Citrix Hypervisor check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/citrix_hypervisor/pyproject.toml
+++ b/citrix_hypervisor/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/clickhouse/pyproject.toml
+++ b/clickhouse/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-clickhouse"
 description = "The ClickHouse check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/clickhouse/pyproject.toml
+++ b/clickhouse/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cloud_foundry_api/pyproject.toml
+++ b/cloud_foundry_api/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-cloud-foundry-api"
 description = "The Cloud Foundry API check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/cloud_foundry_api/pyproject.toml
+++ b/cloud_foundry_api/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cockroachdb/pyproject.toml
+++ b/cockroachdb/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-cockroachdb"
 description = "The CockroachDB check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/cockroachdb/pyproject.toml
+++ b/cockroachdb/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/confluent_platform/pyproject.toml
+++ b/confluent_platform/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-confluent-platform"
 description = "The Confluent Platform check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/confluent_platform/pyproject.toml
+++ b/confluent_platform/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/consul/pyproject.toml
+++ b/consul/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-consul"
 description = "The Consul check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/consul/pyproject.toml
+++ b/consul/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/coredns/pyproject.toml
+++ b/coredns/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-coredns"
 description = "The CoreDNS check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/coredns/pyproject.toml
+++ b/coredns/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/couch/pyproject.toml
+++ b/couch/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-couch"
 description = "The CouchDB check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/couch/pyproject.toml
+++ b/couch/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/couchbase/pyproject.toml
+++ b/couchbase/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-couchbase"
 description = "The Couchbase check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/couchbase/pyproject.toml
+++ b/couchbase/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/crio/pyproject.toml
+++ b/crio/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-crio"
 description = "The CRI-O check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/crio/pyproject.toml
+++ b/crio/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-checks-base"
 description = "The Datadog Check Toolkit"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "agent",

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-{project_name}"
 description = "The {integration_name} check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {{text = "BSD-3-Clause"}}
 keywords = [
     "datadog",
     "datadog agent",

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-{project_name}"
 description = "The {integration_name} check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {{text = "BSD-3-Clause"}}
 keywords = [
     "datadog",
     "datadog agent",

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-{project_name}"
 description = "The {integration_name} check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {{text = "BSD-3-Clause"}}
 keywords = [
     "datadog",
     "datadog agent",

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -81,7 +81,7 @@ cli = [
     "twine>=1.11.0",
     "virtualenv>=20.5.0,<20.14.0",
     # TODO: Remove once every check has a pyproject.toml
-    "setuptools>=38.6.0",
+    "setuptools<61",
     "wheel>=0.31.0",
 ]
 

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-checks-dev"
 description = "The Datadog Checks Developer Tool"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_downloader/pyproject.toml
+++ b/datadog_checks_downloader/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-checks-downloader"
 description = "The Datadog Checks Downloader"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/datadog_checks_downloader/pyproject.toml
+++ b/datadog_checks_downloader/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_cluster_agent/pyproject.toml
+++ b/datadog_cluster_agent/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-datadog-cluster-agent"
 description = "The Datadog Cluster Agent check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/datadog_cluster_agent/pyproject.toml
+++ b/datadog_cluster_agent/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/directory/pyproject.toml
+++ b/directory/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-directory"
 description = "The Directory check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/directory/pyproject.toml
+++ b/directory/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/disk/pyproject.toml
+++ b/disk/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-disk"
 description = "The Disk check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/disk/pyproject.toml
+++ b/disk/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/dns_check/pyproject.toml
+++ b/dns_check/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-dns-check"
 description = "The DNS check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/dns_check/pyproject.toml
+++ b/dns_check/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/dotnetclr/pyproject.toml
+++ b/dotnetclr/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-dotnetclr"
 description = "The .NET CLR check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/dotnetclr/pyproject.toml
+++ b/dotnetclr/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/druid/pyproject.toml
+++ b/druid/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-druid"
 description = "The Druid check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/druid/pyproject.toml
+++ b/druid/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ecs_fargate/pyproject.toml
+++ b/ecs_fargate/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ecs_fargate/pyproject.toml
+++ b/ecs_fargate/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-ecs-fargate"
 description = "The Amazon Fargate check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/eks_fargate/pyproject.toml
+++ b/eks_fargate/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-eks-fargate"
 description = "The EKS Fargate check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/eks_fargate/pyproject.toml
+++ b/eks_fargate/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/elastic/pyproject.toml
+++ b/elastic/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-elastic"
 description = "The Elasticsearch check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/elastic/pyproject.toml
+++ b/elastic/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/envoy/pyproject.toml
+++ b/envoy/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-envoy"
 description = "The Envoy check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/envoy/pyproject.toml
+++ b/envoy/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/etcd/pyproject.toml
+++ b/etcd/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-etcd"
 description = "The etcd check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/etcd/pyproject.toml
+++ b/etcd/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/exchange_server/pyproject.toml
+++ b/exchange_server/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-exchange-server"
 description = "The Exchange Server check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/exchange_server/pyproject.toml
+++ b/exchange_server/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/external_dns/pyproject.toml
+++ b/external_dns/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-external-dns"
 description = "The External DNS check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/external_dns/pyproject.toml
+++ b/external_dns/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/flink/pyproject.toml
+++ b/flink/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-flink"
 description = "The flink check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/flink/pyproject.toml
+++ b/flink/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/fluentd/pyproject.toml
+++ b/fluentd/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-fluentd"
 description = "The fluentd check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/fluentd/pyproject.toml
+++ b/fluentd/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/foundationdb/pyproject.toml
+++ b/foundationdb/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-foundationdb"
 description = "The FoundationDB check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/foundationdb/pyproject.toml
+++ b/foundationdb/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/gearmand/pyproject.toml
+++ b/gearmand/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-gearmand"
 description = "The Gearman check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/gearmand/pyproject.toml
+++ b/gearmand/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/gitlab/pyproject.toml
+++ b/gitlab/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-gitlab"
 description = "The Gitlab check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/gitlab/pyproject.toml
+++ b/gitlab/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/gitlab_runner/pyproject.toml
+++ b/gitlab_runner/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-gitlab-runner"
 description = "The Gitlab Runner check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/gitlab_runner/pyproject.toml
+++ b/gitlab_runner/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/glusterfs/pyproject.toml
+++ b/glusterfs/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-glusterfs"
 description = "The GlusterFS check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/glusterfs/pyproject.toml
+++ b/glusterfs/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/go_expvar/pyproject.toml
+++ b/go_expvar/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-go-expvar"
 description = "The Go-Expvar check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/go_expvar/pyproject.toml
+++ b/go_expvar/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/gunicorn/pyproject.toml
+++ b/gunicorn/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-gunicorn"
 description = "The Gunicorn check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/gunicorn/pyproject.toml
+++ b/gunicorn/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/haproxy/pyproject.toml
+++ b/haproxy/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-haproxy"
 description = "The HAProxy check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/haproxy/pyproject.toml
+++ b/haproxy/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/harbor/pyproject.toml
+++ b/harbor/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-harbor"
 description = "The Harbor check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/harbor/pyproject.toml
+++ b/harbor/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hazelcast/pyproject.toml
+++ b/hazelcast/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-hazelcast"
 description = "The Hazelcast check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/hazelcast/pyproject.toml
+++ b/hazelcast/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hdfs_datanode/pyproject.toml
+++ b/hdfs_datanode/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-hdfs-datanode"
 description = "The HDFS Datanode check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/hdfs_datanode/pyproject.toml
+++ b/hdfs_datanode/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hdfs_namenode/pyproject.toml
+++ b/hdfs_namenode/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-hdfs-namenode"
 description = "The HDFS Namenode check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/hdfs_namenode/pyproject.toml
+++ b/hdfs_namenode/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hive/pyproject.toml
+++ b/hive/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hive/pyproject.toml
+++ b/hive/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-hive"
 description = "The Hive check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/hivemq/pyproject.toml
+++ b/hivemq/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-hivemq"
 description = "The HiveMQ check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/hivemq/pyproject.toml
+++ b/hivemq/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-http-check"
 description = "The HTTP check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hudi/pyproject.toml
+++ b/hudi/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-hudi"
 description = "The Hudi check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/hudi/pyproject.toml
+++ b/hudi/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hyperv/pyproject.toml
+++ b/hyperv/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-hyperv"
 description = "The HyperV check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/hyperv/pyproject.toml
+++ b/hyperv/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ibm_ace/pyproject.toml
+++ b/ibm_ace/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 name = "datadog-ibm-ace"
 description = "The IBM ACE check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 requires-python = ">=3.8"
 keywords = [
     "datadog",

--- a/ibm_db2/pyproject.toml
+++ b/ibm_db2/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-ibm-db2"
 description = "The IBM Db2 check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/ibm_db2/pyproject.toml
+++ b/ibm_db2/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ibm_i/pyproject.toml
+++ b/ibm_i/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-ibm-i"
 description = "The IBM i check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 requires-python = ">=3.8"
 keywords = [
     "datadog",

--- a/ibm_i/pyproject.toml
+++ b/ibm_i/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ibm_mq/pyproject.toml
+++ b/ibm_mq/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-ibm-mq"
 description = "The IBM MQ check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/ibm_mq/pyproject.toml
+++ b/ibm_mq/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ibm_was/pyproject.toml
+++ b/ibm_was/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-ibm-was"
 description = "The IBM WAS check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/ibm_was/pyproject.toml
+++ b/ibm_was/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ignite/pyproject.toml
+++ b/ignite/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ignite/pyproject.toml
+++ b/ignite/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-ignite"
 description = "The Ignite check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/iis/pyproject.toml
+++ b/iis/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-iis"
 description = "The IIS check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/iis/pyproject.toml
+++ b/iis/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/istio/pyproject.toml
+++ b/istio/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-istio"
 description = "The Istio check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/istio/pyproject.toml
+++ b/istio/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/jboss_wildfly/pyproject.toml
+++ b/jboss_wildfly/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-jboss-wildfly"
 description = "The JBoss/WildFly check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/jboss_wildfly/pyproject.toml
+++ b/jboss_wildfly/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/journald/pyproject.toml
+++ b/journald/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-journald"
 description = "The journald check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/journald/pyproject.toml
+++ b/journald/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kafka/pyproject.toml
+++ b/kafka/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-kafka"
 description = "The Kafka check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/kafka/pyproject.toml
+++ b/kafka/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kafka_consumer/pyproject.toml
+++ b/kafka_consumer/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-kafka-consumer"
 description = "The Kafka Consumer check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/kafka_consumer/pyproject.toml
+++ b/kafka_consumer/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kong/pyproject.toml
+++ b/kong/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-kong"
 description = "The Kong check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/kong/pyproject.toml
+++ b/kong/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_apiserver_metrics/pyproject.toml
+++ b/kube_apiserver_metrics/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_apiserver_metrics/pyproject.toml
+++ b/kube_apiserver_metrics/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-kube-apiserver-metrics"
 description = "The Kubernetes API server metrics check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/kube_controller_manager/pyproject.toml
+++ b/kube_controller_manager/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-kube-controller-manager"
 description = "The Kubernetes Controller Manager check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/kube_controller_manager/pyproject.toml
+++ b/kube_controller_manager/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_dns/pyproject.toml
+++ b/kube_dns/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-kube-dns"
 description = "The Kube DNS check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/kube_dns/pyproject.toml
+++ b/kube_dns/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_metrics_server/pyproject.toml
+++ b/kube_metrics_server/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_metrics_server/pyproject.toml
+++ b/kube_metrics_server/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-kube-metrics-server"
 description = "The Kube metrics server check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/kube_proxy/pyproject.toml
+++ b/kube_proxy/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-kube-proxy"
 description = "The Kube Proxy check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/kube_proxy/pyproject.toml
+++ b/kube_proxy/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_scheduler/pyproject.toml
+++ b/kube_scheduler/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-kube-scheduler"
 description = "The Kube_scheduler check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/kube_scheduler/pyproject.toml
+++ b/kube_scheduler/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kubelet/pyproject.toml
+++ b/kubelet/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kubelet/pyproject.toml
+++ b/kubelet/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-kubelet"
 description = "The Kubelet check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/kubernetes_state/pyproject.toml
+++ b/kubernetes_state/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-kubernetes-state"
 description = "The Kubernetes State check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/kubernetes_state/pyproject.toml
+++ b/kubernetes_state/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kyototycoon/pyproject.toml
+++ b/kyototycoon/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-kyototycoon"
 description = "The Kyoto Tycoon check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/kyototycoon/pyproject.toml
+++ b/kyototycoon/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/lighttpd/pyproject.toml
+++ b/lighttpd/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-lighttpd"
 description = "The Lighttpd check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/lighttpd/pyproject.toml
+++ b/lighttpd/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/linkerd/pyproject.toml
+++ b/linkerd/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-linkerd"
 description = "The Linkerd check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/linkerd/pyproject.toml
+++ b/linkerd/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/linux_proc_extras/pyproject.toml
+++ b/linux_proc_extras/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-linux-proc-extras"
 description = "The Linux proc extras check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/linux_proc_extras/pyproject.toml
+++ b/linux_proc_extras/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mapr/pyproject.toml
+++ b/mapr/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-mapr"
 description = "The MapR check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/mapr/pyproject.toml
+++ b/mapr/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mapreduce/pyproject.toml
+++ b/mapreduce/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-mapreduce"
 description = "The MapReduce check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/mapreduce/pyproject.toml
+++ b/mapreduce/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/marathon/pyproject.toml
+++ b/marathon/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-marathon"
 description = "The Marathon check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/marathon/pyproject.toml
+++ b/marathon/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/marklogic/pyproject.toml
+++ b/marklogic/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-marklogic"
 description = "The MarkLogic check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/marklogic/pyproject.toml
+++ b/marklogic/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mcache/pyproject.toml
+++ b/mcache/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-mcache"
 description = "The Memcached check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/mcache/pyproject.toml
+++ b/mcache/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mesos_master/pyproject.toml
+++ b/mesos_master/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-mesos-master"
 description = "The Mesos Master check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/mesos_master/pyproject.toml
+++ b/mesos_master/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mesos_slave/pyproject.toml
+++ b/mesos_slave/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-mesos-slave"
 description = "The Mesos check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/mesos_slave/pyproject.toml
+++ b/mesos_slave/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-mongo"
 description = "The MongoDB check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-mysql"
 description = "The MySQL check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/nagios/pyproject.toml
+++ b/nagios/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-nagios"
 description = "The Nagios check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/nagios/pyproject.toml
+++ b/nagios/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/network/pyproject.toml
+++ b/network/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-network"
 description = "The Network check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/network/pyproject.toml
+++ b/network/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/nfsstat/pyproject.toml
+++ b/nfsstat/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-nfsstat"
 description = "The Nfsstat check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/nfsstat/pyproject.toml
+++ b/nfsstat/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/nginx/pyproject.toml
+++ b/nginx/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-nginx"
 description = "The Nginx check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/nginx/pyproject.toml
+++ b/nginx/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/nginx_ingress_controller/pyproject.toml
+++ b/nginx_ingress_controller/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-nginx-ingress-controller"
 description = "The nginx-ingress-controller check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/nginx_ingress_controller/pyproject.toml
+++ b/nginx_ingress_controller/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/openldap/pyproject.toml
+++ b/openldap/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-openldap"
 description = "The OpenLDAP check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/openldap/pyproject.toml
+++ b/openldap/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/openmetrics/pyproject.toml
+++ b/openmetrics/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-openmetrics"
 description = "The OpenMetrics check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/openmetrics/pyproject.toml
+++ b/openmetrics/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/openstack/pyproject.toml
+++ b/openstack/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-openstack"
 description = "The OpenStack check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/openstack/pyproject.toml
+++ b/openstack/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/openstack_controller/pyproject.toml
+++ b/openstack_controller/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-openstack-controller"
 description = "The Openstack_controller check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/openstack_controller/pyproject.toml
+++ b/openstack_controller/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/oracle/pyproject.toml
+++ b/oracle/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-oracle"
 description = "The Oracle Database check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/oracle/pyproject.toml
+++ b/oracle/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/pan_firewall/pyproject.toml
+++ b/pan_firewall/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-pan-firewall"
 description = "The Palo Alto Networks Firewall check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/pan_firewall/pyproject.toml
+++ b/pan_firewall/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/pdh_check/pyproject.toml
+++ b/pdh_check/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-pdh-check"
 description = "The PDH check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/pdh_check/pyproject.toml
+++ b/pdh_check/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/pgbouncer/pyproject.toml
+++ b/pgbouncer/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-pgbouncer"
 description = "The PGBouncer check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/pgbouncer/pyproject.toml
+++ b/pgbouncer/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/php_fpm/pyproject.toml
+++ b/php_fpm/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-php-fpm"
 description = "The PHP-FPM check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/php_fpm/pyproject.toml
+++ b/php_fpm/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/postfix/pyproject.toml
+++ b/postfix/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-postfix"
 description = "The Postfix check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/postfix/pyproject.toml
+++ b/postfix/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-postgres"
 description = "The Postgres check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/powerdns_recursor/pyproject.toml
+++ b/powerdns_recursor/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-powerdns-recursor"
 description = "The PowerDNS Recursor check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/powerdns_recursor/pyproject.toml
+++ b/powerdns_recursor/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/presto/pyproject.toml
+++ b/presto/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-presto"
 description = "The Presto check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/presto/pyproject.toml
+++ b/presto/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/process/pyproject.toml
+++ b/process/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-process"
 description = "The Process check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/process/pyproject.toml
+++ b/process/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/prometheus/pyproject.toml
+++ b/prometheus/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-prometheus"
 description = "The Prometheus check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/prometheus/pyproject.toml
+++ b/prometheus/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/proxysql/pyproject.toml
+++ b/proxysql/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-proxysql"
 description = "The ProxySQL check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/proxysql/pyproject.toml
+++ b/proxysql/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/pulsar/pyproject.toml
+++ b/pulsar/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 name = "datadog-pulsar"
 description = "The pulsar check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 requires-python = ">=3.8"
 keywords = [
     "datadog",

--- a/rabbitmq/pyproject.toml
+++ b/rabbitmq/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-rabbitmq"
 description = "The RabbitMQ check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/rabbitmq/pyproject.toml
+++ b/rabbitmq/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/redisdb/pyproject.toml
+++ b/redisdb/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-redisdb"
 description = "The Redis check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/redisdb/pyproject.toml
+++ b/redisdb/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/rethinkdb/pyproject.toml
+++ b/rethinkdb/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/rethinkdb/pyproject.toml
+++ b/rethinkdb/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-rethinkdb"
 description = "The RethinkDB check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/riak/pyproject.toml
+++ b/riak/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-riak"
 description = "The Riak check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/riak/pyproject.toml
+++ b/riak/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/riakcs/pyproject.toml
+++ b/riakcs/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-riakcs"
 description = "The RiakCS check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/riakcs/pyproject.toml
+++ b/riakcs/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/sap_hana/pyproject.toml
+++ b/sap_hana/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-sap-hana"
 description = "The SAP HANA check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/sap_hana/pyproject.toml
+++ b/sap_hana/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/scylla/pyproject.toml
+++ b/scylla/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-scylla"
 description = "The Scylla check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/scylla/pyproject.toml
+++ b/scylla/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/sidekiq/pyproject.toml
+++ b/sidekiq/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-sidekiq"
 description = "The Sidekiq check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/sidekiq/pyproject.toml
+++ b/sidekiq/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/silk/pyproject.toml
+++ b/silk/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-silk"
 description = "The Silk check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/silk/pyproject.toml
+++ b/silk/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/singlestore/pyproject.toml
+++ b/singlestore/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-singlestore"
 description = "The SingleStore check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/singlestore/pyproject.toml
+++ b/singlestore/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/snmp/pyproject.toml
+++ b/snmp/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-snmp"
 description = "The SNMP check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/snmp/pyproject.toml
+++ b/snmp/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/snowflake/pyproject.toml
+++ b/snowflake/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 name = "datadog-snowflake"
 description = "The Snowflake check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 requires-python = ">=3.8"
 keywords = [
     "datadog",

--- a/solr/pyproject.toml
+++ b/solr/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-solr"
 description = "The Solr check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/solr/pyproject.toml
+++ b/solr/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/sonarqube/pyproject.toml
+++ b/sonarqube/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-sonarqube"
 description = "The SonarQube check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/sonarqube/pyproject.toml
+++ b/sonarqube/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/spark/pyproject.toml
+++ b/spark/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-spark"
 description = "The Spark check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/spark/pyproject.toml
+++ b/spark/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-sqlserver"
 description = "The SQL Server check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/squid/pyproject.toml
+++ b/squid/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-squid"
 description = "The Squid check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/squid/pyproject.toml
+++ b/squid/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ssh_check/pyproject.toml
+++ b/ssh_check/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-ssh-check"
 description = "The SSH check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/ssh_check/pyproject.toml
+++ b/ssh_check/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/statsd/pyproject.toml
+++ b/statsd/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-statsd"
 description = "The StatsD check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/statsd/pyproject.toml
+++ b/statsd/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/supervisord/pyproject.toml
+++ b/supervisord/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-supervisord"
 description = "The Supervisord check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/supervisord/pyproject.toml
+++ b/supervisord/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/system_core/pyproject.toml
+++ b/system_core/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-system-core"
 description = "The System Core check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/system_core/pyproject.toml
+++ b/system_core/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/system_swap/pyproject.toml
+++ b/system_swap/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-system-swap"
 description = "The System Swap check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/system_swap/pyproject.toml
+++ b/system_swap/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/tcp_check/pyproject.toml
+++ b/tcp_check/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-tcp-check"
 description = "The TCP check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/tcp_check/pyproject.toml
+++ b/tcp_check/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/teamcity/pyproject.toml
+++ b/teamcity/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-teamcity"
 description = "The Teamcity check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/teamcity/pyproject.toml
+++ b/teamcity/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/tenable/pyproject.toml
+++ b/tenable/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-tenable"
 description = "The Tenable check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/tenable/pyproject.toml
+++ b/tenable/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-tls"
 description = "The TLS check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/tokumx/pyproject.toml
+++ b/tokumx/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-tokumx"
 description = "The TokuMX check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 requires-python = "==2.7.*"
 keywords = [
     "datadog",

--- a/tokumx/pyproject.toml
+++ b/tokumx/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/tomcat/pyproject.toml
+++ b/tomcat/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-tomcat"
 description = "The Tomcat check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/tomcat/pyproject.toml
+++ b/tomcat/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/traffic_server/pyproject.toml
+++ b/traffic_server/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 name = "datadog-traffic_server"
 description = "The Traffic Server check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 requires-python = ">=3.8"
 keywords = [
     "datadog",

--- a/twemproxy/pyproject.toml
+++ b/twemproxy/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-twemproxy"
 description = "The Twemproxy check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/twemproxy/pyproject.toml
+++ b/twemproxy/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/twistlock/pyproject.toml
+++ b/twistlock/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-twistlock"
 description = "The Twistlock check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/twistlock/pyproject.toml
+++ b/twistlock/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/varnish/pyproject.toml
+++ b/varnish/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-varnish"
 description = "The Varnish check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/varnish/pyproject.toml
+++ b/varnish/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/vault/pyproject.toml
+++ b/vault/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-vault"
 description = "The Vault check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/vault/pyproject.toml
+++ b/vault/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/vertica/pyproject.toml
+++ b/vertica/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/vertica/pyproject.toml
+++ b/vertica/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-vertica"
 description = "The Vertica check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/voltdb/pyproject.toml
+++ b/voltdb/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-voltdb"
 description = "The VoltDB check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/voltdb/pyproject.toml
+++ b/voltdb/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/vsphere/pyproject.toml
+++ b/vsphere/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-vsphere"
 description = "The vSphere check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/vsphere/pyproject.toml
+++ b/vsphere/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/weblogic/pyproject.toml
+++ b/weblogic/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-weblogic"
 description = "The WebLogic check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/weblogic/pyproject.toml
+++ b/weblogic/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/win32_event_log/pyproject.toml
+++ b/win32_event_log/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-win32-event-log"
 description = "The Win32 check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/win32_event_log/pyproject.toml
+++ b/win32_event_log/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/windows_performance_counters/pyproject.toml
+++ b/windows_performance_counters/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/windows_performance_counters/pyproject.toml
+++ b/windows_performance_counters/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-windows-performance-counters"
 description = "The Windows performance counters check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 requires-python = ">=3.8"
 keywords = [
     "datadog",

--- a/windows_service/pyproject.toml
+++ b/windows_service/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-windows-service"
 description = "The Windows Service check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/windows_service/pyproject.toml
+++ b/windows_service/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/wmi_check/pyproject.toml
+++ b/wmi_check/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-wmi-check"
 description = "The WMI check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/wmi_check/pyproject.toml
+++ b/wmi_check/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/yarn/pyproject.toml
+++ b/yarn/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/yarn/pyproject.toml
+++ b/yarn/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-yarn"
 description = "The Yarn check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/zk/pyproject.toml
+++ b/zk/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-zk"
 description = "The ZooKeeper check"
 readme = "README.md"
-license = "BSD-3-Clause"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",

--- a/zk/pyproject.toml
+++ b/zk/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR pins the `setuptools` version in every check's `pyproject.toml`. 

### Motivation
<!-- What inspired you to submit this pull request? -->
CI is failing because the license needs to be `license = {text = "BSD-3-Clause"}` instead of `license = "BSD-3-Clause"`, although this is preventable on older versions of `setuptools`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
