### PR TITLE
Add newer metric to check

### DIFF
--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -13,6 +13,7 @@
   "manifest_version": "1.0.0",
   "metric_prefix": "haproxy.",
   "metric_to_check": [
+    "haproxy.frontend.bytes.in.count",
     "haproxy.frontend.bytes.in_rate",
     "haproxy.frontend.bytes.in.total"
   ],


### PR DESCRIPTION
in_rate is marked as Legacy and  in_total is only available if using V1 of the check so the tile does not detect the integration when running v2