### PR TITLE
Don't pin urllib3

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -91,7 +91,6 @@ tuf,PyPI,Apache-2.0,https://www.updateframework.com
 tuf,PyPI,MIT,https://www.updateframework.com
 typing,PyPI,PSF,"Guido van Rossum, Jukka Lehtosalo, Łukasz Langa, Ivan Levkivskyi"
 uptime,PyPI,BSD-2-Clause,Koen Crolla
-urllib3,PyPI,MIT,Andrey Petrov
 vertica-python,PyPI,Apache-2.0,"Justin Berka, Alex Kim, Siting Ren"
 win-inet-pton,PyPI,Unlicense,Ryan Vennell
 wrapt,PyPI,BSD-3-Clause,Graham Dumpleton

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -105,7 +105,6 @@ tuf==0.17.0; python_version < '3.0'
 tuf==0.19.0; python_version > '3.0'
 typing==3.10.0.0; python_version < '3.0'
 uptime==3.0.1
-urllib3==1.26.9
 vertica-python==1.0.4
 win-inet-pton==1.1.0; sys_platform == 'win32' and python_version < '3.0'
 wrapt==1.14.0

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -40,7 +40,6 @@ deps = [
     "cryptography==3.3.2; python_version < '3.0'",
     "cryptography==3.4.8; python_version > '3.0'",
     "requests-ntlm==1.1.0",
-    "urllib3==1.26.9",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
Unpins urllib3

### Motivation
The code that originally sparked the addition of it is now deleted: https://github.com/DataDog/integrations-core/pull/11926 https://github.com/DataDog/integrations-core/pull/11069

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
