### PR TITLE
Don't use deprecated param in tests

### DIFF
--- a/snowflake/tests/common.py
+++ b/snowflake/tests/common.py
@@ -9,7 +9,7 @@ HERE = get_here()
 
 CHECK_NAME = 'snowflake'
 INSTANCE = {
-    'user': 'testuser',
+    'username': 'testuser',
     'password': 'pass',
     'account': 'test_acct.us-central1.gcp',
     'database': 'SNOWFLAKE',
@@ -19,7 +19,7 @@ INSTANCE = {
     'login_timeout': 3,
 }
 OAUTH_INSTANCE = {
-    'user': 'testuser',
+    'username': 'testuser',
     'account': 'test_acct.us-central1.gcp',
     'database': 'SNOWFLAKE',
     'schema': 'ACCOUNT_USAGE',

--- a/snowflake/tests/test_snowflake.py
+++ b/snowflake/tests/test_snowflake.py
@@ -161,7 +161,7 @@ def test_warehouse_load(dd_run_check, aggregator, instance):
 
 def test_token_path(dd_run_check, aggregator):
     instance = {
-        'user': 'testuser',
+        'username': 'testuser',
         'account': 'account',
         'role': 'ACCOUNTADMIN',
         'authenticator': 'oauth',

--- a/snowflake/tests/test_unit.py
+++ b/snowflake/tests/test_unit.py
@@ -50,7 +50,7 @@ def test_invalid_oauth(oauth_instance):
 
     # Test oauth without token
     no_token_config = copy.deepcopy(INVALID_CONFIG)
-    no_token_config['user'] = "test_user"
+    no_token_config['username'] = "test_user"
     with pytest.raises(Exception, match='If using OAuth, you must specify a `token` or a `token_path`'):
         SnowflakeCheck(CHECK_NAME, {}, [no_token_config])
 
@@ -315,7 +315,7 @@ def test_emit_non_generic_tags_when_disabled(instance):
 def test_aggregate_last_24_hours_queries(aggregate_last_24_hours, expected_query):
     inst = {
         'metric_groups': ['snowflake.replication'],
-        'user': 'user',
+        'username': 'user',
         'password': 'password',
         'account': 'account',
         'role': 'role',


### PR DESCRIPTION
### What does this PR do?
Don't use the deprecated parameter `user` in tests

### Motivation
clean up, stop logging a deprecation warning in tests

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
