### PR TITLE
Add the ability to exclude endpoint tag

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -175,6 +175,7 @@ class OpenMetricsScraper:
                     )
 
         custom_tags = config.get('tags', [])
+        custom_tags.append(f'endpoint:{self.endpoint}')
         if not isinstance(custom_tags, list):
             raise ConfigurationError('Setting `tags` must be an array')
 
@@ -190,12 +191,10 @@ class OpenMetricsScraper:
         ignore_tags = config.get('ignore_tags', [])
         if ignore_tags:
             ignored_tags_re = re.compile('|'.join(set(ignore_tags)))
-            custom_tags = [tag for tag in custom_tags if not ignored_tags_re.search(tag)]
+            custom_tags = {tag for tag in custom_tags if not ignored_tags_re.search(tag)}
 
         # These will be applied only to service checks
-        self.static_tags = [f'endpoint:{self.endpoint}']
-        self.static_tags.extend(custom_tags)
-        self.static_tags = tuple(self.static_tags)
+        self.static_tags = tuple(custom_tags)
 
         # These will be applied to everything except service checks
         self.tags = self.static_tags

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -4,9 +4,10 @@
 import fnmatch
 import inspect
 import re
-from copy import deepcopy
+from copy import deepcopy, copy
 from itertools import chain
 from math import isinf, isnan
+from typing import List
 
 from prometheus_client.openmetrics.parser import text_fd_to_metric_families as parse_metric_families_strict
 from prometheus_client.parser import text_fd_to_metric_families as parse_metric_families
@@ -174,8 +175,7 @@ class OpenMetricsScraper:
                         f'Label `{label}` of setting `exclude_metrics_by_labels` must be an array or set to `true`'
                     )
 
-        custom_tags = config.get('tags', [])
-        custom_tags.append(f'endpoint:{self.endpoint}')
+        custom_tags = config.get('tags', [])  # type: List[str]
         if not isinstance(custom_tags, list):
             raise ConfigurationError('Setting `tags` must be an array')
 
@@ -191,11 +191,14 @@ class OpenMetricsScraper:
         ignore_tags = config.get('ignore_tags', [])
         if ignore_tags:
             ignored_tags_re = re.compile('|'.join(set(ignore_tags)))
-            custom_tags = {tag for tag in custom_tags if not ignored_tags_re.search(tag)}
+            custom_tags = [tag for tag in custom_tags if not ignored_tags_re.search(tag)]
+
+        self.static_tags = copy(custom_tags)
+        if is_affirmative(self.config.get('tag_by_endpoint', True)):
+            self.static_tags.append(f'endpoint:{self.endpoint}')
 
         # These will be applied only to service checks
-        self.static_tags = tuple(custom_tags)
-
+        self.static_tags = tuple(self.static_tags)
         # These will be applied to everything except service checks
         self.tags = self.static_tags
 

--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -4,7 +4,7 @@
 import fnmatch
 import inspect
 import re
-from copy import deepcopy, copy
+from copy import copy, deepcopy
 from itertools import chain
 from math import isinf, isnan
 from typing import List

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_interface.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_interface.py
@@ -36,7 +36,7 @@ def test_default_config(aggregator, dd_run_check, mock_http_response):
     aggregator.assert_all_metrics_covered()
 
 
-def test_ignore_tags_excludes_default_tags(aggregator, dd_run_check, mock_http_response):
+def test_tag_by_endpoint(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
         """
         # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
@@ -44,7 +44,7 @@ def test_ignore_tags_excludes_default_tags(aggregator, dd_run_check, mock_http_r
         go_memstats_alloc_bytes{foo="baz"} 6.396288e+06
         """
     )
-    check = get_check({'metrics': ['.+'], 'ignore_tags': ['endpoint']})
+    check = get_check({'metrics': ['.+'], 'tag_by_endpoint': False})
     dd_run_check(check)
 
     aggregator.assert_metric('test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['foo:baz'])

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_interface.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_interface.py
@@ -48,7 +48,7 @@ def test_ignore_tags_excludes_default_tags(aggregator, dd_run_check, mock_http_r
     dd_run_check(check)
 
     aggregator.assert_metric(
-        'test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['endpoint:test', 'foo:baz']
+        'test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['foo:baz']
     )
 
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_interface.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_interface.py
@@ -36,6 +36,22 @@ def test_default_config(aggregator, dd_run_check, mock_http_response):
     aggregator.assert_all_metrics_covered()
 
 
+def test_ignore_tags_excludes_default_tags(aggregator, dd_run_check, mock_http_response):
+    mock_http_response(
+        """
+        # HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+        # TYPE go_memstats_alloc_bytes gauge
+        go_memstats_alloc_bytes{foo="baz"} 6.396288e+06
+        """
+    )
+    check = get_check({'metrics': ['.+'], 'ignore_tags': ['endpoint']})
+    dd_run_check(check)
+
+    aggregator.assert_metric(
+        'test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['endpoint:test', 'foo:baz']
+    )
+
+
 def test_service_check_dynamic_tags(aggregator, dd_run_check, mock_http_response):
     mock_http_response(
         """

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_interface.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_interface.py
@@ -47,9 +47,7 @@ def test_ignore_tags_excludes_default_tags(aggregator, dd_run_check, mock_http_r
     check = get_check({'metrics': ['.+'], 'ignore_tags': ['endpoint']})
     dd_run_check(check)
 
-    aggregator.assert_metric(
-        'test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['foo:baz']
-    )
+    aggregator.assert_metric('test.go_memstats_alloc_bytes', 6396288, metric_type=aggregator.GAUGE, tags=['foo:baz'])
 
 
 def test_service_check_dynamic_tags(aggregator, dd_run_check, mock_http_response):

--- a/datadog_checks_base/tests/models/test_interface.py
+++ b/datadog_checks_base/tests/models/test_interface.py
@@ -44,6 +44,7 @@ def test_defaults(dd_run_check):
 
     assert not check.warnings
 
+
 def test_errors_shared_config(dd_run_check):
     init_config = {'timeout': 'foo'}
     instance = {}

--- a/datadog_checks_base/tests/models/test_interface.py
+++ b/datadog_checks_base/tests/models/test_interface.py
@@ -44,7 +44,6 @@ def test_defaults(dd_run_check):
 
     assert not check.warnings
 
-
 def test_errors_shared_config(dd_run_check):
     init_config = {'timeout': 'foo'}
     instance = {}


### PR DESCRIPTION
We should have the ability to ignore the endpoint tag. This should be with ignore_tags and not exclude_labels (see https://github.com/DataDog/integrations-core/pull/11955)