### PR TITLE
Update cilium README

### DIFF
--- a/cilium/README.md
+++ b/cilium/README.md
@@ -58,7 +58,7 @@ To configure this check for an Agent running on a host:
     ```yaml  
         instances:
         
-            ## @param use_openmetrics - boolean - optional - default: true
+            ## @param use_openmetrics - boolean - optional - default: false
             ## Use the latest OpenMetrics V2 implementation for more features and better performance.
             ##
             ## Note: To see the configuration options for the legacy OpenMetrics implementation (Agent 7.33 or older),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR fixes a README error: `default: true` should be `default: false` for `use_openmetrics` to match actual implementation: https://github.com/DataDog/integrations-core/blob/master/cilium/assets/configuration/spec.yaml#L19-L20
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
