### PR TITLE
Specify public AWS ECR registry for DataDog agent in ECS Fargate example

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -86,7 +86,7 @@ Resources:
       Memory: 1GB
       ContainerDefinitions:
         - Name: datadog-agent
-          Image: 'gcr.io/datadoghq/agent:latest'
+          Image: 'public.ecr.aws/datadog/agent:latest'
           Cpu: 100
           Memory: 256MB
 ```


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Currently the docs specify Google Cloud Registry for the DataDog container image. This change switches that to the public Amazon ECR registry since the doc example is an ECS Fargate example.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
