### PR TITLE
Oracle to not fail to create directory

### DIFF
--- a/oracle/tests/scripts/install_instant_client.sh
+++ b/oracle/tests/scripts/install_instant_client.sh
@@ -2,7 +2,7 @@
 
 INSTANT_CLIENT_URL="https://ddintegrations.blob.core.windows.net/oracle/instantclient-basiclite-linux.x64-19.3.0.0.0dbru.zip"
 
-mkdir /opt/oracle
+mkdir -p /opt/oracle
 apt-get update
 apt-get install unzip
 


### PR DESCRIPTION
In https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=98800&view=logs&j=c3a06451-088b-587c-b2b9-012b146267bb&t=8b8da6bd-8c7d-5c16-284a-eb82cfe91ae0&l=147

Environment set up failed with:

```
Setting up unzip (6.0-26ubuntu1) ...
Archive:  /opt/oracle/instantclient.zip
  inflating: /opt/oracle/instantclient_19_3/adrci  
  ...
mkdir: cannot create directory '/opt/oracle': File exists
debconf: delaying package configuration, since apt-utils is not installed
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
 11 35.0M   11 4112k    0     0  4412k      0  0:00:08 --:--:--  0:00:08 4407k
100 35.0M  100 35.0M    0     0  19.8M      0  0:00:01  0:00:01 --:--:-- 19.8M

An error occurred.
Stopping the environment...
Stopping the Agent...
##[error]Bash exited with code '1'.

```
What I don't understand is why mkdir fails in the end if that instruction is before installing unzip and unzipping instantclient.zip