### PR TITLE
Fix flakey rethinkdb

### DIFF
--- a/rethinkdb/tests/test_e2e.py
+++ b/rethinkdb/tests/test_e2e.py
@@ -8,7 +8,7 @@ import pytest
 from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.rethinkdb import RethinkDBCheck
 
-from .common import E2E_METRICS
+from .common import CURRENT_ISSUES_METRICS, E2E_METRICS
 
 
 @pytest.mark.e2e
@@ -18,6 +18,8 @@ def test_check_ok(dd_agent_check):
 
     for metric, _ in E2E_METRICS:
         aggregator.assert_metric(metric)
+    for metric, _ in CURRENT_ISSUES_METRICS:
+        aggregator.assert_metric(metric, at_least=0)
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_service_check('rethinkdb.can_connect', RethinkDBCheck.OK)


### PR DESCRIPTION
E2E failed on https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=98800&view=logs&j=4f5d2ea1-5083-5d5a-df50-b08bc24acbee&t=88102fdf-7a3a-503e-8dd7-742daee12a79&l=185

With:

```
=================================== FAILURES ===================================
________________________________ test_check_ok _________________________________
tests/test_e2e.py:22: in test_check_ok
    aggregator.assert_all_metrics_covered()
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:419: in assert_all_metrics_covered
    assert condition, msg
E   AssertionError: Some metrics are collected but not asserted:
E     Asserted Metrics:
E     	- rethinkdb.config.databases
E     	...
E     Found metrics that are not asserted:
E     	- rethinkdb.current_issues.critical_issues
E     	- rethinkdb.current_issues.issues
E   assert False
```