### PR TITLE
Fortinet Fortigate: Add metrics for VPN Tunnels

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/_fortinet-fortigate-vpn-tunnel.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/_fortinet-fortigate-vpn-tunnel.yaml
@@ -1,0 +1,17 @@
+metrics:
+  - MIB: FORTINET-FORTIGATE-MIB
+    table:
+      OID: 1.3.6.1.4.1.12356.101.12.2.2
+      name: fgVpnTunTable
+    symbols:
+      - OID: 1.3.6.1.4.1.12356.101.12.2.2.1.18
+        name: fgVpnTunEntInOctets
+      - OID: 1.3.6.1.4.1.12356.101.12.2.2.1.19
+        name: fgVpnTunEntOutOctets
+      - OID: 1.3.6.1.4.1.12356.101.12.2.2.1.20
+        name: fgVpnTunEntStatus
+    metric_tags:
+      - tag: vpn_tunnel
+        column:
+          OID: 1.3.6.1.4.1.12356.101.12.2.2.1.2
+          name: fgVpnTunEntPhase1Name

--- a/snmp/datadog_checks/snmp/data/profiles/fortinet-fortigate.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/fortinet-fortigate.yaml
@@ -6,6 +6,7 @@ extends:
   - _base.yaml
   - _generic-if.yaml
   - _fortinet-fortigate-cpu-memory.yaml
+  - _fortinet-fortigate-vpn-tunnel.yaml
 
 device:
   vendor: "fortinet"


### PR DESCRIPTION
### What does this PR do?
This PR adds metrics for VPN Tunnels in the Fortinet Fortigate-integration.

### Motivation
We developed this feature as we needed to monitor the VPN Tunnel state.

### Additional Notes
n/a

### Review checklist (to be filled by reviewers)

- [] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [] PR must have `changelog/` and `integration/` labels attached
