### PR TITLE
Bump e2e docker image version

### DIFF
--- a/ibm_was/tests/docker/scripts/9.0.5.5/init.jython
+++ b/ibm_was/tests/docker/scripts/9.0.5.5/init.jython
@@ -1,4 +1,0 @@
-AdminApp.install('/opt/IBM/WebSphere/AppServer/installableApps/PerfServletApp.ear', '[-node DefaultNode01 -cell DefaultCell01 -server server1]')
-AdminConfig.save()
-
-AdminControl.invoke('WebSphere:name=ApplicationManager,process=server1,platform=proxy,node=DefaultNode01,version=9.0.5.5,type=ApplicationManager,mbeanIdentifier=ApplicationManager,cell=DefaultCell01,spec=1.0', 'startApplication', '[perfServletApp]')

--- a/ibm_was/tests/docker/scripts/9.0.5.9/init.jython
+++ b/ibm_was/tests/docker/scripts/9.0.5.9/init.jython
@@ -1,0 +1,4 @@
+AdminApp.install('/opt/IBM/WebSphere/AppServer/installableApps/PerfServletApp.ear', '[-node DefaultNode01 -cell DefaultCell01 -server server1]')
+AdminConfig.save()
+
+AdminControl.invoke('WebSphere:name=ApplicationManager,process=server1,platform=proxy,node=DefaultNode01,version=9.0.5.9,type=ApplicationManager,mbeanIdentifier=ApplicationManager,cell=DefaultCell01,spec=1.0', 'startApplication', '[perfServletApp]')

--- a/ibm_was/tox.ini
+++ b/ibm_was/tox.ini
@@ -29,4 +29,4 @@ setenv =
     ## Docker image for v8 not available anymore.
     ## Waiting upstream update, see issue: https://github.com/WASdev/ci.docker.websphere-traditional/issues/198
     # 8.5: IBM_WAS_VERSION=8.5.5.14-profile
-    9: IBM_WAS_VERSION=9.0.5.5
+    9: IBM_WAS_VERSION=9.0.5.9


### PR DESCRIPTION
### What does this PR do?
Fix broken ibm_was e2e by bumping the ibm_was docker image version. 

### Motivation
Broken CI

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
