### PR TITLE
Add test asserting _total suffix counters

### DIFF
--- a/openmetrics/tests/conftest.py
+++ b/openmetrics/tests/conftest.py
@@ -31,6 +31,8 @@ def poll_mock(mock_http_response):
     g2.labels(matched_label="foobar", node="host2", timestamp="123").set(12.2)
     c1 = Counter('counter1', 'hits', ['node'], registry=registry)
     c1.labels(node="host2").inc(42)
+    c2 = Counter('counter2_total', 'hits total', ['node'], registry=registry)
+    c2.labels(node="host2").inc(42)
     g3 = Gauge('metric3', 'memory usage', ['matched_label', 'node', 'timestamp'], registry=registry)
     g3.labels(matched_label="foobar", node="host2", timestamp="456").set(float('inf'))
 

--- a/openmetrics/tests/test_openmetrics.py
+++ b/openmetrics/tests/test_openmetrics.py
@@ -21,7 +21,7 @@ instance = {
 instance_new = {
     'openmetrics_endpoint': 'http://localhost:10249/metrics',
     'namespace': 'openmetrics',
-    'metrics': [{'metric1': 'renamed.metric1'}, 'metric2', 'counter1'],
+    'metrics': [{'metric1': 'renamed.metric1'}, 'metric2', 'counter1', 'counter2'],
     'collect_histogram_buckets': True,
 }
 
@@ -117,6 +117,11 @@ def test_linkerd_v2_new(aggregator, dd_run_check):
     )
     aggregator.assert_metric(
         '{}.counter1.count'.format(CHECK_NAME),
+        tags=['endpoint:http://localhost:10249/metrics', 'node:host2'],
+        metric_type=aggregator.MONOTONIC_COUNT,
+    )
+    aggregator.assert_metric(
+        '{}.counter2.count'.format(CHECK_NAME),
         tags=['endpoint:http://localhost:10249/metrics', 'node:host2'],
         metric_type=aggregator.MONOTONIC_COUNT,
     )


### PR DESCRIPTION
### What does this PR do?
Adds test to assert counters with `_total` suffix. 

### Motivation
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
