### PR TITLE
Add support to ingest cloud_metadata for DBM host linking

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -290,65 +290,83 @@ files:
 
     - name: aws
       description: |
-        Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
+        This block defines the configuration for AWS RDS and Aurora instances. 
         
-        Requires setting the field `instance_endpoint`, which should be equal to the Endpoint.Address of the instance
-        the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
-        then setting this configuration is not necessary.
+        Complete this section if you have installed the Datadog AWS Integration 
+        (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+        with SQL Server integration telemetry.
+        
+        These values are only applied when `dbm: true` option is set.
       options:
         - name: instance_endpoint
           description: |
-            Equal to the Endpoint.Address of the instance the agent is connecting to.
+            Equal to the Endpoint.Address of the instance the agent is connecting to. 
+            This value is optional if the value of `host` is already configured to the instance endpoint.
             
             For more information on instance endpoints, 
             see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
           value:
             type: string
-            example: foo.bar.us-east-1.rds.amazonaws.com
+            example: mydb–instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com
 
     - name: gcp
       description: |
-        Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
+        This block defines the configuration for Google Cloud SQL instances.
+        
+        Complete this section if you have installed the Datadog GCP Integration 
+        (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+        with SQL Server integration telemetry.
+
+        These values are only applied when `dbm: true` option is set.
       options:
         - name: project_id
           description: |
-            Equal to the GCP resource's project id.
+            Equal to the GCP resource's project ID.
             
-            For more information on project ids,
+            For more information on project IDs,
             See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
           value:
             type: string
             example: foo-project
         - name: instance_id
           description: |
-            Equal to the GCP resource's instance id.
+            Equal to the GCP resource's instance ID.
             
-            For more information on instance ids,
-            See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+            For more information on instance IDs,
+            See the GCP docs https://cloud.google.com/sql/docs/sqlserver/instance-settings#instance-id-2ndgen
           value:
             type: string
             example: foo-database
 
     - name: azure
       description: |
-        Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
+        This block defines the configuration for Azure Managed Instance, Azure SQL Database or 
+        SQLServer on Virtual Machines.
+        
+        Complete this section if you have installed the Datadog Azure Integration 
+        (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+        with SQL Server integration telemetry.
+
+        These values are only applied when `dbm: true` option is set.
       options:
-        - name: product
+        - name: managed_instance_name
           description: |
-            Equal to the managed Azure DB product. 
-            
-            Acceptable values are:
-              - `flexible_server` 
-              - `single_server`
+            Equal to the name of the managed SQL instance.
           value:
             type: string
-            example: flexible_server
-        - name: name
+            example: my-managed-instance
+        - name: sql_database_name
           description: |
-            Equal to the name of the database.
+            Equal to the name of the Azure SQL database
           value:
             type: string
-            example: foo.database
+            example: my-sql-database
+        - name: vm_name
+          description: |
+            Equal to the name of the name of the virtual machine where SQLServer is running.
+          value:
+            type: string
+            example: my-sql-database
 
     - name: obfuscator_options
       description: |

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -287,85 +287,69 @@ files:
           value:
             type: number
             example: 10
+
     - name: aws
       description: |
         Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
         
         Requires setting the field `hostname`, which should be equal to the Endpoint.Address of the instance
-        the agent is connecting to. For example:
-        aws:
-          - hostname: foo.bar.us-east-1.rds.amazonaws.com
-        
-        Note, if the `host` field is already equal to the instance's Endpoint.Address value, then setting 
-        this configuration is not necessary.
-        
-        For more information on instance endpoints, 
-        see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
-      value:
-        type: array
-        items:
-          anyOf:
-            - type: string
-            - type: object
-          properties:
-            - name: hostname
-              type: string
-          example:
-            - hostname: foo.bar.us-east-1.rds.amazonaws.com
+        the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
+        then setting this configuration is not necessary.
+      options:
+        - name: hostname
+          description: |
+            Equal to the Endpoint.Address of the instance the agent is connecting to.
+            
+            For more information on instance endpoints, 
+            see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
+          value:
+            type: string
+            example: foo.bar.us-east-1.rds.amazonaws.com
+
     - name: gcp
       description: |
         Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
-        
-        Requires setting the following fields:
-        
-        `project_id` the resources's project https://cloud.google.com/resource-manager/docs/creating-managing-projects
-        `instance_id` the resource's id https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
-        
-        For example:
-        gcp:
-          - project_id: foo-project
-          - instance_id: foo-database
-      value:
-        type: array
-        items:
-          anyOf:
-            - type: string
-            - type: object
-          properties:
-            - name: project_id
-              type: string
-            - name: instance_id
-              type: string
-          example:
-            - project_id: foo-project
-            - instance_id: foo-database
+      options:
+        - name: project_id
+          description: |
+            Equal to the GCP resource's project id.
+            
+            For more information on project ids,
+            See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
+          value:
+            type: string
+            example: foo-project
+        - name: instance_id
+          description: |
+            Equal to the GCP resource's instance id.
+            
+            For more information on instance ids,
+            See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+          value:
+            type: string
+            example: foo-database
+
     - name: azure
       description: |
         Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
-        
-        Requires setting the following fields:
-        
-        `product` the managed azure DB product. Acceptable values are `flexible_server` or `single_server`. 
-        `name` the name of the database.
-        
-        For example:
-        azure:
-          - product: flexible_server
-          - name: foo.bar.database
-      value:
-        type: array
-        items:
-          anyOf:
-            - type: string
-            - type: object
-          properties:
-            - name: product
-              type: string
-            - name: name
-              type: string
-          example:
-            - product: flexible_server
-            - name: foo.bar.database
+      options:
+        - name: product
+          description: |
+            Equal to the managed Azure DB product. 
+            
+            Acceptable values are:
+              - `flexible_server` 
+              - `single_server`
+          value:
+            type: string
+            example: flexible_server
+        - name: name
+          description: |
+            Equal to the name of the database.
+          value:
+            type: string
+            example: foo.database
+
     - name: obfuscator_options
       description: |
         Configure how the SQL obfuscator behaves.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -363,7 +363,7 @@ files:
           value:
             type: string
             example: sql_database
-        - name: database_name
+        - name: name
           description: |
             Equal to the name of the SQL Database, Managed Instance (SQL MI) or virtual machine.
           value:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -349,24 +349,26 @@ files:
 
         These values are only applied when `dbm: true` option is set.
       options:
-        - name: managed_instance_name
+        - name: deployment_type
           description: |
-            Equal to the name of the managed SQL instance.
+            Equal to the deployment type for the managed database. 
+            
+            Acceptable values are:
+              - `sql_database` 
+              - `managed_instance`
+              - `virtual_machine`
+            
+            For more information on deployment types, see the Azure
+            docs https://docs.microsoft.com/en-us/azure/azure-sql/azure-sql-iaas-vs-paas-what-is-overview?view=azuresql
           value:
             type: string
-            example: my-managed-instance
-        - name: sql_database_name
+            example: sql_database
+        - name: database_name
           description: |
-            Equal to the name of the Azure SQL database
+            Equal to the name of the SQL Database, Managed Instance (SQL MI) or virtual machine.
           value:
             type: string
-            example: my-sql-database
-        - name: vm_name
-          description: |
-            Equal to the name of the name of the virtual machine where SQLServer is running.
-          value:
-            type: string
-            example: my-sql-database
+            example: my-sqlserver-instance
 
     - name: obfuscator_options
       description: |

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -287,6 +287,85 @@ files:
           value:
             type: number
             example: 10
+    - name: aws
+      description: |
+        Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
+        
+        Requires setting the field `hostname`, which should be equal to the Endpoint.Address of the instance
+        the agent is connecting to. For example:
+        aws:
+          - hostname: foo.bar.us-east-1.rds.amazonaws.com
+        
+        Note, if the `host` field is already equal to the instance's Endpoint.Address value, then setting 
+        this configuration is not necessary.
+        
+        For more information on instance endpoints, 
+        see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
+      value:
+        type: array
+        items:
+          anyOf:
+            - type: string
+            - type: object
+          properties:
+            - name: hostname
+              type: string
+          example:
+            - hostname: foo.bar.us-east-1.rds.amazonaws.com
+    - name: gcp
+      description: |
+        Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
+        
+        Requires setting the following fields:
+        
+        `project_id` the resources's project https://cloud.google.com/resource-manager/docs/creating-managing-projects
+        `instance_id` the resource's id https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+        
+        For example:
+        gcp:
+          - project_id: foo-project
+          - instance_id: foo-database
+      value:
+        type: array
+        items:
+          anyOf:
+            - type: string
+            - type: object
+          properties:
+            - name: project_id
+              type: string
+            - name: instance_id
+              type: string
+          example:
+            - project_id: foo-project
+            - instance_id: foo-database
+    - name: azure
+      description: |
+        Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
+        
+        Requires setting the following fields:
+        
+        `product` the managed azure DB product. Acceptable values are `flexible_server` or `single_server`. 
+        `name` the name of the database.
+        
+        For example:
+        azure:
+          - product: flexible_server
+          - name: foo.bar.database
+      value:
+        type: array
+        items:
+          anyOf:
+            - type: string
+            - type: object
+          properties:
+            - name: product
+              type: string
+            - name: name
+              type: string
+          example:
+            - product: flexible_server
+            - name: foo.bar.database
     - name: obfuscator_options
       description: |
         Configure how the SQL obfuscator behaves.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -307,7 +307,7 @@ files:
             see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
           value:
             type: string
-            example: mydb–instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+            example: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
 
     - name: gcp
       description: |

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -292,11 +292,11 @@ files:
       description: |
         Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
         
-        Requires setting the field `hostname`, which should be equal to the Endpoint.Address of the instance
+        Requires setting the field `instance_endpoint`, which should be equal to the Endpoint.Address of the instance
         the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
         then setting this configuration is not necessary.
       options:
-        - name: hostname
+        - name: instance_endpoint
           description: |
             Equal to the Endpoint.Address of the instance the agent is connecting to.
             

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -46,6 +46,14 @@ def instance_availability_group(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_aws(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_azure(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_command_timeout(field, value):
     return 5
 
@@ -96,6 +104,10 @@ def instance_dsn(field, value):
 
 def instance_empty_default_hostname(field, value):
     return False
+
+
+def instance_gcp(field, value):
+    return get_default_field_value(field, value)
 
 
 def instance_ignore_missing_database(field, value):

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -19,6 +19,21 @@ from datadog_checks.base.utils.models import validation
 from . import defaults, validators
 
 
+class Aws(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    hostname: Optional[str]
+
+
+class Azure(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    name: Optional[str]
+    product: Optional[str]
+
+
 class CustomQuery(BaseModel):
     class Config:
         allow_mutation = False
@@ -26,6 +41,14 @@ class CustomQuery(BaseModel):
     columns: Optional[Sequence[Mapping[str, Any]]]
     query: Optional[str]
     tags: Optional[Sequence[str]]
+
+
+class Gcp(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    instance_id: Optional[str]
+    project_id: Optional[str]
 
 
 class MetricPatterns(BaseModel):
@@ -77,6 +100,8 @@ class InstanceConfig(BaseModel):
     autodiscovery_exclude: Optional[Sequence[str]]
     autodiscovery_include: Optional[Sequence[str]]
     availability_group: Optional[str]
+    aws: Optional[Aws]
+    azure: Optional[Azure]
     command_timeout: Optional[int]
     connection_string: Optional[str]
     connector: Optional[str]
@@ -90,6 +115,7 @@ class InstanceConfig(BaseModel):
     driver: Optional[str]
     dsn: Optional[str]
     empty_default_hostname: Optional[bool]
+    gcp: Optional[Gcp]
     host: str
     ignore_missing_database: Optional[bool]
     include_ao_metrics: Optional[bool]

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -30,8 +30,8 @@ class Azure(BaseModel):
     class Config:
         allow_mutation = False
 
-    database_name: Optional[str]
     deployment_type: Optional[str]
+    name: Optional[str]
 
 
 class CustomQuery(BaseModel):

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -23,7 +23,7 @@ class Aws(BaseModel):
     class Config:
         allow_mutation = False
 
-    hostname: Optional[str]
+    instance_endpoint: Optional[str]
 
 
 class Azure(BaseModel):

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -30,8 +30,9 @@ class Azure(BaseModel):
     class Config:
         allow_mutation = False
 
-    name: Optional[str]
-    product: Optional[str]
+    managed_instance_name: Optional[str]
+    sql_database_name: Optional[str]
+    vm_name: Optional[str]
 
 
 class CustomQuery(BaseModel):

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -30,9 +30,8 @@ class Azure(BaseModel):
     class Config:
         allow_mutation = False
 
-    managed_instance_name: Optional[str]
-    sql_database_name: Optional[str]
-    vm_name: Optional[str]
+    database_name: Optional[str]
+    deployment_type: Optional[str]
 
 
 class CustomQuery(BaseModel):

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -262,14 +262,14 @@ instances:
     #
     aws:
 
-        ## @param instance_endpoint - string - optional - default: mydb–instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+        ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
         ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
         ## This value is optional if the value of `host` is already configured to the instance endpoint.
         ##
         ## For more information on instance endpoints, 
         ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
         #
-        # instance_endpoint: "mydb\u2013instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com"
+        # instance_endpoint: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
 
     ## This block defines the configuration for Google Cloud SQL instances.
     ##

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -254,19 +254,19 @@ instances:
 
     ## Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
     ##
-    ## Requires setting the field `hostname`, which should be equal to the Endpoint.Address of the instance
+    ## Requires setting the field `instance_endpoint`, which should be equal to the Endpoint.Address of the instance
     ## the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
     ## then setting this configuration is not necessary.
     #
     aws:
 
-        ## @param hostname - string - optional - default: foo.bar.us-east-1.rds.amazonaws.com
+        ## @param instance_endpoint - string - optional - default: foo.bar.us-east-1.rds.amazonaws.com
         ## Equal to the Endpoint.Address of the instance the agent is connecting to.
         ##
         ## For more information on instance endpoints, 
         ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
         #
-        # hostname: foo.bar.us-east-1.rds.amazonaws.com
+        # instance_endpoint: foo.bar.us-east-1.rds.amazonaws.com
 
     ## Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
     #

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -308,20 +308,23 @@ instances:
     #
     azure:
 
-        ## @param managed_instance_name - string - optional - default: my-managed-instance
-        ## Equal to the name of the managed SQL instance.
+        ## @param deployment_type - string - optional - default: sql_database
+        ## Equal to the deployment type for the managed database. 
+        ##
+        ## Acceptable values are:
+        ##   - `sql_database` 
+        ##   - `managed_instance`
+        ##   - `virtual_machine`
+        ##
+        ## For more information on deployment types, see the Azure
+        ## docs https://docs.microsoft.com/en-us/azure/azure-sql/azure-sql-iaas-vs-paas-what-is-overview?view=azuresql
         #
-        # managed_instance_name: my-managed-instance
+        # deployment_type: sql_database
 
-        ## @param sql_database_name - string - optional - default: my-sql-database
-        ## Equal to the name of the Azure SQL database
+        ## @param database_name - string - optional - default: my-sqlserver-instance
+        ## Equal to the name of the SQL Database, Managed Instance (SQL MI) or virtual machine.
         #
-        # sql_database_name: my-sql-database
-
-        ## @param vm_name - string - optional - default: my-sql-database
-        ## Equal to the name of the name of the virtual machine where SQLServer is running.
-        #
-        # vm_name: my-sql-database
+        # database_name: my-sqlserver-instance
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -252,6 +252,52 @@ instances:
         #
         # collection_interval: 10
 
+    ## @param aws - (list of string or mapping) - optional
+    ## Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
+    ##
+    ## Requires setting the field `hostname`, which should be equal to the Endpoint.Address of the instance
+    ## the agent is connecting to. For example:
+    ## aws:
+    ##   - hostname: foo.bar.us-east-1.rds.amazonaws.com
+    ##
+    ## Note, if the `host` field is already equal to the instance's Endpoint.Address value, then setting 
+    ## this configuration is not necessary.
+    ##
+    ## For more information on instance endpoints, 
+    ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
+    #
+    # aws: []
+
+    ## @param gcp - (list of string or mapping) - optional
+    ## Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
+    ##
+    ## Requires setting the following fields:
+    ##
+    ## `project_id` the resources's project https://cloud.google.com/resource-manager/docs/creating-managing-projects
+    ## `instance_id` the resource's id https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+    ##
+    ## For example:
+    ## gcp:
+    ##   - project_id: foo-project
+    ##   - instance_id: foo-database
+    #
+    # gcp: []
+
+    ## @param azure - (list of string or mapping) - optional
+    ## Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
+    ##
+    ## Requires setting the following fields:
+    ##
+    ## `product` the managed azure DB product. Acceptable values are `flexible_server` or `single_server`. 
+    ## `name` the name of the database.
+    ##
+    ## For example:
+    ## azure:
+    ##   - product: flexible_server
+    ##   - name: foo.bar.database
+    #
+    # azure: []
+
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.
     #

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -252,59 +252,76 @@ instances:
         #
         # collection_interval: 10
 
-    ## Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
+    ## This block defines the configuration for AWS RDS and Aurora instances. 
     ##
-    ## Requires setting the field `instance_endpoint`, which should be equal to the Endpoint.Address of the instance
-    ## the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
-    ## then setting this configuration is not necessary.
+    ## Complete this section if you have installed the Datadog AWS Integration 
+    ## (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+    ## with SQL Server integration telemetry.
+    ##
+    ## These values are only applied when `dbm: true` option is set.
     #
     aws:
 
-        ## @param instance_endpoint - string - optional - default: foo.bar.us-east-1.rds.amazonaws.com
-        ## Equal to the Endpoint.Address of the instance the agent is connecting to.
+        ## @param instance_endpoint - string - optional - default: mydb–instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+        ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
+        ## This value is optional if the value of `host` is already configured to the instance endpoint.
         ##
         ## For more information on instance endpoints, 
         ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
         #
-        # instance_endpoint: foo.bar.us-east-1.rds.amazonaws.com
+        # instance_endpoint: "mydb\u2013instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com"
 
-    ## Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
+    ## This block defines the configuration for Google Cloud SQL instances.
+    ##
+    ## Complete this section if you have installed the Datadog GCP Integration 
+    ## (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+    ## with SQL Server integration telemetry.
+    ##
+    ## These values are only applied when `dbm: true` option is set.
     #
     gcp:
 
         ## @param project_id - string - optional - default: foo-project
-        ## Equal to the GCP resource's project id.
+        ## Equal to the GCP resource's project ID.
         ##
-        ## For more information on project ids,
+        ## For more information on project IDs,
         ## See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
         #
         # project_id: foo-project
 
         ## @param instance_id - string - optional - default: foo-database
-        ## Equal to the GCP resource's instance id.
+        ## Equal to the GCP resource's instance ID.
         ##
-        ## For more information on instance ids,
-        ## See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+        ## For more information on instance IDs,
+        ## See the GCP docs https://cloud.google.com/sql/docs/sqlserver/instance-settings#instance-id-2ndgen
         #
         # instance_id: foo-database
 
-    ## Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
+    ## This block defines the configuration for Azure Managed Instance, Azure SQL Database or 
+    ## SQLServer on Virtual Machines.
+    ##
+    ## Complete this section if you have installed the Datadog Azure Integration 
+    ## (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+    ## with SQL Server integration telemetry.
+    ##
+    ## These values are only applied when `dbm: true` option is set.
     #
     azure:
 
-        ## @param product - string - optional - default: flexible_server
-        ## Equal to the managed Azure DB product. 
-        ##
-        ## Acceptable values are:
-        ##   - `flexible_server` 
-        ##   - `single_server`
+        ## @param managed_instance_name - string - optional - default: my-managed-instance
+        ## Equal to the name of the managed SQL instance.
         #
-        # product: flexible_server
+        # managed_instance_name: my-managed-instance
 
-        ## @param name - string - optional - default: foo.database
-        ## Equal to the name of the database.
+        ## @param sql_database_name - string - optional - default: my-sql-database
+        ## Equal to the name of the Azure SQL database
         #
-        # name: foo.database
+        # sql_database_name: my-sql-database
+
+        ## @param vm_name - string - optional - default: my-sql-database
+        ## Equal to the name of the name of the virtual machine where SQLServer is running.
+        #
+        # vm_name: my-sql-database
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -252,51 +252,59 @@ instances:
         #
         # collection_interval: 10
 
-    ## @param aws - (list of string or mapping) - optional
     ## Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
     ##
     ## Requires setting the field `hostname`, which should be equal to the Endpoint.Address of the instance
-    ## the agent is connecting to. For example:
-    ## aws:
-    ##   - hostname: foo.bar.us-east-1.rds.amazonaws.com
-    ##
-    ## Note, if the `host` field is already equal to the instance's Endpoint.Address value, then setting 
-    ## this configuration is not necessary.
-    ##
-    ## For more information on instance endpoints, 
-    ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
+    ## the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
+    ## then setting this configuration is not necessary.
     #
-    # aws: []
+    aws:
 
-    ## @param gcp - (list of string or mapping) - optional
+        ## @param hostname - string - optional - default: foo.bar.us-east-1.rds.amazonaws.com
+        ## Equal to the Endpoint.Address of the instance the agent is connecting to.
+        ##
+        ## For more information on instance endpoints, 
+        ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
+        #
+        # hostname: foo.bar.us-east-1.rds.amazonaws.com
+
     ## Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
-    ##
-    ## Requires setting the following fields:
-    ##
-    ## `project_id` the resources's project https://cloud.google.com/resource-manager/docs/creating-managing-projects
-    ## `instance_id` the resource's id https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
-    ##
-    ## For example:
-    ## gcp:
-    ##   - project_id: foo-project
-    ##   - instance_id: foo-database
     #
-    # gcp: []
+    gcp:
 
-    ## @param azure - (list of string or mapping) - optional
+        ## @param project_id - string - optional - default: foo-project
+        ## Equal to the GCP resource's project id.
+        ##
+        ## For more information on project ids,
+        ## See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
+        #
+        # project_id: foo-project
+
+        ## @param instance_id - string - optional - default: foo-database
+        ## Equal to the GCP resource's instance id.
+        ##
+        ## For more information on instance ids,
+        ## See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+        #
+        # instance_id: foo-database
+
     ## Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
-    ##
-    ## Requires setting the following fields:
-    ##
-    ## `product` the managed azure DB product. Acceptable values are `flexible_server` or `single_server`. 
-    ## `name` the name of the database.
-    ##
-    ## For example:
-    ## azure:
-    ##   - product: flexible_server
-    ##   - name: foo.bar.database
     #
-    # azure: []
+    azure:
+
+        ## @param product - string - optional - default: flexible_server
+        ## Equal to the managed Azure DB product. 
+        ##
+        ## Acceptable values are:
+        ##   - `flexible_server` 
+        ##   - `single_server`
+        #
+        # product: flexible_server
+
+        ## @param name - string - optional - default: foo.database
+        ## Equal to the name of the database.
+        #
+        # name: foo.database
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -321,10 +321,10 @@ instances:
         #
         # deployment_type: sql_database
 
-        ## @param database_name - string - optional - default: my-sqlserver-instance
+        ## @param name - string - optional - default: my-sqlserver-instance
         ## Equal to the name of the SQL Database, Managed Instance (SQL MI) or virtual machine.
         #
-        # database_name: my-sqlserver-instance
+        # name: my-sqlserver-instance
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -210,7 +210,7 @@ instances:
 
     ## Configure collection of query metrics
     #
-    query_metrics:
+    # query_metrics:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of query metrics. Requires `dbm: true`.
@@ -237,7 +237,7 @@ instances:
 
     ## Configure collection of active sessions monitoring
     #
-    query_activity:
+    # query_activity:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of active sessions. Requires `dbm: true`.
@@ -260,7 +260,7 @@ instances:
     ##
     ## These values are only applied when `dbm: true` option is set.
     #
-    aws:
+    # aws:
 
         ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
         ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
@@ -279,7 +279,7 @@ instances:
     ##
     ## These values are only applied when `dbm: true` option is set.
     #
-    gcp:
+    # gcp:
 
         ## @param project_id - string - optional - default: foo-project
         ## Equal to the GCP resource's project ID.
@@ -306,7 +306,7 @@ instances:
     ##
     ## These values are only applied when `dbm: true` option is set.
     #
-    azure:
+    # azure:
 
         ## @param deployment_type - string - optional - default: sql_database
         ## Equal to the deployment type for the managed database. 
@@ -329,7 +329,7 @@ instances:
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.
     #
-    obfuscator_options:
+    # obfuscator_options:
 
         ## @param replace_digits - boolean - optional - default: false
         ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -115,6 +115,16 @@ class SQLServer(AgentCheck):
         self.statement_metrics = SqlserverStatementMetrics(self)
         self.activity_config = self.instance.get('query_activity', {}) or {}
         self.activity = SqlserverActivity(self)
+        self.cloud_metadata = {}
+        aws = self.instance.get('aws', {})
+        gcp = self.instance.get('gcp', {})
+        azure = self.instance.get('azure', {})
+        if aws:
+            self.cloud_metadata.update({'aws': aws})
+        if gcp:
+            self.cloud_metadata.update({'gcp': gcp})
+        if azure:
+            self.cloud_metadata.update({'azure': azure})
         obfuscator_options_config = self.instance.get('obfuscator_options', {}) or {}
         self.obfuscator_options = to_native_string(
             json.dumps(

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -292,6 +292,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             'timestamp': time.time() * 1000,
             'min_collection_interval': self.collection_interval,
             'tags': self.check.tags,
+            'cloud_metadata': self.check.cloud_metadata,
             'sqlserver_rows': [self._to_metrics_payload_row(r) for r in rows],
             'sqlserver_version': self.check.static_info_cache.get("version", ""),
             'ddagentversion': datadog_agent.get_version(),

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -352,7 +352,7 @@ def test_statement_metadata(
         },
         {
             'aws': {
-                'hostname': 'foo.aws.com',
+                'instance_endpoint': 'foo.aws.com',
             },
             'azure': {
                 'product': 'flexible_server',

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -368,9 +368,7 @@ def test_statement_metadata(
         },
     ],
 )
-def test_statement_cloud_metadata(
-        aggregator, dd_run_check, dbm_instance, bob_conn, datadog_agent, cloud_metadata
-):
+def test_statement_cloud_metadata(aggregator, dd_run_check, dbm_instance, bob_conn, datadog_agent, cloud_metadata):
     if cloud_metadata:
         for k, v in cloud_metadata.items():
             dbm_instance[k] = v

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -346,8 +346,7 @@ def test_statement_metadata(
         {},
         {
             'azure': {
-                'product': 'flexible_server',
-                'name': 'test-server',
+                'managed_instance_name': 'my-instance',
             },
         },
         {
@@ -355,8 +354,7 @@ def test_statement_metadata(
                 'instance_endpoint': 'foo.aws.com',
             },
             'azure': {
-                'product': 'flexible_server',
-                'name': 'test-server',
+                'managed_instance_name': 'my-instance',
             },
         },
         {

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -346,7 +346,8 @@ def test_statement_metadata(
         {},
         {
             'azure': {
-                'managed_instance_name': 'my-instance',
+                'deployment_type': 'managed_instance',
+                'database_name': 'my-instance',
             },
         },
         {
@@ -354,7 +355,8 @@ def test_statement_metadata(
                 'instance_endpoint': 'foo.aws.com',
             },
             'azure': {
-                'managed_instance_name': 'my-instance',
+                'deployment_type': 'managed_instance',
+                'database_name': 'my-instance',
             },
         },
         {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds three new fields associated with the database-monitoring product in order to help support the new (beta) DB List feature. Ingesting this extra cloud related metadata will allow for us to link managed cloud resource metrics emitted by Datadog cloud crawlers to database-monitoring reported hosts.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
