### PR TITLE
Fix missing object_name for index fragmentation metrics

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -806,7 +806,7 @@ class SqlDbFragmentation(BaseSqlServerMetric):
     DEFAULT_METRIC_TYPE = 'gauge'
 
     QUERY_BASE = (
-        "select DB_NAME(database_id) as database_name, OBJECT_NAME(object_id) as object_name, "
+        "select DB_NAME(database_id) as database_name, OBJECT_NAME(object_id, database_id) as object_name, "
         "index_id, partition_number, fragment_count, avg_fragment_size_in_pages, "
         "avg_fragmentation_in_percent "
         "from {table} (DB_ID('{{db}}'),null,null,null,null) "

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -9,6 +9,7 @@ from __future__ import division
 from collections import defaultdict
 from functools import partial
 
+from datadog_checks.base import ensure_unicode
 from datadog_checks.base.errors import CheckException
 from datadog_checks.base.utils.time import get_precise_time
 
@@ -870,14 +871,13 @@ class SqlDbFragmentation(BaseSqlServerMetric):
                 continue
 
             metric_tags = [
-                'database_name:{}'.format(str(self.instance)),
-                'object_name:{}'.format(str(object_name)),
-                'index_id:{}'.format(str(index_id)),
+                u'database_name:{}'.format(ensure_unicode(self.instance)),
+                u'object_name:{}'.format(ensure_unicode(object_name)),
+                u'index_id:{}'.format(ensure_unicode(index_id)),
             ]
 
             metric_tags.extend(self.tags)
-            metric_name = '{}'.format(self.datadog_name)
-            self.report_function(metric_name, column_val, tags=metric_tags)
+            self.report_function(self.datadog_name, column_val, tags=metric_tags)
 
 
 # https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-hadr-database-replica-states-transact-sql?view=sql-server-ver15

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -416,8 +416,6 @@ def test_index_fragmentation_metrics(aggregator, dd_run_check, instance_docker, 
     sqlserver_check = SQLServer(CHECK_NAME, {}, [instance_docker])
     dd_run_check(sqlserver_check)
     seen_databases = set()
-    # import pdb
-    # pdb.set_trace()
     for m in aggregator.metrics("sqlserver.database.avg_fragmentation_in_percent"):
         tags_by_key = {k: v for k, v in [t.split(':') for t in m.tags]}
         seen_databases.add(tags_by_key['database_name'])

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -406,3 +406,23 @@ def test_resolved_hostname(instance_docker, dbm_enabled, instance_host, reported
     instance_docker['reported_hostname'] = reported_hostname
     sqlserver_check = SQLServer(CHECK_NAME, {}, [instance_docker])
     assert sqlserver_check.resolved_hostname == expected_hostname
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize('database_autodiscovery', [True, False])
+def test_index_fragmentation_metrics(aggregator, dd_run_check, instance_docker, database_autodiscovery):
+    instance_docker['database_autodiscovery'] = database_autodiscovery
+    sqlserver_check = SQLServer(CHECK_NAME, {}, [instance_docker])
+    dd_run_check(sqlserver_check)
+    seen_databases = set()
+    # import pdb
+    # pdb.set_trace()
+    for m in aggregator.metrics("sqlserver.database.avg_fragmentation_in_percent"):
+        tags_by_key = {k: v for k, v in [t.split(':') for t in m.tags]}
+        seen_databases.add(tags_by_key['database_name'])
+        assert tags_by_key['object_name'].lower() != 'none'
+
+    assert 'master' in seen_databases
+    if database_autodiscovery:
+        assert 'datadog_test' in seen_databases


### PR DESCRIPTION
### What does this PR do?

Explicitly specify `database_id` when calling `OBJECT_NAME` when collecting fragmentation metrics. 

Also fix python2 unicode handling. 

### Motivation

When `database_autodiscovery: True` then `object_name` was always `none` for any objects that came from a database other than the default database.

This is because [object_name](https://docs.microsoft.com/en-us/sql/t-sql/functions/object-name-transact-sql?view=sql-server-ver15) defaults to assuming it's in the current database context if not specified.

The broken unicode handling was revealed only when this query was changed to start including some DB objects with non-ascii characters in them which were not included previously. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
