### PR TITLE
Add support to ingest cloud_metadata for DBM host linking

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -459,6 +459,7 @@ files:
             Acceptable values are:
               - `flexible_server` 
               - `single_server`
+              - `virtual_machine`
             
             For more information on deployment types, 
             see the Azure docs https://docs.microsoft.com/en-us/azure/postgresql/overview-postgres-choose-server-options

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -412,7 +412,7 @@ files:
             see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
           value:
             type: string
-            example: mydb–instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+            example: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
 
     - name: gcp
       description: |

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -392,6 +392,69 @@ files:
           value:
             type: number
             example: 3500
+            
+    - name: aws
+      description: |
+        Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
+        
+        Requires setting the field `instance_endpoint`, which should be equal to the Endpoint.Address of the instance
+        the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
+        then setting this configuration is not necessary.
+      options:
+        - name: instance_endpoint
+          description: |
+            Equal to the Endpoint.Address of the instance the agent is connecting to.
+            
+            For more information on instance endpoints, 
+            see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
+          value:
+            type: string
+            example: foo.bar.us-east-1.rds.amazonaws.com
+
+    - name: gcp
+      description: |
+        Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
+      options:
+        - name: project_id
+          description: |
+            Equal to the GCP resource's project id.
+            
+            For more information on project ids,
+            See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
+          value:
+            type: string
+            example: foo-project
+        - name: instance_id
+          description: |
+            Equal to the GCP resource's instance id.
+            
+            For more information on instance ids,
+            See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+          value:
+            type: string
+            example: foo-database
+
+    - name: azure
+      description: |
+        Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
+      options:
+        - name: product
+          description: |
+            Equal to the managed Azure DB product. 
+            
+            Acceptable values are:
+              - `flexible_server` 
+              - `single_server`
+          value:
+            type: string
+            example: flexible_server
+        - name: name
+          description: |
+            Equal to the name of the database.
+          value:
+            type: string
+            example: foo.database
+
     - name: obfuscator_options
       description: |
         Configure how the SQL obfuscator behaves.

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -395,65 +395,82 @@ files:
             
     - name: aws
       description: |
-        Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
+        This block defines the configuration for AWS RDS and Aurora instances. 
         
-        Requires setting the field `instance_endpoint`, which should be equal to the Endpoint.Address of the instance
-        the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
-        then setting this configuration is not necessary.
+        Complete this section if you have installed the Datadog AWS Integration 
+        (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+        with Postgres integration telemetry.
+        
+        These values are only applied when `dbm: true` option is set.
       options:
         - name: instance_endpoint
           description: |
-            Equal to the Endpoint.Address of the instance the agent is connecting to.
+            Equal to the Endpoint.Address of the instance the agent is connecting to. 
+            This value is optional if the value of `host` is already configured to the instance endpoint.
             
             For more information on instance endpoints, 
             see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
           value:
             type: string
-            example: foo.bar.us-east-1.rds.amazonaws.com
+            example: mydb–instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com
 
     - name: gcp
       description: |
-        Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
+        This block defines the configuration for Google Cloud SQL instances.
+        
+        Complete this section if you have installed the Datadog GCP Integration 
+        (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+        with Postgres integration telemetry.
+        
+        These values are only applied when `dbm: true` option is set.
       options:
         - name: project_id
           description: |
-            Equal to the GCP resource's project id.
+            Equal to the GCP resource's project ID.
             
-            For more information on project ids,
+            For more information on project IDs,
             See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
           value:
             type: string
             example: foo-project
         - name: instance_id
           description: |
-            Equal to the GCP resource's instance id.
+            Equal to the GCP resource's instance ID.
             
-            For more information on instance ids,
-            See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+            For more information on instance IDs,
+            See the GCP docs https://cloud.google.com/sql/docs/postgres/instance-settings#instance-id-2ndgen
           value:
             type: string
             example: foo-database
 
     - name: azure
       description: |
-        Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
+        This block defines the configuration for Azure Database for PostgreSQL.
+        
+        Complete this section if you have installed the Datadog Azure Integration 
+        (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+        with Postgres integration telemetry.
+        These values are only applied when `dbm: true` option is set.
       options:
-        - name: product
+        - name: deployment_type
           description: |
-            Equal to the managed Azure DB product. 
+            Equal to the deployment type for the managed database. 
             
             Acceptable values are:
               - `flexible_server` 
               - `single_server`
+            
+            For more information on deployment types, 
+            see the Azure docs https://docs.microsoft.com/en-us/azure/postgresql/overview-postgres-choose-server-options
           value:
             type: string
             example: flexible_server
-        - name: name
+        - name: database_name
           description: |
-            Equal to the name of the database.
+            Equal to the name of the Azure PostgreSQL database.
           value:
             type: string
-            example: foo.database
+            example: my-postgres-database
 
     - name: obfuscator_options
       description: |

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -466,7 +466,7 @@ files:
           value:
             type: string
             example: flexible_server
-        - name: database_name
+        - name: name
           description: |
             Equal to the name of the Azure PostgreSQL database.
           value:

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -90,6 +90,16 @@ class PostgresConfig:
         self.statement_samples_config = instance.get('query_samples', instance.get('statement_samples', {})) or {}
         self.statement_activity_config = instance.get('query_activity', {}) or {}
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}
+        self.cloud_metadata = {}
+        aws = instance.get('aws', {})
+        gcp = instance.get('gcp', {})
+        azure = instance.get('azure', {})
+        if aws:
+            self.cloud_metadata.update({'aws': aws})
+        if gcp:
+            self.cloud_metadata.update({'gcp': gcp})
+        if azure:
+            self.cloud_metadata.update({'azure': azure})
         obfuscator_options_config = instance.get('obfuscator_options', {}) or {}
         self.obfuscator_options = {
             # Valid values for this can be found at

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -18,6 +18,14 @@ def instance_application_name(field, value):
     return 'datadog-agent'
 
 
+def instance_aws(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_azure(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_collect_activity_metrics(field, value):
     return False
 
@@ -72,6 +80,10 @@ def instance_disable_generic_tags(field, value):
 
 def instance_empty_default_hostname(field, value):
     return False
+
+
+def instance_gcp(field, value):
+    return get_default_field_value(field, value)
 
 
 def instance_ignore_databases(field, value):

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -30,8 +30,8 @@ class Azure(BaseModel):
     class Config:
         allow_mutation = False
 
-    database_name: Optional[str]
     deployment_type: Optional[str]
+    name: Optional[str]
 
 
 class Gcp(BaseModel):

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -30,8 +30,8 @@ class Azure(BaseModel):
     class Config:
         allow_mutation = False
 
-    name: Optional[str]
-    product: Optional[str]
+    database_name: Optional[str]
+    deployment_type: Optional[str]
 
 
 class Gcp(BaseModel):

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -19,6 +19,29 @@ from datadog_checks.base.utils.models import validation
 from . import defaults, validators
 
 
+class Aws(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    instance_endpoint: Optional[str]
+
+
+class Azure(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    name: Optional[str]
+    product: Optional[str]
+
+
+class Gcp(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    instance_id: Optional[str]
+    project_id: Optional[str]
+
+
 class MetricPatterns(BaseModel):
     class Config:
         allow_mutation = False
@@ -84,6 +107,8 @@ class InstanceConfig(BaseModel):
         allow_mutation = False
 
     application_name: Optional[str]
+    aws: Optional[Aws]
+    azure: Optional[Azure]
     collect_activity_metrics: Optional[bool]
     collect_bloat_metrics: Optional[bool]
     collect_count_metrics: Optional[bool]
@@ -98,6 +123,7 @@ class InstanceConfig(BaseModel):
     dbstrict: Optional[bool]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]
+    gcp: Optional[Gcp]
     host: str
     ignore_databases: Optional[Sequence[str]]
     max_relations: Optional[int]

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -398,10 +398,10 @@ instances:
         #
         # deployment_type: flexible_server
 
-        ## @param database_name - string - optional - default: my-postgres-database
+        ## @param name - string - optional - default: my-postgres-database
         ## Equal to the name of the Azure PostgreSQL database.
         #
-        # database_name: my-postgres-database
+        # name: my-postgres-database
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -391,6 +391,7 @@ instances:
         ## Acceptable values are:
         ##   - `flexible_server` 
         ##   - `single_server`
+        ##   - `virtual_machine`
         ##
         ## For more information on deployment types, 
         ## see the Azure docs https://docs.microsoft.com/en-us/azure/postgresql/overview-postgres-choose-server-options

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -331,59 +331,76 @@ instances:
         #
         # payload_row_limit: 3500
 
-    ## Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
+    ## This block defines the configuration for AWS RDS and Aurora instances. 
     ##
-    ## Requires setting the field `instance_endpoint`, which should be equal to the Endpoint.Address of the instance
-    ## the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
-    ## then setting this configuration is not necessary.
+    ## Complete this section if you have installed the Datadog AWS Integration 
+    ## (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+    ## with Postgres integration telemetry.
+    ##
+    ## These values are only applied when `dbm: true` option is set.
     #
     aws:
 
-        ## @param instance_endpoint - string - optional - default: foo.bar.us-east-1.rds.amazonaws.com
-        ## Equal to the Endpoint.Address of the instance the agent is connecting to.
+        ## @param instance_endpoint - string - optional - default: mydb–instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+        ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
+        ## This value is optional if the value of `host` is already configured to the instance endpoint.
         ##
         ## For more information on instance endpoints, 
         ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
         #
-        # instance_endpoint: foo.bar.us-east-1.rds.amazonaws.com
+        # instance_endpoint: "mydb\u2013instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com"
 
-    ## Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
+    ## This block defines the configuration for Google Cloud SQL instances.
+    ##
+    ## Complete this section if you have installed the Datadog GCP Integration 
+    ## (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+    ## with Postgres integration telemetry.
+    ##
+    ## These values are only applied when `dbm: true` option is set.
     #
     gcp:
 
         ## @param project_id - string - optional - default: foo-project
-        ## Equal to the GCP resource's project id.
+        ## Equal to the GCP resource's project ID.
         ##
-        ## For more information on project ids,
+        ## For more information on project IDs,
         ## See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
         #
         # project_id: foo-project
 
         ## @param instance_id - string - optional - default: foo-database
-        ## Equal to the GCP resource's instance id.
+        ## Equal to the GCP resource's instance ID.
         ##
-        ## For more information on instance ids,
-        ## See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+        ## For more information on instance IDs,
+        ## See the GCP docs https://cloud.google.com/sql/docs/postgres/instance-settings#instance-id-2ndgen
         #
         # instance_id: foo-database
 
-    ## Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
+    ## This block defines the configuration for Azure Database for PostgreSQL.
+    ##
+    ## Complete this section if you have installed the Datadog Azure Integration 
+    ## (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+    ## with Postgres integration telemetry.
+    ## These values are only applied when `dbm: true` option is set.
     #
     azure:
 
-        ## @param product - string - optional - default: flexible_server
-        ## Equal to the managed Azure DB product. 
+        ## @param deployment_type - string - optional - default: flexible_server
+        ## Equal to the deployment type for the managed database. 
         ##
         ## Acceptable values are:
         ##   - `flexible_server` 
         ##   - `single_server`
+        ##
+        ## For more information on deployment types, 
+        ## see the Azure docs https://docs.microsoft.com/en-us/azure/postgresql/overview-postgres-choose-server-options
         #
-        # product: flexible_server
+        # deployment_type: flexible_server
 
-        ## @param name - string - optional - default: foo.database
-        ## Equal to the name of the database.
+        ## @param database_name - string - optional - default: my-postgres-database
+        ## Equal to the name of the Azure PostgreSQL database.
         #
-        # name: foo.database
+        # database_name: my-postgres-database
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -331,6 +331,60 @@ instances:
         #
         # payload_row_limit: 3500
 
+    ## Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
+    ##
+    ## Requires setting the field `instance_endpoint`, which should be equal to the Endpoint.Address of the instance
+    ## the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
+    ## then setting this configuration is not necessary.
+    #
+    aws:
+
+        ## @param instance_endpoint - string - optional - default: foo.bar.us-east-1.rds.amazonaws.com
+        ## Equal to the Endpoint.Address of the instance the agent is connecting to.
+        ##
+        ## For more information on instance endpoints, 
+        ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
+        #
+        # instance_endpoint: foo.bar.us-east-1.rds.amazonaws.com
+
+    ## Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
+    #
+    gcp:
+
+        ## @param project_id - string - optional - default: foo-project
+        ## Equal to the GCP resource's project id.
+        ##
+        ## For more information on project ids,
+        ## See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
+        #
+        # project_id: foo-project
+
+        ## @param instance_id - string - optional - default: foo-database
+        ## Equal to the GCP resource's instance id.
+        ##
+        ## For more information on instance ids,
+        ## See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+        #
+        # instance_id: foo-database
+
+    ## Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
+    #
+    azure:
+
+        ## @param product - string - optional - default: flexible_server
+        ## Equal to the managed Azure DB product. 
+        ##
+        ## Acceptable values are:
+        ##   - `flexible_server` 
+        ##   - `single_server`
+        #
+        # product: flexible_server
+
+        ## @param name - string - optional - default: foo.database
+        ## Equal to the name of the database.
+        #
+        # name: foo.database
+
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.
     #

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -341,14 +341,14 @@ instances:
     #
     aws:
 
-        ## @param instance_endpoint - string - optional - default: mydb–instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+        ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
         ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
         ## This value is optional if the value of `host` is already configured to the instance endpoint.
         ##
         ## For more information on instance endpoints, 
         ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
         #
-        # instance_endpoint: "mydb\u2013instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com"
+        # instance_endpoint: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
 
     ## This block defines the configuration for Google Cloud SQL instances.
     ##

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -252,7 +252,7 @@ instances:
 
     ## Configure collection of query metrics
     #
-    query_metrics:
+    # query_metrics:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of query metrics. Requires `dbm: true`.
@@ -268,7 +268,7 @@ instances:
 
     ## Configure collection of query samples
     #
-    query_samples:
+    # query_samples:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of query samples. Requires `dbm: true`.
@@ -312,7 +312,7 @@ instances:
 
     ## Configure collection of query activity
     #
-    query_activity:
+    # query_activity:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of query activity. Requires `dbm: true`, and enabling query_samples.
@@ -339,7 +339,7 @@ instances:
     ##
     ## These values are only applied when `dbm: true` option is set.
     #
-    aws:
+    # aws:
 
         ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
         ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
@@ -358,7 +358,7 @@ instances:
     ##
     ## These values are only applied when `dbm: true` option is set.
     #
-    gcp:
+    # gcp:
 
         ## @param project_id - string - optional - default: foo-project
         ## Equal to the GCP resource's project ID.
@@ -383,7 +383,7 @@ instances:
     ## with Postgres integration telemetry.
     ## These values are only applied when `dbm: true` option is set.
     #
-    azure:
+    # azure:
 
         ## @param deployment_type - string - optional - default: flexible_server
         ## Equal to the deployment type for the managed database. 
@@ -406,7 +406,7 @@ instances:
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.
     #
-    obfuscator_options:
+    # obfuscator_options:
 
         ## @param replace_digits - boolean - optional - default: false
         ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -181,6 +181,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 'timestamp': time.time() * 1000,
                 'min_collection_interval': self._metrics_collection_interval,
                 'tags': self._tags_no_db,
+                'cloud_metadata': self._config.cloud_metadata,
                 'postgres_rows': rows,
                 'postgres_version': self._payload_pg_version(),
                 'ddagentversion': datadog_agent.get_version(),

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -228,9 +228,7 @@ def test_statement_metrics(
         },
     ],
 )
-def test_statement_metrics_cloud_metadata(
-        aggregator, integration_check, dbm_instance, cloud_metadata, datadog_agent
-):
+def test_statement_metrics_cloud_metadata(aggregator, integration_check, dbm_instance, cloud_metadata, datadog_agent):
     dbm_instance['pg_stat_statements_view'] = "pg_stat_statements"
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -200,6 +200,77 @@ def test_statement_metrics(
         conn.close()
 
 
+@pytest.mark.parametrize(
+    "cloud_metadata",
+    [
+        {},
+        {
+            'azure': {
+                'product': 'flexible_server',
+                'name': 'test-server',
+            },
+        },
+        {
+            'aws': {
+                'instance_endpoint': 'foo.aws.com',
+            },
+            'azure': {
+                'product': 'flexible_server',
+                'name': 'test-server',
+            },
+        },
+        {
+            'gcp': {
+                'project_id': 'foo-project',
+                'instance_id': 'bar',
+                'extra_field': 'included',
+            },
+        },
+    ],
+)
+def test_statement_metrics_cloud_metadata(
+        aggregator, integration_check, dbm_instance, cloud_metadata, datadog_agent
+):
+    dbm_instance['pg_stat_statements_view'] = "pg_stat_statements"
+    # don't need samples for this test
+    dbm_instance['query_samples'] = {'enabled': False}
+    # very low collection interval for test purposes
+    dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    if cloud_metadata:
+        for k, v in cloud_metadata.items():
+            dbm_instance[k] = v
+    connections = {}
+
+    def _run_queries():
+        for user, password, dbname, query, arg in SAMPLE_QUERIES:
+            if dbname not in connections:
+                connections[dbname] = psycopg2.connect(host=HOST, dbname=dbname, user=user, password=password)
+            connections[dbname].cursor().execute(query, (arg,))
+
+    check = integration_check(dbm_instance)
+    check._connect()
+
+    _run_queries()
+    check.check(dbm_instance)
+    _run_queries()
+    check.check(dbm_instance)
+
+    events = aggregator.get_event_platform_events("dbm-metrics")
+    assert len(events) == 1, "should capture exactly one metrics payload"
+    event = events[0]
+
+    assert event['host'] == 'stubbed.hostname'
+    assert event['timestamp'] > 0
+    assert event['postgres_version'] == check.statement_metrics._payload_pg_version()
+    assert event['ddagentversion'] == datadog_agent.get_version()
+    assert event['ddagenthostname'] == datadog_agent.get_hostname()
+    assert event['min_collection_interval'] == dbm_instance['query_metrics']['collection_interval']
+    assert event['cloud_metadata'] == cloud_metadata, "wrong cloud_metadata"
+
+    for conn in connections.values():
+        conn.close()
+
+
 def test_statement_metrics_with_duplicates(aggregator, integration_check, dbm_instance, datadog_agent):
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -206,8 +206,8 @@ def test_statement_metrics(
         {},
         {
             'azure': {
-                'product': 'flexible_server',
-                'name': 'test-server',
+                'deployment_type': 'flexible_server',
+                'database_name': 'test-server',
             },
         },
         {
@@ -215,8 +215,8 @@ def test_statement_metrics(
                 'instance_endpoint': 'foo.aws.com',
             },
             'azure': {
-                'product': 'flexible_server',
-                'name': 'test-server',
+                'deployment_type': 'flexible_server',
+                'database_name': 'test-server',
             },
         },
         {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds three new fields associated with the database-monitoring product in order to help support the new (beta) DB List feature. Ingesting this extra cloud related metadata will allow for us to link managed cloud resource metrics emitted by Datadog cloud crawlers to database-monitoring reported hosts.

Follow on PR to https://github.com/DataDog/integrations-core/pull/11982

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
