### PR TITLE
Add support to ingest cloud_metadata for DBM host linking

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -457,40 +457,49 @@ files:
                   example: 10
       - name: aws
         description: |
-          Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
+          This block defines the configuration for AWS RDS and Aurora instances. 
           
-          Requires setting the field `instance_endpoint`, which should be equal to the Endpoint.Address of the instance
-          the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
-          then setting this configuration is not necessary.
+          Complete this section if you have installed the Datadog AWS Integration 
+          (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+          with MySQL integration telemetry.
+          
+          These values are only applied when `dbm: true` option is set.
         options:
           - name: instance_endpoint
             description: |
-              Equal to the Endpoint.Address of the instance the agent is connecting to.
+              Equal to the Endpoint.Address of the instance the agent is connecting to. 
+              This value is optional if the value of `host` is already configured to the instance endpoint.
               
               For more information on instance endpoints, 
               see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
             value:
               type: string
-              example: foo.bar.us-east-1.rds.amazonaws.com
+              example: mydb–instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com
 
       - name: gcp
         description: |
-          Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
+          This block defines the configuration for Google Cloud SQL instances.
+          
+          Complete this section if you have installed the Datadog GCP Integration 
+          (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+          with MySQL integration telemetry.
+          
+          These values are only applied when `dbm: true` option is set.
         options:
           - name: project_id
             description: |
-              Equal to the GCP resource's project id.
+              Equal to the GCP resource's project ID.
               
-              For more information on project ids,
+              For more information on project IDs,
               See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
             value:
               type: string
               example: foo-project
           - name: instance_id
             description: |
-              Equal to the GCP resource's instance id.
+              Equal to the GCP resource's instance ID.
               
-              For more information on instance ids,
+              For more information on instance IDs,
               See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
             value:
               type: string
@@ -498,24 +507,34 @@ files:
 
       - name: azure
         description: |
-          Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
+          This block defines the configuration for Azure Database for MySQL.
+          
+          Complete this section if you have installed the Datadog Azure Integration 
+          (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+          with MySQL integration telemetry.
+          
+          These values are only applied when `dbm: true` option is set.
         options:
-          - name: product
+          - name: deployment_type
             description: |
-              Equal to the managed Azure DB product. 
+              Equal to the deployment type for the managed database. 
               
               Acceptable values are:
                 - `flexible_server` 
                 - `single_server`
+                - `virtual_machine`
+              
+              For more information on deployment types, 
+              see the Azure docs https://docs.microsoft.com/en-us/azure/mysql/select-right-deployment-type
             value:
               type: string
               example: flexible_server
-          - name: name
+          - name: database_name
             description: |
-              Equal to the name of the database.
+              Equal to the name of the Azure MySQL database instance.
             value:
               type: string
-              example: foo.database
+              example: mysql-database
 
           - name: obfuscator_options
             description: |

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -474,7 +474,7 @@ files:
               see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
             value:
               type: string
-              example: mydb–instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+              example: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
 
       - name: gcp
         description: |

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -529,7 +529,7 @@ files:
             value:
               type: string
               example: flexible_server
-          - name: database_name
+          - name: name
             description: |
               Equal to the name of the Azure MySQL database instance.
             value:

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -455,6 +455,68 @@ files:
                 value:
                   type: number
                   example: 10
+      - name: aws
+        description: |
+          Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
+          
+          Requires setting the field `instance_endpoint`, which should be equal to the Endpoint.Address of the instance
+          the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
+          then setting this configuration is not necessary.
+        options:
+          - name: instance_endpoint
+            description: |
+              Equal to the Endpoint.Address of the instance the agent is connecting to.
+              
+              For more information on instance endpoints, 
+              see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
+            value:
+              type: string
+              example: foo.bar.us-east-1.rds.amazonaws.com
+
+      - name: gcp
+        description: |
+          Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
+        options:
+          - name: project_id
+            description: |
+              Equal to the GCP resource's project id.
+              
+              For more information on project ids,
+              See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
+            value:
+              type: string
+              example: foo-project
+          - name: instance_id
+            description: |
+              Equal to the GCP resource's instance id.
+              
+              For more information on instance ids,
+              See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+            value:
+              type: string
+              example: foo-database
+
+      - name: azure
+        description: |
+          Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
+        options:
+          - name: product
+            description: |
+              Equal to the managed Azure DB product. 
+              
+              Acceptable values are:
+                - `flexible_server` 
+                - `single_server`
+            value:
+              type: string
+              example: flexible_server
+          - name: name
+            description: |
+              Equal to the name of the database.
+            value:
+              type: string
+              example: foo.database
+
           - name: obfuscator_options
             description: |
               Configure how the SQL obfuscator behaves.

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -40,6 +40,16 @@ class MySQLConfig(object):
         self.statement_samples_config = instance.get('query_samples', instance.get('statement_samples', {})) or {}
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}
         self.activity_config = instance.get('query_activity', {}) or {}
+        self.cloud_metadata = {}
+        aws = instance.get('aws', {})
+        gcp = instance.get('gcp', {})
+        azure = instance.get('azure', {})
+        if aws:
+            self.cloud_metadata.update({'aws': aws})
+        if gcp:
+            self.cloud_metadata.update({'gcp': gcp})
+        if azure:
+            self.cloud_metadata.update({'azure': azure})
         self.min_collection_interval = instance.get('min_collection_interval', 15)
         self.only_custom_queries = is_affirmative(instance.get('only_custom_queries', False))
         obfuscator_options_config = instance.get('obfuscator_options', {}) or {}

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -46,32 +46,12 @@ def instance_defaults_file(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_disable_generic_tags(field, value):
-    return False
-
-
-def instance_empty_default_hostname(field, value):
-    return False
-
-
 def instance_host(field, value):
     return get_default_field_value(field, value)
 
 
 def instance_max_custom_queries(field, value):
     return 20
-
-
-def instance_metric_patterns(field, value):
-    return get_default_field_value(field, value)
-
-
-def instance_min_collection_interval(field, value):
-    return 15
-
-
-def instance_obfuscator_options(field, value):
-    return get_default_field_value(field, value)
 
 
 def instance_only_custom_queries(field, value):
@@ -110,19 +90,11 @@ def instance_reported_hostname(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_service(field, value):
-    return get_default_field_value(field, value)
-
-
 def instance_sock(field, value):
     return get_default_field_value(field, value)
 
 
 def instance_ssl(field, value):
-    return get_default_field_value(field, value)
-
-
-def instance_tags(field, value):
     return get_default_field_value(field, value)
 
 

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -28,25 +28,6 @@ class CustomQuery(BaseModel):
     tags: Optional[Sequence[str]]
 
 
-class MetricPatterns(BaseModel):
-    class Config:
-        allow_mutation = False
-
-    exclude: Optional[Sequence[str]]
-    include: Optional[Sequence[str]]
-
-
-class ObfuscatorOptions(BaseModel):
-    class Config:
-        allow_mutation = False
-
-    collect_commands: Optional[bool]
-    collect_comments: Optional[bool]
-    collect_metadata: Optional[bool]
-    collect_tables: Optional[bool]
-    replace_digits: Optional[bool]
-
-
 class Options(BaseModel):
     class Config:
         allow_mutation = False
@@ -121,13 +102,8 @@ class InstanceConfig(BaseModel):
     custom_queries: Optional[Sequence[CustomQuery]]
     dbm: Optional[bool]
     defaults_file: Optional[str]
-    disable_generic_tags: Optional[bool]
-    empty_default_hostname: Optional[bool]
     host: Optional[str]
     max_custom_queries: Optional[int]
-    metric_patterns: Optional[MetricPatterns]
-    min_collection_interval: Optional[float]
-    obfuscator_options: Optional[ObfuscatorOptions]
     only_custom_queries: Optional[bool]
     options: Optional[Options]
     password: Optional[str]
@@ -137,10 +113,8 @@ class InstanceConfig(BaseModel):
     query_metrics: Optional[QueryMetrics]
     query_samples: Optional[QuerySamples]
     reported_hostname: Optional[str]
-    service: Optional[str]
     sock: Optional[str]
     ssl: Optional[Ssl]
-    tags: Optional[Sequence[str]]
     use_global_custom_queries: Optional[str]
     username: Optional[str]
 

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -485,10 +485,10 @@ azure:
     #
     # deployment_type: flexible_server
 
-    ## @param database_name - string - optional - default: mysql-database
+    ## @param name - string - optional - default: mysql-database
     ## Equal to the name of the Azure MySQL database instance.
     #
-    # database_name: mysql-database
+    # name: mysql-database
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -193,7 +193,7 @@ instances:
 
     ## Enable options to collect extra metrics from your MySQL integration.
     #
-    options:
+    # options:
 
         ## @param replication - boolean - optional - default: false
         ## Set to `true` to collect replication metrics or group replication metrics.
@@ -299,7 +299,7 @@ instances:
 
     ## Configure collection of query metrics
     #
-    query_metrics:
+    # query_metrics:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of query metrics. Requires `dbm: true`.
@@ -315,7 +315,7 @@ instances:
 
     ## Configure collection of query samples
     #
-    query_samples:
+    # query_samples:
 
         ## @param enabled - boolean - optional - default: true
         ## Enables collection of query samples. Requires `dbm: true`.
@@ -405,7 +405,7 @@ instances:
 
     ## Configure collection of active sessions monitoring
     #
-    query_activity:
+    # query_activity:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of active sessions. Requires `dbm: true`.
@@ -425,7 +425,7 @@ instances:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-aws:
+# aws:
 
     ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
     ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
@@ -444,7 +444,7 @@ aws:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-gcp:
+# gcp:
 
     ## @param project_id - string - optional - default: foo-project
     ## Equal to the GCP resource's project ID.
@@ -470,7 +470,7 @@ gcp:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-azure:
+# azure:
 
     ## @param deployment_type - string - optional - default: flexible_server
     ## Equal to the deployment type for the managed database. 
@@ -493,7 +493,7 @@ azure:
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.
     #
-    obfuscator_options:
+    # obfuscator_options:
 
         ## @param replace_digits - boolean - optional - default: false
         ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -417,6 +417,60 @@ instances:
         #
         # collection_interval: 10
 
+## Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
+##
+## Requires setting the field `instance_endpoint`, which should be equal to the Endpoint.Address of the instance
+## the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
+## then setting this configuration is not necessary.
+#
+aws:
+
+    ## @param instance_endpoint - string - optional - default: foo.bar.us-east-1.rds.amazonaws.com
+    ## Equal to the Endpoint.Address of the instance the agent is connecting to.
+    ##
+    ## For more information on instance endpoints, 
+    ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
+    #
+    # instance_endpoint: foo.bar.us-east-1.rds.amazonaws.com
+
+## Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
+#
+gcp:
+
+    ## @param project_id - string - optional - default: foo-project
+    ## Equal to the GCP resource's project id.
+    ##
+    ## For more information on project ids,
+    ## See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
+    #
+    # project_id: foo-project
+
+    ## @param instance_id - string - optional - default: foo-database
+    ## Equal to the GCP resource's instance id.
+    ##
+    ## For more information on instance ids,
+    ## See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+    #
+    # instance_id: foo-database
+
+## Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
+#
+azure:
+
+    ## @param product - string - optional - default: flexible_server
+    ## Equal to the managed Azure DB product. 
+    ##
+    ## Acceptable values are:
+    ##   - `flexible_server` 
+    ##   - `single_server`
+    #
+    # product: flexible_server
+
+    ## @param name - string - optional - default: foo.database
+    ## Equal to the name of the database.
+    #
+    # name: foo.database
+
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.
     #

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -427,14 +427,14 @@ instances:
 #
 aws:
 
-    ## @param instance_endpoint - string - optional - default: mydb–instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+    ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
     ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
     ## This value is optional if the value of `host` is already configured to the instance endpoint.
     ##
     ## For more information on instance endpoints, 
     ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
     #
-    # instance_endpoint: "mydb\u2013instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com"
+    # instance_endpoint: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
 
 ## This block defines the configuration for Google Cloud SQL instances.
 ##

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -417,59 +417,78 @@ instances:
         #
         # collection_interval: 10
 
-## Provide the following if you are instrumenting a managed AWS database. Requires `dbm:true`.
+## This block defines the configuration for AWS RDS and Aurora instances. 
 ##
-## Requires setting the field `instance_endpoint`, which should be equal to the Endpoint.Address of the instance
-## the agent is connecting to. Note, if the `host` field is already equal to the instance's Endpoint.Address value, 
-## then setting this configuration is not necessary.
+## Complete this section if you have installed the Datadog AWS Integration 
+## (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+## with MySQL integration telemetry.
+##
+## These values are only applied when `dbm: true` option is set.
 #
 aws:
 
-    ## @param instance_endpoint - string - optional - default: foo.bar.us-east-1.rds.amazonaws.com
-    ## Equal to the Endpoint.Address of the instance the agent is connecting to.
+    ## @param instance_endpoint - string - optional - default: mydb–instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+    ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
+    ## This value is optional if the value of `host` is already configured to the instance endpoint.
     ##
     ## For more information on instance endpoints, 
     ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
     #
-    # instance_endpoint: foo.bar.us-east-1.rds.amazonaws.com
+    # instance_endpoint: "mydb\u2013instance.cfxgae8cilcf.us-east-1.rds.amazonaws.com"
 
-## Provide the following if you are instrumenting a managed GCP database. Requires `dbm:true`.
+## This block defines the configuration for Google Cloud SQL instances.
+##
+## Complete this section if you have installed the Datadog GCP Integration 
+## (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+## with MySQL integration telemetry.
+##
+## These values are only applied when `dbm: true` option is set.
 #
 gcp:
 
     ## @param project_id - string - optional - default: foo-project
-    ## Equal to the GCP resource's project id.
+    ## Equal to the GCP resource's project ID.
     ##
-    ## For more information on project ids,
+    ## For more information on project IDs,
     ## See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
     #
     # project_id: foo-project
 
     ## @param instance_id - string - optional - default: foo-database
-    ## Equal to the GCP resource's instance id.
+    ## Equal to the GCP resource's instance ID.
     ##
-    ## For more information on instance ids,
+    ## For more information on instance IDs,
     ## See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
     #
     # instance_id: foo-database
 
-## Provide the following if you are instrumenting a managed Azure database. Requires `dbm:true`.
+## This block defines the configuration for Azure Database for MySQL.
+##
+## Complete this section if you have installed the Datadog Azure Integration 
+## (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+## with MySQL integration telemetry.
+##
+## These values are only applied when `dbm: true` option is set.
 #
 azure:
 
-    ## @param product - string - optional - default: flexible_server
-    ## Equal to the managed Azure DB product. 
+    ## @param deployment_type - string - optional - default: flexible_server
+    ## Equal to the deployment type for the managed database. 
     ##
     ## Acceptable values are:
     ##   - `flexible_server` 
     ##   - `single_server`
+    ##   - `virtual_machine`
+    ##
+    ## For more information on deployment types, 
+    ## see the Azure docs https://docs.microsoft.com/en-us/azure/mysql/select-right-deployment-type
     #
-    # product: flexible_server
+    # deployment_type: flexible_server
 
-    ## @param name - string - optional - default: foo.database
-    ## Equal to the name of the database.
+    ## @param database_name - string - optional - default: mysql-database
+    ## Equal to the name of the Azure MySQL database instance.
     #
-    # name: foo.database
+    # database_name: mysql-database
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -146,6 +146,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
             'ddagentversion': datadog_agent.get_version(),
             'min_collection_interval': self._metric_collection_interval,
             'tags': self._tags,
+            'cloud_metadata': self._config.cloud_metadata,
             'mysql_rows': rows,
         }
         self._check.database_monitoring_query_metrics(json.dumps(payload, default=default_json_event_encoding))

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -230,8 +230,8 @@ def test_statement_metrics_with_duplicates(aggregator, dd_run_check, dbm_instanc
         {},
         {
             'azure': {
-                'product': 'flexible_server',
-                'name': 'test-server',
+                'deployment_type': 'flexible_server',
+                'database_name': 'test-server',
             },
         },
         {
@@ -239,8 +239,8 @@ def test_statement_metrics_with_duplicates(aggregator, dd_run_check, dbm_instanc
                 'instance_endpoint': 'foo.aws.com',
             },
             'azure': {
-                'product': 'flexible_server',
-                'name': 'test-server',
+                'deployment_type': 'flexible_server',
+                'database_name': 'test-server',
             },
         },
         {

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -252,9 +252,7 @@ def test_statement_metrics_with_duplicates(aggregator, dd_run_check, dbm_instanc
         },
     ],
 )
-def test_statement_metrics_cloud_metadata(
-        aggregator, dd_run_check, dbm_instance, cloud_metadata, datadog_agent
-):
+def test_statement_metrics_cloud_metadata(aggregator, dd_run_check, dbm_instance, cloud_metadata, datadog_agent):
     if cloud_metadata:
         for k, v in cloud_metadata.items():
             dbm_instance[k] = v

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -225,6 +225,71 @@ def test_statement_metrics_with_duplicates(aggregator, dd_run_check, dbm_instanc
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
+    "cloud_metadata",
+    [
+        {},
+        {
+            'azure': {
+                'product': 'flexible_server',
+                'name': 'test-server',
+            },
+        },
+        {
+            'aws': {
+                'instance_endpoint': 'foo.aws.com',
+            },
+            'azure': {
+                'product': 'flexible_server',
+                'name': 'test-server',
+            },
+        },
+        {
+            'gcp': {
+                'project_id': 'foo-project',
+                'instance_id': 'bar',
+                'extra_field': 'included',
+            },
+        },
+    ],
+)
+def test_statement_metrics_cloud_metadata(
+        aggregator, dd_run_check, dbm_instance, cloud_metadata, datadog_agent
+):
+    if cloud_metadata:
+        for k, v in cloud_metadata.items():
+            dbm_instance[k] = v
+    mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
+
+    def run_query(q):
+        with mysql_check._connect() as db:
+            with closing(db.cursor()) as cursor:
+                cursor.execute(q)
+
+    query = "SELECT * FROM `testdb` . `users`"
+
+    # Run a query
+    run_query(query)
+    dd_run_check(mysql_check)
+
+    # Run the query and check a second time so statement metrics are computed from the previous run
+    run_query(query)
+    dd_run_check(mysql_check)
+
+    events = aggregator.get_event_platform_events("dbm-metrics")
+    assert len(events) == 1, "should produce exactly one metrics payload"
+    event = events[0]
+
+    assert event['host'] == 'stubbed.hostname'
+    assert event['ddagentversion'] == datadog_agent.get_version()
+    assert event['ddagenthostname'] == datadog_agent.get_hostname()
+    assert event['mysql_version'] == mysql_check.version.version + '+' + mysql_check.version.build
+    assert event['mysql_flavor'] == mysql_check.version.flavor
+    assert event['cloud_metadata'] == cloud_metadata, "wrong cloud_metadata"
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize(
     "events_statements_table",
     ["events_statements_history_long"],
 )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds three new fields associated with the database-monitoring product in order to help support the new (beta) DB List feature. Ingesting this extra cloud related metadata will allow for us to link managed cloud resource metrics emitted by Datadog cloud crawlers to database-monitoring reported hosts.

Follow on PR to https://github.com/DataDog/integrations-core/pull/11987

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
