### PR TITLE
[kubelet] Sanitize the `url` tag

### DIFF
--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -1452,3 +1452,12 @@ def test_detect_probes_req_exception(monkeypatch, mock_request):
     assert available is False
     assert check._probes_available is None
     assert mock_request.call_count == 1
+
+
+def test_sanitize_url_label():
+    input = (
+        "https://35.242.243.158/api/v1/namespaces/%7Bnamespace%7D/configmaps"
+        + "?fieldSelector=%7Bvalue%7D&limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D"
+    )
+    expected = "/api/v1/namespaces/%7Bnamespace%7D/configmaps"
+    assert KubeletCheck._sanitize_url_label(input) == expected


### PR DESCRIPTION
### What does this PR do?

Sanitise the `url` tag of the `kubernetes.rest.client.latency` metric of the `kubelet` check.

### Motivation

The `url` tag of the `kubernetes.rest.client.latency` metric is causing some high cardinality issue.
In order to reduce the cardinality, we strip the `url` tag to keep only the path.

The `url` tag contains all the possible values for the Kubernetes API server calls made by the kubelet.
Ex.: `https://35.242.243.158/api/v1/namespaces/%7Bnamespace%7D/configmaps?fieldSelector=%7Bvalue%7D&limit=%7Bvalue%7D&resourceVersion=%7Bvalue%7D`

The host of the url is the Kubernetes API server.
Whereas it is the same for all the kubelet inside a cluster, it will be different in two different clusters.
Dropping the host part of the url will ease the comparison of `kubernetes.rest.client.latency` between different clusters.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
