### PR TITLE
Properly validate `only_custom_queries`

### DIFF
--- a/snowflake/datadog_checks/snowflake/config_models/validators.py
+++ b/snowflake/datadog_checks/snowflake/config_models/validators.py
@@ -17,7 +17,7 @@ def initialize_instance(values, **kwargs):
             'Set `private_key_path` or remove `private_key_password` entry.'
         )
 
-    if values.get('only_custom_queries', False) and len(values('metric_groups', [])) > 0:
+    if values.get('only_custom_queries', False) and len(values.get('metric_groups', [])) > 0:
         raise ConfigurationError(
             'Option `only_custom_queries` and `metric_groups` are not compatible. '
             '`only_custom_queries` prevents `metric_groups` to be collected.'

--- a/snowflake/tests/test_config.py
+++ b/snowflake/tests/test_config.py
@@ -43,6 +43,7 @@ def test_authenticator_option_fail(options):
         pytest.param({'authenticator': 'snowflake_jwt', 'private_key_path': '/path/to/key'}, id='key pair auth'),
         pytest.param({'authenticator': 'oauth', 'token_path': '/path/to/token'}, id='token path'),
         pytest.param({'authenticator': 'oauth', 'token': 'mytoken'}, id='token'),
+        pytest.param({'only_custom_queries': True, 'metric_groups': []}, id='valid only_custom_queries'),
     ],
 )
 def test_authenticator_option_pass(options):

--- a/snowflake/tests/test_config.py
+++ b/snowflake/tests/test_config.py
@@ -16,7 +16,15 @@ from .common import CHECK_NAME
         pytest.param({'token': 'mytoken'}, id='wrong parameters'),
         pytest.param({'authenticator': 'unknown'}, id='wrong authenticator'),
         pytest.param({'password': 'pass', 'private_key_password': 'pass'}, id='missing private_key_path'),
-        pytest.param({'only_custom_queries': True, 'metric_groups': ['snowflake.billing']}, id='incompatible options'),
+        pytest.param(
+            {
+                'only_custom_queries': True,
+                'username': 'test',
+                'password': 'test',
+                'metric_groups': ['snowflake.billing'],
+            },
+            id='incompatible options',
+        ),
     ],
 )
 def test_authenticator_option_fail(options):
@@ -43,7 +51,16 @@ def test_authenticator_option_fail(options):
         pytest.param({'authenticator': 'snowflake_jwt', 'private_key_path': '/path/to/key'}, id='key pair auth'),
         pytest.param({'authenticator': 'oauth', 'token_path': '/path/to/token'}, id='token path'),
         pytest.param({'authenticator': 'oauth', 'token': 'mytoken'}, id='token'),
-        pytest.param({'only_custom_queries': True, 'metric_groups': []}, id='valid only_custom_queries'),
+        pytest.param(
+            {
+                'only_custom_queries': True,
+                'username': 'test',
+                'password': 'test',
+                'metric_groups': [],
+                'custom_queries': [{}],
+            },
+            id='valid only_custom_queries',
+        ),
     ],
 )
 def test_authenticator_option_pass(options):


### PR DESCRIPTION
### What does this PR do?
Properly validate metric groups and `only_custom_queries`
### Motivation
previously when `only_custom_queries` was enabled, it errored:
```
__root__
  'dict' object is not callable
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 1095, in run
          initialization()
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 489, in load_configuration_models
          instance_config = self.load_configuration_model(package_path, 'InstanceConfig', raw_instance_config)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 533, in load_configuration_model
          raise_from(ConfigurationError('\n'.join(message_lines)), None)
        File "<string>", line 3, in raise_from
      datadog_checks.base.errors.ConfigurationError: Detected 1 error while loading configuration model `InstanceConfig`:
      __root__
        'dict' object is not callable
```
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
