### PR TITLE
Pin Calico test env to v3.22

### DIFF
--- a/calico/tests/conftest.py
+++ b/calico/tests/conftest.py
@@ -23,7 +23,7 @@ HERE = path.dirname(path.abspath(__file__))
 
 def setup_calico():
     # Deploy calico
-    # Pinning the test manifests to v3.22. v3.23 deprecated a metric that we check for `felix_active_local_tags`
+    # Pinned the test manifests to v3.22. v3.23 deprecated a metric that we check for `felix_active_local_tags`
     # https://projectcalico.docs.tigera.io/archive/v3.22/reference/felix/prometheus
     run_command(["kubectl", "apply", "-f", "https://projectcalico.docs.tigera.io/archive/v3.22/manifests/calico.yaml"])
 

--- a/calico/tests/conftest.py
+++ b/calico/tests/conftest.py
@@ -23,10 +23,12 @@ HERE = path.dirname(path.abspath(__file__))
 
 def setup_calico():
     # Deploy calico
-    run_command(["kubectl", "apply", "-f", "https://docs.projectcalico.org/manifests/calico.yaml"])
+    run_command(["kubectl", "apply", "-f", "https://projectcalico.docs.tigera.io/archive/v3.22/manifests/calico.yaml"])
 
     # Install calicoctl as a pod
-    run_command(["kubectl", "apply", "-f", "https://docs.projectcalico.org/manifests/calicoctl.yaml"])
+    run_command(
+        ["kubectl", "apply", "-f", "https://projectcalico.docs.tigera.io/archive/v3.22/manifests/calicoctl.yaml"]
+    )
 
     # Create felix metrics service
     run_command(["kubectl", "apply", "-f", path.join(HERE, 'felix-service.yaml')])

--- a/calico/tests/conftest.py
+++ b/calico/tests/conftest.py
@@ -23,6 +23,8 @@ HERE = path.dirname(path.abspath(__file__))
 
 def setup_calico():
     # Deploy calico
+    # Pinning the test manifests to v3.22. v3.23 deprecated a metric that we check for `felix_active_local_tags`
+    # https://projectcalico.docs.tigera.io/archive/v3.22/reference/felix/prometheus
     run_command(["kubectl", "apply", "-f", "https://projectcalico.docs.tigera.io/archive/v3.22/manifests/calico.yaml"])
 
     # Install calicoctl as a pod


### PR DESCRIPTION
### What does this PR do?
Pins the version of calico to 3.22. Between 3.23 and 3.22, one of the metric we assert got deprecated:

`felix_active_local_tags`:

https://projectcalico.docs.tigera.io/archive/v3.22/reference/felix/prometheus
Versus:
https://projectcalico.docs.tigera.io/reference/felix/prometheus
