### PR TITLE
Metadata updates from releases off of 7.36.x branch

### DIFF
--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - mysql
 
+## 8.2.2 / 2022-04-20
+
+* [Fixed] Fix activity host reporting. See [#11854](https://github.com/DataDog/integrations-core/pull/11854).
+
 ## 8.2.1 / 2022-04-14
 
 * [Fixed] Update base version. See [#11825](https://github.com/DataDog/integrations-core/pull/11825).

--- a/mysql/datadog_checks/mysql/__about__.py
+++ b/mysql/datadog_checks/mysql/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "8.2.1"
+__version__ = "8.2.2"

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - postgres
 
+## 12.3.2 / 2022-04-20
+
+* [Fixed] Fix activity and sample host reporting. See [#11855](https://github.com/DataDog/integrations-core/pull/11855).
+
 ## 12.3.1 / 2022-04-14
 
 * [Fixed] Update base version. See [#11824](https://github.com/DataDog/integrations-core/pull/11824).

--- a/postgres/datadog_checks/postgres/__about__.py
+++ b/postgres/datadog_checks/postgres/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "12.3.1"
+__version__ = "12.3.2"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -95,7 +95,7 @@ datadog-mcache==3.2.0; sys_platform != 'win32'
 datadog-mesos-master==3.1.0; sys_platform != 'win32'
 datadog-mesos-slave==3.1.0; sys_platform != 'win32'
 datadog-mongo==3.2.1
-datadog-mysql==8.2.1
+datadog-mysql==8.2.2
 datadog-nagios==1.11.0
 datadog-network==2.7.0
 datadog-nfsstat==1.11.0; sys_platform == 'linux2'
@@ -111,7 +111,7 @@ datadog-pdh-check==1.16.0; sys_platform == 'win32'
 datadog-pgbouncer==4.2.0; sys_platform != 'win32'
 datadog-php-fpm==2.1.0
 datadog-postfix==1.12.0; sys_platform != 'win32'
-datadog-postgres==12.3.1
+datadog-postgres==12.3.2
 datadog-powerdns-recursor==2.1.0
 datadog-presto==2.6.1
 datadog-process==2.3.0
@@ -133,7 +133,7 @@ datadog-snowflake==4.3.0
 datadog-solr==1.11.1
 datadog-sonarqube==2.0.1
 datadog-spark==3.1.0
-datadog-sqlserver==7.6.1
+datadog-sqlserver==7.6.2
 datadog-squid==2.1.0
 datadog-ssh-check==2.3.0
 datadog-statsd==1.10.0
@@ -146,7 +146,7 @@ datadog-tenable==1.4.0
 datadog-tls==2.8.0
 datadog-tokumx==3.1.1
 datadog-tomcat==1.11.1
-datadog-traffic-server==1.0.0
+datadog-traffic-server==1.0.1
 datadog-twemproxy==1.13.0
 datadog-twistlock==3.1.0
 datadog-varnish==1.14.0

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - sqlserver
 
+## 7.6.2 / 2022-04-20
+
+* [Fixed] Fix activity and plan host reporting. See [#11853](https://github.com/DataDog/integrations-core/pull/11853).
+
 ## 7.6.1 / 2022-04-14
 
 * [Fixed] Update base version. See [#11826](https://github.com/DataDog/integrations-core/pull/11826).

--- a/sqlserver/datadog_checks/sqlserver/__about__.py
+++ b/sqlserver/datadog_checks/sqlserver/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '7.6.1'
+__version__ = '7.6.2'

--- a/traffic_server/CHANGELOG.md
+++ b/traffic_server/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG - Traffic Server
 
+## 1.0.1 / 2022-04-20
+
+* [Fixed] Add `traffic_server_url` tag. See [#11862](https://github.com/DataDog/integrations-core/pull/11862).
+* [Fixed] Add more default metrics. See [#11858](https://github.com/DataDog/integrations-core/pull/11858).
+
 ## 1.0.0 / 2022-04-05
 
 * [Added] Add Traffic Server integration. See [#11471](https://github.com/DataDog/integrations-core/pull/11471).

--- a/traffic_server/datadog_checks/traffic_server/__about__.py
+++ b/traffic_server/datadog_checks/traffic_server/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.0.0'
+__version__ = '1.0.1'


### PR DESCRIPTION
### What does this PR do?
Metadata ports from the releases off of 7.36.x. Duplicate of #11868.