### PR TITLE
Fix Typo in HAProxy Params, Add Deployment Example

### DIFF
--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -81,9 +81,9 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 | `<INIT_CONFIG>`      | blank or `{}`                                                                           |
 | `<INSTANCE_CONFIG>`  | `{"openmetrics_endpoint": "http://%%host%%:<PORT>/metrics", "use_openmetrics": "true"}` |
 
-##### Kubernetes Deployment Example
+##### Kubernetes Deployment example
 
-Add the pod annotations under .spec.template.metadata for a Deployment:
+Add pod annotations under `.spec.template.metadata` for a Deployment:
 
 ```yaml
 apiVersion: apps/v1

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -75,11 +75,39 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 
 ##### Metric collection
 
-| Parameter            | Value                                                                                 |
-|----------------------|---------------------------------------------------------------------------------------|
-| `<INTEGRATION_NAME>` | `haproxy`                                                                             |
-| `<INIT_CONFIG>`      | blank or `{}`                                                                         |
-| `<INSTANCE_CONFIG>`  | `{"openmetrics_endpoint": "http://%%host%%:<PORT>/metrics", "use_openmetrics": True}` |
+| Parameter            | Value                                                                                   |
+|----------------------|-----------------------------------------------------------------------------------------|
+| `<INTEGRATION_NAME>` | `haproxy`                                                                               |
+| `<INIT_CONFIG>`      | blank or `{}`                                                                           |
+| `<INSTANCE_CONFIG>`  | `{"openmetrics_endpoint": "http://%%host%%:<PORT>/metrics", "use_openmetrics": "true"}` |
+
+##### Kubernetes Deployment Example
+
+Add the pod annotations under .spec.template.metadata for a Deployment:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: haproxy
+spec:
+  template:
+    metadata:
+      labels:
+        name: haproxy
+      annotations:
+        ad.datadoghq.com/haproxy.check_names: '["haproxy"]'
+        ad.datadoghq.com/haproxy.init_configs: '[{}]'
+        ad.datadoghq.com/haproxy.instances: |
+          [
+            {
+              "openmetrics_endpoint": "http://%%host%%:<PORT>/metrics", "use_openmetrics": "true"
+            }
+          ]
+    spec:
+      containers:
+        - name: haproxy
+```
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->


### PR DESCRIPTION
### What does this PR do?
The parameter for "use_openmetrics" in the HAProxy configuration should be `"true"` not `True`. It throws an error reading the annotation due to bad syntax.

There are also no examples in any of the docs for how to use the annotations on a k8s Deployment type, so I added one.

### Motivation

The doc has a wrong value in it, which was not clear. 

There also are no examples in any of the docs for using a k8s deployment template with autodiscovery. It is briefly alluded to in: https://docs.datadoghq.com/agent/kubernetes/integrations/?tab=kubernetes#configuration however there are no examples shown anywhere. The examples are all use `Pod`, so it would be nice to show what a `Deployment` is supposed to look like.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
