### PR TITLE
Remove execution plan `user_name` attribute

### DIFF
--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -97,11 +97,10 @@ def test_get_statement_metrics_query_cached(aggregator, dbm_instance, caplog):
 
 
 test_statement_metrics_and_plans_parameterized = (
-    "database,plan_user,query,match_pattern,param_groups,disable_secondary_tags",
+    "database,query,match_pattern,param_groups,disable_secondary_tags",
     [
         [
             "datadog_test",
-            "dbo",
             "SELECT * FROM ϑings",
             r"SELECT \* FROM ϑings",
             ((),),
@@ -109,7 +108,6 @@ test_statement_metrics_and_plans_parameterized = (
         ],
         [
             "datadog_test",
-            "dbo",
             "SELECT * FROM ϑings where id = ?",
             r"\(@P1 \w+\)SELECT \* FROM ϑings where id = @P1",
             (
@@ -121,7 +119,6 @@ test_statement_metrics_and_plans_parameterized = (
         ],
         [
             "master",
-            None,
             "SELECT * FROM datadog_test.dbo.ϑings where id = ?",
             r"\(@P1 \w+\)SELECT \* FROM datadog_test.dbo.ϑings where id = @P1",
             (
@@ -133,7 +130,6 @@ test_statement_metrics_and_plans_parameterized = (
         ],
         [
             "datadog_test",
-            "dbo",
             "SELECT * FROM ϑings where id = ? and name = ?",
             r"\(@P1 \w+,@P2 (N)?VARCHAR\(\d+\)\)SELECT \* FROM ϑings where id = @P1 and name = @P2",
             (
@@ -145,7 +141,6 @@ test_statement_metrics_and_plans_parameterized = (
         ],
         [
             "datadog_test",
-            "dbo",
             "SELECT * FROM ϑings where id = ?",
             r"\(@P1 \w+\)SELECT \* FROM ϑings where id = @P1",
             (
@@ -168,7 +163,6 @@ def test_statement_metrics_and_plans(
     dbm_instance,
     bob_conn,
     database,
-    plan_user,
     query,
     param_groups,
     disable_secondary_tags,
@@ -226,10 +220,8 @@ def test_statement_metrics_and_plans(
         assert row['query_signature'], "missing query signature"
         if disable_secondary_tags:
             assert 'database_name' not in row
-            assert 'user_name' not in row
         else:
             assert row['database_name'] == database, "incorrect database_name"
-            assert row['user_name'] == plan_user, "incorrect user_name"
         for column in available_query_metrics_columns:
             assert column in row, "missing required metrics column {}".format(column)
             assert type(row[column]) in (float, int), "wrong type for metrics column {}".format(column)


### PR DESCRIPTION
### What does this PR do?

Remove the `user_name` attribute from query metrics and execution plans.

### Motivation

This user attribute has turned out to be confusing to use because it doesn't represent the user that actually executed the query. Instead, it represents the following (from [the docs](https://docs.microsoft.com/en-us/sql/relational-databases/system-dynamic-management-views/sys-dm-exec-plan-attributes-transact-sql)): *Value of -2 indicates that the batch submitted does not depend on implicit name resolution and can be shared among different users. This is the preferred method. Any other value represents the user ID of the user submitting the query in the database*.

To remove the confusion we are removing this attribute.

By removing the plan user attribute the statement metrics query also becomes less expensive because we no longer need to aggregate by the plan user and we no longer need to join on `sysusers`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
