### PR TITLE
Install latest dev package

### DIFF
--- a/calico/requirements-dev.txt
+++ b/calico/requirements-dev.txt
@@ -1,1 +1,1 @@
-datadog-checks-dev
+-e ../datadog_checks_dev

--- a/foundationdb/requirements-dev.txt
+++ b/foundationdb/requirements-dev.txt
@@ -1,2 +1,2 @@
-datadog-checks-dev
+-e ../datadog_checks_dev
 foundationdb==6.3.24


### PR DESCRIPTION
### What does this PR do?
Installs the correct dev package in tests

### Motivation
Calico e2e is failing even when a [fix](https://github.com/DataDog/integrations-core/pull/12004) is implemented in ddev. These two checks were previously in integrations-extras and their `requirements-dev.txt` were not updated after the move. Foundationdb does not currently have an e2e test but could in the future

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
