### PR TITLE
mysql: Add option to keep aliases in mysql (`keep_sql_alias`)

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -587,13 +587,13 @@ files:
                   type: boolean
                   example: true
                   display_default: true
-      - template: instances/default
-        overrides:
-          disable_generic_tags.hidden: false
-          disable_generic_tags.enabled: true
-          disable_generic_tags.description: |
-              Replaces generic tag such as `server` with `mysql_server` to avoid getting it mixed with
-              other integrations tags.
+          - template: instances/default
+            overrides:
+              disable_generic_tags.hidden: false
+              disable_generic_tags.enabled: true
+              disable_generic_tags.description: |
+                  Replaces generic tag such as `server` with `mysql_server` to avoid getting it mixed with
+                  other integrations tags.
 
       - template: logs
         example:

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -578,6 +578,24 @@ files:
                 value:
                   type: boolean
                   example: true
+              - name: keep_sql_alias
+                description: |
+                  Set to `true` to keep sql aliases in obfuscated SQL statements. Examples of aliases are
+                  `with select 1 as alias`, `select column as other_name`, or `select * from table t`.
+                  When `true` these aliases will not be removed.
+                value:
+                  type: boolean
+                  example: true
+                  display_default: true
+              - name: keep_dollar_quoted_func
+                description: |
+                  Set to `true` to prevent dollar quoted function strings (e.g. `$func$`) from being removed.
+                  When not removed, the sql content of dollar quoted func strings will be obfuscated.
+                  Only strings with the tag `$func$` are supported.
+                value:
+                  type: boolean
+                  example: true
+                  display_default: true
           - template: instances/default
             overrides:
               disable_generic_tags.hidden: false

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -587,15 +587,6 @@ files:
                   type: boolean
                   example: true
                   display_default: true
-              - name: keep_dollar_quoted_func
-                description: |
-                  Set to `true` to prevent dollar quoted function strings (e.g. `$func$`) from being removed.
-                  When not removed, the sql content of dollar quoted func strings will be obfuscated.
-                  Only strings with the tag `$func$` are supported.
-                value:
-                  type: boolean
-                  example: true
-                  display_default: true
           - template: instances/default
             overrides:
               disable_generic_tags.hidden: false

--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -455,86 +455,86 @@ files:
                 value:
                   type: number
                   example: 10
-      - name: aws
-        description: |
-          This block defines the configuration for AWS RDS and Aurora instances. 
-          
-          Complete this section if you have installed the Datadog AWS Integration 
-          (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
-          with MySQL integration telemetry.
-          
-          These values are only applied when `dbm: true` option is set.
-        options:
-          - name: instance_endpoint
+          - name: aws
             description: |
-              Equal to the Endpoint.Address of the instance the agent is connecting to. 
-              This value is optional if the value of `host` is already configured to the instance endpoint.
+              This block defines the configuration for AWS RDS and Aurora instances. 
               
-              For more information on instance endpoints, 
-              see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
-            value:
-              type: string
-              example: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+              Complete this section if you have installed the Datadog AWS Integration 
+              (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+              with MySQL integration telemetry.
+              
+              These values are only applied when `dbm: true` option is set.
+            options:
+              - name: instance_endpoint
+                description: |
+                  Equal to the Endpoint.Address of the instance the agent is connecting to. 
+                  This value is optional if the value of `host` is already configured to the instance endpoint.
+                  
+                  For more information on instance endpoints, 
+                  see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
+                value:
+                  type: string
+                  example: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
 
-      - name: gcp
-        description: |
-          This block defines the configuration for Google Cloud SQL instances.
-          
-          Complete this section if you have installed the Datadog GCP Integration 
-          (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
-          with MySQL integration telemetry.
-          
-          These values are only applied when `dbm: true` option is set.
-        options:
-          - name: project_id
+          - name: gcp
             description: |
-              Equal to the GCP resource's project ID.
+              This block defines the configuration for Google Cloud SQL instances.
               
-              For more information on project IDs,
-              See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
-            value:
-              type: string
-              example: foo-project
-          - name: instance_id
-            description: |
-              Equal to the GCP resource's instance ID.
+              Complete this section if you have installed the Datadog GCP Integration 
+              (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+              with MySQL integration telemetry.
               
-              For more information on instance IDs,
-              See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
-            value:
-              type: string
-              example: foo-database
+              These values are only applied when `dbm: true` option is set.
+            options:
+              - name: project_id
+                description: |
+                  Equal to the GCP resource's project ID.
+                  
+                  For more information on project IDs,
+                  See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
+                value:
+                  type: string
+                  example: foo-project
+              - name: instance_id
+                description: |
+                  Equal to the GCP resource's instance ID.
+                  
+                  For more information on instance IDs,
+                  See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+                value:
+                  type: string
+                  example: foo-database
 
-      - name: azure
-        description: |
-          This block defines the configuration for Azure Database for MySQL.
-          
-          Complete this section if you have installed the Datadog Azure Integration 
-          (https://docs.datadoghq.com/integrations/azure) to enrich instances 
-          with MySQL integration telemetry.
-          
-          These values are only applied when `dbm: true` option is set.
-        options:
-          - name: deployment_type
+          - name: azure
             description: |
-              Equal to the deployment type for the managed database. 
+              This block defines the configuration for Azure Database for MySQL.
               
-              Acceptable values are:
-                - `flexible_server` 
-                - `single_server`
-                - `virtual_machine`
+              Complete this section if you have installed the Datadog Azure Integration 
+              (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+              with MySQL integration telemetry.
               
-              For more information on deployment types, 
-              see the Azure docs https://docs.microsoft.com/en-us/azure/mysql/select-right-deployment-type
-            value:
-              type: string
-              example: flexible_server
-          - name: name
-            description: |
-              Equal to the name of the Azure MySQL database instance.
-            value:
-              type: string
-              example: mysql-database
+              These values are only applied when `dbm: true` option is set.
+            options:
+              - name: deployment_type
+                description: |
+                  Equal to the deployment type for the managed database. 
+                  
+                  Acceptable values are:
+                    - `flexible_server` 
+                    - `single_server`
+                    - `virtual_machine`
+                  
+                  For more information on deployment types, 
+                  see the Azure docs https://docs.microsoft.com/en-us/azure/mysql/select-right-deployment-type
+                value:
+                  type: string
+                  example: flexible_server
+              - name: name
+                description: |
+                  Equal to the name of the Azure MySQL database instance.
+                value:
+                  type: string
+                  example: mysql-database
 
           - name: obfuscator_options
             description: |
@@ -587,13 +587,13 @@ files:
                   type: boolean
                   example: true
                   display_default: true
-          - template: instances/default
-            overrides:
-              disable_generic_tags.hidden: false
-              disable_generic_tags.enabled: true
-              disable_generic_tags.description: |
-                  Replaces generic tag such as `server` with `mysql_server` to avoid getting it mixed with
-                  other integrations tags.
+      - template: instances/default
+        overrides:
+          disable_generic_tags.hidden: false
+          disable_generic_tags.enabled: true
+          disable_generic_tags.description: |
+              Replaces generic tag such as `server` with `mysql_server` to avoid getting it mixed with
+              other integrations tags.
 
       - template: logs
         example:

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -62,8 +62,8 @@ class MySQLConfig(object):
                     'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
                 )
             ),
-            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', False)),
-            'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', False)),
+            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', True)),
+            'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', True)),
             'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
             'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),
             'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -62,8 +62,8 @@ class MySQLConfig(object):
                     'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
                 )
             ),
-            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('dollar_quoted_func', True)),
-            'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', True)),
+            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('dollar_quoted_func', False)),
+            'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', False)),
             'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
             'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),
             'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -62,7 +62,6 @@ class MySQLConfig(object):
                     'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
                 )
             ),
-            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', True)),
             'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', True)),
             'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
             'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -62,6 +62,8 @@ class MySQLConfig(object):
                     'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
                 )
             ),
+            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('dollar_quoted_func', True)),
+            'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', True)),
             'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
             'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),
             'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -62,7 +62,7 @@ class MySQLConfig(object):
                     'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
                 )
             ),
-            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('dollar_quoted_func', False)),
+            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', False)),
             'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', False)),
             'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
             'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -54,6 +54,14 @@ def instance_defaults_file(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_disable_generic_tags(field, value):
+    return False
+
+
+def instance_empty_default_hostname(field, value):
+    return False
+
+
 def instance_gcp(field, value):
     return get_default_field_value(field, value)
 
@@ -64,6 +72,14 @@ def instance_host(field, value):
 
 def instance_max_custom_queries(field, value):
     return 20
+
+
+def instance_metric_patterns(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_min_collection_interval(field, value):
+    return 15
 
 
 def instance_obfuscator_options(field, value):
@@ -106,11 +122,19 @@ def instance_reported_hostname(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_service(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_sock(field, value):
     return get_default_field_value(field, value)
 
 
 def instance_ssl(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_tags(field, value):
     return get_default_field_value(field, value)
 
 

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -26,6 +26,14 @@ def instance_additional_variable(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_aws(field, value):
+    return get_default_field_value(field, value)
+
+
+def instance_azure(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_charset(field, value):
     return get_default_field_value(field, value)
 
@@ -46,12 +54,20 @@ def instance_defaults_file(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_gcp(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_host(field, value):
     return get_default_field_value(field, value)
 
 
 def instance_max_custom_queries(field, value):
     return 20
+
+
+def instance_obfuscator_options(field, value):
+    return get_default_field_value(field, value)
 
 
 def instance_only_custom_queries(field, value):

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -19,6 +19,21 @@ from datadog_checks.base.utils.models import validation
 from . import defaults, validators
 
 
+class Aws(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    instance_endpoint: Optional[str]
+
+
+class Azure(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    deployment_type: Optional[str]
+    name: Optional[str]
+
+
 class CustomQuery(BaseModel):
     class Config:
         allow_mutation = False
@@ -26,6 +41,26 @@ class CustomQuery(BaseModel):
     columns: Optional[Sequence[Mapping[str, Any]]]
     query: Optional[str]
     tags: Optional[Sequence[str]]
+
+
+class Gcp(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    instance_id: Optional[str]
+    project_id: Optional[str]
+
+
+class ObfuscatorOptions(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    collect_commands: Optional[bool]
+    collect_comments: Optional[bool]
+    collect_metadata: Optional[bool]
+    collect_tables: Optional[bool]
+    keep_sql_alias: Optional[bool]
+    replace_digits: Optional[bool]
 
 
 class Options(BaseModel):
@@ -97,13 +132,17 @@ class InstanceConfig(BaseModel):
 
     additional_status: Optional[Sequence[Mapping[str, Any]]]
     additional_variable: Optional[Sequence[Mapping[str, Any]]]
+    aws: Optional[Aws]
+    azure: Optional[Azure]
     charset: Optional[str]
     connect_timeout: Optional[float]
     custom_queries: Optional[Sequence[CustomQuery]]
     dbm: Optional[bool]
     defaults_file: Optional[str]
+    gcp: Optional[Gcp]
     host: Optional[str]
     max_custom_queries: Optional[int]
+    obfuscator_options: Optional[ObfuscatorOptions]
     only_custom_queries: Optional[bool]
     options: Optional[Options]
     password: Optional[str]

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -51,6 +51,14 @@ class Gcp(BaseModel):
     project_id: Optional[str]
 
 
+class MetricPatterns(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    exclude: Optional[Sequence[str]]
+    include: Optional[Sequence[str]]
+
+
 class ObfuscatorOptions(BaseModel):
     class Config:
         allow_mutation = False
@@ -139,9 +147,13 @@ class InstanceConfig(BaseModel):
     custom_queries: Optional[Sequence[CustomQuery]]
     dbm: Optional[bool]
     defaults_file: Optional[str]
+    disable_generic_tags: Optional[bool]
+    empty_default_hostname: Optional[bool]
     gcp: Optional[Gcp]
     host: Optional[str]
     max_custom_queries: Optional[int]
+    metric_patterns: Optional[MetricPatterns]
+    min_collection_interval: Optional[float]
     obfuscator_options: Optional[ObfuscatorOptions]
     only_custom_queries: Optional[bool]
     options: Optional[Options]
@@ -152,8 +164,10 @@ class InstanceConfig(BaseModel):
     query_metrics: Optional[QueryMetrics]
     query_samples: Optional[QuerySamples]
     reported_hostname: Optional[str]
+    service: Optional[str]
     sock: Optional[str]
     ssl: Optional[Ssl]
+    tags: Optional[Sequence[str]]
     use_global_custom_queries: Optional[str]
     username: Optional[str]
 

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -574,7 +574,7 @@
     ## Replaces generic tag such as `server` with `mysql_server` to avoid getting it mixed with
     ## other integrations tags.
     #
-    # disable_generic_tags: true
+    disable_generic_tags: true
 
     ## @param metric_patterns - mapping - optional
     ## A mapping of metrics to include or exclude, with each entry being a regular expression.

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -534,13 +534,6 @@ instances:
         #
         # keep_sql_alias: true
 
-        ## @param keep_dollar_quoted_func - boolean - optional - default: true
-        ## Set to `true` to prevent dollar quoted function strings (e.g. `$func$`) from being removed.
-        ## When not removed, the sql content of dollar quoted func strings will be obfuscated.
-        ## Only strings with the tag `$func$` are supported.
-        #
-        # keep_dollar_quoted_func: true
-
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -193,7 +193,7 @@ instances:
 
     ## Enable options to collect extra metrics from your MySQL integration.
     #
-    options:
+    # options:
 
         ## @param replication - boolean - optional - default: false
         ## Set to `true` to collect replication metrics or group replication metrics.
@@ -299,7 +299,7 @@ instances:
 
     ## Configure collection of query metrics
     #
-    query_metrics:
+    # query_metrics:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of query metrics. Requires `dbm: true`.
@@ -315,7 +315,7 @@ instances:
 
     ## Configure collection of query samples
     #
-    query_samples:
+    # query_samples:
 
         ## @param enabled - boolean - optional - default: true
         ## Enables collection of query samples. Requires `dbm: true`.
@@ -405,7 +405,7 @@ instances:
 
     ## Configure collection of active sessions monitoring
     #
-    query_activity:
+    # query_activity:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of active sessions. Requires `dbm: true`.
@@ -425,7 +425,7 @@ instances:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-aws:
+# aws:
 
     ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
     ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
@@ -444,7 +444,7 @@ aws:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-gcp:
+# gcp:
 
     ## @param project_id - string - optional - default: foo-project
     ## Equal to the GCP resource's project ID.
@@ -470,7 +470,7 @@ gcp:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-azure:
+# azure:
 
     ## @param deployment_type - string - optional - default: flexible_server
     ## Equal to the deployment type for the managed database. 
@@ -493,7 +493,7 @@ azure:
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.
     #
-    obfuscator_options:
+    # obfuscator_options:
 
         ## @param replace_digits - boolean - optional - default: false
         ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -417,78 +417,78 @@ instances:
         #
         # collection_interval: 10
 
-## This block defines the configuration for AWS RDS and Aurora instances. 
-##
-## Complete this section if you have installed the Datadog AWS Integration 
-## (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
-## with MySQL integration telemetry.
-##
-## These values are only applied when `dbm: true` option is set.
-#
-# aws:
-
-    ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
-    ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
-    ## This value is optional if the value of `host` is already configured to the instance endpoint.
+    ## This block defines the configuration for AWS RDS and Aurora instances. 
     ##
-    ## For more information on instance endpoints, 
-    ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
-    #
-    # instance_endpoint: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
-
-## This block defines the configuration for Google Cloud SQL instances.
-##
-## Complete this section if you have installed the Datadog GCP Integration 
-## (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
-## with MySQL integration telemetry.
-##
-## These values are only applied when `dbm: true` option is set.
-#
-# gcp:
-
-    ## @param project_id - string - optional - default: foo-project
-    ## Equal to the GCP resource's project ID.
+    ## Complete this section if you have installed the Datadog AWS Integration 
+    ## (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+    ## with MySQL integration telemetry.
     ##
-    ## For more information on project IDs,
-    ## See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
+    ## These values are only applied when `dbm: true` option is set.
     #
-    # project_id: foo-project
+    # aws:
 
-    ## @param instance_id - string - optional - default: foo-database
-    ## Equal to the GCP resource's instance ID.
+        ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+        ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
+        ## This value is optional if the value of `host` is already configured to the instance endpoint.
+        ##
+        ## For more information on instance endpoints, 
+        ## see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
+        #
+        # instance_endpoint: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+
+    ## This block defines the configuration for Google Cloud SQL instances.
     ##
-    ## For more information on instance IDs,
-    ## See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
-    #
-    # instance_id: foo-database
-
-## This block defines the configuration for Azure Database for MySQL.
-##
-## Complete this section if you have installed the Datadog Azure Integration 
-## (https://docs.datadoghq.com/integrations/azure) to enrich instances 
-## with MySQL integration telemetry.
-##
-## These values are only applied when `dbm: true` option is set.
-#
-# azure:
-
-    ## @param deployment_type - string - optional - default: flexible_server
-    ## Equal to the deployment type for the managed database. 
+    ## Complete this section if you have installed the Datadog GCP Integration 
+    ## (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+    ## with MySQL integration telemetry.
     ##
-    ## Acceptable values are:
-    ##   - `flexible_server` 
-    ##   - `single_server`
-    ##   - `virtual_machine`
-    ##
-    ## For more information on deployment types, 
-    ## see the Azure docs https://docs.microsoft.com/en-us/azure/mysql/select-right-deployment-type
+    ## These values are only applied when `dbm: true` option is set.
     #
-    # deployment_type: flexible_server
+    # gcp:
 
-    ## @param name - string - optional - default: mysql-database
-    ## Equal to the name of the Azure MySQL database instance.
+        ## @param project_id - string - optional - default: foo-project
+        ## Equal to the GCP resource's project ID.
+        ##
+        ## For more information on project IDs,
+        ## See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
+        #
+        # project_id: foo-project
+
+        ## @param instance_id - string - optional - default: foo-database
+        ## Equal to the GCP resource's instance ID.
+        ##
+        ## For more information on instance IDs,
+        ## See the GCP docs https://cloud.google.com/sql/docs/mysql/instance-settings#instance-id-2ndgen
+        #
+        # instance_id: foo-database
+
+    ## This block defines the configuration for Azure Database for MySQL.
+    ##
+    ## Complete this section if you have installed the Datadog Azure Integration 
+    ## (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+    ## with MySQL integration telemetry.
+    ##
+    ## These values are only applied when `dbm: true` option is set.
     #
-    # name: mysql-database
+    # azure:
+
+        ## @param deployment_type - string - optional - default: flexible_server
+        ## Equal to the deployment type for the managed database. 
+        ##
+        ## Acceptable values are:
+        ##   - `flexible_server` 
+        ##   - `single_server`
+        ##   - `virtual_machine`
+        ##
+        ## For more information on deployment types, 
+        ## see the Azure docs https://docs.microsoft.com/en-us/azure/mysql/select-right-deployment-type
+        #
+        # deployment_type: flexible_server
+
+        ## @param name - string - optional - default: mysql-database
+        ## Equal to the name of the Azure MySQL database instance.
+        #
+        # name: mysql-database
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.
@@ -534,51 +534,51 @@ instances:
         #
         # keep_sql_alias: true
 
-    ## @param tags - list of strings - optional
-    ## A list of tags to attach to every metric and service check emitted by this instance.
-    ##
-    ## Learn more about tagging at https://docs.datadoghq.com/tagging
-    #
-    # tags:
-    #   - <KEY_1>:<VALUE_1>
-    #   - <KEY_2>:<VALUE_2>
+## @param tags - list of strings - optional
+## A list of tags to attach to every metric and service check emitted by this instance.
+##
+## Learn more about tagging at https://docs.datadoghq.com/tagging
+#
+# tags:
+#   - <KEY_1>:<VALUE_1>
+#   - <KEY_2>:<VALUE_2>
 
-    ## @param service - string - optional
-    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
-    ##
-    ## Overrides any `service` defined in the `init_config` section.
-    #
-    # service: <SERVICE>
+## @param service - string - optional
+## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+##
+## Overrides any `service` defined in the `init_config` section.
+#
+# service: <SERVICE>
 
-    ## @param min_collection_interval - number - optional - default: 15
-    ## This changes the collection interval of the check. For more information, see:
-    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
-    #
-    # min_collection_interval: 15
+## @param min_collection_interval - number - optional - default: 15
+## This changes the collection interval of the check. For more information, see:
+## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+#
+# min_collection_interval: 15
 
-    ## @param empty_default_hostname - boolean - optional - default: false
-    ## This forces the check to send metrics with no hostname.
-    ##
-    ## This is useful for cluster-level checks.
-    #
-    # empty_default_hostname: false
+## @param empty_default_hostname - boolean - optional - default: false
+## This forces the check to send metrics with no hostname.
+##
+## This is useful for cluster-level checks.
+#
+# empty_default_hostname: false
 
-    ## @param disable_generic_tags - boolean - optional - default: false
-    ## Replaces generic tag such as `server` with `mysql_server` to avoid getting it mixed with
-    ## other integrations tags.
-    #
-    disable_generic_tags: true
+## @param disable_generic_tags - boolean - optional - default: false
+## Replaces generic tag such as `server` with `mysql_server` to avoid getting it mixed with
+## other integrations tags.
+#
+disable_generic_tags: true
 
-    ## @param metric_patterns - mapping - optional
-    ## A mapping of metrics to include or exclude, with each entry being a regular expression.
-    ##
-    ## Metrics defined in `exclude` will take precedence in case of overlap.
-    #
-    # metric_patterns:
-    #   include:
-    #   - <INCLUDE_REGEX>
-    #   exclude:
-    #   - <EXCLUDE_REGEX>
+## @param metric_patterns - mapping - optional
+## A mapping of metrics to include or exclude, with each entry being a regular expression.
+##
+## Metrics defined in `exclude` will take precedence in case of overlap.
+#
+# metric_patterns:
+#   include:
+#   - <INCLUDE_REGEX>
+#   exclude:
+#   - <EXCLUDE_REGEX>
 
 ## Log Section
 ##

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -1,6 +1,6 @@
 ## All options defined here are available to all instances.
 #
-init_config:
+# init_config:
 
     ## @param global_custom_queries - list of mappings - optional
     ## See `custom_queries` defined below.
@@ -22,7 +22,7 @@ init_config:
 
 ## Every instance is scheduled independent of the others.
 #
-instances:
+# instances:
 
     ## @param host - string - optional
     ## MySQL host to connect to.
@@ -193,7 +193,7 @@ instances:
 
     ## Enable options to collect extra metrics from your MySQL integration.
     #
-    options:
+    # options:
 
         ## @param replication - boolean - optional - default: false
         ## Set to `true` to collect replication metrics or group replication metrics.
@@ -299,7 +299,7 @@ instances:
 
     ## Configure collection of query metrics
     #
-    query_metrics:
+    # query_metrics:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of query metrics. Requires `dbm: true`.
@@ -315,7 +315,7 @@ instances:
 
     ## Configure collection of query samples
     #
-    query_samples:
+    # query_samples:
 
         ## @param enabled - boolean - optional - default: true
         ## Enables collection of query samples. Requires `dbm: true`.
@@ -405,7 +405,7 @@ instances:
 
     ## Configure collection of active sessions monitoring
     #
-    query_activity:
+    # query_activity:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of active sessions. Requires `dbm: true`.
@@ -425,7 +425,7 @@ instances:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-aws:
+# aws:
 
     ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
     ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
@@ -444,7 +444,7 @@ aws:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-gcp:
+# gcp:
 
     ## @param project_id - string - optional - default: foo-project
     ## Equal to the GCP resource's project ID.
@@ -470,7 +470,7 @@ gcp:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-azure:
+# azure:
 
     ## @param deployment_type - string - optional - default: flexible_server
     ## Equal to the deployment type for the managed database. 
@@ -493,7 +493,7 @@ azure:
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.
     #
-    obfuscator_options:
+    # obfuscator_options:
 
         ## @param replace_digits - boolean - optional - default: false
         ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
@@ -574,7 +574,7 @@ azure:
     ## Replaces generic tag such as `server` with `mysql_server` to avoid getting it mixed with
     ## other integrations tags.
     #
-    disable_generic_tags: true
+    # disable_generic_tags: true
 
     ## @param metric_patterns - mapping - optional
     ## A mapping of metrics to include or exclude, with each entry being a regular expression.

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -193,7 +193,7 @@ instances:
 
     ## Enable options to collect extra metrics from your MySQL integration.
     #
-    # options:
+    options:
 
         ## @param replication - boolean - optional - default: false
         ## Set to `true` to collect replication metrics or group replication metrics.
@@ -299,7 +299,7 @@ instances:
 
     ## Configure collection of query metrics
     #
-    # query_metrics:
+    query_metrics:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of query metrics. Requires `dbm: true`.
@@ -315,7 +315,7 @@ instances:
 
     ## Configure collection of query samples
     #
-    # query_samples:
+    query_samples:
 
         ## @param enabled - boolean - optional - default: true
         ## Enables collection of query samples. Requires `dbm: true`.
@@ -405,7 +405,7 @@ instances:
 
     ## Configure collection of active sessions monitoring
     #
-    # query_activity:
+    query_activity:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of active sessions. Requires `dbm: true`.
@@ -425,7 +425,7 @@ instances:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-# aws:
+aws:
 
     ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
     ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
@@ -444,7 +444,7 @@ instances:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-# gcp:
+gcp:
 
     ## @param project_id - string - optional - default: foo-project
     ## Equal to the GCP resource's project ID.
@@ -470,7 +470,7 @@ instances:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-# azure:
+azure:
 
     ## @param deployment_type - string - optional - default: flexible_server
     ## Equal to the deployment type for the managed database. 
@@ -493,7 +493,7 @@ instances:
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.
     #
-    # obfuscator_options:
+    obfuscator_options:
 
         ## @param replace_digits - boolean - optional - default: false
         ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -1,6 +1,6 @@
 ## All options defined here are available to all instances.
 #
-# init_config:
+init_config:
 
     ## @param global_custom_queries - list of mappings - optional
     ## See `custom_queries` defined below.
@@ -22,7 +22,7 @@
 
 ## Every instance is scheduled independent of the others.
 #
-# instances:
+instances:
 
     ## @param host - string - optional
     ## MySQL host to connect to.

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -534,51 +534,51 @@ instances:
         #
         # keep_sql_alias: true
 
-## @param tags - list of strings - optional
-## A list of tags to attach to every metric and service check emitted by this instance.
-##
-## Learn more about tagging at https://docs.datadoghq.com/tagging
-#
-# tags:
-#   - <KEY_1>:<VALUE_1>
-#   - <KEY_2>:<VALUE_2>
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>
 
-## @param service - string - optional
-## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
-##
-## Overrides any `service` defined in the `init_config` section.
-#
-# service: <SERVICE>
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Overrides any `service` defined in the `init_config` section.
+    #
+    # service: <SERVICE>
 
-## @param min_collection_interval - number - optional - default: 15
-## This changes the collection interval of the check. For more information, see:
-## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
-#
-# min_collection_interval: 15
+    ## @param min_collection_interval - number - optional - default: 15
+    ## This changes the collection interval of the check. For more information, see:
+    ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
+    #
+    # min_collection_interval: 15
 
-## @param empty_default_hostname - boolean - optional - default: false
-## This forces the check to send metrics with no hostname.
-##
-## This is useful for cluster-level checks.
-#
-# empty_default_hostname: false
+    ## @param empty_default_hostname - boolean - optional - default: false
+    ## This forces the check to send metrics with no hostname.
+    ##
+    ## This is useful for cluster-level checks.
+    #
+    # empty_default_hostname: false
 
-## @param disable_generic_tags - boolean - optional - default: false
-## Replaces generic tag such as `server` with `mysql_server` to avoid getting it mixed with
-## other integrations tags.
-#
-disable_generic_tags: true
+    ## @param disable_generic_tags - boolean - optional - default: false
+    ## Replaces generic tag such as `server` with `mysql_server` to avoid getting it mixed with
+    ## other integrations tags.
+    #
+    disable_generic_tags: true
 
-## @param metric_patterns - mapping - optional
-## A mapping of metrics to include or exclude, with each entry being a regular expression.
-##
-## Metrics defined in `exclude` will take precedence in case of overlap.
-#
-# metric_patterns:
-#   include:
-#   - <INCLUDE_REGEX>
-#   exclude:
-#   - <EXCLUDE_REGEX>
+    ## @param metric_patterns - mapping - optional
+    ## A mapping of metrics to include or exclude, with each entry being a regular expression.
+    ##
+    ## Metrics defined in `exclude` will take precedence in case of overlap.
+    #
+    # metric_patterns:
+    #   include:
+    #   - <INCLUDE_REGEX>
+    #   exclude:
+    #   - <EXCLUDE_REGEX>
 
 ## Log Section
 ##

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -193,7 +193,7 @@ instances:
 
     ## Enable options to collect extra metrics from your MySQL integration.
     #
-    # options:
+    options:
 
         ## @param replication - boolean - optional - default: false
         ## Set to `true` to collect replication metrics or group replication metrics.
@@ -299,7 +299,7 @@ instances:
 
     ## Configure collection of query metrics
     #
-    # query_metrics:
+    query_metrics:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of query metrics. Requires `dbm: true`.
@@ -315,7 +315,7 @@ instances:
 
     ## Configure collection of query samples
     #
-    # query_samples:
+    query_samples:
 
         ## @param enabled - boolean - optional - default: true
         ## Enables collection of query samples. Requires `dbm: true`.
@@ -405,7 +405,7 @@ instances:
 
     ## Configure collection of active sessions monitoring
     #
-    # query_activity:
+    query_activity:
 
         ## @param enabled - boolean - optional - default: true
         ## Enable collection of active sessions. Requires `dbm: true`.
@@ -425,7 +425,7 @@ instances:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-# aws:
+aws:
 
     ## @param instance_endpoint - string - optional - default: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
     ## Equal to the Endpoint.Address of the instance the agent is connecting to. 
@@ -444,7 +444,7 @@ instances:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-# gcp:
+gcp:
 
     ## @param project_id - string - optional - default: foo-project
     ## Equal to the GCP resource's project ID.
@@ -470,7 +470,7 @@ instances:
 ##
 ## These values are only applied when `dbm: true` option is set.
 #
-# azure:
+azure:
 
     ## @param deployment_type - string - optional - default: flexible_server
     ## Equal to the deployment type for the managed database. 
@@ -493,7 +493,7 @@ instances:
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.
     #
-    # obfuscator_options:
+    obfuscator_options:
 
         ## @param replace_digits - boolean - optional - default: false
         ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
@@ -526,6 +526,20 @@ instances:
         ## Requires `collect_metadata: true`.
         #
         # collect_comments: true
+
+        ## @param keep_sql_alias - boolean - optional - default: true
+        ## Set to `true` to keep sql aliases in obfuscated SQL statements. Examples of aliases are
+        ## `with select 1 as alias`, `select column as other_name`, or `select * from table t`.
+        ## When `true` these aliases will not be removed.
+        #
+        # keep_sql_alias: true
+
+        ## @param keep_dollar_quoted_func - boolean - optional - default: true
+        ## Set to `true` to prevent dollar quoted function strings (e.g. `$func$`) from being removed.
+        ## When not removed, the sql content of dollar quoted func strings will be obfuscated.
+        ## Only strings with the tag `$func$` are supported.
+        #
+        # keep_dollar_quoted_func: true
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.


### PR DESCRIPTION
### What does this PR do?
Adds configuration options for parsing dollar quoted functions and for keeping sql aliases to mysql.

### Motivation
The obfuscator has options to enable parsing for dollar quoted functions and keeping sql aliases, however these options are not currently configurable from DBM.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
