### PR TITLE
postgres: Add option to keep alias and dollar quote functions in postgres (`keep_sql_alias` and `keep_dollar_quoted_func`)

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -434,6 +434,24 @@ files:
           value:
             type: boolean
             example: true
+        - name: keep_sql_alias
+          description: |
+            Set to `true` to keep sql aliases in obfuscated SQL statements. Examples of aliases are
+            `with select 1 as alias`, `select column as other_name`, or `select * from table t`.
+            When `true` these aliases will not be removed.
+          value:
+            type: boolean
+            example: true
+            display_default: true
+        - name: keep_dollar_quoted_func
+          description: |
+            Set to `true` to prevent dollar quoted function strings (e.g. `$func$`) from being removed.
+            When not removed, the sql content of dollar quoted func strings will be obfuscated.
+            Only strings with the tag `$func$` are supported.
+          value:
+            type: boolean
+            example: true
+            display_default: true
     - template: instances/default
       overrides:
         disable_generic_tags.hidden: False

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -100,7 +100,7 @@ class PostgresConfig:
                     'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
                 )
             ),
-            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('dollar_quoted_func', False)),
+            'keep_dollar_quoted_func': is_affirmative(obfuscator_options_config.get('dollar_quoted_func', False)),
             'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', False)),
             'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
             'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -100,6 +100,8 @@ class PostgresConfig:
                     'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
                 )
             ),
+            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('dollar_quoted_func', False)),
+            'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', False)),
             'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
             'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),
             'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -100,7 +100,7 @@ class PostgresConfig:
                     'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
                 )
             ),
-            'keep_dollar_quoted_func': is_affirmative(obfuscator_options_config.get('dollar_quoted_func', False)),
+            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', False)),
             'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', False)),
             'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
             'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -100,8 +100,8 @@ class PostgresConfig:
                     'replace_digits', obfuscator_options_config.get('quantize_sql_tables', False)
                 )
             ),
-            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', False)),
-            'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', False)),
+            'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', True)),
+            'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', True)),
             'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
             'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),
             'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -35,6 +35,8 @@ class ObfuscatorOptions(BaseModel):
     collect_comments: Optional[bool]
     collect_metadata: Optional[bool]
     collect_tables: Optional[bool]
+    keep_dollar_quoted_func: Optional[bool]
+    keep_sql_alias: Optional[bool]
     replace_digits: Optional[bool]
 
 

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -368,6 +368,20 @@ instances:
         #
         # collect_comments: true
 
+        ## @param keep_sql_alias - boolean - optional - default: true
+        ## Set to `true` to keep sql aliases in obfuscated SQL statements. Examples of aliases are
+        ## `with select 1 as alias`, `select column as other_name`, or `select * from table t`.
+        ## When `true` these aliases will not be removed.
+        #
+        # keep_sql_alias: true
+
+        ## @param keep_dollar_quoted_func - boolean - optional - default: true
+        ## Set to `true` to prevent dollar quoted function strings (e.g. `$func$`) from being removed.
+        ## When not removed, the sql content of dollar quoted func strings will be obfuscated.
+        ## Only strings with the tag `$func$` are supported.
+        #
+        # keep_dollar_quoted_func: true
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##


### PR DESCRIPTION
### What does this PR do?
Adds configuration options for parsing dollar quoted functions and for keeping sql aliases to postgres.

### Motivation
The obfuscator has options to enable parsing for dollar quoted functions and keeping sql aliases, however these options are not currently configurable from DBM.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
