### PR TITLE
sqlserver: Add option to keep aliases in sql server (`keep_sql_alias`)

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -416,6 +416,24 @@ files:
           value:
             type: boolean
             example: true
+        - name: keep_sql_alias
+          description: |
+            Set to `true` to keep sql aliases in obfuscated SQL statements. Examples of aliases are
+            `with select 1 as alias`, `select column as other_name`, or `select * from table t`.
+            When `true` these aliases will not be removed.
+          value:
+            type: boolean
+            example: true
+            display_default: true
+        - name: keep_dollar_quoted_func
+          description: |
+            Set to `true` to prevent dollar quoted function strings (e.g. `$func$`) from being removed.
+            When not removed, the sql content of dollar quoted func strings will be obfuscated.
+            Only strings with the tag `$func$` are supported.
+          value:
+            type: boolean
+            example: true
+            display_default: true
     - name: command_timeout
       description: Timeout in seconds for the connection and each command run
       value:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -425,15 +425,6 @@ files:
             type: boolean
             example: true
             display_default: true
-        - name: keep_dollar_quoted_func
-          description: |
-            Set to `true` to prevent dollar quoted function strings (e.g. `$func$`) from being removed.
-            When not removed, the sql content of dollar quoted func strings will be obfuscated.
-            Only strings with the tag `$func$` are supported.
-          value:
-            type: boolean
-            example: true
-            display_default: true
     - name: command_timeout
       description: Timeout in seconds for the connection and each command run
       value:

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -67,7 +67,6 @@ class ObfuscatorOptions(BaseModel):
     collect_comments: Optional[bool]
     collect_metadata: Optional[bool]
     collect_tables: Optional[bool]
-    keep_dollar_quoted_func: Optional[bool]
     keep_sql_alias: Optional[bool]
     replace_digits: Optional[bool]
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -67,6 +67,8 @@ class ObfuscatorOptions(BaseModel):
     collect_comments: Optional[bool]
     collect_metadata: Optional[bool]
     collect_tables: Optional[bool]
+    keep_dollar_quoted_func: Optional[bool]
+    keep_sql_alias: Optional[bool]
     replace_digits: Optional[bool]
 
 

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -367,6 +367,20 @@ instances:
         #
         # collect_comments: true
 
+        ## @param keep_sql_alias - boolean - optional - default: true
+        ## Set to `true` to keep sql aliases in obfuscated SQL statements. Examples of aliases are
+        ## `with select 1 as alias`, `select column as other_name`, or `select * from table t`.
+        ## When `true` these aliases will not be removed.
+        #
+        # keep_sql_alias: true
+
+        ## @param keep_dollar_quoted_func - boolean - optional - default: true
+        ## Set to `true` to prevent dollar quoted function strings (e.g. `$func$`) from being removed.
+        ## When not removed, the sql content of dollar quoted func strings will be obfuscated.
+        ## Only strings with the tag `$func$` are supported.
+        #
+        # keep_dollar_quoted_func: true
+
     ## @param command_timeout - integer - optional - default: 5
     ## Timeout in seconds for the connection and each command run
     #

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -374,13 +374,6 @@ instances:
         #
         # keep_sql_alias: true
 
-        ## @param keep_dollar_quoted_func - boolean - optional - default: true
-        ## Set to `true` to prevent dollar quoted function strings (e.g. `$func$`) from being removed.
-        ## When not removed, the sql content of dollar quoted func strings will be obfuscated.
-        ## Only strings with the tag `$func$` are supported.
-        #
-        # keep_dollar_quoted_func: true
-
     ## @param command_timeout - integer - optional - default: 5
     ## Timeout in seconds for the connection and each command run
     #

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -136,6 +136,8 @@ class SQLServer(AgentCheck):
                             obfuscator_options_config.get('quantize_sql_tables', False),
                         )
                     ),
+                    'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('dollar_quoted_func', True)),
+                    'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', True)),
                     'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
                     'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),
                     'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -136,8 +136,8 @@ class SQLServer(AgentCheck):
                             obfuscator_options_config.get('quantize_sql_tables', False),
                         )
                     ),
-                    'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', True)),
-                    'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', True)),
+                    'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', False)),
+                    'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', False)),
                     'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
                     'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),
                     'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -136,7 +136,6 @@ class SQLServer(AgentCheck):
                             obfuscator_options_config.get('quantize_sql_tables', False),
                         )
                     ),
-                    'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', True)),
                     'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', True)),
                     'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
                     'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -136,7 +136,7 @@ class SQLServer(AgentCheck):
                             obfuscator_options_config.get('quantize_sql_tables', False),
                         )
                     ),
-                    'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('dollar_quoted_func', True)),
+                    'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', True)),
                     'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', True)),
                     'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
                     'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -136,8 +136,8 @@ class SQLServer(AgentCheck):
                             obfuscator_options_config.get('quantize_sql_tables', False),
                         )
                     ),
-                    'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', False)),
-                    'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', False)),
+                    'dollar_quoted_func': is_affirmative(obfuscator_options_config.get('keep_dollar_quoted_func', True)),
+                    'keep_sql_alias': is_affirmative(obfuscator_options_config.get('keep_sql_alias', True)),
                     'return_json_metadata': is_affirmative(obfuscator_options_config.get('collect_metadata', True)),
                     'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),
                     'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),


### PR DESCRIPTION
### What does this PR do?
Adds configuration options for parsing dollar quoted functions and for keeping sql aliases to sql server.

### Motivation
The obfuscator has options to enable parsing for dollar quoted functions and keeping sql aliases, however these options are not currently configurable from DBM.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
