### PR TITLE
change default value for the send_monotonic_counter to false

### DIFF
--- a/gitlab/assets/configuration/spec.yaml
+++ b/gitlab/assets/configuration/spec.yaml
@@ -24,6 +24,7 @@ files:
         send_distribution_counts_as_monotonic.value.example: true
         send_monotonic_counter.enabled: true
         send_monotonic_counter.value.example: true
+        send_monotonic_counter.value.display_default: false
   - template: init_config
     options:
       - template: init_config/openmetrics_legacy

--- a/gitlab/datadog_checks/gitlab/config_models/defaults.py
+++ b/gitlab/datadog_checks/gitlab/config_models/defaults.py
@@ -223,7 +223,7 @@ def instance_send_histograms_buckets(field, value):
 
 
 def instance_send_monotonic_counter(field, value):
-    return True
+    return False
 
 
 def instance_send_monotonic_with_gauge(field, value):

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -74,7 +74,7 @@ instances:
     #
     # send_distribution_buckets: false
 
-    ## @param send_monotonic_counter - boolean - optional - default: true
+    ## @param send_monotonic_counter - boolean - optional - default: false
     ## Set send_monotonic_counter to true to send counters as monotonic counter.
     #
     send_monotonic_counter: true


### PR DESCRIPTION
### What does this PR do?
It updates the comment section of the conf.yaml.example file to reflect the actual default value

### Motivation
A Jira escalation : https://datadoghq.atlassian.net/browse/AGENT-7874  
For the gitlab integration, in our sample config file, we say that  the send_monotonic_counter  defaults to true, but in our code we set it to false.
The value is set to false [here](https://github.com/DataDog/integrations-core/blob/master/gitlab/datadog_checks/gitlab/gitlab.py#L92), but we say it defaults to true:
`    ## @param send_monotonic_counter - boolean - optional - default: true `

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
