### PR TITLE
Fix the units of postgresql.deadlocks

### DIFF
--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -11,7 +11,7 @@ postgresql.rows_updated,gauge,,row,second,The number of rows updated by queries 
 postgresql.rows_deleted,gauge,,row,second,The number of rows deleted by queries in this database,0,postgres,rows del,
 postgresql.database_size,gauge,,byte,,The disk space used by this database.,0,postgres,db size,
 postgresql.db.count,gauge,,item,,The number of available databases.,0,postgres,db cnt,
-postgresql.deadlocks,gauge,,,,The number of deadlocks detected in this database,-1,postgres,deadlocks,
+postgresql.deadlocks,gauge,,lock,second,The number of deadlocks detected in this database,-1,postgres,deadlocks,
 postgresql.temp_bytes,gauge,,byte,second,The amount of data written to temporary files by queries in this database.,0,postgres,temp bytes,
 postgresql.temp_files,gauge,,file,second,The number of temporary files created by queries in this database.,0,postgres,temp files,
 postgresql.bgwriter.checkpoints_timed,count,,,,The number of scheduled checkpoints that were performed.,0,postgres,bgw cp timed,

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -11,7 +11,7 @@ postgresql.rows_updated,gauge,,row,second,The number of rows updated by queries 
 postgresql.rows_deleted,gauge,,row,second,The number of rows deleted by queries in this database,0,postgres,rows del,
 postgresql.database_size,gauge,,byte,,The disk space used by this database.,0,postgres,db size,
 postgresql.db.count,gauge,,item,,The number of available databases.,0,postgres,db cnt,
-postgresql.deadlocks,gauge,,lock,second,The number of deadlocks detected in this database,-1,postgres,deadlocks,
+postgresql.deadlocks,gauge,,lock,second,The rate of deadlocks detected in this database,-1,postgres,deadlocks,
 postgresql.temp_bytes,gauge,,byte,second,The amount of data written to temporary files by queries in this database.,0,postgres,temp bytes,
 postgresql.temp_files,gauge,,file,second,The number of temporary files created by queries in this database.,0,postgres,temp files,
 postgresql.bgwriter.checkpoints_timed,count,,,,The number of scheduled checkpoints that were performed.,0,postgres,bgw cp timed,


### PR DESCRIPTION
### What does this PR do?

`postgresql.deadlocks` is currently implemented as a rate (long-term this should be added as a count). This PR fixes the metadata and documentation for the metric.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
