### PR TITLE
Don't use connection resiliency for older versions of sqlserver and update valid driver list

### DIFF
--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -24,7 +24,7 @@ parameters:
 jobs:
 - job: '${{ coalesce(parameters.job_name, parameters.check) }}_Windows'
   displayName: '${{ parameters.display }}'
-  timeoutInMinutes: 90
+  timeoutInMinutes: 180
 
   services:
     ${{ if eq(parameters.ddtrace_flag, '--ddtrace') }}:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -44,7 +44,7 @@ files:
         Server version year of sqlserver the agent will connect to. 
         Important for validating connection string attributes for older sqlserver versions.
         
-        Defaults to `2019`.
+        This is required if connecting to a SQLServer instance older than 2014.
       value:
         type: string
         example: "2019"

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -39,6 +39,15 @@ files:
       description: Password for the Datadog-SQL server check user. It will be ignored if using Windows authentication.
       value:
         type: string
+    - name: server_version
+      description: |
+        Server version year of sqlserver the agent will connect to. 
+        Important for validating connection string attributes for older sqlserver versions.
+        
+        Defaults to `2019`.
+      value:
+        type: string
+        example: "2019"
     - name: database
       description: |
         Database name to query.  Not compatible with `database_autodiscovery`.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -47,7 +47,7 @@ files:
         This is required if connecting to a SQLServer instance older than 2014.
       value:
         type: string
-        example: "2019"
+        example: "2014"
     - name: database
       description: |
         Database name to query.  Not compatible with `database_autodiscovery`.

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -183,7 +183,7 @@ def instance_reported_hostname(field, value):
 
 
 def instance_server_version(field, value):
-    return '2019'
+    return '2014'
 
 
 def instance_service(field, value):

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -182,6 +182,10 @@ def instance_reported_hostname(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_server_version(field, value):
+    return '2019'
+
+
 def instance_service(field, value):
     return get_default_field_value(field, value)
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -136,6 +136,7 @@ class InstanceConfig(BaseModel):
     query_activity: Optional[QueryActivity]
     query_metrics: Optional[QueryMetrics]
     reported_hostname: Optional[str]
+    server_version: Optional[str]
     service: Optional[str]
     stored_procedure: Optional[str]
     tags: Optional[Sequence[str]]

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -110,7 +110,7 @@ class Connection(object):
     DEFAULT_DATABASE = 'master'
     DEFAULT_DRIVER = 'SQL Server'
     DEFAULT_DB_KEY = 'database'
-    DEFAULT_SQLSERVER_VERSION = "2019"
+    DEFAULT_SQLSERVER_VERSION = 1e9
     SQLSERVER_2014 = 2014
     PROC_GUARD_DB_KEY = 'proc_only_if_database'
 

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -110,9 +110,11 @@ class Connection(object):
     DEFAULT_DATABASE = 'master'
     DEFAULT_DRIVER = 'SQL Server'
     DEFAULT_DB_KEY = 'database'
+    DEFAULT_SQLSERVER_VERSION = "2019"
+    SQLSERVER_2014 = 2014
     PROC_GUARD_DB_KEY = 'proc_only_if_database'
 
-    valid_adoproviders = ['SQLOLEDB', 'MSOLEDBSQL', 'SQLNCLI11']
+    valid_adoproviders = ['SQLOLEDB', 'MSOLEDBSQL', 'MSOLEDBSQL19', 'SQLNCLI11']
     default_adoprovider = 'SQLOLEDB'
 
     def __init__(self, init_config, instance_config, service_check_handler):
@@ -124,6 +126,7 @@ class Connection(object):
         self._conns = {}
         self.timeout = int(self.instance.get('command_timeout', self.DEFAULT_COMMAND_TIMEOUT))
         self.existing_databases = None
+        self.server_version = int(self.instance.get('server_version', self.DEFAULT_SQLSERVER_VERSION))
 
         self.adoprovider = self.default_adoprovider
 
@@ -437,17 +440,20 @@ class Connection(object):
         else:
             dsn, host, username, password, database, driver = self._get_access_info(db_key, db_name)
 
-        conn_str = 'ConnectRetryCount=2;'
+        # The connection resiliency feature is supported on Microsoft Azure SQL Database
+        # and SQL Server 2014 (and later) server versions. See the SQLServer docs for more information
+        # https://docs.microsoft.com/en-us/sql/connect/odbc/connection-resiliency?view=sql-server-ver15
+        conn_str = ''
+        if self.server_version >= self.SQLSERVER_2014:
+            conn_str += 'ConnectRetryCount=2;'
         if dsn:
             conn_str += 'DSN={};'.format(dsn)
-
         if driver:
             conn_str += 'DRIVER={};'.format(driver)
         if host:
             conn_str += 'Server={};'.format(host)
         if database:
             conn_str += 'Database={};'.format(database)
-
         if username:
             conn_str += 'UID={};'.format(username)
         self.log.debug("Connection string (before password) %s", conn_str)
@@ -463,7 +469,10 @@ class Connection(object):
             _, host, username, password, database, _ = self._get_access_info(db_key, db_name)
 
         provider = self._get_adoprovider()
-        conn_str = 'ConnectRetryCount=2;Provider={};Data Source={};Initial Catalog={};'.format(provider, host, database)
+        retry_conn_count = ''
+        if self.server_version >= self.SQLSERVER_2014:
+            retry_conn_count = 'ConnectRetryCount=2;'
+        conn_str = '{}Provider={};Data Source={};Initial Catalog={};'.format(retry_conn_count, provider, host, database)
 
         if username:
             conn_str += 'User ID={};'.format(username)

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -51,6 +51,14 @@ instances:
     #
     # password: <PASSWORD>
 
+    ## @param server_version - string - optional - default: 2019
+    ## Server version year of sqlserver the agent will connect to. 
+    ## Important for validating connection string attributes for older sqlserver versions.
+    ##
+    ## Defaults to `2019`.
+    #
+    # server_version: '2019'
+
     ## @param database - string - optional - default: master
     ## Database name to query.  Not compatible with `database_autodiscovery`.
     #

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -55,7 +55,7 @@ instances:
     ## Server version year of sqlserver the agent will connect to. 
     ## Important for validating connection string attributes for older sqlserver versions.
     ##
-    ## Defaults to `2019`.
+    ## This is required if connecting to a SQLServer instance older than 2014.
     #
     # server_version: '2019'
 

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -51,13 +51,13 @@ instances:
     #
     # password: <PASSWORD>
 
-    ## @param server_version - string - optional - default: 2019
+    ## @param server_version - string - optional - default: 2014
     ## Server version year of sqlserver the agent will connect to. 
     ## Important for validating connection string attributes for older sqlserver versions.
     ##
     ## This is required if connecting to a SQLServer instance older than 2014.
     #
-    # server_version: '2019'
+    # server_version: '2014'
 
     ## @param database - string - optional - default: master
     ## Database name to query.  Not compatible with `database_autodiscovery`.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fixes bug where `ConnectRetryCount` was being set by default for all SQLServer connection strings. This feature is only available for server versions 2014, and newer.  See these [docs](https://docs.microsoft.com/en-us/sql/connect/odbc/connection-resiliency?view=sql-server-ver15) on the connection resiliency feature for more information. 

Also adds `MSOLEDBSQL19` to the list of valid `adoproviders` drivers. The latest versions of the driver for SQLServer 2018+ were renamed. See this [documentation](https://docs.microsoft.com/en-us/sql/connect/oledb/oledb-driver-for-sql-server?view=sql-server-ver15#3-microsoft-ole-db-driver-for-sql-server-msoledbsql) for more details. This was causing the following error: 

```
MSOLEDBSQL 'Provider cannot be found. It may not be properly installed.' error 
```

with the only work around being to downgrade the driver version. From the Microsoft docs:

```
To use the new Microsoft OLE DB Driver for SQL Server in existing applications, you should plan to convert your connection strings from SQLOLEDB or SQLNCLI, to MSOLEDBSQL19 or MSOLEDBSQL.
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

A longer term solution would be to add more test coverage for the latest driver, and use the `pyodbc` api to get the list of available drivers on the host by calling `pyodbc.drivers()` instead of keeping this hardcoded list. I am not sure if `adodbapi` provides a similar API call. 

Given the time requirement for agent release freeze, we will make those improvements in a following PR. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
