### PR TITLE
Fix python command

### DIFF
--- a/oracle/README.md
+++ b/oracle/README.md
@@ -489,7 +489,7 @@ variable to the new install as explained above.
 Ensure the displayed output matches the correct value.
 
     ```shell script
-      sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/python -c "import os; print("JAVA_HOME:{}".format(os.environ.get("JAVA_HOME")))"
+      sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/python -c "import os; print(\"JAVA_HOME:{}\".format(os.environ.get(\"JAVA_HOME\")))"
     ```
 
 Need help? Contact [Datadog support][16].


### PR DESCRIPTION
### What does this PR do?
Fix shell command to escape nested double quotes- currently this will throw the following error:

```
  File "<string>", line 1
    import os; print(JAVA_HOME:{}.format(os.environ.get(JAVA_HOME)))
                              ^
SyntaxError: invalid syntax
```

### Motivation
Support ticket

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
