### PR TITLE
Increase timeout for windows tests

### DIFF
--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -24,7 +24,7 @@ parameters:
 jobs:
 - job: '${{ coalesce(parameters.job_name, parameters.check) }}_Windows'
   displayName: '${{ parameters.display }}'
-  timeoutInMinutes: 90
+  timeoutInMinutes: 180
 
   services:
     ${{ if eq(parameters.ddtrace_flag, '--ddtrace') }}:


### PR DESCRIPTION
### What does this PR do?

We have seen a large number of increase in windows test timeouts, so I am requesting that we raise the limit.

![image](https://user-images.githubusercontent.com/717862/168403415-346ef238-067b-462c-bbf5-b91878bd4ae3.png)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
