### PR TITLE
QA status ddev fix

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -28,8 +28,8 @@ class TrelloClient:
             'Core': '5ae1e3d62a5167779e65e87d',
             'Database Monitoring': '60ec3d30532b9072b44d3900',
             'Integrations': '5ae1e3e2c81fff836d00497e',
-            'Platform': '5d9b687492952e6578ecf04d',
             'Triage': '5d9b687492952e6578ecf04d',  # unused
+            'Platform': '5d9b687492952e6578ecf04d',
             'Networks': '5e1de8cf867357791ec5ee47',
             'Processes': '5aeca4c8621e4359b9cb9c27',
             'Trace': '5bcf3ffbe0651642ae029038',
@@ -81,8 +81,8 @@ class TrelloClient:
             'Core': '5e79105d4c45a45adb9e7730',
             'Integrations': '5e790ff25bd3dd48da67608d',
             'Database Monitoring': '60ec4973bd1b8652312af938',
-            'Platform': '5e7910a45d711a6382f08bb9',
             'Triage': '5e7910a45d711a6382f08bb9',  # unused
+            'Platform': '5e7910a45d711a6382f08bb9',
             'Networks': '5e79109821620a60014fc016',
             'Processes': '5e7910789f92a918152b700d',
             'Trace': '5c050640ecb34f0915ec589a',


### PR DESCRIPTION
### What does this PR do?
https://github.com/DataDog/integrations-core/pull/11924 broke ddev release trello status command - new 'Triage' label was added with the same id as 'Platform' - this made dictionaries built on top of those maps to overwrite key 'Platform' with 'Triage' and break QA cards count. I just swapped the position of the entries, so when the dict is built it ends up with 'Platform' being used.

### Motivation
Right now ddev release trello status command does now work. This PR fixes it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
