### PR TITLE
Add test for invalid varnishadm

### DIFF
--- a/varnish/tests/test_varnish.py
+++ b/varnish/tests/test_varnish.py
@@ -30,6 +30,7 @@ def test_check(aggregator, instance, dd_run_check):
 
 
 def test_check_invalid_varnishadm(aggregator, instance, dd_run_check):
+    # Note: this test may prompt you to enter a password when locally, if so, enter anything and it will pass
     instance['varnishadm'] = 'invalid-thing'
     check = Varnish(common.CHECK_NAME, {}, [instance])
     dd_run_check(check)

--- a/varnish/tests/test_varnish.py
+++ b/varnish/tests/test_varnish.py
@@ -29,6 +29,14 @@ def test_check(aggregator, instance, dd_run_check):
     aggregator.assert_metrics_using_metadata(metadata_metrics, check_submission_type=True)
 
 
+def test_check_invalid_varnishadm(aggregator, instance, dd_run_check):
+    instance['varnishadm'] = 'invalid-thing'
+    check = Varnish(common.CHECK_NAME, {}, [instance])
+    dd_run_check(check)
+
+    aggregator.assert_service_check(Varnish.SERVICE_CHECK_NAME, count=0)
+
+
 def test_inclusion_filter(aggregator, instance, dd_run_check):
     instance['metrics_filter'] = ['SMA.*']
 


### PR DESCRIPTION
### What does this PR do?
Add a test for invalid varnishadm
### Motivation
QA for https://github.com/DataDog/integrations-core/pull/11908
### Additional Notes
Note: you may be prompted to enter your password for this test when running locally:
`tests/test_varnish.py::test_check_invalid_varnishadm Password:`
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
