### PR TITLE
Update etcd service check documentation

### DIFF
--- a/etcd/assets/configuration/spec.yaml
+++ b/etcd/assets/configuration/spec.yaml
@@ -8,7 +8,9 @@ files:
   - template: instances
     options:
       - name: use_preview
-        description: Whether or not to preview the new version of the check supporting only ETCD 3+
+        description: |
+          Enable this option to run the Prometheus-based check of etcd.
+          Note: this requires etcd v3+.
         value:
           type: boolean
           example: true

--- a/etcd/assets/configuration/spec.yaml
+++ b/etcd/assets/configuration/spec.yaml
@@ -10,7 +10,7 @@ files:
       - name: use_preview
         description: |
           Enable this option to run the Prometheus-based check of etcd.
-          Note: this requires etcd v3+.
+          Note: This requires etcd v3 or greater.
         value:
           type: boolean
           example: true

--- a/etcd/assets/service_checks.json
+++ b/etcd/assets/service_checks.json
@@ -12,7 +12,7 @@
             "url"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if unable to get metrics from etcd (timeout or non-200 HTTP code)"
+        "description": "Returns `CRITICAL` if unable to get metrics from etcd (timeout or non-200 HTTP code). This service check is only available on the legacy version of the etcd check."
     },
     {
         "agent_version": "5.21.0",
@@ -28,6 +28,21 @@
             "url"
         ],
         "name": "Healthy",
-        "description": "Returns `CRITICAL` when a member is unhealthy"
+        "description": "Returns `CRITICAL` when a member is unhealthy. This service check is only available on the legacy version of the etcd check."
+    },
+    {
+        "agent_version": "6.8.0",
+        "integration": "etcd",
+        "check": "etcd.prometheus.health",
+        "statuses": [
+            "ok",
+            "critical"
+        ],
+        "groups": [
+            "host",
+            "url"
+        ],
+        "name": "etcd prometheus health",
+        "description": "Returns `CRITICAL` if the check cannot access a metrics endpoint. Otherwise, returns `OK`. This service check is only available when `use_preview` is enabled."
     }
 ]

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -47,7 +47,8 @@ instances:
 
   -
     ## @param use_preview - boolean - optional - default: true
-    ## Whether or not to preview the new version of the check supporting only ETCD 3+
+    ## Enable this option to run the Prometheus-based check of etcd.
+    ## Note: this requires etcd v3+.
     #
     # use_preview: true
 

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -48,7 +48,7 @@ instances:
   -
     ## @param use_preview - boolean - optional - default: true
     ## Enable this option to run the Prometheus-based check of etcd.
-    ## Note: this requires etcd v3+.
+    ## Note: This requires etcd v3 or greater.
     #
     # use_preview: true
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR updates the etcd service check docs to include `etcd.prometheus.health`.

### Motivation
<!-- What inspired you to submit this pull request? -->
The etcd check has a Prometheus and non-Prometheus check depending on `use_preview`. The service checks emitted by the two versions are different, although this isn't documented.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
