### PR TITLE
improve handling of encrypted stored procedures

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -63,7 +63,7 @@ qstats_aggr as (
     left join sys.databases D on S.dbid = D.database_id
     group by query_hash, query_plan_hash, S.dbid, D.name
 )
-select text, * from qstats_aggr
+select text, encrypted as is_encrypted, * from qstats_aggr
     cross apply sys.dm_exec_sql_text(plan_handle)
 """
 
@@ -77,12 +77,12 @@ with qstats_aggr as (
         where last_execution_time > dateadd(second, -?, getdate())
         group by query_hash, query_plan_hash
 )
-select text, * from qstats_aggr
+select text, encrypted as is_encrypted, * from qstats_aggr
     cross apply sys.dm_exec_sql_text(plan_handle)
 """
 
 PLAN_LOOKUP_QUERY = """\
-select cast(query_plan as nvarchar(max)) as query_plan
+select cast(query_plan as nvarchar(max)) as query_plan, encrypted as is_encrypted
 from sys.dm_exec_query_plan(CONVERT(varbinary(max), ?, 1))
 """
 
@@ -376,10 +376,10 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         self.log.debug("Running query [%s] %s", PLAN_LOOKUP_QUERY, (plan_handle,))
         cursor.execute(PLAN_LOOKUP_QUERY, ("0x" + plan_handle,))
         result = cursor.fetchall()
-        if not result:
+        if not result or not result[0]:
             self.log.debug("failed to loan plan, it must have just been expired out of the plan cache")
-            return None
-        return result[0][0]
+            return None, None
+        return result[0]
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_plans(self, rows, cursor, deadline):
@@ -390,11 +390,12 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                 return
             plan_key = (row['query_signature'], row['query_hash'], row['query_plan_hash'])
             if self._seen_plans_ratelimiter.acquire(plan_key):
-                raw_plan = self._load_plan(row['plan_handle'], cursor)
+                raw_plan, is_encrypted = self._load_plan(row['plan_handle'], cursor)
                 obfuscated_plan, collection_errors = None, None
 
                 try:
-                    obfuscated_plan = obfuscate_xml_plan(raw_plan, self.check.obfuscator_options)
+                    if raw_plan:
+                        obfuscated_plan = obfuscate_xml_plan(raw_plan, self.check.obfuscator_options)
                 except Exception as e:
                     self.log.debug(
                         (
@@ -429,9 +430,11 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                             "definition": obfuscated_plan,
                             "signature": row['query_plan_hash'],
                             "collection_errors": collection_errors,
+                            "is_encrypted": is_encrypted,
                         },
                         "query_signature": row['query_signature'],
                         "statement": row['text'],
+                        "is_statement_encrypted": row['is_encrypted'],
                         "metadata": {
                             "tables": row['dd_tables'],
                             "commands": row['dd_commands'],

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -390,7 +390,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                 return
             plan_key = (row['query_signature'], row['query_hash'], row['query_plan_hash'])
             if self._seen_plans_ratelimiter.acquire(plan_key):
-                raw_plan, is_encrypted = self._load_plan(row['plan_handle'], cursor)
+                raw_plan, is_plan_encrypted = self._load_plan(row['plan_handle'], cursor)
                 obfuscated_plan, collection_errors = None, None
 
                 try:
@@ -430,11 +430,10 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                             "definition": obfuscated_plan,
                             "signature": row['query_plan_hash'],
                             "collection_errors": collection_errors,
-                            "is_encrypted": is_encrypted,
+
                         },
                         "query_signature": row['query_signature'],
                         "statement": row['text'],
-                        "is_statement_encrypted": row['is_encrypted'],
                         "metadata": {
                             "tables": row['dd_tables'],
                             "commands": row['dd_commands'],
@@ -442,6 +441,8 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                         },
                     },
                     'sqlserver': {
+                        "is_plan_encrypted": is_plan_encrypted,
+                        "is_statement_encrypted": row['is_encrypted'],
                         'query_hash': row['query_hash'],
                         'query_plan_hash': row['query_plan_hash'],
                         'plan_handle': row['plan_handle'],

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -430,7 +430,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                             "definition": obfuscated_plan,
                             "signature": row['query_plan_hash'],
                             "collection_errors": collection_errors,
-
                         },
                         "query_signature": row['query_signature'],
                         "statement": row['text'],

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -86,6 +86,13 @@ GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
 GO
 
+CREATE OR ALTER PROCEDURE encryptedProc WITH ENCRYPTION AS
+BEGIN
+    select count(*) from sys.databases;
+END;
+GO
+GRANT EXECUTE on encryptedProc to bob;
+
 -----------------------------------
 -- AGOG setup
 

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -51,6 +51,14 @@ GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
 GO
 
+CREATE OR ALTER PROCEDURE encryptedProc WITH ENCRYPTION AS
+BEGIN
+    select count(*) from sys.databases;
+END;
+GO
+GRANT EXECUTE on encryptedProc to bob;
+
+
 -- Create test database for integration tests.
 -- Only bob and fred have read/write access to this database.
 CREATE DATABASE datadog_test;

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -51,6 +51,13 @@ GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
 GO
 
+CREATE OR ALTER PROCEDURE encryptedProc WITH ENCRYPTION AS
+BEGIN
+    select count(*) from sys.databases;
+END;
+GO
+GRANT EXECUTE on encryptedProc to bob;
+
 -- Create test database for integration tests.
 -- Only bob and fred have read/write access to this database.
 CREATE DATABASE datadog_test;

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -66,6 +66,7 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
+GRANT EXECUTE on pyStoredProc to bob;
 GO
 
 CREATE PROCEDURE exampleProcWithoutNocount AS
@@ -79,4 +80,12 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
+GRANT EXECUTE on exampleProcWithoutNocount to bob;
 GO
+
+CREATE OR ALTER PROCEDURE encryptedProc WITH ENCRYPTION AS
+BEGIN
+    select count(*) from sys.databases;
+END;
+GO
+GRANT EXECUTE on encryptedProc to bob;

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -66,7 +66,6 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on pyStoredProc to datadog;
-GRANT EXECUTE on pyStoredProc to bob;
 GO
 
 CREATE PROCEDURE exampleProcWithoutNocount AS
@@ -80,7 +79,6 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
-GRANT EXECUTE on exampleProcWithoutNocount to bob;
 GO
 
 CREATE OR ALTER PROCEDURE encryptedProc WITH ENCRYPTION AS

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -81,3 +81,10 @@ END;
 GO
 GRANT EXECUTE on exampleProcWithoutNocount to datadog;
 GO
+
+CREATE OR ALTER PROCEDURE encryptedProc WITH ENCRYPTION AS
+BEGIN
+    select count(*) from sys.databases;
+END;
+GO
+GRANT EXECUTE on encryptedProc to bob;

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -172,6 +172,7 @@ class SelfHealingConnection:
         for attempt in range(retries):
             try:
                 logging.info("executing query with retries. query='%s' params=%s attempt=%s", query, params, attempt)
+
                 with self.conn.cursor() as cursor:
                     if database:
                         cursor.execute("USE {}".format(database))

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -172,7 +172,6 @@ class SelfHealingConnection:
         for attempt in range(retries):
             try:
                 logging.info("executing query with retries. query='%s' params=%s attempt=%s", query, params, attempt)
-
                 with self.conn.cursor() as cursor:
                     if database:
                         cursor.execute("USE {}".format(database))

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -275,14 +275,14 @@ def test_statement_metrics_and_plans(
     for event in plan_events:
         if is_encrypted:
             assert not event['db']['plan']['definition']
-            assert event['db']['sqlserver']['is_plan_encrypted']
-            assert event['db']['sqlserver']['is_statement_encrypted']
+            assert event['sqlserver']['is_plan_encrypted']
+            assert event['sqlserver']['is_statement_encrypted']
         else:
             assert event['db']['plan']['definition'], "event plan definition missing"
             parsed_plan = ET.fromstring(event['db']['plan']['definition'])
             assert parsed_plan.tag.endswith("ShowPlanXML"), "plan does not match expected structure"
-            assert not event['db']['sqlserver']['is_plan_encrypted']
-            assert not event['db']['sqlserver']['is_statement_encrypted']
+            assert not event['sqlserver']['is_plan_encrypted']
+            assert not event['sqlserver']['is_statement_encrypted']
 
     fqt_events = [s for s in matching_samples if s['dbm_type'] == "fqt"]
     assert fqt_events, "should have collected some FQT events"

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -275,10 +275,14 @@ def test_statement_metrics_and_plans(
     for event in plan_events:
         if is_encrypted:
             assert not event['db']['plan']['definition']
+            assert event['db']['sqlserver']['is_plan_encrypted']
+            assert event['db']['sqlserver']['is_statement_encrypted']
         else:
             assert event['db']['plan']['definition'], "event plan definition missing"
             parsed_plan = ET.fromstring(event['db']['plan']['definition'])
             assert parsed_plan.tag.endswith("ShowPlanXML"), "plan does not match expected structure"
+            assert not event['db']['sqlserver']['is_plan_encrypted']
+            assert not event['db']['sqlserver']['is_statement_encrypted']
 
     fqt_events = [s for s in matching_samples if s['dbm_type'] == "fqt"]
     assert fqt_events, "should have collected some FQT events"


### PR DESCRIPTION
### What does this PR do?

Include query stats & plan samples for encrypted plan cache entires:

* read out the `encrypted` field from both `sys.dm_exec_sql_text` and `sys.dm_exec_query_plan`
* allow `None` values for `query_signature`, `statement`, `obfuscated_statement`, `db.plan.definition` when we know it's encrypted

This also fixes the `collection_errors` message which used to say `can only parse strings` because it used to try to obfuscate a NULL plan. Now there will be no collection error as encrypted plans are expected to be NULL, and the `is_encrypted` field will make it clear that the plan or statement are missing because it's encrypted.

### Motivation

* Fix missing stats in case of encrypted procs. 
* Fix incorrect plan collection_error message in case of encrypted procs. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
