### PR TITLE
Add error handling when collecting version

### DIFF
--- a/teradata/datadog_checks/teradata/check.py
+++ b/teradata/datadog_checks/teradata/check.py
@@ -95,7 +95,7 @@ class TeradataCheck(AgentCheck, ConfigMixin):
         self._tags.extend(global_tags)
         self._query_manager.tags = self._tags
 
-        self._tables_filter = create_tables_filter(self)
+        self._tables_filter = create_tables_filter(self.config.tables)
 
     def _execute_query_raw(self, query):
         # type: (AnyStr) -> Iterable[Sequence]
@@ -175,12 +175,12 @@ class TeradataCheck(AgentCheck, ConfigMixin):
             and is_affirmative(self.config.collect_table_disk_metrics)
             and self._tables_filter
         ):
-            tables_filtered_row = filter_tables(self, unprocessed_row)
+            tables_filtered_row = filter_tables(self._tables_filter, unprocessed_row)
             if tables_filtered_row:
-                processed_row = tags_normalizer(self, tables_filtered_row, query_name)
+                processed_row = tags_normalizer(tables_filtered_row, query_name)
                 return processed_row
             # Discard row if empty (table is filtered out)
             return tables_filtered_row
-        processed_row = tags_normalizer(self, unprocessed_row, query_name)
+        processed_row = tags_normalizer(unprocessed_row, query_name)
         self.log.trace('Row processor returned: %s. \nFrom query: "%s"', processed_row, query_name)
         return processed_row

--- a/teradata/datadog_checks/teradata/check.py
+++ b/teradata/datadog_checks/teradata/check.py
@@ -95,7 +95,7 @@ class TeradataCheck(AgentCheck, ConfigMixin):
         self._tags.extend(global_tags)
         self._query_manager.tags = self._tags
 
-        self._tables_filter = create_tables_filter(self.config.tables)
+        self._tables_filter = create_tables_filter(self)
 
     def _execute_query_raw(self, query):
         # type: (AnyStr) -> Iterable[Sequence]

--- a/teradata/datadog_checks/teradata/check.py
+++ b/teradata/datadog_checks/teradata/check.py
@@ -175,12 +175,12 @@ class TeradataCheck(AgentCheck, ConfigMixin):
             and is_affirmative(self.config.collect_table_disk_metrics)
             and self._tables_filter
         ):
-            tables_filtered_row = filter_tables(self._tables_filter, unprocessed_row)
+            tables_filtered_row = filter_tables(self, unprocessed_row)
             if tables_filtered_row:
-                processed_row = tags_normalizer(tables_filtered_row, query_name)
+                processed_row = tags_normalizer(self, tables_filtered_row, query_name)
                 return processed_row
             # Discard row if empty (table is filtered out)
             return tables_filtered_row
-        processed_row = tags_normalizer(unprocessed_row, query_name)
+        processed_row = tags_normalizer(self, unprocessed_row, query_name)
         self.log.trace('Row processor returned: %s. \nFrom query: "%s"', processed_row, query_name)
         return processed_row

--- a/teradata/datadog_checks/teradata/utils.py
+++ b/teradata/datadog_checks/teradata/utils.py
@@ -8,9 +8,9 @@ from datadog_checks.base import AgentCheck
 from datadog_checks.teradata.config_models.instance import Table
 
 
-def filter_tables(tables_filter, row):
+def filter_tables(self, row):
     # type: (Any, Sequence) -> Sequence
-    tables_to_collect, tables_to_exclude = tables_filter
+    tables_to_collect, tables_to_exclude = self._tables_filter
     table_name = row[3]
     # No tables filter
     if not tables_to_collect and not tables_to_exclude:
@@ -25,11 +25,13 @@ def filter_tables(tables_filter, row):
     return []
 
 
-def create_tables_filter(tables):
+def create_tables_filter(self):
     # type: (Any) -> Tuple[Set, Set]
 
     tables_to_collect = set()
     tables_to_exclude = set()
+
+    tables = self.config.tables
 
     if isinstance(tables, tuple):
         tables_to_collect = set(tables)
@@ -52,14 +54,14 @@ def create_tables_filter(tables):
         return (tables_to_collect, tables_to_exclude)
 
 
-def timestamp_validator(check, row):
+def timestamp_validator(self, row):
     # type: (Any, Sequence) -> Sequence
     now = time.time()
     row_ts = row[0]
     if type(row_ts) is not int:
         msg = 'Returned timestamp `{}` is invalid.'.format(row_ts)
-        check.log.warning(msg)
-        check._query_errors += 1
+        self.log.warning(msg)
+        self._query_errors += 1
         return []
     diff = now - row_ts
     # Valid metrics should be no more than 10 min in the future or 1h in the past
@@ -69,13 +71,13 @@ def timestamp_validator(check, row):
             msg = msg.format('Row timestamp is more than 1h in the past. Is `SPMA` Resource Usage Logging enabled?')
         elif diff < -600:
             msg = msg.format('Row timestamp is more than 10 min in the future. Try checking system time settings.')
-        check.log.warning(msg)
-        check._query_errors += 1
+        self.log.warning(msg)
+        self._query_errors += 1
         return []
     return row
 
 
-def tags_normalizer(row, query_name):
+def tags_normalizer(self, row, query_name):
     # type: (Any, Sequence, AnyStr) -> Sequence
     base_tags = [{"name": "td_amp", "col": row[0]}, {"name": "td_account", "col": row[1]}]
     tags_map = [

--- a/teradata/tests/test_utils.py
+++ b/teradata/tests/test_utils.py
@@ -6,7 +6,7 @@ import time
 import pytest
 
 from datadog_checks.teradata.check import TeradataCheck
-from datadog_checks.teradata.utils import timestamp_validator
+from datadog_checks.teradata.utils import submit_version, timestamp_validator
 
 from .common import CHECK_NAME
 
@@ -51,3 +51,23 @@ def test_timestamp_validator(caplog, instance, row, expected, msg):
         assert msg in caplog.text
     else:
         assert not caplog.text
+
+
+@pytest.mark.parametrize(
+    'row, expected_log',
+    [
+        pytest.param(['17.10.03'], None, id='short version'),
+        pytest.param(['17'], None, id='valid version'),
+        pytest.param(['a'], None, id='somewhat valid version'),
+        pytest.param([], 'Could not collect version info', id='no version returned'),
+    ],
+)
+def test_submit_version(instance, caplog, row, expected_log):
+    caplog.clear()
+    check = TeradataCheck(CHECK_NAME, {}, [instance])
+    submit_version(check, row)
+
+    if expected_log:
+        assert expected_log in caplog.text
+    else:
+        assert caplog.text == ''


### PR DESCRIPTION
### What does this PR do?
Adds error handling when collecting teradata version
### Motivation
If the version query in teradata returns nothing, then the check will fail. Version collection should not block the check run, so we should handle this error, log it, and continue.

QA for: https://github.com/DataDog/integrations-core/pull/11701/files
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
