### PR TITLE
Clarify no cert service check message

### DIFF
--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -303,7 +303,10 @@ class HTTPCheck(AgentCheck):
 
             ssl_sock = context.wrap_socket(sock, server_hostname=server_name)
             cert = ssl_sock.getpeercert()
-            exp_date = datetime.strptime(cert['notAfter'], "%b %d %H:%M:%S %Y %Z")
+            if cert:
+                exp_date = datetime.strptime(cert['notAfter'], "%b %d %H:%M:%S %Y %Z")
+            else:
+                raise Exception("Empty or no certificate found.")
         except Exception as e:
             msg = repr(e)
             if any(word in msg for word in ['expired', 'expiration']):

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -49,7 +49,7 @@ def test_cert_expiration_no_cert(http_check):
 
         status, days_left, seconds_left, msg = http_check.check_cert_expiration(instance, 10, cert_path)
         assert status == AgentCheck.UNKNOWN
-        expected_msg = 'KeyError(\'notAfter\')'
+        expected_msg = 'Exception(\'Empty or no certificate found.\')'
         if PY2:
             expected_msg = (
                 'ValueError(\'empty or no certificate, match_hostname needs a SSL socket '


### PR DESCRIPTION
### What does this PR do?
This PR checks whether there is a cert returned from `getpeercert()` before getting the expiration date from the cert and logs a more straight-forward message when there is no cert. This prevents the `KeyError` that would otherwise return when attempting to retrieve the expiration date from a non-existent cert. 

### Motivation
QA https://github.com/DataDog/integrations-core/pull/11793

### Additional Notes
There seem to be some differences in how `ssl.SSLSocket.getpeercert()` handles empty/no certificates between py27 and py38. The `getpeercert` method matches hostname in both python versions, but py27 uses the `match_hostname()` method (which returns the `ValueError` when there is no [cert](https://github.com/python/cpython/blob/8d21aa21f2cbc6d50aab3f420bb23be1d081dac4/Lib/ssl.py#L263-L266)) and it was changed in python 3.7 to use OpenSSL to match hostname. 

https://docs.python.org/3.8/library/ssl.html#ssl.match_hostname

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
