### PR TITLE
Add additional header assertions 

### DIFF
--- a/openmetrics/tests/test_openmetrics.py
+++ b/openmetrics/tests/test_openmetrics.py
@@ -102,7 +102,10 @@ def test_openmetrics_wildcard(dd_run_check, aggregator):
 
 @pytest.mark.skipif(PY2, reason='Test only available on Python 3')
 def test_linkerd_v2_new(aggregator, dd_run_check):
+    from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsScraper
+
     check = OpenMetricsCheck('openmetrics', {}, [instance_new])
+    scraper = OpenMetricsScraper(check, instance_new)
     dd_run_check(check)
 
     aggregator.assert_metric(
@@ -126,3 +129,6 @@ def test_linkerd_v2_new(aggregator, dd_run_check):
         metric_type=aggregator.MONOTONIC_COUNT,
     )
     aggregator.assert_all_metrics_covered()
+
+    assert check.http.options['headers']['Accept'] == '*/*'
+    assert scraper.http.options['headers']['Accept'] == 'text/plain'

--- a/openmetrics/tests/test_openmetrics_strict.py
+++ b/openmetrics/tests/test_openmetrics_strict.py
@@ -9,7 +9,10 @@ from datadog_checks.openmetrics import OpenMetricsCheck
 
 from .common import CHECK_NAME
 
-pytestmark = pytest.mark.usefixtures("strict_poll_mock")
+pytestmark = [
+    pytest.mark.usefixtures("strict_poll_mock"),
+    pytest.mark.skipif(PY2, reason='Test only available on Python 3'),
+]
 
 instance_new_strict = {
     'openmetrics_endpoint': 'http://localhost:10249/metrics',
@@ -20,7 +23,6 @@ instance_new_strict = {
 }
 
 
-@pytest.mark.skipif(PY2, reason='Test only available on Python 3')
 def test_linkerd_v2_new_strict(aggregator, dd_run_check, caplog):
     from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsScraper
 

--- a/openmetrics/tests/test_openmetrics_strict.py
+++ b/openmetrics/tests/test_openmetrics_strict.py
@@ -21,7 +21,7 @@ instance_new_strict = {
 
 
 @pytest.mark.skipif(PY2, reason='Test only available on Python 3')
-def test_linkerd_v2_new_strict(aggregator, dd_run_check):
+def test_linkerd_v2_new_strict(aggregator, dd_run_check, caplog):
     check = OpenMetricsCheck('openmetrics', {}, [instance_new_strict])
     dd_run_check(check)
 
@@ -41,3 +41,5 @@ def test_linkerd_v2_new_strict(aggregator, dd_run_check):
         metric_type=aggregator.MONOTONIC_COUNT,
     )
     aggregator.assert_all_metrics_covered()
+    assert check.http.options['headers']['Accept'] == 'application/openmetrics-text; version=0.0.1; charset=utf-8'
+    assert caplog.text == ''

--- a/openmetrics/tests/test_openmetrics_strict.py
+++ b/openmetrics/tests/test_openmetrics_strict.py
@@ -22,7 +22,10 @@ instance_new_strict = {
 
 @pytest.mark.skipif(PY2, reason='Test only available on Python 3')
 def test_linkerd_v2_new_strict(aggregator, dd_run_check, caplog):
+    from datadog_checks.base.checks.openmetrics.v2.scraper import OpenMetricsScraper
+
     check = OpenMetricsCheck('openmetrics', {}, [instance_new_strict])
+    scraper = OpenMetricsScraper(check, instance_new_strict)
     dd_run_check(check)
 
     aggregator.assert_metric(
@@ -41,5 +44,7 @@ def test_linkerd_v2_new_strict(aggregator, dd_run_check, caplog):
         metric_type=aggregator.MONOTONIC_COUNT,
     )
     aggregator.assert_all_metrics_covered()
-    assert check.http.options['headers']['Accept'] == 'application/openmetrics-text; version=0.0.1; charset=utf-8'
+
+    assert check.http.options['headers']['Accept'] == '*/*'
+    assert scraper.http.options['headers']['Accept'] == 'application/openmetrics-text; version=0.0.1; charset=utf-8'
     assert caplog.text == ''


### PR DESCRIPTION
### What does this PR do?
Add additional header assertions to openmetrics v2 tests to validate that the scraper http header is properly getting updated when `use_latest_spec: True`.

### Motivation
QA https://github.com/DataDog/integrations-core/pull/11899

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
