### PR TITLE
Remove mac support docs

### DIFF
--- a/teradata/manifest.json
+++ b/teradata/manifest.json
@@ -11,7 +11,6 @@
   "support": "core",
   "supported_os": [
     "linux",
-    "mac_os",
     "windows"
   ],
   "public_title": "Teradata",


### PR DESCRIPTION
### What does this PR do?
Excludes mac as a supported platform for teradata 
### Motivation
QA for https://github.com/DataDog/integrations-core/pull/11701, teradatasql  is not properly signed for mac. see https://github.com/DataDog/datadog-agent/pull/12119
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
