### PR TITLE
Change refreshing counters log level to debug

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/base.py
@@ -65,7 +65,7 @@ class PerfCountersBaseCheck(AgentCheck):
         collection_queue = []
 
         for perf_object in self.perf_objects:
-            self.log.info('Refreshing counters for performance object: %s', perf_object.name)
+            self.log.debug('Refreshing counters for performance object: %s', perf_object.name)
             try:
                 perf_object.refresh()
             except ConfigurationError as e:

--- a/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/base.py
@@ -90,7 +90,7 @@ class PerfCountersBaseCheck(AgentCheck):
             return
 
         for perf_object in collection_queue:
-            self.log.info('Collecting query data for performance object: %s', perf_object.name)
+            self.log.debug('Collecting query data for performance object: %s', perf_object.name)
             try:
                 perf_object.collect()
             except Exception as e:


### PR DESCRIPTION
Client feels as though events related to performance counters ("Refreshing counters for performance object..." and "Collecting query data for performance object...") are filling up their INFO level logs too quickly. They would like for us to downgrade performance counter events to DEBUG level. 