### PR TITLE
add log filtering by eventID example

### DIFF
--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -169,6 +169,24 @@ Double-check your filters' values with <code>Get-WmiObject</code> if the integra
 
 For more examples of filtering logs, see the [Advanced Log Collection documentation][12].
 
+### Filtering by EventID
+
+Here is an example regex pattern to only collect Windows Events Logs from a certain EventID:
+
+```yaml
+logs:
+    - type: windows_event
+      channel_path: Security
+      source: windows.event
+      service: Windows
+      log_processing_rules:
+        - type: include_at_match
+          name: include_x01
+          pattern: \"value\":\"(101|201|301)\"         
+```
+
+**Note**: the pattern may vary based on the format of the logs
+
 ### Validation
 
 Check the info page in the Datadog Agent Manager or run the [Agent's `status` subcommand][6] and look for `win32_event_log` under the Checks section. It should display a section similar to the following:

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -175,14 +175,14 @@ Here is an example regex pattern to only collect Windows Events Logs from a cert
 
 ```yaml
 logs:
-    - type: windows_event
-      channel_path: Security
-      source: windows.event
-      service: Windows
-      log_processing_rules:
-        - type: include_at_match
-          name: include_x01
-          pattern: \"value\":\"(101|201|301)\"         
+  - type: windows_event
+    channel_path: Security
+    source: windows.event
+    service: Windows
+    log_processing_rules:
+      - type: include_at_match
+        name: include_x01
+        pattern: \"value\":\"(101|201|301)\"
 ```
 
 **Note**: the pattern may vary based on the format of the logs


### PR DESCRIPTION
### What does this PR do?
this change adds an example containing a regex pattern that many customers have found useful in filtering their win32 logs

### Motivation
this doc update was requested by the customer in this ticket: https://datadog.zendesk.com/agent/tickets/787828

### Additional Notes
related internal wiki: https://datadoghq.atlassian.net/wiki/spaces/TS/pages/328631826/Send+Windows+Event+Logs+to+DD+Logs

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
