### PR TITLE
Fix incorrect connection metric type and add users connected metric

### DIFF
--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -18,21 +18,6 @@ try:
 except ImportError:
     from ..stubs import datadog_agent
 
-CONNECTIONS_QUERY = """\
-SELECT
-    processlist_user,
-    processlist_host,
-    processlist_db,
-    processlist_state,
-    COUNT(processlist_user) AS connections
-FROM
-    performance_schema.threads
-WHERE
-    processlist_user IS NOT NULL AND
-    processlist_state IS NOT NULL
-    GROUP BY processlist_user, processlist_host, processlist_db, processlist_state
-"""
-
 ACTIVITY_QUERY = """\
 SELECT
     thread_a.thread_id,
@@ -149,10 +134,9 @@ class MySQLActivity(DBMAsyncJob):
     def _collect_activity(self):
         # type: () -> None
         with closing(self._get_db_connection().cursor(pymysql.cursors.DictCursor)) as cursor:
-            connections = self._get_active_connections(cursor)
             rows = self._get_activity(cursor)
             rows = self._normalize_rows(rows)
-            event = self._create_activity_event(rows, connections)
+            event = self._create_activity_event(rows)
             payload = json.dumps(event, default=self._json_event_encoding)
             self._check.database_monitoring_query_activity(payload)
             self._check.histogram(
@@ -160,15 +144,6 @@ class MySQLActivity(DBMAsyncJob):
                 len(payload),
                 tags=self._tags + self._check._get_debug_tags(),
             )
-
-    @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
-    def _get_active_connections(self, cursor):
-        # type: (pymysql.cursor) -> List[Dict[str]]
-        self._log.debug("Running connections query [%s]", CONNECTIONS_QUERY)
-        cursor.execute(CONNECTIONS_QUERY)
-        rows = cursor.fetchall()
-        self._log.debug("Loaded [%s] current connections", len(rows))
-        return rows
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _get_activity(self, cursor):
@@ -230,8 +205,8 @@ class MySQLActivity(DBMAsyncJob):
         # type: (Dict[str]) -> int
         return len(str(row))
 
-    def _create_activity_event(self, active_sessions, active_connections):
-        # type: (List[Dict[str]], List[Dict[str]]) -> Dict[str]
+    def _create_activity_event(self, active_sessions):
+        # type: (List[Dict[str]]) -> Dict[str]
         return {
             "host": self._check.resolved_hostname,
             "ddagentversion": datadog_agent.get_version(),
@@ -241,7 +216,6 @@ class MySQLActivity(DBMAsyncJob):
             "ddtags": self._tags,
             "timestamp": time.time() * 1000,
             "mysql_activity": active_sessions,
-            "mysql_connections": active_connections,
         }
 
     @staticmethod

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -8,10 +8,6 @@ COUNT = "count"
 MONOTONIC = "monotonic_count"
 PROC_NAME = 'mysqld'
 
-DBM_MIGRATED_METRICS = {
-    'Connections': ('mysql.net.connections', GAUGE),
-}
-
 # Vars found in "SHOW STATUS;"
 STATUS_VARS = {
     # Command Metrics
@@ -30,6 +26,7 @@ STATUS_VARS = {
     'Com_delete_multi': ('mysql.performance.com_delete_multi', RATE),
     'Com_replace_select': ('mysql.performance.com_replace_select', RATE),
     # Connection Metrics
+    'Connections': ('mysql.net.connections', RATE),
     'Max_used_connections': ('mysql.net.max_connections', GAUGE),
     'Aborted_clients': ('mysql.net.aborted_clients', RATE),
     'Aborted_connects': ('mysql.net.aborted_connects', RATE),

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -463,15 +463,19 @@ class MySql(AgentCheck):
                 cursor.execute(SQL_USER_CONNECTIONS)
                 connections = cursor.fetchall()
                 self.log.debug("Loaded [%s] user connections", len(connections))
-                # Emit the metrics now, so we're able to add: user, host, db, and state tags
-                for user, host, db, state, connections in connections:
-                    conn_tags = [
+                # Emit the metrics now, so we're able to add: user, db, and state tags
+                for user, db, state, connections in connections:
+                    conn_tags = self._config.tags + [
                         "user:{}".format(user),
-                        "host:{}".format(host),
                         "db:{}".format(db),
                         "state:{}".format(state),
                     ]
-                    self.gauge("mysql.performance.users_connected", connections, tags=conn_tags)
+                    self.gauge(
+                        "mysql.performance.users_connected",
+                        connections,
+                        tags=conn_tags,
+                        hostname=self.resolved_hostname,
+                    )
         except Exception as e:
             self.warning("Error occurred when querying for user connections: %s", e)
             return {}

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -22,7 +22,6 @@ from .config import MySQLConfig
 from .const import (
     BINLOG_VARS,
     COUNT,
-    DBM_MIGRATED_METRICS,
     GALERA_VARS,
     GAUGE,
     GROUP_REPLICATION_VARS,
@@ -54,6 +53,7 @@ from .queries import (
     SQL_QUERY_TABLE_SIZE,
     SQL_REPLICATION_ROLE_AWS_AURORA,
     SQL_SERVER_ID_AWS_AURORA,
+    SQL_USER_CONNECTIONS,
     SQL_WORKER_THREADS,
     show_replica_status_query,
 )
@@ -296,9 +296,6 @@ class MySql(AgentCheck):
         # Get aggregate of all VARS we want to collect
         metrics = STATUS_VARS
 
-        if not self._config.dbm_enabled:
-            metrics.update(DBM_MIGRATED_METRICS)
-
         # collect results from db
         results = self._get_stats_from_status(db)
         results.update(self._get_stats_from_variables(db))
@@ -347,6 +344,9 @@ class MySql(AgentCheck):
             # already in result-set after 'SHOW STATUS' just add vars to collect
             self.log.debug("Collecting Galera Metrics.")
             metrics.update(GALERA_VARS)
+
+        if self.performance_schema_enabled:
+            self._collect_users_connected_metric(db)
 
         above_560 = self.version.version_compatible((5, 6, 0))
         if (
@@ -455,6 +455,26 @@ class MySql(AgentCheck):
                 self.warning(
                     "Maximum number (%s) of custom queries reached. Skipping the rest.", self._config.max_custom_queries
                 )
+
+    def _collect_users_connected_metric(self, db):
+        try:
+            with closing(db.cursor()) as cursor:
+                self.log.debug("Running connections query [%s]", SQL_USER_CONNECTIONS)
+                cursor.execute(SQL_USER_CONNECTIONS)
+                connections = cursor.fetchall()
+                self.log.debug("Loaded [%s] user connections", len(connections))
+                # Emit the metrics now, so we're able to add: user, host, db, and state tags
+                for user, host, db, state, connections in connections:
+                    conn_tags = [
+                        "user:{}".format(user),
+                        "host:{}".format(host),
+                        "db:{}".format(db),
+                        "state:{}".format(state),
+                    ]
+                    self.gauge("mysql.performance.users_connected", connections, tags=conn_tags)
+        except Exception as e:
+            self.warning("Error occurred when querying for user connections: %s", e)
+            return {}
 
     def _collect_replication_metrics(self, db, results, above_560):
         # Get replica stats

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -53,7 +53,7 @@ from .queries import (
     SQL_QUERY_TABLE_SIZE,
     SQL_REPLICATION_ROLE_AWS_AURORA,
     SQL_SERVER_ID_AWS_AURORA,
-    SQL_USER_CONNECTIONS,
+    SQL_USERS_CONNECTED,
     SQL_WORKER_THREADS,
     show_replica_status_query,
 )
@@ -459,8 +459,8 @@ class MySql(AgentCheck):
     def _collect_users_connected_metric(self, db):
         try:
             with closing(db.cursor()) as cursor:
-                self.log.debug("Running connections query [%s]", SQL_USER_CONNECTIONS)
-                cursor.execute(SQL_USER_CONNECTIONS)
+                self.log.debug("Running connections query [%s]", SQL_USERS_CONNECTED)
+                cursor.execute(SQL_USERS_CONNECTED)
                 connections = cursor.fetchall()
                 self.log.debug("Loaded [%s] user connections", len(connections))
                 # Emit the metrics now, so we're able to add: user, db, and state tags

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -39,7 +39,7 @@ GROUP BY schema_name"""
 
 SQL_WORKER_THREADS = "SELECT THREAD_ID, NAME FROM performance_schema.threads WHERE NAME LIKE '%worker'"
 
-SQL_USER_CONNECTIONS = """\
+SQL_USERS_CONNECTED = """\
 SELECT
     processlist_user,
     processlist_db,

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -39,6 +39,21 @@ GROUP BY schema_name"""
 
 SQL_WORKER_THREADS = "SELECT THREAD_ID, NAME FROM performance_schema.threads WHERE NAME LIKE '%worker'"
 
+SQL_USER_CONNECTIONS = """\
+SELECT
+    processlist_user,
+    processlist_host,
+    processlist_db,
+    processlist_state,
+    COUNT(processlist_user) AS connections
+FROM
+    performance_schema.threads
+WHERE
+    processlist_user IS NOT NULL AND
+    processlist_state IS NOT NULL
+    GROUP BY processlist_user, processlist_host, processlist_db, processlist_state
+"""
+
 SQL_PROCESS_LIST = "SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST WHERE COMMAND LIKE '%Binlog dump%'"
 
 SQL_INNODB_ENGINES = """\

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -42,7 +42,6 @@ SQL_WORKER_THREADS = "SELECT THREAD_ID, NAME FROM performance_schema.threads WHE
 SQL_USER_CONNECTIONS = """\
 SELECT
     processlist_user,
-    processlist_host,
     processlist_db,
     processlist_state,
     COUNT(processlist_user) AS connections
@@ -51,7 +50,7 @@ FROM
 WHERE
     processlist_user IS NOT NULL AND
     processlist_state IS NOT NULL
-    GROUP BY processlist_user, processlist_host, processlist_db, processlist_state
+    GROUP BY processlist_user, processlist_db, processlist_state
 """
 
 SQL_PROCESS_LIST = "SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST WHERE COMMAND LIKE '%Binlog dump%'"

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -16,7 +16,7 @@ mysql.innodb.mutex_spin_waits,gauge,,event,second,The rate of mutex spin waits.,
 mysql.innodb.os_log_fsyncs,gauge,,write,second,The rate of fsync writes to the log file.,0,mysql,log fsyncs,
 mysql.innodb.row_lock_time,gauge,,fraction,,Fraction of time spent (ms/s) acquiring row locks.,-1,mysql,row lock time,
 mysql.innodb.row_lock_waits,gauge,,event,second,The number of times per second a row lock had to be waited for.,0,mysql,innodb row lock waits,
-mysql.net.connections,gauge,,connection,second,The rate of connections to the server.,0,mysql,conns per s,cpu
+mysql.net.connections,rate,,connection,second,The rate of connections to the server.,0,mysql,conns per s,cpu
 mysql.net.max_connections,gauge,,connection,,The maximum number of connections that have been in use simultaneously since the server started.,-1,mysql,max used conn,
 mysql.net.max_connections_available,gauge,,connection,,The maximum permitted number of simultaneous client connections.,-1,mysql,max used conn avail,
 mysql.performance.com_delete,gauge,,query,second,The rate of delete statements.,0,mysql,deletes,
@@ -41,6 +41,7 @@ mysql.performance.slow_queries,gauge,,query,second,The rate of slow queries.,-1,
 mysql.performance.table_locks_waited,gauge,,,,The total number of times that a request for a table lock could not be granted immediately and a wait was needed.,-1,mysql,table locks waited,
 mysql.performance.table_locks_waited.rate,gauge,,,,"The rate of times that a request for a table lock could not be granted immediately and a wait was needed.",0,mysql,table locks waited rate,
 mysql.performance.threads_connected,gauge,,connection,,The number of currently open connections.,0,mysql,threads connected,cpu
+mysql.performance.users_connected,gauge,,connection,,The number of currently open user connections.,0,mysql,users connected,cpu
 mysql.performance.threads_running,gauge,,thread,,The number of threads that are not sleeping.,0,mysql,threads running,
 mysql.performance.cpu_time,gauge,,percent,,Percentage of CPU time spent by MySQL.,-1,mysql,cpu,cpu
 mysql.performance.user_time,gauge,,percent,,Percentage of CPU time spent in user space by MySQL.,-1,mysql,cpu user,

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -16,7 +16,7 @@ mysql.innodb.mutex_spin_waits,gauge,,event,second,The rate of mutex spin waits.,
 mysql.innodb.os_log_fsyncs,gauge,,write,second,The rate of fsync writes to the log file.,0,mysql,log fsyncs,
 mysql.innodb.row_lock_time,gauge,,fraction,,Fraction of time spent (ms/s) acquiring row locks.,-1,mysql,row lock time,
 mysql.innodb.row_lock_waits,gauge,,event,second,The number of times per second a row lock had to be waited for.,0,mysql,innodb row lock waits,
-mysql.net.connections,rate,,connection,second,The rate of connections to the server.,0,mysql,conns per s,cpu
+mysql.net.connections,gauge,,connection,second,The rate of connections to the server.,0,mysql,conns per s,cpu
 mysql.net.max_connections,gauge,,connection,,The maximum number of connections that have been in use simultaneously since the server started.,-1,mysql,max used conn,
 mysql.net.max_connections_available,gauge,,connection,,The maximum permitted number of simultaneous client connections.,-1,mysql,max used conn avail,
 mysql.performance.com_delete,gauge,,query,second,The rate of delete statements.,0,mysql,deletes,

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -41,7 +41,13 @@ def test_minimal_config(aggregator, dd_run_check, instance_basic):
     aggregator.assert_service_check('mysql.can_connect', status=MySql.OK, tags=tags.SC_TAGS_MIN, count=1)
 
     # Test metrics
-    testable_metrics = variables.STATUS_VARS + variables.VARIABLES_VARS + variables.INNODB_VARS + variables.BINLOG_VARS
+    testable_metrics = (
+        variables.STATUS_VARS
+        + variables.VARIABLES_VARS
+        + variables.INNODB_VARS
+        + variables.BINLOG_VARS
+        + variables.ACTIVITY_VARS
+    )
 
     for mname in testable_metrics:
         aggregator.assert_metric(mname, at_least=1)
@@ -104,6 +110,7 @@ def _assert_complex_config(aggregator, hostname='stubbed.hostname'):
         + variables.SYNTHETIC_VARS
         + variables.STATEMENT_VARS
         + variables.TABLE_VARS
+        + variables.ACTIVITY_VARS
     )
     if MYSQL_REPLICATION == 'group':
         testable_metrics.extend(variables.GROUP_REPLICATION_VARS)

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -221,6 +221,7 @@ def test_complex_config_replica(aggregator, dd_run_check, instance_complex):
         + variables.SYNTHETIC_VARS
         + variables.STATEMENT_VARS
         + variables.TABLE_VARS
+        + variables.ACTIVITY_VARS
     )
 
     if MYSQL_VERSION_PARSED >= parse_version('5.6') and environ.get('MYSQL_FLAVOR') != 'mariadb':

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -105,18 +105,6 @@ def test_collect_activity(aggregator, dbm_instance, dd_run_check):
     assert blocked_row['event_timer_end'], "missing event timer end"
     assert blocked_row['lock_time'], "missing lock time"
 
-    connections = activity['mysql_connections']
-    assert len(connections) > 0, "expected to have active connections"
-    fred_conn = None
-    for conn in connections:
-        if conn['processlist_user'] == 'fred':
-            fred_conn = conn
-            break
-
-    assert fred_conn is not None
-    assert fred_conn['connections'] == 1
-    assert fred_conn['processlist_state'], "missing state"
-
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -242,6 +242,8 @@ OPTIONAL_INNODB_VARS = [
     'mysql.innodb.x_lock_spin_waits',
 ]
 
+ACTIVITY_VARS = ['mysql.performance.users_connected']
+
 PERFORMANCE_VARS = ['mysql.performance.query_run_time.avg', 'mysql.performance.digest_95th_percentile.avg_us']
 
 SCHEMA_VARS = ['mysql.info.schema.size']


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Re: https://github.com/DataDog/integrations-core/issues/12074

#### Why was the metric type changed?
This PR reverts the change in metric_type for the `mysql.net.connections` metric. Originally, the python code had the metric_type as a `RATE`, but was later changed due to confusion from the `metadata.csv` file where it's declared as `GAUGE`. The reason why the python code declares this as `RATE` type is because this informs the agent on how to handle/compute the **value** of the metric, but it's later mapped to a gauge type when sent to our back-end. This is why the metadata file declares this as a `GAUGE`.

#### Why was the metric migrated to the Database Monitoring team?
This PR additionally reverts the migration of the metric `mysql.net.connections` to the database monitoring (DBM) team. This metric was migrated to DBM (if dbm was enabled for this integration) for a few reasons, but to list the main points:
1. This metric was supposed to represent active user connections (this turned out to be the incorrect metric for this)
2. We prefer to send everything to our back-end so we have more control and to perform an necessary mutations such as adding tags

After further internal discussions, we realized that (2) was not necessary, so we opted to do this in the integration instead. This change introduces a new metric `mysql.performance.users_connected` which represents the number of active users connected.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
