### PR TITLE
Add user connections metric

### DIFF
--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -8,6 +8,10 @@ COUNT = "count"
 MONOTONIC = "monotonic_count"
 PROC_NAME = 'mysqld'
 
+DBM_MIGRATED_METRICS = {
+    'Connections': ('mysql.net.connections', GAUGE),
+}
+
 # Vars found in "SHOW STATUS;"
 STATUS_VARS = {
     # Command Metrics
@@ -26,7 +30,6 @@ STATUS_VARS = {
     'Com_delete_multi': ('mysql.performance.com_delete_multi', RATE),
     'Com_replace_select': ('mysql.performance.com_replace_select', RATE),
     # Connection Metrics
-    'Connections': ('mysql.net.connections', RATE),
     'Max_used_connections': ('mysql.net.max_connections', GAUGE),
     'Aborted_clients': ('mysql.net.aborted_clients', RATE),
     'Aborted_connects': ('mysql.net.aborted_connects', RATE),

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -8,10 +8,6 @@ COUNT = "count"
 MONOTONIC = "monotonic_count"
 PROC_NAME = 'mysqld'
 
-DBM_MIGRATED_METRICS = {
-    'Connections': ('mysql.net.connections', GAUGE),
-}
-
 # Vars found in "SHOW STATUS;"
 STATUS_VARS = {
     # Command Metrics
@@ -30,6 +26,7 @@ STATUS_VARS = {
     'Com_delete_multi': ('mysql.performance.com_delete_multi', RATE),
     'Com_replace_select': ('mysql.performance.com_replace_select', RATE),
     # Connection Metrics
+    'Connections': ('mysql.net.connections', RATE),
     'Max_used_connections': ('mysql.net.max_connections', GAUGE),
     'Aborted_clients': ('mysql.net.aborted_clients', RATE),
     'Aborted_connects': ('mysql.net.aborted_connects', RATE),

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -22,6 +22,7 @@ from .config import MySQLConfig
 from .const import (
     BINLOG_VARS,
     COUNT,
+    DBM_MIGRATED_METRICS,
     GALERA_VARS,
     GAUGE,
     GROUP_REPLICATION_VARS,
@@ -295,6 +296,9 @@ class MySql(AgentCheck):
 
         # Get aggregate of all VARS we want to collect
         metrics = STATUS_VARS
+
+        if not self._config.dbm_enabled:
+            metrics.update(DBM_MIGRATED_METRICS)
 
         # collect results from db
         results = self._get_stats_from_status(db)

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -39,6 +39,20 @@ GROUP BY schema_name"""
 
 SQL_WORKER_THREADS = "SELECT THREAD_ID, NAME FROM performance_schema.threads WHERE NAME LIKE '%worker'"
 
+SQL_USERS_CONNECTED = """\
+SELECT
+    processlist_user,
+    processlist_db,
+    processlist_state,
+    COUNT(processlist_user) AS connections
+FROM
+    performance_schema.threads
+WHERE
+    processlist_user IS NOT NULL AND
+    processlist_state IS NOT NULL
+    GROUP BY processlist_user, processlist_db, processlist_state
+"""
+
 SQL_PROCESS_LIST = "SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST WHERE COMMAND LIKE '%Binlog dump%'"
 
 SQL_INNODB_ENGINES = """\

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -41,6 +41,7 @@ mysql.performance.slow_queries,gauge,,query,second,The rate of slow queries.,-1,
 mysql.performance.table_locks_waited,gauge,,,,The total number of times that a request for a table lock could not be granted immediately and a wait was needed.,-1,mysql,table locks waited,
 mysql.performance.table_locks_waited.rate,gauge,,,,"The rate of times that a request for a table lock could not be granted immediately and a wait was needed.",0,mysql,table locks waited rate,
 mysql.performance.threads_connected,gauge,,connection,,The number of currently open connections.,0,mysql,threads connected,cpu
+mysql.performance.users_connected,gauge,,connection,,The number of currently open user connections.,0,mysql,users connected,cpu
 mysql.performance.threads_running,gauge,,thread,,The number of threads that are not sleeping.,0,mysql,threads running,
 mysql.performance.cpu_time,gauge,,percent,,Percentage of CPU time spent by MySQL.,-1,mysql,cpu,cpu
 mysql.performance.user_time,gauge,,percent,,Percentage of CPU time spent in user space by MySQL.,-1,mysql,cpu user,

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -52,6 +52,7 @@ def test_minimal_config(aggregator, dd_run_check, instance_basic):
         + variables.COMPLEX_INNODB_VARS
         + variables.SYSTEM_METRICS
         + variables.SYNTHETIC_VARS
+        + variables.ACTIVITY_VARS
     )
 
     _test_optional_metrics(aggregator, optional_metrics)
@@ -104,6 +105,7 @@ def _assert_complex_config(aggregator, hostname='stubbed.hostname'):
         + variables.SYNTHETIC_VARS
         + variables.STATEMENT_VARS
         + variables.TABLE_VARS
+        + variables.ACTIVITY_VARS
     )
     if MYSQL_REPLICATION == 'group':
         testable_metrics.extend(variables.GROUP_REPLICATION_VARS)
@@ -214,6 +216,7 @@ def test_complex_config_replica(aggregator, dd_run_check, instance_complex):
         + variables.SYNTHETIC_VARS
         + variables.STATEMENT_VARS
         + variables.TABLE_VARS
+        + variables.ACTIVITY_VARS
     )
 
     if MYSQL_VERSION_PARSED >= parse_version('5.6') and environ.get('MYSQL_FLAVOR') != 'mariadb':

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -137,18 +137,6 @@ def test_collect_activity(aggregator, dbm_instance, dd_run_check, query, query_s
     assert blocked_row['lock_time'], "missing lock time"
     assert blocked_row['query_truncated'] == expected_query_truncated
 
-    connections = activity['mysql_connections']
-    assert len(connections) > 0, "expected to have active connections"
-    fred_conn = None
-    for conn in connections:
-        if conn['processlist_user'] == 'fred':
-            fred_conn = conn
-            break
-
-    assert fred_conn is not None
-    assert fred_conn['connections'] == 1
-    assert fred_conn['processlist_state'], "missing state"
-
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -242,6 +242,8 @@ OPTIONAL_INNODB_VARS = [
     'mysql.innodb.x_lock_spin_waits',
 ]
 
+ACTIVITY_VARS = ['mysql.performance.users_connected']
+
 PERFORMANCE_VARS = ['mysql.performance.query_run_time.avg', 'mysql.performance.digest_95th_percentile.avg_us']
 
 SCHEMA_VARS = ['mysql.info.schema.size']


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a new metric `mysql.performance.user_connections` as a follow up to the reversion of a metric type ([PR](https://github.com/DataDog/integrations-core/pull/12088)). 

Initially, the migrated metric was used to surface _user connections_, but because this metric (`mysql.net.connections`) had a different meaning:

> The rate of connections to the server

another metric has to replace it. There is an existing metric `mysql.performance.threads_connected` that seemed to be a good candidate, however, this metric represents all open connections which **includes** background threads which is not what we need. We need a metric to surface the number of user connections.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
