### PR TITLE
Revert mysql.net.connections metric type

### DIFF
--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -8,10 +8,6 @@ COUNT = "count"
 MONOTONIC = "monotonic_count"
 PROC_NAME = 'mysqld'
 
-DBM_MIGRATED_METRICS = {
-    'Connections': ('mysql.net.connections', GAUGE),
-}
-
 # Vars found in "SHOW STATUS;"
 STATUS_VARS = {
     # Command Metrics
@@ -30,6 +26,7 @@ STATUS_VARS = {
     'Com_delete_multi': ('mysql.performance.com_delete_multi', RATE),
     'Com_replace_select': ('mysql.performance.com_replace_select', RATE),
     # Connection Metrics
+    'Connections': ('mysql.net.connections', RATE),
     'Max_used_connections': ('mysql.net.max_connections', GAUGE),
     'Aborted_clients': ('mysql.net.aborted_clients', RATE),
     'Aborted_connects': ('mysql.net.aborted_connects', RATE),

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -22,7 +22,6 @@ from .config import MySQLConfig
 from .const import (
     BINLOG_VARS,
     COUNT,
-    DBM_MIGRATED_METRICS,
     GALERA_VARS,
     GAUGE,
     GROUP_REPLICATION_VARS,
@@ -295,9 +294,6 @@ class MySql(AgentCheck):
 
         # Get aggregate of all VARS we want to collect
         metrics = STATUS_VARS
-
-        if not self._config.dbm_enabled:
-            metrics.update(DBM_MIGRATED_METRICS)
 
         # collect results from db
         results = self._get_stats_from_status(db)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Re: https://github.com/DataDog/integrations-core/issues/12074

#### Why was the metric type changed?
This PR reverts the change in metric_type for the mysql.net.connections metric. Originally, the python code had the metric_type as a RATE, but was later changed due to confusion from the metadata.csv file where it's declared as GAUGE. The reason why the python code declares this as RATE type is because this informs the agent on how to handle/compute the value of the metric, but it's later mapped to a gauge type when sent to our back-end. This is why the metadata file declares this as a GAUGE.

#### Why was the metric migrated to DBM?
This PR reverts the migration of the metric `mysql.net.connections` from DBM's back-end. This metric was migrated to DBM (if dbm was enabled for this integration) for a few reasons, but to list the main points:
- This metric was supposed to represent active user connections (this turned out to be the incorrect metric for this)
- We prefer to send everything to our back-end so we have more control and to perform an necessary mutations such as adding tags

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Before (A = 7.35 -- B = 7.36):
<img width="428" alt="Screen Shot 2022-05-25 at 5 44 09 PM" src="https://user-images.githubusercontent.com/30381624/170372463-a5d7f6a6-58a9-4755-bbcc-07a3f6fcdc61.png">
After (A = 7.35 -- B = This PR change on 7.36):
<img width="429" alt="Screen Shot 2022-05-25 at 5 40 51 PM" src="https://user-images.githubusercontent.com/30381624/170372554-3119ef9a-df90-4d4b-ab7c-2c8463147032.png">

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
