### PR TITLE
[Mongo] Allow hosts to be a singular value

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -32,9 +32,11 @@ files:
       value:
         example:
         - <HOST>:<PORT>
-        type: array
-        items:
-          type: string
+        anyOf:
+          - type: string
+          - type: array
+            items:
+              type: string
     - name: username
       description: |
         The username to use for authentication.

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -44,6 +44,8 @@ class MongoConfig(object):
         else:
             self.server = None
             self.hosts = instance.get('hosts', [])
+            if type(self.hosts) == str:
+                self.hosts = [self.hosts]
             self.username = instance.get('username')
             self.password = instance.get('password')
             # Deprecated

--- a/mongo/datadog_checks/mongo/config_models/instance.py
+++ b/mongo/datadog_checks/mongo/config_models/instance.py
@@ -9,7 +9,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence, Union
 
 from pydantic import BaseModel, root_validator, validator
 
@@ -58,7 +58,7 @@ class InstanceConfig(BaseModel):
     database: Optional[str]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]
-    hosts: Optional[Sequence[str]]
+    hosts: Optional[Union[str, Sequence[str]]]
     metric_patterns: Optional[MetricPatterns]
     min_collection_interval: Optional[float]
     options: Optional[Mapping[str, Any]]

--- a/mongo/datadog_checks/mongo/config_models/validators.py
+++ b/mongo/datadog_checks/mongo/config_models/validators.py
@@ -7,4 +7,6 @@ from pydantic import ValidationError
 def initialize_instance(values, **kwargs):
     if 'hosts' not in values and 'server' not in values:
         raise ValidationError('Hosts is a required field')
+    if 'hosts' in values and type(values['hosts']) == str:
+        values['hosts'] = [values['hosts']]
     return values

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -13,7 +13,7 @@ init_config:
 #
 instances:
 
-    ## @param hosts - list of strings - optional
+    ## @param hosts - string or list of strings - optional
     ## The host (and optional port number) where the mongod instance (or mongos instances for
     ## a sharded cluster) is running. You can specify a hostname, IP address, or UNIX domain
     ## socket. Specify as many hosts as appropriate for your deployment topology:

--- a/mongo/tests/test_config.py
+++ b/mongo/tests/test_config.py
@@ -3,8 +3,10 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import mock
 import pytest
+from six import PY2
 
 from datadog_checks.base import ConfigurationError
+from datadog_checks.mongo import MongoDb
 from datadog_checks.mongo.config import MongoConfig
 
 
@@ -18,3 +20,13 @@ def test_deprecated_schema(instance):
     instance['hosts'] = ['mongodb+srv://sandbox.foo.bar.mongodb.com:27017']
     with pytest.raises(ConfigurationError, match='Could not build a mongo uri with the given hosts'):
         MongoConfig(instance, mock.Mock())
+
+
+def test_hosts_can_be_singular(instance):
+    instance['hosts'] = 'localfoost'
+    check = MongoDb('mongo_check', {}, instances=[instance])
+    assert check._config.hosts == ['localfoost']
+
+    if not PY2:
+        check.load_configuration_models()
+        assert check._config_model_instance.hosts == ('localfoost',)


### PR DESCRIPTION
Most integrations only take a single host as input, this one requires a list. This is confusing to customers and we've had support cases where they've set a string instead of a list.
This PR allows to pass in a single host as a string and converts it to a list