### PR TITLE
Port mysql version 8.3.1 metadata

### DIFF
--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - mysql
 
+## 8.3.1 / 2022-05-27
+
+* [Fixed] Revert mysql.net.connections metric type. See [#12088](https://github.com/DataDog/integrations-core/pull/12088).
+
 ## 8.3.0 / 2022-05-15
 
 * [Added] Add option to keep aliases in mysql (`keep_sql_alias`). See [#12018](https://github.com/DataDog/integrations-core/pull/12018).

--- a/mysql/datadog_checks/mysql/__about__.py
+++ b/mysql/datadog_checks/mysql/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "8.3.0"
+__version__ = "8.3.1"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -96,7 +96,7 @@ datadog-mcache==3.2.0; sys_platform != 'win32'
 datadog-mesos-master==3.1.0; sys_platform != 'win32'
 datadog-mesos-slave==3.1.0; sys_platform != 'win32'
 datadog-mongo==3.2.2
-datadog-mysql==8.3.0
+datadog-mysql==8.3.1
 datadog-nagios==1.11.0
 datadog-network==2.7.0
 datadog-nfsstat==1.11.0; sys_platform == 'linux2'


### PR DESCRIPTION
### What does this PR do?
Port metadata from the mysql 8.3.1 release from the 7.36.x branch
