### PR TITLE
Support new `daemonset.updated` metric name from kube-state-metrics

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -223,6 +223,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                         'kube_daemonset_status_desired_number_scheduled': 'daemonset.desired',
                         'kube_daemonset_status_number_misscheduled': 'daemonset.misscheduled',
                         'kube_daemonset_status_number_ready': 'daemonset.ready',
+                        'kube_daemonset_status_updated_number_scheduled': 'daemonset.updated',
                         'kube_daemonset_updated_number_scheduled': 'daemonset.updated',
                         'kube_deployment_spec_paused': 'deployment.paused',
                         'kube_deployment_spec_replicas': 'deployment.replicas_desired',

--- a/kubernetes_state/tests/fixtures/ksm-standard-tags-gke.txt
+++ b/kubernetes_state/tests/fixtures/ksm-standard-tags-gke.txt
@@ -120,13 +120,13 @@ kube_daemonset_status_number_unavailable{namespace="default",daemonset="datadog-
 kube_daemonset_status_number_unavailable{namespace="kube-system",daemonset="fluentd-gcp-v3.1.1"} 0
 kube_daemonset_status_number_unavailable{namespace="kube-system",daemonset="metadata-proxy-v0.1"} 0
 kube_daemonset_status_number_unavailable{namespace="kube-system",daemonset="nvidia-gpu-device-plugin"} 0
-# HELP kube_daemonset_updated_number_scheduled The total number of nodes that are running updated daemon pod
-# TYPE kube_daemonset_updated_number_scheduled gauge
-kube_daemonset_updated_number_scheduled{namespace="default",daemonset="datadog-monitoring"} 3
-kube_daemonset_updated_number_scheduled{namespace="kube-system",daemonset="fluentd-gcp-v3.1.1"} 3
-kube_daemonset_updated_number_scheduled{namespace="kube-system",daemonset="metadata-proxy-v0.1"} 0
-kube_daemonset_updated_number_scheduled{namespace="kube-system",daemonset="nvidia-gpu-device-plugin"} 0
-kube_daemonset_updated_number_scheduled{namespace="kube-system",daemonset="prometheus-to-sd"} 3
+# HELP kube_daemonset_status_updated_number_scheduled The total number of nodes that are running updated daemon pod
+# TYPE kube_daemonset_status_updated_number_scheduled gauge
+kube_daemonset_status_updated_number_scheduled{namespace="default",daemonset="datadog-monitoring"} 3
+kube_daemonset_status_updated_number_scheduled{namespace="kube-system",daemonset="fluentd-gcp-v3.1.1"} 3
+kube_daemonset_status_updated_number_scheduled{namespace="kube-system",daemonset="metadata-proxy-v0.1"} 0
+kube_daemonset_status_updated_number_scheduled{namespace="kube-system",daemonset="nvidia-gpu-device-plugin"} 0
+kube_daemonset_status_updated_number_scheduled{namespace="kube-system",daemonset="prometheus-to-sd"} 3
 # HELP kube_daemonset_metadata_generation Sequence number representing a specific generation of the desired state.
 # TYPE kube_daemonset_metadata_generation gauge
 kube_daemonset_metadata_generation{namespace="default",daemonset="datadog-monitoring"} 5

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -894,11 +894,14 @@ kube_resourcequota{namespace="default",resource="pods",resourcequota="custom-res
 # HELP kube_limitrange Information about limit range.
 # TYPE kube_limitrange gauge
 kube_limitrange{constraint="defaultRequest",limitrange="limits",namespace="default",resource="cpu",type="Container"} 0.1
-# HELP kube_daemonset_updated_number_scheduled The total number of nodes that are running updated daemon pod
+# HELP kube_daemonset_status_updated_number_scheduled The total number of nodes that are running updated daemon pod
+# TYPE kube_daemonset_status_updated_number_scheduled gauge
+kube_daemonset_status_updated_number_scheduled{namespace="kube-system",daemonset="kube-proxy",metricnameversion="new"} 3
+kube_daemonset_status_updated_number_scheduled{namespace="kube-system",daemonset="kube-svc-redirect",metricnameversion="new"} 3
+kube_daemonset_status_updated_number_scheduled{namespace="default",daemonset="dd-datadog",metricnameversion="new"} 3
+# HELP kube_daemonset_updated_number_scheduled The total number of nodes that are running updated daemon pod (legacy name)
 # TYPE kube_daemonset_updated_number_scheduled gauge
-kube_daemonset_updated_number_scheduled{namespace="kube-system",daemonset="kube-proxy"} 3
-kube_daemonset_updated_number_scheduled{namespace="kube-system",daemonset="kube-svc-redirect"} 3
-kube_daemonset_updated_number_scheduled{namespace="default",daemonset="dd-datadog"} 3
+kube_daemonset_updated_number_scheduled{namespace="default",daemonset="dd-datadog",metricnameversion="old"} 3
 # HELP kube_hpa_status_condition The condition of this autoscaler.
 # TYPE kube_hpa_status_condition gauge
 kube_hpa_status_condition{namespace="default",hpa="myhpa",condition="true",status="AbleToScale"} 1

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -167,6 +167,7 @@ TAGS = {
     NAMESPACE + '.job.failed': ['job:hello', 'job_name:hello2', 'kube_job:hello2'],
     NAMESPACE + '.job.succeeded': ['job:hello', 'job_name:hello2', 'kube_job:hello2'],
     NAMESPACE + '.hpa.condition': ['namespace:default', 'hpa:myhpa', 'condition:true', 'status:abletoscale'],
+    NAMESPACE + '.daemonset.updated': ['metricnameversion:old','metricnameversion:new']
 }
 
 JOINED_METRICS = {
@@ -963,9 +964,9 @@ def test_telemetry(aggregator, instance):
 
     for _ in range(2):
         check.check(instance)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=94499.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=1004.0)
-    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1336.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.payload.size', tags=['optional:tag1'], value=94892.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.processed.count', tags=['optional:tag1'], value=1006.0)
+    aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.input.count', tags=['optional:tag1'], value=1338.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.blacklist.count', tags=['optional:tag1'], value=24.0)
     aggregator.assert_metric(NAMESPACE + '.telemetry.metrics.ignored.count', tags=['optional:tag1'], value=332.0)
     aggregator.assert_metric(

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -167,7 +167,7 @@ TAGS = {
     NAMESPACE + '.job.failed': ['job:hello', 'job_name:hello2', 'kube_job:hello2'],
     NAMESPACE + '.job.succeeded': ['job:hello', 'job_name:hello2', 'kube_job:hello2'],
     NAMESPACE + '.hpa.condition': ['namespace:default', 'hpa:myhpa', 'condition:true', 'status:abletoscale'],
-    NAMESPACE + '.daemonset.updated': ['metricnameversion:old', 'metricnameversion:new']
+    NAMESPACE + '.daemonset.updated': ['metricnameversion:old', 'metricnameversion:new'],
 }
 
 JOINED_METRICS = {

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -167,7 +167,7 @@ TAGS = {
     NAMESPACE + '.job.failed': ['job:hello', 'job_name:hello2', 'kube_job:hello2'],
     NAMESPACE + '.job.succeeded': ['job:hello', 'job_name:hello2', 'kube_job:hello2'],
     NAMESPACE + '.hpa.condition': ['namespace:default', 'hpa:myhpa', 'condition:true', 'status:abletoscale'],
-    NAMESPACE + '.daemonset.updated': ['metricnameversion:old','metricnameversion:new']
+    NAMESPACE + '.daemonset.updated': ['metricnameversion:old', 'metricnameversion:new']
 }
 
 JOINED_METRICS = {


### PR DESCRIPTION
### What does this PR do?
Adds a new metric mapping to `daemonset.updated` from the kube-state-metrics `kube_daemonset_status_updated_number_scheduled` metric (previously called `kube_daemonset_updated_number_scheduled`).

### Motivation
In https://github.com/kubernetes/kube-state-metrics/commit/8031a708543563583990abfead7559bc29cc5b0c, the metric name was changed from `kube_daemonset_updated_number_scheduled` to `kube_daemonset_status_updated_number_scheduled` to be consistent with other metric names. 
This PR adds the new mapping and leaves the old mapping for backward compatibility.

### Additional Notes
n/a

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
