### PR TITLE
[kafka-check] add under min ISR partition count metric

### DIFF
--- a/kafka/datadog_checks/kafka/data/metrics.yaml
+++ b/kafka/datadog_checks/kafka/data/metrics.yaml
@@ -560,6 +560,13 @@ jmx_metrics:
             alias: kafka.replication.under_replicated_partitions
     - include:
         domain: 'kafka.server'
+        bean: 'kafka.server:type=ReplicaManager,name=UnderMinIsrPartitionCount'
+        attribute:
+          Value:
+            metric_type: gauge
+            alias: kafka.replication.under_min_isr_partition_count
+    - include:
+        domain: 'kafka.server'
         bean: 'kafka.server:type=ReplicaManager,name=IsrShrinksPerSec'
         attribute:
           Count:

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -31,6 +31,7 @@ kafka.replication.max_lag,gauge,10,offset,,Maximum lag in messages between the f
 kafka.replication.partition_count,gauge,10,,,Number of partitions across all topics in the cluster.,0,kafka,rep partition count,
 kafka.replication.unclean_leader_elections.rate,gauge,10,event,second,Unclean leader election rate.,-1,kafka,rep leader dirty elect,
 kafka.replication.under_replicated_partitions,gauge,10,,,Number of under replicated partitions.,-1,kafka,rep under replicated part,
+kafka.replication.under_min_isr_partition_count,gauge,10,,,Number of under min ISR partitions.,-1,kafka,rep under min ISR part,
 kafka.replication.offline_partitions_count,gauge,10,,,Number of partitions that don't have an active leader.,0,kafka,rep offline partitions count,
 kafka.session.zookeeper.disconnect.rate,gauge,10,event,second,Zookeeper client disconnect rate.,-1,kafka,zookeeper disconnect rate,
 kafka.session.zookeeper.expire.rate,gauge,10,event,second,Zookeeper client session expiration rate.,-1,kafka,zookeeper expiration rate,

--- a/kafka/tests/common.py
+++ b/kafka/tests/common.py
@@ -44,6 +44,7 @@ KAFKA_E2E_METRICS = [
     "kafka.replication.offline_partitions_count",
     "kafka.replication.partition_count",
     "kafka.replication.under_replicated_partitions",
+    "kafka.replication.under_min_isr_partition_count",
     # Rates
     "kafka.messages_in.rate",
     "kafka.net.bytes_in.rate",


### PR DESCRIPTION
### What does this PR do?
Add a metric about the number of partitions whose in-sync replicas count is less than minIsr.

### Motivation
We'd need to monitor that metric to be alerted when some producers with `acks=all` config are not able to produce to a given topic.

### Additional Notes
Since the cardinality is pretty low, it shouldn't be a problem regarding the number of metrics collected by the check.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached