### PR TITLE
kafka_consumer: failed reading and writing to cache when file is too …

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -27,7 +27,7 @@ class NewKafkaConsumerCheck(object):
         self._parent_check = parent_check
         self._broker_requests_batch_size = self.instance.get('broker_requests_batch_size', BROKER_REQUESTS_BATCH_SIZE)
         self._kafka_client = None
-        self._broker_timestamp_cache_key = 'broker_timestamps' + "".join(sorted(self._custom_tags))
+        self._broker_timestamp_cache_key = 'broker_timestamps_{}'.format(hash("".join(sorted(self._custom_tags))))
 
     def __getattr__(self, item):
         try:

--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -27,7 +27,7 @@ class NewKafkaConsumerCheck(object):
         self._parent_check = parent_check
         self._broker_requests_batch_size = self.instance.get('broker_requests_batch_size', BROKER_REQUESTS_BATCH_SIZE)
         self._kafka_client = None
-        self._broker_timestamp_cache_key = 'broker_timestamps_{}'.format(hash("".join(sorted(self._custom_tags))))
+        self._broker_timestamp_cache_key = 'broker_timestamps'
 
     def __getattr__(self, item):
         try:

--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -14,6 +14,7 @@ from datadog_checks.base import AgentCheck, ConfigurationError
 from .constants import BROKER_REQUESTS_BATCH_SIZE, KAFKA_INTERNAL_TOPICS
 
 MAX_TIMESTAMPS = 1000
+BROKER_TIMESTAMP_CACHE_KEY = 'broker_timestamps'
 
 
 class NewKafkaConsumerCheck(object):
@@ -27,7 +28,6 @@ class NewKafkaConsumerCheck(object):
         self._parent_check = parent_check
         self._broker_requests_batch_size = self.instance.get('broker_requests_batch_size', BROKER_REQUESTS_BATCH_SIZE)
         self._kafka_client = None
-        self._broker_timestamp_cache_key = 'broker_timestamps'
 
     def __getattr__(self, item):
         try:
@@ -108,10 +108,10 @@ class NewKafkaConsumerCheck(object):
             self.log.warning('Could not read broker timestamps from cache: %s', str(e))
 
     def _read_persistent_cache(self):
-        return self._parent_check.read_persistent_cache(self._broker_timestamp_cache_key)
+        return self._parent_check.read_persistent_cache(BROKER_TIMESTAMP_CACHE_KEY)
 
     def _save_broker_timestamps(self):
-        self._parent_check.write_persistent_cache(self._broker_timestamp_cache_key, json.dumps(self._broker_timestamps))
+        self._parent_check.write_persistent_cache(BROKER_TIMESTAMP_CACHE_KEY, json.dumps(self._broker_timestamps))
 
     def _create_kafka_admin_client(self, api_version):
         """Return a KafkaAdminClient."""


### PR DESCRIPTION
…long

### What does this PR do?
Bug introduced by https://github.com/DataDog/integrations-core/pull/11861
The issue is that the value in the cache can't be set / read when we have too many tags.
And `self.instance.get('tags', [])` doesn't return only `custom_tags` as I thought, but all the host tags. (Where is that logic?)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
