### PR TITLE
Port metadata from arangodb release

### DIFF
--- a/arangodb/CHANGELOG.md
+++ b/arangodb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - ArangoDB
 
+## 1.1.0 / 2022-05-27
+
+* [Added] Add connectivity metrics. See [#12093](https://github.com/DataDog/integrations-core/pull/12093).
+
 ## 1.0.1 / 2022-05-18
 
 * [Fixed] Fix extra metrics description example. See [#12043](https://github.com/DataDog/integrations-core/pull/12043).

--- a/arangodb/datadog_checks/arangodb/__about__.py
+++ b/arangodb/datadog_checks/arangodb/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.0.1'
+__version__ = '1.1.0'

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -6,7 +6,7 @@ datadog-airflow==3.1.0
 datadog-amazon-msk==3.1.2
 datadog-ambari==3.1.0; sys_platform != 'win32'
 datadog-apache==4.1.0
-datadog-arangodb==1.0.1
+datadog-arangodb==1.1.0
 datadog-aspdotnet==1.11.1; sys_platform == 'win32'
 datadog-avi-vantage==3.1.1
 datadog-azure-iot-edge==3.2.0


### PR DESCRIPTION
### What does this PR do?
Port metadata from arangodb release off of the release branch for RC4

### Motivation
release from: https://github.com/DataDog/integrations-core/pull/12097
mysql metadata is added in https://github.com/DataDog/integrations-core/pull/12100
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
