### PR TITLE
Port kafka consumer release metadata for RC4

### DIFF
--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - kafka_consumer
 
+## 2.15.1 / 2022-05-31
+
+* [Fixed] Don't fail reading and writing to cache when file is too long. See [#12109](https://github.com/DataDog/integrations-core/pull/12109).
+
 ## 2.15.0 / 2022-05-15
 
 * [Added] Add new lag in seconds metric. See [#11861](https://github.com/DataDog/integrations-core/pull/11861).

--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.15.1 / 2022-05-31
 
-* [Fixed] Don't fail reading and writing to cache when file is too long. See [#12109](https://github.com/DataDog/integrations-core/pull/12109).
+* [Fixed] Does not fail reading and writing to cache when file is too long. See [#12109](https://github.com/DataDog/integrations-core/pull/12109).
 
 ## 2.15.0 / 2022-05-15
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/__about__.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "2.15.0"
+__version__ = "2.15.1"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -73,7 +73,7 @@ datadog-iis==2.16.2; sys_platform == 'win32'
 datadog-istio==4.2.1
 datadog-jboss-wildfly==2.0.1
 datadog-journald==1.1.0
-datadog-kafka-consumer==2.15.0
+datadog-kafka-consumer==2.15.1
 datadog-kafka==2.12.1
 datadog-kong==2.1.1
 datadog-kube-apiserver-metrics==3.2.0


### PR DESCRIPTION
### What does this PR do?
Ports release metadata from the release branch from https://github.com/DataDog/integrations-core/pull/12113/files

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
