### PR TITLE
[integrations-core] windows not supported

### DIFF
--- a/ibm_i/manifest.json
+++ b/ibm_i/manifest.json
@@ -11,8 +11,7 @@
   "support": "core",
   "supported_os": [
     "linux",
-    "mac_os",
-    "windows"
+    "mac_os"
   ],
   "public_title": "IBM i",
   "categories": [


### PR DESCRIPTION
### What does this PR do?

Remove windows from the list of supported OS.

### Motivation
The integration uses `fcntl` which is not supported in Windows.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
