### PR TITLE
Register pytest markers in dev package

### DIFF
--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -118,3 +118,13 @@ include = [
 dev-mode-dirs = [
     ".",
 ]
+
+[tool.pytest.ini_options]
+markers = [
+    "conf",
+    "conf_consumer",
+    "conf_consumer_example",
+    "conf_consumer_model",
+    "conf_template",
+    "docker",
+]


### PR DESCRIPTION
This removes the large number of warnings that appear when running the tests.

