### PR TITLE
Move v2 manifest field `classifier_tags` under `tile`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/common/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/common/validator.py
@@ -269,7 +269,7 @@ class LogsCategoryValidator(BaseManifestValidator):
 
     LOG_COLLECTION_CATEGORY = {V1: "log collection", V2: "Category::Log Collection"}
 
-    CATEGORY_PATH = {V1: "/categories", V2: "/classifier_tags"}
+    CATEGORY_PATH = {V1: "/categories", V2: "/tile/classifier_tags"}
 
     IGNORE_LIST = {
         'databricks',  # Logs are provided by Spark

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/migration.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/migration.py
@@ -26,7 +26,6 @@ V2_TO_V1_MAP = JSONDict(
     {
         "/manifest_version": SKIP_IF_FOUND,
         "/app_id": "/integration_id",
-        "/classifier_tags": [],
         "/display_on_public_website": "/is_public",
         "/tile": {},
         "/tile/overview": "README.md#Overview",
@@ -36,6 +35,7 @@ V2_TO_V1_MAP = JSONDict(
         "/tile/description": "/short_description",
         "/tile/title": "/public_title",
         "/tile/media": [],
+        "/tile/classifier_tags": [],
         "/author": {},
         "/author/homepage": "/author/homepage",
         "/author/name": "/author/name",
@@ -152,7 +152,7 @@ def migrate_manifest(repo_name, integration, to_version):
 
     # Update any previously skipped field in which we can use logic to assume the value of
     # Also iterate through any lists to include new/updated fields at each index of the list
-    migrated_manifest.set_path("/classifier_tags", TODO_FILL_IN)
+    migrated_manifest.set_path("/tile/classifier_tags", TODO_FILL_IN)
 
     # Retrieve and map all categories from other fields
     classifier_tags = []
@@ -169,7 +169,7 @@ def migrate_manifest(repo_name, integration, to_version):
             classifier_tags.append(category_tag)
 
     # Write the manifest back to disk
-    migrated_manifest.set_path("/classifier_tags", classifier_tags)
+    migrated_manifest.set_path("/tile/classifier_tags", classifier_tags)
 
     # Temporarily required official fields
     if repo_name == "integrations-core":


### PR DESCRIPTION
### Additional Notes

Example migration:

```json
  "tile": {
    "overview": "README.md#Overview",
    "configuration": "README.md#Setup",
    "support": "README.md#Support",
    "changelog": "CHANGELOG.md",
    "description": "Forward your Cacti RRDs to Datadog for richer alerting and beautiful graphing.",
    "title": "Datadog-Cacti Integration",
    "media": [],
    "classifier_tags": [
      "Supported OS::Linux",
      "Category::Monitoring",
      "Category::Log Collection"
    ]
  },
  "author": {
```