### PR TITLE
Ensure Unix line feeds for all tracked non-binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
### Motivation

Prevent carriage returns