### PR TITLE
Fix YAML indentation for better readability

### DIFF
--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -116,7 +116,7 @@ Double-check your filters' values with <code>Get-WmiObject</code> if the integra
     Some example filters:
     
     ```yaml
-    - type: windows_event
+      - type: windows_event
         channel_path: Security
         source: windows.events
         service: Windows       


### PR DESCRIPTION
### What does this PR do?
Fixes indentation (for example YAML file) to avoid customer confusion and/or to avoid errors that arise from copy-pasting. 

### Motivation
The docs for Win32 integration (link: https://docs.datadoghq.com/integrations/win32_event_log/#filtering-events)
have some formatting issues around `- type:  ` : Maybe the doc needs to be updated for better readability

Screenshot link: https://a.cl.ly/BluGpXxo

Customer from this ticket (https://datadog.zendesk.com/agent/tickets/825320) seemed to have copied the configuration settings directly from the example.

### Additional Notes
Correct YAML formatting:

```
  - type: windows_event
    channel_path: Security
    source: windows.events
    service: Windows       
    log_processing_rules:
    - type: include_at_match
      name: relevant_security_events
      pattern: .*(?i)eventid.+(1102|4624|4625|4634|4648|4728|4732|4735|4737|4740|4755|4756)
  - type: windows_event
    channel_path: System
    source: windows.events
    service: Windows       
    log_processing_rules:
    - type: include_at_match
      name: system_errors_and_warnings
      pattern: .*(?i)level.+((?i)(warning|error))
  - type: windows_event
    channel_path: Application
    source: windows.events
    service: Windows       
    log_processing_rules:
    - type: include_at_match
      name: application_errors_and_warnings
      pattern: .*(?i)level.+((?i)(warning|error))
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
