### PR TITLE
Fix dev package tests for executables with spaces

### DIFF
--- a/datadog_checks_dev/tests/test_conditions.py
+++ b/datadog_checks_dev/tests/test_conditions.py
@@ -38,23 +38,21 @@ class TestWaitFor:
 class TestCheckCommandOutput:
     def test_no_matches(self):
         check_command_output = CheckCommandOutput(
-            '{} -c "import os;print(\'foo\')"'.format(sys.executable), ['bar'], attempts=1
+            [sys.executable, '-c', 'import os;print(\'foo\')'], ['bar'], attempts=1
         )
 
         with pytest.raises(RetryError):
             check_command_output()
 
     def test_matches(self):
-        check_command_output = CheckCommandOutput(
-            '{} -c "import os;print(\'foo\')"'.format(sys.executable), ['foo', 'bar']
-        )
+        check_command_output = CheckCommandOutput([sys.executable, '-c', 'import os;print(\'foo\')'], ['foo', 'bar'])
 
         matches = check_command_output()
         assert matches == 1
 
     def test_matches_all_fail(self):
         check_command_output = CheckCommandOutput(
-            '{} -c "import os;print(\'foo\')"'.format(sys.executable), ['foo', 'bar'], matches='all', attempts=1
+            [sys.executable, '-c', 'import os;print(\'foo\')'], ['foo', 'bar'], matches='all', attempts=1
         )
 
         with pytest.raises(RetryError):
@@ -62,7 +60,7 @@ class TestCheckCommandOutput:
 
     def test_matches_all_success(self):
         check_command_output = CheckCommandOutput(
-            '{} -c "import os;print(\'foobar\')"'.format(sys.executable), ['foo', 'bar'], matches='all'
+            [sys.executable, '-c', 'import os;print(\'foobar\')'], ['foo', 'bar'], matches='all'
         )
 
         matches = check_command_output()

--- a/datadog_checks_dev/tests/test_subprocess.py
+++ b/datadog_checks_dev/tests/test_subprocess.py
@@ -9,7 +9,7 @@ from datadog_checks.dev.subprocess import run_command
 
 class TestRunCommand:
     def test_output(self):
-        result = run_command('{} -c "import sys;print(sys.version)"'.format(sys.executable), capture='out')
+        result = run_command([sys.executable, '-c', 'import sys;print(sys.version)'], capture='out')
 
         assert result.stdout.strip() == sys.version.strip()
 
@@ -17,7 +17,7 @@ class TestRunCommand:
         env = dict(os.environ)
         env['DDEV_ENV_VAR'] = 'is_set'
         result = run_command(
-            '{} -c "import os;print(os.getenv(\'DDEV_ENV_VAR\'))"'.format(sys.executable), capture='out', env=env
+            [sys.executable, '-c', 'import os;print(os.getenv(\'DDEV_ENV_VAR\'))'], capture='out', env=env
         )
 
         assert result.stdout.strip() == 'is_set'


### PR DESCRIPTION
A few tests would break when the python executable was on a path with spaces in it (which happens when running the tests with `ddev test` on a mac), because we were passing a command as a string, which is split by spaces. This changes those to use the list form, which has spaces escaped automatically.
