### PR TITLE
Validate emails when running `ddev validate package`

### DIFF
--- a/datadog_checks_dev/tests/tooling/commands/validate/test_package.py
+++ b/datadog_checks_dev/tests/tooling/commands/validate/test_package.py
@@ -1,0 +1,50 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+import sys
+
+import pytest
+from click.testing import CliRunner
+
+from datadog_checks.dev import run_command
+
+
+def _build_pyproject_file(authors):
+    return f'''
+[project]
+name = "datadog-my-check"
+authors = {authors}
+[tool.hatch.version]
+path = "datadog_checks/my_check/__about__.py"
+'''
+
+
+@pytest.mark.parametrize(
+    'authors,expected_exit_code,expected_output',
+    [
+        ('[{ name = "Datadog", email = "packages@datadoghq.com" }]', 0, '1 valid'),
+        ('[{ name = "Datadog"}]', 0, '1 valid'),
+        ('[{ name = "Datadog", email = "invalid_email" }]', 1, 'Invalid email'),
+    ],
+)
+def test_validate_package_validates_emails(authors, expected_exit_code, expected_output):
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        os.mkdir('my_check')
+
+        with open('my_check/pyproject.toml', 'w') as f:
+            f.write(_build_pyproject_file(authors))
+
+        os.makedirs('my_check/datadog_checks/my_check')
+        with open('my_check/datadog_checks/my_check/__about__.py', 'w') as f:
+            f.write('__version__ = "1.0.0"')
+
+        result = run_command(
+            [sys.executable, '-m', 'datadog_checks.dev', '-x', 'validate', 'package', 'my_check'],
+            capture=True,
+        )
+
+        assert result.code == expected_exit_code
+        assert expected_output in result.stdout


### PR DESCRIPTION
### What does this PR do?
Adds email validation to `ddev validate package`

### Motivation
[AI-2350](https://datadoghq.atlassian.net/browse/AI-2350)

### Additional Notes

The test I added is more indirect than I wanted, but currently importing anything from under `datadog_checks.dev.tooling.commands` makes an unrelated test fail, so this will have to do until that gets solved separately.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
