### PR TITLE
Strip superfluous prefix on manifest titles

### DIFF
--- a/active_directory/manifest.json
+++ b/active_directory/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "active_directory.",
   "metric_to_check": "active_directory.dra.inbound.objects.persec",
   "name": "active_directory",
-  "public_title": "Datadog-Active Directory Integration",
+  "public_title": "Active Directory Integration",
   "short_description": "Collect and graph Microsoft Active Directory metrics",
   "support": "core",
   "supported_os": [
@@ -26,9 +26,9 @@
       "spec": "assets/configuration/spec.yaml"
     },
     "monitors": {
-      "[Active Directory] Elevated LDAP binding duration for host {{host.name}}":"assets/monitors/ldap_binding.json",
-      "[Active Directory] Anomalous number of sessions for connected LDAP clients for host: {{host.name}}":"assets/monitors/ldap_client_sessions.json",
-      "[Active Directory] Anomalous number of successful LDAP bindings for host: {{host.name}}":"assets/monitors/ldap_binding_successful.json"
+      "[Active Directory] Elevated LDAP binding duration for host {{host.name}}": "assets/monitors/ldap_binding.json",
+      "[Active Directory] Anomalous number of sessions for connected LDAP clients for host: {{host.name}}": "assets/monitors/ldap_client_sessions.json",
+      "[Active Directory] Anomalous number of successful LDAP bindings for host: {{host.name}}": "assets/monitors/ldap_binding_successful.json"
     },
     "dashboards": {
       "Active Directory": "assets/dashboards/active_directory.json"

--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -13,14 +13,14 @@
   "manifest_version": "1.0.0",
   "metric_prefix": "activemq.",
   "metric_to_check": [
-      "activemq.queue.size",
-      "activemq.artemis.queue.message_count"
+    "activemq.queue.size",
+    "activemq.artemis.queue.message_count"
   ],
   "name": "activemq",
   "process_signatures": [
     "activemq"
   ],
-  "public_title": "Datadog-ActiveMQ Integration",
+  "public_title": "ActiveMQ Integration",
   "short_description": "Collect metrics for brokers and queues, producers and consumers, and more.",
   "support": "core",
   "supported_os": [

--- a/activemq_xml/manifest.json
+++ b/activemq_xml/manifest.json
@@ -14,7 +14,7 @@
   "metric_prefix": "activemq.",
   "metric_to_check": "activemq.queue.count",
   "name": "activemq_xml",
-  "public_title": "Datadog-ActiveMQ XML Integration",
+  "public_title": "ActiveMQ XML Integration",
   "short_description": "Collect metrics for brokers and queues, producers and consumers, and more.",
   "support": "core",
   "supported_os": [

--- a/aerospike/manifest.json
+++ b/aerospike/manifest.json
@@ -12,7 +12,7 @@
   "supported_os": [
     "linux"
   ],
-  "public_title": "Datadog-Aerospike Integration",
+  "public_title": "Aerospike Integration",
   "categories": [
     "data store",
     "autodiscovery",

--- a/agent_metrics/manifest.json
+++ b/agent_metrics/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "datadog.agent.",
   "metric_to_check": "",
   "name": "agent_metrics",
-  "public_title": "Datadog-Agent Metrics Integration",
+  "public_title": "Agent Metrics Integration",
   "short_description": "agent_metrics description.",
   "support": "core",
   "supported_os": [

--- a/airflow/manifest.json
+++ b/airflow/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Airflow Integration",
+  "public_title": "Airflow Integration",
   "categories": [
     "processing",
     "log collection"

--- a/amazon_eks/manifest.json
+++ b/amazon_eks/manifest.json
@@ -13,7 +13,7 @@
   "manifest_version": "1.0.0",
   "metric_prefix": "aws.eks.",
   "name": "amazon_eks",
-  "public_title": "Datadog-Amazon-EKS Integration",
+  "public_title": "Amazon-EKS Integration",
   "short_description": "Amazon EKS is a managed service that makes it easy to run Kubernetes on AWS",
   "support": "core",
   "supported_os": [

--- a/ambari/manifest.json
+++ b/ambari/manifest.json
@@ -13,7 +13,7 @@
     "linux",
     "mac_os"
   ],
-  "public_title": "Datadog-Ambari Integration",
+  "public_title": "Ambari Integration",
   "categories": [
     "processing",
     "log collection",

--- a/apache/manifest.json
+++ b/apache/manifest.json
@@ -22,7 +22,7 @@
     "apache",
     "apache2"
   ],
-  "public_title": "Datadog-Apache Integration",
+  "public_title": "Apache Integration",
   "short_description": "Track requests per second, bytes served, worker threads, uptime, and more.",
   "support": "core",
   "supported_os": [

--- a/aspdotnet/manifest.json
+++ b/aspdotnet/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "aspdotnet.",
   "metric_to_check": "aspdotnet.request.wait_time",
   "name": "aspdotnet",
-  "public_title": "Datadog-ASP.NET Integration",
+  "public_title": "ASP.NET Integration",
   "short_description": "Track your ASP.NET service metrics in real time",
   "support": "core",
   "supported_os": [

--- a/azure_active_directory/manifest.json
+++ b/azure_active_directory/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Azure Active Directory Integration",
+  "public_title": "Azure Active Directory Integration",
   "categories": [
     "azure",
     "log collection",

--- a/azure_iot_edge/manifest.json
+++ b/azure_iot_edge/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Azure IoT Edge Integration",
+  "public_title": "Azure IoT Edge Integration",
   "categories": [
     "azure",
     "log collection"

--- a/btrfs/manifest.json
+++ b/btrfs/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "btrfs.",
   "metric_to_check": "system.disk.btrfs.total",
   "name": "btrfs",
-  "public_title": "Datadog-Btrfs Integration",
+  "public_title": "Btrfs Integration",
   "short_description": "Monitor usage on Btrfs volumes so you can respond before they fill up.",
   "support": "core",
   "supported_os": [

--- a/cacti/manifest.json
+++ b/cacti/manifest.json
@@ -12,7 +12,7 @@
   "metric_prefix": "cacti.",
   "metric_to_check": "cacti.rrd.count",
   "name": "cacti",
-  "public_title": "Datadog-Cacti Integration",
+  "public_title": "Cacti Integration",
   "short_description": "Forward your Cacti RRDs to Datadog for richer alerting and beautiful graphing.",
   "support": "core",
   "supported_os": [

--- a/cassandra/manifest.json
+++ b/cassandra/manifest.json
@@ -16,7 +16,7 @@
   "process_signatures": [
     "java org.apache.cassandra.service.CassandraDaemon"
   ],
-  "public_title": "Datadog-Cassandra Integration",
+  "public_title": "Cassandra Integration",
   "short_description": "Track cluster performance, capacity, overall health, and much more.",
   "support": "core",
   "supported_os": [

--- a/cassandra_nodetool/manifest.json
+++ b/cassandra_nodetool/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "cassandra.",
   "metric_to_check": "cassandra.nodetool.status.status",
   "name": "cassandra_nodetool",
-  "public_title": "Datadog-Cassandra Nodetool Integration",
+  "public_title": "Cassandra Nodetool Integration",
   "short_description": "monitor cassandra using the nodetool utility",
   "support": "core",
   "supported_os": [

--- a/ceph/manifest.json
+++ b/ceph/manifest.json
@@ -18,7 +18,7 @@
     "ceph-mgr",
     "ceph-osd"
   ],
-  "public_title": "Datadog-Ceph Integration",
+  "public_title": "Ceph Integration",
   "short_description": "Collect per-pool performance metrics and monitor overall cluster status.",
   "support": "core",
   "supported_os": [

--- a/cilium/manifest.json
+++ b/cilium/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Cilium Integration",
+  "public_title": "Cilium Integration",
   "categories": [
     "containers",
     "network",

--- a/cisco_aci/manifest.json
+++ b/cisco_aci/manifest.json
@@ -12,7 +12,7 @@
   "metric_prefix": "cisco_aci.",
   "metric_to_check": "cisco_aci.fabric.node.health.cur",
   "name": "cisco_aci",
-  "public_title": "Datadog-CiscoACI Integration",
+  "public_title": "CiscoACI Integration",
   "short_description": "Track Cisco ACI performance and usage.",
   "support": "core",
   "supported_os": [

--- a/clickhouse/manifest.json
+++ b/clickhouse/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-ClickHouse Integration",
+  "public_title": "ClickHouse Integration",
   "categories": [
     "data store",
     "log collection"

--- a/cloud_foundry_api/manifest.json
+++ b/cloud_foundry_api/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Cloud Foundry API Integration",
+  "public_title": "Cloud Foundry API Integration",
   "categories": [
     "cloud",
     "orchestration"

--- a/cockroachdb/manifest.json
+++ b/cockroachdb/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-CockroachDB Integration",
+  "public_title": "CockroachDB Integration",
   "categories": [
     "cloud",
     "data store",

--- a/confluent_platform/manifest.json
+++ b/confluent_platform/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Confluent Platform Integration",
+  "public_title": "Confluent Platform Integration",
   "categories": [
     "processing",
     "messaging",

--- a/consul/manifest.json
+++ b/consul/manifest.json
@@ -21,7 +21,7 @@
     "consul_agent",
     "consul-agent"
   ],
-  "public_title": "Datadog-Consul Integration",
+  "public_title": "Consul Integration",
   "short_description": "Alert on Consul health checks, see service-to-node mappings, and much more.",
   "support": "core",
   "supported_os": [

--- a/container/manifest.json
+++ b/container/manifest.json
@@ -11,7 +11,7 @@
     "linux",
     "windows"
   ],
-  "public_title": "Datadog-Container Integration",
+  "public_title": "Container Integration",
   "categories": [
     "containers"
   ],

--- a/containerd/manifest.json
+++ b/containerd/manifest.json
@@ -11,7 +11,7 @@
     "linux",
     "windows"
   ],
-  "public_title": "Datadog-Containerd Integration",
+  "public_title": "Containerd Integration",
   "categories": [
     "containers"
   ],

--- a/coredns/manifest.json
+++ b/coredns/manifest.json
@@ -11,7 +11,7 @@
     "linux"
   ],
   "guid": "9b316155-fc8e-4cb0-8bd5-8af270759cfb",
-  "public_title": "Datadog-CoreDNS Integration",
+  "public_title": "CoreDNS Integration",
   "categories": [
     "containers",
     "network",

--- a/couch/manifest.json
+++ b/couch/manifest.json
@@ -23,7 +23,7 @@
   "process_signatures": [
     "couchjs"
   ],
-  "public_title": "Datadog-CouchDB Integration",
+  "public_title": "CouchDB Integration",
   "short_description": "Track and graph your CouchDB activity and performance metrics.",
   "support": "core",
   "supported_os": [

--- a/couchbase/manifest.json
+++ b/couchbase/manifest.json
@@ -16,7 +16,7 @@
   "process_signatures": [
     "beam.smp couchbase"
   ],
-  "public_title": "Datadog-CouchBase Integration",
+  "public_title": "CouchBase Integration",
   "short_description": "Track and graph your Couchbase activity and performance metrics.",
   "support": "core",
   "supported_os": [

--- a/cri/manifest.json
+++ b/cri/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "cri.",
   "metric_to_check": "cri.cpu.usage",
   "name": "CRI",
-  "public_title": "Datadog-CRI Integration",
+  "public_title": "CRI Integration",
   "short_description": "Track all your CRI metrics with Datadog",
   "support": "core",
   "supported_os": [

--- a/crio/manifest.json
+++ b/crio/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "crio.",
   "metric_to_check": "crio.operations.count",
   "name": "crio",
-  "public_title": "Datadog-CRI-O Integration",
+  "public_title": "CRI-O Integration",
   "short_description": "Track all your CRI-O metrics with Datadog",
   "support": "core",
   "supported_os": [

--- a/directory/manifest.json
+++ b/directory/manifest.json
@@ -1,5 +1,7 @@
 {
-  "categories": ["os & system"],
+  "categories": [
+    "os & system"
+  ],
   "creates_events": false,
   "display_name": "Directory",
   "guid": "0c38c4ef-5266-4667-9fb1-de8f2b73708a",
@@ -9,10 +11,14 @@
   "metric_prefix": "system.",
   "metric_to_check": "system.disk.directory.file.bytes",
   "name": "directory",
-  "public_title": "Datadog-Directory Integration",
+  "public_title": "Directory Integration",
   "short_description": "The Directory integration reports metrics on files for a provided directory",
   "support": "core",
-  "supported_os": ["linux", "mac_os", "windows"],
+  "supported_os": [
+    "linux",
+    "mac_os",
+    "windows"
+  ],
   "type": "check",
   "integration_id": "system",
   "assets": {

--- a/disk/manifest.json
+++ b/disk/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "system.",
   "metric_to_check": "system.disk.free",
   "name": "disk",
-  "public_title": "Datadog-Disk Integration",
+  "public_title": "Disk Integration",
   "short_description": "The disk check gathers metrics on mounted disks.",
   "support": "core",
   "supported_os": [

--- a/dns_check/manifest.json
+++ b/dns_check/manifest.json
@@ -15,7 +15,7 @@
   "metric_prefix": "dns.",
   "metric_to_check": "dns.response_time",
   "name": "dns_check",
-  "public_title": "Datadog-DNS Check Integration",
+  "public_title": "DNS Check Integration",
   "short_description": "Monitor the resolvablity of and lookup times for any DNS record.",
   "support": "core",
   "supported_os": [

--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -22,7 +22,7 @@
     "docker daemon",
     "docker-containerd-shim"
   ],
-  "public_title": "Datadog-Docker Daemon Integration",
+  "public_title": "Docker Daemon Integration",
   "short_description": "Correlate container performance with that of the services running inside them.",
   "support": "core",
   "supported_os": [

--- a/dotnetclr/manifest.json
+++ b/dotnetclr/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "dotnetclr.",
   "metric_to_check": "dotnetclr.memory.time_in_gc",
   "name": "dotnetclr",
-  "public_title": "Datadog-.NET CLR Integration",
+  "public_title": ".NET CLR Integration",
   "short_description": "Visualize and monitor Dotnetclr states",
   "support": "core",
   "supported_os": [

--- a/druid/manifest.json
+++ b/druid/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Druid Integration",
+  "public_title": "Druid Integration",
   "categories": [
     "processing",
     "data store",

--- a/ecs_fargate/manifest.json
+++ b/ecs_fargate/manifest.json
@@ -14,7 +14,7 @@
   "metric_prefix": "ecs.",
   "metric_to_check": "ecs.fargate.cpu.user",
   "name": "ecs_fargate",
-  "public_title": "Datadog-Amazon ECS on AWS Fargate Integration",
+  "public_title": "Amazon ECS on AWS Fargate Integration",
   "short_description": "Track metrics for containers running with ECS Fargate",
   "support": "core",
   "supported_os": [

--- a/eks_anywhere/manifest.json
+++ b/eks_anywhere/manifest.json
@@ -13,7 +13,7 @@
   "manifest_version": "1.0.0",
   "metric_prefix": "aws.eks.",
   "name": "eks_anywhere",
-  "public_title": "Datadog-Amazon EKS Anywhere Integration",
+  "public_title": "Amazon EKS Anywhere Integration",
   "short_description": "An EKS deployment option for operating Kubernetes clusters on-premises",
   "support": "core",
   "supported_os": [

--- a/eks_fargate/manifest.json
+++ b/eks_fargate/manifest.json
@@ -15,7 +15,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Amazon EKS on AWS Fargate Integration",
+  "public_title": "Amazon EKS on AWS Fargate Integration",
   "categories": [
     "cloud",
     "aws",

--- a/elastic/manifest.json
+++ b/elastic/manifest.json
@@ -19,7 +19,7 @@
   "process_signatures": [
     "java org.elasticsearch.bootstrap.Elasticsearch"
   ],
-  "public_title": "Datadog-ElasticSearch Integration",
+  "public_title": "ElasticSearch Integration",
   "short_description": "Monitor overall cluster status down to JVM heap usage and everything in between.",
   "support": "core",
   "supported_os": [

--- a/envoy/manifest.json
+++ b/envoy/manifest.json
@@ -14,7 +14,7 @@
   "metric_prefix": "envoy.",
   "metric_to_check": "envoy.server.uptime",
   "name": "envoy",
-  "public_title": "Datadog-Envoy Integration",
+  "public_title": "Envoy Integration",
   "short_description": "Envoy is an open source edge and service proxy",
   "support": "core",
   "supported_os": [

--- a/etcd/manifest.json
+++ b/etcd/manifest.json
@@ -21,7 +21,7 @@
   "process_signatures": [
     "etcd"
   ],
-  "public_title": "Datadog-etcd Integration",
+  "public_title": "etcd Integration",
   "short_description": "Track writes, updates, deletes, inter-node latencies, and more Etcd metrics.",
   "support": "core",
   "supported_os": [

--- a/exchange_server/manifest.json
+++ b/exchange_server/manifest.json
@@ -12,7 +12,7 @@
   "metric_prefix": "exchange.",
   "metric_to_check": "exchange.processor.cpu_user",
   "name": "exchange_server",
-  "public_title": "Datadog-Microsoft Exchange Server Integration",
+  "public_title": "Microsoft Exchange Server Integration",
   "short_description": "Collect and graph Microsoft Exchange Server metrics",
   "support": "core",
   "supported_os": [

--- a/external_dns/manifest.json
+++ b/external_dns/manifest.json
@@ -12,7 +12,7 @@
   "metric_prefix": "external_dns.",
   "metric_to_check": "external_dns.source.endpoints.total",
   "name": "external_dns",
-  "public_title": "Datadog-External DNS Integration",
+  "public_title": "External DNS Integration",
   "short_description": "Track all your External DNS metrics with Datadog",
   "support": "core",
   "supported_os": [

--- a/flink/manifest.json
+++ b/flink/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Flink Integration",
+  "public_title": "Flink Integration",
   "categories": [
     "processing",
     "log collection"

--- a/fluentd/manifest.json
+++ b/fluentd/manifest.json
@@ -20,7 +20,7 @@
     "fluentd",
     "ruby td-agent"
   ],
-  "public_title": "Datadog-FluentD Integration",
+  "public_title": "FluentD Integration",
   "short_description": "Monitor buffer queues and retry counts for each Fluentd plugin you've enabled.",
   "support": "core",
   "supported_os": [

--- a/gearmand/manifest.json
+++ b/gearmand/manifest.json
@@ -20,7 +20,7 @@
     "gearmand",
     "gearman"
   ],
-  "public_title": "Datadog-Gearman Integration",
+  "public_title": "Gearman Integration",
   "short_description": "Track the number of jobs queued and running - in total or by task.",
   "support": "core",
   "supported_os": [

--- a/gitlab/manifest.json
+++ b/gitlab/manifest.json
@@ -18,7 +18,7 @@
     "gitlab.ruby.process_start_time_seconds"
   ],
   "name": "gitlab",
-  "public_title": "Datadog-Gitlab Integration",
+  "public_title": "Gitlab Integration",
   "short_description": "Track all your Gitlab metrics with Datadog",
   "support": "core",
   "supported_os": [

--- a/gitlab_runner/manifest.json
+++ b/gitlab_runner/manifest.json
@@ -14,7 +14,7 @@
   "metric_prefix": "gitlab_runner.",
   "metric_to_check": "gitlab_runner.process_max_fds",
   "name": "gitlab_runner",
-  "public_title": "Datadog-Gitlab Runners Integration",
+  "public_title": "Gitlab Runners Integration",
   "short_description": "Track all the metrics from your Gitlab runners with Datadog",
   "support": "core",
   "supported_os": [

--- a/go-metro/manifest.json
+++ b/go-metro/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "system.",
   "metric_to_check": "system.net.tcp.rtt",
   "name": "go-metro",
-  "public_title": "Datadog-Go-Metro Integration",
+  "public_title": "Go-Metro Integration",
   "short_description": "Passively calculate TCP RTT between hosts",
   "support": "core",
   "supported_os": [

--- a/go_expvar/manifest.json
+++ b/go_expvar/manifest.json
@@ -15,7 +15,7 @@
   "metric_prefix": "go_expvar.",
   "metric_to_check": "go_expvar.memstats.alloc",
   "name": "go_expvar",
-  "public_title": "Datadog-Go-Expvar Integration",
+  "public_title": "Go-Expvar Integration",
   "short_description": "Collect expvar-instrumented metrics and memory stats from your Go service.",
   "support": "core",
   "supported_os": [

--- a/gunicorn/manifest.json
+++ b/gunicorn/manifest.json
@@ -15,7 +15,7 @@
   "process_signatures": [
     "gunicorn: master"
   ],
-  "public_title": "Datadog-Gunicorn Integration",
+  "public_title": "Gunicorn Integration",
   "short_description": "Monitor request rates and durations, log-message rates, and worker processes.",
   "support": "core",
   "supported_os": [

--- a/haproxy/manifest.json
+++ b/haproxy/manifest.json
@@ -23,7 +23,7 @@
     "haproxy-master",
     "haproxy-controller"
   ],
-  "public_title": "Datadog-HAProxy Integration",
+  "public_title": "HAProxy Integration",
   "short_description": "Monitor key metrics for requests, responses, errors, bytes served, and more.",
   "support": "core",
   "supported_os": [

--- a/harbor/manifest.json
+++ b/harbor/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Harbor Integration",
+  "public_title": "Harbor Integration",
   "categories": [
     "containers",
     "log collection",

--- a/hazelcast/manifest.json
+++ b/hazelcast/manifest.json
@@ -17,7 +17,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Hazelcast Integration",
+  "public_title": "Hazelcast Integration",
   "categories": [
     "data store",
     "caching",

--- a/hive/manifest.json
+++ b/hive/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Hive Integration",
+  "public_title": "Hive Integration",
   "categories": [
     "web",
     "log collection",

--- a/hivemq/manifest.json
+++ b/hivemq/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-HiveMQ Integration",
+  "public_title": "HiveMQ Integration",
   "categories": [
     "messaging",
     "processing",

--- a/http_check/manifest.json
+++ b/http_check/manifest.json
@@ -15,7 +15,7 @@
   "metric_prefix": "network.",
   "metric_to_check": "network.http.response_time",
   "name": "http_check",
-  "public_title": "Datadog-HTTP Check Integration",
+  "public_title": "HTTP Check Integration",
   "short_description": "Monitor any HTTP service for bad responses, soon-to-expire SSL certs, and more.",
   "support": "core",
   "supported_os": [

--- a/hyperv/manifest.json
+++ b/hyperv/manifest.json
@@ -12,7 +12,7 @@
   "supported_os": [
     "windows"
   ],
-  "public_title": "Datadog-HyperV Integration",
+  "public_title": "HyperV Integration",
   "categories": [
     "azure",
     "cloud",

--- a/ibm_db2/manifest.json
+++ b/ibm_db2/manifest.json
@@ -15,7 +15,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-IBM Db2 Integration",
+  "public_title": "IBM Db2 Integration",
   "categories": [
     "data store",
     "log collection",

--- a/ibm_mq/manifest.json
+++ b/ibm_mq/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-IBM MQ Integration",
+  "public_title": "IBM MQ Integration",
   "categories": [
     "processing",
     "messaging",

--- a/ibm_was/manifest.json
+++ b/ibm_was/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-IBM WAS Integration",
+  "public_title": "IBM WAS Integration",
   "categories": [
     "web",
     "os & system",

--- a/ignite/manifest.json
+++ b/ignite/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-ignite Integration",
+  "public_title": "ignite Integration",
   "categories": [
     "caching",
     "data store",

--- a/iis/manifest.json
+++ b/iis/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "iis.",
   "metric_to_check": "iis.uptime",
   "name": "iis",
-  "public_title": "Datadog-IIS Integration",
+  "public_title": "IIS Integration",
   "short_description": "Track total or per-site metrics and monitor each site's up/down status.",
   "support": "core",
   "supported_os": [

--- a/istio/manifest.json
+++ b/istio/manifest.json
@@ -17,7 +17,7 @@
     "istio.galley.endpoint_no_pod"
   ],
   "name": "istio",
-  "public_title": "Datadog-Istio Integration",
+  "public_title": "Istio Integration",
   "short_description": "Collect performance schema metrics, query throughput, custom metrics, and more.",
   "support": "core",
   "supported_os": [

--- a/jboss_wildfly/manifest.json
+++ b/jboss_wildfly/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-JBoss/WildFly Integration",
+  "public_title": "JBoss/WildFly Integration",
   "categories": [
     "web",
     "log collection",

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -17,7 +17,7 @@
   "process_signatures": [
     "java kafka.kafka"
   ],
-  "public_title": "Datadog-Kafka Integration",
+  "public_title": "Kafka Integration",
   "short_description": "Collect metrics for producers and consumers, replication, max lag, and more.",
   "support": "core",
   "supported_os": [

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "kafka.",
   "metric_to_check": "kafka.consumer_lag",
   "name": "kafka_consumer",
-  "public_title": "Datadog-Kafka Consumer Integration",
+  "public_title": "Kafka Consumer Integration",
   "short_description": "Collect metrics for Kafka consumers.",
   "support": "core",
   "supported_os": [

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -16,7 +16,7 @@
   "process_signatures": [
     "kong start"
   ],
-  "public_title": "Datadog-Kong Integration",
+  "public_title": "Kong Integration",
   "short_description": "Track total requests, response codes, client connections, and more.",
   "support": "core",
   "supported_os": [

--- a/kube_apiserver_metrics/manifest.json
+++ b/kube_apiserver_metrics/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Kubernetes API server metrics Integration",
+  "public_title": "Kubernetes API server metrics Integration",
   "categories": [
     "containers"
   ],

--- a/kube_controller_manager/manifest.json
+++ b/kube_controller_manager/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Kubernetes Controller Manager Integration",
+  "public_title": "Kubernetes Controller Manager Integration",
   "categories": [
     "orchestration",
     "containers"

--- a/kube_dns/manifest.json
+++ b/kube_dns/manifest.json
@@ -12,7 +12,7 @@
   "metric_prefix": "kubedns.",
   "metric_to_check": "kubedns.request_count",
   "name": "kube_dns",
-  "public_title": "Datadog-Kube DNS Integration",
+  "public_title": "Kube DNS Integration",
   "short_description": "Track all your Kube DNS metrics with Datadog",
   "support": "core",
   "supported_os": [

--- a/kube_metrics_server/manifest.json
+++ b/kube_metrics_server/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Kubernetes Metrics Server Integration",
+  "public_title": "Kubernetes Metrics Server Integration",
   "categories": [
     "orchestration",
     "containers"

--- a/kube_proxy/manifest.json
+++ b/kube_proxy/manifest.json
@@ -12,7 +12,7 @@
   "metric_prefix": "kubeproxy.",
   "metric_to_check": "kubeproxy.cpu.time",
   "name": "kube_proxy",
-  "public_title": "Datadog-Kube Proxy Integration",
+  "public_title": "Kube Proxy Integration",
   "short_description": "kube_proxy description.",
   "support": "core",
   "supported_os": [

--- a/kube_scheduler/manifest.json
+++ b/kube_scheduler/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Kubernetes Scheduler Integration",
+  "public_title": "Kubernetes Scheduler Integration",
   "categories": [
     "orchestration",
     "containers",

--- a/kubelet/manifest.json
+++ b/kubelet/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "kubernetes.",
   "metric_to_check": "kubernetes.cpu.usage.total",
   "name": "kubelet",
-  "public_title": "Datadog-Kubelet Integration",
+  "public_title": "Kubelet Integration",
   "short_description": "Collects container stats from kubelet.",
   "support": "core",
   "supported_os": [

--- a/kubernetes/manifest.json
+++ b/kubernetes/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "kubernetes",
   "metric_to_check": "kubernetes.cpu.usage.total",
   "name": "kubernetes",
-  "public_title": "Datadog-Kubernetes Integration",
+  "public_title": "Kubernetes Integration",
   "short_description": "Capture Pod scheduling events, track the status of your Kubelets, and much more.",
   "support": "core",
   "supported_os": [

--- a/kubernetes_state/manifest.json
+++ b/kubernetes_state/manifest.json
@@ -12,7 +12,7 @@
   "metric_prefix": "kubernetes_state.",
   "metric_to_check": "kubernetes_state.container.running",
   "name": "kubernetes_state",
-  "public_title": "Datadog-Kubernetes State Integration",
+  "public_title": "Kubernetes State Integration",
   "short_description": "Capture Pod scheduling events, track the status of your Kubelets, and more.",
   "support": "core",
   "supported_os": [

--- a/kyototycoon/manifest.json
+++ b/kyototycoon/manifest.json
@@ -15,7 +15,7 @@
   "process_signatures": [
     "ktserver"
   ],
-  "public_title": "Datadog-Kyoto Tycoon Integration",
+  "public_title": "Kyoto Tycoon Integration",
   "short_description": "Track get, set, and delete operations; monitor replication lag.",
   "support": "core",
   "supported_os": [

--- a/lighttpd/manifest.json
+++ b/lighttpd/manifest.json
@@ -16,7 +16,7 @@
   "process_signatures": [
     "lighttpd"
   ],
-  "public_title": "Datadog-Lighttpd Integration",
+  "public_title": "Lighttpd Integration",
   "short_description": "Track uptime, bytes served, requests per second, response codes, and more.",
   "support": "core",
   "supported_os": [

--- a/linkerd/manifest.json
+++ b/linkerd/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "linkerd.",
   "metric_to_check": "linkerd.prometheus.health",
   "name": "linkerd",
-  "public_title": "Datadog-Linkerd Integration",
+  "public_title": "Linkerd Integration",
   "short_description": "Monitor your services health with metrics from linkerd.",
   "support": "core",
   "supported_os": [

--- a/linux_proc_extras/manifest.json
+++ b/linux_proc_extras/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "system.",
   "metric_to_check": "system.inodes.total",
   "name": "linux_proc_extras",
-  "public_title": "Datadog-Linux Proc Extras Integration",
+  "public_title": "Linux Proc Extras Integration",
   "short_description": "Visualize and monitor linux_proc_extras states.",
   "support": "core",
   "supported_os": [

--- a/mapr/manifest.json
+++ b/mapr/manifest.json
@@ -12,7 +12,7 @@
   "supported_os": [
     "linux"
   ],
-  "public_title": "Datadog-MapR Integration",
+  "public_title": "MapR Integration",
   "categories": [
     "data store",
     "os & system",

--- a/mapreduce/manifest.json
+++ b/mapreduce/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "mapreduce.",
   "metric_to_check": "mapreduce.job.elapsed_time.max",
   "name": "mapreduce",
-  "public_title": "Datadog-Map Reduce Integration",
+  "public_title": "Map Reduce Integration",
   "short_description": "Monitor the status and duration of map and reduce tasks.",
   "support": "core",
   "supported_os": [

--- a/marathon/manifest.json
+++ b/marathon/manifest.json
@@ -17,7 +17,7 @@
   "process_signatures": [
     "start --master mesos marathon"
   ],
-  "public_title": "Datadog-Marathon Integration",
+  "public_title": "Marathon Integration",
   "short_description": "Track application metrics: required memory and disk, instance count, and more.",
   "support": "core",
   "supported_os": [

--- a/marklogic/manifest.json
+++ b/marklogic/manifest.json
@@ -17,7 +17,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-MarkLogic Integration",
+  "public_title": "MarkLogic Integration",
   "categories": [
     "data store",
     "log collection"

--- a/mcache/manifest.json
+++ b/mcache/manifest.json
@@ -20,7 +20,7 @@
   "process_signatures": [
     "memcached"
   ],
-  "public_title": "Datadog-Memcache Integration",
+  "public_title": "Memcache Integration",
   "short_description": "Track memory use, hits, misses, evictions, fill percent, and more.",
   "support": "core",
   "supported_os": [

--- a/mesos_master/manifest.json
+++ b/mesos_master/manifest.json
@@ -21,7 +21,7 @@
     "mesos-master.sh",
     "mesos-agent.sh"
   ],
-  "public_title": "Datadog-Mesos Master Integration",
+  "public_title": "Mesos Master Integration",
   "short_description": "Track cluster resource usage, master and slave counts, tasks statuses, and more.",
   "support": "core",
   "supported_os": [

--- a/mesos_slave/manifest.json
+++ b/mesos_slave/manifest.json
@@ -14,7 +14,7 @@
   "metric_prefix": "mesos.",
   "metric_to_check": "mesos.stats.uptime_secs",
   "name": "mesos_slave",
-  "public_title": "Datadog-Mesos Slave Integration",
+  "public_title": "Mesos Slave Integration",
   "short_description": "Track cluster resource usage, master and slave counts, tasks statuses, and more.",
   "support": "core",
   "supported_os": [

--- a/mongo/manifest.json
+++ b/mongo/manifest.json
@@ -19,7 +19,7 @@
   "process_signatures": [
     "mongod"
   ],
-  "public_title": "Datadog-MongoDB Integration",
+  "public_title": "MongoDB Integration",
   "short_description": "Track read/write performance, most-used replicas, collection metrics, and more.",
   "support": "core",
   "supported_os": [

--- a/mysql/manifest.json
+++ b/mysql/manifest.json
@@ -16,7 +16,7 @@
   "process_signatures": [
     "mysqld"
   ],
-  "public_title": "Datadog-MySQL Integration",
+  "public_title": "MySQL Integration",
   "short_description": "Collect performance schema metrics, query throughput, custom metrics, and more.",
   "support": "core",
   "supported_os": [

--- a/nagios/manifest.json
+++ b/nagios/manifest.json
@@ -16,7 +16,7 @@
   "process_signatures": [
     "nagios"
   ],
-  "public_title": "Datadog-Nagios Integration",
+  "public_title": "Nagios Integration",
   "short_description": "Send Nagios service flaps, host alerts, and more to your Datadog event stream.",
   "support": "core",
   "supported_os": [

--- a/network/manifest.json
+++ b/network/manifest.json
@@ -12,7 +12,7 @@
   "metric_prefix": "system.",
   "metric_to_check": "system.net.bytes_rcvd",
   "name": "network",
-  "public_title": "Datadog-Network Integration",
+  "public_title": "Network Integration",
   "short_description": "Track bytes and packets in/out, connection states, round trip times, and more.",
   "support": "core",
   "supported_os": [

--- a/nfsstat/manifest.json
+++ b/nfsstat/manifest.json
@@ -12,7 +12,7 @@
   "metric_prefix": "system.",
   "metric_to_check": "system.nfs.ops",
   "name": "nfsstat",
-  "public_title": "Datadog-Nfsstat Integration",
+  "public_title": "Nfsstat Integration",
   "short_description": "nfsstat gets nfsiostat-sysstat metrics.",
   "support": "core",
   "supported_os": [

--- a/nginx/manifest.json
+++ b/nginx/manifest.json
@@ -18,7 +18,7 @@
   "process_signatures": [
     "nginx: master process"
   ],
-  "public_title": "Datadog-Nginx Integration",
+  "public_title": "Nginx Integration",
   "short_description": "Monitor connection and request metrics. Get more metrics with NGINX Plus.",
   "support": "core",
   "supported_os": [

--- a/nginx_ingress_controller/manifest.json
+++ b/nginx_ingress_controller/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-nginx-ingress-controller Integration",
+  "public_title": "nginx-ingress-controller Integration",
   "categories": [
     "orchestration",
     "containers",

--- a/ntp/manifest.json
+++ b/ntp/manifest.json
@@ -12,7 +12,7 @@
   "metric_prefix": "ntp.",
   "metric_to_check": "ntp.offset",
   "name": "ntp",
-  "public_title": "Datadog-NTP Integration",
+  "public_title": "NTP Integration",
   "short_description": "Get alerts when your hosts drift out of sync with your chosen NTP server.",
   "support": "core",
   "supported_os": [

--- a/oke/manifest.json
+++ b/oke/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Oracle Container Engine for Kubernetes Integration",
+  "public_title": "Oracle Container Engine for Kubernetes Integration",
   "categories": [
     "oracle",
     "containers",

--- a/oom_kill/manifest.json
+++ b/oom_kill/manifest.json
@@ -12,7 +12,7 @@
   "supported_os": [
     "linux"
   ],
-  "public_title": "Datadog-OOM Kill Integration",
+  "public_title": "OOM Kill Integration",
   "categories": [
     "os & system"
   ],

--- a/openldap/manifest.json
+++ b/openldap/manifest.json
@@ -14,7 +14,7 @@
   "metric_prefix": "openldap.",
   "metric_to_check": "openldap.connections.current",
   "name": "openldap",
-  "public_title": "Datadog-OpenLDAP Integration",
+  "public_title": "OpenLDAP Integration",
   "short_description": "Collect metrics from your OpenLDAP server using the cn=monitor backend",
   "support": "core",
   "supported_os": [

--- a/openmetrics/manifest.json
+++ b/openmetrics/manifest.json
@@ -10,7 +10,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "name": "openmetrics",
-  "public_title": "Datadog-OpenMetrics Integration",
+  "public_title": "OpenMetrics Integration",
   "short_description": "OpenMetrics is an open standard for exposing metric data",
   "support": "core",
   "supported_os": [

--- a/openshift/manifest.json
+++ b/openshift/manifest.json
@@ -16,7 +16,7 @@
     "openshift.clusterquota.cpu.used"
   ],
   "name": "openshift",
-  "public_title": "Datadog-OpenShift Integration",
+  "public_title": "OpenShift Integration",
   "short_description": "The Kubernetes platform for big ideas",
   "support": "core",
   "supported_os": [

--- a/oracle/manifest.json
+++ b/oracle/manifest.json
@@ -12,7 +12,7 @@
   "metric_prefix": "oracle.",
   "metric_to_check": "oracle.session_count",
   "name": "Oracle",
-  "public_title": "Datadog-Oracle Integration",
+  "public_title": "Oracle Integration",
   "short_description": "Oracle relational database system designed for enterprise grid computing",
   "support": "core",
   "supported_os": [

--- a/pan_firewall/manifest.json
+++ b/pan_firewall/manifest.json
@@ -15,7 +15,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Palo Alto Networks Firewall Integration",
+  "public_title": "Palo Alto Networks Firewall Integration",
   "categories": [
     "log collection",
     "security"

--- a/pdh_check/manifest.json
+++ b/pdh_check/manifest.json
@@ -10,7 +10,7 @@
   "manifest_version": "1.0.0",
   "metric_prefix": "pdh.",
   "name": "pdh_check",
-  "public_title": "Datadog-PDH Check Integration",
+  "public_title": "PDH Check Integration",
   "short_description": "Collect and graph any Windows Performance Counters.",
   "support": "core",
   "supported_os": [

--- a/pgbouncer/manifest.json
+++ b/pgbouncer/manifest.json
@@ -16,7 +16,7 @@
   "process_signatures": [
     "pgbouncer"
   ],
-  "public_title": "Datadog-PGBouncer Integration",
+  "public_title": "PGBouncer Integration",
   "short_description": "Track connection pool metrics and monitor traffic to and from your application.",
   "support": "core",
   "supported_os": [

--- a/php_fpm/manifest.json
+++ b/php_fpm/manifest.json
@@ -26,7 +26,7 @@
     "systemctl restart php-fpm.service",
     "php7.0-fpm.service"
   ],
-  "public_title": "Datadog-PHP FPM Integration",
+  "public_title": "PHP FPM Integration",
   "short_description": "Monitor process states, slow requests, and accepted requests.",
   "support": "core",
   "supported_os": [

--- a/pivotal_pks/manifest.json
+++ b/pivotal_pks/manifest.json
@@ -11,7 +11,7 @@
     "linux",
     "mac_os"
   ],
-  "public_title": "Datadog-Pivotal Container Service Integration",
+  "public_title": "Pivotal Container Service Integration",
   "categories": [
     "containers",
     "orchestration",

--- a/postfix/manifest.json
+++ b/postfix/manifest.json
@@ -16,7 +16,7 @@
     "postfix start",
     "sendmail -bd"
   ],
-  "public_title": "Datadog-Postfix Integration",
+  "public_title": "Postfix Integration",
   "short_description": "Monitor the size of all your Postfix queues.",
   "support": "core",
   "supported_os": [

--- a/postgres/manifest.json
+++ b/postgres/manifest.json
@@ -24,7 +24,7 @@
     "pg_ctl start -l logfile",
     "postgres -c 'pg_ctl start -D -l"
   ],
-  "public_title": "Datadog-Postgres Integration",
+  "public_title": "Postgres Integration",
   "short_description": "Collect a wealth of database performance and health metrics.",
   "support": "core",
   "supported_os": [

--- a/powerdns_recursor/manifest.json
+++ b/powerdns_recursor/manifest.json
@@ -21,7 +21,7 @@
     "pdns_server",
     "systemctl start pdns@"
   ],
-  "public_title": "Datadog-Power DNS Recursor Integration",
+  "public_title": "Power DNS Recursor Integration",
   "short_description": "Keep an eye on strange traffic to and from your PowerDNS recursors.",
   "support": "core",
   "supported_os": [

--- a/presto/manifest.json
+++ b/presto/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Presto Integration",
+  "public_title": "Presto Integration",
   "categories": [
     "data store",
     "log collection"

--- a/process/manifest.json
+++ b/process/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "system.",
   "metric_to_check": "system.processes.cpu.pct",
   "name": "process",
-  "public_title": "Datadog-Processes Integration",
+  "public_title": "Processes Integration",
   "short_description": "Capture metrics and monitor the status of running processes.",
   "support": "core",
   "supported_os": [

--- a/prometheus/manifest.json
+++ b/prometheus/manifest.json
@@ -9,7 +9,7 @@
   "maintainer": "help@datadoghq.com",
   "manifest_version": "1.0.0",
   "name": "prometheus",
-  "public_title": "Datadog-Prometheus (legacy) Integration",
+  "public_title": "Prometheus (legacy) Integration",
   "short_description": "Prometheus is an open source monitoring system for timeseries metric data",
   "support": "core",
   "supported_os": [

--- a/proxysql/manifest.json
+++ b/proxysql/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-ProxySQL Integration",
+  "public_title": "ProxySQL Integration",
   "categories": [
     "data store",
     "log collection",

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -17,7 +17,7 @@
     "rabbitmq",
     "rabbitmq-server"
   ],
-  "public_title": "Datadog-RabbitMQ Integration",
+  "public_title": "RabbitMQ Integration",
   "short_description": "Track queue size, consumer count, unacknowledged messages, and more.",
   "support": "core",
   "supported_os": [

--- a/redisdb/manifest.json
+++ b/redisdb/manifest.json
@@ -19,7 +19,7 @@
   "process_signatures": [
     "redis-server"
   ],
-  "public_title": "Datadog-Redis Integration",
+  "public_title": "Redis Integration",
   "short_description": "Track redis performance, memory use, blocked clients, evicted keys, and more.",
   "support": "core",
   "supported_os": [

--- a/rethinkdb/manifest.json
+++ b/rethinkdb/manifest.json
@@ -17,7 +17,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-RethinkDB Integration",
+  "public_title": "RethinkDB Integration",
   "categories": [
     "data store",
     "log collection"

--- a/riak/manifest.json
+++ b/riak/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "riak.",
   "metric_to_check": "riak.memory_processes",
   "name": "riak",
-  "public_title": "Datadog-Riak Integration",
+  "public_title": "Riak Integration",
   "short_description": "Track node, vnode and ring performance metrics for RiakKV or RiakTS.",
   "support": "core",
   "supported_os": [

--- a/riakcs/manifest.json
+++ b/riakcs/manifest.json
@@ -14,7 +14,7 @@
   "process_signatures": [
     "riak-cs start"
   ],
-  "public_title": "Datadog-Riak CS Integration",
+  "public_title": "Riak CS Integration",
   "short_description": "Track the rate and mean latency of GETs, PUTs, DELETEs, and other operations.",
   "support": "core",
   "supported_os": [

--- a/sap_hana/manifest.json
+++ b/sap_hana/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-SAP HANA Integration",
+  "public_title": "SAP HANA Integration",
   "categories": [
     "data store"
   ],

--- a/scylla/manifest.json
+++ b/scylla/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Scylla Integration",
+  "public_title": "Scylla Integration",
   "categories": [
     "data store",
     "log collection"

--- a/sidekiq/manifest.json
+++ b/sidekiq/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Sidekiq Integration",
+  "public_title": "Sidekiq Integration",
   "categories": [
     "log collection"
   ],

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -13,7 +13,7 @@
   "manifest_version": "1.0.0",
   "metric_prefix": "snmp.",
   "name": "snmp",
-  "public_title": "Datadog-SNMP Integration",
+  "public_title": "SNMP Integration",
   "short_description": "Collect SNMP metrics from your network devices.",
   "support": "core",
   "supported_os": [

--- a/snmp_cisco/manifest.json
+++ b/snmp_cisco/manifest.json
@@ -16,11 +16,11 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Cisco Integration",
-  "categories": [ 
-    "monitoring", 
-    "notification", 
-    "network", 
+  "public_title": "Cisco Integration",
+  "categories": [
+    "monitoring",
+    "notification",
+    "network",
     "autodiscovery",
     "snmp"
   ],

--- a/snmp_dell/manifest.json
+++ b/snmp_dell/manifest.json
@@ -17,11 +17,11 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Dell Inc.",
-  "categories": [ 
-    "monitoring", 
-    "notification", 
-    "network", 
+  "public_title": "Dell Inc.",
+  "categories": [
+    "monitoring",
+    "notification",
+    "network",
     "autodiscovery",
     "snmp"
   ],

--- a/snmp_f5/manifest.json
+++ b/snmp_f5/manifest.json
@@ -17,7 +17,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-F5 Networks",
+  "public_title": "F5 Networks",
   "categories": [
     "monitoring",
     "notification",

--- a/snmp_juniper/manifest.json
+++ b/snmp_juniper/manifest.json
@@ -17,7 +17,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Juniper Networks",
+  "public_title": "Juniper Networks",
   "categories": [
     "monitoring",
     "notification",

--- a/snowflake/manifest.json
+++ b/snowflake/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Snowflake Integration",
+  "public_title": "Snowflake Integration",
   "categories": [
     "cloud",
     "data store",

--- a/solr/manifest.json
+++ b/solr/manifest.json
@@ -16,7 +16,7 @@
   "process_signatures": [
     "solr start"
   ],
-  "public_title": "Datadog-Solr Integration",
+  "public_title": "Solr Integration",
   "short_description": "Monitor request rate, handler errors, cache misses and evictions, and more.",
   "support": "core",
   "supported_os": [

--- a/spark/manifest.json
+++ b/spark/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "spark.",
   "metric_to_check": "spark.job.count",
   "name": "spark",
-  "public_title": "Datadog-Spark Integration",
+  "public_title": "Spark Integration",
   "short_description": "Track failed task rates, shuffled bytes, and much more.",
   "support": "core",
   "supported_os": [

--- a/sqlserver/manifest.json
+++ b/sqlserver/manifest.json
@@ -12,7 +12,7 @@
   "metric_prefix": "sqlserver.",
   "metric_to_check": "sqlserver.stats.connections",
   "name": "sqlserver",
-  "public_title": "Datadog-SQL Server Integration",
+  "public_title": "SQL Server Integration",
   "short_description": "Collect important SQL Server performance and health metrics.",
   "support": "core",
   "supported_os": [

--- a/squid/manifest.json
+++ b/squid/manifest.json
@@ -14,7 +14,7 @@
   "metric_prefix": "squid.",
   "metric_to_check": "squid.cachemgr.cpu_time",
   "name": "squid",
-  "public_title": "Datadog-Squid Integration",
+  "public_title": "Squid Integration",
   "short_description": "Track metrics from your squid-cache servers with Datadog",
   "support": "core",
   "supported_os": [

--- a/statsd/manifest.json
+++ b/statsd/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "statsd.",
   "metric_to_check": "statsd.counters.count",
   "name": "statsd",
-  "public_title": "Datadog-StatsD Integration",
+  "public_title": "StatsD Integration",
   "short_description": "Monitor the availability of StatsD servers and track metric counts.",
   "support": "core",
   "supported_os": [

--- a/supervisord/manifest.json
+++ b/supervisord/manifest.json
@@ -20,7 +20,7 @@
     "python supervisord",
     "supervisord"
   ],
-  "public_title": "Datadog-Supervisord Integration",
+  "public_title": "Supervisord Integration",
   "short_description": "Monitor the status, uptime, and number of supervisor-managed processes.",
   "support": "core",
   "supported_os": [

--- a/system_core/manifest.json
+++ b/system_core/manifest.json
@@ -14,7 +14,7 @@
   "metric_prefix": "system.",
   "metric_to_check": "system.core.user",
   "name": "system_core",
-  "public_title": "Datadog-System Core Integration",
+  "public_title": "System Core Integration",
   "short_description": "Collect the number of CPU cores and CPU times on a host",
   "support": "core",
   "supported_os": [

--- a/system_swap/manifest.json
+++ b/system_swap/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "system.",
   "metric_to_check": "system.swap.swapped_in",
   "name": "system_swap",
-  "public_title": "Datadog-System Swap Integration",
+  "public_title": "System Swap Integration",
   "short_description": "Adds some optional swap memory checks.",
   "support": "core",
   "supported_os": [

--- a/systemd/manifest.json
+++ b/systemd/manifest.json
@@ -12,7 +12,7 @@
   "supported_os": [
     "linux"
   ],
-  "public_title": "Datadog-Systemd Integration",
+  "public_title": "Systemd Integration",
   "categories": [
     "os & system"
   ],

--- a/tcp_check/manifest.json
+++ b/tcp_check/manifest.json
@@ -16,7 +16,7 @@
   "metric_prefix": "network.",
   "metric_to_check": "network.tcp.can_connect",
   "name": "tcp_check",
-  "public_title": "Datadog-TCP Check Integration",
+  "public_title": "TCP Check Integration",
   "short_description": "Monitor TCP connectivity to remote hosts.",
   "support": "core",
   "supported_os": [

--- a/tcp_queue_length/manifest.json
+++ b/tcp_queue_length/manifest.json
@@ -10,7 +10,7 @@
   "supported_os": [
     "linux"
   ],
-  "public_title": "Datadog-TCP Queue Length Integration",
+  "public_title": "TCP Queue Length Integration",
   "categories": [
     "network"
   ],

--- a/teamcity/manifest.json
+++ b/teamcity/manifest.json
@@ -16,7 +16,7 @@
     "teamcity-server.sh",
     "teamcity-server"
   ],
-  "public_title": "Datadog-Teamcity Integration",
+  "public_title": "Teamcity Integration",
   "short_description": "Track builds and understand the performance impact of every deploy.",
   "support": "core",
   "supported_os": [

--- a/tenable/manifest.json
+++ b/tenable/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Tenable Nessus Integration",
+  "public_title": "Tenable Nessus Integration",
   "categories": [
     "log collection"
   ],

--- a/tls/manifest.json
+++ b/tls/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-TLS Integration",
+  "public_title": "TLS Integration",
   "categories": [
     "network",
     "web",

--- a/tokumx/manifest.json
+++ b/tokumx/manifest.json
@@ -13,7 +13,7 @@
   "metric_to_check": "tokumx.uptime",
   "name": "tokumx",
   "process_signatures": [],
-  "public_title": "Datadog-TokuMX Integration",
+  "public_title": "TokuMX Integration",
   "short_description": "Track metrics for opcounters, replication lag, cache table size, and more.",
   "support": "core",
   "supported_os": [

--- a/tomcat/manifest.json
+++ b/tomcat/manifest.json
@@ -16,7 +16,7 @@
   "process_signatures": [
     "java tomcat"
   ],
-  "public_title": "Datadog-Tomcat Integration",
+  "public_title": "Tomcat Integration",
   "short_description": "Track requests per second, bytes served, cache hits, servlet metrics, and more.",
   "support": "core",
   "supported_os": [

--- a/twemproxy/manifest.json
+++ b/twemproxy/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "twemproxy.",
   "metric_to_check": "twemproxy.total_connections",
   "name": "twemproxy",
-  "public_title": "Datadog-Twemproxy Integration",
+  "public_title": "Twemproxy Integration",
   "short_description": "Visualize twemproxy performance and correlate with the rest of your applications",
   "support": "core",
   "supported_os": [

--- a/twistlock/manifest.json
+++ b/twistlock/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Prisma Cloud Compute Edition Integration",
+  "public_title": "Prisma Cloud Compute Edition Integration",
   "categories": [
     "security",
     "log collection",

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -17,7 +17,7 @@
     "service varnish start",
     "varnishd"
   ],
-  "public_title": "Datadog-Varnish Integration",
+  "public_title": "Varnish Integration",
   "short_description": "Track client and backend connections, cache misses and evictions, and more.",
   "support": "core",
   "supported_os": [

--- a/vault/manifest.json
+++ b/vault/manifest.json
@@ -14,7 +14,7 @@
   "metric_prefix": "vault.",
   "metric_to_check": "vault.is_leader",
   "name": "vault",
-  "public_title": "Datadog-Vault Integration",
+  "public_title": "Vault Integration",
   "short_description": "Vault is a secrets management service application",
   "support": "core",
   "supported_os": [

--- a/vertica/manifest.json
+++ b/vertica/manifest.json
@@ -14,7 +14,7 @@
     "mac_os",
     "windows"
   ],
-  "public_title": "Datadog-Vertica Integration",
+  "public_title": "Vertica Integration",
   "categories": [
     "data store",
     "log collection"

--- a/vsphere/manifest.json
+++ b/vsphere/manifest.json
@@ -15,7 +15,7 @@
   "metric_prefix": "vsphere.",
   "metric_to_check": "vsphere.vm.count",
   "name": "vsphere",
-  "public_title": "Datadog-vSphere Integration",
+  "public_title": "vSphere Integration",
   "short_description": "Understand how vSphere resource usage affects your application.",
   "support": "core",
   "supported_os": [

--- a/win32_event_log/manifest.json
+++ b/win32_event_log/manifest.json
@@ -16,7 +16,7 @@
   "manifest_version": "1.0.0",
   "metric_prefix": "win32_event_log.",
   "name": "win32_event_log",
-  "public_title": "Datadog-Win 32 event log Integration",
+  "public_title": "Win 32 event log Integration",
   "short_description": "Send Windows events to your Datadog event stream.",
   "support": "core",
   "supported_os": [

--- a/windows_service/manifest.json
+++ b/windows_service/manifest.json
@@ -13,7 +13,7 @@
   "manifest_version": "1.0.0",
   "metric_prefix": "windows_service.",
   "name": "windows_service",
-  "public_title": "Datadog-Windows Services Integration",
+  "public_title": "Windows Services Integration",
   "short_description": "Monitor the state of your Windows services.",
   "support": "core",
   "supported_os": [

--- a/winkmem/manifest.json
+++ b/winkmem/manifest.json
@@ -11,7 +11,7 @@
   "metric_prefix": "winkmem.",
   "metric_to_check": "winkmem.paged_pool_bytes",
   "name": "winkmem",
-  "public_title": "Datadog-Windows Kernel Memory Integration",
+  "public_title": "Windows Kernel Memory Integration",
   "short_description": "Monitor your Windows kernel memory allocation.",
   "support": "core",
   "supported_os": [

--- a/wmi_check/manifest.json
+++ b/wmi_check/manifest.json
@@ -13,7 +13,7 @@
   "manifest_version": "1.0.0",
   "metric_prefix": "wmi.",
   "name": "wmi_check",
-  "public_title": "Datadog-WMI Check Integration",
+  "public_title": "WMI Check Integration",
   "short_description": "Collect and graph any WMI metrics.",
   "support": "core",
   "supported_os": [

--- a/yarn/manifest.json
+++ b/yarn/manifest.json
@@ -13,7 +13,7 @@
   "metric_prefix": "yarn.",
   "metric_to_check": "yarn.metrics.total_mb",
   "name": "yarn",
-  "public_title": "Datadog-Yarn Integration",
+  "public_title": "Yarn Integration",
   "short_description": "Collect cluster-wide health metrics and track application progress.",
   "support": "core",
   "supported_os": [

--- a/zk/manifest.json
+++ b/zk/manifest.json
@@ -21,7 +21,7 @@
     "zkServer.sh start",
     "java zoo.cfg"
   ],
-  "public_title": "Datadog-ZooKeeper Integration",
+  "public_title": "ZooKeeper Integration",
   "short_description": "Track client connections and latencies, and know when requests are backing up.",
   "support": "core",
   "supported_os": [


### PR DESCRIPTION
### Additional Notes

```python
import json
import os

DIRECTORY = '/path/to/integrations-core'


def main():
    for check in sorted(os.listdir(DIRECTORY)):
        manifest_file = os.path.join(DIRECTORY, check, 'manifest.json')
        if not os.path.isfile(manifest_file):
            continue

        with open(manifest_file, 'r', encoding='utf-8') as f:
            manifest_data = json.loads(f.read())

        if not manifest_data.get('public_title', '').lower().startswith('datadog-'):
            continue

        manifest_data['public_title'] = manifest_data['public_title'][8:]

        with open(manifest_file, 'w', encoding='utf-8') as f:
            f.write(f'{json.dumps(manifest_data, indent=2)}\n')


if __name__ == '__main__':
    main()
```