### PR TITLE
Remove unused pytest markers

### DIFF
--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_bench.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_bench.py
@@ -11,7 +11,7 @@ from datadog_checks.dev.testing import requires_py3
 
 from ..bench_utils import AMAZON_MSK_JMX_METRICS_MAP, AMAZON_MSK_JMX_METRICS_OVERRIDES
 
-pytestmark = [requires_py3, pytest.mark.openmetrics, pytest.mark.openmetrics_config]
+pytestmark = [requires_py3]
 
 HERE = get_here()
 FIXTURE_PATH = os.path.abspath(os.path.join(os.path.dirname(HERE), '..', '..', '..', 'fixtures', 'prometheus'))

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_compat_scraper.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_compat_scraper.py
@@ -7,7 +7,7 @@ from datadog_checks.dev.testing import requires_py3
 
 from .utils import get_legacy_check
 
-pytestmark = [requires_py3, pytest.mark.openmetrics, pytest.mark.openmetrics_compat_scraper]
+pytestmark = [requires_py3]
 
 
 class TestRawMetricPrefix:

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_bench.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_bench.py
@@ -11,7 +11,7 @@ from datadog_checks.dev.testing import requires_py3
 
 from ..bench_utils import AMAZON_MSK_JMX_METRICS_MAP, AMAZON_MSK_JMX_METRICS_OVERRIDES
 
-pytestmark = [requires_py3, pytest.mark.openmetrics, pytest.mark.openmetrics_config]
+pytestmark = [requires_py3]
 
 HERE = get_here()
 FIXTURE_PATH = os.path.abspath(os.path.join(os.path.dirname(HERE), '..', '..', '..', 'fixtures', 'prometheus'))

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_config.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_config.py
@@ -7,7 +7,7 @@ from datadog_checks.dev.testing import requires_py3
 
 from .utils import get_check
 
-pytestmark = [requires_py3, pytest.mark.openmetrics, pytest.mark.openmetrics_config]
+pytestmark = [requires_py3]
 
 
 class TestPrometheusEndpoint:

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_first_scrape_handler.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_first_scrape_handler.py
@@ -10,7 +10,6 @@ from .utils import get_check
 
 pytestmark = [
     requires_py3,
-    pytest.mark.openmetrics,
 ]
 
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_first_scrape_handler.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_first_scrape_handler.py
@@ -8,9 +8,7 @@ from datadog_checks.dev.testing import requires_py3
 
 from .utils import get_check
 
-pytestmark = [
-    requires_py3,
-]
+pytestmark = [requires_py3]
 
 
 test_use_process_start_time_data = """\

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_interface.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_interface.py
@@ -1,15 +1,13 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.base import OpenMetricsBaseCheckV2
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.testing import requires_py3
 
 from .utils import get_check
 
-pytestmark = [requires_py3, pytest.mark.openmetrics, pytest.mark.openmetrics_interface]
+pytestmark = [requires_py3]
 
 
 def test_default_config(aggregator, dd_run_check, mock_http_response):

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_options.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_options.py
@@ -9,7 +9,7 @@ from datadog_checks.dev.testing import requires_py3
 
 from .utils import get_check
 
-pytestmark = [requires_py3, pytest.mark.openmetrics, pytest.mark.openmetrics_options]
+pytestmark = [requires_py3]
 
 
 class TestNamespace:

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter.py
@@ -1,17 +1,12 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3
 
 from ..utils import get_check
 
 pytestmark = [
     requires_py3,
-    pytest.mark.openmetrics,
-    pytest.mark.openmetrics_transformers,
-    pytest.mark.openmetrics_transformers_counter,
 ]
 
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter_gauge.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_counter_gauge.py
@@ -1,17 +1,12 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3
 
 from ..utils import get_check
 
 pytestmark = [
     requires_py3,
-    pytest.mark.openmetrics,
-    pytest.mark.openmetrics_transformers,
-    pytest.mark.openmetrics_transformers_counter_gauge,
 ]
 
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_gauge.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_gauge.py
@@ -1,17 +1,12 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3
 
 from ..utils import get_check
 
 pytestmark = [
     requires_py3,
-    pytest.mark.openmetrics,
-    pytest.mark.openmetrics_transformers,
-    pytest.mark.openmetrics_transformers_gauge,
 ]
 
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_histogram.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_histogram.py
@@ -1,17 +1,12 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3
 
 from ..utils import get_check
 
 pytestmark = [
     requires_py3,
-    pytest.mark.openmetrics,
-    pytest.mark.openmetrics_transformers,
-    pytest.mark.openmetrics_transformers_histogram,
 ]
 
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_metadata.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_metadata.py
@@ -1,17 +1,12 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3
 
 from ..utils import get_check
 
 pytestmark = [
     requires_py3,
-    pytest.mark.openmetrics,
-    pytest.mark.openmetrics_transformers,
-    pytest.mark.openmetrics_transformers_metadata,
 ]
 
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_native_dynamic.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_native_dynamic.py
@@ -1,17 +1,12 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3
 
 from ..utils import get_check
 
 pytestmark = [
     requires_py3,
-    pytest.mark.openmetrics,
-    pytest.mark.openmetrics_transformers,
-    pytest.mark.openmetrics_transformers_native_dynamic,
 ]
 
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_rate.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_rate.py
@@ -1,17 +1,12 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3
 
 from ..utils import get_check
 
 pytestmark = [
     requires_py3,
-    pytest.mark.openmetrics,
-    pytest.mark.openmetrics_transformers,
-    pytest.mark.openmetrics_transformers_rate,
 ]
 
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_service_check.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_service_check.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.testing import requires_py3
 
@@ -10,9 +8,6 @@ from ..utils import get_check
 
 pytestmark = [
     requires_py3,
-    pytest.mark.openmetrics,
-    pytest.mark.openmetrics_transformers,
-    pytest.mark.openmetrics_transformers_service_check,
 ]
 
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_summary.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_summary.py
@@ -1,17 +1,12 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3
 
 from ..utils import get_check
 
 pytestmark = [
     requires_py3,
-    pytest.mark.openmetrics,
-    pytest.mark.openmetrics_transformers,
-    pytest.mark.openmetrics_transformers_summary,
 ]
 
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_temporal_percent.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_temporal_percent.py
@@ -1,17 +1,12 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3
 
 from ..utils import get_check
 
 pytestmark = [
     requires_py3,
-    pytest.mark.openmetrics,
-    pytest.mark.openmetrics_transformers,
-    pytest.mark.openmetrics_transformers_temporal_percent,
 ]
 
 

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_time_elapsed.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_transformers/test_time_elapsed.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.base.utils.time import get_timestamp
 from datadog_checks.dev.testing import requires_py3
 
@@ -10,9 +8,6 @@ from ..utils import get_check
 
 pytestmark = [
     requires_py3,
-    pytest.mark.openmetrics,
-    pytest.mark.openmetrics_transformers,
-    pytest.mark.openmetrics_transformers_time_elapsed,
 ]
 
 

--- a/datadog_checks_base/tests/base/checks/win/test_wmicheck.py
+++ b/datadog_checks_base/tests/base/checks/win/test_wmicheck.py
@@ -2,8 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import pytest
-
 from datadog_checks.dev.testing import requires_windows
 
 try:
@@ -13,7 +11,6 @@ except ImportError:
 
 
 @requires_windows
-@pytest.mark.unit
 def test_get_running_sampler_does_not_leak():
     check = WinWMICheck('wmi_base_check', {}, [{}])
     with check.get_running_wmi_sampler(properties=[], filters=[]) as sampler:

--- a/datadog_checks_base/tests/base/checks/win/test_wmisampler.py
+++ b/datadog_checks_base/tests/base/checks/win/test_wmisampler.py
@@ -3,8 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import collections
 
-import pytest
-
 from datadog_checks.dev.testing import requires_windows
 
 try:
@@ -20,7 +18,6 @@ except ImportError:
 
 
 @requires_windows
-@pytest.mark.unit
 def test_format_filter_value():
     filters = [{'a': 'b'}, {'c': 'd'}]
     sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=filters)
@@ -29,7 +26,6 @@ def test_format_filter_value():
 
 
 @requires_windows
-@pytest.mark.unit
 def test_format_filter_like():
     filters = [{'a': '%foo'}]
     sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=filters)
@@ -38,7 +34,6 @@ def test_format_filter_like():
 
 
 @requires_windows
-@pytest.mark.unit
 def test_format_filter_list_expected():
     filters = [{'a': ['<', 3]}]
     sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=filters)
@@ -52,7 +47,6 @@ def test_format_filter_list_expected():
 
 
 @requires_windows
-@pytest.mark.unit
 def test_format_filter_tuple():
     # needed for backwards compatibility and hardcoded filters
     filters = [{'a': ('<', 3)}]
@@ -62,7 +56,6 @@ def test_format_filter_tuple():
 
 
 @requires_windows
-@pytest.mark.unit
 def test_format_filter_bool_op_alt():
     filters = [{'a': {'OR': [['>=', 10], ['<', 0]]}}]
     sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=filters)
@@ -95,7 +88,6 @@ def test_format_filter_bool_op_alt():
 
 
 @requires_windows
-@pytest.mark.unit
 def test_format_filter_bool_op_not():
     filters = [{'my.prop': {'NOT': ['c', 'd']}}]
     sampler = WMISampler(logger=None, class_name='MyClass', property_names='my.prop', filters=filters)
@@ -110,7 +102,6 @@ def test_format_filter_bool_op_not():
 
 
 @requires_windows
-@pytest.mark.unit
 def test_format_filter_bool_op_invalid():
     # Falls back to default_bool_op
     filters = [{'my.prop': {'XXX': ['c', 'd']}}]
@@ -126,7 +117,6 @@ def test_format_filter_bool_op_invalid():
 
 
 @requires_windows
-@pytest.mark.unit
 def test_format_filter_wql_op_invalid():
     # Falls back to default_wql_op
     filters = [{'a': [['XXX', 3]]}]
@@ -136,7 +126,6 @@ def test_format_filter_wql_op_invalid():
 
 
 @requires_windows
-@pytest.mark.unit
 def test_format_filter_win32_log():
     query = collections.OrderedDict(
         (
@@ -155,7 +144,6 @@ def test_format_filter_win32_log():
 
 
 @requires_windows
-@pytest.mark.unit
 def test_caseinsensitivedict():
     test_dict = CaseInsensitiveDict({})
     key1 = "CAPS_KEY"

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/test_aggregation.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/test_aggregation.py
@@ -1,13 +1,11 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from .utils import GLOBAL_TAGS, get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 def test_single_instance(aggregator, dd_run_check, mock_performance_objects):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/test_config.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/test_config.py
@@ -9,7 +9,7 @@ from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from .utils import get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 @pytest.fixture(autouse=True)

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/test_filter.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/test_filter.py
@@ -1,13 +1,11 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from .utils import GLOBAL_TAGS, get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 def test_include(aggregator, dd_run_check, mock_performance_objects):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/test_health.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/test_health.py
@@ -3,14 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 
-import pytest
-
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from .utils import GLOBAL_TAGS, get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 def test_disable(aggregator, dd_run_check, mock_performance_objects):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/test_integration.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/test_integration.py
@@ -3,14 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
-import pytest
-
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from .utils import SERVER, get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 def test(aggregator, dd_run_check):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/test_legacy_support.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/test_legacy_support.py
@@ -3,8 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 
-import pytest
-
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
@@ -16,7 +14,7 @@ try:
 except Exception:
     PerfCountersBaseCheckWithLegacySupport = object
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 class CustomCheck(PerfCountersBaseCheckWithLegacySupport):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/test_localization.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/test_localization.py
@@ -2,14 +2,13 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import mock
-import pytest
 
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from .utils import GLOBAL_TAGS, SERVER, get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 def test_default(aggregator, dd_run_check, mock_performance_objects):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/test_refresh.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/test_refresh.py
@@ -1,13 +1,11 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from .utils import GLOBAL_TAGS, SERVER, get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 def test_detection(aggregator, dd_run_check, mock_performance_objects):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/test_subclass.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/test_subclass.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
@@ -16,7 +14,7 @@ except Exception:
     PerfCountersBaseCheck = object
     PerfObject = object
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 class CustomCheck(PerfCountersBaseCheck):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_count.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_count.py
@@ -1,13 +1,11 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from ..utils import GLOBAL_TAGS, get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 def test(aggregator, dd_run_check, mock_performance_objects):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_gauge.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_gauge.py
@@ -1,13 +1,11 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from ..utils import GLOBAL_TAGS, get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 def test_explicit(aggregator, dd_run_check, mock_performance_objects):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_monotonic_count.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_monotonic_count.py
@@ -1,13 +1,11 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from ..utils import GLOBAL_TAGS, get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 def test(aggregator, dd_run_check, mock_performance_objects):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_rate.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_rate.py
@@ -1,13 +1,11 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from ..utils import GLOBAL_TAGS, get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 def test(aggregator, dd_run_check, mock_performance_objects):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_service_check.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_service_check.py
@@ -1,14 +1,12 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from ..utils import GLOBAL_TAGS, get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 def test_known(aggregator, dd_run_check, mock_performance_objects):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_temporal_percent.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_temporal_percent.py
@@ -1,13 +1,11 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from ..utils import GLOBAL_TAGS, get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 def test_named(aggregator, dd_run_check, mock_performance_objects):

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_time_elapsed.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/transformers/test_time_elapsed.py
@@ -1,14 +1,12 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.base.utils.time import get_timestamp
 from datadog_checks.dev.testing import requires_py3, requires_windows
 
 from ..utils import GLOBAL_TAGS, get_check
 
-pytestmark = [requires_py3, requires_windows, pytest.mark.perf_counters]
+pytestmark = [requires_py3, requires_windows]
 
 
 def test(aggregator, dd_run_check, mock_performance_objects):

--- a/datadog_checks_base/tests/base/test_constants.py
+++ b/datadog_checks_base/tests/base/test_constants.py
@@ -1,10 +1,7 @@
-import pytest
-
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.constants import ServiceCheck
 
 
-@pytest.mark.unit
 def test_service_check_constants():
     # type: () -> None
     assert ServiceCheck.OK == AgentCheck.OK == 0

--- a/datadog_checks_base/tests/base/utils/db/test_custom_queries.py
+++ b/datadog_checks_base/tests/base/utils/db/test_custom_queries.py
@@ -7,8 +7,6 @@ from datadog_checks.base import AgentCheck
 
 from .common import create_query_manager, mock_executor
 
-pytestmark = pytest.mark.db
-
 
 class TestCustomQueries:
     def test_instance(self, aggregator):

--- a/datadog_checks_base/tests/base/utils/db/test_query_executor.py
+++ b/datadog_checks_base/tests/base/utils/db/test_query_executor.py
@@ -1,14 +1,10 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.db import QueryExecutor
 
 from .common import mock_executor
-
-pytestmark = pytest.mark.db
 
 
 class TestQueryExecutor:

--- a/datadog_checks_base/tests/base/utils/db/test_query_manager.py
+++ b/datadog_checks_base/tests/base/utils/db/test_query_manager.py
@@ -11,8 +11,6 @@ from datadog_checks.base.utils.db import QueryManager
 
 from .common import create_query_manager, mock_executor
 
-pytestmark = pytest.mark.db
-
 
 class TestQueryCompilation:
     def test_no_query_name(self):

--- a/datadog_checks_base/tests/base/utils/db/test_query_result.py
+++ b/datadog_checks_base/tests/base/utils/db/test_query_result.py
@@ -5,8 +5,6 @@ import pytest
 
 from .common import create_query_manager, mock_executor
 
-pytestmark = pytest.mark.db
-
 
 class TestQueryResultIteration:
     def test_executor_empty_result(self):

--- a/datadog_checks_base/tests/base/utils/db/test_transformers.py
+++ b/datadog_checks_base/tests/base/utils/db/test_transformers.py
@@ -4,14 +4,11 @@
 import time
 from datetime import datetime, timedelta
 
-import pytest
 from dateutil.tz import gettz
 
 from datadog_checks.base.utils.time import UTC
 
 from .common import create_query_manager, mock_executor
-
-pytestmark = pytest.mark.db
 
 
 class TestColumnTransformers:

--- a/datadog_checks_base/tests/base/utils/test_aws.py
+++ b/datadog_checks_base/tests/base/utils/test_aws.py
@@ -5,8 +5,6 @@ import pytest
 
 from datadog_checks.base.utils.aws import rds_parse_tags_from_endpoint
 
-pytestmark = pytest.mark.aws
-
 
 class TestRDS:
     @pytest.mark.parametrize(

--- a/datadog_checks_base/tests/base/utils/test_http.py
+++ b/datadog_checks_base/tests/base/utils/test_http.py
@@ -29,8 +29,6 @@ from datadog_checks.dev.fs import read_file, write_file
 from datadog_checks.dev.http import MockResponse
 from datadog_checks.dev.utils import ON_WINDOWS
 
-pytestmark = pytest.mark.http
-
 DEFAULT_OPTIONS = {
     'auth': None,
     'cert': None,

--- a/datadog_checks_base/tests/base/utils/test_time.py
+++ b/datadog_checks_base/tests/base/utils/test_time.py
@@ -17,8 +17,6 @@ from datadog_checks.base.utils.time import (
     get_timestamp,
 )
 
-pytestmark = pytest.mark.time
-
 
 class TestNormalization:
     def test_replace(self):

--- a/datadog_checks_base/tests/test_metadata.py
+++ b/datadog_checks_base/tests/test_metadata.py
@@ -13,8 +13,6 @@ from six import PY3
 
 from datadog_checks.base import AgentCheck, ensure_bytes, ensure_unicode
 
-pytestmark = pytest.mark.metadata
-
 SET_CHECK_METADATA_METHOD = 'datadog_checks.base.stubs.datadog_agent.set_check_metadata'
 GET_CONFIG_METHOD = 'datadog_checks.base.stubs.datadog_agent.get_config'
 

--- a/datadog_checks_dev/tests/test_conditions.py
+++ b/datadog_checks_dev/tests/test_conditions.py
@@ -68,7 +68,7 @@ class TestCheckCommandOutput:
 
 
 class TestCheckDockerLogs:
-    pytestmark = [pytest.mark.docker, not_windows_ci]
+    pytestmark = [not_windows_ci]
 
     def test_no_matches(self):
         compose_file = os.path.join(DOCKER_DIR, 'test_default.yaml')

--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -3,14 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
-import pytest
-
 from datadog_checks.dev.docker import compose_file_active, docker_run
 from datadog_checks.dev.subprocess import run_command
 
 from .common import not_windows_ci
 
-pytestmark = [pytest.mark.docker, not_windows_ci]
+pytestmark = [not_windows_ci]
 HERE = os.path.dirname(os.path.abspath(__file__))
 DOCKER_DIR = os.path.join(HERE, 'docker')
 

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_all_required.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_all_required.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_array.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_array.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_both_models_basic.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_both_models_basic.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_common_validators.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_common_validators.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_defaults.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_defaults.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_deprecations.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_deprecations.py
@@ -1,11 +1,7 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from ...utils import get_model_consumer
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_duplicate_hidden.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_duplicate_hidden.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_enum.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_enum.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test_enum_of_strings():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_merge_instances.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_merge_instances.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_nested_option.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_nested_option.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_no_models.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_no_models.py
@@ -1,11 +1,7 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from ...utils import get_model_consumer
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_object_arbitrary_values.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_object_arbitrary_values.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_object_model.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_object_model.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_object_typed_values.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_object_typed_values.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_only_shared.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_only_shared.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_option_name_normalization.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_option_name_normalization.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_union_types.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_union_types.py
@@ -1,13 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev.tooling.configuration.consumers.model.model_consumer import VALIDATORS_DOCUMENTATION
 
 from ...utils import get_model_consumer, normalize_yaml
-
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_model]
 
 
 def test():

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -8,8 +8,6 @@ from datadog_checks.dev.tooling.configuration.consumers.example import DESCRIPTI
 
 from ..utils import get_example_consumer, normalize_yaml
 
-pytestmark = [pytest.mark.conf, pytest.mark.conf_consumer, pytest.mark.conf_consumer_example]
-
 
 def test_option_no_section():
     consumer = get_example_consumer(

--- a/datadog_checks_dev/tests/tooling/configuration/test_load.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_load.py
@@ -1,14 +1,10 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-
 from datadog_checks.dev import TempDir
 from datadog_checks.dev.fs import ensure_parent_dir_exists, path_join, write_file
 
 from .utils import get_spec
-
-pytestmark = pytest.mark.conf
 
 
 def test_cache():

--- a/datadog_checks_dev/tests/tooling/configuration/test_template.py
+++ b/datadog_checks_dev/tests/tooling/configuration/test_template.py
@@ -9,8 +9,6 @@ from datadog_checks.dev import TempDir
 from datadog_checks.dev.fs import ensure_parent_dir_exists, path_join, write_file
 from datadog_checks.dev.tooling.configuration.template import ConfigTemplates
 
-pytestmark = [pytest.mark.conf, pytest.mark.conf_template]
-
 
 class TestLoadBasic:
     def test_default(self):


### PR DESCRIPTION
### What does this PR do?

This PR removes unused pytest markers from the `base` and `dev`.

### Motivation

Unregistered markers trigger warnings when running the tests which results in a few screenfuls of unhelpful warnings. Initially I intended to register the markers to remove the warnings (https://github.com/DataDog/integrations-core/pull/12121) but since the markers don't seem to be used anyway, we might as well remove them.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
