### PR TITLE
Move classifier_tags in test fixtures

### DIFF
--- a/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
@@ -9,15 +9,6 @@ ORACLE_METADATA_CSV_EXAMPLE = [(0, {"metric_name": "oracle.session_count"})]
 
 V2_VALID_MANIFEST = {
     "app_id": "datadog-oracle",
-    "classifier_tags": [
-        "Category::Marketplace",
-        "Category::Cloud",
-        "Category::Log Collection",
-        "Supported OS::Windows",
-        "Supported OS::Mac OS",
-        "Offering::Integration",
-        "Offering::UI Extension",
-    ],
     "assets": {
         "dashboards": {"oracle": "assets/dashboards/example.json"},
         "integration": {
@@ -52,6 +43,15 @@ V2_VALID_MANIFEST = {
         "media": [],
         "overview": "README.md#Overview",
         "title": "Oracle",
+        "classifier_tags": [
+            "Category::Marketplace",
+            "Category::Cloud",
+            "Category::Log Collection",
+            "Supported OS::Windows",
+            "Supported OS::Mac OS",
+            "Offering::Integration",
+            "Offering::UI Extension",
+        ],
     },
 }
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Finish the classifier_tag migration by updating the test fixtures to properly be in the right location

### Motivation
<!-- What inspired you to submit this pull request? -->
Tests were failing since classifier_tags were at the root instead of the new proper location (under tile)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
