### PR TITLE
Add per-client/server metrics

### DIFF
--- a/pgbouncer/assets/configuration/spec.yaml
+++ b/pgbouncer/assets/configuration/spec.yaml
@@ -39,6 +39,22 @@ files:
         value:
           example: true
           type: boolean
+      - name: collect_per_client_metrics
+        description: |
+          Whether to collect detailed per-client metrics.
+
+          This is useful for detailed analysis of client behavior (e.g., wait time).
+        value:
+          example: false
+          type: boolean
+      - name: collect_per_server_metrics
+        description: |
+          Whether to collect detailed per-server metrics.
+
+          This is useful for detailed analysis of server behavior (e.g., last request time).
+        value:
+          example: false
+          type: boolean
       - template: instances/default
   - template: logs
     example:

--- a/pgbouncer/datadog_checks/pgbouncer/config_models/defaults.py
+++ b/pgbouncer/datadog_checks/pgbouncer/config_models/defaults.py
@@ -14,6 +14,14 @@ def shared_service(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_collect_per_client_metrics(field, value):
+    return False
+
+
+def instance_collect_per_server_metrics(field, value):
+    return False
+
+
 def instance_database_url(field, value):
     return 'postgresql://<USERNAME>:<PASSWORD>@<HOSTNAME>:<PORT>/<DATABASE_URL>?sslmode=require'
 

--- a/pgbouncer/datadog_checks/pgbouncer/config_models/instance.py
+++ b/pgbouncer/datadog_checks/pgbouncer/config_models/instance.py
@@ -31,6 +31,8 @@ class InstanceConfig(BaseModel):
     class Config:
         allow_mutation = False
 
+    collect_per_client_metrics: Optional[bool]
+    collect_per_server_metrics: Optional[bool]
     database_url: Optional[str]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]

--- a/pgbouncer/datadog_checks/pgbouncer/data/conf.yaml.example
+++ b/pgbouncer/datadog_checks/pgbouncer/data/conf.yaml.example
@@ -48,6 +48,20 @@ instances:
     #
     # use_cached: true
 
+    ## @param collect_per_client_metrics - boolean - optional - default: false
+    ## Whether to collect detailed per-client metrics.
+    ##
+    ## This is useful for detailed analysis of client behavior (e.g., wait time).
+    #
+    # collect_per_client_metrics: false
+
+    ## @param collect_per_server_metrics - boolean - optional - default: false
+    ## Whether to collect detailed per-server metrics.
+    ##
+    ## This is useful for detailed analysis of server behavior (e.g., last request time).
+    #
+    # collect_per_server_metrics: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/pgbouncer/datadog_checks/pgbouncer/metrics.py
+++ b/pgbouncer/datadog_checks/pgbouncer/metrics.py
@@ -63,3 +63,23 @@ DATABASES_METRICS = {
     ],
     'query': """SHOW DATABASES""",
 }
+
+CLIENTS_METRICS = {
+    'descriptors': [('database', 'db'), ('user', 'user'), ('state', 'state')],
+    'metrics': [
+        ('connect_time', ('pgbouncer.clients.connect_time', GAUGE)),
+        ('request_time', ('pgbouncer.clients.request_time', GAUGE)),
+        ('wait', ('pgbouncer.clients.wait', GAUGE)),  # >= 1.8
+        ('wait_us', ('pgbouncer.clients.wait_us', GAUGE)),  # >= 1.8
+    ],
+    'query': """SHOW CLIENTS""",
+}
+
+SERVERS_METRICS = {
+    'descriptors': [('database', 'db'), ('user', 'user'), ('state', 'state')],
+    'metrics': [
+        ('connect_time', ('pgbouncer.servers.connect_time', GAUGE)),
+        ('request_time', ('pgbouncer.servers.request_time', GAUGE)),
+    ],
+    'query': """SHOW SERVERS""",
+}

--- a/pgbouncer/metadata.csv
+++ b/pgbouncer/metadata.csv
@@ -29,3 +29,9 @@ pgbouncer.pools.maxwait_us,gauge,,microsecond,,Microsecond part of the maximum w
 pgbouncer.databases.pool_size,gauge,,connection,,Maximum number of server connections,0,pgbouncer,database pool size,
 pgbouncer.databases.max_connections,gauge,,connection,,Maximum number of allowed connections,0,pgbouncer,database max conns,
 pgbouncer.databases.current_connections,gauge,,connection,,Current number of connections for this database,0,pgbouncer,database current conns,cpu
+pgbouncer.clients.connect_time,gauge,,second,,"When the connection was made (seconds since epoch)",-1,pgbouncer,client connect time,
+pgbouncer.clients.request_time,gauge,,second,,"When last request was issued (seconds since epoch)",-1,pgbouncer,client request time,
+pgbouncer.clients.wait,gauge,,second,,"Current waiting time in seconds",-1,pgbouncer,client wait,
+pgbouncer.clients.wait_us,gauge,,microsecond,,The microsecond portion of the current waiting time,-1,pgbouncer,client wait,
+pgbouncer.servers.connect_time,gauge,,second,,"When the connection was made (seconds since epoch)",-1,pgbouncer,server connect time,
+pgbouncer.servers.request_time,gauge,,second,,"When last request was issued (seconds since epoch)",-1,pgbouncer,server request time,

--- a/pgbouncer/tests/test_pgbouncer_integration_e2e.py
+++ b/pgbouncer/tests/test_pgbouncer_integration_e2e.py
@@ -46,6 +46,68 @@ def test_check(instance, aggregator, datadog_agent, dd_run_check):
 
 
 @pytest.mark.integration
+@pytest.mark.usefixtures("dd_environment")
+def test_check_with_clients(instance, aggregator, datadog_agent, dd_run_check):
+    # add some stats
+    connection = psycopg2.connect(
+        host=common.HOST,
+        port=common.PORT,
+        user=common.USER,
+        password=common.PASS,
+        database=common.DB,
+        connect_timeout=1,
+    )
+    connection.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+    cur = connection.cursor()
+    cur.execute('SELECT * FROM persons;')
+
+    instance.update(
+        {
+            'collect_per_client_metrics': True,
+        }
+    )
+
+    # run the check
+    check_with_clients = PgBouncer('pgbouncer', {}, [instance])
+    check_with_clients.check_id = 'test:123'
+    dd_run_check(check_with_clients)
+
+    env_version = common.get_version_from_env()
+    assert_metric_coverage(env_version, aggregator, include_clients=True)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("dd_environment")
+def test_check_with_servers(instance, aggregator, datadog_agent, dd_run_check):
+    # add some stats
+    connection = psycopg2.connect(
+        host=common.HOST,
+        port=common.PORT,
+        user=common.USER,
+        password=common.PASS,
+        database=common.DB,
+        connect_timeout=1,
+    )
+    connection.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+    cur = connection.cursor()
+    cur.execute('SELECT * FROM persons;')
+
+    instance.update(
+        {
+            'collect_per_server_metrics': True,
+        }
+    )
+
+    # run the check
+    check_with_servers = PgBouncer('pgbouncer', {}, [instance])
+    check_with_servers.check_id = 'test:123'
+    dd_run_check(check_with_servers)
+
+    env_version = common.get_version_from_env()
+    assert_metric_coverage(env_version, aggregator, include_servers=True)
+
+
+@pytest.mark.integration
 def test_critical_service_check(instance, aggregator, dd_run_check):
     instance['port'] = '123'  # Bad port
     check = PgBouncer('pgbouncer', {}, [instance])
@@ -83,7 +145,7 @@ def test_check_e2e(dd_agent_check, instance):
     assert_metric_coverage(version, aggregator)
 
 
-def assert_metric_coverage(env_version, aggregator):
+def assert_metric_coverage(env_version, aggregator, include_clients=False, include_servers=False):
     aggregator.assert_metric('pgbouncer.pools.cl_active')
     aggregator.assert_metric('pgbouncer.pools.cl_waiting')
     aggregator.assert_metric('pgbouncer.pools.sv_active')
@@ -120,6 +182,17 @@ def assert_metric_coverage(env_version, aggregator):
     aggregator.assert_metric('pgbouncer.databases.current_connections')
 
     aggregator.assert_metric('pgbouncer.max_client_conn')
+
+    if include_clients:
+        aggregator.assert_metric('pgbouncer.clients.connect_time')
+        aggregator.assert_metric('pgbouncer.clients.request_time')
+        if env_version >= version.parse('1.8.0'):
+            aggregator.assert_metric('pgbouncer.clients.wait')
+            aggregator.assert_metric('pgbouncer.clients.wait_us')
+
+    if include_servers:
+        aggregator.assert_metric('pgbouncer.servers.connect_time')
+        aggregator.assert_metric('pgbouncer.servers.request_time')
 
     # Service checks
     sc_tags = ['host:{}'.format(common.HOST), 'port:{}'.format(common.PORT), 'db:pgbouncer', 'optional:tag1']


### PR DESCRIPTION

Because this could potentially bump up the level of data collected a
good bit, we've made these new metrics optionally collected.

Co-authored-by: Lisa Cicatello <cicatello.lisa@gmail.com>

### What does this PR do?
Add optional per-client and per-server connection metrics to the pgbouncer integration.

### Motivation
The pre-summarized metrics provided by pgbouncer are missing critical
information. For example, the `pgbouncer.stats.total_wait_time` metric
only increases when a backend connection is assigned to a client
connection. But that means that currently waiting client connections
aren't included in this metric. There is `pgbouncer.pools.maxwait`, but
there's no way to get more granular information (e.g., average or P95)
or even total currently accumulated wait time.

### Additional Notes
N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
