### PR TITLE
Fix validation for readme images

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/readmes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/readmes.py
@@ -119,7 +119,7 @@ def validate_readme(integration, repo, display_queue, files_failed, readme_count
     for img_src in img_srcs:
         image_name = os.path.split(img_src)[-1]
         file_path = os.path.join(get_root(), integration, "images", image_name)
-        if img_src.startswith("https://raw.githubusercontent") or (img_src.startswith("images/") and allow_relative):
+        if img_src.startswith("https://raw.githubusercontent.com/DataDog") or (img_src.startswith("images/") and allow_relative):
             if not os.path.exists(file_path):
                 files_failed[readme_path] = True
                 display_queue.append(

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/readmes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/readmes.py
@@ -115,11 +115,12 @@ def validate_readme(integration, repo, display_queue, files_failed, readme_count
     allow_relative = False
     if repo == "marketplace":
         allow_relative = True
+    github_path = f"https://raw.githubusercontent.com/DataDog/{repo}"
     img_srcs = [img.attrs.get("src") for img in soup.find_all("img")]
     for img_src in img_srcs:
         image_name = os.path.split(img_src)[-1]
         file_path = os.path.join(get_root(), integration, "images", image_name)
-        if img_src.startswith("https://raw.githubusercontent.com/DataDog") or (img_src.startswith("images/") and allow_relative):
+        if img_src.startswith(github_path) or (img_src.startswith("images/") and allow_relative):
             if not os.path.exists(file_path):
                 files_failed[readme_path] = True
                 display_queue.append(


### PR DESCRIPTION
### What does this PR do?
Fix validation for readme images
### Motivation
Validation is failing for this PR but giving a misleading message: https://github.com/DataDog/integrations-extras/pull/1339/files
```
     image: https://raw.githubusercontent.com/RoadieHQ/roadie-backstage-plugins/main/plugins/frontend/backstage-plugin-datadog/docs/datadog-widget.png is linked in its readme but does not exist
```
Since the image is from github, right now we attempt to look for it in integrations-extras, but it is not there. This updates the validation to only check for images that live in the repo, and otherwise fail validation. Now the error will look like:
```
     All images must be checked into the repo under the `backstage/images` folder. This image path must be in the form: https://raw.githubusercontent.com/DataDog/integrations-extras/master/backstage/images/<IMAGE_NAME> Image currently is: https://raw.githubusercontent.com/RoadieHQ/roadie-backstage-plugins/main/plugins/frontend/backstage-plugin-datadog/docs/datadog-widget.png
```
### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
