### PR TITLE
Update tested versions

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -138,7 +138,7 @@ def docker_run(
     """
     A convenient context manager for safely setting up and tearing down Docker environments.
 
-    - **compose_file** (_str_) - A path to a Docker compose file. A custom tear
+    - **compose_file** (_str_) - A path totests/base/utils/test_http.py a Docker compose file. A custom tear
       down is not required when using this.
     - **build** (_bool_) - Whether or not to build images for when `compose_file` is provided
     - **service_name** (_str_) - Optional name for when ``compose_file`` is provided

--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -13,16 +13,16 @@ redis.aof.loading_loaded_bytes,gauge,,byte,,The amount of bytes to load.,0,redis
 redis.aof.loading_loaded_perc,gauge,,percent,,The percent loaded.,0,redis,aof loaded percent,
 redis.aof.loading_eta_seconds,gauge,,second,,The estimated amount of time left to load.,0,redis,aof loading time left,
 redis.clients.biggest_input_buf,gauge,,,,The biggest input buffer among current client connections [v3 & v4].,0,redis,biggest input buf,
-redis.clients.recent_max_input_buffer,gauge,,,,The biggest input buffer among recent client connections [v>=5].,0,redis,biggest input buf,
+redis.clients.recent_max_input_buffer,gauge,,,,The biggest input buffer among recent client connections [v5+].,0,redis,biggest input buf,
 redis.clients.blocked,gauge,,connection,,The number of connections waiting on a blocking call.,0,redis,clients blocked,memory
 redis.clients.longest_output_list,gauge,,,,The longest output list among current client connections [v3 & v4].,0,redis,long output list,
-redis.clients.recent_max_output_buffer,gauge,,,,The longest output buffer among recent client connections [v>=5].,0,redis,long output list,
+redis.clients.recent_max_output_buffer,gauge,,,,The longest output buffer among recent client connections [v5+].,0,redis,long output list,
 redis.cpu.sys,gauge,,,,System CPU consumed by the Redis server.,-1,redis,cpu sys,cpu
 redis.cpu.sys_children,gauge,,,,System CPU consumed by the background processes.,-1,redis,cpu sys children,
 redis.cpu.user,gauge,,,,User CPU consumed by the Redis server.,-1,redis,cpu user,
 redis.cpu.user_children,gauge,,,,User CPU consumed by the background processes.,-1,redis,cpu user children,
 redis.cpu.sys_main_thread,gauge,,,,System CPU consumed by the Redis server main thread. This metric is only provided by redis >=7.x.,-1,redis,cpu sys main thread,
-redis.cpu.user_main_thread,gauge,,,,User CPU consumed by the Redis server main thread. This metric is only provided by redis >=7.x.,-1,redis,cpu sys main thread,
+redis.cpu.user_main_thread,gauge,,,,User CPU consumed by the Redis server main thread. [v7+].,-1,redis,cpu sys main thread,
 redis.expires,gauge,,key,,The number of keys with an expiration.,0,redis,expires,
 redis.expires.percent,gauge,,percent,,Percentage of total keys with an expiration.,0,redis,expires pct,
 redis.info.latency_ms,gauge,,millisecond,,The latency of the redis INFO command.,0,redis,info latency,cpu
@@ -37,7 +37,7 @@ redis.mem.peak,gauge,,byte,,The peak amount of memory used by Redis.,-1,redis,me
 redis.mem.rss,gauge,,byte,,Amount of memory that Redis allocated as seen by the os.,-1,redis,mem rss,
 redis.mem.used,gauge,,byte,,Amount of memory allocated by Redis.,-1,redis,mem used,memory
 redis.mem.startup,gauge,,byte,,Amount of memory consumed by Redis at startup.,-1,redis,mem startup,
-redis.mem.overhead,gauge,,byte,,Sum of all overheads allocated by Redis for managing its internal datastructures [v>=4].,-1,redis,mem overhead,
+redis.mem.overhead,gauge,,byte,,Sum of all overheads allocated by Redis for managing its internal datastructures [v4+].,-1,redis,mem overhead,
 redis.net.clients,gauge,,connection,,The number of connected clients (excluding slaves).,0,redis,clients,cpu
 redis.net.commands,gauge,,command,,The number of commands processed by the server.,0,redis,net commands,
 redis.net.commands.instantaneous_ops_per_sec,gauge,,command,second,The number of commands processed by the server per second.,0,redis,net commands,cpu

--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -21,7 +21,7 @@ redis.cpu.sys,gauge,,,,System CPU consumed by the Redis server.,-1,redis,cpu sys
 redis.cpu.sys_children,gauge,,,,System CPU consumed by the background processes.,-1,redis,cpu sys children,
 redis.cpu.user,gauge,,,,User CPU consumed by the Redis server.,-1,redis,cpu user,
 redis.cpu.user_children,gauge,,,,User CPU consumed by the background processes.,-1,redis,cpu user children,
-redis.cpu.sys_main_thread,gauge,,,,System CPU consumed by the Redis server main thread. This metric is only provided by redis >=7.x.,-1,redis,cpu sys main thread,
+redis.cpu.sys_main_thread,gauge,,,,System CPU consumed by the Redis server main thread. [v7+].,-1,redis,cpu sys main thread,
 redis.cpu.user_main_thread,gauge,,,,User CPU consumed by the Redis server main thread. [v7+].,-1,redis,cpu sys main thread,
 redis.expires,gauge,,key,,The number of keys with an expiration.,0,redis,expires,
 redis.expires.percent,gauge,,percent,,Percentage of total keys with an expiration.,0,redis,expires pct,

--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -37,7 +37,7 @@ redis.mem.peak,gauge,,byte,,The peak amount of memory used by Redis.,-1,redis,me
 redis.mem.rss,gauge,,byte,,Amount of memory that Redis allocated as seen by the os.,-1,redis,mem rss,
 redis.mem.used,gauge,,byte,,Amount of memory allocated by Redis.,-1,redis,mem used,memory
 redis.mem.startup,gauge,,byte,,Amount of memory consumed by Redis at startup.,-1,redis,mem startup,
-redis.mem.overhead,gauge,,byte,,Sum of all overheads allocated by Redis for managing its internal datastructures.,-1,redis,mem overhead,
+redis.mem.overhead,gauge,,byte,,Sum of all overheads allocated by Redis for managing its internal datastructures [v>=4].,-1,redis,mem overhead,
 redis.net.clients,gauge,,connection,,The number of connected clients (excluding slaves).,0,redis,clients,cpu
 redis.net.commands,gauge,,command,,The number of commands processed by the server.,0,redis,net commands,
 redis.net.commands.instantaneous_ops_per_sec,gauge,,command,second,The number of commands processed by the server per second.,0,redis,net commands,cpu

--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -12,17 +12,17 @@ redis.aof.loading_total_bytes,gauge,,byte,,The total amount of bytes already loa
 redis.aof.loading_loaded_bytes,gauge,,byte,,The amount of bytes to load.,0,redis,aof total bytes loaded,
 redis.aof.loading_loaded_perc,gauge,,percent,,The percent loaded.,0,redis,aof loaded percent,
 redis.aof.loading_eta_seconds,gauge,,second,,The estimated amount of time left to load.,0,redis,aof loading time left,
-redis.clients.biggest_input_buf,gauge,,,,The biggest input buffer among current client connections.,0,redis,biggest input buf,
-redis.clients.recent_max_input_buffer,gauge,,,,The biggest input buffer among recent client connections.,0,redis,biggest input buf,
+redis.clients.biggest_input_buf,gauge,,,,The biggest input buffer among current client connections [v3 & v4].,0,redis,biggest input buf,
+redis.clients.recent_max_input_buffer,gauge,,,,The biggest input buffer among recent client connections [v>=5].,0,redis,biggest input buf,
 redis.clients.blocked,gauge,,connection,,The number of connections waiting on a blocking call.,0,redis,clients blocked,memory
-redis.clients.longest_output_list,gauge,,,,The longest output list among current client connections.,0,redis,long output list,
-redis.clients.recent_max_output_buffer,gauge,,,,The longest output buffer among recent client connections.,0,redis,long output list,
+redis.clients.longest_output_list,gauge,,,,The longest output list among current client connections [v3 & v4].,0,redis,long output list,
+redis.clients.recent_max_output_buffer,gauge,,,,The longest output buffer among recent client connections [v>=5].,0,redis,long output list,
 redis.cpu.sys,gauge,,,,System CPU consumed by the Redis server.,-1,redis,cpu sys,cpu
 redis.cpu.sys_children,gauge,,,,System CPU consumed by the background processes.,-1,redis,cpu sys children,
 redis.cpu.user,gauge,,,,User CPU consumed by the Redis server.,-1,redis,cpu user,
 redis.cpu.user_children,gauge,,,,User CPU consumed by the background processes.,-1,redis,cpu user children,
-redis.cpu.sys_main_thread,gauge,,,,System CPU consumed by the Redis server main thread. This metric is only provided by redis >=6.x.,-1,redis,cpu sys main thread,
-redis.cpu.user_main_thread,gauge,,,,User CPU consumed by the Redis server main thread. This metric is only provided by redis >=6.x.,-1,redis,cpu sys main thread,
+redis.cpu.sys_main_thread,gauge,,,,System CPU consumed by the Redis server main thread. This metric is only provided by redis >=7.x.,-1,redis,cpu sys main thread,
+redis.cpu.user_main_thread,gauge,,,,User CPU consumed by the Redis server main thread. This metric is only provided by redis >=7.x.,-1,redis,cpu sys main thread,
 redis.expires,gauge,,key,,The number of keys with an expiration.,0,redis,expires,
 redis.expires.percent,gauge,,percent,,Percentage of total keys with an expiration.,0,redis,expires pct,
 redis.info.latency_ms,gauge,,millisecond,,The latency of the redis INFO command.,0,redis,info latency,cpu

--- a/redisdb/tests/test_e2e.py
+++ b/redisdb/tests/test_e2e.py
@@ -92,8 +92,6 @@ def test_e2e(dd_agent_check, master_instance):
     if redis_version == 'latest' or int(redis_version) > 6:
         aggregator.assert_metric('redis.cpu.sys_main_thread', count=1, tags=tags)
         aggregator.assert_metric('redis.cpu.user_main_thread', count=1, tags=tags)
-        aggregator.assert_metric('redis.clients.recent_max_input_buffer', count=2, tags=tags)
-        aggregator.assert_metric('redis.clients.recent_max_output_buffer', count=2, tags=tags)
 
     assert_optional_slowlog_metrics(aggregator)
     aggregator.assert_all_metrics_covered()

--- a/redisdb/tests/test_e2e.py
+++ b/redisdb/tests/test_e2e.py
@@ -67,28 +67,6 @@ def assert_common_metrics(aggregator):
 
     aggregator.assert_metric('redis.replication.delay', count=2)
 
-
-@pytest.mark.skipif(os.environ.get('REDIS_VERSION') != '3.2', reason='Test for redisdb v3.2')
-def test_e2e_v_3_2(dd_agent_check, master_instance):
-    aggregator = dd_agent_check(master_instance, rate=True)
-
-    assert_common_metrics(aggregator)
-
-    tags = ['redis_host:{}'.format(common.HOST), 'redis_port:6382', 'redis_role:master']
-    aggregator.assert_metric('redis.clients.biggest_input_buf', count=2, tags=tags)
-    aggregator.assert_metric('redis.clients.longest_output_list', count=2, tags=tags)
-
-    assert_optional_slowlog_metrics(aggregator)
-    assert_all(aggregator)
-
-
-@pytest.mark.skipif(os.environ.get('REDIS_VERSION') != '4.0', reason='Test for redisdb v4.0')
-def test_e2e_v_4_0(dd_agent_check, master_instance):
-    aggregator = dd_agent_check(master_instance, rate=True)
-
-    assert_common_metrics(aggregator)
-
-    tags = ['redis_host:{}'.format(common.HOST), 'redis_port:6382', 'redis_role:master']
     aggregator.assert_metric('redis.clients.biggest_input_buf', count=2, tags=tags)
     aggregator.assert_metric('redis.mem.overhead', count=2, tags=tags)
     aggregator.assert_metric('redis.clients.longest_output_list', count=2, tags=tags)
@@ -98,9 +76,6 @@ def test_e2e_v_4_0(dd_agent_check, master_instance):
     aggregator.assert_metric('redis.active_defrag.misses', count=2, tags=tags)
     aggregator.assert_metric('redis.active_defrag.key_hits', count=2, tags=tags)
     aggregator.assert_metric('redis.active_defrag.key_misses', count=2, tags=tags)
-
-    assert_optional_slowlog_metrics(aggregator)
-    assert_all(aggregator)
 
 
 @pytest.mark.skipif(os.environ.get('REDIS_VERSION') != 'latest', reason='Test for the latest redisdb version')
@@ -110,13 +85,6 @@ def test_e2e_v_latest(dd_agent_check, master_instance):
     assert_common_metrics(aggregator)
 
     tags = ['redis_host:{}'.format(common.HOST), 'redis_port:6382', 'redis_role:master']
-    aggregator.assert_metric('redis.mem.overhead', count=2, tags=tags)
-    aggregator.assert_metric('redis.mem.startup', count=2, tags=tags)
-    aggregator.assert_metric('redis.active_defrag.running', count=2, tags=tags)
-    aggregator.assert_metric('redis.active_defrag.hits', count=2, tags=tags)
-    aggregator.assert_metric('redis.active_defrag.misses', count=2, tags=tags)
-    aggregator.assert_metric('redis.active_defrag.key_hits', count=2, tags=tags)
-    aggregator.assert_metric('redis.active_defrag.key_misses', count=2, tags=tags)
     aggregator.assert_metric('redis.server.io_threads_active', count=2, tags=tags)
     aggregator.assert_metric('redis.stats.io_threaded_reads_processed', count=1, tags=tags)
     aggregator.assert_metric('redis.stats.io_threaded_writes_processed', count=1, tags=tags)

--- a/redisdb/tests/test_e2e.py
+++ b/redisdb/tests/test_e2e.py
@@ -51,51 +51,53 @@ def assert_common_metrics(aggregator):
     aggregator.assert_metric('redis.rdb.last_bgsave_time', count=2, tags=tags)
     aggregator.assert_metric('redis.rdb.changes_since_last', count=2, tags=tags)
 
-    if not is_affirmative(common.CLOUD_ENV):
-        assert_non_cloud_metrics(aggregator, tags)
-
-    tags += ['redis_db:db14']
-    aggregator.assert_metric('redis.expires', count=2, tags=tags)
-    aggregator.assert_metric('redis.expires.percent', count=2, tags=tags)
-    aggregator.assert_metric('redis.persist', count=2, tags=tags)
-    aggregator.assert_metric('redis.persist.percent', count=2, tags=tags)
-    aggregator.assert_metric('redis.keys', count=2, tags=tags)
-
-    aggregator.assert_metric('redis.key.length', count=2, tags=(['key:test_key1', 'key_type:list'] + tags))
-    aggregator.assert_metric('redis.key.length', count=2, tags=(['key:test_key2', 'key_type:list'] + tags))
-    aggregator.assert_metric('redis.key.length', count=2, tags=(['key:test_key3', 'key_type:list'] + tags))
-
-    aggregator.assert_metric('redis.replication.delay', count=2)
-
-    aggregator.assert_metric('redis.clients.biggest_input_buf', count=2, tags=tags)
-    aggregator.assert_metric('redis.mem.overhead', count=2, tags=tags)
-    aggregator.assert_metric('redis.clients.longest_output_list', count=2, tags=tags)
     aggregator.assert_metric('redis.mem.startup', count=2, tags=tags)
     aggregator.assert_metric('redis.active_defrag.running', count=2, tags=tags)
     aggregator.assert_metric('redis.active_defrag.hits', count=2, tags=tags)
     aggregator.assert_metric('redis.active_defrag.misses', count=2, tags=tags)
     aggregator.assert_metric('redis.active_defrag.key_hits', count=2, tags=tags)
     aggregator.assert_metric('redis.active_defrag.key_misses', count=2, tags=tags)
+    aggregator.assert_metric('redis.clients.recent_max_input_buffer', count=2, tags=tags)
+    aggregator.assert_metric('redis.clients.recent_max_output_buffer', count=2, tags=tags)
+    aggregator.assert_metric('redis.mem.overhead', count=2, tags=tags)
+
+    if not is_affirmative(common.CLOUD_ENV):
+        assert_non_cloud_metrics(aggregator, tags)
+
+    tags_with_db = tags + ['redis_db:db14']
+    aggregator.assert_metric('redis.expires', count=2, tags=tags_with_db)
+    aggregator.assert_metric('redis.expires.percent', count=2, tags=tags_with_db)
+    aggregator.assert_metric('redis.persist', count=2, tags=tags_with_db)
+    aggregator.assert_metric('redis.persist.percent', count=2, tags=tags_with_db)
+    aggregator.assert_metric('redis.keys', count=2, tags=tags_with_db)
+
+    aggregator.assert_metric('redis.key.length', count=2, tags=(['key:test_key1', 'key_type:list'] + tags_with_db))
+    aggregator.assert_metric('redis.key.length', count=2, tags=(['key:test_key2', 'key_type:list'] + tags_with_db))
+    aggregator.assert_metric('redis.key.length', count=2, tags=(['key:test_key3', 'key_type:list'] + tags_with_db))
+
+    aggregator.assert_metric('redis.replication.delay', count=2)
 
 
-@pytest.mark.skipif(os.environ.get('REDIS_VERSION') != 'latest', reason='Test for the latest redisdb version')
-def test_e2e_v_latest(dd_agent_check, master_instance):
+def test_e2e(dd_agent_check, master_instance):
+    redis_version = os.environ.get('REDIS_VERSION').split('.')[0]
     aggregator = dd_agent_check(master_instance, rate=True)
-
     assert_common_metrics(aggregator)
 
     tags = ['redis_host:{}'.format(common.HOST), 'redis_port:6382', 'redis_role:master']
-    aggregator.assert_metric('redis.server.io_threads_active', count=2, tags=tags)
-    aggregator.assert_metric('redis.stats.io_threaded_reads_processed', count=1, tags=tags)
-    aggregator.assert_metric('redis.stats.io_threaded_writes_processed', count=1, tags=tags)
-    aggregator.assert_metric('redis.cpu.sys_main_thread', count=1, tags=tags)
-    aggregator.assert_metric('redis.cpu.user_main_thread', count=1, tags=tags)
-    aggregator.assert_metric('redis.clients.recent_max_input_buffer', count=2, tags=tags)
-    aggregator.assert_metric('redis.clients.recent_max_output_buffer', count=2, tags=tags)
+
+    if redis_version == 'latest' or int(redis_version) > 5:
+        aggregator.assert_metric('redis.server.io_threads_active', count=2, tags=tags)
+        aggregator.assert_metric('redis.stats.io_threaded_reads_processed', count=1, tags=tags)
+        aggregator.assert_metric('redis.stats.io_threaded_writes_processed', count=1, tags=tags)
+    if redis_version == 'latest' or int(redis_version) > 6:
+        aggregator.assert_metric('redis.cpu.sys_main_thread', count=1, tags=tags)
+        aggregator.assert_metric('redis.cpu.user_main_thread', count=1, tags=tags)
+        aggregator.assert_metric('redis.clients.recent_max_input_buffer', count=2, tags=tags)
+        aggregator.assert_metric('redis.clients.recent_max_output_buffer', count=2, tags=tags)
 
     assert_optional_slowlog_metrics(aggregator)
-
-    assert_all(aggregator)
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 def assert_non_cloud_metrics(aggregator, tags):
@@ -110,8 +112,3 @@ def assert_optional_slowlog_metrics(aggregator):
     aggregator.assert_metric('redis.slowlog.micros.count', at_least=0)
     aggregator.assert_metric('redis.slowlog.micros.max', at_least=0)
     aggregator.assert_metric('redis.slowlog.micros.median', at_least=0)
-
-
-def assert_all(aggregator):
-    aggregator.assert_all_metrics_covered()
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics())

--- a/redisdb/tox.ini
+++ b/redisdb/tox.ini
@@ -3,15 +3,15 @@ isolated_build = true
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{3.2,4.0,6.0,cloud}
+    py{py27,38}-{5.0,6.0,7.0,cloud}
 
 [testenv]
 ensure_default_envdir = true
 envdir =
-    py27: {toxworkdir}/py27
+    py27: {toxworkdir}/py38
     py38: {toxworkdir}/py38
 description =
-    py{27,38},latest: e2e ready
+    py{py27,38},latest: e2e ready
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
@@ -27,9 +27,9 @@ commands =
 setenv =
     LEGACY_DOCKER_COMPOSE = true
     CLOUD_ENV=false
-    3.2: REDIS_VERSION=3.2
-    4.0: REDIS_VERSION=4.0
+    5.0: REDIS_VERSION=5.5
     6.0: REDIS_VERSION=6.0
+    7.0: REDIS_VERSION=7.0
     cloud: CLOUD_ENV=true
     cloud: REDIS_VERSION=6.0
 

--- a/redisdb/tox.ini
+++ b/redisdb/tox.ini
@@ -3,15 +3,14 @@ isolated_build = true
 minversion = 2.0
 basepython = py38
 envlist =
-    py{py27,38}-{5.0,6.0,7.0,cloud}
+    py{38}-{5.0,6.0,7.0,cloud}
 
 [testenv]
 ensure_default_envdir = true
 envdir =
-    py27: {toxworkdir}/py38
     py38: {toxworkdir}/py38
 description =
-    py{py27,38},latest: e2e ready
+    py{38},latest: e2e ready
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32
@@ -27,11 +26,11 @@ commands =
 setenv =
     LEGACY_DOCKER_COMPOSE = true
     CLOUD_ENV=false
-    5.0: REDIS_VERSION=5.5
+    5.0: REDIS_VERSION=5.0
     6.0: REDIS_VERSION=6.0
     7.0: REDIS_VERSION=7.0
     cloud: CLOUD_ENV=true
-    cloud: REDIS_VERSION=6.0
+    cloud: REDIS_VERSION=7.0
 
 [testenv:latest]
 setenv =


### PR DESCRIPTION
Ensure that the integration works well with 7.0. Ensure version comments on metadata.csv are right.
Refactor e2e test to have a single test instead of per-redis-version tests
Remove old versions from testing, since they are not supported anymore by redis.

> The latest stable release is always fully supported and maintained.
>
> Two additional versions receive maintenance only, meaning that only fixes for critical bugs and major security issues are committed and released as patches:
> 
> * The previous minor version of the latest stable release.
> * The previous stable major release.

Source: https://redis.io/docs/about/releases/#support