### PR TITLE
Update the wording for the curated_metrics metadata.csv column

### DIFF
--- a/docs/dev/check_references.md
+++ b/docs/dev/check_references.md
@@ -202,7 +202,7 @@ Descriptions of each column of the `metadata.csv` file:
 | `orientation`   | Mandatory          | Set to `1` if the metric should go up, i.e `myapp.turnover`. Set to `0` if the metric variations are irrelevant. Set to `-1` if the metric should go down, i.e `myapp.latency`.                                                                                                                                                         |
 | `integration`   | Mandatory          | The name of the integration that emits the metric. Must be the normalized version of the `display_name` from the `manifest.json` file. Any character besides letters, underscores, dashes, and numbers are converted to underscores, for example: `Openstack Controller` -> `openstack_controller`and `ASP.NET` -> `asp_net` and `CRI-o` -> `cri-o`. |
 | `short_name`    | Mandatory          | Explicit Unique ID for the metric.                                                                                                                                                                                                                                                                                                      |
-| `curated_metric`| Optional           | Mark which metrics for an integration are noteworthy for a given type (`cpu` and `memory` are both accepted). These are displayed in the UI above the other integration metrics.
+| `curated_metric`| Optional           | Marks which metrics for an integration are noteworthy for a given type (`cpu` and `memory` are both accepted). These are displayed in the UI above the other integration metrics.
 
 
 [1]: https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md

--- a/docs/dev/check_references.md
+++ b/docs/dev/check_references.md
@@ -202,7 +202,7 @@ Descriptions of each column of the `metadata.csv` file:
 | `orientation`   | Mandatory          | Set to `1` if the metric should go up, i.e `myapp.turnover`. Set to `0` if the metric variations are irrelevant. Set to `-1` if the metric should go down, i.e `myapp.latency`.                                                                                                                                                         |
 | `integration`   | Mandatory          | The name of the integration that emits the metric. Must be the normalized version of the `display_name` from the `manifest.json` file. Any character besides letters, underscores, dashes, and numbers are converted to underscores, for example: `Openstack Controller` -> `openstack_controller`and `ASP.NET` -> `asp_net` and `CRI-o` -> `cri-o`. |
 | `short_name`    | Mandatory          | Explicit Unique ID for the metric.                                                                                                                                                                                                                                                                                                      |
-| `curated_metric`| Optional           | Marks the metric as noteworthy for a given type (`cpu` and `memory` are both accepted types).
+| `curated_metric`| Optional           | Mark which metrics for an integration are noteworthy for a given type (`cpu` and `memory` are both accepted). These are displayed in the UI above the other integration metrics.
 
 
 [1]: https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
### What does this PR do?
We can update the wording of the curated metrics description under the [Metrics metadata file](https://docs.datadoghq.com/developers/integrations/check_references/?tab=manifestversion2#metrics-metadata-file) section to be more descriptive.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
