### PR TITLE
Check for missing assets on validation (saved views and config)

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/config.py
@@ -66,6 +66,10 @@ def config(ctx, check, sync, verbose):
 
         spec_file_path = manifest.get_config_spec()
         if not file_exists(spec_file_path):
+            check_display_queue.append(
+                lambda: echo_warning(f"Did not find spec file {spec_file_path} for check {check}")
+            )
+
             validate_config_legacy(check, check_display_queue, files_failed, files_warned, file_counter)
             if verbose:
                 check_display_queue.append(lambda: echo_warning('No spec found', indent=True))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/saved_views.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/saved_views.py
@@ -58,7 +58,7 @@ def saved_views(check):
     echo_info(f"Validating saved views for {len(integrations)} checks ...")
 
     for integration in integrations:
-        saved_views, _ = get_assets_from_manifest(integration, 'saved_views')
+        saved_views, non_existing = get_assets_from_manifest(integration, 'saved_views')
 
         for saved_view in saved_views:
             display_queue = []
@@ -192,6 +192,10 @@ def saved_views(check):
                 annotate_display_queue(saved_view, display_queue)
                 for func, message in display_queue:
                     func(message)
+
+        for saved_view in non_existing:
+            errors = True
+            echo_failure(f"{integration} saved view does not exist: {saved_view}")
 
     if errors:
         abort()


### PR DESCRIPTION
### What does this PR do?

Saved views validations didn't report failures when a file in the manifest is not found, as opposed to most of the other asset validation, and this fixes that.

This also adds a warning when the config spec is not found.
### Motivation

[AI-2334](https://datadoghq.atlassian.net/browse/AI-2334)

### Additional Notes

This is currently hard to write tests for, so it was tested manually.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
