### PR TITLE
Update ddtrace dependency to 1.1.4

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -21,7 +21,7 @@ cryptography==3.4.8; python_version > '3.0'
 cx-oracle==7.3.0; python_version < '3.0'
 cx-oracle==8.3.0; python_version > '3.0'
 ddtrace==0.32.2; sys_platform == 'win32' and python_version < '3.0'
-ddtrace==0.53.2; sys_platform != 'win32' or python_version > '3.0'
+ddtrace==1.1.4; sys_platform != 'win32' or python_version > '3.0'
 dnspython==1.16.0
 enum34==1.1.10; python_version < '3.0'
 foundationdb==6.3.24; python_version > '3.0'

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -44,7 +44,7 @@ deps = [
     "cryptography==3.3.2; python_version < '3.0'",
     "cryptography==3.4.8; python_version > '3.0'",
     "ddtrace==0.32.2; sys_platform == 'win32' and python_version < '3.0'",
-    "ddtrace==0.53.2; sys_platform != 'win32' or python_version > '3.0'",
+    "ddtrace==1.1.4; sys_platform != 'win32' or python_version > '3.0'",
     "enum34==1.1.10; python_version < '3.0'",
     "immutables==0.17; python_version > '3.0'",
     "ipaddress==1.0.23; python_version < '3.0'",


### PR DESCRIPTION
### What does this PR do?

Update `ddtrace` dependency to latest stable version (1.1.4).

### Motivation

Apart from staying up to date, the original motivation for this was that I couldn't run py27 tests locally on an M1 due to this dependency, and I found that using a newer version solved the problem.

### Additional Notes

This PR doesn't update the dependency for windows py2.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
