### PR TITLE
Fix missing import in PHP-FPM's check

### DIFF
--- a/php_fpm/datadog_checks/php_fpm/vendor/fcgi_app.py
+++ b/php_fpm/datadog_checks/php_fpm/vendor/fcgi_app.py
@@ -28,6 +28,7 @@ __author__ = 'Allan Saddi <allan@saddi.com>'
 __version__ = '$Revision$'
 
 import select
+import sys
 import struct
 import socket
 import errno


### PR DESCRIPTION
### What does this PR do?
This PR fixes the PHP-FPM status read out using FastCGI. `sys` is used in determining the default encoding when retrieving the data on `FCGI_STDERR` in Python 3. Failing to import it causes the plugin to crash.

### Motivation
We'd like to collect metrics from & monitor our PHP-FPM instances using DataDog, but we don't want to expose those metrics using HTTP.

### Additional Notes
There are no tests for handling the UNIX path case, but we configured our instances such that they are only accessible by a UNIX socket. I'm unsure as to how to add those tests. If you _need_ tests, I'd like to give a try adding them.

I've also searched the issue list before creating this PR, and it seems #11480 was already created but closed, due to the fact that the bug report was incomplete.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
