### PR TITLE
Fix reading of `token_path` option

### DIFF
--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -85,7 +85,7 @@ class SnowflakeCheck(AgentCheck):
     def read_token(self):
         if self._config.token_path:
             self.log.debug("Renewing Snowflake client token")
-            with open(self._config.token_path, 'rb', encoding="UTF-8") as f:
+            with open(self._config.token_path, 'rb') as f:
                 self._config.token = f.read()
 
         return self._config.token

--- a/snowflake/tests/keys/token
+++ b/snowflake/tests/keys/token
@@ -1,0 +1,1 @@
+testtoken

--- a/snowflake/tests/test_unit.py
+++ b/snowflake/tests/test_unit.py
@@ -60,7 +60,7 @@ def test_invalid_oauth(oauth_instance):
         SnowflakeCheck(CHECK_NAME, {}, [oauth_inst])
 
 
-def test_read_token(oauth_instance, dd_run_check):
+def test_read_token(oauth_instance):
     oauth_token_path_inst = copy.deepcopy(oauth_instance)
     oauth_token_path_inst['token'] = None
     oauth_token_path_inst['token_path'] = os.path.join(os.path.dirname(__file__), 'keys', 'token')

--- a/snowflake/tests/test_unit.py
+++ b/snowflake/tests/test_unit.py
@@ -60,6 +60,14 @@ def test_invalid_oauth(oauth_instance):
         SnowflakeCheck(CHECK_NAME, {}, [oauth_inst])
 
 
+def test_read_token(oauth_instance, dd_run_check):
+    oauth_token_path_inst = copy.deepcopy(oauth_instance)
+    oauth_token_path_inst['token'] = None
+    oauth_token_path_inst['token_path'] = os.path.join(os.path.dirname(__file__), 'keys', 'token')
+    check = SnowflakeCheck(CHECK_NAME, {}, [oauth_token_path_inst])
+    check.read_token()
+
+
 def test_default_auth(instance):
     check = SnowflakeCheck(CHECK_NAME, {}, [instance])
     check._conn = mock.MagicMock()


### PR DESCRIPTION
### What does this PR do?
The `open` method with `binary` mode, does not accept an `encoding` argument. Removes the unnecessary `encoding` argument.

### Motivation
Support case
Fixes the error: `ValueError: binary mode doesn't take an encoding argument`

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
