### PR TITLE
ECS Fargate cleanup for deployment tabs, instructions, and samples

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -55,8 +55,8 @@ The instructions below show you how to configure the task using the [Amazon Web 
     4. Add another environment variable using the **Key** `ECS_FARGATE` and the value `true`. Click **Add** to add the container.
     5. Add another environment variable using the **Key** `DD_SITE` and the value {{< region-param key="dd_site" code="true" >}}. This defaults to `datadoghq.com` if you don't set it.
     6. (Windows Only) Select `C:\` as the working directory.
-11. Add your other application containers to the task definition. For details on collecting integration metrics, see [Integration Setup for ECS Fargate][3].
-12. Click **Create** to create the task definition.
+5. Add your other application containers to the task definition. For details on collecting integration metrics, see [Integration Setup for ECS Fargate][3].
+6. Click **Create** to create the task definition.
 
 [1]: https://aws.amazon.com/console
 [2]: https://app.datadoghq.com/organization-settings/api-keys
@@ -85,7 +85,7 @@ aws ecs register-task-definition --cli-input-json file://<PATH_TO_FILE>/datadog-
 
 You can use [AWS CloudFormation][1] templating to configure your Fargate containers. Use the `AWS::ECS::TaskDefinition` resource within your CloudFormation template to set the Amazon ECS task and specify `FARGATE` as the required launch type for that task.
 
-Update this this CloudFormation template below with your [Datadog API Key][2]. As well as include the appropriate `DD_SITE` ({{< region-param key="dd_site" code="true" >}}) environment variable if necessary, as this defaults to `datadoghq.com` if you don't set it.
+Update this CloudFormation template below with your [Datadog API Key][2]. As well as include the appropriate `DD_SITE` ({{< region-param key="dd_site" code="true" >}}) environment variable if necessary, as this defaults to `datadoghq.com` if you don't set it.
 
 ```yaml
 Resources:
@@ -277,7 +277,7 @@ Datadog's default CloudWatch crawler polls metrics once every 10 minutes. If you
 ### Log collection
 
 You can monitor Fargate logs by using either:
-- The AWS FireLens integration built on Datadog's Fluentbit output plugin to send logs directly to Datadog
+- The AWS FireLens integration built on Datadog's Fluent Bit output plugin to send logs directly to Datadog
 - Using the `awslogs` log driver to store the logs in a CloudWatch Log Group, and then a Lambda function to route logs to Datadog
 
 Datadog recommends using AWS FireLens because you can configure Fluent Bit directly in your Fargate tasks.
@@ -300,7 +300,7 @@ Configure the AWS FireLens integration built on Datadog's Fluent Bit output plug
    }
    ```
 
-    If your containers are publishing serialized JSON logs over stdout, you should use this [extra firelens configuration][23] to get them correctly parsed within Datadog:
+    If your containers are publishing serialized JSON logs over stdout, you should use this [extra FireLens configuration][23] to get them correctly parsed within Datadog:
 
    ```json
    {
@@ -426,7 +426,7 @@ Configure the AWS FireLens integration built on Datadog's Fluent Bit output plug
   ```
 {{< /site-region >}}
 
-  **Note**: Set your `apikey` as well as the `Host` relative to your respective site `http-intake.logs.{{< region-param key="dd_site" code="true" >}}`. The full list of available parameters is described in the [Datadog Fluentbit documentation][24].
+  **Note**: Set your `apikey` as well as the `Host` relative to your respective site `http-intake.logs.{{< region-param key="dd_site" code="true" >}}`. The full list of available parameters is described in the [Datadog Fluent Bit documentation][24].
 
   The `dd_service`, `dd_source`, and `dd_tags` can be adjusted for your desired tags.
 
@@ -436,7 +436,7 @@ Configure the AWS FireLens integration built on Datadog's Fluent Bit output plug
 {{% tab "Web UI" %}}
 ##### Web UI
 
-To add the FluentBit container to your existing Task Definition check the **Enable FireLens integration** checkbox under **Log router integration** to automatically create the `log_router` container for you. This pulls the regional image, however, we do recommend to use the `stable` image tag instead of `latest`. Once you click **Apply** this creates the base container. To further customize the `firelensConfiguration` click the **Configure via JSON** button at the bottom to edit this manually.
+To add the Fluent Bit container to your existing Task Definition check the **Enable FireLens integration** checkbox under **Log router integration** to automatically create the `log_router` container for you. This pulls the regional image, however, we do recommend to use the `stable` image tag instead of `latest`. Once you click **Apply** this creates the base container. To further customize the `firelensConfiguration` click the **Configure via JSON** button at the bottom to edit this manually.
 
 After this has been added edit the application container in your Task Definition that you want to submit logs from and change the **Log driver** to `awsfirelens` filling in the **Log options** with the keys shown in the above example.
 

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -225,20 +225,16 @@ For environment variables available with the Docker Agent container, see the [Do
 | Environment Variable               | Description                                    |
 |------------------------------------|------------------------------------------------|
 | `DD_DOCKER_LABELS_AS_TAGS`         | Extract docker container labels                |
-| `DD_CONTAINER_LABELS_AS_TAGS`      | Extract container labels                       |
-| `DD_DOCKER_ENV_AS_TAGS`            | Extract docker container environment variables |
-| `DD_CONTAINER_ENV_AS_TAGS`         | Extract container environment variables        |
-| `DD_KUBERNETES_POD_LABELS_AS_TAGS` | Extract pod labels                             |
 | `DD_CHECKS_TAG_CARDINALITY`        | Add tags to check metrics                      |
 | `DD_DOGSTATSD_TAG_CARDINALITY`     | Add tags to custom metrics                     |
 
-For global tagging, it is recommended to use `DD_CONTAINER_LABELS_AS_TAGS`. With this method, the Agent pulls in tags from your container labels. This requires you to add the appropriate labels to your other containers. Labels can be added directly in the [task definition][15].
+For global tagging, it is recommended to use `DD_DOCKER_LABELS_AS_TAGS`. With this method, the Agent pulls in tags from your container labels. This requires you to add the appropriate labels to your other containers. Labels can be added directly in the [task definition][15].
 
 Format for the Agent container:
 
 ```json
 {
-  "name": "DD_CONTAINER_LABELS_AS_TAGS",
+  "name": "DD_DOCKER_LABELS_AS_TAGS",
   "value": "{\"<LABEL_NAME_TO_COLLECT>\":\"<TAG_KEY_FOR_DATADOG>\"}"
 }
 ```
@@ -247,7 +243,7 @@ Example for the Agent container:
 
 ```json
 {
-  "name": "DD_CONTAINER_LABELS_AS_TAGS",
+  "name": "DD_DOCKER_LABELS_AS_TAGS",
   "value": "{\"com.docker.compose.service\":\"service_name\"}"
 }
 ```
@@ -258,7 +254,7 @@ CloudFormation example (YAML):
       ContainerDefinitions:
         - #(...)
           Environment:
-            - Name: DD_CONTAINER_LABELS_AS_TAGS
+            - Name: DD_DOCKER_LABELS_AS_TAGS
               Value: "{\"com.docker.compose.service\":\"service_name\"}"
 ```
 

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -42,13 +42,13 @@ The instructions below show you how to configure the task using the [Amazon Web 
 ##### Web UI Task Definition
 
 1. Log in to your [AWS Web Console][1] and navigate to the ECS section.
-2. Click on **Task Definitions** in the left menu, then click the **Create new Task Definition** button or choose an existing Fargate task definition
+2. Click on **Task Definitions** in the left menu, then click the **Create new Task Definition** button or choose an existing Fargate task definition.
 3. For new task definitions:
     1. Select **Fargate** as the launch type, then click the **Next step** button.
     2. Enter a **Task Definition Name**, such as `my-app-and-datadog`.
     3. Select a task execution IAM role. See permission requirements in the [Create or Modify your IAM Policy](#create-or-modify-your-iam-policy) section below.
     4. Choose **Task memory** and **Task CPU** based on your needs.
-4. Click the **Add container** button to begin adding the Datadog agent container
+4. Click the **Add container** button to begin adding the Datadog Agent container.
     1. For **Container name** enter `datadog-agent`.
     2. For **Image** enter `public.ecr.aws/datadog/agent:latest`.
     3. For **Env Variables**, add the **Key** `DD_API_KEY` and enter your [Datadog API Key][2] as the value.

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -11,9 +11,9 @@ Get metrics from all your containers running in ECS Fargate:
 
 The Datadog Agent retrieves metrics for the task definition's containers with the ECS task metadata endpoint. According to the [ECS Documentation][2] on that endpoint:
 
-> This endpoint returns Docker stats JSON for all of the containers associated with the task. For more information about each of the returned stats, see [ContainerStats][3] in the Docker API documentation.
+- This endpoint returns Docker stats JSON for all of the containers associated with the task. For more information about each of the returned stats, see [ContainerStats][3] in the Docker API documentation.
 
-The Task Metadata endpoint is only available from within the task definition itself, which is why the Datadog Agent needs to be run as an additional container within the task definition.
+The Task Metadata endpoint is only available from within the task definition itself, which is why the Datadog Agent needs to be run as an additional container within each task definition to be monitored.
 
 The only configuration required to enable this metrics collection is to set an environment variable `ECS_FARGATE` to `"true"` in the task definition.
 
@@ -25,7 +25,7 @@ Tasks that do not have the Datadog Agent still report metrics with Cloudwatch, h
 
 ### Installation
 
-To monitor your ECS Fargate tasks with Datadog, run the Agent as a container in same task definition as your application. To collect metrics with Datadog, each task definition should include a Datadog Agent container in addition to the application containers. Follow these setup steps:
+To monitor your ECS Fargate tasks with Datadog, run the Agent as a container in **same task definition** as your application container. To collect metrics with Datadog, each task definition should include a Datadog Agent container in addition to the application containers. Follow these setup steps:
 
 1. **Create an ECS Fargate task**
 2. **Create or Modify your IAM Policy**
@@ -35,67 +35,95 @@ To monitor your ECS Fargate tasks with Datadog, run the Agent as a container in 
 
 The primary unit of work in Fargate is the task, which is configured in the task definition. A task definition is comparable to a pod in Kubernetes. A task definition must contain one or more containers. In order to run the Datadog Agent, create your task definition to run your application container(s), as well as the Datadog Agent container.
 
-The instructions below show you how to configure the task using the [AWS CLI tools][4] or the [Amazon Web Console][5].
+The instructions below show you how to configure the task using the [Amazon Web Console][4], [AWS CLI tools][5], or [AWS CloudFormation][6].
 
-##### Web UI
+{{< tabs >}}
+{{% tab "Web UI" %}}
+##### Web UI Task Definition
 
-1. Log in to your [AWS Web Console][5] and navigate to the ECS section.
-2. Click on **Task Definitions** in the left menu, then click the **Create new Task Definition** button.
-3. Select **Fargate** as the launch type, then click the **Next step** button.
-4. Enter a **Task Definition Name**, such as `my-app-and-datadog`.
-5. Select a task execution IAM role. See permission requirements in the [Create or Modify your IAM Policy](#create-or-modify-your-iam-policy) section below.
-6. Choose **Task memory** and **Task CPU** based on your needs.
-7. Click the **Add container** button.
-8. For **Container name** enter `datadog-agent`.
-9. For **Image** enter `datadog/agent:latest`.
-10. For **Memory Limits** enter `256` soft limit.
-11. Scroll down to the **Advanced container configuration** section and enter `10` in **CPU units**.
-12. For **Env Variables**, add the **Key** `DD_API_KEY` and enter your [Datadog API Key][6] as the value. _If you feel more comfortable storing secrets in s3, see the [ECS Configuration guide][7]._
-13. Add another environment variable using the **Key** `ECS_FARGATE` and the value `true`. Click **Add** to add the container.
-14. Add another environment variable using the **Key** `DD_SITE` and the value {{< region-param key="dd_site" code="true" >}}. This defaults to `datadoghq.com` if you don't set it.
-15. (Windows Only) Select `C:\` as the working directory.
-16. Add your other containers such as your app. For details on collecting integration metrics, see [Integration Setup for ECS Fargate][8].
-17. Click **Create** to create the task definition.
+1. Log in to your [AWS Web Console][1] and navigate to the ECS section.
+2. Click on **Task Definitions** in the left menu, then click the **Create new Task Definition** button or choose an existing Fargate task definition
+3. For new task definitions:
+    1. Select **Fargate** as the launch type, then click the **Next step** button.
+    2. Enter a **Task Definition Name**, such as `my-app-and-datadog`.
+    3. Select a task execution IAM role. See permission requirements in the [Create or Modify your IAM Policy](#create-or-modify-your-iam-policy) section below.
+    4. Choose **Task memory** and **Task CPU** based on your needs.
+4. Click the **Add container** button to begin adding the Datadog agent container
+    1. For **Container name** enter `datadog-agent`.
+    2. For **Image** enter `public.ecr.aws/datadog/agent:latest`.
+    3. For **Env Variables**, add the **Key** `DD_API_KEY` and enter your [Datadog API Key][2] as the value.
+    4. Add another environment variable using the **Key** `ECS_FARGATE` and the value `true`. Click **Add** to add the container.
+    5. Add another environment variable using the **Key** `DD_SITE` and the value {{< region-param key="dd_site" code="true" >}}. This defaults to `datadoghq.com` if you don't set it.
+    6. (Windows Only) Select `C:\` as the working directory.
+11. Add your other application containers to the task definition. For details on collecting integration metrics, see [Integration Setup for ECS Fargate][3].
+12. Click **Create** to create the task definition.
 
-##### AWS CLI
+[1]: https://aws.amazon.com/console
+[2]: https://app.datadoghq.com/organization-settings/api-keys
+[3]: http://docs.datadoghq.com/integrations/faq/integration-setup-ecs-fargate
+{{% /tab %}}
 
-1. Download [datadog-agent-ecs-fargate][9]. **Note**: If you are using Internet Explorer, this may download as gzip file, which contains the JSON file mentioned below.**
-2. Update the JSON with a `TASK_NAME`, your [Datadog API Key][6], and the appropriate `DD_SITE` ({{< region-param key="dd_site" code="true" >}}). **Note**: The environment variable `ECS_FARGATE` is already set to `"true"`.
-3. Add your other containers such as your app. For details on collecting integration metrics, see [Integration Setup for ECS Fargate][8].
+{{% tab "AWS CLI" %}}
+##### AWS CLI Task Definition
+
+1. Download [datadog-agent-ecs-fargate][1]. **Note**: If you are using Internet Explorer, this may download as gzip file, which contains the JSON file mentioned below.**
+2. Update the JSON with a `TASK_NAME`, your [Datadog API Key][2], and the appropriate `DD_SITE` ({{< region-param key="dd_site" code="true" >}}). **Note**: The environment variable `ECS_FARGATE` is already set to `"true"`.
+3. Add your other application containers to the task definition. For details on collecting integration metrics, see [Integration Setup for ECS Fargate][3].
 4. Execute the following command to register the ECS task definition:
 
 ```bash
 aws ecs register-task-definition --cli-input-json file://<PATH_TO_FILE>/datadog-agent-ecs-fargate.json
 ```
 
-##### AWS CloudFormation
+[1]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs-fargate.json
+[2]: https://app.datadoghq.com/organization-settings/api-keys
+[3]: http://docs.datadoghq.com/integrations/faq/integration-setup-ecs-fargate
+{{% /tab %}}
 
-You can use [AWS CloudFormation][10] templating to configure your Fargate containers. Use the `AWS::ECS::TaskDefinition` resource within your CloudFormation template to set the Amazon ECS task and specify `FARGATE` as the required launch type for that task. 
+{{% tab "CloudFormation" %}}
+##### AWS CloudFormation Task Definition
 
-For example:
+You can use [AWS CloudFormation][1] templating to configure your Fargate containers. Use the `AWS::ECS::TaskDefinition` resource within your CloudFormation template to set the Amazon ECS task and specify `FARGATE` as the required launch type for that task.
+
+Update this this CloudFormation template below with your [Datadog API Key][2]. As well as include the appropriate `DD_SITE` ({{< region-param key="dd_site" code="true" >}}) environment variable if necessary, as this defaults to `datadoghq.com` if you don't set it.
 
 ```yaml
 Resources:
-  ECSTDNJH3:
+  ECSTaskDefinition:
     Type: 'AWS::ECS::TaskDefinition'
     Properties:
       NetworkMode: awsvpc
       RequiresCompatibilities:
-          - FARGATE
+        - FARGATE
       Cpu: 256
-      Memory: 1GB
+      Memory: 512
       ContainerDefinitions:
         - Name: datadog-agent
           Image: 'public.ecr.aws/datadog/agent:latest'
-          Cpu: 100
-          Memory: 256MB
+          Environment:
+            - Name: DD_API_KEY
+              Value: <DATADOG_API_KEY>
+            - Name: ECS_FARGATE
+              Value: true
 ```
 
-For more information on CloudFormation templating and syntax, see the [AWS CloudFormation documentation][12].
+Lastly, include your other application containers within the `ContainerDefinitions` and deploy through CloudFormation.
+
+For more information on CloudFormation templating and syntax, see the [AWS CloudFormation task definition documentation][3].
+
+
+[1]: https://aws.amazon.com/cloudformation/
+[2]: https://app.datadoghq.com/organization-settings/api-keys
+[3]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html
+{{% /tab %}}
+
+{{< /tabs >}}
+
+For all of these examples the `DD_API_KEY` environment variable can alternatively be populated by referencing the the [ARN of a "Plaintext" secret stored in AWS Secret Manager][7].
 
 #### Create or modify your IAM policy
 
-Add the following permissions to your [Datadog IAM policy][13] to collect ECS Fargate metrics. For more information, see the [ECS policies][14] on the AWS website.
+Add the following permissions to your [Datadog IAM policy][8] to collect ECS Fargate metrics. For more information, see the [ECS policies][9] on the AWS website.
 
 | AWS Permission                   | Description                                                       |
 | -------------------------------- | ----------------------------------------------------------------- |
@@ -105,11 +133,32 @@ Add the following permissions to your [Datadog IAM policy][13] to collect ECS Fa
 
 #### Run the task as a replica service
 
-The only option in ECS Fargate is to run the task as a [Replica Service][15]. The Datadog Agent runs in the same task definition as your application and integration containers.
+The only option in ECS Fargate is to run the task as a [Replica Service][10]. The Datadog Agent runs in the same task definition as your application and integration containers.
 
-##### AWS CLI
+{{< tabs >}}
+{{% tab "Web UI" %}}
+##### Web UI Replica Service
 
-Run the following commands using the [AWS CLI tools][4].
+1. Log in to your [AWS Web Console][1] and navigate to the ECS section. If needed, create a cluster with the **Networking only** cluster template.
+2. Choose the cluster to run the Datadog Agent on.
+3. On the **Services** tab, click the **Create** button.
+4. For **Launch type**, choose **FARGATE**.
+5. For **Task Definition**, select the task created in the previous steps.
+6. Enter a **Service name**.
+7. For **Number of tasks** enter `1`, then click the **Next step** button.
+8. Select the **Cluster VPC**, **Subnets**, and **Security Groups**.
+9. **Load balancing** and **Service discovery** are optional based on your preference.
+10. Click the **Next step** button.
+11. **Auto Scaling** is optional based on your preference.
+12. Click the **Next step** button, then click the **Create service** button.
+
+[1]: https://aws.amazon.com/console
+{{% /tab %}}
+
+{{% tab "AWS CLI" %}}
+##### AWS CLI Replica Service
+
+Run the following commands using the [AWS CLI tools][1].
 
 **Note**: Fargate version 1.1.0 or greater is required, so the command below specifies the platform version.
 
@@ -128,36 +177,49 @@ aws ecs run-task --cluster <CLUSTER_NAME> \
 --region <AWS_REGION> --launch-type FARGATE --platform-version 1.4.0
 ```
 
-##### Web UI
+[1]: https://aws.amazon.com/cli
+{{% /tab %}}
 
-1. Log in to your [AWS Web Console][5] and navigate to the ECS section. If needed, create a cluster with the **Networking only** cluster template.
-2. Choose the cluster to run the Datadog Agent on.
-3. On the **Services** tab, click the **Create** button.
-4. For **Launch type**, choose **FARGATE**.
-5. For **Task Definition**, select the task created in the previous steps.
-6. Enter a **Service name**.
-7. For **Number of tasks** enter `1`, then click the **Next step** button.
-8. Select the **Cluster VPC**, **Subnets**, and **Security Groups**.
-9. **Load balancing** and **Service discovery** are optional based on your preference.
-10. Click the **Next step** button.
-11. **Auto Scaling** is optional based on your preference.
-12. Click the **Next step** button, then click the **Create service** button.
+{{% tab "CloudFormation" %}}
+##### AWS CloudFormation Replica Service
 
+In the CloudFormation template you can reference the `ECSTaskDefinition` resource created in the previous example into the `AWS::ECS::Service` resource being created. After this specify your `Cluster`, `DesiredCount`, and any other parameters necessary for your application in your replica service.
+
+```yaml
+Resources:
+  ECSTaskDefinition:
+    #(...)
+  ECSService:
+    Type: 'AWS::ECS::Service'
+    Properties:
+      Cluster: <CLUSTER_NAME>
+      TaskDefinition:
+        Ref: "ECSTaskDefinition"
+      DesiredCount: 1
+      #(...)
+```
+
+For more information on CloudFormation templating and syntax, see the [AWS CloudFormation ECS service documentation][1].
+
+[1]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html
+{{% /tab %}}
+
+{{< /tabs >}}
 ### Metric collection
 
-After the Datadog Agent is setup as described above, the [ecs_fargate check][16] collects metrics with autodiscovery enabled. Add Docker labels to your other containers in the same task to collect additional metrics.
+After the Datadog Agent is setup as described above, the [ecs_fargate check][11] collects metrics with autodiscovery enabled. Add Docker labels to your other containers in the same task to collect additional metrics.
 
-For details on collecting integration metrics, see [Integration Setup for ECS Fargate][8].
+For details on collecting integration metrics, see [Integration Setup for ECS Fargate][12].
 
 #### DogStatsD
 
-Metrics are collected with [DogStatsD][17] through UDP port 8125.
+Metrics are collected with [DogStatsD][13] through UDP port 8125.
 
 To send custom metrics by listening to DogStatsD packets from other containers, set the environment variable `DD_DOGSTATSD_NON_LOCAL_TRAFFIC` to `true` within the Datadog Agent container.
 
 #### Other environment variables
 
-For environment variables available with the Docker Agent container, see the [Docker Agent][18] page. **Note**: Some variables are not be available for Fargate.
+For environment variables available with the Docker Agent container, see the [Docker Agent][14] page. **Note**: Some variables are not be available for Fargate.
 
 
 | Environment Variable               | Description                                    |
@@ -170,7 +232,7 @@ For environment variables available with the Docker Agent container, see the [Do
 | `DD_CHECKS_TAG_CARDINALITY`        | Add tags to check metrics                      |
 | `DD_DOGSTATSD_TAG_CARDINALITY`     | Add tags to custom metrics                     |
 
-For global tagging, it is recommended to use `DD_CONTAINER_LABELS_AS_TAGS`. With this method, the Agent pulls in tags from your container labels. This requires you to add the appropriate labels to your other containers. Labels can be added directly in the [task definition][19].
+For global tagging, it is recommended to use `DD_CONTAINER_LABELS_AS_TAGS`. With this method, the Agent pulls in tags from your container labels. This requires you to add the appropriate labels to your other containers. Labels can be added directly in the [task definition][15].
 
 Format for the Agent container:
 
@@ -194,7 +256,7 @@ CloudFormation example (YAML):
 
 ```yaml
       ContainerDefinitions:
-        - 
+        - #(...)
           Environment:
             - Name: DD_CONTAINER_LABELS_AS_TAGS
               Value: "{\"com.docker.compose.service\":\"service_name\"}"
@@ -204,29 +266,31 @@ CloudFormation example (YAML):
 
 ### Crawler-based metrics
 
-In addition to the metrics collected by the Datadog Agent, Datadog has a CloudWatch based ECS integration. This integration collects the [Amazon ECS CloudWatch Metrics][20].
+In addition to the metrics collected by the Datadog Agent, Datadog has a CloudWatch based ECS integration. This integration collects the [Amazon ECS CloudWatch Metrics][16].
 
 As noted there, Fargate tasks also report metrics in this way:
 
 > The metrics made available will depend on the launch type of the tasks and services in your clusters. If you are using the Fargate launch type for your services then CPU and memory utilization metrics are provided to assist in the monitoring of your services.
 
-Since this method does not use the Datadog Agent, you need to configure the AWS integration by checking **ECS** on the integration tile. Then, Datadog pulls these CloudWatch metrics (namespaced `aws.ecs.*` in Datadog) on your behalf. See the [Data Collected][21] section of the documentation.
+Since this method does not use the Datadog Agent, you need to configure the AWS integration by checking **ECS** on the integration tile. Then, Datadog pulls these CloudWatch metrics (namespaced `aws.ecs.*` in Datadog) on your behalf. See the [Data Collected][17] section of the documentation.
 
 If these are the only metrics you need, you could rely on this integration for collection using CloudWatch metrics. **Note**: CloudWatch data is less granular (1-5 min depending on the type of monitoring you have enabled) and delayed in reporting to Datadog. This is because the data collection from CloudWatch must adhere to AWS API limits, instead of pushing it to Datadog with the Agent.
 
-Datadog's default CloudWatch crawler polls metrics once every 10 minutes. If you need a faster crawl schedule, contact [Datadog support][22] for availability. **Note**: There are cost increases involved on the AWS side as CloudWatch bills for API calls.
+Datadog's default CloudWatch crawler polls metrics once every 10 minutes. If you need a faster crawl schedule, contact [Datadog support][18] for availability. **Note**: There are cost increases involved on the AWS side as CloudWatch bills for API calls.
 
 ### Log collection
 
-You can monitor Fargate logs by using the AWS FireLens integration built on Datadog's Fluentbit output plugin to send logs to Datadog, or by using the `awslogs` log driver and a Lambda function to route logs to Datadog. Datadog recommends using AWS FireLens because you can configure Fluent Bit directly in your Fargate tasks.
+You can monitor Fargate logs by using either:
+- The AWS FireLens integration built on Datadog's Fluentbit output plugin to send logs directly to Datadog
+- Using the `awslogs` log driver to store the logs in a CloudWatch Log Group, and then a Lambda function to route logs to Datadog
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Fluent Bit and Firelens" xxx -->
+Datadog recommends using AWS FireLens because you can configure Fluent Bit directly in your Fargate tasks.
+
 #### Fluent Bit and FireLens
 
-Configure the AWS FireLens integration built on Datadog's Fluent Bit output plugin to connect your FireLens monitored log data to Datadog Logs.
+Configure the AWS FireLens integration built on Datadog's Fluent Bit output plugin to connect your FireLens monitored log data to Datadog Logs. You can find a full [sample task definition for this configuration here][19].
 
-1. Enable Fluent Bit in the FireLens log router container in your Fargate task. For more information about enabling FireLens, see the dedicated [AWS Firelens docs][23]. For more information about Fargate container definitions, see the [AWS docs on Container Definitions][24]. AWS recommends that you use [the regional Docker image][25]. Here is an example snippet of a task definition where the Fluent Bit image is configured:
+1. Add the Fluent Bit FireLens log router container in your existing Fargate task. For more information about enabling FireLens, see the dedicated [AWS Firelens docs][20]. For more information about Fargate container definitions, see the [AWS docs on Container Definitions][21]. AWS recommends that you use [the regional Docker image][22]. Here is an example snippet of a task definition where the Fluent Bit image is configured:
 
    ```json
    {
@@ -240,7 +304,7 @@ Configure the AWS FireLens integration built on Datadog's Fluent Bit output plug
    }
    ```
 
-    If your containers are publishing serialized JSON logs over stdout, you should use this [extra firelens configuration][26] to get them correctly parsed within Datadog:
+    If your containers are publishing serialized JSON logs over stdout, you should use this [extra firelens configuration][23] to get them correctly parsed within Datadog:
 
    ```json
    {
@@ -258,128 +322,346 @@ Configure the AWS FireLens integration built on Datadog's Fluent Bit output plug
    }
    ```
 
-    This converts serialized JSON from the `log:` field into top-level fields. See the AWS sample [Parsing container stdout logs that are serialized JSON][26] for more details.
+    This converts serialized JSON from the `log:` field into top-level fields. See the AWS sample [Parsing container stdout logs that are serialized JSON][23] for more details.
 
-2. Next, in the same Fargate task, define a log configuration with AWS FireLens as the log driver, and with data being output to Fluent Bit. Here is an example snippet of a task definition where the FireLens is the log driver, and it is outputting data to Fluent Bit:
+2. Next, in the same Fargate task define a log configuration for the desired containers to ship logs. This log configuration should have AWS FireLens as the log driver, and with data being output to Fluent Bit. Here is an example snippet of a task definition where the FireLens is the log driver, and it is outputting data to Fluent Bit:
+
 {{< site-region region="us" >}}
-   ```json
-   {
-     "logConfiguration": {
-       "logDriver": "awsfirelens",
-       "options": {
-         "Name": "datadog",
-         "apikey": "<DATADOG_API_KEY>",
-         "Host": "http-intake.logs.datadoghq.com",
-         "dd_service": "firelens-test",
-         "dd_source": "redis",
-         "dd_message_key": "log",
-         "dd_tags": "project:fluentbit",
-         "TLS": "on",
-         "provider": "ecs"
-       }
-     }
-   }
-   ```
+  ```json
+  {
+    "logConfiguration": {
+      "logDriver": "awsfirelens",
+      "options": {
+        "Name": "datadog",
+        "apikey": "<DATADOG_API_KEY>",
+        "Host": "http-intake.logs.datadoghq.com",
+        "dd_service": "firelens-test",
+        "dd_source": "redis",
+        "dd_message_key": "log",
+        "dd_tags": "project:fluentbit",
+        "TLS": "on",
+        "provider": "ecs"
+      }
+    }
+  }
+  ```
 {{< /site-region >}}
-   
+
 {{< site-region region="us3" >}}
-   ```json
-   {
-     "logConfiguration": {
-       "logDriver": "awsfirelens",
-       "options": {
-         "Name": "datadog",
-         "apikey": "<DATADOG_API_KEY>",
-         "Host": "http-intake.logs.us3.datadoghq.com",
-         "dd_service": "firelens-test",
-         "dd_source": "redis",
-         "dd_message_key": "log",
-         "dd_tags": "project:fluentbit",
-         "TLS": "on",
-         "provider": "ecs"
-       }
-     }
-   }
-   ```
+  ```json
+  {
+    "logConfiguration": {
+      "logDriver": "awsfirelens",
+      "options": {
+        "Name": "datadog",
+        "apikey": "<DATADOG_API_KEY>",
+        "Host": "http-intake.logs.us3.datadoghq.com",
+        "dd_service": "firelens-test",
+        "dd_source": "redis",
+        "dd_message_key": "log",
+        "dd_tags": "project:fluentbit",
+        "TLS": "on",
+        "provider": "ecs"
+      }
+    }
+  }
+  ```
 {{< /site-region >}}
-   
+
 {{< site-region region="us5" >}}
-   ```json
-   {
-     "logConfiguration": {
-       "logDriver": "awsfirelens",
-       "options": {
-         "Name": "datadog",
-         "apikey": "<DATADOG_API_KEY>",
-         "Host": "http-intake.logs.us5.datadoghq.com",
-         "dd_service": "firelens-test",
-         "dd_source": "redis",
-         "dd_message_key": "log",
-         "dd_tags": "project:fluentbit",
-         "TLS": "on",
-         "provider": "ecs"
-       }
-     }
-   }
-   ```
+  ```json
+  {
+    "logConfiguration": {
+      "logDriver": "awsfirelens",
+      "options": {
+        "Name": "datadog",
+        "apikey": "<DATADOG_API_KEY>",
+        "Host": "http-intake.logs.us5.datadoghq.com",
+        "dd_service": "firelens-test",
+        "dd_source": "redis",
+        "dd_message_key": "log",
+        "dd_tags": "project:fluentbit",
+        "TLS": "on",
+        "provider": "ecs"
+      }
+    }
+  }
+  ```
 {{< /site-region >}}
-   
+
 {{< site-region region="eu" >}}
-   ```json
-   {
-     "logConfiguration": {
-       "logDriver": "awsfirelens",
-       "options": {
-         "Name": "datadog",
-         "apikey": "<DATADOG_API_KEY>",
-         "Host": "http-intake.logs.datadoghq.eu",
-         "dd_service": "firelens-test",
-         "dd_source": "redis",
-         "dd_message_key": "log",
-         "dd_tags": "project:fluentbit",
-         "TLS": "on",
-         "provider": "ecs"
-       }
-     }
-   }
-   ```  
+  ```json
+  {
+    "logConfiguration": {
+      "logDriver": "awsfirelens",
+      "options": {
+        "Name": "datadog",
+        "apikey": "<DATADOG_API_KEY>",
+        "Host": "http-intake.logs.datadoghq.eu",
+        "dd_service": "firelens-test",
+        "dd_source": "redis",
+        "dd_message_key": "log",
+        "dd_tags": "project:fluentbit",
+        "TLS": "on",
+        "provider": "ecs"
+      }
+    }
+  }
+  ```
+{{< /site-region >}}
+{{< site-region region="gov" >}}
+  ```json
+  {
+    "logConfiguration": {
+      "logDriver": "awsfirelens",
+      "options": {
+        "Name": "datadog",
+        "apikey": "<DATADOG_API_KEY>",
+        "Host": "http-intake.logs.ddog-gov.datadoghq.com",
+        "dd_service": "firelens-test",
+        "dd_source": "redis",
+        "dd_message_key": "log",
+        "dd_tags": "project:fluentbit",
+        "TLS": "on",
+        "provider": "ecs"
+      }
+    }
+  }
+  ```
+{{< /site-region >}}
+
+  **Note**: Set your `apikey` as well as the `Host` relative to your respective site `http-intake.logs.{{< region-param key="dd_site" code="true" >}}`. The full list of available parameters is described in the [Datadog Fluentbit documentation][24].
+
+  The `dd_service`, `dd_source`, and `dd_tags` can be adjusted for your desired tags.
+
+3. Whenever a Fargate task runs, Fluent Bit sends the container logs to Datadog with information about all of the containers managed by your Fargate tasks. You can see the raw logs on the [Log Explorer page][25], [build monitors][26] for the logs, and use the [Live Container view][27].
+
+{{< tabs >}}
+{{% tab "Web UI" %}}
+##### Web UI
+
+To add the FluentBit container to your existing Task Definition check the **Enable FireLens integration** checkbox under **Log router integration** to automatically create the `log_router` container for you. This pulls the regional image, however, we do recommend to use the `stable` image tag instead of `latest`. Once you click **Apply** this creates the base container. To further customize the `firelensConfiguration` click the **Configure via JSON** button at the bottom to edit this manually.
+
+After this has been added edit the application container in your Task Definition that you want to submit logs from and change the **Log driver** to `awsfirelens` filling in the **Log options** with the keys shown in the above example.
+
+{{% /tab %}}
+
+{{% tab "AWS CLI" %}}
+##### AWS CLI
+
+Edit the existing task definition JSON file that you have to contain the `log_router` container and the updated `logConfiguration` for your application container, as described in the previous section. Once this is done you can create a new revision of your task definition with:
+
+```bash
+aws ecs register-task-definition --cli-input-json file://<PATH_TO_FILE>/datadog-agent-ecs-fargate.json
+```
+
+{{% /tab %}}
+
+{{% tab "CloudFormation" %}}
+##### AWS CloudFormation
+
+To use [AWS CloudFormation][1] templating, use the `AWS::ECS::TaskDefinition` resource and set the `Datadog` option to configure log management.
+
+For example, to configure Fluent Bit to send logs to Datadog:
+
+{{< site-region region="us" >}}
+```yaml
+Resources:
+  ECSTaskDefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+          - FARGATE
+      Cpu: 256
+      Memory: 1GB
+      ContainerDefinitions:
+        - Name: tomcat-test
+          Image: 'tomcat:jdk8-adoptopenjdk-openj9'
+          LogConfiguration:
+            LogDriver: awsfirelens
+            Options:
+              Name: datadog
+              apikey: <DATADOG_API_KEY>
+              Host: http-intake.logs.datadoghq.com
+              dd_service: test-service
+              dd_source: test-source
+              TLS: 'on'
+              provider: ecs
+          MemoryReservation: 500
+        - Name: log_router
+          Image: 'amazon/aws-for-fluent-bit:stable'
+          Essential: true
+          FirelensConfiguration:
+            Type: fluentbit
+            Options:
+              enable-ecs-log-metadata: true
+          MemoryReservation: 50
+```
+{{< /site-region >}}
+
+{{< site-region region="us3" >}}
+```yaml
+Resources:
+  ECSTaskDefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+          - FARGATE
+      Cpu: 256
+      Memory: 1GB
+      ContainerDefinitions:
+        - Name: tomcat-test
+          Image: 'tomcat:jdk8-adoptopenjdk-openj9'
+          LogConfiguration:
+            LogDriver: awsfirelens
+            Options:
+              Name: datadog
+              apikey: <DATADOG_API_KEY>
+              Host: http-intake.logs.us3.datadoghq.com
+              dd_service: test-service
+              dd_source: test-source
+              TLS: 'on'
+              provider: ecs
+          MemoryReservation: 500
+        - Name: log_router
+          Image: 'amazon/aws-for-fluent-bit:stable'
+          Essential: true
+          FirelensConfiguration:
+            Type: fluentbit
+            Options:
+              enable-ecs-log-metadata: true
+          MemoryReservation: 50
+```
+{{< /site-region >}}
+
+{{< site-region region="us5" >}}
+```yaml
+Resources:
+  ECSTaskDefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+          - FARGATE
+      Cpu: 256
+      Memory: 1GB
+      ContainerDefinitions:
+        - Name: tomcat-test
+          Image: 'tomcat:jdk8-adoptopenjdk-openj9'
+          LogConfiguration:
+            LogDriver: awsfirelens
+            Options:
+              Name: datadog
+              apikey: <DATADOG_API_KEY>
+              Host: http-intake.logs.us5.datadoghq.com
+              dd_service: test-service
+              dd_source: test-source
+              TLS: 'on'
+              provider: ecs
+          MemoryReservation: 500
+        - Name: log_router
+          Image: 'amazon/aws-for-fluent-bit:stable'
+          Essential: true
+          FirelensConfiguration:
+            Type: fluentbit
+            Options:
+              enable-ecs-log-metadata: true
+          MemoryReservation: 50
+```
+{{< /site-region >}}
+
+{{< site-region region="eu" >}}
+```yaml
+Resources:
+  ECSTaskDefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+          - FARGATE
+      Cpu: 256
+      Memory: 1GB
+      ContainerDefinitions:
+        - Name: tomcat-test
+          Image: 'tomcat:jdk8-adoptopenjdk-openj9'
+          LogConfiguration:
+            LogDriver: awsfirelens
+            Options:
+              Name: datadog
+              apikey: <DATADOG_API_KEY>
+              Host: http-intake.logs.datadoghq.eu
+              dd_service: test-service
+              dd_source: test-source
+              TLS: 'on'
+              provider: ecs
+          MemoryReservation: 500
+        - Name: log_router
+          Image: 'amazon/aws-for-fluent-bit:stable'
+          Essential: true
+          FirelensConfiguration:
+            Type: fluentbit
+            Options:
+              enable-ecs-log-metadata: true
+          MemoryReservation: 50
+```
 {{< /site-region >}}
 
 {{< site-region region="gov" >}}
-   ```json
-   {
-     "logConfiguration": {
-       "logDriver": "awsfirelens",
-       "options": {
-         "Name": "datadog",
-         "apikey": "<DATADOG_API_KEY>",
-         "Host": "http-intake.logs.ddog-gov.datadoghq.com",
-         "dd_service": "firelens-test",
-         "dd_source": "redis",
-         "dd_message_key": "log",
-         "dd_tags": "project:fluentbit",
-         "TLS": "on",
-         "provider": "ecs"
-       }
-     }
-   }
-   ```  
+```yaml
+Resources:
+  ECSTaskDefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+          - FARGATE
+      Cpu: 256
+      Memory: 1GB
+      ContainerDefinitions:
+        - Name: tomcat-test
+          Image: 'tomcat:jdk8-adoptopenjdk-openj9'
+          LogConfiguration:
+            LogDriver: awsfirelens
+            Options:
+              Name: datadog
+              apikey: <DATADOG_API_KEY>
+              Host: http-intake.logs.ddog-gov.datadoghq.com
+              dd_service: test-service
+              dd_source: test-source
+              TLS: 'on'
+              provider: ecs
+          MemoryReservation: 500
+        - Name: log_router
+          Image: 'amazon/aws-for-fluent-bit:stable'
+          Essential: true
+          FirelensConfiguration:
+            Type: fluentbit
+            Options:
+              enable-ecs-log-metadata: true
+          MemoryReservation: 50
+```
 {{< /site-region >}}
 
-    **Note**: If your organization is in Datadog EU site, use `http-intake.logs.datadoghq.eu` for the `Host` option instead. The full list of available parameters is described in the [Datadog Fluentbit documentation][27].
+For more information on CloudFormation templating and syntax, see the [AWS CloudFormation documentation][2].
 
-3. Whenever a Fargate task runs, Fluent Bit sends the container logs to your Datadog monitoring with information about all of the containers managed by your Fargate tasks. You can see the raw logs on the [Log Explorer page][28], [build monitors][29] for the logs, and use the [Live Container view][30].
 
-<!-- xxz tab xxx -->
-<!-- xxx tab "logDriver" xxx -->
+[1]: https://aws.amazon.com/cloudformation/
+[2]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html
+{{% /tab %}}
+
+{{< /tabs >}}
+
+**Note**: Use a [TaskDefinition secret][28] to avoid exposing the `apikey` in plain text.
 
 #### AWS log driver
 
 Monitor Fargate logs by using the `awslogs` log driver and a Lambda function to route logs to Datadog.
 
-1. Define the Fargate AwsLogDriver in your task. [Consult the AWS Fargate developer guide][31] for instructions.
+1. Define the log driver as `awslogs` in the application container in your task you want to collect logs from. [Consult the AWS Fargate developer guide][29] for instructions.
 
-2. Fargate task definitions only support the awslogs log driver for the log configuration. This configures your Fargate tasks to send log information to Amazon CloudWatch Logs. The following shows a snippet of a task definition where the awslogs log driver is configured:
+2. This configures your Fargate tasks to send log information to Amazon CloudWatch Logs. The following shows a snippet of a task definition where the awslogs log driver is configured:
 
    ```json
    {
@@ -394,216 +676,21 @@ Monitor Fargate logs by using the `awslogs` log driver and a Lambda function to 
    }
    ```
 
-    For more information about using the awslogs log driver in your task definitions to send container logs to CloudWatch Logs, see [Using the awslogs Log Driver][32]. This driver collects logs generated by the container and sends them to CloudWatch directly.
+    For more information about using the `awslogs` log driver in your task definitions to send container logs to CloudWatch Logs, see [Using the awslogs Log Driver][30]. This driver collects logs generated by the container and sends them to CloudWatch directly.
 
-3. Finally, use a [Lambda function][33] to collect logs from CloudWatch and send them to Datadog.
-
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
-
-
-### AWS CloudFormation
-
-To use [AWS CloudFormation][10] templating, use the `AWS::ECS::TaskDefinition` resource and set the `Datadog` option to configure log management.
-
-For example, to configure Fluent Bit to send logs to Datadog:
-
-{{< site-region region="us" >}}
-```yaml
-Resources:
-  ECSTDNJH3:
-    Type: 'AWS::ECS::TaskDefinition'
-    Properties:
-      NetworkMode: awsvpc
-      RequiresCompatibilities:
-          - FARGATE
-      Cpu: 256
-      Memory: 1GB
-      ContainerDefinitions:
-        - Name: tomcat-test
-          Image: 'tomcat:jdk8-adoptopenjdk-openj9'
-          LogConfiguration:
-            LogDriver: awsfirelens
-            Options:
-              Name: datadog
-              Host: http-intake.logs.datadoghq.com
-              TLS: 'on'
-              dd_service: test-service
-              dd_source: test-source
-              provider: ecs
-              apikey: <API_KEY>
-          MemoryReservation: 500
-        - Name: log_router
-          Image: 'amazon/aws-for-fluent-bit:stable'
-          Essential: true
-          FirelensConfiguration:
-            Type: fluentbit
-            Options:
-              enable-ecs-log-metadata: true
-          MemoryReservation: 50
-```
-{{< /site-region >}}
-
-{{< site-region region="us3" >}}
-```yaml
-Resources:
-  ECSTDNJH3:
-    Type: 'AWS::ECS::TaskDefinition'
-    Properties:
-      NetworkMode: awsvpc
-      RequiresCompatibilities:
-          - FARGATE
-      Cpu: 256
-      Memory: 1GB
-      ContainerDefinitions:
-        - Name: tomcat-test
-          Image: 'tomcat:jdk8-adoptopenjdk-openj9'
-          LogConfiguration:
-            LogDriver: awsfirelens
-            Options:
-              Name: datadog
-              Host: http-intake.logs.us3.datadoghq.com
-              TLS: 'on'
-              dd_service: test-service
-              dd_source: test-source
-              provider: ecs
-              apikey: <API_KEY>
-          MemoryReservation: 500
-        - Name: log_router
-          Image: 'amazon/aws-for-fluent-bit:stable'
-          Essential: true
-          FirelensConfiguration:
-            Type: fluentbit
-            Options:
-              enable-ecs-log-metadata: true
-          MemoryReservation: 50
-```
-{{< /site-region >}}
-
-{{< site-region region="us5" >}}
-```yaml
-Resources:
-  ECSTDNJH3:
-    Type: 'AWS::ECS::TaskDefinition'
-    Properties:
-      NetworkMode: awsvpc
-      RequiresCompatibilities:
-          - FARGATE
-      Cpu: 256
-      Memory: 1GB
-      ContainerDefinitions:
-        - Name: tomcat-test
-          Image: 'tomcat:jdk8-adoptopenjdk-openj9'
-          LogConfiguration:
-            LogDriver: awsfirelens
-            Options:
-              Name: datadog
-              Host: http-intake.logs.us5.datadoghq.com
-              TLS: 'on'
-              dd_service: test-service
-              dd_source: test-source
-              provider: ecs
-              apikey: <API_KEY>
-          MemoryReservation: 500
-        - Name: log_router
-          Image: 'amazon/aws-for-fluent-bit:stable'
-          Essential: true
-          FirelensConfiguration:
-            Type: fluentbit
-            Options:
-              enable-ecs-log-metadata: true
-          MemoryReservation: 50
-```
-{{< /site-region >}}
-
-{{< site-region region="eu" >}}
-```yaml
-Resources:
-  ECSTDNJH3:
-    Type: 'AWS::ECS::TaskDefinition'
-    Properties:
-      NetworkMode: awsvpc
-      RequiresCompatibilities:
-          - FARGATE
-      Cpu: 256
-      Memory: 1GB
-      ContainerDefinitions:
-        - Name: tomcat-test
-          Image: 'tomcat:jdk8-adoptopenjdk-openj9'
-          LogConfiguration:
-            LogDriver: awsfirelens
-            Options:
-              Name: datadog
-              Host: http-intake.logs.datadoghq.eu
-              TLS: 'on'
-              dd_service: test-service
-              dd_source: test-source
-              provider: ecs
-              apikey: <API_KEY>
-          MemoryReservation: 500
-        - Name: log_router
-          Image: 'amazon/aws-for-fluent-bit:stable'
-          Essential: true
-          FirelensConfiguration:
-            Type: fluentbit
-            Options:
-              enable-ecs-log-metadata: true
-          MemoryReservation: 50
-```
-{{< /site-region >}}
-
-{{< site-region region="gov" >}}
-```yaml
-Resources:
-  ECSTDNJH3:
-    Type: 'AWS::ECS::TaskDefinition'
-    Properties:
-      NetworkMode: awsvpc
-      RequiresCompatibilities:
-          - FARGATE
-      Cpu: 256
-      Memory: 1GB
-      ContainerDefinitions:
-        - Name: tomcat-test
-          Image: 'tomcat:jdk8-adoptopenjdk-openj9'
-          LogConfiguration:
-            LogDriver: awsfirelens
-            Options:
-              Name: datadog
-              Host: http-intake.logs.ddog-gov.datadoghq.com
-              TLS: 'on'
-              dd_service: test-service
-              dd_source: test-source
-              provider: ecs
-              apikey: <API_KEY>
-          MemoryReservation: 500
-        - Name: log_router
-          Image: 'amazon/aws-for-fluent-bit:stable'
-          Essential: true
-          FirelensConfiguration:
-            Type: fluentbit
-            Options:
-              enable-ecs-log-metadata: true
-          MemoryReservation: 50
-```
-{{< /site-region >}}
-
-**Note**: Use a [TaskDefinition secret][11] to avoid exposing the `apikey` in plain text.
-
-For more information on CloudFormation templating and syntax, see the [AWS CloudFormation documentation][12].
+3. Finally, use the [Datadog Lambda Log Forwarder function][31] to collect logs from CloudWatch and send them to Datadog.
 
 ### Trace collection
 
-1. Follow the [instructions above](#installation) to add the Datadog Agent container to your task definition with the additional environment variable `DD_APM_ENABLED` set to `true` and set up a host port that uses **8126** with **tcp** protocol under port mappings. Set the `DD_SITE` variable to {{< region-param key="dd_site" code="true" >}}. It defaults to `datadoghq.com` if you don't set it.
+1. Follow the [instructions above](#installation) to add the Datadog Agent container to your task definition with the additional environment variable `DD_APM_ENABLED` set to `true` and set up a container port that uses **8126** with **tcp** protocol under port mappings. Set the `DD_SITE` variable to {{< region-param key="dd_site" code="true" >}}. It defaults to `datadoghq.com` if you don't set it.
 
-2. [Instrument your application][34] based on your setup.
+2. [Instrument your application][32] based on your setup. With Fargate APM applications do **not** set `DD_AGENT_HOST`, the default of `localhost` works.
 
 3. Ensure your application is running in the same task definition as the Datadog Agent container.
 
 ## Out-of-the-box tags
 
-The Agent can autodiscover and attach tags to all data emitted by the entire task or an individual container within this task. The list of tags automatically attached depends on the Agent's [cardinality configuration][44].
+The Agent can autodiscover and attach tags to all data emitted by the entire task or an individual container within this task. The list of tags automatically attached depends on the Agent's [cardinality configuration][33].
 
   | Tag                           | Cardinality  | Source               |
   |-------------------------------|--------------|----------------------|
@@ -640,61 +727,58 @@ See [service_checks.json][36] for a list of service checks provided by this inte
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][22].
+Need help? Contact [Datadog support][18].
 
 ## Further Reading
 
-- Blog post: [Monitor AWS Fargate applications with Datadog][37]
-- FAQ: [Integration Setup for ECS Fargate][8]
-- Blog post: [Monitor your Fargate container logs with FireLens and Datadog][38]
-- Blog post: [Key metrics for monitoring AWS Fargate][39]
-- Blog post: [How to collect metrics and logs from AWS Fargate workloads][40]
-- Blog post: [AWS Fargate monitoring with Datadog][41]
-- Blog post: [Graviton2-powered AWS Fargate deployments][42]
-- Blog post: [Monitor AWS Fargate for Windows containerized apps][43]
+- Blog post: [Monitor AWS Fargate applications with Datadog][34]
+- FAQ: [Integration Setup for ECS Fargate][12]
+- Blog post: [Monitor your Fargate container logs with FireLens and Datadog][35]
+- Blog post: [Key metrics for monitoring AWS Fargate][36]
+- Blog post: [How to collect metrics and logs from AWS Fargate workloads][37]
+- Blog post: [AWS Fargate monitoring with Datadog][38]
+- Blog post: [Graviton2-powered AWS Fargate deployments][39]
+- Blog post: [Monitor AWS Fargate for Windows containerized apps][40]
+
+
 
 [1]: http://docs.datadoghq.com/integrations/eks_fargate
 [2]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html
 [3]: https://docs.docker.com/engine/api/v1.30/#operation/ContainerStats
-[4]: https://aws.amazon.com/cli
-[5]: https://aws.amazon.com/console
-[6]: https://app.datadoghq.com/organization-settings/api-keys
-[7]: http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-config.html#ecs-config-s3
-[8]: http://docs.datadoghq.com/integrations/faq/integration-setup-ecs-fargate
-[9]: https://docs.datadoghq.com/resources/json/datadog-agent-ecs-fargate.json
-[10]: https://aws.amazon.com/cloudformation/
-[11]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-secret.html
-[12]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html
-[13]: https://docs.datadoghq.com/integrations/amazon_web_services/#installation
-[14]: https://docs.aws.amazon.com/IAM/latest/UserGuide/list_ecs.html
-[15]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html#service_scheduler_replica
-[16]: https://github.com/DataDog/integrations-core/blob/master/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
-[17]: https://docs.datadoghq.com/developers/dogstatsd/
-[18]: https://docs.datadoghq.com/agent/docker/#environment-variables
-[19]: https://docs.aws.amazon.com/AmazonECS/latest/userguide/task_definition_parameters.html#container_definition_labels
-[20]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-metrics.html
-[21]: https://docs.datadoghq.com/integrations/amazon_ecs/#data-collected
-[22]: https://docs.datadoghq.com/help/
-[23]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html
-[24]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions
-[25]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html#firelens-using-fluentbit
-[26]: https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/master/examples/fluent-bit/parse-json
-[27]: https://docs.datadoghq.com/integrations/fluentbit/#configuration-parameters
-[28]: https://app.datadoghq.com/logs
-[29]: https://docs.datadoghq.com/monitors/monitor_types/
-[30]: https://docs.datadoghq.com/infrastructure/livecontainers/?tab=linuxwindows
-[31]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html
-[32]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html
-[33]: https://docs.datadoghq.com/integrations/amazon_lambda/#log-collection
-[34]: https://docs.datadoghq.com/tracing/setup/
-[35]: https://github.com/DataDog/integrations-core/blob/master/ecs_fargate/metadata.csv
-[36]: https://github.com/DataDog/integrations-core/blob/master/ecs_fargate/assets/service_checks.json
-[37]: https://www.datadoghq.com/blog/monitor-aws-fargate
-[38]: https://www.datadoghq.com/blog/collect-fargate-logs-with-firelens/
-[39]: https://www.datadoghq.com/blog/aws-fargate-metrics/
-[40]: https://www.datadoghq.com/blog/tools-for-collecting-aws-fargate-metrics/
-[41]: https://www.datadoghq.com/blog/aws-fargate-monitoring-with-datadog/
-[42]: https://www.datadoghq.com/blog/aws-fargate-on-graviton2-monitoring/
-[43]: https://www.datadoghq.com/blog/aws-fargate-windows-containers-support/
-[44]: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
-
+[4]: https://aws.amazon.com/console
+[5]: https://aws.amazon.com/cli
+[6]: https://aws.amazon.com/cloudformation/
+[7]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-tutorial.html
+[8]: https://docs.datadoghq.com/integrations/amazon_web_services/#installation
+[9]: https://docs.aws.amazon.com/IAM/latest/UserGuide/list_ecs.html
+[10]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html#service_scheduler_replica
+[11]: https://github.com/DataDog/integrations-core/blob/master/ecs_fargate/datadog_checks/ecs_fargate/data/conf.yaml.example
+[12]: http://docs.datadoghq.com/integrations/faq/integration-setup-ecs-fargate
+[13]: https://docs.datadoghq.com/developers/dogstatsd/
+[14]: https://docs.datadoghq.com/agent/docker/#environment-variables
+[15]: https://docs.aws.amazon.com/AmazonECS/latest/userguide/task_definition_parameters.html#container_definition_labels
+[16]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-metrics.html
+[17]: https://docs.datadoghq.com/integrations/amazon_ecs/#data-collected
+[18]: https://docs.datadoghq.com/help/
+[19]: https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/mainline/examples/fluent-bit/datadog
+[20]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html
+[21]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definitions
+[22]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_firelens.html#firelens-using-fluentbit
+[23]: https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/master/examples/fluent-bit/parse-json
+[24]: https://docs.datadoghq.com/integrations/fluentbit/#configuration-parameters
+[25]: https://app.datadoghq.com/logs
+[26]: https://docs.datadoghq.com/monitors/monitor_types/
+[27]: https://docs.datadoghq.com/infrastructure/livecontainers/?tab=linuxwindows
+[28]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecs-taskdefinition-secret.html
+[29]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS_Fargate.html
+[30]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html
+[31]: https://docs.datadoghq.com/logs/guide/forwarder/
+[32]: https://docs.datadoghq.com/tracing/setup/
+[33]: https://docs.datadoghq.com/getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
+[34]: https://www.datadoghq.com/blog/monitor-aws-fargate
+[35]: https://www.datadoghq.com/blog/collect-fargate-logs-with-firelens/
+[36]: https://www.datadoghq.com/blog/aws-fargate-metrics/
+[37]: https://www.datadoghq.com/blog/tools-for-collecting-aws-fargate-metrics/
+[38]: https://www.datadoghq.com/blog/aws-fargate-monitoring-with-datadog/
+[39]: https://www.datadoghq.com/blog/aws-fargate-on-graviton2-monitoring/
+[40]: https://www.datadoghq.com/blog/aws-fargate-windows-containers-support/


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Several changes are being made here for general cleanup purposes of the ECS Fargate docs.

- Moved the 3 deployment methods (Web UI, AWS CLI, CloudFormation) into selectable tabs to cleanup the instructions
  - Added indented bullets to web ui for easier reading
  - Bringing more consistency between the examples. Such as: same image repo/name (`public.ecr.aws/datadog/agent:latest`) for each, same CPU/Memory for the Task, `datadog-agent` container now doesn't have container specific CPU/Memory listed
  - Cleaned up CloudFormation examples to properly list env vars and use nicer resource names (`ECSTDNJH3` -> `ECSTaskDefinition`)
- Added generic CloudFormation examples for Replica Service
- Changed the log collection from tabs of "Fluent Bit & Firelens" vs "logDriver" to not use tabs, as to not conflict with the new 3 tabs
  - Added more explicit Web UI and AWS CLI instructions for log collection, as well as included these and CloudFormation into that same tabbed approach
  - Added link to the example in the AWS repo (https://github.com/aws-samples/amazon-ecs-firelens-examples/tree/mainline/examples/fluent-bit/datadog)
- Minor fixes for APM instructions for Fargate
- Remove unsupported Agent env vars from list.
- General formatting fixes for certain code blocks

Also took advantage of the documentation commit hook for link cleanup, which was especially helpful with all the tab changes.

### Motivation
<!-- What inspired you to submit this pull request? -->
Lots of cleanup to simplify reading the instructions per deployment strategy, bring consistency between samples, and fixes

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Validated formatting in local build

Current Docs Page:  
- https://docs.datadoghq.com/integrations/ecs_fargate/?tab=fluentbitandfirelens#overview


For consistency, all the `datadog-agent` containers instructions and samples to not set specific container cpu/memory constraints (to match current example (https://docs.datadoghq.com/resources/json/datadog-agent-ecs-fargate.json). 

Specific CPU/Memory constraints specific for the `datadog-agent` container can be added in the future. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
