### PR TITLE
Emulate an Agent shutdown after every test that uses the `dd_run_check` fixture by default

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -206,7 +206,12 @@ def dd_agent_check(request, aggregator, datadog_agent):
 
 @pytest.fixture
 def dd_run_check():
-    def run_check(check, extract_message=False):
+    checks = {}
+
+    def run_check(check, extract_message=False, cancel=True):
+        if cancel:
+            checks[id(check)] = check
+
         error = check.run()
 
         if error:
@@ -220,7 +225,13 @@ def dd_run_check():
 
         return ''
 
-    return run_check
+    yield run_check
+
+    for c in checks.values():
+        try:
+            c.cancel()
+        except Exception:
+            pass
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
### Motivation

Some checks need to clean up resources like long running threads