### PR TITLE
[PerfCountersBaseCheck] Refresh performance objects in a separate thread

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/base.py
@@ -15,9 +15,11 @@ from ....utils.functions import raise_exception
 from ... import AgentCheck
 from .connection import Connection
 from .counter import PerfObject
+from .refresh import WindowsPerformanceObjectRefresher
 
 
 class PerfCountersBaseCheck(AgentCheck):
+    OBJECT_REFRESHER = WindowsPerformanceObjectRefresher()
     SERVICE_CHECK_HEALTH = 'windows.perf.health'
 
     def __init__(self, name, init_config, instances):
@@ -38,6 +40,7 @@ class PerfCountersBaseCheck(AgentCheck):
         self._static_tags = None
 
         self.check_initializations.append(self.create_connection)
+        self.check_initializations.append(self.setup_refresher)
         self.check_initializations.append(self.configure_perf_objects)
 
     def check(self, _):
@@ -48,19 +51,6 @@ class PerfCountersBaseCheck(AgentCheck):
             self._query_counters()
 
     def _query_counters(self):
-        # Refresh the list of performance objects, see:
-        # https://docs.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhenumobjectitemsa#remarks
-        try:
-            # https://docs.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhenumobjectsa
-            # https://mhammond.github.io/pywin32/win32pdh__EnumObjects_meth.html
-            win32pdh.EnumObjects(None, self._connection.server, win32pdh.PERF_DETAIL_WIZARD, True)
-        except pywintypes.error as error:
-            message = 'Error refreshing performance objects: {}'.format(error.strerror)
-            self.submit_health_check(self.CRITICAL, message=message)
-            self.log.error(message)
-
-            return
-
         # Avoid collection of performance objects that failed to refresh
         collection_queue = []
 
@@ -131,6 +121,13 @@ class PerfCountersBaseCheck(AgentCheck):
         self.log.debug('Setting `server` to `%s`', self._connection.server)
         self._connection.connect()
 
+    def setup_refresher(self):
+        self.OBJECT_REFRESHER.add_server(self._connection.server)
+
+        # Expected for multiple calls
+        with suppress(RuntimeError):
+            self.OBJECT_REFRESHER.start()
+
     def get_perf_object(self, connection, object_name, object_config, use_localized_counters, tags):
         return PerfObject(self, connection, object_name, object_config, use_localized_counters, tags)
 
@@ -155,6 +152,8 @@ class PerfCountersBaseCheck(AgentCheck):
             self.__NAMESPACE__ = old_namespace
 
     def cancel(self):
+        self.OBJECT_REFRESHER.remove_server(self._connection.server)
+
         for perf_object in self.perf_objects:
             with suppress(Exception):
                 perf_object.clear()

--- a/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/refresh.py
+++ b/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/refresh.py
@@ -59,6 +59,11 @@ class WindowsPerformanceObjectRefresher(threading.Thread):
 
     def add_server(self, server):
         self.servers[server] += 1
+        self.log_server_count(server)
 
     def remove_server(self, server):
         self.servers[server] -= 1
+        self.log_server_count(server)
+
+    def log_server_count(self, server):
+        self.logger.info('Refresh counter set to %d for server: %s', self.servers[server], server)

--- a/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/refresh.py
+++ b/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/refresh.py
@@ -41,6 +41,7 @@ class WindowsPerformanceObjectRefresher(threading.Thread):
                 if server in self.last_refresh and now - self.last_refresh[server] < self.INTERVAL:
                     continue
                 else:
+                    self.logger.info('Refreshing performance objects for server: %s', server)
                     try:
                         # https://docs.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhenumobjectsa
                         # https://mhammond.github.io/pywin32/win32pdh__EnumObjects_meth.html
@@ -50,7 +51,7 @@ class WindowsPerformanceObjectRefresher(threading.Thread):
                             'Error refreshing performance objects for server `%s`: %s', server, error.strerror
                         )
                     else:
-                        self.logger.info('Refreshing performance objects for server: %s', server)
+                        self.logger.info('Successfully refreshed performance objects for server: %s', server)
 
                     self.last_refresh[server] = now
 

--- a/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/refresh.py
+++ b/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/refresh.py
@@ -1,0 +1,63 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
+import threading
+import time
+from collections import defaultdict
+
+import pywintypes
+import win32pdh
+
+from ....utils.time import get_precise_time
+
+
+class WindowsPerformanceObjectRefresher(threading.Thread):
+    INTERVAL = 60
+
+    def __init__(self):
+        name = self.__class__.__name__
+        super(WindowsPerformanceObjectRefresher, self).__init__(name=name)
+
+        self.logger = logging.getLogger(name)
+        self.last_refresh = {}
+        self.servers = defaultdict(int)
+
+    def run(self):
+        # Refresh the list of performance objects for every server, see:
+        # https://docs.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhenumobjectitemsa#remarks
+        #
+        # We do this in a separate thread to avoid internal lock contention of Windows APIs
+        while True:
+            # Agent is shutting down
+            if not any(self.servers.values()):
+                return
+
+            for server, count in self.servers.items():
+                if not count:
+                    continue
+
+                now = get_precise_time()
+                if server in self.last_refresh and now - self.last_refresh[server] < self.INTERVAL:
+                    continue
+                else:
+                    try:
+                        # https://docs.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhenumobjectsa
+                        # https://mhammond.github.io/pywin32/win32pdh__EnumObjects_meth.html
+                        win32pdh.EnumObjects(None, server, win32pdh.PERF_DETAIL_WIZARD, True)
+                    except pywintypes.error as error:
+                        self.logger.error(
+                            'Error refreshing performance objects for server `%s`: %s', server, error.strerror
+                        )
+                    else:
+                        self.logger.info('Refreshing performance objects for server: %s', server)
+
+                    self.last_refresh[server] = now
+
+            time.sleep(2)
+
+    def add_server(self, server):
+        self.servers[server] += 1
+
+    def remove_server(self, server):
+        self.servers[server] -= 1

--- a/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/refresh.py
+++ b/datadog_checks_base/datadog_checks/base/checks/windows/perf_counters/refresh.py
@@ -40,20 +40,20 @@ class WindowsPerformanceObjectRefresher(threading.Thread):
                 now = get_precise_time()
                 if server in self.last_refresh and now - self.last_refresh[server] < self.INTERVAL:
                     continue
-                else:
-                    self.logger.info('Refreshing performance objects for server: %s', server)
-                    try:
-                        # https://docs.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhenumobjectsa
-                        # https://mhammond.github.io/pywin32/win32pdh__EnumObjects_meth.html
-                        win32pdh.EnumObjects(None, server, win32pdh.PERF_DETAIL_WIZARD, True)
-                    except pywintypes.error as error:
-                        self.logger.error(
-                            'Error refreshing performance objects for server `%s`: %s', server, error.strerror
-                        )
-                    else:
-                        self.logger.info('Successfully refreshed performance objects for server: %s', server)
 
-                    self.last_refresh[server] = now
+                self.logger.info('Refreshing performance objects for server: %s', server)
+                try:
+                    # https://docs.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhenumobjectsa
+                    # https://mhammond.github.io/pywin32/win32pdh__EnumObjects_meth.html
+                    win32pdh.EnumObjects(None, server, win32pdh.PERF_DETAIL_WIZARD, True)
+                except pywintypes.error as error:
+                    self.logger.error(
+                        'Error refreshing performance objects for server `%s`: %s', server, error.strerror
+                    )
+                else:
+                    self.logger.info('Successfully refreshed performance objects for server: %s', server)
+
+                self.last_refresh[server] = now
 
             time.sleep(2)
 

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/test_health.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/test_health.py
@@ -39,28 +39,6 @@ def test_ok(aggregator, dd_run_check, mock_performance_objects):
     aggregator.assert_service_check('test.windows.perf.health', ServiceCheck.OK, tags=GLOBAL_TAGS)
 
 
-def test_critical_objects_refresh(aggregator, dd_run_check, mock_performance_objects, mocker, caplog):
-    import pywintypes
-
-    mock_performance_objects({'Foo': (['baz'], {'Bar': [9000]})})
-    mocker.patch('win32pdh.EnumObjects', side_effect=pywintypes.error(None, None, 'foo failed'))
-    check = get_check({'metrics': {'Foo': {'name': 'foo', 'counters': [{'Bar': 'bar'}]}}})
-    dd_run_check(check)
-
-    aggregator.assert_all_metrics_covered()
-
-    expected_message = 'Error refreshing performance objects: foo failed'
-    aggregator.assert_service_check(
-        'test.windows.perf.health', ServiceCheck.CRITICAL, message=expected_message, tags=GLOBAL_TAGS
-    )
-
-    for _, level, message in caplog.record_tuples:
-        if level == logging.ERROR and message == expected_message:
-            break
-    else:
-        raise AssertionError('Expected ERROR log with message `{}`'.format(expected_message))
-
-
 def test_critical_query(aggregator, dd_run_check, mock_performance_objects, mocker, caplog):
     import pywintypes
 


### PR DESCRIPTION
### Motivation

With many check instances configured, on certain versions of Windows, the internal lock contention of Windows APIs significantly increases execution times