### PR TITLE
Add ext_authz metrics to envoy integration

### DIFF
--- a/envoy/datadog_checks/envoy/metrics.py
+++ b/envoy/datadog_checks/envoy/metrics.py
@@ -757,6 +757,46 @@ METRICS = {
         ),
         'method': 'monotonic_count',
     },
+    'cluster.ext_authz.ok': {
+        'tags': (
+            ('envoy_cluster', ),
+            (),
+            (),
+        ),
+        'method': 'monotonic_count',
+    },
+    'cluster.ext_authz.error': {
+        'tags': (
+            ('envoy_cluster', ),
+            (),
+            (),
+        ),
+        'method': 'monotonic_count',
+    },
+    'cluster.ext_authz.denied': {
+        'tags': (
+            ('envoy_cluster', ),
+            (),
+            (),
+        ),
+        'method': 'monotonic_count',
+    },
+    'cluster.ext_authz.disabled': {
+        'tags': (
+            ('envoy_cluster', ),
+            (),
+            (),
+        ),
+        'method': 'monotonic_count',
+    },
+    'cluster.ext_authz.failure_mode_allowed': {
+        'tags': (
+            ('envoy_cluster', ),
+            (),
+            (),
+        ),
+        'method': 'monotonic_count',
+    },
     'cluster.ratelimit.ok': {
         'tags': (
             ('envoy_cluster', ),
@@ -774,6 +814,14 @@ METRICS = {
         'method': 'monotonic_count',
     },
     'cluster.ratelimit.over_limit': {
+        'tags': (
+            ('envoy_cluster', ),
+            (),
+            (),
+        ),
+        'method': 'monotonic_count',
+    },
+    'cluster.ratelimit.failure_mode_allowed': {
         'tags': (
             ('envoy_cluster', ),
             (),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

I've observed we are missing metrics from envoy ext_authz http filters. [Documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/ext_authz_filter#statistics)
Also the `failure_mode_allowed` is missing for the rate limit filter even the other metrics are present [Documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/rate_limit_filter#statistics)

### Motivation
<!-- What inspired you to submit this pull request? -->

Gathering a broader set of metrics

### Additional Notes
<!-- Anything else we should know when reviewing? -->


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
