### PR TITLE
Change get_commits_since so that it won't take commits from other branches

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -86,7 +86,7 @@ def get_commits_since(check_name, target_tag=None, end=None, exclude_branch=None
     elif exclude_branch is not None:
         command = f"git cherry -v {exclude_branch} HEAD {'' if target_tag is None else f'{target_tag} '}"
     else:
-        command = f"git log --pretty=%s {'' if target_tag is None else f'{target_tag}...{end} '}{target_path}"
+        command = f"git log --pretty=%s {'' if target_tag is None else f'{target_tag}..{end} '}{target_path}"
 
     with chdir(root):
         return run_command(command, capture=True, check=True).stdout.splitlines()

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -90,7 +90,7 @@ def test_get_commits_since():
             chdir.assert_called_once_with('/foo/')
             get_commits_since('my-check', target_tag='the-tag')
             run.assert_any_call('git log --pretty=%s /foo/my-check', capture=True, check=True)
-            run.assert_any_call('git log --pretty=%s the-tag... /foo/my-check', capture=True, check=True)
+            run.assert_any_call('git log --pretty=%s the-tag.. /foo/my-check', capture=True, check=True)
 
 
 def test_git_show_file():


### PR DESCRIPTION
### What does this PR do?

Changes the behaviour of `get_commits_since` so that it uses git's `..` operator instead of `...` to define the commit range.

### Motivation

[AI-2131](https://datadoghq.atlassian.net/browse/AI-2131). This is trying to avoid incorporating commits from non-master branches into releases.

### Additional Notes

I'm not sure what the original expected behaviour for this function was, so the reason why `...` was being used originally is unknown to me. I'm also not very confident about my understanding of `...` and why it does what it does in this case.

To test this manually, based on reproducing the case reported in [AI-2131](https://datadoghq.atlassian.net/browse/AI-2131), what I did was:

- Clone `integrations-core` separately.
- `git checkout 7.34.0-rc.2`
- `ddev -x release make http_check`

I also tried the git commands that this function runs to check that `..` gives us what we want for this case:

```
git log --pretty=%s http_check-6.1.2... http_check

Release integrations for 7.34 (#11076)
Release changed integrations for 7.33.0-rc.14 (#11072)
Add urllib3 as dependency (#11069) (#11071)
Add urllib3 as dependency (#11069)
Fix urllib3 import statement (#11065)
add comment to autogenerated model files (#10945)
Generate example usage of custom config model validators (#10927)
DOCS-2530 Lint Integrations section (part 5) (#10805)
Update `test_instance_auth_token` to run check twice and add more header tests (#10653)
```
(note the duplicate #11069)

```
git log --pretty=%s http_check-6.1.2.. http_check
Release integrations for 7.34 (#11076)
Add urllib3 as dependency (#11069)
Fix urllib3 import statement (#11065)
add comment to autogenerated model files (#10945)
Generate example usage of custom config model validators (#10927)
DOCS-2530 Lint Integrations section (part 5) (#10805)
Update `test_instance_auth_token` to run check twice and add more header tests (#10653)
```

After the change, if I run `ddev -x release make http_check`, I get a changelog that looks right:

```
+## 6.1.3 / 2022-06-16
+
+* [Fixed] Add urllib3 as dependency. See [#11069](https://github.com/DataDog/integrations-core/pull/11069).
+* [Fixed] Fix urllib3 import statement. See [#11065](https://github.com/DataDog/integrations-core/pull/11065).
+* [Fixed] Add comment to autogenerated model files. See [#10945](https://github.com/DataDog/integrations-core/pull/10945).
+
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
