### PR TITLE
Fix CPU time metrics unit name to use `percent`

### DIFF
--- a/system_core/metadata.csv
+++ b/system_core/metadata.csv
@@ -1,5 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 system.core.count,gauge,,core,,The number of CPU cores on the host,0,system,cpu cores,
-system.core.user,gauge,,second,,A given core's user-space CPU time,0,system,cpu user,
-system.core.system,gauge,,second,,A given core's system CPU time,0,system,cpu system,
-system.core.idle,gauge,,second,,A given core's idle CPU time,0,system,cpu idle,
+system.core.user,gauge,,percent,,A given core's user-space CPU time percentage,0,system,cpu user,
+system.core.system,gauge,,percent,,A given core's system CPU time percentage,0,system,cpu system,
+system.core.idle,gauge,,percent,,A given core's idle CPU time percentage,0,system,cpu idle,


### PR DESCRIPTION
### What does this PR do?
Fixes the unit name for the `system_core` CPU time metrics to use `percent` instead of `second`. According to [psutil](https://psutil.readthedocs.io/en/stable/#psutil.cpu_times), `psutil.cpu_times` returns values that represent "the seconds the CPU has spent in the given mode". 

The check submits these values as a percentage with the rate metric type: https://github.com/DataDog/integrations-core/blob/da2cde8a7827abd89edcfb4becf79208393b1f67/system_core/datadog_checks/system_core/system_core.py#L20

The resulting value is `(delta CPU time/collection interval) * 100`, which is a percentage.

### Motivation
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
