### PR TITLE
Add a `--debug` (`-d`) flag to `ddev env test`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -46,9 +46,23 @@ from .stop import stop
 @click.option('--ddtrace', is_flag=True, help='Run tests using dd-trace-py')
 @click.option('--filter', '-k', 'test_filter', help='Only run tests matching given substring expression')
 @click.option('--changed', is_flag=True, help='Only test changed checks')
+@click.option('--debug', '-d', is_flag=True, help='Set the log level to debug')
 @click.pass_context
 def test(
-    ctx, checks, agent, python, dev, base, env_vars, new_env, profile_memory, junit, ddtrace, test_filter, changed
+    ctx,
+    checks,
+    agent,
+    python,
+    dev,
+    base,
+    env_vars,
+    new_env,
+    profile_memory,
+    junit,
+    ddtrace,
+    test_filter,
+    changed,
+    debug,
 ):
     """Test an environment."""
     check_envs = get_test_envs(checks, e2e_tests_only=True, changed_only=changed)
@@ -104,7 +118,7 @@ def test(
                     ctx.invoke(
                         test_command,
                         checks=[f'{check}:{env}'],
-                        debug=DEBUG_OUTPUT,
+                        debug=debug or DEBUG_OUTPUT,
                         e2e=True,
                         passenv=' '.join(persisted_env_vars) if persisted_env_vars else None,
                         junit=junit,


### PR DESCRIPTION
### What does this PR do?

Adds a new `--debug` option that gets passed to the test command and has the same behaviour as that for `ddev test`.

### Motivation

I wanted to be able to see output from prints while running tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
