### PR TITLE
Track blk_read_time and blk_write_time for Postgres databases if track_io_timing is enabled

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -35,7 +35,7 @@ except ImportError:
 
 MAX_CUSTOM_RESULTS = 100
 
-PG_SETTINGS_QUERY = "SELECT name, setting FROM pg_settings WHERE name IN (%s, %s)"
+PG_SETTINGS_QUERY = "SELECT name, setting FROM pg_settings WHERE name IN (%s, %s, %s)"
 
 
 class PostgreSql(AgentCheck):
@@ -417,7 +417,7 @@ class PostgreSql(AgentCheck):
                 self.log.debug("Running query [%s]", PG_SETTINGS_QUERY)
                 cursor.execute(
                     PG_SETTINGS_QUERY,
-                    ("pg_stat_statements.max", "track_activity_query_size"),
+                    ("pg_stat_statements.max", "track_activity_query_size", "track_io_timing"),
                 )
                 rows = cursor.fetchall()
                 self.pg_settings.clear()

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -84,10 +84,7 @@ PG_STAT_STATEMENTS_TAG_COLUMNS = frozenset(
 PG_STAT_STATEMENTS_OPTIONAL_COLUMNS = frozenset({'queryid'})
 
 PG_STAT_ALL_DESIRED_COLUMNS = (
-    PG_STAT_STATEMENTS_METRICS_COLUMNS
-    | PG_STAT_STATEMENTS_TAG_COLUMNS
-    | PG_STAT_STATEMENTS_OPTIONAL_COLUMNS
-    | PG_STAT_STATEMENTS_TIMING_COLUMNS
+    PG_STAT_STATEMENTS_METRICS_COLUMNS | PG_STAT_STATEMENTS_TAG_COLUMNS | PG_STAT_STATEMENTS_OPTIONAL_COLUMNS
 )
 
 
@@ -228,10 +225,12 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 )
                 return []
 
-            if self._check.pg_settings.get("track_io_timing") != "on":
-                missing_columns -= PG_STAT_STATEMENTS_TIMING_COLUMNS
+            desired_columns = PG_STAT_ALL_DESIRED_COLUMNS
 
-            query_columns = sorted(list(available_columns & PG_STAT_ALL_DESIRED_COLUMNS))
+            if self._check.pg_settings.get("track_io_timing") == "on":
+                desired_columns |= PG_STAT_STATEMENTS_TIMING_COLUMNS
+
+            query_columns = sorted(list(available_columns & desired_columns))
             params = ()
             filters = ""
             if self._config.dbstrict:

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -79,6 +79,8 @@ postgresql.queries.local_blks_dirtied,count,,block,,"Total number of local block
 postgresql.queries.local_blks_written,count,,block,,"Total number of local blocks written per query_signature, db, and user. (DBM only)",0,postgres,postgres queries local blocks written,
 postgresql.queries.temp_blks_read,count,,block,,"Total number of temp blocks read per query_signature, db, and user. (DBM only)",0,postgres,postgres queries temp blocks read,
 postgresql.queries.temp_blks_written,count,,block,,"Total number of temp blocks written per query_signature, db, and user. (DBM only)",0,postgres,postgres queries temp blocks written,
+postgresql.queries.blk_read_time,count,,nanosecond,,"Total time spent reading blocks per query_signature, db, and user. (DBM only)",0,postgres, postgres queries block read time,
+postgresql.queries.blk_write_time,count,,nanosecond,,"Total time spent writing blocks per query_signature, db, and user. (DBM only)",0,postgres, postgres queries block write time,
 postgresql.queries.duration.max,gauge,,nanosecond,,"The age of the longest running query per user, db and app. (DBM only)",0,postgres,postgres queries duration max,
 postgresql.queries.duration.sum,gauge,,nanosecond,,"The sum of the age of all running queries per user, db and app. (DBM only)",0,postgres,postgres queries duration sum,
 postgresql.transactions.duration.max,gauge,,nanosecond,,"The age of the longest running transaction per user, db and app. (DBM only)",0,postgres,postgres transactions duration max,

--- a/postgres/tests/compose/etc/postgresql/postgresql.conf
+++ b/postgres/tests/compose/etc/postgresql/postgresql.conf
@@ -2,3 +2,4 @@ listen_addresses='*'
 shared_preload_libraries=pg_stat_statements
 pg_stat_statements.max=10000
 pg_stat_statements.track=all
+track_io_timing=on

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -19,7 +19,7 @@ from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.postgres.statement_samples import DBExplainError, StatementTruncationState
-from datadog_checks.postgres.statements import PG_STAT_STATEMENTS_METRICS_COLUMNS
+from datadog_checks.postgres.statements import PG_STAT_STATEMENTS_METRICS_COLUMNS, PG_STAT_STATEMENTS_TIMING_COLUMNS
 
 from .common import DB_NAME, HOST, PORT, POSTGRES_VERSION
 
@@ -103,8 +103,15 @@ def test_statement_metrics_version(integration_check, dbm_instance, version, exp
 
 @pytest.mark.parametrize("dbstrict", [True, False])
 @pytest.mark.parametrize("pg_stat_statements_view", ["pg_stat_statements", "datadog.pg_stat_statements()"])
+@pytest.mark.parametrize("track_io_timing_enabled", [True, False])
 def test_statement_metrics(
-    aggregator, integration_check, dbm_instance, dbstrict, pg_stat_statements_view, datadog_agent
+    aggregator,
+    integration_check,
+    dbm_instance,
+    dbstrict,
+    pg_stat_statements_view,
+    datadog_agent,
+    track_io_timing_enabled,
 ):
     dbm_instance['dbstrict'] = dbstrict
     dbm_instance['pg_stat_statements_view'] = pg_stat_statements_view
@@ -122,6 +129,11 @@ def test_statement_metrics(
 
     check = integration_check(dbm_instance)
     check._connect()
+    check.check(dbm_instance)
+
+    # We can't change track_io_timing at runtime, but we can change what the integration thinks the runtime value is
+    # This must be done after the first check since postgres settings are loaded from the database then
+    check.pg_settings["track_io_timing"] = "on" if track_io_timing_enabled else "off"
 
     _run_queries()
     check.check(dbm_instance)
@@ -141,8 +153,8 @@ def test_statement_metrics(
         return True
 
     events = aggregator.get_event_platform_events("dbm-metrics")
-    assert len(events) == 1
-    event = events[0]
+    assert len(events) == 2
+    event = events[1]  # first item is from the initial dummy check to load pg_settings
 
     assert event['host'] == 'stubbed.hostname'
     assert event['timestamp'] > 0
@@ -175,6 +187,10 @@ def test_statement_metrics(
         assert row['query'] == expected_query[0:200], "query should be truncated when sending to metrics"
         available_columns = set(row.keys())
         metric_columns = available_columns & PG_STAT_STATEMENTS_METRICS_COLUMNS
+        if track_io_timing_enabled:
+            metric_columns |= PG_STAT_STATEMENTS_TIMING_COLUMNS
+        else:
+            assert (available_columns & PG_STAT_STATEMENTS_TIMING_COLUMNS) == set()
         for col in metric_columns:
             assert type(row[col]) in (float, int)
 


### PR DESCRIPTION
### What does this PR do?

This adds support for tracking `blk_read_time` and `blk_write_time` data in Postgres databases if the configuration value which enables their usage is set.

### Motivation

This PR is an extension of #11618.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
