### PR TITLE
Fix missing sys import

### DIFF
--- a/php_fpm/datadog_checks/php_fpm/vendor/fcgi_app.py
+++ b/php_fpm/datadog_checks/php_fpm/vendor/fcgi_app.py
@@ -28,6 +28,7 @@ __author__ = 'Allan Saddi <allan@saddi.com>'
 __version__ = '$Revision$'
 
 import select
+import sys
 import struct
 import socket
 import errno


### PR DESCRIPTION
sys is used in determining the default encoding when retrieving the
data on FCGI_STDERR
