### PR TITLE
Ai 2456 solve problem with tests where certificate has expired

### DIFF
--- a/datadog_checks_base/tests/base/utils/test_http.py
+++ b/datadog_checks_base/tests/base/utils/test_http.py
@@ -2041,9 +2041,7 @@ class TestIntegration:
 class TestAIAChasing:
     def test_incomplete_chain(self):
         # Protocol 1.2 is allowed by default
-        http = RequestsWrapper(
-            {'tls_cert': '/etc/ssl/certs/ca-root.crt', 'tls_private_key': '/etc/ssl/certs/ca-root.key'}, {}
-        )
+        http = RequestsWrapper({}, {})
         http.get("https://badssl.test/")
 
     def test_cant_allow_unknown_protocol(self, caplog):

--- a/datadog_checks_base/tests/base/utils/test_http.py
+++ b/datadog_checks_base/tests/base/utils/test_http.py
@@ -2041,8 +2041,10 @@ class TestIntegration:
 class TestAIAChasing:
     def test_incomplete_chain(self):
         # Protocol 1.2 is allowed by default
-        http = RequestsWrapper({}, {})
-        http.get("https://incomplete-chain.badssl.com/")
+        http = RequestsWrapper(
+            {'tls_cert': '/etc/ssl/certs/ca-root.crt', 'tls_private_key': '/etc/ssl/certs/ca-root.key'}, {}
+        )
+        http.get("https://badssl.test/")
 
     def test_cant_allow_unknown_protocol(self, caplog):
         with caplog.at_level(logging.WARNING):


### PR DESCRIPTION
### What does this PR do?
Skip test in badssl.com with expired certified. Test will be reactivated when valid certified will be available.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
