### PR TITLE
Updated vsphere_overview.json

### DIFF
--- a/vsphere/assets/dashboards/vsphere_overview.json
+++ b/vsphere/assets/dashboards/vsphere_overview.json
@@ -289,7 +289,7 @@
         "title_align": "center",
         "check": "vsphere.can_connect",
         "grouping": "cluster",
-        "group_by": ["$vcenter_server"],
+        "group_by": ["vcenter_server"],
         "tags": ["*"]
       },
       "layout": { "x": 0, "y": 12, "width": 15, "height": 9 }


### PR DESCRIPTION
Had to change the group by portion of the widget "check_status" as it was grouping by the template variable and not vcenter_server. Noticed this was an issue with a particular customer (https://datadog.zendesk.com/agent/tickets/836725)

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This properly displays the amount of vcenters by changing the group by option in the "check_status" widget. 

### Motivation
<!-- What inspired you to submit this pull request? -->
This ticket (https://datadog.zendesk.com/agent/tickets/834591) in which the customer reached out saying that they are being shown the incorrect amount of vcenters. They've isolated the issue to be the above fix. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
