### PR TITLE
Update README.md

### DIFF
--- a/otel/README.md
+++ b/otel/README.md
@@ -94,8 +94,8 @@ Need help? Contact [Datadog support][6].
 
 [1]: https://opentelemetry.io/docs/collector/getting-started/
 [2]: https://app.datadoghq.com/organization-settings/api-keys
-[3]: https://docs.datadoghq.com/tracing/setup_overview/open_standards/#opentelemetry-collector-datadog-exporter
+[3]: https://docs.datadoghq.com/tracing/setup_overview/open_standards/otel_collector_datadog_exporter/
 [4]: https://github.com/open-telemetry/opentelemetry-collector/tree/master/receiver/hostmetricsreceiver
 [5]: https://github.com/DataDog/integrations-core/blob/master/opentelemetry/metadata.csv
 [6]: https://docs.datadoghq.com/help/
-[7]: https://docs.datadoghq.com/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent
+[7]: https://docs.datadoghq.com/tracing/setup_overview/open_standards/otlp_ingest_in_the_agent/


### PR DESCRIPTION
Updated link to public documentation for OTel datadog exporter and OTLP ingest. More specifically, instead of pointing to the generic link: https://docs.datadoghq.com/tracing/setup_overview/open_standards/#otlp-ingest-in-datadog-agent
Datadog Exporter is pointing to: https://docs.datadoghq.com/tracing/setup_overview/open_standards/otel_collector_datadog_exporter/
OTLP ingest is pointing to: https://docs.datadoghq.com/tracing/setup_overview/open_standards/otlp_ingest_in_the_agent/

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
