### PR TITLE
Fix rows with empty SQL text in DBM Activity Query

### DIFF
--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -87,7 +87,7 @@ WHERE
         waits_a.event_id = (
            SELECT
               MAX(waits_b.EVENT_ID)
-          FROM  performance_schema.events_waits_current AS waits_b 
+          FROM  performance_schema.events_waits_current AS waits_b
           Where waits_b.thread_id = thread_a.thread_id
     ) OR waits_a.event_id is NULL)
     -- We ignore rows without SQL text because there will be rows for background operations that do not have

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -44,9 +44,7 @@ SELECT
     thread_a.processlist_db,
     thread_a.processlist_command,
     thread_a.processlist_state,
-    COALESCE(
-        COALESCE(statement.sql_text, thread_a.PROCESSLIST_info), thread_a.processlist_state)
-            AS sql_text,
+    COALESCE(statement.sql_text, thread_a.PROCESSLIST_info) AS sql_text,
     statement.timer_start AS event_timer_start,
     statement.timer_end AS event_timer_end,
     statement.lock_time,
@@ -91,7 +89,10 @@ WHERE
               MAX(waits_b.EVENT_ID)
           FROM  performance_schema.events_waits_current AS waits_b 
           Where waits_b.thread_id = thread_a.thread_id
-    ) OR waits_a.event_id is NULL);
+    ) OR waits_a.event_id is NULL)
+    -- We ignore rows without SQL text because there will be rows for background operations that do not have
+    -- SQL text associated with it.
+    AND COALESCE(statement.sql_text, thread_a.PROCESSLIST_info) != "";
 """
 
 

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -59,7 +59,7 @@ SELECT
             IF(thread_a.processlist_state = 'User sleep', 'User sleep',
             IF(waits_a.event_id = waits_a.end_event_id, 'CPU', waits_a.event_name)), 'CPU'
         )
-    ) AS event_name,
+    ) AS wait_event,
     waits_a.operation,
     waits_a.timer_start AS wait_timer_start,
     waits_a.timer_end AS wait_timer_end,

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -52,7 +52,7 @@ SELECT
     waits_a.event_id AS event_id,
     waits_a.end_event_id,
     IF(waits_a.thread_id IS NULL,
-        thread_a.processlist_state,
+        'other',
         COALESCE(
             IF(thread_a.processlist_state = 'User sleep', 'User sleep',
             IF(waits_a.event_id = waits_a.end_event_id, 'CPU', waits_a.event_name)), 'CPU'

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -45,7 +45,7 @@ SELECT
     thread_a.processlist_command,
     thread_a.processlist_state,
     COALESCE(
-        COALESCE(statement.sql_text, thread_a.PROCESSLIST_info), thread_a.processlist_state) 
+        COALESCE(statement.sql_text, thread_a.PROCESSLIST_info), thread_a.processlist_state)
             AS sql_text,
     statement.timer_start AS event_timer_start,
     statement.timer_end AS event_timer_end,
@@ -53,7 +53,7 @@ SELECT
     statement.current_schema,
     MAX(waits_a.event_id) AS event_id,
     waits_a.end_event_id,
-    IF(waits_a.thread_id IS NULL, 
+    IF(waits_a.thread_id IS NULL,
         thread_a.processlist_state,
         COALESCE(
             IF(thread_a.processlist_state = 'User sleep', 'User sleep',
@@ -77,11 +77,11 @@ FROM
     LEFT JOIN performance_schema.events_statements_current AS statement ON statement.thread_id = thread_a.thread_id
     LEFT JOIN performance_schema.socket_instances AS socket ON socket.thread_id = thread_a.thread_id
 WHERE
-    thread_a.processlist_state IS NOT NULL 
-    AND thread_a.processlist_command != 'Sleep' 
-    AND thread_a.processlist_id != CONNECTION_ID() 
+    thread_a.processlist_state IS NOT NULL
+    AND thread_a.processlist_command != 'Sleep'
+    AND thread_a.processlist_id != CONNECTION_ID()
     AND thread_a.PROCESSLIST_COMMAND != 'Daemon'
-    AND (waits_a.EVENT_NAME != 'idle' OR waits_a.EVENT_NAME IS NULL) 
+    AND (waits_a.EVENT_NAME != 'idle' OR waits_a.EVENT_NAME IS NULL)
     AND (waits_a.operation != 'idle' OR waits_a.operation IS NULL)
 GROUP BY
     thread_a.thread_id,
@@ -98,10 +98,10 @@ GROUP BY
     statement.lock_time,
     statement.current_schema,
     waits_a.end_event_id,
-    If(waits_a.thread_id IS NULL, 
-        thread_a.processlist_state, 
+    If(waits_a.thread_id IS NULL,
+        thread_a.processlist_state,
         COALESCE(
-            IF(thread_a.processlist_state = 'User sleep', 'User sleep', 
+            IF(thread_a.processlist_state = 'User sleep', 'User sleep',
             IF(waits_a.event_id = waits_a.end_event_id, 'CPU', waits_a.event_name)), 'CPU'
         )
     ),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates MySQL's query activity query.

Query author and expert: @kyle-hailey 

### Motivation
<!-- What inspired you to submit this pull request? -->
The previous iteration of this query included rows without SQL text due to an incorrect outer `JOIN` statement in conjunction with the inner `SELECT` statement.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Behavior from the previous iteration of the query:
- Notice we receive many rows without SQL text

![Screen Shot 2022-06-23 at 5 05 35 PM](https://user-images.githubusercontent.com/30381624/175400332-5d76b689-9051-49b0-8ebb-9f57d02c8684.png)

New query:
![Screen Shot 2022-06-23 at 5 33 37 PM](https://user-images.githubusercontent.com/30381624/175406274-d9f75f50-c3e3-4b01-872a-6d9d859df1e1.png)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
