### PR TITLE
Make integration compatible with Vertica 11

### DIFF
--- a/vertica/datadog_checks/vertica/utils.py
+++ b/vertica/datadog_checks/vertica/utils.py
@@ -30,3 +30,7 @@ def node_state_to_service_check(node_state):
 
 def kilobytes_to_bytes(kb):
     return convert_units(kb, unit=KILOBYTE, to=BYTE)[0]
+
+
+def parse_major_version(version_string):
+    return int(version_string.split('.')[0].lstrip('v'))

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -224,7 +224,7 @@ class VerticaCheck(AgentCheck):
 
         # Vertica v11 has removed some columns, skip these metrics until we implement them
         if self._major_version() >= 11:
-            self.log.debug('Skipping collection of projection_storage metrics as they're not yet supported for v11+')
+            self.log.debug("Skipping collection of projection_storage metrics as they're not yet supported for v11+")
             return
 
         projection_data = defaultdict(
@@ -326,7 +326,7 @@ class VerticaCheck(AgentCheck):
 
         # Vertica v11 has removed some columns, skip these metrics until we implement them
         if self._major_version() >= 11:
-            self.log.debug('Skipping collection of storage_containers metrics as they're not yet supported for v11+')
+            self.log.debug("Skipping collection of storage_containers metrics as they're not yet supported for v11+")
             return
 
         container_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: {'delete_vectors': 0})))

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -224,7 +224,7 @@ class VerticaCheck(AgentCheck):
 
         # Vertica v11 has removed some columns, skip these metrics until we implement them
         if self._major_version() >= 11:
-            self.log.debug('Skipping collection of projection_storage metrics as not yet supported for v11+')
+            self.log.debug('Skipping collection of projection_storage metrics as they're not yet supported for v11+')
             return
 
         projection_data = defaultdict(
@@ -326,7 +326,7 @@ class VerticaCheck(AgentCheck):
 
         # Vertica v11 has removed some columns, skip these metrics until we implement them
         if self._major_version() >= 11:
-            self.log.debug('Skipping collection of storage_containers metrics as not yet supported for v11+')
+            self.log.debug('Skipping collection of storage_containers metrics as they're not yet supported for v11+')
             return
 
         container_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: {'delete_vectors': 0})))

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -224,6 +224,7 @@ class VerticaCheck(AgentCheck):
 
         # Vertica v11 has removed some columns, skip these metrics until we implement them
         if self._major_version() >= 11:
+            self.log.debug('Skipping collection of projection_storage metrics as not yet supported for v11+')
             return
 
         projection_data = defaultdict(
@@ -325,6 +326,7 @@ class VerticaCheck(AgentCheck):
 
         # Vertica v11 has removed some columns, skip these metrics until we implement them
         if self._major_version() >= 11:
+            self.log.debug('Skipping collection of storage_containers metrics as not yet supported for v11+')
             return
 
         container_data = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: {'delete_vectors': 0})))

--- a/vertica/tests/README.md
+++ b/vertica/tests/README.md
@@ -1,0 +1,8 @@
+# Test environment for Vertica
+
+This integration can be tested using the Docker Compose environment.
+
+There is no official image for version 9, so we're relying on a [community maintained image](https://hub.docker.com/r/jbfavre/vertica.).
+
+For versions 10+, we have our own Dockerfile that uses the [official vertica-ce images](https://hub.docker.com/r/vertica/vertica-ce)
+as a base but customizes the entrypoint to avoid loading data, so that startup times are shorter.

--- a/vertica/tests/README.md
+++ b/vertica/tests/README.md
@@ -2,7 +2,7 @@
 
 This integration can be tested using the Docker Compose environment.
 
-There is no official image for version 9, so we're relying on a [community maintained image](https://hub.docker.com/r/jbfavre/vertica.).
+Because there is no official image for version 9, we are relying on a [community maintained image](https://hub.docker.com/r/jbfavre/vertica.).
 
 For versions 10+, we have our own Dockerfile that uses the [official vertica-ce images](https://hub.docker.com/r/vertica/vertica-ce)
-as a base but customizes the entrypoint to avoid loading data, so that startup times are shorter.
+as a base, but customizes the entrypoint to avoid loading data to shorten startup times.

--- a/vertica/tests/common.py
+++ b/vertica/tests/common.py
@@ -6,8 +6,6 @@ import os
 from datadog_checks.dev import get_docker_hostname, get_here
 
 HERE = get_here()
-COMPOSE_FILE = os.path.join(HERE, 'docker', 'docker-compose.yaml')
-
 HOST = get_docker_hostname()
 PORT = 5433
 ID = 'datadog'
@@ -58,3 +56,14 @@ TLS_CONFIG_LEGACY = {
     'private_key': private_key,
     'ca_cert': CERTIFICATE_DIR,
 }
+
+
+def compose_file(vertica_version):
+    major_version = int(vertica_version.split('.', 1)[0])
+
+    if major_version < 10:
+        fname = 'docker-compose-9.yaml'
+    else:
+        fname = 'docker-compose.yaml'
+
+    return os.path.join(HERE, 'docker', fname)

--- a/vertica/tests/common.py
+++ b/vertica/tests/common.py
@@ -56,14 +56,3 @@ TLS_CONFIG_LEGACY = {
     'private_key': private_key,
     'ca_cert': CERTIFICATE_DIR,
 }
-
-
-def compose_file(vertica_version):
-    major_version = int(vertica_version.split('.', 1)[0])
-
-    if major_version < 10:
-        fname = 'docker-compose-9.yaml'
-    else:
-        fname = 'docker-compose.yaml'
-
-    return os.path.join(HERE, 'docker', fname)

--- a/vertica/tests/conftest.py
+++ b/vertica/tests/conftest.py
@@ -38,7 +38,7 @@ class InitializeDB(LazyFunction):
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    compose_file = common.compose_file(os.environ['VERTICA_VERSION'])
+    compose_file = get_compose_file(os.environ['VERTICA_VERSION'])
 
     with docker_run(compose_file, log_patterns=['Vertica is now running'], conditions=[InitializeDB(common.CONFIG)]):
         yield common.CONFIG
@@ -57,3 +57,14 @@ def tls_instance():
 @pytest.fixture
 def tls_instance_legacy():
     return deepcopy(common.TLS_CONFIG_LEGACY)
+
+
+def get_compose_file(vertica_version):
+    major_version = int(vertica_version.split('.', 1)[0])
+
+    if major_version < 10:
+        fname = 'docker-compose-9.yaml'
+    else:
+        fname = 'docker-compose.yaml'
+
+    return os.path.join(common.HERE, 'docker', fname)

--- a/vertica/tests/conftest.py
+++ b/vertica/tests/conftest.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
 from copy import deepcopy
 
 import pytest
@@ -37,9 +38,9 @@ class InitializeDB(LazyFunction):
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    with docker_run(
-        common.COMPOSE_FILE, log_patterns=['Vertica is now running'], conditions=[InitializeDB(common.CONFIG)]
-    ):
+    compose_file = common.compose_file(os.environ['VERTICA_VERSION'])
+
+    with docker_run(compose_file, log_patterns=['Vertica is now running'], conditions=[InitializeDB(common.CONFIG)]):
         yield common.CONFIG
 
 

--- a/vertica/tests/docker/Dockerfile_custom
+++ b/vertica/tests/docker/Dockerfile_custom
@@ -1,0 +1,10 @@
+ARG VERTICA_VERSION="latest"
+
+FROM vertica/vertica-ce:${VERTICA_VERSION}
+
+ADD ./custom-entrypoint.sh ${VERTICA_HOME_DIR}/custom-entrypoint.sh
+# Deleting the extension packages prevents those packages from being
+# installed when creating the database, leading to a faster startup time
+RUN rm -rf "${VERTICA_OPT_DIR}/packages"
+
+ENTRYPOINT ${VERTICA_HOME_DIR}/custom-entrypoint.sh

--- a/vertica/tests/docker/custom-entrypoint.sh
+++ b/vertica/tests/docker/custom-entrypoint.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+
+# NOTICE: This is a slightly modified version of the file found at
+# https://github.com/vertica/vertica-containers/blob/0d200b500c3c47b4d6dc10c8f170210301b0ffe5/one-node-ce/docker-entrypoint.sh
+
+# (c) Copyright [2021] Micro Focus or one of its affiliates.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DEBUG_FAILING_STARTUP=y
+if [ "${DEBUG_FAILING_STARTUP}" != "y" ]; then
+  # Stop container, if any error occurs during startup
+  # Can be overriden by setting DEBUG_FAILING_STARTUP to "y"
+  set -e
+fi
+
+# We have to export it here, vertica_env.sh is not propagated into entrypoint script
+export VERTICA_DB_USER="`whoami`"
+echo VERTICA_DB_USER is \"$VERTICA_DB_USER\"
+STOP_LOOP="false"
+VSQL="${VERTICA_OPT_DIR}/bin/vsql -U ${VERTICA_DB_USER}"
+ADMINTOOLS="${VERTICA_OPT_DIR}/bin/admintools"
+
+function start_agent() {
+    echo "Starting MC agent"
+    # suppress errors about lack of systemd
+    sudo ${VERTICA_OPT_DIR}/sbin/vertica_agent start \
+         2> ${VERTICA_DATA_DIR}/${VERTICA_DB_NAME}/agent_start.err \
+         1> ${VERTICA_DATA_DIR}/${VERTICA_DB_NAME}/agent_start.out
+}
+
+function stop_agent() {
+    echo "Shutting down MC agent"
+    # suppress errors about lack of systemd
+    sudo ${VERTICA_OPT_DIR}/sbin/vertica_agent stop \
+         2> ${VERTICA_DATA_DIR}/${VERTICA_DB_NAME}/agent_stop.err \
+         1> ${VERTICA_DATA_DIR}/${VERTICA_DB_NAME}/agent_stop.out
+}
+
+# Vertica should be shut down properly
+function shut_down() {
+    echo "Shutting Down"
+    vertica_proper_shutdown
+    echo 'Stopping loop'
+    STOP_LOOP="true"
+}
+
+function vertica_proper_shutdown() {
+    db=$(${ADMINTOOLS} -t show_active_db)
+    case "$db"x in
+        x) 
+            echo "Database not running --- shutting down"
+            ;;
+        *)
+            stop_agent
+            echo 'Vertica: Closing active sessions'
+            ${VSQL} -c 'SELECT CLOSE_ALL_SESSIONS();'
+            echo 'Vertica: Flushing everything on disk'
+            ${VSQL} -c 'SELECT MAKE_AHM_NOW();'
+            echo 'Vertica: Stopping database'
+            ${ADMINTOOLS} -t stop_db -d $VERTICA_DB_NAME -i
+            ;;
+    esac
+}
+
+function create_app_db_user() {
+    echo ''
+    echo "Creating APP DB user ${APP_DB_USER} ... "
+    CHECK_STRING="ALREADY_EXISTS"
+    CHECK_QUERY="select case when count(*) > 0 then '${CHECK_STRING}' end from users where user_name = '${APP_DB_USER}'"
+    ALREADY_EXISTS=$($VSQL -c "${CHECK_QUERY}" | grep ${CHECK_STRING} | sed 's/ //g' || true)
+    if [ "${ALREADY_EXISTS}" != "${CHECK_STRING}" ]; then
+        ${VSQL} -c "create user ${APP_DB_USER}"
+        ${VSQL} -c "grant pseudosuperuser to ${APP_DB_USER}"
+        ${VSQL} -c "alter user ${APP_DB_USER} default role all"
+    fi
+    # Alter the user password everytime to support change of the password
+    # We must prevent error "ROLLBACK 2301:  Can not reuse current password" with " || true"
+    ${VSQL} -c "alter user ${APP_DB_USER} identified by '${APP_DB_PASSWORD}'" || true
+}
+
+function preserve_config() {
+    # unfortunately, admintools doesn't (always) obey symlinks when
+    # manipulating its admintools.conf file, so we have to move the
+    # entire config directory  
+    if [ -f ${VERTICA_DATA_DIR}/config/admintools.conf ]; then
+        # second and subsequent times starting the container
+        # we have an admintools.conf in ${VERTICA_DATA_DIR}
+        echo "config has already been preserved"
+    else
+        # first time through docker-entrypoint.sh we need to move
+        # the config directory to persistent store
+        echo "Moving config directory tree to persistent store"
+        sudo cp --archive ${VERTICA_OPT_DIR}/config ${VERTICA_DATA_DIR}
+        sudo chown -R ${VERTICA_DB_USER} ${VERTICA_DATA_DIR}/config
+    fi
+    # unfortunately, the symlink is in the container image
+    # so we have to renew it each time
+    if [ ! -L ${VERTICA_OPT_DIR}/config ]; then
+        echo "symlink ${VERTICA_OPT_DIR}/config -> ${VERTICA_DATA_DIR}/config"
+        rm -rf ${VERTICA_OPT_DIR}/config
+        ln -s  ${VERTICA_DATA_DIR}/config  ${VERTICA_OPT_DIR}/config
+    fi
+}       
+
+
+trap "shut_down" SIGKILL SIGTERM SIGHUP SIGINT
+if [ -n "${TZ}" ]; then
+  echo "Custom time zone required - ${TZ}"
+  if [ ! -f "${VERTICA_OPT_DIR}/share/timezone/${TZ}" ]; then
+    echo "ERROR: timezone file ${VERTICA_OPT_DIR}/${TZ} does not exist"
+    echo "Check Dockerfile and uncomment a workaround solution linking system time zones"
+    exit 1
+  fi
+fi
+
+echo 'Starting up'
+if [ ! -d ${VERTICA_DATA_DIR}/${VERTICA_DB_NAME} ]; then
+    # first time through --- create db, etc.
+    mkdir -p ${VERTICA_DATA_DIR}/config
+    preserve_config
+    echo 'Creating database'
+
+    ${ADMINTOOLS} -t create_db \
+                  --skip-fs-checks \
+                  -s localhost \
+                  --database=$VERTICA_DB_NAME \
+                  --catalog_path=${VERTICA_DATA_DIR} \
+                  --data_path=${VERTICA_DATA_DIR}
+
+    # These are the lines that we remove from the original script
+    # echo 'Loading VMart schema ...'
+    # ${VMART_DIR}/${VMART_ETL_SCRIPT}
+
+    if [ -n "${APP_DB_USER}" ]; then
+        create_app_db_user
+    fi
+else
+    # ${VERTICA_OPT_DIR}/config/admintools.conf is the unmodified container
+    # copy, but we symlinked it the first time through, and have to
+    # recreate that symlink
+    preserve_config
+    echo 'Starting Database'
+    ${ADMINTOOLS} -t start_db \
+                  --database=$VERTICA_DB_NAME \
+                  --noprompts
+fi
+
+echo
+if [ -d /docker-entrypoint-initdb.d/ ]; then
+    echo "Running entrypoint scripts ..."
+    for f in $(ls /docker-entrypoint-initdb.d/* | sort); do
+        case "$f" in
+            *.sh)     echo "$0: running $f"; . "$f" ;;
+            *.sql)    echo "$0: running $f"; ${VSQL} -f $f; echo ;;
+            *)        echo "$0: ignoring $f" ;;
+        esac
+        echo
+    done
+fi
+
+# cron(d) daemonizes, so no need for launching as background process
+if grep -q -i debian /etc/os-release; then
+    sudo /usr/sbin/cron
+else
+    sudo /usr/sbin/crond
+fi
+start_agent
+
+echo
+echo "Vertica is now running"
+
+while [ "${STOP_LOOP}" == "false" ]; do
+    # We could use admintools -t show_active_db to see if the
+    # db is still running, and restart it if it isn't
+    sleep 1
+done
+

--- a/vertica/tests/docker/docker-compose-9.yaml
+++ b/vertica/tests/docker/docker-compose-9.yaml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+
+  vertica:
+    image: jbfavre/vertica:${VERTICA_VERSION}
+    container_name: vertica
+    ports:
+      - "5433:5433"
+    environment:
+      - DATABASE_NAME=datadog
+      - DATABASE_PASSWORD=monitor

--- a/vertica/tests/docker/docker-compose.yaml
+++ b/vertica/tests/docker/docker-compose.yaml
@@ -1,12 +1,29 @@
-version: '3'
+version: "3.9"
 
 services:
-
   vertica:
-    image: jbfavre/vertica:${VERTICA_VERSION}
-    container_name: vertica
+    build:
+      # We use a custom Dockerfile that adds a modified entrypoint
+      # script that avoids loading the data.
+      context: .
+      dockerfile: ./Dockerfile_custom
+      args:
+        VERTICA_VERSION: ${VERTICA_VERSION}
+    image: datadog/vertica-ce-custom:${VERTICA_VERSION}
+    environment:
+      APP_DB_PASSWORD: "monitor"
+      # VERTICA_MEMDEBUG=2 solves problems when running this image on M1
+      # https://forum.vertica.com/discussion/242629/support-apple-silicon-m1-for-docker-vertica-ce
+      VERTICA_MEMDEBUG: 2
+      VERTICA_DB_NAME: "datadog"
+    container_name: vertica-ce
     ports:
       - "5433:5433"
-    environment:
-      - DATABASE_NAME=datadog
-      - DATABASE_PASSWORD=monitor
+      - "5444:5444"
+    volumes:
+      - type: volume
+        source: vertica-data2
+        target: /data
+
+volumes:
+  vertica-data2:

--- a/vertica/tests/test_unit.py
+++ b/vertica/tests/test_unit.py
@@ -10,6 +10,7 @@ import pytest
 from datadog_checks.base import AgentCheck
 from datadog_checks.base.log import TRACE_LEVEL
 from datadog_checks.vertica import VerticaCheck
+from datadog_checks.vertica.utils import parse_major_version
 
 CERTIFICATE_DIR = os.path.join(os.path.dirname(__file__), 'certificate')
 cert = os.path.join(CERTIFICATE_DIR, 'cert.cert')
@@ -150,3 +151,8 @@ def test_client_logging_disabled_if_agent_uses_info(aggregator, instance):
             connection_load_balance=mock.ANY,
             connection_timeout=mock.ANY,
         )
+
+
+@pytest.mark.parametrize('version_string, expected', [('v9.2.0-7', 9), ('v11.1.1-0', 11)])
+def test_parse_major_version(version_string, expected):
+    assert parse_major_version(version_string) == expected

--- a/vertica/tests/test_vertica.py
+++ b/vertica/tests/test_vertica.py
@@ -40,7 +40,8 @@ def test_check(aggregator, datadog_agent, instance, dd_run_check):
 
     aggregator.assert_all_metrics_covered()
 
-    version_metadata = {'version.scheme': 'semver', 'version.major': os.environ['VERTICA_VERSION'][0]}
+    major_version = parse_major_version(os.environ['VERTICA_VERSION'])
+    version_metadata = {'version.scheme': 'semver', 'version.major': str(major_version)}
     datadog_agent.assert_metadata('test:123', version_metadata)
     datadog_agent.assert_metadata_count(len(version_metadata) + 4)
 

--- a/vertica/tests/test_vertica.py
+++ b/vertica/tests/test_vertica.py
@@ -14,6 +14,9 @@ from .metrics import ALL_METRICS
 
 
 @pytest.mark.e2e
+@pytest.mark.skipif(
+    parse_major_version(os.environ.get('VERTICA_VERSION', 9)) >= 11, reason='Some metrics are not yet supported on v11'
+)
 def test_check_e2e(dd_agent_check, instance):
     aggregator = dd_agent_check(instance, rate=True)
 

--- a/vertica/tests/test_vertica.py
+++ b/vertica/tests/test_vertica.py
@@ -7,6 +7,7 @@ import mock
 import pytest
 
 from datadog_checks.vertica import VerticaCheck
+from datadog_checks.vertica.utils import parse_major_version
 
 from . import common
 from .metrics import ALL_METRICS
@@ -24,6 +25,9 @@ def test_check_e2e(dd_agent_check, instance):
 
 
 @pytest.mark.usefixtures('dd_environment')
+@pytest.mark.xfail(
+    parse_major_version(os.environ.get('VERTICA_VERSION', 9)) >= 11, reason='Some metrics are not yet supported on v11'
+)
 def test_check(aggregator, datadog_agent, instance, dd_run_check):
 
     check = VerticaCheck('vertica', {}, [instance])
@@ -88,6 +92,9 @@ def test_custom_queries(aggregator, instance, dd_run_check):
 
 
 @pytest.mark.usefixtures('dd_environment')
+@pytest.mark.xfail(
+    parse_major_version(os.environ.get('VERTICA_VERSION', 9)) >= 11, reason='Some metrics are not yet supported on v11'
+)
 def test_include_all_metric_groups(aggregator, instance, dd_run_check):
     check = VerticaCheck('vertica', {}, [instance])
     dd_run_check(check)

--- a/vertica/tox.ini
+++ b/vertica/tox.ini
@@ -4,7 +4,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py{27,38}-{9,11}
+    py{27,38}-{9,10,11}
 
 [testenv]
 ensure_default_envdir = true
@@ -26,4 +26,5 @@ commands =
 setenv =
     DDEV_SKIP_GENERIC_TAGS_CHECK=true
     9: VERTICA_VERSION=9.x
+    10: VERTICA_VERSION=10.1.1-0
     11: VERTICA_VERSION=11.1.1-0

--- a/vertica/tox.ini
+++ b/vertica/tox.ini
@@ -4,7 +4,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py{27,38}-9
+    py{27,38}-{9,11}
 
 [testenv]
 ensure_default_envdir = true
@@ -26,3 +26,4 @@ commands =
 setenv =
     DDEV_SKIP_GENERIC_TAGS_CHECK=true
     9: VERTICA_VERSION=9.x
+    11: VERTICA_VERSION=11.1.1-0


### PR DESCRIPTION
### What does this PR do?

- It adds Vertica versions 10 and 11 to the testing environments.
- For Vertica 11, it skips the portion of the check that is currently incompatible with it to avoid having the check crash resulting in no metrics at all.

### Motivation

[AI-2467](https://datadoghq.atlassian.net/browse/AI-2467) (and [original GitHub issue](https://github.com/DataDog/integrations-core/issues/11565))

Vertica 11 dropped some columns that the integration relies on for some metrics, involving the distinction between WOS and ROS, see https://www.vertica.com/docs/ReleaseNotes/11.0.x/Vertica_11.0.x_Release_Notes.htm#Removed11.0.2.

### Additional Notes

- I plan to implement the support for the _incompatible_ metrics for v11 in a follow-up PR to keep this focused. I tried to get the minimum here so that we have something that's an improvement over the current situation and focuses on adding the new environments since that's already somewhat involved.
- As part of that, I've marked some tests as `xfail` for Vertica 11 until we go and implement the equivalent functionality. However, _enough_ tests pass to give confidence that these changes at least allow the integration to work with Vertica 11, currently at the expense of not emitting a subset of metrics.
- The addition of the Vertica 10 environment confirms that the integration properly supports that version.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
