### PR TITLE
Add functionality to load the legacy version of the integration

### DIFF
--- a/active_directory/datadog_checks/active_directory/active_directory.py
+++ b/active_directory/datadog_checks/active_directory/active_directory.py
@@ -3,14 +3,14 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from six import PY3
 
-from datadog_checks.base import is_affirmative, PDHBaseCheck
+from datadog_checks.base import PDHBaseCheck, is_affirmative
 
 from .metrics import DEFAULT_COUNTERS
 
 
 class ActiveDirectoryCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False):
+        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False)):
             from .check import ActiveDirectoryCheckV2
 
             return ActiveDirectoryCheckV2(name, init_config, instances)

--- a/active_directory/datadog_checks/active_directory/active_directory.py
+++ b/active_directory/datadog_checks/active_directory/active_directory.py
@@ -3,14 +3,14 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from six import PY3
 
-from datadog_checks.base.checks.win import PDHBaseCheck
+from datadog_checks.base import is_affirmative, PDHBaseCheck
 
 from .metrics import DEFAULT_COUNTERS
 
 
 class ActiveDirectoryCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        if PY3:
+        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False):
             from .check import ActiveDirectoryCheckV2
 
             return ActiveDirectoryCheckV2(name, init_config, instances)

--- a/active_directory/datadog_checks/active_directory/config_models/defaults.py
+++ b/active_directory/datadog_checks/active_directory/config_models/defaults.py
@@ -82,5 +82,9 @@ def instance_tags(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_use_legacy_check_version(field, value):
+    return False
+
+
 def instance_username(field, value):
     return get_default_field_value(field, value)

--- a/active_directory/datadog_checks/active_directory/config_models/instance.py
+++ b/active_directory/datadog_checks/active_directory/config_models/instance.py
@@ -115,6 +115,7 @@ class InstanceConfig(BaseModel):
     server_tag: Optional[str]
     service: Optional[str]
     tags: Optional[Sequence[str]]
+    use_legacy_check_version: Optional[bool]
     username: Optional[str]
 
     @root_validator(pre=True)

--- a/aspdotnet/datadog_checks/aspdotnet/aspdotnet.py
+++ b/aspdotnet/datadog_checks/aspdotnet/aspdotnet.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from six import PY3
 
-from datadog_checks.base import is_affirmative, PDHBaseCheck
+from datadog_checks.base import PDHBaseCheck, is_affirmative
 
 from .metrics import DEFAULT_COUNTERS
 
@@ -12,8 +12,10 @@ EVENT_TYPE = SOURCE_TYPE_NAME = 'aspdotnet'
 
 class AspdotnetCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        import pdb; pdb.set_trace()
-        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False):
+        import pdb
+
+        pdb.set_trace()
+        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False)):
             from .check import AspdotnetCheckV2
 
             return AspdotnetCheckV2(name, init_config, instances)

--- a/aspdotnet/datadog_checks/aspdotnet/aspdotnet.py
+++ b/aspdotnet/datadog_checks/aspdotnet/aspdotnet.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from six import PY3
 
-from datadog_checks.base import PDHBaseCheck
+from datadog_checks.base import is_affirmative, PDHBaseCheck
 
 from .metrics import DEFAULT_COUNTERS
 
@@ -12,7 +12,8 @@ EVENT_TYPE = SOURCE_TYPE_NAME = 'aspdotnet'
 
 class AspdotnetCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        if PY3:
+        import pdb; pdb.set_trace()
+        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False):
             from .check import AspdotnetCheckV2
 
             return AspdotnetCheckV2(name, init_config, instances)

--- a/aspdotnet/datadog_checks/aspdotnet/config_models/defaults.py
+++ b/aspdotnet/datadog_checks/aspdotnet/config_models/defaults.py
@@ -82,5 +82,9 @@ def instance_tags(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_use_legacy_check_version(field, value):
+    return False
+
+
 def instance_username(field, value):
     return get_default_field_value(field, value)

--- a/aspdotnet/datadog_checks/aspdotnet/config_models/instance.py
+++ b/aspdotnet/datadog_checks/aspdotnet/config_models/instance.py
@@ -115,6 +115,7 @@ class InstanceConfig(BaseModel):
     server_tag: Optional[str]
     service: Optional[str]
     tags: Optional[Sequence[str]]
+    use_legacy_check_version: Optional[bool]
     username: Optional[str]
 
     @root_validator(pre=True)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/perf_counters.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/perf_counters.yaml
@@ -37,3 +37,12 @@
     hidden: true
 - template: common/perf_counters.metrics
   name: extra_metrics  # Hidden for the `windows_performance_counters` provider integration
+- name: use_legacy_check_version
+  hidden: true
+  required: false
+  description: |
+    For backward compatibility reasons, it is possible to use a legacy version of the 
+    integration by setting this field to "true".
+  value:
+      type: boolean
+      example: false

--- a/dotnetclr/datadog_checks/dotnetclr/dotnetclr.py
+++ b/dotnetclr/datadog_checks/dotnetclr/dotnetclr.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from six import PY3
 
-from datadog_checks.base import is_affirmative, PDHBaseCheck
+from datadog_checks.base import PDHBaseCheck, is_affirmative
 
 from .metrics import DEFAULT_COUNTERS
 
@@ -12,7 +12,7 @@ EVENT_TYPE = SOURCE_TYPE_NAME = 'dotnetclr'
 
 class DotnetclrCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False):
+        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False)):
             from .check import DotnetclrCheckV2
 
             return DotnetclrCheckV2(name, init_config, instances)

--- a/dotnetclr/datadog_checks/dotnetclr/dotnetclr.py
+++ b/dotnetclr/datadog_checks/dotnetclr/dotnetclr.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from six import PY3
 
-from datadog_checks.base import PDHBaseCheck
+from datadog_checks.base import is_affirmative, PDHBaseCheck
 
 from .metrics import DEFAULT_COUNTERS
 
@@ -12,7 +12,7 @@ EVENT_TYPE = SOURCE_TYPE_NAME = 'dotnetclr'
 
 class DotnetclrCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        if PY3:
+        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False):
             from .check import DotnetclrCheckV2
 
             return DotnetclrCheckV2(name, init_config, instances)

--- a/exchange_server/datadog_checks/exchange_server/config_models/defaults.py
+++ b/exchange_server/datadog_checks/exchange_server/config_models/defaults.py
@@ -82,5 +82,9 @@ def instance_tags(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_use_legacy_check_version(field, value):
+    return False
+
+
 def instance_username(field, value):
     return get_default_field_value(field, value)

--- a/exchange_server/datadog_checks/exchange_server/config_models/instance.py
+++ b/exchange_server/datadog_checks/exchange_server/config_models/instance.py
@@ -115,6 +115,7 @@ class InstanceConfig(BaseModel):
     server_tag: Optional[str]
     service: Optional[str]
     tags: Optional[Sequence[str]]
+    use_legacy_check_version: Optional[bool]
     username: Optional[str]
 
     @root_validator(pre=True)

--- a/exchange_server/datadog_checks/exchange_server/exchange_server.py
+++ b/exchange_server/datadog_checks/exchange_server/exchange_server.py
@@ -3,14 +3,14 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from six import PY3
 
-from datadog_checks.base import PDHBaseCheck
+from datadog_checks.base import is_affirmative, PDHBaseCheck
 
 from .metrics import DEFAULT_COUNTERS
 
 
 class ExchangeCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        if PY3:
+        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False):
             from .check import ExchangeCheckV2
 
             return ExchangeCheckV2(name, init_config, instances)

--- a/exchange_server/datadog_checks/exchange_server/exchange_server.py
+++ b/exchange_server/datadog_checks/exchange_server/exchange_server.py
@@ -3,14 +3,14 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from six import PY3
 
-from datadog_checks.base import is_affirmative, PDHBaseCheck
+from datadog_checks.base import PDHBaseCheck, is_affirmative
 
 from .metrics import DEFAULT_COUNTERS
 
 
 class ExchangeCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False):
+        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False)):
             from .check import ExchangeCheckV2
 
             return ExchangeCheckV2(name, init_config, instances)

--- a/hyperv/datadog_checks/hyperv/config_models/defaults.py
+++ b/hyperv/datadog_checks/hyperv/config_models/defaults.py
@@ -82,5 +82,9 @@ def instance_tags(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_use_legacy_check_version(field, value):
+    return False
+
+
 def instance_username(field, value):
     return get_default_field_value(field, value)

--- a/hyperv/datadog_checks/hyperv/config_models/instance.py
+++ b/hyperv/datadog_checks/hyperv/config_models/instance.py
@@ -115,6 +115,7 @@ class InstanceConfig(BaseModel):
     server_tag: Optional[str]
     service: Optional[str]
     tags: Optional[Sequence[str]]
+    use_legacy_check_version: Optional[bool]
     username: Optional[str]
 
     @root_validator(pre=True)

--- a/hyperv/datadog_checks/hyperv/hyperv.py
+++ b/hyperv/datadog_checks/hyperv/hyperv.py
@@ -3,14 +3,14 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from six import PY3
 
-from datadog_checks.base import is_affirmative, PDHBaseCheck
+from datadog_checks.base import PDHBaseCheck, is_affirmative
 
 from .metrics import DEFAULT_COUNTERS
 
 
 class HypervCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False):
+        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False)):
             from .check import HypervCheckV2
 
             return HypervCheckV2(name, init_config, instances)

--- a/hyperv/datadog_checks/hyperv/hyperv.py
+++ b/hyperv/datadog_checks/hyperv/hyperv.py
@@ -3,14 +3,14 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from six import PY3
 
-from datadog_checks.base import PDHBaseCheck
+from datadog_checks.base import is_affirmative, PDHBaseCheck
 
 from .metrics import DEFAULT_COUNTERS
 
 
 class HypervCheck(PDHBaseCheck):
     def __new__(cls, name, init_config, instances):
-        if PY3:
+        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False):
             from .check import HypervCheckV2
 
             return HypervCheckV2(name, init_config, instances)

--- a/iis/datadog_checks/iis/config_models/defaults.py
+++ b/iis/datadog_checks/iis/config_models/defaults.py
@@ -90,5 +90,9 @@ def instance_tags(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_use_legacy_check_version(field, value):
+    return False
+
+
 def instance_username(field, value):
     return get_default_field_value(field, value)

--- a/iis/datadog_checks/iis/config_models/instance.py
+++ b/iis/datadog_checks/iis/config_models/instance.py
@@ -133,6 +133,7 @@ class InstanceConfig(BaseModel):
     service: Optional[str]
     sites: Optional[Union[Sequence[str], Site]]
     tags: Optional[Sequence[str]]
+    use_legacy_check_version: Optional[bool]
     username: Optional[str]
 
     @root_validator(pre=True)

--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from six import PY3, iteritems
 
-from datadog_checks.base import PDHBaseCheck
+from datadog_checks.base import is_affirmative,PDHBaseCheck
 
 DEFAULT_COUNTERS = [
     ["Web Service", None, "Service Uptime", "iis.uptime", "gauge"],
@@ -47,7 +47,7 @@ class IIS(PDHBaseCheck):
     APP_POOL = 'app_pool'
 
     def __new__(cls, name, init_config, instances):
-        if PY3:
+        if PY3 and not is_affirmative(instances[0].get('use_legacy_check_version', False)):
             from .check import IISCheckV2
 
             return IISCheckV2(name, init_config, instances)


### PR DESCRIPTION
### What does this PR do?
Some customer reported that the new implementation of collecting metrics via windows performance counters are generating excessive amounts of windows events. This PR includes a `use_legacy_check_version` parameter that allows the user to swap back to the previous method of collection (PDH).