### PR TITLE
sqlserver simplify configuration for Azure SQL Database 

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -243,12 +243,19 @@ class SQLServer(AgentCheck):
                 if engine_edition == ENGINE_EDITION_SQL_DATABASE:
                     configured_database = self.instance.get('database', None)
                     if not configured_database:
-                        self.warning("Missing 'database' in instance configuration. For Azure SQL Database a non-master application database must be specified.")
+                        self.warning(
+                            "Missing 'database' in instance configuration."
+                            "For Azure SQL Database a non-master application database must be specified."
+                        )
                     elif configured_database == 'master':
-                        self.warning("Wrong 'database' configured for this instance. For Azure SQL Database a non-master application database must be specified.")
+                        self.warning(
+                            "Wrong 'database' configured."
+                            "For Azure SQL Database a non-master application database must be specified."
+                        )
                     else:
-                        # for Azure SQL Database, each database on a given "server" has isolated compute resources, meaning that the agent is only able to
-                        # see query activity for the specific database it is connected to. For this reason, each Azure SQL database is modeled as an independent host.
+                        # for Azure SQL Database, each database on a given "server" has isolated compute resources,
+                        # meaning that the agent is only able to see query activity for the specific database it's
+                        # connected to. For this reason, each Azure SQL database is modeled as an independent host.
                         self._resolved_hostname = "{}/{}".format(host, configured_database)
             else:
                 self._resolved_hostname = self.agent_hostname
@@ -644,7 +651,8 @@ class SQLServer(AgentCheck):
         if self.do_check:
             self.load_static_information()
 
-            # re-initialize resolved_hostname to ensure we take into consideration the static information after it's loaded from the database
+            # re-initialize resolved_hostname to ensure we take into consideration the static information
+            # after it's loaded
             self._resolved_hostname = None
             self.resolved_hostname()
 

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     from ..stubs import datadog_agent
 
-from .const import STATIC_INFO_VERSION, STATIC_INFO_ENGINE_EDITION
+from .const import STATIC_INFO_ENGINE_EDITION, STATIC_INFO_VERSION
 
 DEFAULT_COLLECTION_INTERVAL = 10
 

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     from ..stubs import datadog_agent
 
-from .const import STATIC_INFO_VERSION
+from .const import STATIC_INFO_VERSION, STATIC_INFO_ENGINE_EDITION
 
 DEFAULT_COLLECTION_INTERVAL = 10
 
@@ -294,6 +294,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             'cloud_metadata': self.check.cloud_metadata,
             'sqlserver_rows': [self._to_metrics_payload_row(r) for r in rows],
             'sqlserver_version': self.check.static_info_cache.get(STATIC_INFO_VERSION, ""),
+            'sqlserver_engine_edition': self.check.static_info_cache.get(STATIC_INFO_ENGINE_EDITION, ""),
             'ddagentversion': datadog_agent.get_version(),
             'ddagenthostname': self._check.agent_hostname,
         }


### PR DESCRIPTION
### What does this PR do?

* Automatically configure `resolved_hostname` to the expected `{server}/{database}` format when the check detects it's connected to Azure SQL Database. This removes the need to manually configure `reported_hostname` when connected to Azure SQL Database.
* Send `sqlserver_engine_edition` in statement metrics payloads to enable the backend systems to know which engine edition this is. This removes the need to manually configure `azure` cloud metadata.

### Motivation

Simplify configuration for Azure SQL Database. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
