### PR TITLE
Fix Postgres calculation of blk_read_time and blk_write_time metrics

### DIFF
--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -339,7 +339,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             return []
 
         available_columns = set(rows[0].keys())
-        metric_columns = available_columns & PG_STAT_STATEMENTS_METRICS_COLUMNS
+        metric_columns = available_columns & (PG_STAT_STATEMENTS_METRICS_COLUMNS | PG_STAT_STATEMENTS_TIMING_COLUMNS)
         rows = self._state.compute_derivative_rows(rows, metric_columns, key=_row_key)
         self._check.gauge(
             'dd.postgres.queries.query_rows_raw',

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -188,7 +188,7 @@ def test_statement_metrics(
         available_columns = set(row.keys())
         metric_columns = available_columns & PG_STAT_STATEMENTS_METRICS_COLUMNS
         if track_io_timing_enabled:
-            metric_columns |= PG_STAT_STATEMENTS_TIMING_COLUMNS
+            assert (available_columns & PG_STAT_STATEMENTS_TIMING_COLUMNS) == PG_STAT_STATEMENTS_TIMING_COLUMNS
         else:
             assert (available_columns & PG_STAT_STATEMENTS_TIMING_COLUMNS) == set()
         for col in metric_columns:


### PR DESCRIPTION
### What does this PR do?

This marks `blk_read_time` and `blk_write_time` as metrics columns so they are computed as derivative values.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
