### PR TITLE
Use digest_text for computing MySQL signature

### DIFF
--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -222,10 +222,10 @@ class MySQLActivity(DBMAsyncJob):
             return row
         try:
             self._finalize_row(
-				row,
-				obfuscate_sql_with_metadata(row["sql_text"], self._obfuscator_options),
-				obfuscate_sql_with_metadata(row["digest_text"], self._obfuscator_options)
-			)
+                row,
+                obfuscate_sql_with_metadata(row["sql_text"], self._obfuscator_options),
+                obfuscate_sql_with_metadata(row["digest_text"], self._obfuscator_options),
+            )
         except Exception as e:
             row["sql_text"] = "ERROR: failed to obfuscate"
             self._log.debug("Failed to obfuscate | err=[%s]", e)

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -50,14 +50,14 @@ def dbm_instance(instance_complex):
     [
         (
             'SELECT id, name FROM testdb.users FOR UPDATE',
-            'aca1be410fbadb61',
+            '4d09873d44c33af7',
             StatementTruncationState.not_truncated.value,
         ),
         (
             'SELECT id, {} FROM testdb.users FOR UPDATE'.format(
                 ", ".join("name as name{}".format(i) for i in range(254))
             ),
-            '63bd1fd025c7f7fb'
+            '87523f8c5aabfda5'
             if MYSQL_VERSION_PARSED > parse_version('5.6') and environ.get('MYSQL_FLAVOR') != 'mariadb'
             else '4a12d7afe06cf40',
             StatementTruncationState.truncated.value,
@@ -193,7 +193,7 @@ def test_activity_metadata(aggregator, dd_run_check, dbm_instance, datadog_agent
     -- Test comment
     SELECT id, name FROM testdb.users FOR UPDATE
     """
-    query_signature = 'e7f7cb251194df29'
+    query_signature = '4d09873d44c33af7'
 
     def _run_test_query(conn, _query):
         conn.cursor().execute(_query)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updates MySQL query activity to compute the `query_signature` from the `digest_text`.

### Motivation
<!-- What inspired you to submit this pull request? -->

FQT and sample events compute the `query_signature` from the `digest_text` whereas activity events compute it based off the `sql_text`. This causes a discrepancy when trying to associate activity rows with FQT and sample rows.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Before (unable to get query details for activity)
![Screen Shot 2022-06-23 at 6 08 37 PM](https://user-images.githubusercontent.com/30381624/175423512-c81cf25f-2f7c-443f-b118-0ef5b82445e7.png)
After
![Screen Shot 2022-06-23 at 6 08 51 PM](https://user-images.githubusercontent.com/30381624/175423567-23a5efb9-bce2-433b-bfae-00fbf8d50623.png)


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
