### PR TITLE
Remove confusing error message on sqlserver integration start up

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -141,6 +141,8 @@ class Connection(object):
             else:
                 self.log.error("Invalid database connector %s, defaulting to adodbapi", connector)
             self.default_connector = 'adodbapi'
+        else:
+            self.default_connector = connector
 
         self.connector = self.get_connector()
 

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -128,6 +128,8 @@ class Connection(object):
         self.existing_databases = None
         self.server_version = int(self.instance.get('server_version', self.DEFAULT_SQLSERVER_VERSION))
 
+        self.adoprovider = self.default_adoprovider
+        
         self.valid_connectors = []
         if adodbapi is not None:
             self.valid_connectors.append('adodbapi')
@@ -151,6 +153,7 @@ class Connection(object):
             self.log.error(
                 "Invalid ADODB provider string %s, defaulting to %s", self.adoprovider, self.default_adoprovider
             )
+            self.adoprovider = self.default_adoprovider
 
         self.log.debug('Connection initialized.')
 

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -128,17 +128,18 @@ class Connection(object):
         self.existing_databases = None
         self.server_version = int(self.instance.get('server_version', self.DEFAULT_SQLSERVER_VERSION))
 
-        self.adoprovider = self.default_adoprovider
-
         self.valid_connectors = []
         if adodbapi is not None:
             self.valid_connectors.append('adodbapi')
         if pyodbc is not None:
             self.valid_connectors.append('odbc')
 
-        self.default_connector = init_config.get('connector', 'adodbapi')
-        if self.default_connector.lower() not in self.valid_connectors:
-            self.log.error("Invalid database connector %s, defaulting to adodbapi", self.default_connector)
+        connector = init_config.get('connector')
+        if connector is None or connector.lower() not in self.valid_connectors:
+            if connector is None:
+                self.log.debug("`connector` config value was not set, defaulting to adodbapi")
+            else:
+                self.log.error("Invalid database connector %s, defaulting to adodbapi", connector)
             self.default_connector = 'adodbapi'
 
         self.connector = self.get_connector()
@@ -148,7 +149,6 @@ class Connection(object):
             self.log.error(
                 "Invalid ADODB provider string %s, defaulting to %s", self.adoprovider, self.default_adoprovider
             )
-            self.adoprovider = self.default_adoprovider
 
         self.log.debug('Connection initialized.')
 

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -129,7 +129,7 @@ class Connection(object):
         self.server_version = int(self.instance.get('server_version', self.DEFAULT_SQLSERVER_VERSION))
 
         self.adoprovider = self.default_adoprovider
-        
+
         self.valid_connectors = []
         if adodbapi is not None:
             self.valid_connectors.append('adodbapi')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fixes error we are seeing on SQL Server integration startup
```
Invalid database connector adodbapi, defaulting to adodbapi
```
this error doesn't make sense as we are incorrectly not adding `adodbapi` to the `valid_connectors` array. This list can just be hardcoded instead. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
