### PR TITLE
Fix agent changelog command for manifest v2

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
@@ -1,14 +1,14 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import json
 import os
 from io import StringIO
 
 import click
 
-from ....fs import read_file, write_file
-from ...constants import get_agent_changelog, get_root
+from ....fs import write_file
+from ...constants import get_agent_changelog
+from ...utils import get_display_name
 from ..console import CONTEXT_SETTINGS, abort, echo_info
 from .common import get_changes_per_agent
 
@@ -66,14 +66,7 @@ def changelog(since, to, write, force):
             for entry in CHANGELOG_MANUAL_ENTRIES.get(agent, []):
                 changelog_contents.write(f'{entry}\n')
             for name, ver in version_changes.items():
-                # get the "display name" for the check
-                manifest_file = os.path.join(get_root(), name, 'manifest.json')
-                if os.path.exists(manifest_file):
-                    decoded = json.loads(read_file(manifest_file).strip())
-                    display_name = decoded.get('display_name')
-                else:
-                    display_name = name
-
+                display_name = get_display_name(name)
                 display_name = DISPLAY_NAME_MAPPING.get(display_name, display_name)
 
                 breaking_notice = " **BREAKING CHANGE**" if ver[1] else ""

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/changelog.py
@@ -8,7 +8,7 @@ import click
 
 from ....fs import write_file
 from ...constants import get_agent_changelog
-from ...utils import get_display_name
+from ...manifest_utils import Manifest
 from ..console import CONTEXT_SETTINGS, abort, echo_info
 from .common import get_changes_per_agent
 
@@ -66,7 +66,11 @@ def changelog(since, to, write, force):
             for entry in CHANGELOG_MANUAL_ENTRIES.get(agent, []):
                 changelog_contents.write(f'{entry}\n')
             for name, ver in version_changes.items():
-                display_name = get_display_name(name)
+                manifest = Manifest.load_manifest(name)
+                if manifest is None:
+                    display_name = name
+                else:
+                    display_name = manifest.get_display_name()
                 display_name = DISPLAY_NAME_MAPPING.get(display_name, display_name)
 
                 breaking_notice = " **BREAKING CHANGE**" if ver[1] else ""


### PR DESCRIPTION
### What does this PR do?
Fixes ddev agent changelog command for manifest V2
### Motivation
Creating changelogs for 7.37.0

### Additional Notes
The old implementation returned a display name of "None" for teamcity since the logic did not handle manifest V2s
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
