### PR TITLE
feat: Add named_service_tags config option to reduce metric cardinality

### DIFF
--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -107,7 +107,7 @@ files:
         where `service-1` is `consul_service` and `active` is a consul tag on the service
       value:
         type: boolean
-        example: false
+        example: true
 
     - name: max_services
       description: |

--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -99,6 +99,13 @@ files:
           - <SERVICE_1>
           - <SERVICE_2>
 
+    - name: named_service_tags
+      description: |
+        Control the addition of metric tags with consul_service name in the key
+      value:
+        type: boolean
+        example: false
+
     - name: max_services
       description: |
         Increase the maximum number of queried services.

--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -107,7 +107,8 @@ files:
         where `service-1` is `consul_service` and `active` is a consul tag on the service
       value:
         type: boolean
-        example: true
+        display_default: true
+        example: false
 
     - name: max_services
       description: |

--- a/consul/assets/configuration/spec.yaml
+++ b/consul/assets/configuration/spec.yaml
@@ -101,7 +101,10 @@ files:
 
     - name: named_service_tags
       description: |
-        Control the addition of metric tags with consul_service name in the key
+        Controls addition of metric tags with `consul_service` name in the tag name
+        If set to `true`, the integrition will emit metrics with tags like:
+        'consul_service-1_service_tag:active'
+        where `service-1` is `consul_service` and `active` is a consul tag on the service
       value:
         type: boolean
         example: false

--- a/consul/datadog_checks/consul/config_models/defaults.py
+++ b/consul/datadog_checks/consul/config_models/defaults.py
@@ -125,8 +125,10 @@ def instance_metric_patterns(field, value):
 def instance_min_collection_interval(field, value):
     return 15
 
+
 def instance_named_service_tags(field, value):
     return True
+
 
 def instance_network_latency_checks(field, value):
     return False

--- a/consul/datadog_checks/consul/config_models/defaults.py
+++ b/consul/datadog_checks/consul/config_models/defaults.py
@@ -125,6 +125,8 @@ def instance_metric_patterns(field, value):
 def instance_min_collection_interval(field, value):
     return 15
 
+def instance_named_service_tags(field, value):
+    return True
 
 def instance_network_latency_checks(field, value):
     return False

--- a/consul/datadog_checks/consul/config_models/instance.py
+++ b/consul/datadog_checks/consul/config_models/instance.py
@@ -73,6 +73,7 @@ class InstanceConfig(BaseModel):
     max_services: Optional[float]
     metric_patterns: Optional[MetricPatterns]
     min_collection_interval: Optional[float]
+    named_service_tags: Optional[bool]
     network_latency_checks: Optional[bool]
     new_leader_checks: Optional[bool]
     ntlm_domain: Optional[str]

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -106,6 +106,7 @@ class ConsulCheck(OpenMetricsBaseCheck):
         )
         self.services_exclude = set(self.instance.get('services_exclude', self.init_config.get('services_exclude', [])))
         self.max_services = self.instance.get('max_services', self.init_config.get('max_services', MAX_SERVICES))
+        self.named_service_tags = self.instance.get('named_service_tags', self.init_config.get('named_service_tags', True))
         self.threads_count = self.instance.get('threads_count', self.init_config.get('threads_count', THREADS_COUNT))
         if self.threads_count > 1:
             self.thread_pool = ThreadPool(self.threads_count)
@@ -316,7 +317,8 @@ class ConsulCheck(OpenMetricsBaseCheck):
         service_tags = ['consul_service_id:{}'.format(service)]
 
         for tag in tags:
-            service_tags.append('consul_{}_service_tag:{}'.format(service, tag))
+            if self.named_service_tags:
+                service_tags.append('consul_{}_service_tag:{}'.format(service, tag))
             service_tags.append('consul_service_tag:{}'.format(tag))
 
         return service_tags

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -313,11 +313,11 @@ class ConsulCheck(OpenMetricsBaseCheck):
         return services
 
     @staticmethod
-    def _get_service_tags(service, tags):
+    def _get_service_tags(named_service_tags, service, tags):
         service_tags = ['consul_service_id:{}'.format(service)]
 
         for tag in tags:
-            if self.named_service_tags:
+            if named_service_tags:
                 service_tags.append('consul_{}_service_tag:{}'.format(service, tag))
             service_tags.append('consul_service_tag:{}'.format(tag))
 
@@ -482,7 +482,7 @@ class ConsulCheck(OpenMetricsBaseCheck):
         # `consul.catalog.nodes_passing` : # of Nodes with service status `passing` from those registered
         # `consul.catalog.nodes_warning` : # of Nodes with service status `warning` from those registered
         # `consul.catalog.nodes_critical` : # of Nodes with service status `critical` from those registered
-        all_service_tags = self._get_service_tags(service, service_tags)
+        all_service_tags = self._get_service_tags(self.named_service_tags, service, service_tags)
         # {'up': 0, 'passing': 0, 'warning': 0, 'critical': 0}
         node_count_per_status = defaultdict(int)
         for node in nodes_with_service:

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -119,9 +119,8 @@ instances:
 
     ## @param named_service_tags - boolean - optional - default: true
     ## Controls addition of metric tags with `consul_service` name in the tag name
-    #
+    ##
     ## If set to `true`, the integrition will emit metrics with tags like:
-    #
     ## 'consul_service-1_service_tag:active'
     ## where `service-1` is `consul_service` and `active` is a consul tag on the service
     #

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -119,7 +119,6 @@ instances:
 
     ## @param named_service_tags - boolean - optional - default: true
     ## Controls addition of metric tags with `consul_service` name in the tag name
-    ##
     ## If set to `true`, the integrition will emit metrics with tags like:
     ## 'consul_service-1_service_tag:active'
     ## where `service-1` is `consul_service` and `active` is a consul tag on the service

--- a/consul/datadog_checks/consul/data/conf.yaml.example
+++ b/consul/datadog_checks/consul/data/conf.yaml.example
@@ -117,6 +117,16 @@ instances:
     #   - <SERVICE_1>
     #   - <SERVICE_2>
 
+    ## @param named_service_tags - boolean - optional - default: true
+    ## Controls addition of metric tags with `consul_service` name in the tag name
+    #
+    ## If set to `true`, the integrition will emit metrics with tags like:
+    #
+    ## 'consul_service-1_service_tag:active'
+    ## where `service-1` is `consul_service` and `active` is a consul tag on the service
+    #
+    # named_service_tags: false
+
     ## @param max_services - number - optional - default: 50
     ## Increase the maximum number of queried services.
     #

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -21,7 +21,6 @@ def test_get_nodes_with_service_no_tags(aggregator):
     consul_mocks.mock_check(consul_check, consul_mocks._get_consul_mocks())
     consul_check.check(None)
 
-    # Big include list with max_services
     consul_check.named_service_tags = False
 
     expected_tags = [
@@ -32,26 +31,6 @@ def test_get_nodes_with_service_no_tags(aggregator):
     ]
 
     aggregator.assert_metric('consul.catalog.nodes_up', value=4, tags=expected_tags)
-    aggregator.assert_metric('consul.catalog.nodes_passing', value=4, tags=expected_tags)
-    aggregator.assert_metric('consul.catalog.nodes_warning', value=0, tags=expected_tags)
-    aggregator.assert_metric('consul.catalog.nodes_critical', value=0, tags=expected_tags)
-
-    expected_tags = ['consul_datacenter:dc1', 'consul_node_id:node-1']
-
-    aggregator.assert_metric('consul.catalog.services_up', value=24, tags=expected_tags)
-    aggregator.assert_metric('consul.catalog.services_passing', value=24, tags=expected_tags)
-    aggregator.assert_metric('consul.catalog.services_warning', value=0, tags=expected_tags)
-    aggregator.assert_metric('consul.catalog.services_critical', value=0, tags=expected_tags)
-
-    expected_tags = [
-        'consul_datacenter:dc1',
-        'consul_service_id:service-1',
-        'consul_node_id:node-1',
-        'consul_status:passing',
-    ]
-    aggregator.assert_metric('consul.catalog.services_count', value=3, tags=expected_tags)
-    expected_tags.append('consul_service-1_service_tag:active')
-    aggregator.assert_metric('consul.catalog.services_count', value=1, tags=expected_tags)
 
 def test_get_nodes_with_service(aggregator):
     consul_check = ConsulCheck(common.CHECK_NAME, {}, [consul_mocks.MOCK_CONFIG])


### PR DESCRIPTION
### What does this PR do?
Add a configuration option to reduce metric cardinality by omitting high-cardinality tags 
<!-- A brief description of the change being made with this pull request. -->

### Motivation
High cardinality metrics emitted from our high-use test cluster
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
