### PR TITLE
Use the correct team when using `ddev -a release trello testable`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -66,7 +66,6 @@ class TrelloClient:
         # Maps the team to the github team
         self.label_github_team_map = {
             'team/agent-apm': 'agent-apm',
-            'team/agent-core': 'agent-core',
             'team/agent-platform': 'agent-platform',
             'team/triage': 'agent-platform',
             'team/networks': 'agent-network',
@@ -81,6 +80,9 @@ class TrelloClient:
             'team/container-ecosystems': 'container-ecosystems',
             'team/agent-metrics-logs': 'agent-metrics-logs',
             'team/agent-shared-components': 'agent-shared-components',
+            # 'agent-core' must be after 'agent-metrics-logs' and 'agent-shared-components'
+            # as the team of a user is the first team available.
+            'team/agent-core': 'agent-core',
         }
 
         # Maps the trello label name to trello label ID


### PR DESCRIPTION

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix team assignment for `agent-metrics-logs` and `agent-shared-component`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
