### PR TITLE
Fix organization data transfer query

### DIFF
--- a/snowflake/datadog_checks/snowflake/queries.py
+++ b/snowflake/datadog_checks/snowflake/queries.py
@@ -358,10 +358,15 @@ OrgRateSheet = {
 OrgDataTransfer = {
     'name': 'organization.data_transfer.metrics',
     'query': (
-        'select ACCOUNT_NAME, BYTES_TRANSFERRED from DATA_TRANSFER_DAILY_HISTORY ORDER BY USAGE_DATE DESC LIMIT 1;'
+        'select ACCOUNT_NAME, SOURCE_CLOUD, TARGET_CLOUD, TRANSFER_TYPE, '
+        'sum(BYTES_TRANSFERRED) from DATA_TRANSFER_HISTORY '
+        'where USAGE_DATE = DATEADD(day, -1, current_date) group by 1, 2, 3, 4;'
     ),
     'columns': [
         {'name': 'billing_account', 'type': 'tag'},
+        {'name': 'source_cloud', 'type': 'tag'},
+        {'name': 'target_cloud', 'type': 'tag'},
+        {'name': 'transfer_type', 'type': 'tag'},
         {'name': 'organization.data_transfer.bytes_transferred', 'type': 'gauge'},
     ],
 }

--- a/snowflake/tests/snowflake_connector_patch/_snowflake_connector_patch/tables.py
+++ b/snowflake/tests/snowflake_connector_patch/_snowflake_connector_patch/tables.py
@@ -115,9 +115,12 @@ ORGANIZATION_RATE_SHEET_DAILY = [
     ),
 ]
 
-ORGANIZATION_DATA_TRANSFER_DAILY_HISTORY = [
+ORGANIZATION_DATA_TRANSFER_HISTORY = [
     (
         'test_account',
+        'AWS',
+        'GCP',
+        'COPY',
         Decimal('13.56'),
     ),
 ]

--- a/snowflake/tests/test_e2e.py
+++ b/snowflake/tests/test_e2e.py
@@ -233,7 +233,7 @@ def test_org_usage_mock_data(dd_agent_check, datadog_agent, instance):
     )
     aggregator.assert_metric('snowflake.organization.balance.rollover', value=455435, tags=EXPECTED_TAGS + balance_tags)
 
-    data_transfer_tags = ['billing_account:test_account']
+    data_transfer_tags = ['billing_account:test_account', 'source_cloud:AWS', 'target_cloud:GCP', 'transfer_type:COPY']
     aggregator.assert_metric(
         'snowflake.organization.data_transfer.bytes_transferred', value=13.56, tags=EXPECTED_TAGS + data_transfer_tags
     )

--- a/snowflake/tests/test_queries.py
+++ b/snowflake/tests/test_queries.py
@@ -352,10 +352,18 @@ def test_org_data_transfer(dd_run_check, aggregator, instance):
     expected_data_transfer_metrics = [
         (
             'test_account',
+            'AWS',
+            'GCP',
+            'COPY',
             Decimal('13.56'),
         ),
     ]
-    expected_tags = EXPECTED_TAGS + ['billing_account:test_account']
+    expected_tags = EXPECTED_TAGS + [
+        'billing_account:test_account',
+        'source_cloud:AWS',
+        'target_cloud:GCP',
+        'transfer_type:COPY',
+    ]
     with mock.patch(
         'datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_data_transfer_metrics
     ):


### PR DESCRIPTION
### What does this PR do?
Fix organization data transfer query

### Motivation
The query was based off of the fields in [DATA_TRANSFER_DAILY_HISTORY](https://docs.snowflake.com/en/sql-reference/organization-usage/data_transfer_daily_history.html) and not [DATA_TRANSFER_HISTORY](https://docs.snowflake.com/en/sql-reference/organization-usage/data_transfer_history.html). This PR updates the query to pull in the correct data from DATA_TRANSFER_HISTORY instead.

QA for https://github.com/DataDog/integrations-core/pull/12375

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
