### PR TITLE
Support version specific AlwaysOn metrics

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -105,110 +105,62 @@ def get_query_ao_availability_groups(sqlserver_major_version):
 
     # AG - sys.availability_groups
     ag_column_definitions = {
-        'availability_group': {
-            'sql_column': 'AG.group_id AS availability_group',
-            'metric_definition': {'name': 'availability_group', 'type': 'tag'},
-        },
-        'availability_group_name': {
-            'sql_column': 'AG.name AS availability_group_name',
-            'metric_definition': {'name': 'availability_group_name', 'type': 'tag'},
-        },
+        'AG.group_id AS availability_group': {'name': 'availability_group', 'type': 'tag'},
+        'AG.name AS availability_group_name': {'name': 'availability_group_name', 'type': 'tag'},
     }
 
     # AR - sys.availability_replicas
     ar_column_definitions = {
-        'replica_server_name': {
-            'sql_column': 'AR.replica_server_name',
-            'metric_definition': {'name': 'replica_server_name', 'type': 'tag'},
-        },
-        'failover_mode': {
-            'sql_column': 'LOWER(AR.failover_mode_desc) AS failover_mode_desc',
-            'metric_definition': {'name': 'failover_mode', 'type': 'tag'},
-        },
-        'availability_mode': {
-            'sql_column': 'LOWER(AR.availability_mode_desc) AS availability_mode_desc',
-            'metric_definition': {'name': 'availability_mode', 'type': 'tag'},
-        },
+        'AR.replica_server_name': {'name': 'replica_server_name', 'type': 'tag'},
+        'LOWER(AR.failover_mode_desc) AS failover_mode_desc': {'name': 'failover_mode', 'type': 'tag'},
+        'LOWER(AR.availability_mode_desc) AS availability_mode_desc': {'name': 'availability_mode', 'type': 'tag'},
     }
 
     # ADC - sys.availability_databases_cluster
     adc_column_definitions = {
-        'database_name': {
-            'sql_column': 'ADC.database_name',
-            'metric_definition': {'name': 'database_name', 'type': 'tag'},
-        },
+        'ADC.database_name': {'name': 'database_name', 'type': 'tag'},
     }
 
     # DRS - sys.dm_hadr_database_replica_states
     drs_column_definitions = {
-        'replica_id': {
-            'sql_column': 'DRS.replica_id',
-            'metric_definition': {'name': 'replica_id', 'type': 'tag'},
+        'DRS.replica_id': {'name': 'replica_id', 'type': 'tag'},
+        'DRS.database_id': {'name': 'database_id', 'type': 'tag'},
+        'DRS.database_state': {'name': 'database_state', 'type': 'tag'},
+        'LOWER(DRS.synchronization_state_desc) AS synchronization_state_desc': {
+            'name': 'synchronization_state',
+            'type': 'tag',
         },
-        'database_id': {
-            'sql_column': 'DRS.database_id',
-            'metric_definition': {'name': 'database_id', 'type': 'tag'},
-        },
-        'database_state': {
-            'sql_column': 'DRS.database_state',
-            'metric_definition': {'name': 'database_state', 'type': 'tag'},
-        },
-        'synchronization_state': {
-            'sql_column': 'LOWER(DRS.synchronization_state_desc) AS synchronization_state_desc',
-            'metric_definition': {'name': 'synchronization_state', 'type': 'tag'},
-        },
-        'ao_log_send_queue_size': {
-            'sql_column': '(DRS.log_send_queue_size * 1024) AS log_send_queue_size',
-            'metric_definition': {'name': 'ao.log_send_queue_size', 'type': 'gauge'},
-        },
-        'ao_log_send_rate': {
-            'sql_column': '(DRS.log_send_rate * 1024) AS log_send_rate',
-            'metric_definition': {'name': 'ao.log_send_rate', 'type': 'gauge'},
-        },
-        'ao_redo_queue_size': {
-            'sql_column': '(DRS.redo_queue_size * 1024) AS redo_queue_size',
-            'metric_definition': {'name': 'ao.redo_queue_size', 'type': 'gauge'},
-        },
-        'ao_redo_rate': {
-            'sql_column': '(DRS.redo_rate * 1024) AS redo_rate',
-            'metric_definition': {'name': 'ao.redo_rate', 'type': 'gauge'},
-        },
-        'ao_low_water_mark_for_ghosts': {
-            'sql_column': 'DRS.low_water_mark_for_ghosts',
-            'metric_definition': {'name': 'ao.low_water_mark_for_ghosts', 'type': 'gauge'},
-        },
-        'ao_filestream_send_rate': {
-            'sql_column': '(DRS.filestream_send_rate * 1024) AS filestream_send_rate',
-            'metric_definition': {'name': 'ao.filestream_send_rate', 'type': 'gauge'},
+        '(DRS.log_send_queue_size * 1024) AS log_send_queue_size': {'name': 'ao.log_send_queue_size', 'type': 'gauge'},
+        '(DRS.log_send_rate * 1024) AS log_send_rate': {'name': 'ao.log_send_rate', 'type': 'gauge'},
+        '(DRS.redo_queue_size * 1024) AS redo_queue_size': {'name': 'ao.redo_queue_size', 'type': 'gauge'},
+        '(DRS.redo_rate * 1024) AS redo_rate': {'name': 'ao.redo_rate', 'type': 'gauge'},
+        'DRS.low_water_mark_for_ghosts': {'name': 'ao.low_water_mark_for_ghosts', 'type': 'gauge'},
+        '(DRS.filestream_send_rate * 1024) AS filestream_send_rate': {
+            'name': 'ao.filestream_send_rate',
+            'type': 'gauge',
         },
     }
 
     # FC - sys.dm_hadr_cluster
     fc_column_definitions = {
-        'failover_cluster': {
-            'sql_column': 'FC.cluster_name',
-            'metric_definition': {'name': 'failover_cluster', 'type': 'tag'},
+        'FC.cluster_name': {
+            'name': 'failover_cluster',
+            'type': 'tag',
         },
     }
 
     # Include metrics based on version
     if sqlserver_major_version >= 2016:
-        drs_column_definitions['ao_secondary_lag_seconds'] = {
-            'sql_column': 'DRS.secondary_lag_seconds',
-            'metric_definition': {'name': 'ao.secondary_lag_seconds', 'type': 'gauge'},
-        }
+        drs_column_definitions['DRS.secondary_lag_seconds'] = {'name': 'ao.secondary_lag_seconds', 'type': 'gauge'}
     if sqlserver_major_version >= 2014:
-        drs_column_definitions['ao_is_primary_replica'] = {
-            'sql_column': 'DRS.is_primary_replica',
-            'metric_definition': {'name': 'ao.is_primary_replica', 'type': 'gauge'},
-        }
+        drs_column_definitions['DRS.is_primary_replica'] = {'name': 'ao.is_primary_replica', 'type': 'gauge'}
 
     def _sort_column_definitions(column_definitions):
         sql_columns = []
         metric_columns = []
         for column in sorted(column_definitions.keys()):
-            sql_columns.append(column_definitions[column]['sql_column'])
-            metric_columns.append(column_definitions[column]['metric_definition'])
+            sql_columns.append(column)
+            metric_columns.append(column_definitions[column])
         return sql_columns, metric_columns
 
     # Sort columns to ensure a static column order

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -70,69 +70,6 @@ QUERY_AO_FAILOVER_CLUSTER_MEMBER = {
     ],
 }
 
-QUERY_AO_AVAILABILITY_GROUPS = {
-    'name': 'sys.availability_groups',
-    'query': """
-        SELECT
-            AG.group_id AS availability_group,
-            AG.name AS availability_group_name,
-            AR.replica_server_name,
-            LOWER(AR.failover_mode_desc) AS failover_mode_desc,
-            LOWER(AR.availability_mode_desc) AS failover_mode_desc,
-            ADC.database_name,
-            DRS.replica_id,
-            DRS.database_id,
-            DRS.is_primary_replica,
-            DRS.database_state,
-            LOWER(DRS.synchronization_state_desc) AS synchronization_state_desc,
-            (DRS.log_send_queue_size * 1024) AS log_send_queue_size,
-            (DRS.log_send_rate * 1024) AS log_send_rate,
-            (DRS.redo_queue_size * 1024) AS redo_queue_size,
-            (DRS.redo_rate * 1024) AS redo_rate,
-            DRS.low_water_mark_for_ghosts,
-            (DRS.filestream_send_rate * 1024) AS filestream_send_rate,
-            DRS.secondary_lag_seconds,
-            FC.cluster_name
-        FROM
-            sys.availability_groups AS AG
-            INNER JOIN sys.availability_replicas AS AR ON AG.group_id = AR.group_id
-            INNER JOIN sys.availability_databases_cluster AS ADC ON AG.group_id = ADC.group_id
-            INNER JOIN sys.dm_hadr_database_replica_states AS DRS ON AG.group_id = DRS.group_id
-                AND ADC.group_database_id = DRS.group_database_id
-                AND AR.replica_id = DRS.replica_id
-            -- `sys.dm_hadr_cluster` does not have a related column to join on, this cross join will add the
-            -- `cluster_name` column to every row by multiplying all the rows in the left table against
-            -- all the rows in the right table. Note, there will only be one row from `sys.dm_hadr_cluster`.
-            CROSS JOIN (SELECT TOP 1 cluster_name FROM sys.dm_hadr_cluster) AS FC
-    """.strip(),
-    'columns': [
-        # AG - sys.availability_groups
-        {'name': 'availability_group', 'type': 'tag'},
-        {'name': 'availability_group_name', 'type': 'tag'},
-        # AR - sys.availability_replicas
-        {'name': 'replica_server_name', 'type': 'tag'},
-        {'name': 'failover_mode', 'type': 'tag'},
-        {'name': 'availability_mode', 'type': 'tag'},
-        # ADC - sys.availability_databases_cluster
-        {'name': 'database_name', 'type': 'tag'},
-        # DRS - sys.dm_hadr_database_replica_states
-        {'name': 'replica_id', 'type': 'tag'},
-        {'name': 'database_id', 'type': 'tag'},
-        {'name': 'ao.is_primary_replica', 'type': 'gauge'},
-        {'name': 'database_state', 'type': 'tag'},
-        {'name': 'synchronization_state', 'type': 'tag'},
-        {'name': 'ao.log_send_queue_size', 'type': 'gauge'},
-        {'name': 'ao.log_send_rate', 'type': 'gauge'},
-        {'name': 'ao.redo_queue_size', 'type': 'gauge'},
-        {'name': 'ao.redo_rate', 'type': 'gauge'},
-        {'name': 'ao.low_water_mark_for_ghosts', 'type': 'gauge'},
-        {'name': 'ao.filestream_send_rate', 'type': 'gauge'},
-        {'name': 'ao.secondary_lag_seconds', 'type': 'gauge'},
-        # FC - sys.dm_hadr_cluster
-        {'name': 'failover_cluster', 'type': 'tag'},
-    ],
-}
-
 QUERY_FAILOVER_CLUSTER_INSTANCE = {
     'name': 'sys.dm_os_cluster_nodes',
     'query': """
@@ -156,6 +93,161 @@ QUERY_FAILOVER_CLUSTER_INSTANCE = {
         {'name': 'failover_cluster', 'type': 'tag'},
     ],
 }
+
+
+def get_ao_availability_groups(sqlserver_major_version):
+    """
+    Construct the sys.availability_groups QueryExecutor configuration based on the SQL Server major version
+
+    :params sqlserver_major_version: SQL Server major version (i.e. 2012, 2019, ...)
+    :return: a QueryExecutor query config object
+    """
+
+    # AG - sys.availability_groups
+    ag_column_definitions = {
+        'availability_group': {
+            'sql_column': 'AG.group_id AS availability_group',
+            'metric_definition': {'name': 'availability_group', 'type': 'tag'},
+        },
+        'availability_group_name': {
+            'sql_column': 'AG.name AS availability_group_name',
+            'metric_definition': {'name': 'availability_group_name', 'type': 'tag'},
+        },
+    }
+
+    # AR - sys.availability_replicas
+    ar_column_definitions = {
+        'replica_server_name': {
+            'sql_column': 'AR.replica_server_name',
+            'metric_definition': {'name': 'replica_server_name', 'type': 'tag'},
+        },
+        'failover_mode': {
+            'sql_column': 'LOWER(AR.failover_mode_desc) AS failover_mode_desc',
+            'metric_definition': {'name': 'failover_mode', 'type': 'tag'},
+        },
+        'availability_mode': {
+            'sql_column': 'LOWER(AR.availability_mode_desc) AS availability_mode_desc',
+            'metric_definition': {'name': 'availability_mode', 'type': 'tag'},
+        },
+    }
+
+    # ADC - sys.availability_databases_cluster
+    adc_column_definitions = {
+        'database_name': {
+            'sql_column': 'ADC.database_name',
+            'metric_definition': {'name': 'database_name', 'type': 'tag'},
+        },
+    }
+
+    # DRS - sys.dm_hadr_database_replica_states
+    drs_column_definitions = {
+        'replica_id': {
+            'sql_column': 'DRS.replica_id',
+            'metric_definition': {'name': 'replica_id', 'type': 'tag'},
+        },
+        'database_id': {
+            'sql_column': 'DRS.database_id',
+            'metric_definition': {'name': 'database_id', 'type': 'tag'},
+        },
+        'ao_is_primary_replica': {
+            'sql_column': 'DRS.is_primary_replica',
+            'metric_definition': {'name': 'ao.is_primary_replica', 'type': 'gauge'},
+        },
+        'database_state': {
+            'sql_column': 'DRS.database_state',
+            'metric_definition': {'name': 'database_state', 'type': 'tag'},
+        },
+        'synchronization_state': {
+            'sql_column': 'LOWER(DRS.synchronization_state_desc) AS synchronization_state_desc',
+            'metric_definition': {'name': 'synchronization_state', 'type': 'tag'},
+        },
+        'ao_log_send_queue_size': {
+            'sql_column': '(DRS.log_send_queue_size * 1024) AS log_send_queue_size',
+            'metric_definition': {'name': 'ao.log_send_queue_size', 'type': 'gauge'},
+        },
+        'ao_log_send_rate': {
+            'sql_column': '(DRS.log_send_rate * 1024) AS log_send_rate',
+            'metric_definition': {'name': 'ao.log_send_rate', 'type': 'gauge'},
+        },
+        'ao_redo_queue_size': {
+            'sql_column': '(DRS.redo_queue_size * 1024) AS redo_queue_size',
+            'metric_definition': {'name': 'ao.redo_queue_size', 'type': 'gauge'},
+        },
+        'ao_redo_rate': {
+            'sql_column': '(DRS.redo_rate * 1024) AS redo_rate',
+            'metric_definition': {'name': 'ao.redo_rate', 'type': 'gauge'},
+        },
+        'ao_low_water_mark_for_ghosts': {
+            'sql_column': 'DRS.low_water_mark_for_ghosts',
+            'metric_definition': {'name': 'ao.low_water_mark_for_ghosts', 'type': 'gauge'},
+        },
+        'ao_filestream_send_rate': {
+            'sql_column': '(DRS.filestream_send_rate * 1024) AS filestream_send_rate',
+            'metric_definition': {'name': 'ao.filestream_send_rate', 'type': 'gauge'},
+        },
+        'ao_secondary_lag_seconds': {
+            'sql_column': 'DRS.secondary_lag_seconds',
+            'metric_definition': {'name': 'ao.secondary_lag_seconds', 'type': 'gauge'},
+        },
+    }
+
+    # FC - sys.dm_hadr_cluster
+    fc_column_definitions = {
+        'failover_cluster': {
+            'sql_column': 'FC.cluster_name',
+            'metric_definition': {'name': 'failover_cluster', 'type': 'tag'},
+        },
+    }
+
+    if sqlserver_major_version <= 2014:
+        drs_column_definitions.pop('ao_secondary_lag_seconds')
+    if sqlserver_major_version <= 2012:
+        drs_column_definitions.pop('ao_is_primary_replica')
+
+    def _sort_column_definitions(column_definitions):
+        sql_columns = []
+        metric_columns = []
+        for column in sorted(column_definitions.keys()):
+            sql_columns.append(column_definitions[column]['sql_column'])
+            metric_columns.append(column_definitions[column]['metric_definition'])
+        return sql_columns, metric_columns
+
+    # sort columns to ensure a static column order
+    ag_sql_columns, ag_metric_columns = _sort_column_definitions(ag_column_definitions)
+    ar_sql_columns, ar_metric_columns = _sort_column_definitions(ar_column_definitions)
+    adc_sql_columns, adc_metric_columns = _sort_column_definitions(adc_column_definitions)
+    drs_sql_columns, drs_metric_columns = _sort_column_definitions(drs_column_definitions)
+    fc_sql_columns, fc_metric_columns = _sort_column_definitions(fc_column_definitions)
+
+    return {
+        'name': 'sys.availability_groups',
+        'query': """
+        SELECT
+            {ag_sql_columns},
+            {ar_sql_columns},
+            {adc_sql_columns},
+            {drs_sql_columns},
+            {fc_sql_columns}
+        FROM
+            sys.availability_groups AS AG
+            INNER JOIN sys.availability_replicas AS AR ON AG.group_id = AR.group_id
+            INNER JOIN sys.availability_databases_cluster AS ADC ON AG.group_id = ADC.group_id
+            INNER JOIN sys.dm_hadr_database_replica_states AS DRS ON AG.group_id = DRS.group_id
+                AND ADC.group_database_id = DRS.group_database_id
+                AND AR.replica_id = DRS.replica_id
+            -- `sys.dm_hadr_cluster` does not have a related column to join on, this cross join will add the
+            -- `cluster_name` column to every row by multiplying all the rows in the left table against
+            -- all the rows in the right table. Note, there will only be one row from `sys.dm_hadr_cluster`.
+            CROSS JOIN (SELECT TOP 1 cluster_name FROM sys.dm_hadr_cluster) AS FC
+    """.strip().format(
+            ag_sql_columns=", ".join(ag_sql_columns),
+            ar_sql_columns=", ".join(ar_sql_columns),
+            adc_sql_columns=", ".join(adc_sql_columns),
+            drs_sql_columns=", ".join(drs_sql_columns),
+            fc_sql_columns=", ".join(fc_sql_columns),
+        ),
+        'columns': ag_metric_columns + ar_metric_columns + adc_metric_columns + drs_metric_columns + fc_metric_columns,
+    }
 
 
 def get_query_file_stats(sqlserver_major_version):

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -688,12 +688,12 @@ class SQLServer(AgentCheck):
                     ]
                 )
             else:
-                self.log.warning('Collecting AlwaysOn metrics is only supported on versions 2014+')
+                self.log.warning('Collecting AlwaysOn metrics is not supported on version 2012')
         if is_affirmative(self.instance.get('include_fci_metrics', False)):
             if major_version > 2012:
                 queries.extend([QUERY_FAILOVER_CLUSTER_INSTANCE])
             else:
-                self.log.warning('Collecting Failover Cluster Instance metrics is only supported on versions 2014+')
+                self.log.warning('Collecting Failover Cluster Instance metrics is not supported on version 2012')
 
         self._dynamic_queries = self._new_query_executor(queries)
         self._dynamic_queries.compile_queries()

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -58,11 +58,11 @@ from datadog_checks.sqlserver.const import (
 )
 from datadog_checks.sqlserver.metrics import DEFAULT_PERFORMANCE_TABLE, VALID_TABLES
 from datadog_checks.sqlserver.queries import (
-    QUERY_AO_AVAILABILITY_GROUPS,
     QUERY_AO_FAILOVER_CLUSTER,
     QUERY_AO_FAILOVER_CLUSTER_MEMBER,
     QUERY_FAILOVER_CLUSTER_INSTANCE,
     QUERY_SERVER_STATIC_INFO,
+    get_ao_availability_groups,
     get_query_file_stats,
 )
 from datadog_checks.sqlserver.utils import set_default_driver_conf
@@ -162,7 +162,6 @@ class SQLServer(AgentCheck):
         if is_affirmative(self.instance.get('include_ao_metrics', False)):
             check_queries.extend(
                 [
-                    QUERY_AO_AVAILABILITY_GROUPS,
                     QUERY_AO_FAILOVER_CLUSTER,
                     QUERY_AO_FAILOVER_CLUSTER_MEMBER,
                 ]
@@ -691,6 +690,10 @@ class SQLServer(AgentCheck):
             return None
 
         queries = [get_query_file_stats(major_version)]
+
+        if is_affirmative(self.instance.get('include_ao_metrics', False)):
+            queries.extend([get_ao_availability_groups(major_version)])
+
         self._dynamic_queries = self._new_query_executor(queries)
         self._dynamic_queries.compile_queries()
         self.log.debug("initialized dynamic queries")

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -688,12 +688,12 @@ class SQLServer(AgentCheck):
                     ]
                 )
             else:
-                self.log.warning('Collecting AlwaysOn metrics is not supported on version 2012')
+                self.log.warning('AlwaysOn metrics are not supported on version 2012')
         if is_affirmative(self.instance.get('include_fci_metrics', False)):
             if major_version > 2012:
                 queries.extend([QUERY_FAILOVER_CLUSTER_INSTANCE])
             else:
-                self.log.warning('Collecting Failover Cluster Instance metrics is not supported on version 2012')
+                self.log.warning('Failover Cluster Instance metrics are not supported on version 2012')
 
         self._dynamic_queries = self._new_query_executor(queries)
         self._dynamic_queries.compile_queries()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds support for handling older versions of SQL Server which may lack columns used for AlwaysOn metrics.

### Motivation
<!-- What inspired you to submit this pull request? -->
Issue was surfaced via logs
```
Error querying sys.availability_groups: ('42S22', "[42S22] [FreeTDS][SQL Server]Invalid column name 'secondary_lag_seconds'. (207) (SQLExecDirectW)")
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
