### PR TITLE
properly apply monospace tagging to metric names

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -39,7 +39,7 @@ Connect Airflow to DogStatsD (included in the Datadog Agent) by using the Airflo
 - [Airflow Metrics][6]
 - [Airflow Metrics Configuration][7]
 
-**Note**: Presence or absence of StatsD metrics reported by Airflow might vary depending on the Airflow Executor used. For example: `airflow.ti_failures/successes, airflow.operator_failures/successes, airflow.dag.task.duration` are [not reported for `KubernetesExecutor`][8]. 
+**Note**: Presence or absence of StatsD metrics reported by Airflow might vary depending on the Airflow Executor used. For example: `airflow.ti_failures/successes`, `airflow.operator_failures/successes`, `airflow.dag.task.duration` are [not reported for `KubernetesExecutor`][8]. 
 
 1. Install the [Airflow StatsD plugin][1].
 


### PR DESCRIPTION
### What does this PR do?

Separates metric names into separate backticked words.

### Motivation

Question raised by translators

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
