### PR TITLE
Fix validation error message and wrong parameters

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
@@ -54,7 +54,7 @@ class TileDescriptionValidator(BaseManifestValidator):
         if current_length > max_desc_length:
             output = (
                 f'  The tile description is {current_length} characters long. It should be no longer than '
-                f'{self.MAX_DESCRIPTION_LENGTH} characters.'
+                f'{max_desc_length} characters.'
             )
             self.fail(output)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
@@ -244,8 +244,8 @@ def get_v2_validators(ctx, is_extras, is_marketplace):
         common.ImmutableAttributesValidator(version=V2),
         common.LogsCategoryValidator(version=V2),
         DisplayOnPublicValidator(version=V2),
-        TileDescriptionValidator(is_marketplace, is_extras, version=V2),
-        MediaGalleryValidator(is_marketplace, is_extras, version=V2),
+        TileDescriptionValidator(is_marketplace=is_marketplace, is_extras=is_extras, version=V2),
+        MediaGalleryValidator(is_marketplace=is_marketplace, is_extras=is_extras, version=V2),
         # keep SchemaValidator last, and avoid running this validation if errors already found
         SchemaValidator(ctx=ctx, version=V2, skip_if_errors=True),
     ]


### PR DESCRIPTION
This error message was displaying the wrong char limit and also we were initialising validators with the parameters in the wrong order so the limit was incorrectly set