### PR TITLE
Fix default value

### DIFF
--- a/gitlab/assets/configuration/spec.yaml
+++ b/gitlab/assets/configuration/spec.yaml
@@ -24,7 +24,7 @@ files:
         send_distribution_counts_as_monotonic.value.example: true
         send_monotonic_counter.enabled: true
         send_monotonic_counter.value.example: true
-        send_monotonic_counter.value.default: true
+        send_monotonic_counter.value.default: false
         send_monotonic_counter.value.display_default: false
   - template: init_config
     options:

--- a/gitlab/datadog_checks/gitlab/config_models/defaults.py
+++ b/gitlab/datadog_checks/gitlab/config_models/defaults.py
@@ -223,7 +223,7 @@ def instance_send_histograms_buckets(field, value):
 
 
 def instance_send_monotonic_counter(field, value):
-    return True
+    return False
 
 
 def instance_send_monotonic_with_gauge(field, value):


### PR DESCRIPTION
This PR https://github.com/DataDog/integrations-core/pull/12022 changed the documented default value to true to match with the actual implementation (https://github.com/DataDog/integrations-core/blob/master/gitlab/datadog_checks/gitlab/gitlab.py#L92). However it also changed the actual default value in the generated models to be true: https://github.com/DataDog/integrations-core/blob/master/gitlab/datadog_checks/gitlab/config_models/defaults.py#L226

The change did not require a models sync since the prior default change was taken from the example field.

This PR fixes the issue by setting the default value to False to match the current implementation.