### PR TITLE
Use metric_id instead of id as a foreign key of log_integrations

### DIFF
--- a/.gitlab/validate-logs-intgs/validate_log_intgs.py
+++ b/.gitlab/validate-logs-intgs/validate_log_intgs.py
@@ -143,8 +143,8 @@ def get_all_log_pipelines_ids():
     files.sort()
     for file in files:
         with open(file, 'r') as f:
-            yield yaml.load(f, Loader=yaml.SafeLoader)['id']
-
+            definition = yaml.load(f, Loader=yaml.SafeLoader)
+            yield definition['id'] if definition['metric_id'] is None else definition['metric_id']
 
 def get_log_to_metric_map(file_path):
     with open(file_path) as f:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
