### PR TITLE
Allow empty username and password for basic auth

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -627,7 +627,7 @@ def should_bypass_proxy(url, no_proxy_uris):
 
 def create_basic_auth(config):
     # Since this is the default case, only activate when all fields are explicitly set
-    if config['username'] and config['password']:
+    if config['username'] is not None and config['password'] is not None:
         if config['use_legacy_auth_encoding']:
             return config['username'], config['password']
         else:

--- a/datadog_checks_base/tests/base/utils/test_http.py
+++ b/datadog_checks_base/tests/base/utils/test_http.py
@@ -314,12 +314,13 @@ class TestAuth:
 
         assert http.options['auth'] is None
 
-    def test_config_basic_allows_empty_string_as_password(self):
-        instance = {'username': 'user', 'password': ''}
+    @pytest.mark.parametrize('username,password', [('user', ''), ('', 'pass'), ('', '')])
+    def test_config_basic_allows_empty_strings(self, username, password):
+        instance = {'username': username, 'password': password}
         init_config = {}
         http = RequestsWrapper(instance, init_config)
 
-        assert http.options['auth'] == ('user', '')
+        assert http.options['auth'] == (username, password)
 
     def test_config_kerberos_legacy(self):
         instance = {'kerberos_auth': 'required'}

--- a/datadog_checks_base/tests/base/utils/test_http.py
+++ b/datadog_checks_base/tests/base/utils/test_http.py
@@ -314,6 +314,13 @@ class TestAuth:
 
         assert http.options['auth'] is None
 
+    def test_config_basic_allows_empty_string_as_password(self):
+        instance = {'username': 'user', 'password': ''}
+        init_config = {}
+        http = RequestsWrapper(instance, init_config)
+
+        assert http.options['auth'] == ('user', '')
+
     def test_config_kerberos_legacy(self):
         instance = {'kerberos_auth': 'required'}
         init_config = {}


### PR DESCRIPTION
### What does this PR do?

Allows configuring the username and the password to be empty strings for basic auth.

The user still has to explicitly add the empty string as a config value so that the original intent of checking for presence of the config values is maintained.

### Motivation

[AI-2469](https://datadoghq.atlassian.net/browse/AI-2469)

A user reported in #12390 that they have a valid use case for having an empty password when using basic auth.

We disable auth if either `username` or `password` are not set in the config, but we check for truthy value, which means that an empty string is interpreted as the value not being set, too. This disallowed the aforementioned use case.

`requests` seems to allow empty username and password for basic auth too, so I think it's safe to allow the same in our wrapper too.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
