### PR TITLE
expand upon example of using an index as a metric_tag

### DIFF
--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -280,7 +280,7 @@ External table indexes must be a subset of the indexes of the current table, or 
 
 Important: "_index_" refers to one digit of the index part of the row OID. For example, if the column OID is `1.2.3.1.2` and the row OID is `1.2.3.1.2.7.8.9`, the full index is `7.8.9`. In this example, `index: 1` refers to `7` and `index: 2` refers to `8`, and so on.  
 
-Here is specific example of an OID with multiple positions in the index ([OID ref](https://oidref.com/1.3.6.1.2.1.4.20.1)):
+Here is an example of an OID with multiple positions in the index ([OID ref](https://oidref.com/1.3.6.1.2.1.4.20.1)):
 
 ```
 ipAddrEntry OBJECT-TYPE

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -153,7 +153,7 @@ exampleColumn2 OBJECT-TYPE
 -- ...
 ```
 
-In profiles, tables can be specified as entries containing the `MIB`, `table` and `symbols` fields:
+In profiles, tables can be specified as entries containing the `MIB`, `table` and `symbols` fields. The syntax for the value contained in each row is typically `<TABLE_OID>.1.<COLUMN_ID>.<INDEX>`:
 
 ```yaml
 metrics:
@@ -166,7 +166,7 @@ metrics:
     symbols:
       # List of symbols ('columns') to retrieve.
       # Same format as for a single OID.
-      # Each row in the table will emit these metrics.
+      # The value from each row (index) in the table will be collected `<TABLE_OID>.1.<COLUMN_ID>.<INDEX>.*`
       - OID: 1.3.6.1.4.1.10.1.1
         name: exampleColumn1
       - OID: 1.3.6.1.4.1.10.1.2
@@ -278,7 +278,37 @@ External table indexes must be a subset of the indexes of the current table, or 
 
 ##### Using an index
 
-Important: "_index_" refers to one digit of the index part of the row OID. Example, if the column OID is `1.2.3.1.2` and the row OID is `1.2.3.1.2.7.8.9`, the full index is `7.8.9`. In this example, when using `index: 1`, we will refer to `7`, `index: 2` will refer to `8`, and so on.
+Important: "_index_" refers to one digit of the index part of the row OID. Example, if the column OID is `1.2.3.1.2` and the row OID is `1.2.3.1.2.7.8.9`, the full index is `7.8.9`. In this example, when using `index: 1`, we will refer to `7`, `index: 2` will refer to `8`, and so on.  
+
+Here is specific example of an OID with multiple positions in the index ([OID ref](https://oidref.com/1.3.6.1.2.1.4.20.1)):
+
+```
+ipAddrEntry OBJECT-TYPE
+    SYNTAX     IpAddrEntry
+    MAX-ACCESS not-accessible
+    STATUS     deprecated
+    DESCRIPTION
+           "The addressing information for one of this entity's IPv4
+            addresses."
+    INDEX      { ipAdEntAddr }
+    ::= { ipAddrTable 1 }
+```
+
+The index in the case is the `ipAdEntAddr`. Inspecting this `OBJECT-TYPE` reveals the `SYNTAX` as `IpAddress` ([OID ref](https://oidref.com/1.3.6.1.2.1.4.20.1.1)):
+
+```
+ipAdEntAddr OBJECT-TYPE
+    SYNTAX     IpAddress
+    MAX-ACCESS read-only
+    STATUS     deprecated
+    DESCRIPTION
+
+
+           "The IPv4 address to which this entry's addressing
+            information pertains."
+    ::= { ipAddrEntry 1 }
+```
+The value corresponding to the `index `of a row in this table will be found at the following OID: `.1.3.6.1.2.1.4.20.1.1.<INDEX>`.  Retrieving the value of `.1.3.6.1.2.1.4.20.1.1.127.0.0.1` will return `127.0.0.1`.  To capture the value `127` and apply it as a metric tag, target `index: 1`.
 
 ```yaml
 metrics:

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -280,35 +280,38 @@ External table indexes must be a subset of the indexes of the current table, or 
 
 Important: "_index_" refers to one digit of the index part of the row OID. For example, if the column OID is `1.2.3.1.2` and the row OID is `1.2.3.1.2.7.8.9`, the full index is `7.8.9`. In this example, `index: 1` refers to `7` and `index: 2` refers to `8`, and so on.  
 
-Here is an example of an OID with multiple positions in the index ([OID ref](https://oidref.com/1.3.6.1.2.1.4.20.1)):
+Here is specific example of an OID with multiple positions in the index ([OID ref](http://oidref.com/1.3.6.1.4.1.5.1.1.19.25.1)):
 
 ```
-ipAddrEntry OBJECT-TYPE
-    SYNTAX     IpAddrEntry
-    MAX-ACCESS not-accessible
-    STATUS     deprecated
-    DESCRIPTION
-           "The addressing information for one of this entity's IPv4
-            addresses."
-    INDEX      { ipAdEntAddr }
-    ::= { ipAddrTable 1 }
+accDnForwardFilterEntry OBJECT-TYPE
+         SYNTAX   AccDnForwardFilterEntry
+         ACCESS   not-accessible
+         STATUS   mandatory
+         DESCRIPTION
+             " A single set of messages that the Network Manager
+               wants selectively treated."
+         INDEX { accDnForwardFilterDest, 
+                 accDnForwardFilterSource }
+         ::= { accDnForwardFilterTable 1 }
 ```
 
-The index in the case is the `ipAdEntAddr`. Inspecting this `OBJECT-TYPE` reveals the `SYNTAX` as `IpAddress` ([OID ref](https://oidref.com/1.3.6.1.2.1.4.20.1.1)):
+The index in the case is a combination of `accDnForwardFilterDest` and `accDnForwardFilterSource`. Inspecting the `OBJECT-TYPE` of `accDnForwardFilterDest` reveals the `SYNTAX` as `INTEGER` ([OID ref](http://oidref.com/1.3.6.1.4.1.5.1.1.19.25.1.1)):
 
 ```
-ipAdEntAddr OBJECT-TYPE
-    SYNTAX     IpAddress
-    MAX-ACCESS read-only
-    STATUS     deprecated
-    DESCRIPTION
-
-
-           "The IPv4 address to which this entry's addressing
-            information pertains."
-    ::= { ipAddrEntry 1 }
+accDnForwardFilterDest OBJECT-TYPE
+             SYNTAX   INTEGER (0..65535)
+             ACCESS   read-write
+             STATUS   mandatory
+            DESCRIPTION
+                 " If 0, all DECNET Addresses.
+                   If an Area with Host Part  0,  all  traffic  to
+                   that Area.
+                   If a DECNET Host ID, all traffic to that Host."
+            ::= { accDnForwardFilterEntry 1 }
 ```
-You can find the value corresponding to the `index` of a row in this table at the following OID: `.1.3.6.1.2.1.4.20.1.1.<INDEX>`.  Retrieving the value of `.1.3.6.1.2.1.4.20.1.1.127.0.0.1` returns `127.0.0.1`. To capture the value `127` and apply it as a metric tag, target `index: 1`.
+The value corresponding to the `accDnForwardFilterDest` of a row in this table will be found at the following OID: `.1.3.6.1.4.1.5.1.1.19.25.1.1.<accDnForwardFilterDest>`.  Retrieving the value of `.1.3.6.1.4.1.5.1.1.19.25.1.1.123` will return `123`.  To capture the value `123` and apply it as a metric tag, target `index: 1`.  
+
+The value corresponding to the `accDnForwardFilterSource` of a row in this table will be found at the following OID: `.1.3.6.1.4.1.5.1.1.19.25.1.1.<accDnForwardFilterDest>.<accDnForwardFilterSource>`.  Retrieving the value of `.1.3.6.1.4.1.5.1.1.19.25.1.1.123.456` will return `456`.  To capture the value `456` and apply it as a metric tag, target `index: 2`.  
 
 ```yaml
 metrics:

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -280,67 +280,48 @@ External table indexes must be a subset of the indexes of the current table, or 
 
 Important: "_index_" refers to one digit of the index part of the row OID. For example, if the column OID is `1.2.3.1.2` and the row OID is `1.2.3.1.2.7.8.9`, the full index is `7.8.9`. In this example, `index: 1` refers to `7` and `index: 2` refers to `8`, and so on.  
 
-Here is specific example of an OID with multiple positions in the index ([OID ref](http://oidref.com/1.3.6.1.4.1.5.1.1.19.25.1)):
+Here is specific example of an OID with multiple positions in the index ([OID ref](http://oidref.com/1.3.6.1.4.1.9.9.147.1.2.2.2.1)):
 
 ```
-accDnForwardFilterEntry OBJECT-TYPE
-         SYNTAX   AccDnForwardFilterEntry
-         ACCESS   not-accessible
-         STATUS   mandatory
-         DESCRIPTION
-             " A single set of messages that the Network Manager
-               wants selectively treated."
-         INDEX { accDnForwardFilterDest, 
-                 accDnForwardFilterSource }
-         ::= { accDnForwardFilterTable 1 }
+cfwConnectionStatEntry OBJECT-TYPE
+    SYNTAX CfwConnectionStatEntry
+    ACCESS not-accessible
+    STATUS mandatory
+    DESCRIPTION
+        "An entry in the table, containing information about a
+        firewall statistic."
+    INDEX { cfwConnectionStatService, cfwConnectionStatType }
+    ::= { cfwConnectionStatTable 1 }
 ```
 
-The index in the case is a combination of `accDnForwardFilterDest` and `accDnForwardFilterSource`. Inspecting the `OBJECT-TYPE` of `accDnForwardFilterDest` reveals the `SYNTAX` as `INTEGER` ([OID ref](http://oidref.com/1.3.6.1.4.1.5.1.1.19.25.1.1)):
+The index in the case is a combination of `cfwConnectionStatService` and `cfwConnectionStatType`. Inspecting the `OBJECT-TYPE` of `cfwConnectionStatService` reveals the `SYNTAX` as `Services` ([OID ref](http://oidref.com/1.3.6.1.4.1.9.9.147.1.2.2.2.1.1)):
 
 ```
-accDnForwardFilterDest OBJECT-TYPE
-             SYNTAX   INTEGER (0..65535)
-             ACCESS   read-write
-             STATUS   mandatory
-            DESCRIPTION
-                 " If 0, all DECNET Addresses.
-                   If an Area with Host Part  0,  all  traffic  to
-                   that Area.
-                   If a DECNET Host ID, all traffic to that Host."
-            ::= { accDnForwardFilterEntry 1 }
+cfwConnectionStatService OBJECT-TYPE
+        SYNTAX     Services
+        MAX-ACCESS not-accessible
+        STATUS     current
+        DESCRIPTION
+            "The identification of the type of connection providing
+            statistics."
+    ::= { cfwConnectionStatEntry 1 }
 ```
-The value corresponding to the `accDnForwardFilterDest` of a row in this table will be found at the following OID: `.1.3.6.1.4.1.5.1.1.19.25.1.1.<accDnForwardFilterDest>`.  Retrieving the value of `.1.3.6.1.4.1.5.1.1.19.25.1.1.123` will return `123`.  To capture the value `123` and apply it as a metric tag, target `index: 1`.  
-
-The value corresponding to the `accDnForwardFilterSource` of a row in this table will be found at the following OID: `.1.3.6.1.4.1.5.1.1.19.25.1.1.<accDnForwardFilterDest>.<accDnForwardFilterSource>`.  Retrieving the value of `.1.3.6.1.4.1.5.1.1.19.25.1.1.123.456` will return `456`.  To capture the value `456` and apply it as a metric tag, target `index: 2`.  
+For example, when we fetch the value of `cfwConnectionStatValue`, the OID with the index is like `1.3.6.1.4.1.9.9.147.1.2.2.2.1.5.20.2` = `4087850099`, here the indexes are 20.2 (`1.3.6.1.4.1.9.9.147.1.2.2.2.1.5.<service type>.<stat type>`).  Here is how we would specify this configuration in the yaml (as seen in the [corresponding profile](https://github.com/DataDog/integrations-core/blob/3a7b1d1877b7a0dfcd16e2ff856e636c8717ef5b/snmp/datadog_checks/snmp/data/profiles/_cisco-asa.yaml#L7-L18) packaged with the agent): 
 
 ```yaml
 metrics:
-  - MIB: CISCO-PROCESS-MIB
+  - MIB: CISCO-FIREWALL-MIB
     table:
-      OID: 1.3.6.1.4.1.9.9.109.1.1.1
-      name: cpmCPUTotalTable
+      OID: 1.3.6.1.4.1.9.9.147.1.2.2.2
+      name: cfwConnectionStatTable
     symbols:
-      - OID: 1.3.6.1.4.1.9.9.109.1.1.1.1.12
-        name: cpmCPUMemoryUsed
+      - OID: 1.3.6.1.4.1.9.9.147.1.2.2.2.1.5
+        name: cfwConnectionStatValue
     metric_tags:
-      # This tagging method is more complex, so let's walk through an example...
-      #
-      # In CISCO-PROCESS-MIB, we can see that entries in the `cpmCPUTotalTable` are indexed by `cpmCPUTotalIndex`,
-      # which corresponds to some sort of CPU position for each row in the table:
-      #
-      #   cpmCPUTotalEntry OBJECT-TYPE
-      #      -- ...
-      #      INDEX    { cpmCPUTotalIndex }  # <-- See?
-      #
-      # We want to tag metrics in this table by this CPU position.
-      #
-      # To do this, we look up the position of this OID in `INDEX`. Here we see it's in 1st position.
-      # So we can reference it here using `index: 1`.
-      # (If there were two OIDs in `INDEX`, and we wanted to use the one in 2nd position, then we would have used `index: 2`.)
-      #
-      # NOTE: currently only indexes that refer to a column in the same table are supported.
-      - tag: cpu
-        index: 1
+      - index: 1 // capture first index digit
+        tag: service_type
+      - index: 2 // capture second index digit
+        tag: stat_type
 ```
 
 ##### Mapping index to tag string value

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -166,7 +166,7 @@ metrics:
     symbols:
       # List of symbols ('columns') to retrieve.
       # Same format as for a single OID.
-      # The value from each row (index) in the table will be collected `<TABLE_OID>.1.<COLUMN_ID>.<INDEX>.*`
+      # The value from each row (index) in the table will be collected `<TABLE_OID>.1.<COLUMN_ID>.<INDEX>`
       - OID: 1.3.6.1.4.1.10.1.1
         name: exampleColumn1
       - OID: 1.3.6.1.4.1.10.1.2

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -278,7 +278,7 @@ External table indexes must be a subset of the indexes of the current table, or 
 
 ##### Using an index
 
-Important: "_index_" refers to one digit of the index part of the row OID. Example, if the column OID is `1.2.3.1.2` and the row OID is `1.2.3.1.2.7.8.9`, the full index is `7.8.9`. In this example, when using `index: 1`, we will refer to `7`, `index: 2` will refer to `8`, and so on.  
+Important: "_index_" refers to one digit of the index part of the row OID. For example, if the column OID is `1.2.3.1.2` and the row OID is `1.2.3.1.2.7.8.9`, the full index is `7.8.9`. In this example, `index: 1` refers to `7` and `index: 2` refers to `8`, and so on.  
 
 Here is specific example of an OID with multiple positions in the index ([OID ref](https://oidref.com/1.3.6.1.2.1.4.20.1)):
 

--- a/docs/developer/tutorials/snmp/profile-format.md
+++ b/docs/developer/tutorials/snmp/profile-format.md
@@ -308,7 +308,7 @@ ipAdEntAddr OBJECT-TYPE
             information pertains."
     ::= { ipAddrEntry 1 }
 ```
-The value corresponding to the `index `of a row in this table will be found at the following OID: `.1.3.6.1.2.1.4.20.1.1.<INDEX>`.  Retrieving the value of `.1.3.6.1.2.1.4.20.1.1.127.0.0.1` will return `127.0.0.1`.  To capture the value `127` and apply it as a metric tag, target `index: 1`.
+You can find the value corresponding to the `index` of a row in this table at the following OID: `.1.3.6.1.2.1.4.20.1.1.<INDEX>`.  Retrieving the value of `.1.3.6.1.2.1.4.20.1.1.127.0.0.1` returns `127.0.0.1`. To capture the value `127` and apply it as a metric tag, target `index: 1`.
 
 ```yaml
 metrics:


### PR DESCRIPTION
### What does this PR do?
Expands on our current documentation surrounding applying the index of an OID as a metric tag.  Adds additional detail regarding the syntax of metric collection from a table.

### Motivation
 conversation with customer on [this ticket](https://datadog.zendesk.com/agent/tickets/843365) and ENG on [this thread](https://dd.slack.com/archives/C0245LJKD5F/p1656361398792919)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
