### PR TITLE
Fix dashboard widget with pods in bad state

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -410,13 +410,13 @@
             {
               "id": 3848732272463314,
               "definition": {
-                "title": "Pods in Bad State (Not Ready) by Namespace",
+                "title": "Pods in Bad State by Namespace",
                 "title_size": "16",
                 "title_align": "left",
                 "type": "toplist",
                 "requests": [
                   {
-                    "q": "top(exclude_null(sum:kubernetes_state.pod.ready{condition:false,$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job} by {kube_namespace}), 25, 'last', 'desc')",
+                    "q": "top(exclude_null(sum:kubernetes_state.pod.ready{condition:false,$scope,$cluster,$namespace,$deployment,$statefulset,$daemonset,$job,!pod_phase:succeeded} by {kube_namespace}), 25, 'last', 'desc')",
                     "conditional_formats": [
                       {
                         "comparator": ">",


### PR DESCRIPTION
### What does this PR do?

Fixes a chart in the "Kubernetes Pods Overview" dashboard. The number of pods in bad state was incorrect because it was including pods in "succeeded" state too.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
