### PR TITLE
Fix integration name in metadata.csv

### DIFF
--- a/kafka_consumer/metadata.csv
+++ b/kafka_consumer/metadata.csv
@@ -1,5 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
-kafka.broker_offset,gauge,,offset,,Current message offset on broker.,0,kafka,broker offset,
-kafka.consumer_lag,gauge,,offset,,Lag in messages between consumer and broker.,-1,kafka,consumer lag,
-kafka.consumer_offset,gauge,,offset,,Current message offset on consumer.,0,kafka,consumer offset,
-kafka.consumer_lag_seconds,gauge,,second,,Lag in seconds between consumer and broker.,-1,kafka,consumer time lag,
+kafka.broker_offset,gauge,,offset,,Current message offset on broker.,0,kafka_consumer,broker offset,
+kafka.consumer_lag,gauge,,offset,,Lag in messages between consumer and broker.,-1,kafka_consumer,consumer lag,
+kafka.consumer_offset,gauge,,offset,,Current message offset on consumer.,0,kafka_consumer,consumer offset,
+kafka.consumer_lag_seconds,gauge,,second,,Lag in seconds between consumer and broker.,-1,kafka_consumer,consumer time lag,


### PR DESCRIPTION
### What does this PR do?

Change integration name to `kafka_consumer` in the metadata.csv file.

### Motivation

It came to our attention that the kafka_consumer tile didn't show any metrics, which led us to find that the integration name was incorrect in the metadata.csv for `kafka_consumer`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
