### PR TITLE
Reintroduce connection_schema in mongo

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -62,7 +62,7 @@ pycryptodomex==3.10.1
 pydantic==1.9.0; python_version > '3.0'
 pyjwt==1.7.1; python_version < '3.0'
 pyjwt==2.3.0; python_version > '3.0'
-pymongo==3.12.3
+Apymongo[srv]==3.12.3
 pymqi==1.12.0
 pymysql==0.10.1; python_version < '3.0'
 pymysql==1.0.2; python_version > '3.0'

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = [
 
 [project.optional-dependencies]
 deps = [
-    "pymongo==3.12.3",
+    "pymongo[srv]==3.12.3",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
In https://github.com/DataDog/integrations-core/pull/7744  we removed the ability to use the  the DNS seed connection schema on the mongo integration because it was poorly handled on our side. However this is a valid connection method https://www.mongodb.com/docs/manual/reference/connection-string/#dns-seed-list-connection-format  and we should support it 

fwiw, I used the server: mongodb+srv://...  param and, ignoring the warnings, the integration was working just fine.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
