### PR TITLE
Fix dashboard widget with "not ready" nodes

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_nodes.json
+++ b/kubernetes/assets/dashboards/kubernetes_nodes.json
@@ -8,7 +8,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "top(sum:kubernetes_state.node.by_condition{$cluster,status:true,$host,!condition:ready} by {status,condition,kube_cluster_name}, 10, 'last', 'desc')",
+                        "q": "top(sum:kubernetes_state.node.by_condition{$cluster,status:false,$host,condition:ready} by {kube_cluster_name}, 10, 'last', 'desc')",
                         "display_type": "line",
                         "style": {
                             "palette": "warm",
@@ -1469,7 +1469,7 @@
                 "type": "query_value",
                 "requests": [
                     {
-                        "q": "sum:kubernetes_state.node.by_condition{$cluster,status:true,$host,!condition:ready}",
+                        "q": "sum:kubernetes_state.node.by_condition{$cluster,status:false,$host,condition:ready}",
                         "aggregator": "avg",
                         "conditional_formats": [
                             {


### PR DESCRIPTION
### What does this PR do?

Fixes the query to get the "not ready" nodes in the Kubernetes nodes dashboard.
We were counting all the nodes with condition != ready. Checking that condition:ready is false seems more accurate.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
