### PR TITLE
Fix the `tcp_check` IPv6 tests by using a more stable DNS hostname

### DIFF
--- a/tcp_check/tests/common.py
+++ b/tcp_check/tests/common.py
@@ -12,7 +12,7 @@ INSTANCE_MULTIPLE = {'multiple_ips': True}
 INSTANCE_MULTIPLE.update(INSTANCE)
 
 INSTANCE_IPV6 = {
-    'host': 'app.datad0g.com',
+    'host': 'ip-ranges.datadoghq.com',
     'port': 80,
     'timeout': 1.5,
     'name': 'UpService',

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -163,7 +163,7 @@ def test_ipv6(aggregator, check):
 
     nb_ipv4, nb_ipv6 = 0, 0
     for addr in check.addrs:
-        expected_tags = ["instance:UpService", "target_host:app.datad0g.com", "port:80", "foo:bar"]
+        expected_tags = ["instance:UpService", "target_host:ip-ranges.datadoghq.com", "port:80", "foo:bar"]
         expected_tags.append("address:{}".format(addr))
         if re.match(r'^[0-9a-f:]+$', addr):
             nb_ipv6 += 1
@@ -177,8 +177,8 @@ def test_ipv6(aggregator, check):
             nb_ipv4 += 1
             aggregator.assert_service_check('tcp.can_connect', status=check.OK, tags=expected_tags)
             aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags)
-    assert nb_ipv4 == 3
+    assert nb_ipv4 == 4
     # The Windows CI machine doesn't return IPv6
-    assert nb_ipv6 == 3 or platform.system() == 'Windows' and nb_ipv6 == 0
+    assert nb_ipv6 == 8 or platform.system() == 'Windows' and nb_ipv6 == 0
     aggregator.assert_all_metrics_covered()
     assert len(aggregator.service_checks('tcp.can_connect')) == nb_ipv4 + nb_ipv6


### PR DESCRIPTION
### What does this PR do?

Change the DNS hostname used to test IPv6 support of the `tcp_check` test to use a more stable one.

### Motivation

The number of IPs behind the `app.datad0g.com` hostname changed.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
