### PR TITLE
Use dockerhub instead of private registry

### DIFF
--- a/.azure-pipelines/scripts/marklogic/linux/55_docker_login.sh
+++ b/.azure-pipelines/scripts/marklogic/linux/55_docker_login.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-set +x
-
-echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-
-set -x

--- a/marklogic/tests/compose/cluster/docker-compose.yml
+++ b/marklogic/tests/compose/cluster/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.6'
 
 services:
   bootstrap:
-    image: store/marklogicdb/marklogic-server:${MARKLOGIC_IMAGE}
+    image: marklogicdb/marklogic-db:${MARKLOGIC_IMAGE}
     environment:
     - MARKLOGIC_INIT=true
     ports:
@@ -10,7 +10,7 @@ services:
     - 8001:8001
     - 8002:8002
   dnode:
-    image: store/marklogicdb/marklogic-server:${MARKLOGIC_IMAGE}
+    image: marklogicdb/marklogic-db:${MARKLOGIC_IMAGE}
     environment:
     - MARKLOGIC_INIT=true
     - MARKLOGIC_JOIN_CLUSTER=true

--- a/marklogic/tests/compose/standalone/docker-compose.yml
+++ b/marklogic/tests/compose/standalone/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.6'
 
 services:
   bootstrap:
-    image: store/marklogicdb/marklogic-server:${MARKLOGIC_IMAGE}
+    image: marklogicdb/marklogic-db:${MARKLOGIC_IMAGE}
     environment:
       - MARKLOGIC_INIT=true
       - MARKLOGIC_ADMIN_USERNAME=admin


### PR DESCRIPTION
Seems the log in on the private registry was not working anymore but these images are now available on the public dockerhub anyway so let's use those which makes it easier to run locally too.

```
E   datadog_checks.dev.errors.SubprocessError: Command: ['docker', 'compose', '--compatibility', '-f', '/home/vsts/work/1/s/marklogic/tests/compose/standalone/docker-compose.yml', 'up', '-d']
E   Exit code: 18
E   Captured Output:
---------------------------- Captured stderr setup -----------------------------
bootstrap Pulling 
bootstrap Error 
Error response from daemon: pull access denied for store/marklogicdb/marklogic-server, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
standalone  Warning: No resource found to remove
```