### PR TITLE
elastic docs: change slm_stats privilege to read_slm

### DIFF
--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -63,7 +63,7 @@ files:
     - name: slm_stats
       description: | 
         Set "slm_stats" to true to collect statistics about Snapshot Lifcycle Management.
-        The user must have `manage_slm` cluster privilege to get these metrics.
+        The user must have the `read_slm` cluster privilege to get these metrics.
       value:
         type: boolean
         example: false

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -93,7 +93,7 @@ instances:
 
     ## @param slm_stats - boolean - optional - default: false
     ## Set "slm_stats" to true to collect statistics about Snapshot Lifcycle Management.
-    ## The user must have `manage_slm` cluster privilege to get these metrics.
+    ## The user must have the `read_slm` cluster privilege to get these metrics.
     #
     # slm_stats: false
 


### PR DESCRIPTION
The datadog agent shouldn't need `manage_slm` to emit SLM metrics for elasticsearch clusters since the [`read_slm` privilege](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-privileges.html#:~:text=pipline%20(get%2C%20simulate).-,read_slm,-All%20read%2Donly) exists. This PR updates the docs for `slm_stats` to reflect this. 


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
