### PR TITLE
AI-2179-fr-collecting-mongo-dbstats-for-all-databases-can-overload-a-cluster-11123

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -65,6 +65,16 @@ files:
       value:
         type: object
         properties: []
+    - name: dbnames
+      description: |
+        Set a list of the names of all databases to collect metrics from.
+        If this key does not exist, all metrics from all databases on the server will be collected.
+      value:
+        type: array
+        items:
+          type: string
+        example:
+          [ one_database, other_database ]
     - name: replica_check
       description: |
         Whether or not to read from available replicas.

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -68,6 +68,8 @@ class MongoConfig(object):
             self.log.info('No MongoDB database found in URI. Defaulting to admin.')
             self.db_name = 'admin'
 
+        self.db_names = instance.get('dbnames', None)
+
         self.timeout = float(instance.get('timeout', DEFAULT_TIMEOUT)) * 1000
         self.additional_metrics = instance.get('additional_metrics', [])
 

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -64,6 +64,14 @@ instances:
     #
     # options: {}
 
+    ## @param dbnames - list of strings - optional
+    ## Set a list of the names of all databases to collect metrics from.
+    ## If this key does not exist, all metrics from all databases on the server will be collected.
+    #
+    # dbnames:
+    #   - one_database
+    #   - other_database
+
     ## @param replica_check - boolean - optional - default: true
     ## Whether or not to read from available replicas.
     ## Disable this if any replicas are inaccessible to the Agent. This option is not supported for sharded clusters.

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -218,7 +218,10 @@ class MongoDb(AgentCheck):
         if isinstance(deployment, ReplicaSetDeployment) and deployment.is_arbiter:
             dbnames = []
         else:
-            dbnames = api.list_database_names()
+            if self._config.db_names is None:
+                dbnames = api.list_database_names()
+            else:
+                dbnames = self._config.db_names
             self.gauge('mongodb.dbs', len(dbnames), tags=tags)
 
         self.refresh_collectors(deployment, mongo_version, dbnames, tags)

--- a/mongo/tests/test_config.py
+++ b/mongo/tests/test_config.py
@@ -30,3 +30,20 @@ def test_hosts_can_be_singular(instance):
     if not PY2:
         check.load_configuration_models()
         assert check._config_model_instance.hosts == ('localfoost',)
+
+
+def test_dbnames_not_exists(instance):
+    config = MongoConfig(instance, mock.Mock())
+    assert config.db_names is None
+
+
+def test_dbnames_empty(instance):
+    instance['dbnames'] = []
+    config = MongoConfig(instance, mock.Mock())
+    assert config.db_names == []
+
+
+def test_dbnames_non_empty(instance):
+    instance['dbnames'] = ['test']
+    config = MongoConfig(instance, mock.Mock())
+    assert config.db_names == ['test']


### PR DESCRIPTION
### What does this PR do?
We have attempted to roll back our fork of a very old Datadog mongo integration and use the current integration. What we found is that the current integration is overloading our database cluster, which contains 658 databases with about 65 collections each.

The problem is in this section of the code:

integrations-core/mongo.py at master · DataDog/integrations-core 

After collecting the database names, it runs the following code in refresh_collectors:

integrations-core/mongo.py at master · DataDog/integrations-core 

        for db_name in all_dbs:
            potential_collectors.append(DbStatCollector(self, db_name, tags))

When this is run through several mongos, it creates an overwhelming CPU load on all of the mongod in the cluster.

We had a similar problem that we addressed in our older fork, where we modified similar code to look like this:

dbnames = instance.get('dbnames', [])

That is, we could opt in to specific databases for which to monitor dbstats.

I think this integration needs something similar, or needs to detect when running through a mongos and not collect dbstats.)https://github.com/DataDog/integrations-core/issues/11123
We have attempted to roll back our fork of a very old Datadog mongo integration and use the current integration. What we found is that the current integration is overloading our database cluster, which contains 658 databases with about 65 collections each.

The problem is in this section of the code:

[integrations-core/mongo.py at master · DataDog/integrations-core](https://github.com/DataDog/integrations-core/blob/master/mongo/datadog_checks/mongo/mongo.py#L221) 

After collecting the database names, it runs the following code in refresh_collectors:

[integrations-core/mongo.py at master · DataDog/integrations-core](https://github.com/DataDog/integrations-core/blob/master/mongo/datadog_checks/mongo/mongo.py#L126) 

        for db_name in all_dbs:
            potential_collectors.append(DbStatCollector(self, db_name, tags))

When this is run through several mongos, it creates an overwhelming CPU load on all of the mongod in the cluster.

We had a similar problem that we addressed in our older fork, where we modified similar code to look like this:

dbnames = instance.get('dbnames', [])

That is, we could opt in to specific databases for which to monitor dbstats.

I think this integration needs something similar, or needs to detect when running through a mongos and not collect dbstats.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
