### PR TITLE
Update mock targets

### DIFF
--- a/snowflake/tests/snowflake_connector_patch/pyproject.toml
+++ b/snowflake/tests/snowflake_connector_patch/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "hatchling==0.11.2",
+    "hatchling<=1.4.0",
 ]
 build-backend = 'hatchling.build'
 

--- a/snowflake/tests/snowflake_connector_patch/pyproject.toml
+++ b/snowflake/tests/snowflake_connector_patch/pyproject.toml
@@ -1,7 +1,5 @@
 [build-system]
-requires = [
-    "hatchling<=1.4.0",
-]
+requires = ['hatchling']
 build-backend = 'hatchling.build'
 
 [project]
@@ -9,5 +7,4 @@ name = 'snowflake-connector-patch'
 version = '0.0.1'
 
 [tool.hatch.build.targets.wheel]
-packages = ['_snowflake_connector_patch']
-include = ['_snowflake_connector_patch.pth']
+only-include = ['_snowflake_connector_patch', '_snowflake_connector_patch.pth']

--- a/snowflake/tests/snowflake_connector_patch/pyproject.toml
+++ b/snowflake/tests/snowflake_connector_patch/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
-requires = ['hatchling']
+requires = [
+    "hatchling==0.11.2",
+]
 build-backend = 'hatchling.build'
 
 [project]


### PR DESCRIPTION
### What does this PR do?
fixes snowflake e2e tests by using only-include: https://github.com/pypa/hatch/pull/299 
### Motivation
the tests were not using the mock properly due to https://github.com/pypa/hatch/releases/tag/hatchling-v1.4.1
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
