### PR TITLE
Change proxysql env log to check

### DIFF
--- a/proxysql/tests/conftest.py
+++ b/proxysql/tests/conftest.py
@@ -66,8 +66,15 @@ def dd_environment():
                 'TMP_DATA_DIR': tmp_dir,
             },
             conditions=[
-                CheckDockerLogs('db', ["mysqld: ready for connections"], wait=5),
-                CheckDockerLogs('proxysql', ["read_only_action RO=0 phase 3"], wait=5),
+                CheckDockerLogs(
+                    'db',
+                    [
+                        "MySQL init process done. Ready for start up.",
+                        "mysqld: ready for connections",
+                        "read_only_action RO=0 phase 3",
+                    ],
+                    wait=5,
+                ),
                 WaitFor(init_mysql, wait=2),
                 WaitFor(init_proxy, wait=2),
             ],

--- a/proxysql/tests/conftest.py
+++ b/proxysql/tests/conftest.py
@@ -68,10 +68,7 @@ def dd_environment():
             conditions=[
                 CheckDockerLogs(
                     'db',
-                    [
-                        "MySQL init process done. Ready for start up.",
-                        "mysqld: ready for connections",
-                    ],
+                    ["MySQL init process done. Ready for start up."],
                     wait=5,
                 ),
                 CheckDockerLogs('proxysql', ["read_only_action RO=0 phase 3"], wait=5),

--- a/proxysql/tests/conftest.py
+++ b/proxysql/tests/conftest.py
@@ -71,10 +71,10 @@ def dd_environment():
                     [
                         "MySQL init process done. Ready for start up.",
                         "mysqld: ready for connections",
-                        "read_only_action RO=0 phase 3",
                     ],
                     wait=5,
                 ),
+                CheckDockerLogs('proxysql', ["read_only_action RO=0 phase 3"], wait=5),
                 WaitFor(init_mysql, wait=2),
                 WaitFor(init_proxy, wait=2),
             ],


### PR DESCRIPTION
ProxySQL is failing to start up on master, changing the log line to check fixes the issue

* https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=103983&view=logs&j=56a8e754-1e17-5104-e044-29b3f48df9b2&t=7c40731b-9272-5842-3e5b-5abe040374e8
* https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=103980&view=logs&j=56a8e754-1e17-5104-e044-29b3f48df9b2&t=7c40731b-9272-5842-3e5b-5abe040374e8
* https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=103974&view=logs&j=56a8e754-1e17-5104-e044-29b3f48df9b2&t=7c40731b-9272-5842-3e5b-5abe040374e8&l=1852