### PR TITLE
update the metrics url

### DIFF
--- a/kong/datadog_checks/kong/metrics.py
+++ b/kong/datadog_checks/kong/metrics.py
@@ -2,7 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-# https://github.com/Kong/kong-plugin-prometheus/blob/1.2.0/kong/plugins/prometheus/exporter.lua
+# https://docs.konghq.com/hub/kong-inc/prometheus/#available-metrics
 METRIC_MAP = {
     'kong_bandwidth': 'bandwidth',
     'kong_datastore_reachable': {


### PR DESCRIPTION
### What does this PR do?
It updates the metrics URL for reference purposes.

### Motivation
Ofek and I were reviewing the kong integration and he noticed that the URL was pointing to an archived repository.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
