### PR TITLE
[Mongo] Added new metric "mongodb.metrics.queryexecutor.scannedobjectsps"

### DIFF
--- a/mongo/datadog_checks/mongo/metrics.py
+++ b/mongo/datadog_checks/mongo/metrics.py
@@ -72,6 +72,7 @@ BASE_METRICS = {
     "metrics.operation.scanAndOrder": RATE,
     "metrics.operation.writeConflicts": RATE,
     "metrics.queryExecutor.scanned": RATE,
+    "metrics.queryExecutor.scannedObjects": RATE,
     "metrics.record.moves": RATE,
     "metrics.repl.apply.batches.num": RATE,
     "metrics.repl.apply.batches.totalMillis": RATE,

--- a/mongo/metadata.csv
+++ b/mongo/metadata.csv
@@ -125,6 +125,7 @@ mongodb.metrics.operation.idhackps,gauge,,query,second,Number of queries per sec
 mongodb.metrics.operation.writeconflictsps,gauge,,event,second,Number of times per second that write concern operations has encounter a conflict.,0,mongodb,write conflict,
 mongodb.metrics.operation.scanandorderps,gauge,,query,second,Number of queries per second that return sorted numbers that cannot perform the sort operation using an index.,0,mongodb,operation scanandorder ps,
 mongodb.metrics.queryexecutor.scannedps,gauge,,operation,second,Number of index items scanned per second during queries and query-plan evaluation.,0,mongodb,queryexecutor scanned ps,
+mongodb.metrics.queryexecutor.scannedobjectsps,gauge,,operation,second,Number of documents scanned per second during queries and query-plan evaluation.,0,mongodb,queryexecutor scanned object ps,
 mongodb.metrics.record.movesps,gauge,,operation,second,Number of times per second documents move within the on-disk representation of the MongoDB data set.,0,mongodb,record moves ps,
 mongodb.metrics.repl.apply.batches.numps,gauge,,operation,second,Number of batches applied across all databases per second.,0,mongodb,repl apply batches num ps,
 mongodb.metrics.repl.apply.batches.totalmillisps,gauge,,fraction,,Fraction of time (ms/s) the mongod has spent applying operations from the oplog.,0,mongodb,repl apply batches totalmillis ps,

--- a/mongo/tests/fixtures/serverStatus
+++ b/mongo/tests/fixtures/serverStatus
@@ -911,7 +911,8 @@
             "idhack": 13
         },
         "queryExecutor": {
-            "scanned": 46
+            "scanned": 46,
+            "scannedObjects": 97
         },
         "record": {
             "moves": 0

--- a/mongo/tests/results/metrics-serverStatus.json
+++ b/mongo/tests/results/metrics-serverStatus.json
@@ -408,6 +408,14 @@
         ]
     },
     {
+        "name": "mongodb.metrics.queryexecutor.scannedobjectsps",
+        "type": 1,
+        "value": 97.0,
+        "tags": [
+            "server:mongodb://testUser2:*****@localhost:27017/test"
+        ]
+    },
+    {
         "name": "mongodb.metrics.record.movesps",
         "type": 1,
         "value": 0.0,

--- a/mongo/tests/test_e2e.py
+++ b/mongo/tests/test_e2e.py
@@ -45,7 +45,11 @@ MONGOS_METRICS = BASE_METRICS + [
     'mongodb.stats.objects',
 ]
 
-MONGOD_METRICS = BASE_METRICS + ['mongodb.fsynclocked']
+MONGOD_METRICS = BASE_METRICS + [
+    'mongodb.metrics.queryexecutor.scannedps',
+    'mongodb.metrics.queryexecutor.scannedobjectsps',
+    'mongodb.fsynclocked',
+]
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
### What does this PR do?
Add new metric based on serverStatus mongo command output.
```
...
"queryExecutor": {
  "scanned" : NumberLong(<num>),
  "scannedObjects" : NumberLong(<num>),
  "collectionScans" : {
    "nonTailable" : NumbeLong(<num>),
    "total" : NumberLong(<num>)
  }
}
...
```
Metric in metadata.csv will be like this:
`mongodb.metrics.queryexecutor.scannedobjectsps,gauge,,operation,second,Number of documents scanned per second during queries and query-plan evaluation.,0,mongodb,queryexecutor scanned object ps`

This metric only works on `mongod` instance.

### Motivation
https://datadoghq.atlassian.net/browse/AI-2504

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
