### PR TITLE
Fix typo detection for config field aliases

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -67,7 +67,7 @@ if datadog_agent.get_config('disable_unsafe_yaml'):
     monkey_patch_pyyaml()
 
 if not PY2:
-    from pydantic import ValidationError, BaseModel
+    from pydantic import ValidationError
 
 if TYPE_CHECKING:
     import ssl
@@ -438,6 +438,7 @@ class AgentCheck(object):
     def log_typos_in_options(self, user_config, models_config, level):
         # only import it when running in python 3
         from jellyfish import jaro_winkler_similarity
+        from pydantic import BaseModel
 
         user_configs = user_config or {}  # type: Dict[str, Any]
         models_config = models_config or {}

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -67,7 +67,7 @@ if datadog_agent.get_config('disable_unsafe_yaml'):
     monkey_patch_pyyaml()
 
 if not PY2:
-    from pydantic import ValidationError
+    from pydantic import ValidationError, BaseModel
 
 if TYPE_CHECKING:
     import ssl
@@ -443,7 +443,12 @@ class AgentCheck(object):
         models_config = models_config or {}
         typos = set()  # type: Set[str]
 
-        known_options = [k for k, _ in models_config]  # type: List[str]
+        known_options = set([k for k, _ in models_config])  # type: Set[str]
+
+        if isinstance(models_config, BaseModel):
+            # Also add aliases, if any
+            known_options.update(set(models_config.dict(by_alias=True)))
+
         unknown_options = [option for option in user_configs.keys() if option not in known_options]  # type: List[str]
 
         for unknown_option in unknown_options:

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -67,7 +67,7 @@ if datadog_agent.get_config('disable_unsafe_yaml'):
     monkey_patch_pyyaml()
 
 if not PY2:
-    from pydantic import ValidationError
+    from pydantic import BaseModel, ValidationError
 
 if TYPE_CHECKING:
     import ssl
@@ -446,7 +446,6 @@ class AgentCheck(object):
         known_options = set([k for k, _ in models_config])  # type: Set[str]
 
         if not PY2:
-            from pydantic import BaseModel
 
             if isinstance(models_config, BaseModel):
                 # Also add aliases, if any

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -438,7 +438,6 @@ class AgentCheck(object):
     def log_typos_in_options(self, user_config, models_config, level):
         # only import it when running in python 3
         from jellyfish import jaro_winkler_similarity
-        from pydantic import BaseModel
 
         user_configs = user_config or {}  # type: Dict[str, Any]
         models_config = models_config or {}
@@ -446,9 +445,12 @@ class AgentCheck(object):
 
         known_options = set([k for k, _ in models_config])  # type: Set[str]
 
-        if isinstance(models_config, BaseModel):
-            # Also add aliases, if any
-            known_options.update(set(models_config.dict(by_alias=True)))
+        if not PY2:
+            from pydantic import BaseModel
+
+            if isinstance(models_config, BaseModel):
+                # Also add aliases, if any
+                known_options.update(set(models_config.dict(by_alias=True)))
 
         unknown_options = [option for option in user_configs.keys() if option not in known_options]  # type: List[str]
 

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -1045,18 +1045,20 @@ def test_load_configuration_models(dd_run_check, mocker):
 
 @requires_py3
 @pytest.mark.parametrize(
-    'check_instance_config, default_instance_config, log_lines',
+    'check_instance_config, default_instance_config, log_lines, unknown_options',
     [
         pytest.param(
             {'endpoint': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
             [],
             None,
+            [],
             id='empty default',
         ),
         pytest.param(
             {'endpoint': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
             [('endpoint', 'url')],
             None,
+            [],
             id='no typo',
         ),
         pytest.param(
@@ -1068,12 +1070,14 @@ def test_load_configuration_models(dd_run_check, mocker):
                     'Did you mean endpoint?'
                 )
             ],
+            ["endpoints"],
             id='typo',
         ),
         pytest.param(
             {'endpoints': 'url', 'tags': ['foo:bar'], 'proxy': {'http': 'http://1.2.3.4:9000'}},
             [('endpoint', 'url'), ('endpoints', 'url')],
             None,
+            [],
             id='no typo similar option',
         ),
         pytest.param(
@@ -1085,9 +1089,10 @@ def test_load_configuration_models(dd_run_check, mocker):
                     'Did you mean endpoint, or endpoints?'
                 )
             ],
+            ["endpont"],
             id='typo two candidates',
         ),
-        pytest.param({'tag': 'test'}, [('tags', 'test')], None, id='short option cant catch'),
+        pytest.param({'tag': 'test'}, [('tags', 'test')], None, [], id='short option cant catch'),
         pytest.param(
             {'testing_long_para': 'test'},
             [('testing_long_param', 'test'), ('test_short_param', 'test')],
@@ -1097,12 +1102,14 @@ def test_load_configuration_models(dd_run_check, mocker):
                     'Did you mean testing_long_param?'
                 )
             ],
+            ["testing_long_para"],
             id='somewhat similar option',
         ),
         pytest.param(
             {'send_distribution_sums_as_monotonic': False, 'exclude_labels': True},
             [('send_distribution_counts_as_monotonic', True), ('include_labels', True)],
             None,
+            [],
             id='different options no typos',
         ),
         pytest.param(
@@ -1123,12 +1130,13 @@ def test_load_configuration_models(dd_run_check, mocker):
                     'Did you mean exclude_labels?'
                 ),
             ],
+            ["send_distribution_count_as_monotonic", "exclude_label"],
             id='different options typo',
         ),
     ],
 )
 def test_detect_typos_configuration_models(
-    dd_run_check, mocker, caplog, check_instance_config, default_instance_config, log_lines
+    dd_run_check, mocker, caplog, check_instance_config, default_instance_config, log_lines, unknown_options,
 ):
     caplog.clear()
     caplog.set_level(logging.WARNING)
@@ -1139,10 +1147,12 @@ def test_detect_typos_configuration_models(
     check = AgentCheck('test', empty_config, [check_instance_config])
     check.check_id = 'test:123'
 
-    check.log_typos_in_options(check_instance_config, default_instance, 'instance')
+    typos = check.log_typos_in_options(check_instance_config, default_instance, 'instance')
 
     if log_lines is not None:
         for log_line in log_lines:
             assert log_line in caplog.text
     else:
         assert 'Detected potential typo in configuration option' not in caplog.text
+
+    assert typos == set(unknown_options)

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -1051,6 +1051,7 @@ if PY3:
     class BaseModelTest(BaseModel):
         field = ""
         schema_ = Field("", alias='schema')
+
 else:
 
     class BaseModelTest:

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -6,7 +6,7 @@
 import json
 import logging
 from collections import OrderedDict
-from typing import Any, Optional
+from typing import Any
 
 import mock
 import pytest
@@ -1049,8 +1049,13 @@ def test_load_configuration_models(dd_run_check, mocker):
 if PY3:
 
     class BaseModelTest(BaseModel):
-        field: str
-        schema_: Optional[str] = Field(None, alias='schema')
+        field = ""
+        schema_ = Field("", alias='schema')
+else:
+
+    class BaseModelTest:
+        def __init__(self, **kwargs):
+            pass
 
 
 @requires_py3

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -1218,6 +1218,21 @@ else:
         pytest.param(
             {
                 "field": "value",
+                "schem": "my_schema",
+            },
+            BaseModelTest(field="my_field", schema_="the_schema"),
+            [
+                (
+                    "Detected potential typo in configuration option in test/instance section: "
+                    "`schem`. Did you mean schema?"
+                ),
+            ],
+            ["schem"],
+            id="typo in an alias",
+        ),
+        pytest.param(
+            {
+                "field": "value",
                 "schema_": "my_schema",
             },
             BaseModelTest(field="my_field", schema_="the_schema"),

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -1047,6 +1047,7 @@ def test_load_configuration_models(dd_run_check, mocker):
 
 
 if PY3:
+
     class BaseModelTest(BaseModel):
         field: str
         schema_: Optional[str] = Field(None, alias='schema')
@@ -1054,149 +1055,150 @@ if PY3:
 
 @requires_py3
 @pytest.mark.parametrize(
-    'check_instance_config, default_instance_config, log_lines, unknown_options',
+    "check_instance_config, default_instance_config, log_lines, unknown_options",
     [
         pytest.param(
             {
-                'endpoint': 'url',
-                'tags': ['foo:bar'],
-                'proxy': {'http': 'http://1.2.3.4:9000'},
+                "endpoint": "url",
+                "tags": ["foo:bar"],
+                "proxy": {"http": "http://1.2.3.4:9000"},
             },
             [],
             None,
             [],
-            id='empty default',
+            id="empty default",
         ),
         pytest.param(
             {
-                'endpoint': 'url',
-                'tags': ['foo:bar'],
-                'proxy': {'http': 'http://1.2.3.4:9000'},
+                "endpoint": "url",
+                "tags": ["foo:bar"],
+                "proxy": {"http": "http://1.2.3.4:9000"},
             },
             [
-                ('endpoint', 'url'),
+                ("endpoint", "url"),
             ],
             None,
             [],
-            id='no typo',
+            id="no typo",
         ),
         pytest.param(
             {
-                'endpoints': 'url',
-                'tags': ['foo:bar'],
-                'proxy': {'http': 'http://1.2.3.4:9000'},
+                "endpoints": "url",
+                "tags": ["foo:bar"],
+                "proxy": {"http": "http://1.2.3.4:9000"},
             },
             [
-                ('endpoint', 'url'),
+                ("endpoint", "url"),
             ],
             [
                 (
-                    'Detected potential typo in configuration option in test/instance section: `endpoints`. '
-                    'Did you mean endpoint?'
+                    "Detected potential typo in configuration option in test/instance section: `endpoints`. "
+                    "Did you mean endpoint?"
                 )
             ],
             ["endpoints"],
-            id='typo',
+            id="typo",
         ),
         pytest.param(
             {
-                'endpoints': 'url',
-                'tags': ['foo:bar'],
-                'proxy': {'http': 'http://1.2.3.4:9000'},
+                "endpoints": "url",
+                "tags": ["foo:bar"],
+                "proxy": {"http": "http://1.2.3.4:9000"},
             },
             [
-                ('endpoint', 'url'),
-                ('endpoints', 'url'),
+                ("endpoint", "url"),
+                ("endpoints", "url"),
             ],
             None,
             [],
-            id='no typo similar option',
+            id="no typo similar option",
         ),
         pytest.param(
             {
-                'endpont': 'url',
-                'tags': ['foo:bar'],
-                'proxy': {'http': 'http://1.2.3.4:9000'},
+                "endpont": "url",
+                "tags": ["foo:bar"],
+                "proxy": {"http": "http://1.2.3.4:9000"},
             },
             [
-                ('endpoint', 'url'),
-                ('endpoints', 'url'),
+                ("endpoint", "url"),
+                ("endpoints", "url"),
             ],
             [
                 (
-                    'Detected potential typo in configuration option in test/instance section: `endpont`. '
-                    'Did you mean endpoint, or endpoints?'
+                    "Detected potential typo in configuration option in test/instance section: `endpont`. "
+                    "Did you mean endpoint, or endpoints?"
                 )
             ],
             ["endpont"],
-            id='typo two candidates',
+            id="typo two candidates",
         ),
         pytest.param(
             {
-                'tag': 'test',
+                "tag": "test",
             },
             [
-                ('tags', 'test'),
+                ("tags", "test"),
             ],
             None,
             [],
-            id='short option cant catch'),
+            id="short option cant catch",
+        ),
         pytest.param(
             {
-                'testing_long_para': 'test',
+                "testing_long_para": "test",
             },
             [
-                ('testing_long_param', 'test'),
-                ('test_short_param', 'test'),
+                ("testing_long_param", "test"),
+                ("test_short_param", "test"),
             ],
             [
                 (
-                    'Detected potential typo in configuration option in test/instance section: `testing_long_para`. '
-                    'Did you mean testing_long_param?'
+                    "Detected potential typo in configuration option in test/instance section: `testing_long_para`. "
+                    "Did you mean testing_long_param?"
                 )
             ],
             ["testing_long_para"],
-            id='somewhat similar option',
+            id="somewhat similar option",
         ),
         pytest.param(
             {
-                'send_distribution_sums_as_monotonic': False,
-                'exclude_labels': True,
+                "send_distribution_sums_as_monotonic": False,
+                "exclude_labels": True,
             },
             [
-                ('send_distribution_counts_as_monotonic', True),
-                ('include_labels', True),
+                ("send_distribution_counts_as_monotonic", True),
+                ("include_labels", True),
             ],
             None,
             [],
-            id='different options no typos',
+            id="different options no typos",
         ),
         pytest.param(
             {
-                'send_distribution_count_as_monotonic': True,
-                'exclude_label': True,
+                "send_distribution_count_as_monotonic": True,
+                "exclude_label": True,
             },
             [
-                ('send_distribution_sums_as_monotonic', False),
-                ('send_distribution_counts_as_monotonic', True),
-                ('exclude_labels', False),
-                ('include_labels', True),
+                ("send_distribution_sums_as_monotonic", False),
+                ("send_distribution_counts_as_monotonic", True),
+                ("exclude_labels", False),
+                ("include_labels", True),
             ],
             [
                 (
-                    'Detected potential typo in configuration option in test/instance section: '
-                    '`send_distribution_count_as_monotonic`. Did you mean send_distribution_counts_as_monotonic?'
+                    "Detected potential typo in configuration option in test/instance section: "
+                    "`send_distribution_count_as_monotonic`. Did you mean send_distribution_counts_as_monotonic?"
                 ),
                 (
-                    'Detected potential typo in configuration option in test/instance section: `exclude_label`. '
-                    'Did you mean exclude_labels?'
+                    "Detected potential typo in configuration option in test/instance section: `exclude_label`. "
+                    "Did you mean exclude_labels?"
                 ),
             ],
             [
                 "send_distribution_count_as_monotonic",
                 "exclude_label",
             ],
-            id='different options typo',
+            id="different options typo",
         ),
         pytest.param(
             {
@@ -1206,7 +1208,7 @@ if PY3:
             BaseModelTest(field="my_field", schema_="the_schema"),
             None,
             [],
-            id='using an alias',
+            id="using an alias",
         ),
         pytest.param(
             {
@@ -1216,26 +1218,31 @@ if PY3:
             BaseModelTest(field="my_field", schema_="the_schema"),
             None,
             [],
-            id='not using an alias',
+            id="not using an alias",
         ),
     ],
 )
 def test_detect_typos_configuration_models(
-    dd_run_check, caplog, check_instance_config, default_instance_config, log_lines, unknown_options,
+    dd_run_check,
+    caplog,
+    check_instance_config,
+    default_instance_config,
+    log_lines,
+    unknown_options,
 ):
     caplog.clear()
     caplog.set_level(logging.WARNING)
     empty_config = {}
 
-    check = AgentCheck('test', empty_config, [check_instance_config])
-    check.check_id = 'test:123'
+    check = AgentCheck("test", empty_config, [check_instance_config])
+    check.check_id = "test:123"
 
-    typos = check.log_typos_in_options(check_instance_config, default_instance_config, 'instance')
+    typos = check.log_typos_in_options(check_instance_config, default_instance_config, "instance")
 
     if log_lines is not None:
         for log_line in log_lines:
             assert log_line in caplog.text
     else:
-        assert 'Detected potential typo in configuration option' not in caplog.text
+        assert "Detected potential typo in configuration option" not in caplog.text
 
     assert typos == set(unknown_options)

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -1046,9 +1046,10 @@ def test_load_configuration_models(dd_run_check, mocker):
     assert check._config_model_shared is shared_config
 
 
-class BaseModelTest(BaseModel):
-    field: str
-    schema_: Optional[str] = Field(None, alias='schema')
+if PY3:
+    class BaseModelTest(BaseModel):
+        field: str
+        schema_: Optional[str] = Field(None, alias='schema')
 
 
 @requires_py3

--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -18,9 +18,6 @@ from datadog_checks.base import to_native_string
 from datadog_checks.base.checks.base import datadog_agent
 from datadog_checks.dev.testing import requires_py3
 
-if PY3:
-    from pydantic import BaseModel, Field
-
 
 def test_instance():
     """
@@ -1047,6 +1044,8 @@ def test_load_configuration_models(dd_run_check, mocker):
 
 
 if PY3:
+
+    from pydantic import BaseModel, Field
 
     class BaseModelTest(BaseModel):
         field = ""


### PR DESCRIPTION
### What does this PR do?

- Take the aliases when looking for typos in the config options
- Update the test case to check the return value
- Update the test case to also verify aliases are taken into account

### Motivation

https://datadoghq.atlassian.net/browse/AI-2362

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
