### PR TITLE
Documents max_returned_metrics for openmetrics integration

### DIFF
--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -670,3 +670,8 @@ instances:
     #   - <INCLUDE_REGEX>
     #   exclude:
     #   - <EXCLUDE_REGEX>
+
+    ## @param max_returned_metrics - integer - optional - default: 2000
+    ## The check limits itself to 2000 metrics by default, increase this limit if needed.
+    #
+    # max_returned_metrics: 2000


### PR DESCRIPTION
### What does this PR do?
Adds the `max_returned_metrics` to the openmetrics example. We've been using this for a year now but only learned about it because it was documented for the [prometheus check](https://github.com/DataDog/integrations-core/blob/master/prometheus/datadog_checks/prometheus/data/conf.yaml.example#L114-L117) but not openmetrics

### Motivation
More complete documentation

### Additional Notes
Would be nice if someone from Datadog would ensure that these examples do, in fact, include all the options. I'd prefer not to find out via reading code that there may be an option that is useful to me.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
