### PR TITLE
Hide `extra_metrics` in example config

### DIFF
--- a/openmetrics/assets/configuration/spec.yaml
+++ b/openmetrics/assets/configuration/spec.yaml
@@ -12,6 +12,7 @@ files:
             namespace.hidden: false
             metrics.required: true
             metrics.hidden: false
+            extra_metrics.hidden: true
             openmetrics_endpoint.required: false
             tag_by_endpoint.example: false
             tag_by_endpoint.hidden: false

--- a/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
+++ b/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
@@ -109,54 +109,6 @@ instances:
     #
     metrics: []
 
-    ## @param extra_metrics - (list of string or mapping) - optional
-    ## This list defines metrics to collect from the `openmetrics_endpoint`, in addition to
-    ## what the check collects by default. If the check already collects a metric, then
-    ## metric definitions here take precedence. Metrics may be defined in 3 ways:
-    ##
-    ## 1. If the item is a string, then it represents the exposed metric name, and
-    ##    the sent metric name will be identical. For example:
-    ##
-    ##      extra_metrics:
-    ##      - <METRIC_1>
-    ##      - <METRIC_2>
-    ## 2. If the item is a mapping, then the keys represent the exposed metric names.
-    ##
-    ##      a. If a value is a string, then it represents the sent metric name. For example:
-    ##
-    ##           extra_metrics:
-    ##           - <EXPOSED_METRIC_1>: <SENT_METRIC_1>
-    ##           - <EXPOSED_METRIC_2>: <SENT_METRIC_2>
-    ##      b. If a value is a mapping, then it must have a `name` and/or `type` key.
-    ##         The `name` represents the sent metric name, and the `type` represents how
-    ##         the metric should be handled, overriding any type information the endpoint
-    ##         may provide. For example:
-    ##
-    ##           extra_metrics:
-    ##           - <EXPOSED_METRIC_1>:
-    ##               name: <SENT_METRIC_1>
-    ##               type: <METRIC_TYPE_1>
-    ##           - <EXPOSED_METRIC_2>:
-    ##               name: <SENT_METRIC_2>
-    ##               type: <METRIC_TYPE_2>
-    ##
-    ##         The supported native types are `gauge`, `counter`, `histogram`, and `summary`.
-    ##
-    ## Note: To collect counter metrics with names ending in `_total`, specify the metric name without the `_total`
-    ## suffix. For example, to collect the counter metric `promhttp_metric_handler_requests_total`, specify
-    ## `promhttp_metric_handler_requests`. This submits to Datadog the metric name appended with `.count`.
-    ## For more information, see:
-    ## https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#suffixes
-    ##
-    ## Regular expressions may be used to match the exposed metric names, for example:
-    ##
-    ##   extra_metrics:
-    ##   - ^network_(ingress|egress)_.+
-    ##   - .+:
-    ##       type: gauge
-    #
-    # extra_metrics: []
-
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.


### PR DESCRIPTION
### What does this PR do?
Hides `extra_metrics` configuration option in example config for the generic openmetrics check
### Motivation
Users will only ever need to use the `metrics` option in the  openmetrics check, `extra_metrics` is the option for the integrations based off of it. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
