### PR TITLE
Fix bug where mysql table row stats were not being collected

### DIFF
--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -32,7 +32,7 @@ class MySQLConfig(object):
         self.max_custom_queries = instance.get('max_custom_queries', DEFAULT_MAX_CUSTOM_QUERIES)
         self.charset = instance.get('charset')
         self.dbm_enabled = is_affirmative(instance.get('dbm', instance.get('deep_database_monitoring', False)))
-        self.table_rows_stats_enabled = is_affirmative(instance.get('table_rows_stats_metrics', False))
+        self.table_rows_stats_enabled = is_affirmative(self.options.get('table_rows_stats_metrics', False))
         self.statement_metrics_limits = instance.get('statement_metrics_limits', None)
         self.full_statement_text_cache_max_size = instance.get('full_statement_text_cache_max_size', 10000)
         self.full_statement_text_samples_per_hour_per_query = instance.get(

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -401,6 +401,7 @@ class MySql(AgentCheck):
 
         if is_affirmative(self._config.options.get('table_rows_stats_metrics', False)) and self.userstat_enabled:
             # report size of tables in MiB to Datadog
+            self.log.debug("Collecting Table Row Stats Metrics.")
             (rows_read_total, rows_changed_total) = self._query_rows_stats_per_table(db)
             results['information_table_rows_read_total'] = rows_read_total
             results['information_table_rows_changed_total'] = rows_changed_total
@@ -1085,7 +1086,6 @@ class MySql(AgentCheck):
                     # set the tag as the dictionary key
                     table_rows_read_total["schema:{},table:{}".format(table_schema, table_name)] = rows_read_total
                     table_rows_changed_total["schema:{},table:{}".format(table_schema, table_name)] = rows_changed_total
-
                 return table_rows_read_total, table_rows_changed_total
         except (pymysql.err.InternalError, pymysql.err.OperationalError) as e:
             self.warning("Tables rows stats metrics unavailable at this time: %s", e)

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -13,27 +13,27 @@ ORDER BY `percentile` ASC
 LIMIT 1"""
 
 SQL_QUERY_TABLE_ROWS_STATS = """\
-SELECT   table_schema, table_name, rows_read, rows_changed
-FROM     information_schema.table_statistics"""
+SELECT table_schema, table_name, rows_read, rows_changed
+FROM information_schema.table_statistics"""
 
 SQL_QUERY_SCHEMA_SIZE = """\
-SELECT   table_schema, IFNULL(SUM(data_length+index_length)/1024/1024,0) AS total_mb
-FROM     information_schema.tables
+SELECT table_schema, IFNULL(SUM(data_length+index_length)/1024/1024,0) AS total_mb
+FROM information_schema.tables
 GROUP BY table_schema"""
 
 SQL_QUERY_TABLE_SIZE = """\
-SELECT   table_schema, table_name,
-         IFNULL(index_length/1024/1024,0) AS index_size_mb,
-         IFNULL(data_length/1024/1024,0) AS data_size_mb
-FROM     information_schema.tables
-WHERE    table_schema not in ('mysql', 'performance_schema', 'information_schema')"""
+SELECT table_schema, table_name,
+ IFNULL(index_length/1024/1024,0) AS index_size_mb,
+ IFNULL(data_length/1024/1024,0) AS data_size_mb
+FROM information_schema.tables
+WHERE table_schema not in ('mysql', 'performance_schema', 'information_schema')"""
 
 SQL_QUERY_SYSTEM_TABLE_SIZE = """\
-SELECT   table_schema, table_name,
-         IFNULL(index_length/1024/1024,0) AS index_size_mb,
-         IFNULL(data_length/1024/1024,0) AS data_size_mb
-FROM     information_schema.tables
-WHERE    table_schema in ('mysql', 'performance_schema', 'information_schema')"""
+SELECT table_schema, table_name,
+ IFNULL(index_length/1024/1024,0) AS index_size_mb,
+ IFNULL(data_length/1024/1024,0) AS data_size_mb
+FROM information_schema.tables
+WHERE table_schema in ('mysql', 'performance_schema', 'information_schema')"""
 
 SQL_AVG_QUERY_RUN_TIME = """\
 SELECT schema_name, ROUND((SUM(sum_timer_wait) / SUM(count_star)) / 1000000) AS avg_us

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -1,7 +1,7 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 mysql.info.schema.size,gauge,,mebibyte,,"Size of schemas in MiB",0,mysql,mysql schema size,
 mysql.info.table.rows.read,count,,row,,"Total number of rows read per table (Percona userstat only)",0,mysql,mysql table rows read,
-mysql.info.table.rows.update,count,,row,,"Total number of rows changed per table (Percona userstat only)",0,mysql,mysql table rows changed,
+mysql.info.table.rows.changed,count,,row,,"Total number of rows changed per table (Percona userstat only)",0,mysql,mysql table rows changed,
 mysql.info.table.index_size,gauge,,mebibyte,,"Size of tables index in MiB",0,mysql,mysql index table size,
 mysql.info.table.data_size,gauge,,mebibyte,,"Size of tables data in MiB",0,mysql,mysql data table size,memory
 mysql.galera.wsrep_cluster_size,gauge,,node,,The current number of nodes in the Galera cluster.,0,mysql,galera cluster size,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Follow up to this PR https://github.com/DataDog/integrations-core/pull/11043

Updates metadata.csv to reflect correct metric name, `mysql.info.table.rows.changed` and fixes the `table_rows_stats_metrics` config option look up, so metrics are properly reported 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
