### PR TITLE
Update trello.py

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -73,6 +73,7 @@ class TrelloClient:
             'team/containers': 'container-integrations',
             'team/container-app': 'container-app',
             'team/integrations': 'agent-integrations',
+            'team/database-monitoring': 'database-monitoring',
             'team/intg-tools-libs': 'integrations-tools-and-libraries',
             'team/agent-security': 'agent-security',
             'team/infra-integrations': 'infrastructure-integrations',


### PR DESCRIPTION
### What does this PR do?
TrelloClient field that maps GH labels to GH team was missing entry for Database Monitoring team. That prevented release QA cards to be automatically assigned.

### Motivation
Fixes the problem with the QA cards assignment.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
