### PR TITLE
Remove legacy variants from tests environments

### DIFF
--- a/envoy/tests/common.py
+++ b/envoy/tests/common.py
@@ -10,7 +10,6 @@ HERE = get_here()
 FIXTURE_DIR = os.path.join(HERE, 'fixtures')
 DOCKER_DIR = os.path.join(HERE, 'docker')
 ENVOY_VERSION = os.getenv('ENVOY_VERSION')
-ENVOY_API_FLAVOR = os.getenv('FLAVOR')
 
 HOST = get_docker_hostname()
 PORT = '8001'

--- a/envoy/tests/common.py
+++ b/envoy/tests/common.py
@@ -4,19 +4,20 @@ import pytest
 
 from datadog_checks.dev import get_docker_hostname, get_here
 
+from .legacy.common import FLAVOR
+
 HERE = get_here()
 FIXTURE_DIR = os.path.join(HERE, 'fixtures')
 DOCKER_DIR = os.path.join(HERE, 'docker')
-ENVOY_LEGACY = os.getenv('ENVOY_LEGACY')
 ENVOY_VERSION = os.getenv('ENVOY_VERSION')
+ENVOY_API_FLAVOR = os.getenv('FLAVOR')
 
 HOST = get_docker_hostname()
 PORT = '8001'
 
 URL = 'http://{}:{}'.format(HOST, PORT)
 DEFAULT_INSTANCE = {'openmetrics_endpoint': '{}/stats/prometheus'.format(URL)}
-LEGACY_INSTANCE = {'stats_url': '{}/stats'.format(URL)}
-requires_new_environment = pytest.mark.skipif(ENVOY_LEGACY != 'false', reason='Requires prometheus environment')
+requires_new_environment = pytest.mark.skipif(FLAVOR == 'api_v2', reason='Requires prometheus environment')
 
 PROMETHEUS_METRICS = [
     "cluster.assignment_stale.count",

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -6,7 +6,7 @@ import requests
 from datadog_checks.dev import docker_run
 from datadog_checks.envoy import Envoy
 
-from .common import DEFAULT_INSTANCE, DOCKER_DIR, ENVOY_LEGACY, FIXTURE_DIR, HOST, URL
+from .common import DEFAULT_INSTANCE, DOCKER_DIR, FIXTURE_DIR, HOST, URL
 from .legacy.common import FLAVOR, INSTANCES
 
 
@@ -17,7 +17,7 @@ def fixture_path():
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    if ENVOY_LEGACY == 'true':
+    if FLAVOR == 'api_v2':
         instance = INSTANCES['main']
     else:
         instance = DEFAULT_INSTANCE

--- a/envoy/tests/legacy/common.py
+++ b/envoy/tests/legacy/common.py
@@ -1,10 +1,6 @@
 import os
 
-import pytest
-
 from datadog_checks.dev import get_docker_hostname
-
-from ..common import ENVOY_LEGACY
 
 FLAVOR = os.getenv('FLAVOR', 'api_v3')
 
@@ -31,6 +27,3 @@ INSTANCES = {
     },
 }
 ENVOY_VERSION = os.getenv('ENVOY_VERSION')
-requires_legacy_environment = pytest.mark.skipif(
-    ENVOY_LEGACY != 'true', reason='Requires legacy non-prometheus environment'
-)

--- a/envoy/tests/legacy/test_bench.py
+++ b/envoy/tests/legacy/test_bench.py
@@ -2,9 +2,7 @@ import pytest
 
 from datadog_checks.envoy import Envoy
 
-from .common import INSTANCES, requires_legacy_environment
-
-pytestmark = [requires_legacy_environment]
+from .common import INSTANCES
 
 
 @pytest.mark.usefixtures('dd_environment')

--- a/envoy/tests/legacy/test_e2e.py
+++ b/envoy/tests/legacy/test_e2e.py
@@ -6,9 +6,7 @@ import pytest
 
 from datadog_checks.envoy import Envoy
 
-from .common import FLAVOR, HOST, requires_legacy_environment
-
-pytestmark = [requires_legacy_environment]
+from .common import FLAVOR, HOST
 
 METRICS = [
     'envoy.cluster.assignment_stale',

--- a/envoy/tests/legacy/test_envoy.py
+++ b/envoy/tests/legacy/test_envoy.py
@@ -7,14 +7,13 @@ import mock
 import pytest
 import requests
 
+from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.envoy import Envoy
 from datadog_checks.envoy.metrics import METRIC_PREFIX, METRICS
 
-from .common import ENVOY_VERSION, FLAVOR, HOST, INSTANCES, requires_legacy_environment
+from .common import ENVOY_VERSION, FLAVOR, HOST, INSTANCES
 
 CHECK_NAME = 'envoy'
-
-pytestmark = [requires_legacy_environment]
 
 
 @pytest.mark.integration
@@ -35,6 +34,12 @@ def test_success(aggregator, check, dd_run_check):
                 ), ('tags ' + str(expected_tags) + ' not found in ' + metric)
         metrics_collected += len(collected_metrics)
     assert metrics_collected >= 445
+
+    metadata_metrics = get_metadata_metrics()
+    # Metric that has a different type in legacy
+    metadata_metrics['envoy.cluster.upstream_cx_tx_bytes_total']['metric_type'] = 'count'
+
+    aggregator.assert_metrics_using_metadata(metadata_metrics)
 
 
 @pytest.mark.unit

--- a/envoy/tests/legacy/test_metrics.py
+++ b/envoy/tests/legacy/test_metrics.py
@@ -1,10 +1,6 @@
 from datadog_checks.envoy.metrics import METRIC_PREFIX, METRIC_TREE, METRICS
 from datadog_checks.envoy.utils import make_metric_tree
 
-from .common import requires_legacy_environment
-
-pytestmark = [requires_legacy_environment]
-
 
 def test_metric_prefix():
     assert METRIC_PREFIX == 'envoy.'

--- a/envoy/tests/legacy/test_parser.py
+++ b/envoy/tests/legacy/test_parser.py
@@ -4,10 +4,6 @@ from datadog_checks.envoy.errors import UnknownMetric, UnknownTags
 from datadog_checks.envoy.metrics import METRIC_PREFIX, METRICS
 from datadog_checks.envoy.parser import parse_histogram, parse_metric
 
-from .common import requires_legacy_environment
-
-pytestmark = [requires_legacy_environment]
-
 
 def test_unknown_metric():
     with pytest.raises(UnknownMetric):

--- a/envoy/tests/legacy/test_utils.py
+++ b/envoy/tests/legacy/test_utils.py
@@ -1,9 +1,5 @@
 from datadog_checks.envoy.utils import make_metric_tree
 
-from .common import requires_legacy_environment
-
-pytestmark = [requires_legacy_environment]
-
 
 def test_make_metric_tree():
     # fmt: off

--- a/envoy/tests/test_check.py
+++ b/envoy/tests/test_check.py
@@ -3,14 +3,7 @@ import pytest
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.envoy.metrics import METRIC_PREFIX, METRICS
 
-from .common import (
-    DEFAULT_INSTANCE,
-    ENVOY_VERSION,
-    FLAKY_METRICS,
-    LEGACY_INSTANCE,
-    PROMETHEUS_METRICS,
-    requires_new_environment,
-)
+from .common import DEFAULT_INSTANCE, ENVOY_VERSION, FLAKY_METRICS, PROMETHEUS_METRICS, requires_new_environment
 
 pytestmark = [requires_new_environment]
 
@@ -46,20 +39,6 @@ def test_check(aggregator, dd_run_check, check):
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
-
-
-@pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
-def test_check_legacy(aggregator, dd_run_check, check):
-    c = check(LEGACY_INSTANCE)
-
-    dd_run_check(c)
-
-    metadata_metrics = get_metadata_metrics()
-    # Metric that has a different type in legacy
-    metadata_metrics['envoy.cluster.upstream_cx_tx_bytes_total']['metric_type'] = 'count'
-
-    aggregator.assert_metrics_using_metadata(metadata_metrics)
 
 
 @pytest.mark.integration

--- a/envoy/tox.ini
+++ b/envoy/tox.ini
@@ -4,8 +4,8 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py{27,38}-{2}
-    py{38}-{3}
+    py{27,38}-2
+    py38-3
     bench
 
 [testenv]

--- a/envoy/tox.ini
+++ b/envoy/tox.ini
@@ -4,7 +4,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py{27,38}-{2,3}-legacy
+    py{27,38}-{2}
     py{38}-{3}
     bench
 
@@ -27,8 +27,6 @@ passenv =
     COMPOSE*
 setenv =
     LEGACY_DOCKER_COMPOSE = true
-    ENVOY_LEGACY=false
-    legacy: ENVOY_LEGACY=true
     2: FLAVOR=api_v2
     2: ENVOY_VERSION=1.14.1
     3: FLAVOR=api_v3


### PR DESCRIPTION
### What does this PR do?

It removes legacy variants from test (tox) environments with the necessary adjustments.

### Motivation

I didn't see a good reason to have `legacy` as a variant, since the envoy environment remains the same regardless of that. This was prompted by realizing a test I added recently looked out of place (was testing legacy only in a supposedly non-legacy env).

### Additional Notes

My assumption here is that api_v2 doesn't support Prometheus, though I haven't checked yet whether that's the case. This assumption is supported by the fact that in our tox envs, api_v2 was only combined with the legacy variant.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
