### PR TITLE
Add tests for table_row_stats_metrics collection

### DIFF
--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -98,6 +98,7 @@ def instance_complex():
             'schema_size_metrics': True,
             'table_size_metrics': True,
             'system_table_size_metrics': True,
+            'table_row_stats_metrics': True,
         },
         'tags': tags.METRIC_TAGS,
         'queries': [

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -104,6 +104,7 @@ def _assert_complex_config(aggregator, hostname='stubbed.hostname'):
         + variables.SYNTHETIC_VARS
         + variables.STATEMENT_VARS
         + variables.TABLE_VARS
+        + variables.ROW_TABLE_STATS_VARS
     )
     if MYSQL_REPLICATION == 'group':
         testable_metrics.extend(variables.GROUP_REPLICATION_VARS)
@@ -214,6 +215,7 @@ def test_complex_config_replica(aggregator, dd_run_check, instance_complex):
         + variables.SYNTHETIC_VARS
         + variables.STATEMENT_VARS
         + variables.TABLE_VARS
+        + variables.ROW_TABLE_STATS_VARS
     )
 
     if MYSQL_VERSION_PARSED >= parse_version('5.6') and environ.get('MYSQL_FLAVOR') != 'mariadb':

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -59,6 +59,11 @@ TABLE_VARS = [
     'mysql.info.table.data_size',
 ]
 
+ROW_TABLE_STATS_VARS = [
+    'mysql.info.table.rows.read',
+    'mysql.info.table.rows.changed',
+]
+
 # Possibly from SHOW GLOBAL VARIABLES
 VARIABLES_VARS = [
     'mysql.myisam.key_buffer_size',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

These metrics had no test coverage before this. This asserts that the metrics are properly emitted. Based on this https://github.com/DataDog/integrations-core/pull/11043

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
