### PR TITLE
Add attempts to IBM DB2 environment

### DIFF
--- a/ibm_db2/tests/conftest.py
+++ b/ibm_db2/tests/conftest.py
@@ -59,7 +59,7 @@ class DbManager(object):
 def dd_environment():
     db = DbManager(CONFIG)
 
-    with docker_run(COMPOSE_FILE, conditions=[db.initialize, WaitFor(db.connect)]):
+    with docker_run(COMPOSE_FILE, conditions=[db.initialize, WaitFor(db.connect)], attempts=2):
         yield CONFIG, E2E_METADATA
 
 


### PR DESCRIPTION
Docker compose command failed on CI
```
Network docker_default  Creating
Network docker_default  Created
Container ibm_db2  Creating
Container ibm_db2  Created
Container ibm_db2  Starting
Error response from daemon: driver failed programming external connectivity on endpoint ibm_db2 (22646172ce50b087ad4b0a782e72c45101e60b723ef4f17e97f66054c73f1c4b): Error starting userland proxy: listen tcp4 0.0.0.0:50000: bind: address already in use
Container ibm_db2  Stopping
Container ibm_db2  Stopping
Container ibm_db2  Stopped
Container ibm_db2  Removing
Container ibm_db2  Removed
Network docker_default  Removing
Network docker_default  Removed
```
So let's add a second attempt to retry in this case