### PR TITLE
Increase memory for oracle tests

### DIFF
--- a/.azure-pipelines/scripts/oracle/linux/55_docker_login.sh
+++ b/.azure-pipelines/scripts/oracle/linux/55_docker_login.sh
@@ -10,4 +10,11 @@ for i in 2 4 8 16 32; do
   sleep $i
 done
 
-set -x
+set -ex
+
+# Allocate 3GB for oracle
+# The default number of memory addresses is 65536, i.e. 512MB (Linux 64-bit).
+# => To get 3GB, we multiply that amount by 6.
+sudo sysctl -w vm.max_map_count=$(expr 6 \* 65536)
+
+set +ex


### PR DESCRIPTION
Oracle environment often fails to start on CI without a trace. This usually means lack of resources, since this environment is heavy let's increase the available memory.