### PR TITLE
Fix test_e2e_core_discovery test

### DIFF
--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -145,7 +145,7 @@ def test_e2e_memory_cpu_f5_big_ip(dd_agent_check):
 def test_e2e_core_discovery(dd_agent_check):
     config = common.generate_container_profile_config_with_ad('apc_ups')
     config['init_config']['loader'] = 'core'
-    aggregator = common.dd_agent_check_wrapper(dd_agent_check, config, rate=False, times=5)
+    aggregator = common.dd_agent_check_wrapper(dd_agent_check, config, rate=False, times=3, pause=500)
 
     network = config['instances'][0]['network_address']
     ip_address = get_container_ip(SNMP_CONTAINER_NAME)
@@ -168,9 +168,9 @@ def test_e2e_core_discovery(dd_agent_check):
     # test that for a specific metric we are getting as many times as we are running the check
     # it might be off by 1 due to devices not being discovered yet at first check run
     aggregator.assert_metric(
-        'snmp.devices_monitored', metric_type=aggregator.GAUGE, tags=tags_with_loader, at_least=4, value=1
+        'snmp.devices_monitored', metric_type=aggregator.GAUGE, tags=tags_with_loader, at_least=2, value=1
     )
-    aggregator.assert_metric('snmp.upsAdvBatteryTemperature', metric_type=aggregator.GAUGE, tags=tags, at_least=4)
+    aggregator.assert_metric('snmp.upsAdvBatteryTemperature', metric_type=aggregator.GAUGE, tags=tags, at_least=2)
 
 
 def test_e2e_regex_match(dd_agent_check):


### PR DESCRIPTION
### What does this PR do?

Fix test_e2e_core_discovery test by adding some pause to let enough time to SNMP check discovery devices.

### Context

The test_e2e_core_discovery is testing SNMP corecheck autodiscovery.
SNMP corecheck autodiscovery goal is to discovery SNMP devices, it is started directly from SNMP corecheck integration and is run in background.

The the test broke after this change https://github.com/DataDog/datadog-agent/pull/12408 that possibly made the autodiscovery slower to discover devices. Hence adding some `pause` is mitigating the issue.

### Motivation
<!-- What inspired you to submit this pull request? -->

Fix e2e test failure for `test_e2e_core_discovery`. Example:

https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=104462&view=logs&j=475ea3e3-a9fc-55a6-2e22-b5a67273560a&t=1a1f47dd-bcf6-5ffb-3d85-8c5dbec3db65&l=106

```
___________________________ test_e2e_core_discovery ____________________________
tests/test_e2e_core.py:170: in test_e2e_core_discovery
    aggregator.assert_metric(
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:366: in assert_metric
    self._assert(condition, msg=msg, expected_stub=expected_metric, submitted_elements=self._metrics)
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:408: in _assert
    assert condition, new_msg
E   AssertionError: Needed at least 4 candidates for 'snmp.devices_monitored', got 0
E   Expected:
E           MetricStub(name='snmp.devices_monitored', type=0, value=1, tags=['autodiscovery_subnet:172.20.0.0/29', 'device_namespace:default', 'device_vendor:apc', 'firmware_version:2.0.3-test', 'loader:core', 'model:APC Smart-UPS 600', 'serial_num:test_serial', 'snmp_device:172.20.0.2', 'snmp_profile:apc_ups', 'ups_name:testIdentName'], hostname=None, device=None, flush_first_value=None)
E   Similar submitted:
E   Score   Most similar
E   0.56    MetricStub(name='snmp.discovered_devices_count', type=0, value=0, tags=['autodiscovery_subnet:172.20.0.0/29', 'device_namespace:default', 'network:172.20.0.0/29'], hostname='fv-az370-496', device=None, flush_first_value=False)
E   0.56    MetricStub(name='snmp.discovered_devices_count', type=0, value=0, tags=['autodiscovery_subnet:172.20.0.0/29', 'device_namespace:default', 'network:172.20.0.0/29'], hostname='fv-az370-496', device=None, flush_first_value=False)
E   0.56    MetricStub(name='snmp.discovered_devices_count', type=0, value=0, tags=['autodiscovery_subnet:172.20.0.0/29', 'device_namespace:default', 'network:172.20.0.0/29'], hostname='fv-az370-496', device=None, flush_first_value=False)
E   0.56    MetricStub(name='snmp.discovered_devices_count', type=0, value=0, tags=['autodiscovery_subnet:172.20.0.0/29', 'device_namespace:default', 'network:172.20.0.0/29'], hostname='fv-az370-496', device=None, flush_first_value=False)
E   0.56    MetricStub(name='snmp.discovered_devices_count', type=0, value=0, tags=['autodiscovery_subnet:172.20.0.0/29', 'device_namespace:default', 'network:172.20.0.0/29'], hostname='fv-az370-496', device=None, flush_first_value=False)

```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
