### PR TITLE
[elastic] Added documentation missing description of required user roles permissions

### DIFF
--- a/elastic/README.md
+++ b/elastic/README.md
@@ -59,6 +59,19 @@ To configure this check for an Agent running on a host:
       - To use the Agent's Elasticsearch integration for the AWS Elasticsearch services, set the `url` parameter to point to your AWS Elasticsearch stats URL.
       - All requests to the Amazon ES configuration API must be signed. See the [Making and signing OpenSearch Service requests][6] for details.
       - The `aws` auth type relies on [boto3][7] to automatically gather AWS credentials from `.aws/credentials`. Use `auth_type: basic` in the `conf.yaml` and define the credentials with `username: <USERNAME>` and `password: <PASSWORD>`.
+      - You have to create a user and a role (if you don't already have them) in Elasticsearch with the proper permissions to monitor. This can be done via the REST API offered by Elasticsearch or for example via Kibana UI. In the created role we must indicate the following properties:
+        ```json
+        name = "datadog"
+        indices {
+          names = [".monitoring-*", "metricbeat-*"]
+          privileges = ["read", "read_cross_cluster", "monitor"]
+        }
+        cluster = ["monitor"]
+        ```
+        And in the user indicate his roles:
+        ```json
+        roles = [<created role>, "monitoring_user"]
+        ```
 
 2. [Restart the Agent][8].
 

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -72,7 +72,7 @@ To configure this check for an Agent running on a host:
         ```json
         roles = [<created role>, "monitoring_user"]
         ```
-        More info: [create or update roles](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html) and [create or update users](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html)
+        For more information, see [create or update roles](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html) and [create or update users](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html).
 
 
 2. [Restart the Agent][8].

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -68,7 +68,7 @@ To configure this check for an Agent running on a host:
         }
         cluster = ["monitor"]
         ```
-        And in the user indicate his roles:
+        Add the role to the user:
         ```json
         roles = [<created role>, "monitoring_user"]
         ```

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -59,7 +59,7 @@ To configure this check for an Agent running on a host:
       - To use the Agent's Elasticsearch integration for the AWS Elasticsearch services, set the `url` parameter to point to your AWS Elasticsearch stats URL.
       - All requests to the Amazon ES configuration API must be signed. See the [Making and signing OpenSearch Service requests][6] for details.
       - The `aws` auth type relies on [boto3][7] to automatically gather AWS credentials from `.aws/credentials`. Use `auth_type: basic` in the `conf.yaml` and define the credentials with `username: <USERNAME>` and `password: <PASSWORD>`.
-      - You have to create a user and a role (if you don't already have them) in Elasticsearch with the proper permissions to monitor. This can be done via the REST API offered by Elasticsearch or for example via Kibana UI. In the created role we must indicate the following properties:
+      - You must create a user and a role (if you don't already have them) in Elasticsearch with the proper permissions to monitor. This can be done through the REST API offered by Elasticsearch, or through the Kibana UI. Include the following properties in the created role:
         ```json
         name = "datadog"
         indices {

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -72,7 +72,7 @@ To configure this check for an Agent running on a host:
         ```json
         roles = [<created role>, "monitoring_user"]
         ```
-        For more information, see [create or update roles](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html) and [create or update users](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html).
+        For more information, see [create or update roles][29] and [create or update users][30].
 
 
 2. [Restart the Agent][8].
@@ -415,3 +415,5 @@ See [service_checks.json][26] for a list of service checks provided by this inte
 [26]: https://github.com/DataDog/integrations-core/blob/master/elastic/assets/service_checks.json
 [27]: https://docs.datadoghq.com/integrations/faq/elastic-agent-can-t-connect/
 [28]: https://www.datadoghq.com/blog/monitor-elasticsearch-performance-metrics
+[29]: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html
+[30]: https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -72,6 +72,8 @@ To configure this check for an Agent running on a host:
         ```json
         roles = [<created role>, "monitoring_user"]
         ```
+        More info: [create or update roles](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html) and [create or update users](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-user.html)
+
 
 2. [Restart the Agent][8].
 


### PR DESCRIPTION
### What does this PR do?
Complete documentation about the permissions in Elasticsearch that the DataDog Agent needs.

### Motivation
Missing documentation about required permissions and/or roles for the Elasticsearch user that is configured for use by the DataDog Agent elastic integration.
https://github.com/DataDog/integrations-core/issues/12466

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
