### PR TITLE
Add atempts to environment startup

### DIFF
--- a/spark/tests/conftest.py
+++ b/spark/tests/conftest.py
@@ -28,6 +28,7 @@ def dd_environment():
             ),
             WaitFor(check_metrics_available, wait=5),
         ],
+        attempts=2,
     ):
         yield INSTANCE_STANDALONE, {'custom_hosts': get_custom_hosts()}
 


### PR DESCRIPTION
On https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=104705&view=logs&j=0cd9da90-064a-56a8-2ada-527efc99b883&t=e9c01749-3339-5e23-efb3-e182b4fdb55b&l=545 docker-compose failed to start 

```
_________________ ERROR at setup of test_integration_driver_2 __________________
tests/conftest.py:18: in dd_environment
    with docker_run(
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/contextlib.py:113: in __enter__
    return next(self.gen)
../datadog_checks_dev/datadog_checks/dev/docker.py:223: in docker_run
    with environment_run(
/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/contextlib.py:113: in __enter__
    return next(self.gen)
../datadog_checks_dev/datadog_checks/dev/env.py:68: in environment_run
    result = up()
../datadog_checks_dev/datadog_checks/dev/docker.py:253: in __call__
    return run_command(self.command, check=True)
../datadog_checks_dev/datadog_checks/dev/subprocess.py:77: in run_command
    raise SubprocessError(
E   datadog_checks.dev.errors.SubprocessError: Command: ['docker', 'compose', '--compatibility', '-f', '/home/vsts/work/1/s/spark/tests/docker/docker-compose.yaml', 'up', '-d', '--build']
E   Exit code: 17
E   Captured Output:
- generated xml file: /home/vsts/work/1/s/spark/.junit/test-unit-py38-2.4.xml --
```