### PR TITLE
[redisdb] Latency measurement not impacted by agent load

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -197,17 +197,16 @@ class Redis(AgentCheck):
         conn = self._get_conn(self.instance)
         # Ping the database for info, and track the latency.
         # Process the service check: the check passes if we can connect to Redis
-        if PY2:
-            start = time.time()
-        else:
-            start = time.process_time()
+        start = (
+            time.time() if PY2 else time.process_time()
+        )  # New in python 3.3: time.process_time (It does not include time elapsed during sleep)
         tags = list(self.tags)
         try:
             info = conn.info()
-            if PY2:
-                latency_ms = round_value((time.time() - start) * 1000, 2)
-            else:
-                latency_ms = round_value((time.process_time() - start) * 1000, 2)
+            cur_time = (
+                time.time() if PY2 else time.process_time()
+            )  # New in python 3.3: time.process_time (It does not include time elapsed during sleep)
+            latency_ms = round_value((cur_time - start) * 1000, 2)
             self._collect_metadata(info)
         except ValueError as e:
             self.service_check('redis.can_connect', AgentCheck.CRITICAL, message=str(e), tags=self.tags)

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -9,7 +9,7 @@ from collections import Counter, defaultdict
 from copy import deepcopy
 
 import redis
-from six import iteritems
+from six import PY2, iteritems
 
 from datadog_checks.base import AgentCheck, ConfigurationError, ensure_unicode, is_affirmative
 from datadog_checks.base.utils.common import round_value
@@ -197,12 +197,17 @@ class Redis(AgentCheck):
         conn = self._get_conn(self.instance)
         # Ping the database for info, and track the latency.
         # Process the service check: the check passes if we can connect to Redis
-        start = time.time()
+        if PY2:
+            start = time.time()
+        else:
+            start = time.process_time()
         tags = list(self.tags)
         try:
             info = conn.info()
-            latency_ms = round_value((time.time() - start) * 1000, 2)
-
+            if PY2:
+                latency_ms = round_value((time.time() - start) * 1000, 2)
+            else:
+                latency_ms = round_value((time.process_time() - start) * 1000, 2)
             self._collect_metadata(info)
         except ValueError as e:
             self.service_check('redis.can_connect', AgentCheck.CRITICAL, message=str(e), tags=self.tags)


### PR DESCRIPTION
### What does this PR do?
Measure real latency in redisdb.
The method used by the Redis integration to calculate latency can be influenced by the load of the agent since it counts the time it takes from the agent not only from the result of redis info command side.

### Motivation
https://datadoghq.atlassian.net/browse/AI-2489

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
