### PR TITLE
Don't modify a user's config on ddev tests

### DIFF
--- a/datadog_checks_dev/tests/tooling/commands/validate/test_models.py
+++ b/datadog_checks_dev/tests/tooling/commands/validate/test_models.py
@@ -17,8 +17,8 @@ from datadog_checks.dev.tooling.utils import get_license_header
 @pytest.mark.parametrize(
     'repo,expect_licenses',
     [
-        ("extras", False),
         ("core", True),
+        ("extras", False),
     ],
 )
 def test_generate_new_files_check_licenses(repo, expect_licenses):

--- a/datadog_checks_dev/tests/tooling/commands/validate/test_models.py
+++ b/datadog_checks_dev/tests/tooling/commands/validate/test_models.py
@@ -17,8 +17,8 @@ from datadog_checks.dev.tooling.utils import get_license_header
 @pytest.mark.parametrize(
     'repo,expect_licenses',
     [
-        ("core", True),
         ("extras", False),
+        ("core", True),
     ],
 )
 def test_generate_new_files_check_licenses(repo, expect_licenses):
@@ -27,10 +27,14 @@ def test_generate_new_files_check_licenses(repo, expect_licenses):
     with runner.isolated_filesystem():
 
         # Generate the check structure
-        shutil.copytree(os.path.dirname(os.path.realpath(__file__)) + "/data/my_check", "./my_check")
-        repo_flag = '--{}'.format(repo)
+        working_repo = 'integrations-{}'.format(repo)
+        shutil.copytree(
+            os.path.dirname(os.path.realpath(__file__)) + "/data/my_check", "./{}/my_check".format(working_repo)
+        )
+        os.chdir(working_repo)
+
         result = run_command(
-            [sys.executable, '-m', 'datadog_checks.dev', repo_flag, '--here', 'validate', 'models', 'my_check', "-s"],
+            [sys.executable, '-m', 'datadog_checks.dev', '--here', 'validate', 'models', 'my_check', "-s"],
             capture=True,
         )
 

--- a/datadog_checks_dev/tests/tooling/commands/validate/test_models.py
+++ b/datadog_checks_dev/tests/tooling/commands/validate/test_models.py
@@ -28,16 +28,9 @@ def test_generate_new_files_check_licenses(repo, expect_licenses):
 
         # Generate the check structure
         shutil.copytree(os.path.dirname(os.path.realpath(__file__)) + "/data/my_check", "./my_check")
-
-        run_command(
-            [sys.executable, '-m', 'datadog_checks.dev', "config", "set", repo, os.getcwd()],
-        )
-        run_command(
-            [sys.executable, '-m', 'datadog_checks.dev', "config", "set", "repo", repo],
-        )
-
+        repo_flag = '--{}'.format(repo)
         result = run_command(
-            [sys.executable, '-m', 'datadog_checks.dev', 'validate', 'models', 'my_check', "-s"],
+            [sys.executable, '-m', 'datadog_checks.dev', repo_flag, '--here', 'validate', 'models', 'my_check', "-s"],
             capture=True,
         )
 


### PR DESCRIPTION
### What does this PR do?
Updates a ddev test to not directly modify a user's `repo` settings
### Motivation
We recently added a test that modifies a user's ddev configuration, and we don't want to have to always update our ddev config after running tests. 
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
