### PR TITLE
Increase memory for confluent platform tests

### DIFF
--- a/.azure-pipelines/scripts/confluent_platform/linux/55_increase_docker_memory.sh
+++ b/.azure-pipelines/scripts/confluent_platform/linux/55_increase_docker_memory.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+
+# Allocate 3GB for confluent platform
+# The default number of memory addresses is 65536, i.e. 512MB (Linux 64-bit).
+# => To get 3GB, we multiply that amount by 6.
+sudo sysctl -w vm.max_map_count=$(expr 6 \* 65536)
+
+set +ex


### PR DESCRIPTION
Increasing memory since env start fails without a trace https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=104853&view=logs&j=83bb99ea-9ab1-5c8c-b843-8f48234d7592&t=41342080-6d4d-5b33-e141-ae960dd7d738