### PR TITLE
Log check warning for missing event statements consumer

### DIFF
--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -633,7 +633,8 @@ class MySQLStatementSamples(DBMAsyncJob):
                     'Cannot collect statement samples as there are no enabled performance_schema.events_statements_* '
                     'consumers. Enable performance_schema and at least one events_statements consumer in order '
                     'to collect statement samples. See https://docs.datadoghq.com/database_monitoring/setup_mysql/'
-                    'troubleshooting/#queries-are-missing-explain-plans for more details.',
+                    'troubleshooting/#%s for more details.',
+                    DatabaseConfigurationError.events_statements_consumer_missing.value,
                     code=DatabaseConfigurationError.events_statements_consumer_missing.value,
                     host=self._check.resolved_hostname,
                 ),

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -627,10 +627,15 @@ class MySQLStatementSamples(DBMAsyncJob):
             enabled_consumers = self._get_enabled_performance_schema_consumers()
 
         if not enabled_consumers:
-            self._log.warning(
-                "Cannot collect statement samples as there are no enabled performance_schema.events_statements_* "
-                "consumers. Enable performance_schema and at least one events_statements consumer in order to collect "
-                "statement samples."
+            self._check.record_warning(
+                DatabaseConfigurationError.events_statements_consumer_missing,
+                warning_with_tags(
+                    'Cannot collect statement samples as there are no enabled performance_schema.events_statements_* '
+                    'consumers. Enable performance_schema and at least one events_statements consumer in order '
+                    'to collect statement samples.',
+                    code=DatabaseConfigurationError.events_statements_consumer_missing.value,
+                    host=self._check.resolved_hostname,
+                ),
             )
             self._check.count(
                 "dd.mysql.query_samples.error",

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -632,7 +632,8 @@ class MySQLStatementSamples(DBMAsyncJob):
                 warning_with_tags(
                     'Cannot collect statement samples as there are no enabled performance_schema.events_statements_* '
                     'consumers. Enable performance_schema and at least one events_statements consumer in order '
-                    'to collect statement samples.',
+                    'to collect statement samples. See https://docs.datadoghq.com/database_monitoring/setup_mysql/'
+                    'troubleshooting/#queries-are-missing-explain-plans for more details.',
                     code=DatabaseConfigurationError.events_statements_consumer_missing.value,
                     host=self._check.resolved_hostname,
                 ),

--- a/mysql/datadog_checks/mysql/util.py
+++ b/mysql/datadog_checks/mysql/util.py
@@ -11,6 +11,7 @@ class DatabaseConfigurationError(Enum):
     explain_plan_procedure_missing = 'explain-plan-procedure-missing'
     explain_plan_fq_procedure_missing = 'explain-plan-fq-procedure-missing'
     performance_schema_not_enabled = 'performance-schema-not-enabled'
+    events_statements_consumer_missing = 'events-statements-consumer-missing'
     events_waits_current_not_enabled = 'events-waits-current-not-enabled'
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Logs a check warning if DBM's statement samples job detects a missing `event_statements_*` consumer.

### Motivation
<!-- What inspired you to submit this pull request? -->
Surface database configuration errors in the UI

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Database configuration errors we're checking for:
https://github.com/DataDog/integrations-core/blob/9f758cd9615d5d05ec069caaee3b0a9d1f9a554c/mysql/datadog_checks/mysql/util.py#L11-L15

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
