### PR TITLE
[mongo] Restore connection_scheme to config

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -47,6 +47,16 @@ files:
         The password to use for authentication.
       value:
         type: string
+    - name: connection_scheme
+      required: false
+      description: |
+        Use `mongodb` to identify that this is a string in the standard connection format. This is the default value.
+        In order to leverage the DNS seed list, use a connection_scheme of `mongodb+srv` rather than the standard
+        `mongodb`.
+        For more information, see: https://www.mongodb.com/docs/manual/reference/connection-string/
+      value:
+        type: string
+        example: mongodb
     - name: database
       description: |
         The database to collect metrics from.

--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -48,7 +48,6 @@ files:
       value:
         type: string
     - name: connection_scheme
-      required: false
       description: |
         Use `mongodb` to identify that this is a string in the standard connection format. This is the default value.
         In order to leverage the DNS seed list, use a connection_scheme of `mongodb+srv` rather than the standard

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -48,7 +48,6 @@ class MongoConfig(object):
                 self.hosts = [self.hosts]
             self.username = instance.get('username')
             self.password = instance.get('password')
-            # Deprecated
             self.scheme = instance.get('connection_scheme', 'mongodb')
             self.db_name = instance.get('database')
             self.additional_options = instance.get('options', {})

--- a/mongo/datadog_checks/mongo/config_models/defaults.py
+++ b/mongo/datadog_checks/mongo/config_models/defaults.py
@@ -26,6 +26,10 @@ def instance_collections_indexes_stats(field, value):
     return False
 
 
+def instance_connection_scheme(field, value):
+    return 'mongodb'
+
+
 def instance_custom_queries(field, value):
     return get_default_field_value(field, value)
 

--- a/mongo/datadog_checks/mongo/config_models/instance.py
+++ b/mongo/datadog_checks/mongo/config_models/instance.py
@@ -54,6 +54,7 @@ class InstanceConfig(BaseModel):
     additional_metrics: Optional[Sequence[str]]
     collections: Optional[Sequence[str]]
     collections_indexes_stats: Optional[bool]
+    connection_scheme: Optional[str]
     custom_queries: Optional[Sequence[CustomQuery]]
     database: Optional[str]
     dbnames: Optional[Sequence[str]]

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -47,6 +47,14 @@ instances:
     #
     # password: <PASSWORD>
 
+    ## @param connection_scheme - string - optional - default: mongodb
+    ## Use `mongodb` to identify that this is a string in the standard connection format. This is the default value.
+    ## In order to leverage the DNS seed list, use a connection_scheme of `mongodb+srv` rather than the standard
+    ## `mongodb`.
+    ## For more information, see: https://www.mongodb.com/docs/manual/reference/connection-string/
+    #
+    # connection_scheme: mongodb
+
     ## @param database - string - optional
     ## The database to collect metrics from.
     ## This is also the authentication database to use if a `username` and `password` is set but the `authSource` is not


### PR DESCRIPTION
### What does this PR do?
Restore connection_scheme to config: spec.yaml, etc...

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
