### PR TITLE
Disable SQL Server 2016 and 2017 test envs

### DIFF
--- a/sqlserver/tox.ini
+++ b/sqlserver/tox.ini
@@ -10,7 +10,9 @@ envlist =
     # sqlserver version
     py{27,38}-windows-{SQLOLEDB,SQLNCLI11,MSOLEDBSQL,odbc}-2019-single
     # older sql server versions tested on only a single python version and driver
-    py38-windows-odbc-{2012,2014,2016,2017}-single
+    # TODO: Investigate versions 2016 & 2017 causing CI to fail. Flaky version as of 7/12/2022.
+    # py38-windows-odbc-{2012,2014,2016,2017}-single
+    py38-windows-odbc-{2012,2014}-single
     # temporarily exclude high cardinality windows env. to be fixed in a follow-up PR
     py38-linux-odbc-2019-high-cardinality
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
SQL Server version 2016 and 2017 are failing in CI resulting in blocked PRs. Temporarily disable these envs until a fix for these versions is found.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
