### PR TITLE
Bump IBM DB dependency

### DIFF
--- a/ibm_db2/requirements-dev.txt
+++ b/ibm_db2/requirements-dev.txt
@@ -1,3 +1,3 @@
 -e ../datadog_checks_dev
 ibm_db==3.0.1; python_version < "3.0" 
-ibm_db==3.1.0; python_version > "3.0" 
+ibm_db==3.1.2; python_version > "3.0"

--- a/ibm_db2/tests/docker/requirements.txt
+++ b/ibm_db2/tests/docker/requirements.txt
@@ -1,2 +1,2 @@
 ibm_db==3.0.1; python_version < "3.0" 
-ibm_db==3.1.0; python_version > "3.0" 
+ibm_db==3.1.2; python_version > "3.0"


### PR DESCRIPTION
In https://github.com/DataDog/integrations-core/pull/12449 we set up an env var to download the clidriver from azure instead of IBM site, but it turns out this variable was not used in the version of the library we are using so the tests for this integration are still being hit by rate limiting and this flaking.
This PR bumps the dependency to the version that introduced the env var.