### PR TITLE
Run extra startup commands with -t

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -196,7 +196,7 @@ def _run_start_commands(metadata, environment, check, env):
         echo_waiting('Running extra start-up commands... ', nl=False)
 
         for command in start_commands:
-            result = environment.exec_command(command, capture=True, interactive=True)
+            result = environment.exec_command(command, capture=True, docker_args=['-t'])
             if result.code:
                 click.echo()
                 echo_info(result.stdout + result.stderr)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -196,7 +196,7 @@ def _run_start_commands(metadata, environment, check, env):
         echo_waiting('Running extra start-up commands... ', nl=False)
 
         for command in start_commands:
-            result = environment.exec_command(command, capture=True)
+            result = environment.exec_command(command, capture=True, interactive=True)
             if result.code:
                 click.echo()
                 echo_info(result.stdout + result.stderr)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -104,6 +104,8 @@ class DockerInterface(object):
 
         if kwargs.pop('interactive', False):
             cmd.append('-it')
+        if kwargs.get('docker_args'):
+            cmd.extend(kwargs.pop('docker_args'))
 
         cmd.append(self.container_name)
 


### PR DESCRIPTION
When starting an e2e environment, if `start_commands` commands fail we don't see the output so it is hard to diagnose what went wrong. This PR makes those run with `-t` (they are `docker exec` commands) so, in case of error, we can print it.

* Note: We are already printing the output but since the commands were not interactive the output was empty.