### PR TITLE
Fix IPv4/IPv6 address resolution

### DIFF
--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -15,7 +15,7 @@ if "inet_pton" in socket.__dict__:
         try:
             socket.inet_pton(socket.AF_INET6, addr)
             return True
-        except socket.error or OSError:
+        except socket.error:
             return False
 
 

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -31,7 +31,6 @@ class TCPCheck(AgentCheck):
         self.ip_cache_last_ts = 0
         self.ip_cache_duration = self.DEFAULT_IP_CACHE_DURATION
         self.multiple_ips = instance.get('multiple_ips', False)
-        # self.addr_tuple = namedtuple('addr_tuple', ['address', 'socket_type'])
 
         ip_cache_duration = instance.get('ip_cache_duration', None)
         if ip_cache_duration is not None:

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -104,8 +104,11 @@ class TCPCheck(AgentCheck):
         self._addrs = [
             sockaddr[0] for (_, _, _, _, sockaddr) in socket.getaddrinfo(self.host, self.port, 0, 0, socket.IPPROTO_TCP)
         ]
-        if not self.multiple_ips and not is_ipv6(self.host):
-            self._addrs = [socket.gethostbyname(self.host)]
+        if not self.multiple_ips:
+            if not is_ipv6(self.host):
+                self._addrs = [socket.gethostbyname(self.host)]
+            else:
+                self._addrs = self._addrs[:1]
 
         if self._addrs == []:
             raise Exception("No IPs attached to host")

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -4,7 +4,7 @@
 import socket
 from collections import namedtuple
 from contextlib import closing
-from typing import Any, List
+from typing import Any, List, Optional
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.errors import CheckException
@@ -162,7 +162,7 @@ class TCPCheck(AgentCheck):
                     self._addrs = None
 
     def report_as_service_check(self, status, addr, msg=None):
-        # type: (AgentCheck.service_check, str, str) -> None
+        # type: (AgentCheck.service_check, str, Optional[str]) -> None
         if status is AgentCheck.OK:
             msg = None
         extra_tags = ['address:{}'.format(addr)]

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -15,7 +15,7 @@ if "inet_pton" in socket.__dict__:
         try:
             socket.inet_pton(socket.AF_INET6, addr)
             return True
-        except socket.error:
+        except socket.error or OSError:
             return False
 
 
@@ -104,8 +104,8 @@ class TCPCheck(AgentCheck):
         self._addrs = [
             sockaddr[0] for (_, _, _, _, sockaddr) in socket.getaddrinfo(self.host, self.port, 0, 0, socket.IPPROTO_TCP)
         ]
-        if not self.multiple_ips:
-            self._addrs = self._addrs[:1]
+        if not self.multiple_ips and not is_ipv6(self.host):
+            self._addrs = [socket.gethostbyname(self.host)]
 
         if self._addrs == []:
             raise Exception("No IPs attached to host")

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -60,9 +60,11 @@ class TCPCheck(AgentCheck):
             'instance:{}'.format(self.instance_name),
         ]
 
+    AddrTuple = namedtuple('AddrTuple', ['address', 'socket_type'])
+
     @property
     def addrs(self):
-        # type: () -> List[namedtuple(str, socket.AddressFamily)]
+        # type: () -> List[self.AddrTuple]
         if self._addrs is None or self._addrs == []:
             try:
                 self.resolve_ips()
@@ -74,10 +76,8 @@ class TCPCheck(AgentCheck):
 
     def resolve_ips(self):
         # type: () -> None
-        addr_tuple = namedtuple('addr_tuple', ['address', 'socket_type'])
-
         self._addrs = [
-            addr_tuple(sockaddr[0], socket_type)
+            self.AddrTuple(sockaddr[0], socket_type)
             for (socket_type, _, _, _, sockaddr) in socket.getaddrinfo(self.host, self.port, 0, 0, socket.IPPROTO_TCP)
         ]
         if not self.multiple_ips:

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -31,7 +31,7 @@ class TCPCheck(AgentCheck):
         self.ip_cache_last_ts = 0
         self.ip_cache_duration = self.DEFAULT_IP_CACHE_DURATION
         self.multiple_ips = instance.get('multiple_ips', False)
-        self.addr_tuple = namedtuple('addr_tuple', ['address', 'socket_type'])
+        # self.addr_tuple = namedtuple('addr_tuple', ['address', 'socket_type'])
 
         ip_cache_duration = instance.get('ip_cache_duration', None)
         if ip_cache_duration is not None:
@@ -76,16 +76,17 @@ class TCPCheck(AgentCheck):
 
     def resolve_ips(self):
         # type: () -> None
+        addr_tuple = namedtuple('addr_tuple', ['address', 'socket_type'])
         if self.socket_type == socket.AF_INET:
             if self._addrs is None:
                 self._addrs = []
             # gethostbyname_ex only translates to IPv4 addresses
             _, _, addrs = socket.gethostbyname_ex(self.host)
             for addr in addrs:
-                self._addrs.append(self.addr_tuple(addr, socket.AF_INET))
+                self._addrs.append(addr_tuple(addr, socket.AF_INET))
         else:
             self._addrs = [
-                self.addr_tuple(sockaddr[0], socket_type)
+                addr_tuple(sockaddr[0], socket_type)
                 for (socket_type, _, _, _, sockaddr) in socket.getaddrinfo(
                     self.host, self.port, 0, 0, socket.IPPROTO_TCP
                 )

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -82,12 +82,21 @@ class TCPCheck(AgentCheck):
         ]
 
         # IPv6 address format: 2001:db8:85a3:8d3:1319:8a2e:370:7348
-        if is_ipv6(self.host):  # It may then be a IP V6 address, we check that
+        if is_ipv6(self.host) or self.has_ipv6_connectivity():  # It may then be a IP V6 address, we check that
             # It's a correct IP V6 address
             self.socket_type = socket.AF_INET6
         else:
             self.socket_type = socket.AF_INET
             # IP will be resolved at check time
+
+    def has_ipv6_connectivity(self):
+        try:
+            for sockaddr in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET6, 0, socket.IPPROTO_TCP):
+                if not sockaddr[0].startswith('fe80:'):
+                    return True
+            return False
+        except socket.gaierror:
+            return False
 
     @property
     def addrs(self):

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -76,20 +76,11 @@ class TCPCheck(AgentCheck):
     def resolve_ips(self):
         # type: () -> None
         addr_tuple = namedtuple('addr_tuple', ['address', 'socket_type'])
-        if self.socket_type == socket.AF_INET:
-            if self._addrs is None:
-                self._addrs = []
-            # gethostbyname_ex only translates to IPv4 addresses
-            _, _, addrs = socket.gethostbyname_ex(self.host)
-            for addr in addrs:
-                self._addrs.append(addr_tuple(addr, socket.AF_INET))
-        else:
-            self._addrs = [
-                addr_tuple(sockaddr[0], socket_type)
-                for (socket_type, _, _, _, sockaddr) in socket.getaddrinfo(
-                    self.host, self.port, 0, 0, socket.IPPROTO_TCP
-                )
-            ]
+
+        self._addrs = [
+            addr_tuple(sockaddr[0], socket_type)
+            for (socket_type, _, _, _, sockaddr) in socket.getaddrinfo(self.host, self.port, 0, 0, socket.IPPROTO_TCP)
+        ]
         if not self.multiple_ips:
             self._addrs = self._addrs[:1]
 

--- a/tcp_check/datadog_checks/tcp_check/tcp_check.py
+++ b/tcp_check/datadog_checks/tcp_check/tcp_check.py
@@ -10,6 +10,8 @@ from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.errors import CheckException
 from datadog_checks.base.utils.time import get_precise_time
 
+AddrTuple = namedtuple('AddrTuple', ['address', 'socket_type'])
+
 
 class TCPCheck(AgentCheck):
 
@@ -60,11 +62,9 @@ class TCPCheck(AgentCheck):
             'instance:{}'.format(self.instance_name),
         ]
 
-    AddrTuple = namedtuple('AddrTuple', ['address', 'socket_type'])
-
     @property
     def addrs(self):
-        # type: () -> List[self.AddrTuple]
+        # type: () -> List[AddrTuple]
         if self._addrs is None or self._addrs == []:
             try:
                 self.resolve_ips()
@@ -77,7 +77,7 @@ class TCPCheck(AgentCheck):
     def resolve_ips(self):
         # type: () -> None
         self._addrs = [
-            self.AddrTuple(sockaddr[0], socket_type)
+            AddrTuple(sockaddr[0], socket_type)
             for (socket_type, _, _, _, sockaddr) in socket.getaddrinfo(self.host, self.port, 0, 0, socket.IPPROTO_TCP)
         ]
         if not self.multiple_ips:

--- a/tcp_check/tests/common.py
+++ b/tcp_check/tests/common.py
@@ -21,7 +21,6 @@ INSTANCE_IPV6 = {
 }
 
 INSTANCE_KO = {'host': '127.0.0.1', 'port': 65530, 'timeout': 1.5, 'name': 'DownService', 'tags': ["foo:bar"]}
-INSTANCE_LOCALHOST = {'host': 'localhost', 'port': 80, 'timeout': 1.5, 'name': 'LocalhostService', 'tags': ["foo:bar"]}
 
 E2E_METADATA = {'docker_platform': 'windows' if using_windows_containers() else 'linux'}
 

--- a/tcp_check/tests/common.py
+++ b/tcp_check/tests/common.py
@@ -21,6 +21,7 @@ INSTANCE_IPV6 = {
 }
 
 INSTANCE_KO = {'host': '127.0.0.1', 'port': 65530, 'timeout': 1.5, 'name': 'DownService', 'tags': ["foo:bar"]}
+INSTANCE_LOCALHOST = {'host': 'localhost', 'port': 80, 'timeout': 1.5, 'name': 'LocalhostService', 'tags': ["foo:bar"]}
 
 E2E_METADATA = {'docker_platform': 'windows' if using_windows_containers() else 'linux'}
 

--- a/tcp_check/tests/common.py
+++ b/tcp_check/tests/common.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import socket
+
 from datadog_checks.dev.docker import using_windows_containers
 from datadog_checks.tcp_check import TCPCheck
 
@@ -24,11 +26,44 @@ INSTANCE_KO = {'host': '127.0.0.1', 'port': 65530, 'timeout': 1.5, 'name': 'Down
 
 E2E_METADATA = {'docker_platform': 'windows' if using_windows_containers() else 'linux'}
 
+DUAL_STACK_GETADDRINFO_LOCALHOST_IPV6 = [
+    (socket.AF_INET6, socket.SOCK_STREAM, 6, '', ('::1', 80, 0, 0)),
+    (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('127.0.0.1', 80)),
+]
+
+DUAL_STACK_GETADDRINFO_LOCALHOST_IPV4 = [
+    (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('127.0.0.1', 80)),
+    (socket.AF_INET6, socket.SOCK_STREAM, 6, '', ('::1', 80, 0, 0)),
+]
+
+SINGLE_STACK_GETADDRINFO_LOCALHOST_IPV4 = [
+    (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('127.0.0.1', 80)),
+    (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('ip2', 80)),
+]
+
+DUAL_STACK_GETADDRINFO_IPV4 = [
+    (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('ip1', 80)),
+    (socket.AF_INET6, socket.SOCK_STREAM, 6, '', ('ip2', 80, 0, 0)),
+    (socket.AF_INET6, socket.SOCK_STREAM, 6, '', ('ip3', 80, 0, 0)),
+]
+
+DUAL_STACK_GETADDRINFO_IPV6 = [
+    (socket.AF_INET6, socket.SOCK_STREAM, 6, '', ('ip1', 80, 0, 0)),
+    (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('ip2', 80)),
+    (socket.AF_INET6, socket.SOCK_STREAM, 6, '', ('ip3', 80, 0, 0)),
+]
+
+SINGLE_STACK_GETADDRINFO_IPV4 = [
+    (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('ip1', 80)),
+    (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('ip2', 80)),
+    (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('ip3', 80)),
+]
+
 
 def _test_check(aggregator, addrs):
     common_tags = ['foo:bar', 'target_host:datadoghq.com', 'port:80', 'instance:UpService']
     for addr in addrs:
-        tags = common_tags + ['address:{}'.format(addr)]
+        tags = common_tags + ['address:{}'.format(addr[0])]
         aggregator.assert_metric('network.tcp.can_connect', value=1, tags=tags)
         aggregator.assert_service_check('tcp.can_connect', status=TCPCheck.OK, tags=tags)
     aggregator.assert_all_metrics_covered()

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -130,7 +130,7 @@ def test_response_time(aggregator):
                 (socket.AF_INET6, socket.SOCK_STREAM, 6, '', ('ip3', 80, 0, 0)),
             ],
             'ip1',
-            id='string hostname ipv4 address 1st in list',
+            id='string hostname: ipv4 address 1st in list',
         ),
         pytest.param(
             'another-hostname',

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -10,7 +10,8 @@ from copy import deepcopy
 import mock
 import pytest
 
-from datadog_checks.tcp_check import TCPCheck
+# from datadog_checks.tcp_check import TCPCheck
+from datadog_checks.tcp_check.tcp_check import AddrTuple, TCPCheck
 
 from . import common
 
@@ -116,7 +117,7 @@ def test_response_time(aggregator):
         pytest.param(
             'localhost',
             common.DUAL_STACK_GETADDRINFO_LOCALHOST_IPV6,
-            [TCPCheck.AddrTuple('::1', socket.AF_INET6)],
+            [AddrTuple('::1', socket.AF_INET6)],
             False,
             1,
             id='Dual IPv4/IPv6: localhost, IPv6 resolution, multiple_ips False',
@@ -124,7 +125,7 @@ def test_response_time(aggregator):
         pytest.param(
             'localhost',
             common.DUAL_STACK_GETADDRINFO_LOCALHOST_IPV4,
-            [TCPCheck.AddrTuple('127.0.0.1', socket.AF_INET)],
+            [AddrTuple('127.0.0.1', socket.AF_INET)],
             False,
             1,
             id='Dual IPv4/IPv6: localhost, IPv4 resolution, multiple_ips False',
@@ -132,7 +133,7 @@ def test_response_time(aggregator):
         pytest.param(
             'localhost',
             common.DUAL_STACK_GETADDRINFO_LOCALHOST_IPV6,
-            [TCPCheck.AddrTuple('::1', socket.AF_INET6), TCPCheck.AddrTuple('127.0.0.1', socket.AF_INET)],
+            [AddrTuple('::1', socket.AF_INET6), AddrTuple('127.0.0.1', socket.AF_INET)],
             True,
             2,
             id='Dual IPv4/IPv6: localhost, IPv6 resolution, multiple_ips True',
@@ -140,7 +141,7 @@ def test_response_time(aggregator):
         pytest.param(
             'localhost',
             common.DUAL_STACK_GETADDRINFO_LOCALHOST_IPV4,
-            [TCPCheck.AddrTuple('127.0.0.1', socket.AF_INET), TCPCheck.AddrTuple('::1', socket.AF_INET6)],
+            [AddrTuple('127.0.0.1', socket.AF_INET), AddrTuple('::1', socket.AF_INET6)],
             True,
             2,
             id='Dual IPv4/IPv6: localhost, IPv4 resolution, multiple_ips True',
@@ -148,7 +149,7 @@ def test_response_time(aggregator):
         pytest.param(
             'some-hostname',
             common.DUAL_STACK_GETADDRINFO_IPV4,
-            [TCPCheck.AddrTuple('ip1', socket.AF_INET)],
+            [AddrTuple('ip1', socket.AF_INET)],
             False,
             1,
             id='Dual IPv4/IPv6: string hostname, IPv4 resolution, multiple_ips False',
@@ -156,7 +157,7 @@ def test_response_time(aggregator):
         pytest.param(
             'another-hostname',
             common.DUAL_STACK_GETADDRINFO_IPV6,
-            [TCPCheck.AddrTuple('ip1', socket.AF_INET6)],
+            [AddrTuple('ip1', socket.AF_INET6)],
             False,
             1,
             id='Dual IPv4/IPv6: string hostname, IPv6 resolution, multiple_ips False',
@@ -165,9 +166,9 @@ def test_response_time(aggregator):
             'some-hostname',
             common.DUAL_STACK_GETADDRINFO_IPV4,
             [
-                TCPCheck.AddrTuple('ip1', socket.AF_INET),
-                TCPCheck.AddrTuple('ip2', socket.AF_INET6),
-                TCPCheck.AddrTuple('ip3', socket.AF_INET6),
+                AddrTuple('ip1', socket.AF_INET),
+                AddrTuple('ip2', socket.AF_INET6),
+                AddrTuple('ip3', socket.AF_INET6),
             ],
             True,
             3,
@@ -177,9 +178,9 @@ def test_response_time(aggregator):
             'another-hostname',
             common.DUAL_STACK_GETADDRINFO_IPV6,
             [
-                TCPCheck.AddrTuple('ip1', socket.AF_INET6),
-                TCPCheck.AddrTuple('ip2', socket.AF_INET),
-                TCPCheck.AddrTuple('ip3', socket.AF_INET6),
+                AddrTuple('ip1', socket.AF_INET6),
+                AddrTuple('ip2', socket.AF_INET),
+                AddrTuple('ip3', socket.AF_INET6),
             ],
             True,
             3,
@@ -188,7 +189,7 @@ def test_response_time(aggregator):
         pytest.param(
             'localhost',
             common.SINGLE_STACK_GETADDRINFO_LOCALHOST_IPV4,
-            [TCPCheck.AddrTuple('127.0.0.1', socket.AF_INET)],
+            [AddrTuple('127.0.0.1', socket.AF_INET)],
             False,
             1,
             id='Single stack IPv4: localhost, IPv4 resolution, multiple_ips False',
@@ -196,7 +197,7 @@ def test_response_time(aggregator):
         pytest.param(
             'localhost',
             common.SINGLE_STACK_GETADDRINFO_LOCALHOST_IPV4,
-            [TCPCheck.AddrTuple('127.0.0.1', socket.AF_INET), TCPCheck.AddrTuple('ip2', socket.AF_INET)],
+            [AddrTuple('127.0.0.1', socket.AF_INET), AddrTuple('ip2', socket.AF_INET)],
             True,
             2,
             id='Single stack IPv4: localhost, IPv4 resolution, multiple_ips True',
@@ -204,7 +205,7 @@ def test_response_time(aggregator):
         pytest.param(
             'another-hostname',
             common.SINGLE_STACK_GETADDRINFO_IPV4,
-            [TCPCheck.AddrTuple('ip1', socket.AF_INET)],
+            [AddrTuple('ip1', socket.AF_INET)],
             False,
             1,
             id='Single stack IPv4: string hostname, IPv4 resolution, multiple_ips False',
@@ -213,9 +214,9 @@ def test_response_time(aggregator):
             'another-hostname',
             common.SINGLE_STACK_GETADDRINFO_IPV4,
             [
-                TCPCheck.AddrTuple('ip1', socket.AF_INET),
-                TCPCheck.AddrTuple('ip2', socket.AF_INET),
-                TCPCheck.AddrTuple('ip3', socket.AF_INET),
+                AddrTuple('ip1', socket.AF_INET),
+                AddrTuple('ip2', socket.AF_INET),
+                AddrTuple('ip3', socket.AF_INET),
             ],
             True,
             3,

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -10,7 +10,6 @@ from copy import deepcopy
 import mock
 import pytest
 
-# from datadog_checks.tcp_check import TCPCheck
 from datadog_checks.tcp_check.tcp_check import AddrTuple, TCPCheck
 
 from . import common

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -248,10 +248,7 @@ def test_hostname_resolution(aggregator, monkeypatch, hostname, getaddrinfo, exp
     assert check._addrs == expected_addrs
     assert check.connect.call_count == ip_count
 
-    calls = []
-    for addr_tuple in expected_addrs:
-        address, socket_type = addr_tuple
-        calls.append(mock.call(address, socket_type))
+    calls = [mock.call(address, socket_type) for address, socket_type in expected_addrs]
     check.connect.assert_has_calls(calls, any_order=True)
 
     aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags, count=1)

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -114,12 +114,12 @@ def test_response_time(aggregator):
 
 
 @pytest.mark.parametrize(
-    'hostname, getaddrinfo, expected_addrs, multiple_ips, service_checks_count',
+    'hostname, getaddrinfo, expected_addrs, multiple_ips, ip_count',
     [
         pytest.param(
             'localhost',
             common.DUAL_STACK_GETADDRINFO_LOCALHOST_IPV6,
-            [addr_tuple('::1', socket.AF_INET6)],
+            [TCPCheck.AddrTuple('::1', socket.AF_INET6)],
             False,
             1,
             id='Dual IPv4/IPv6: localhost, IPv6 resolution, multiple_ips False',
@@ -127,7 +127,7 @@ def test_response_time(aggregator):
         pytest.param(
             'localhost',
             common.DUAL_STACK_GETADDRINFO_LOCALHOST_IPV4,
-            [addr_tuple('127.0.0.1', socket.AF_INET)],
+            [TCPCheck.AddrTuple('127.0.0.1', socket.AF_INET)],
             False,
             1,
             id='Dual IPv4/IPv6: localhost, IPv4 resolution, multiple_ips False',
@@ -135,7 +135,7 @@ def test_response_time(aggregator):
         pytest.param(
             'localhost',
             common.DUAL_STACK_GETADDRINFO_LOCALHOST_IPV6,
-            [addr_tuple('::1', socket.AF_INET6), addr_tuple('127.0.0.1', socket.AF_INET)],
+            [TCPCheck.AddrTuple('::1', socket.AF_INET6), TCPCheck.AddrTuple('127.0.0.1', socket.AF_INET)],
             True,
             2,
             id='Dual IPv4/IPv6: localhost, IPv6 resolution, multiple_ips True',
@@ -143,7 +143,7 @@ def test_response_time(aggregator):
         pytest.param(
             'localhost',
             common.DUAL_STACK_GETADDRINFO_LOCALHOST_IPV4,
-            [addr_tuple('127.0.0.1', socket.AF_INET), addr_tuple('::1', socket.AF_INET6)],
+            [TCPCheck.AddrTuple('127.0.0.1', socket.AF_INET), TCPCheck.AddrTuple('::1', socket.AF_INET6)],
             True,
             2,
             id='Dual IPv4/IPv6: localhost, IPv4 resolution, multiple_ips True',
@@ -151,7 +151,7 @@ def test_response_time(aggregator):
         pytest.param(
             'some-hostname',
             common.DUAL_STACK_GETADDRINFO_IPV4,
-            [addr_tuple('ip1', socket.AF_INET)],
+            [TCPCheck.AddrTuple('ip1', socket.AF_INET)],
             False,
             1,
             id='Dual IPv4/IPv6: string hostname, IPv4 resolution, multiple_ips False',
@@ -159,7 +159,7 @@ def test_response_time(aggregator):
         pytest.param(
             'another-hostname',
             common.DUAL_STACK_GETADDRINFO_IPV6,
-            [addr_tuple('ip1', socket.AF_INET6)],
+            [TCPCheck.AddrTuple('ip1', socket.AF_INET6)],
             False,
             1,
             id='Dual IPv4/IPv6: string hostname, IPv6 resolution, multiple_ips False',
@@ -167,7 +167,11 @@ def test_response_time(aggregator):
         pytest.param(
             'some-hostname',
             common.DUAL_STACK_GETADDRINFO_IPV4,
-            [addr_tuple('ip1', socket.AF_INET), addr_tuple('ip2', socket.AF_INET6), addr_tuple('ip3', socket.AF_INET6)],
+            [
+                TCPCheck.AddrTuple('ip1', socket.AF_INET),
+                TCPCheck.AddrTuple('ip2', socket.AF_INET6),
+                TCPCheck.AddrTuple('ip3', socket.AF_INET6),
+            ],
             True,
             3,
             id='Dual IPv4/IPv6: string hostname, IPv4 resolution, multiple_ips True',
@@ -175,7 +179,11 @@ def test_response_time(aggregator):
         pytest.param(
             'another-hostname',
             common.DUAL_STACK_GETADDRINFO_IPV6,
-            [addr_tuple('ip1', socket.AF_INET6), addr_tuple('ip2', socket.AF_INET), addr_tuple('ip3', socket.AF_INET6)],
+            [
+                TCPCheck.AddrTuple('ip1', socket.AF_INET6),
+                TCPCheck.AddrTuple('ip2', socket.AF_INET),
+                TCPCheck.AddrTuple('ip3', socket.AF_INET6),
+            ],
             True,
             3,
             id='Dual IPv4/IPv6: string hostname, IPv6 resolution, multiple_ips True',
@@ -183,7 +191,7 @@ def test_response_time(aggregator):
         pytest.param(
             'localhost',
             common.SINGLE_STACK_GETADDRINFO_LOCALHOST_IPV4,
-            [addr_tuple('127.0.0.1', socket.AF_INET)],
+            [TCPCheck.AddrTuple('127.0.0.1', socket.AF_INET)],
             False,
             1,
             id='Single stack IPv4: localhost, IPv4 resolution, multiple_ips False',
@@ -191,7 +199,7 @@ def test_response_time(aggregator):
         pytest.param(
             'localhost',
             common.SINGLE_STACK_GETADDRINFO_LOCALHOST_IPV4,
-            [addr_tuple('127.0.0.1', socket.AF_INET), addr_tuple('ip2', socket.AF_INET)],
+            [TCPCheck.AddrTuple('127.0.0.1', socket.AF_INET), TCPCheck.AddrTuple('ip2', socket.AF_INET)],
             True,
             2,
             id='Single stack IPv4: localhost, IPv4 resolution, multiple_ips True',
@@ -199,7 +207,7 @@ def test_response_time(aggregator):
         pytest.param(
             'another-hostname',
             common.SINGLE_STACK_GETADDRINFO_IPV4,
-            [addr_tuple('ip1', socket.AF_INET)],
+            [TCPCheck.AddrTuple('ip1', socket.AF_INET)],
             False,
             1,
             id='Single stack IPv4: string hostname, IPv4 resolution, multiple_ips False',
@@ -207,16 +215,18 @@ def test_response_time(aggregator):
         pytest.param(
             'another-hostname',
             common.SINGLE_STACK_GETADDRINFO_IPV4,
-            [addr_tuple('ip1', socket.AF_INET), addr_tuple('ip2', socket.AF_INET), addr_tuple('ip3', socket.AF_INET)],
+            [
+                TCPCheck.AddrTuple('ip1', socket.AF_INET),
+                TCPCheck.AddrTuple('ip2', socket.AF_INET),
+                TCPCheck.AddrTuple('ip3', socket.AF_INET),
+            ],
             True,
             3,
             id='Single stack IPv4: string hostname, IPv4 resolution, multiple_ips True',
         ),
     ],
 )
-def test_hostname_resolution(
-    aggregator, monkeypatch, hostname, getaddrinfo, expected_addrs, multiple_ips, service_checks_count
-):
+def test_hostname_resolution(aggregator, monkeypatch, hostname, getaddrinfo, expected_addrs, multiple_ips, ip_count):
     """
     Test that string hostnames get resolved to ipv4 address format properly.
     """
@@ -239,10 +249,18 @@ def test_hostname_resolution(
     check.check(instance)
 
     assert check._addrs == expected_addrs
+
+    calls = []
+    for addr_tuple in expected_addrs:
+        address, socket_type = addr_tuple
+        calls.append(mock.call(address, socket_type))
+    check.connect.assert_has_calls(calls, any_order=True)
+    assert check.connect.call_count == ip_count
+
     aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags, count=1)
     aggregator.assert_service_check('tcp.can_connect', status=check.OK, tags=expected_tags, count=1)
     aggregator.assert_all_metrics_covered()
-    assert len(aggregator.service_checks('tcp.can_connect')) == service_checks_count
+    assert len(aggregator.service_checks('tcp.can_connect')) == ip_count
 
 
 def test_multiple(aggregator):

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -217,7 +217,9 @@ def test_multiple(aggregator):
 
 def has_ipv6_connectivity():
     try:
-        for sockaddr in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET6, 0, socket.IPPROTO_TCP):
+        for _, _, _, _, sockaddr in socket.getaddrinfo(
+            socket.gethostname(), None, socket.AF_INET6, 0, socket.IPPROTO_TCP
+        ):
             if not sockaddr[0].startswith('fe80:'):
                 return True
         return False

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -148,7 +148,7 @@ def test_hostname_resolution(aggregator, hostname, getaddrinfo, expected_addrs):
     """
     Test that string hostnames get resolved to ipv4 address format properly.
     """
-    instance = deepcopy(common.INSTANCE_LOCALHOST)
+    instance = deepcopy(common.INSTANCE)
     instance['host'] = hostname
     instance['multiple_ips'] = False
     check = TCPCheck(common.CHECK_NAME, {}, [instance])
@@ -158,7 +158,7 @@ def test_hostname_resolution(aggregator, hostname, getaddrinfo, expected_addrs):
     ), mock.patch.object(check, 'connect', wraps=check.connect) as connect:
         connect.side_effect = [None, Exception(), None]
         expected_tags = [
-            "instance:LocalhostService",
+            "instance:UpService",
             "target_host:{}".format(hostname),
             "port:80",
             "foo:bar",

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -5,7 +5,6 @@
 import platform
 import re
 import socket
-from collections import namedtuple
 from copy import deepcopy
 
 import mock
@@ -14,8 +13,6 @@ import pytest
 from datadog_checks.tcp_check import TCPCheck
 
 from . import common
-
-addr_tuple = namedtuple('addr_tuple', ['address', 'socket_type'])
 
 
 def test_down(aggregator):
@@ -249,13 +246,13 @@ def test_hostname_resolution(aggregator, monkeypatch, hostname, getaddrinfo, exp
     check.check(instance)
 
     assert check._addrs == expected_addrs
+    assert check.connect.call_count == ip_count
 
     calls = []
     for addr_tuple in expected_addrs:
         address, socket_type = addr_tuple
         calls.append(mock.call(address, socket_type))
     check.connect.assert_has_calls(calls, any_order=True)
-    assert check.connect.call_count == ip_count
 
     aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags, count=1)
     aggregator.assert_service_check('tcp.can_connect', status=check.OK, tags=expected_tags, count=1)

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -217,9 +217,7 @@ def test_multiple(aggregator):
 
 def has_ipv6_connectivity():
     try:
-        for _, _, _, _, sockaddr in socket.getaddrinfo(
-            socket.gethostname(), None, socket.AF_INET6, 0, socket.IPPROTO_TCP
-        ):
+        for sockaddr in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET6, 0, socket.IPPROTO_TCP):
             if not sockaddr[0].startswith('fe80:'):
                 return True
         return False


### PR DESCRIPTION
### What does this PR do?
* Refactors and fixes the logic for determining the socket address family (IPv4 vs IPv6) for an instance host's corresponding IP address(es). 
* Fixes IP resolution for hostnames that resolve to both IPv4 and IPv6 addresses

### Motivation
Support case.

This [PR](https://github.com/DataDog/integrations-core/pull/11740) added IPv6 support, however it did not consistently [resolve hostnames to the correct IP address format](https://github.com/DataDog/integrations-core/pull/11740/files#diff-e1afdae3cf81bdf12d2888a230f697bfd8eda2d5ab2e8d7267e30183986a636bR108) with respect to `self.socket_type`. In one reported case, `localhost` sometimes resolved to the IPv4 format `127.0.0.1` and other times to the IPv6 format `::1`, while `self.socket_type` was always `socket.AF_INET` (IPv4). 

In addition, `self.socket_type` was defined in the [check initialization](https://github.com/DataDog/integrations-core/blob/f3f2b8eef562a8d29b1e77184f2f1af478f7cb29/tcp_check/datadog_checks/tcp_check/tcp_check.py#L84-L90) and did not get updated when resolving IP addresses to either IPv4/IPv6. Together, these two issues resulted in the `socket.connect()` method being called with mismatching IP address and socket type, causing this error to be thrown: `[Errno -9] Address family for hostname not supported.`



### Additional Notes
Also adds type hints since the data structure for `self.addrs` has now changed from `List[str]` to `List[namedtuple(str, socket.AddressFamily)]`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
