### PR TITLE
Include the conditions in the retry for the `docker_run` function

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -215,6 +215,7 @@ def docker_run(
         down=tear_down,
         on_error=on_error,
         sleep=sleep,
+        endpoints=endpoints,
         conditions=docker_conditions,
         env_vars=env_vars,
         wrappers=wrappers,

--- a/datadog_checks_dev/datadog_checks/dev/env.py
+++ b/datadog_checks_dev/datadog_checks/dev/env.py
@@ -4,6 +4,8 @@
 import time
 from contextlib import contextmanager
 
+from tenacity import retry, stop_after_attempt, wait_fixed
+
 from ._env import (
     deserialize_data,
     get_env_vars,
@@ -24,7 +26,18 @@ except ImportError:
 
 
 @contextmanager
-def environment_run(up, down, on_error=None, sleep=None, endpoints=None, conditions=None, env_vars=None, wrappers=None):
+def environment_run(
+    up,
+    down,
+    on_error=None,
+    sleep=None,
+    endpoints=None,
+    conditions=None,
+    env_vars=None,
+    wrappers=None,
+    attempts=None,
+    attempts_wait=1,
+):
     """This utility provides a convenient way to safely set up and tear down arbitrary types of environments.
 
     :param up: A custom setup callable.
@@ -43,6 +56,10 @@ def environment_run(up, down, on_error=None, sleep=None, endpoints=None, conditi
     :param env_vars: A dictionary to update ``os.environ`` with during execution.
     :type env_vars: ``dict``
     :param wrappers: A list of context managers to use during execution.
+    :param attempts: Number of attempts to run `up` and the `conditions` successfully
+    :type attempts: ``int``
+    :param attempts_wait: Time to wait between attempts
+    :type attempts_wait: ``int``
     """
     if not callable(up):
         raise TypeError('The custom setup `{}` is not callable.'.format(repr(up)))
@@ -57,6 +74,24 @@ def environment_run(up, down, on_error=None, sleep=None, endpoints=None, conditi
     if env_vars is not None:
         wrappers.insert(0, EnvVars(env_vars))
 
+    def set_up():
+        set_up_result = up()
+
+        for condition in conditions:
+            condition()
+
+        return set_up_result
+
+    set_up_func = set_up
+
+    if attempts is not None:
+
+        @retry(wait=wait_fixed(attempts_wait), stop=stop_after_attempt(attempts))
+        def set_up_with_retry():
+            return set_up()
+
+        set_up_func = set_up_with_retry
+
     with ExitStack() as stack:
         for wrapper in wrappers:
             stack.enter_context(wrapper)
@@ -65,12 +100,9 @@ def environment_run(up, down, on_error=None, sleep=None, endpoints=None, conditi
             # Create an environment variable to store setup result
             key = 'environment_result_{}'.format(up.__class__.__name__.lower())
             if set_up_env():
-                result = up()
+                result = set_up_func()
                 # Store the serialized data in the environment
                 set_env_vars({key: serialize_data(result)})
-
-                for condition in conditions:
-                    condition()
 
                 if sleep:
                     time.sleep(sleep)

--- a/datadog_checks_dev/tests/test__env.py
+++ b/datadog_checks_dev/tests/test__env.py
@@ -1,7 +1,11 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from datadog_checks.dev import EnvVars
+import pytest
+import tenacity
+from mock import mock
+
+from datadog_checks.dev import EnvVars, RetryError, environment_run
 from datadog_checks.dev._env import E2E_SET_UP, E2E_TEAR_DOWN, set_up_env, tear_down_env
 
 
@@ -23,3 +27,37 @@ def test_tear_down_env_default_true():
 def test_tear_down_env_false():
     with EnvVars({E2E_TEAR_DOWN: 'false'}):
         assert tear_down_env() is False
+
+
+@pytest.mark.parametrize(
+    "attempts,expected_call_count",
+    [
+        (None, 1),
+        (0, 1),
+        (1, 1),
+        (3, 3),
+    ],
+)
+def test_environment_run_on_failed_conditions(attempts, expected_call_count):
+    up = mock.MagicMock()
+    down = mock.MagicMock()
+    condition = mock.MagicMock()
+    condition.side_effect = RetryError("error")
+
+    with pytest.raises(RetryError if attempts is None else tenacity.RetryError):
+        with environment_run(up=up, down=down, attempts=attempts, conditions=[condition]):
+            pass
+
+    assert condition.call_count == expected_call_count
+
+
+def test_environment_run_condition_failed_only_on_first_run():
+    up = mock.MagicMock()
+    up.return_value = "{}"
+    down = mock.MagicMock()
+    condition = mock.MagicMock()
+    condition.side_effect = [RetryError("error"), None, None]
+
+    with environment_run(up=up, down=down, attempts=3, conditions=[condition]) as result:
+        assert condition.call_count == 2
+        assert result == "{}"


### PR DESCRIPTION
### What does this PR do?

The `docker_run` helper has a `attempts` option to retry in case of failure. The retry does include the conditions. This PR include the conditions in the retries.

### Motivation
AI-2550

### Additional Notes

At first I wanted to add the `retry` decorator to the `environment_run` or directly the `docker_run` functions, but it's not working with generators, so I decided to include the conditions in the retry using the set up function. 

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
