### PR TITLE
Support custom messages in `QueryManager` queries of type `'service_check'`

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/transform.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/transform.py
@@ -240,15 +240,26 @@ def get_service_check(transformers, column_name, **modifiers):
     - `UNKNOWN`
 
     Any encountered values that are not defined will be sent as `UNKNOWN`.
+
+    In addition, a `message` modifier can be passed which can contain placeholders
+    (based on Python's str.format) for other column names from the same query to add a message
+    dynamically to the service_check.
     """
     # Do work in a separate function to avoid having to `del` a bunch of variables
     status_map = _compile_service_check_statuses(modifiers)
+    message_field = modifiers.pop('message', None)
 
     service_check_method = transformers['__service_check'](transformers, column_name, **modifiers)  # type: Callable
 
-    def service_check(_, value, **kwargs):
+    def service_check(sources, value, **kwargs):
         # type: (List, str, Dict[str, Any]) -> None
-        service_check_method(_, status_map.get(value, ServiceCheck.UNKNOWN), **kwargs)
+        check_status = status_map.get(value, ServiceCheck.UNKNOWN)
+        if not message_field or check_status == ServiceCheck.OK:
+            message = None
+        else:
+            message = message_field.format(**sources)
+
+        service_check_method(sources, check_status, message=message, **kwargs)
 
     return service_check
 

--- a/datadog_checks_base/tests/base/utils/db/test_transformers.py
+++ b/datadog_checks_base/tests/base/utils/db/test_transformers.py
@@ -295,6 +295,31 @@ class TestColumnTransformers:
         aggregator.assert_service_check('test.foo', 3, message='baz', tags=['test:foo', 'test:bar'])
         aggregator.assert_all_metrics_covered()
 
+    def test_service_check_unknown_with_message_from_source(self, aggregator):
+        query_manager = create_query_manager(
+            {
+                'name': 'test query',
+                'query': 'foo',
+                'columns': [
+                    {'name': 'message_source', 'type': 'source'},
+                    {
+                        'name': 'test.foo',
+                        'type': 'service_check',
+                        'status_map': {'known': 'ok'},
+                        'message': 'failed due to {message_source}',
+                    },
+                ],
+                'tags': ['test:bar'],
+            },
+            executor=mock_executor([['crash', 'unknown']]),
+            tags=['test:foo'],
+        )
+        query_manager.compile_queries()
+        query_manager.execute()
+
+        aggregator.assert_service_check('test.foo', 3, message='failed due to crash', tags=['test:foo', 'test:bar'])
+        aggregator.assert_all_metrics_covered()
+
     def test_time_elapsed_native(self, aggregator):
         query_manager = create_query_manager(
             {


### PR DESCRIPTION
### What does this PR do?

Adds a way to dynamically set the message field on queries of `service_check` type, based on columns from the same query, via `str.format`-based placeholders. It disables the message (sets it to `None`) when the reported check status is `OK`.

### Motivation

I'm working on refactoring the Vertica integration to make use of the QueryManager and I need to be able to set the message to avoid a change in behavior.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
