### PR TITLE
Move metric from always present to optional, increase attempts

### DIFF
--- a/confluent_platform/tests/conftest.py
+++ b/confluent_platform/tests/conftest.py
@@ -62,6 +62,6 @@ def dd_environment():
             WaitFor(create_connectors),
             CheckDockerLogs('connect', 'flushing 0 outstanding messages for offset commit'),
         ],
-        attempts=2,
+        attempts=3,
     ):
         yield CHECK_CONFIG, {'use_jmx': True}

--- a/confluent_platform/tests/metrics.py
+++ b/confluent_platform/tests/metrics.py
@@ -7,7 +7,6 @@ BROKER_METRICS = [
     'confluent.kafka.cluster.partition.under_min_isr',
     'confluent.kafka.controller.active_controller_count',
     'confluent.kafka.controller.leader_election_rate_and_time_ms.avg',
-    'confluent.kafka.controller.leader_election_rate_and_time_ms.rate',
     'confluent.kafka.controller.offline_partitions_count',
     'confluent.kafka.controller.unclean_leader_elections_per_sec.rate',
     'confluent.kafka.controller.preferred_replica_imbalance_count',
@@ -320,6 +319,7 @@ SCHEMA_REGISTRY_JERSEY_METRICS_DEPRECATED = [
 ]
 
 BROKER_OPTIONAL_METRICS = [
+    'confluent.kafka.controller.leader_election_rate_and_time_ms.rate',
     'confluent.kafka.log.log_flush_rate_and_time_ms.avg',
     'confluent.kafka.log.size',
     'confluent.kafka.server.broker_topic_metrics.bytes_in_per_sec',


### PR DESCRIPTION
This metric was missing on this build https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=105167&view=logs&j=83bb99ea-9ab1-5c8c-b843-8f48234d7592&t=41342080-6d4d-5b33-e141-ae960dd7d738&l=84 so I'm moving it to optional

On this build the environment failed two start even with a second attempt so adding another one https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=105159&view=logs&j=83bb99ea-9ab1-5c8c-b843-8f48234d7592&t=41342080-6d4d-5b33-e141-ae960dd7d738&l=76

```
self = <Retrying object at 0x7feb36e6f940 (stop=<tenacity.stop.stop_after_attempt object at 0x7feb36e6f880>, wait=<tenacity.w...0x7feb39e25190>, before=<function before_nothing at 0x7feb39e20310>, after=<function after_nothing at 0x7feb39e20550>)>
fn = <function environment_run.<locals>.set_up_with_retry at 0x7feb36e7a550>
args = (), kwargs = {}
retry_state = <RetryCallState 140648215149008: attempt #2; slept for 1.0; last result: failed (RetryError Command: ['docker', 'logs'...constraint configuration problems the provider io.confluent.metadataapi.resources.MetadataResource will be ignored. 
)>
do = <tenacity.DoAttempt object at 0x7feb36e6fac0>
```