### PR TITLE
Add attempts

### DIFF
--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -27,7 +27,7 @@ def dd_environment():
         build=True,
         endpoints="{}/stats".format(URL),
         log_patterns=['front-envoy(.*?)all dependencies initialized. starting workers'],
-        attempts=2
+        attempts=2,
     ):
         # Exercising envoy a bit will trigger extra metrics
         requests.get('http://{}:8000/service/1'.format(HOST))

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -27,6 +27,7 @@ def dd_environment():
         build=True,
         endpoints="{}/stats".format(URL),
         log_patterns=['front-envoy(.*?)all dependencies initialized. starting workers'],
+        attempts=2
     ):
         # Exercising envoy a bit will trigger extra metrics
         requests.get('http://{}:8000/service/1'.format(HOST))


### PR DESCRIPTION
On https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=105245&view=logs&j=5e7fd8a3-b132-5246-3e9c-553f252343b6&t=36a24245-babb-5541-8262-5d1e0ec640e2&l=512 environment failed with:

```
Step 1/9 : FROM envoyproxy/envoy-alpine:v1.18.3
Attaching to 
---------------------------- Captured stderr setup -----------------------------
Creating network "api_v3_envoymesh" with the default driver
Pulling front-envoy (envoyproxy/envoy:v1.18.3)...
Building xds
Building service1
Head "[https://registry-1.docker.io/v2/envoyproxy/envoy-alpine/manifests/v1.18.3"](https://registry-1.docker.io/v2/envoyproxy/envoy-alpine/manifests/v1.18.3%22): Get "[https://auth.docker.io/token?account=githubactions&scope=repository%3Aenvoyproxy%2Fenvoy-alpine%3Apull&service=registry.docker.io"](https://auth.docker.io/token?account=githubactions&scope=repository%3Aenvoyproxy%2Fenvoy-alpine%3Apull&service=registry.docker.io%22): net/http: request canceled (Client.Timeout exceeded while awaiting headers)
Service 'service1' failed to build : Build failed
Removing network api_v3_envoymesh
```