### PR TITLE
gitlab runner better conditions

### DIFF
--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -27,7 +27,6 @@ def dd_environment():
         build=True,
         endpoints="{}/stats".format(URL),
         log_patterns=['front-envoy(.*?)all dependencies initialized. starting workers'],
-        attempts=2
     ):
         # Exercising envoy a bit will trigger extra metrics
         requests.get('http://{}:8000/service/1'.format(HOST))

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -27,6 +27,7 @@ def dd_environment():
         build=True,
         endpoints="{}/stats".format(URL),
         log_patterns=['front-envoy(.*?)all dependencies initialized. starting workers'],
+        attempts=2
     ):
         # Exercising envoy a bit will trigger extra metrics
         requests.get('http://{}:8000/service/1'.format(HOST))

--- a/gitlab_runner/tests/conftest.py
+++ b/gitlab_runner/tests/conftest.py
@@ -13,6 +13,7 @@ from .common import (
     CONFIG,
     GITLAB_LOCAL_MASTER_PORT,
     GITLAB_LOCAL_RUNNER_PORT,
+    GITLAB_MASTER_URL,
     GITLAB_RUNNER_URL,
     GITLAB_TEST_TOKEN,
     HERE,
@@ -39,10 +40,12 @@ def dd_environment():
         compose_file=compose_file,
         env_vars=env,
         conditions=[
-            CheckDockerLogs(
-                compose_file, ['Gitlab is up!', 'Configuration loaded', 'Metrics server listening'], wait=5
-            ),
+            CheckDockerLogs(compose_file, 'Gitlab is up!', wait=5),
+            CheckDockerLogs(compose_file, 'Configuration loaded', wait=5),
+            CheckDockerLogs('Metrics server listening', wait=5),
             CheckEndpoints(GITLAB_RUNNER_URL, attempts=180),
+            CheckEndpoints('{}/ci'.format(GITLAB_MASTER_URL), attempts=90),
         ],
+        attempts=2,
     ):
         yield CONFIG, E2E_METADATA


### PR DESCRIPTION
Currently we are checking only that one of those logs lines are present and we are not checking the second endpoint of the integration which failed on https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=105242&view=logs&j=862ed81a-8e19-5033-1e0e-8beefda74c81&t=6b8ffdb0-e906-595b-d288-8ee79a1a7aba

```
tests/test_e2e.py:12: in test_e2e
    aggregator = dd_agent_check(CONFIG, rate=True)
../datadog_checks_dev/datadog_checks/dev/plugin/pytest.py:198: in run_check
    replay_check_run(collector, aggregator, datadog_agent)
../datadog_checks_dev/datadog_checks/dev/_env.py:172: in replay_check_run
    raise Exception("\n".join("Message: {}\n{}".format(err['message'], err['traceback']) for err in errors))
E   Exception: Message: Http status code 502 on url http://localhost:8085/ci
E   Traceback (most recent call last):
E     File "/home/datadog_checks_base/datadog_checks/base/checks/base.py", line 1116, in run
E       self.check(instance)
E     File "/home/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py", line 63, in check
E       self._check_connectivity_to_master(instance, custom_tags)
E     File "/home/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py", line 127, in _check_connectivity_to_master
E       raise Exception("Http status code {} on url {}".format(r.status_code, url))
E   Exception: Http status code 502 on url http://localhost:8085/ci

```