### PR TITLE
Use stats database for proxysql backends count

### DIFF
--- a/proxysql/datadog_checks/proxysql/queries.py
+++ b/proxysql/datadog_checks/proxysql/queries.py
@@ -236,9 +236,9 @@ STATS_MEMORY_METRICS = {
 
 STATS_MYSQL_BACKENDS = {
     'name': 'stats_mysql_backends',
-    'query': 'SELECT  hostgroup_id, status, COUNT(*) FROM runtime_mysql_servers GROUP BY hostgroup_id, status',
+    'query': 'SELECT  hostgroup, status, COUNT(*) FROM stats_mysql_connection_pool GROUP BY hostgroup, status',
     'columns': [
-        {'name': 'hostgroup_id', 'type': 'tag'},
+        {'name': 'hostgroup', 'type': 'tag'},
         {'name': 'status', 'type': 'tag'},
         {'name': 'backends.count', 'type': 'gauge'},
     ],

--- a/proxysql/tests/test_integration.py
+++ b/proxysql/tests/test_integration.py
@@ -67,7 +67,7 @@ def test_server_down(aggregator, instance_basic, dd_run_check):
         (['connection_pool_metrics'], CONNECTION_POOL_METRICS, ['hostgroup', 'srv_host', 'srv_port']),
         (['users_metrics'], USER_TAGS_METRICS, ['username']),
         (['memory_metrics'], MEMORY_METRICS, []),
-        (['backends_metrics'], BACKENDS_METRICS, ['hostgroup_id', 'status']),
+        (['backends_metrics'], BACKENDS_METRICS, ['hostgroup', 'status']),
         (['query_rules_metrics'], QUERY_RULES_TAGS_METRICS, ['rule_id']),
     ),
     ids=('global', 'command_counters', 'connection_pool', 'users', 'memory', 'backends', 'query_rules'),


### PR DESCRIPTION
### What does this PR do?
This PR will change the query for the `proxysql.backends.count` metric from a query in a [runtime table](https://proxysql.com/documentation/main-runtime/) (`admin-admin_credentials` required) to a query in a [stats table](https://proxysql.com/documentation/stats-statistics/) (allowing `admin-stats_credentials` only)

### Motivation
Query in the `runtime_mysql_servers` table require admin credential by default. Runtime tables such as `runtime_mysql_users` contains sensitive data so it is not recommended to use `admin-admin_credentials` nor grant permissions.

While we can get the relevant data about backends count from the stats table `stats_mysql_connection_pool` we can update the query to this table instead.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
