### PR TITLE
Prevent from publishing datadog-checks-downloader to PyPI

### DIFF
--- a/datadog_checks_downloader/pyproject.toml
+++ b/datadog_checks_downloader/pyproject.toml
@@ -19,6 +19,7 @@ authors = [
     { name = "Datadog", email = "packages@datadoghq.com" },
 ]
 classifiers = [
+    "Private :: Do Not Upload",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",


### PR DESCRIPTION
### What does this PR do?

This PR adds a classifier that makes sure the download-checks-downloader is not published on PyPI.