### PR TITLE
Avoid using assert statement by creating UpdatedTargetsError exception

### DIFF
--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -30,8 +30,10 @@ from .exceptions import (
     NoSuchDatadogPackage,
     NoSuchDatadogPackageVersion,
     PythonVersionMismatch,
+    UpdatedTargetsError,
     RevokedDeveloperOrMachine,
 )
+
 from .parameters import substitute
 
 # Increase requests timeout.
@@ -115,9 +117,14 @@ class TUFDownloader:
         # or, it has been updated, in which case...
         else:
             # First, we use TUF to download and verify the target.
-            assert len(updated_targets) == 1
+            if len(updated_targets) != 1:
+                raise UpdatedTargetsError(f"Expecting only one target {target!r} to be updated; got: {', '.join(updated_targets)}")
+
             updated_target = updated_targets[0]
-            assert updated_target == target
+
+            if updated_target != target:
+                raise UpdatedTargetsError(f"Unknown target updated, expected {target!r} but got {updated_target!r}")
+
             self.__updater.download_target(updated_target, self.__targets_dir)
 
         logger.info('TUF verified %s', target_relpath)

--- a/datadog_checks_downloader/datadog_checks/downloader/exceptions.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/exceptions.py
@@ -32,6 +32,9 @@ class NonDatadogPackage(CLIError):
 # Exceptions for the download module.
 
 
+class UpdatedTargetsError(ChecksDownloaderException):
+    """An exception raised when any issue with updated target arises."""
+
 class IncorrectRootLayoutType(ChecksDownloaderException):
     def __init__(self, found, expected):
         self.found = found

--- a/datadog_checks_downloader/datadog_checks/downloader/exceptions.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/exceptions.py
@@ -5,8 +5,11 @@
 
 # Exceptions for the CLI module.
 
+class ChecksDownloaderException(Exception):
+    """A top level exception type for datadog-checks-downloader module."""
 
-class CLIError(Exception):
+
+class CLIError(ChecksDownloaderException):
     pass
 
 
@@ -29,7 +32,7 @@ class NonDatadogPackage(CLIError):
 # Exceptions for the download module.
 
 
-class IncorrectRootLayoutType(Exception):
+class IncorrectRootLayoutType(ChecksDownloaderException):
     def __init__(self, found, expected):
         self.found = found
         self.expected = expected
@@ -42,7 +45,7 @@ class IncorrectRootLayoutType(Exception):
         )
 
 
-class SimpleIndexError(Exception):
+class SimpleIndexError(ChecksDownloaderException):
     def __init__(self, standard_distribution_name):
         self.standard_distribution_name = standard_distribution_name
 
@@ -99,7 +102,7 @@ class PythonVersionMismatch(SimpleIndexError):
         )
 
 
-class TUFInTotoError(Exception):
+class TUFInTotoError(ChecksDownloaderException):
     def __init__(self, target_relpath):
         self.target_relpath = target_relpath
 


### PR DESCRIPTION
### What does this PR do?

Do not use assert statements in the code. Instead, create UpdatedTargetsError
exception to report any issues.

Related: #12557