### PR TITLE
Use packaging instead of pkg_resources for parsing version

### DIFF
--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -14,7 +14,7 @@ import tempfile
 from in_toto import verifylib
 from in_toto.exceptions import LinkNotFoundError
 from in_toto.models.metadata import Metablock
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 from securesystemslib import interface
 from tuf import settings as tuf_settings
 from tuf.client.updater import Updater

--- a/datadog_checks_downloader/pyproject.toml
+++ b/datadog_checks_downloader/pyproject.toml
@@ -38,6 +38,7 @@ deps = [
     "securesystemslib[crypto,pynacl]==0.20.1",
     "tuf==0.17.0; python_version < '3.0'",
     "tuf==0.19.0; python_version > '3.0'",
+    "packaging==21.3",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?

datadog-checks-downloader should use packaging to parse Python package versions.

