### PR TITLE
datadog-checks-downloader does not provide dev extras

### DIFF
--- a/datadog_checks_downloader/README.md
+++ b/datadog_checks_downloader/README.md
@@ -28,7 +28,7 @@ to work with the check.
 To install the check in dev mode:
 
 ```shell
-pip install -e .[dev,deps]
+pip install -e '.[deps]'
 ```
 
 To download a new or updated integration, you may specify a precise


### PR DESCRIPTION
### What does this PR do?

No dev extras provided by the package. Only deps -- adjust README accordingly.
