### PR TITLE
Adjust logging setup when multiple -v flags are supplied

### DIFF
--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -67,8 +67,7 @@ class TUFDownloader:
         # 3 => 30 (WARNING)
         # 4 => 20 (INFO)
         # 5 => 10 (DEBUG)
-        # And so it repeats from here...
-        remainder = verbose % 6
+        remainder = min(verbose, 5) % 6
         level = (6 - remainder) * 10
         assert level in range(10, 70, 10), level
         logging.basicConfig(format='%(levelname)-8s: %(message)s', level=level)


### PR DESCRIPTION
### What does this PR do?

Verbose mode is confusing when multiple -v flags are supplied. -vvvvv means debug mode, but -vvvvvv means no verbosity at all (and cycles to higher log levels when additional -v flags are added). This change makes sure only debug mode is set if 5 or more -v flags are supplied.