### PR TITLE
Add hostname to docker agent start command for windows

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -300,6 +300,8 @@ class DockerInterface(object):
         env_vars = {
             # Agent 6 will simply fail without an API key
             'DD_API_KEY': self.api_key,
+            # Windows agent needs explicit hostname
+            'DD_HOSTNAME': self.container_name,
             # Run expvar on a random port
             'DD_EXPVAR_PORT': 0,
             # Run API on a random port

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -329,7 +329,7 @@ class DockerInterface(object):
         ]
 
         if self.windows_container:
-            volumes.append('/var/run/docker.sock:/var/run/docker.sock:ro')
+            volumes.append('//var/run/docker.sock:/var/run/docker.sock:ro')
         else:
             volumes.append('/proc:/host/proc')
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -300,6 +300,8 @@ class DockerInterface(object):
         env_vars = {
             # Agent 6 will simply fail without an API key
             'DD_API_KEY': self.api_key,
+            # Set agent hostname for CI
+            'DD_HOSTNAME': get_hostname(),
             # Run expvar on a random port
             'DD_EXPVAR_PORT': 0,
             # Run API on a random port
@@ -321,9 +323,6 @@ class DockerInterface(object):
         if self.log_url:
             # Set custom agent log intake
             env_vars['DD_LOGS_CONFIG_DD_URL'] = self.log_url
-        if self.windows_container:
-            # Set socket hostname for Windows CI
-            env_vars['DD_HOSTNAME'] = get_hostname()
         env_vars.update(self.env_vars)
 
         volumes = [

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -322,6 +322,7 @@ class DockerInterface(object):
             # Set custom agent log intake
             env_vars['DD_LOGS_CONFIG_DD_URL'] = self.log_url
         if self.windows_container:
+            # Set socket hostname for Windows CI
             env_vars['DD_HOSTNAME'] = get_hostname()
         env_vars.update(self.env_vars)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 
 from ...errors import SubprocessError
 from ...subprocess import run_command
-from ...utils import ON_WINDOWS, file_exists, find_free_port, get_ip, path_join, get_hostname
+from ...utils import ON_WINDOWS, file_exists, find_free_port, get_hostname, get_ip, path_join
 from ..commands.console import echo_debug, echo_warning
 from ..constants import get_root
 from .agent import (

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -321,6 +321,8 @@ class DockerInterface(object):
         if self.log_url:
             # Set custom agent log intake
             env_vars['DD_LOGS_CONFIG_DD_URL'] = self.log_url
+        if self.windows_container:
+            env_vars['DD_HOSTNAME'] = get_hostname()
         env_vars.update(self.env_vars)
 
         volumes = [
@@ -328,9 +330,7 @@ class DockerInterface(object):
             f'{path_join(get_root(), self.check)}:{self.check_mount_dir}',
         ]
 
-        if self.windows_container:
-            volumes.append('//var/run/docker.sock:/var/run/docker.sock:ro')
-        else:
+        if not self.windows_container:
             volumes.append('/proc:/host/proc')
 
         if self.config:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 
 from ...errors import SubprocessError
 from ...subprocess import run_command
-from ...utils import ON_WINDOWS, file_exists, find_free_port, get_ip, path_join
+from ...utils import ON_WINDOWS, file_exists, find_free_port, get_ip, path_join, get_hostname
 from ..commands.console import echo_debug, echo_warning
 from ..constants import get_root
 from .agent import (

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -300,8 +300,6 @@ class DockerInterface(object):
         env_vars = {
             # Agent 6 will simply fail without an API key
             'DD_API_KEY': self.api_key,
-            # Windows agent needs explicit hostname
-            'DD_HOSTNAME': self.container_name,
             # Run expvar on a random port
             'DD_EXPVAR_PORT': 0,
             # Run API on a random port
@@ -330,7 +328,9 @@ class DockerInterface(object):
             f'{path_join(get_root(), self.check)}:{self.check_mount_dir}',
         ]
 
-        if not self.windows_container:
+        if self.windows_container:
+            volumes.append('/var/run/docker.sock:/var/run/docker.sock:ro')
+        else:
             volumes.append('/proc:/host/proc')
 
         if self.config:

--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -141,3 +141,7 @@ def get_metadata_metrics():
         for row in csv.DictReader(f):
             metrics[row['metric_name']] = row
     return metrics
+
+def get_hostname():
+    """Return the socket hostname"""
+    return socket.gethostname()

--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -142,6 +142,7 @@ def get_metadata_metrics():
             metrics[row['metric_name']] = row
     return metrics
 
+
 def get_hostname():
     """Return the socket hostname"""
     return socket.gethostname()


### PR DESCRIPTION
### What does this PR do?
* Add `DD_HOSTNAME` environment variable to the docker E2E `start_agent` command. 
* Add `get_hostname` util to return the host's socket hostname. 

### Motivation
Fix CI: Latest windows agent container dev builds are unable to determine the Windows VM hostname automatically. 

### Additional Notes
I initially tried using the `self.container_name` as the hostname, but the name's underscores make it non-compliant with RFC 1123 as a hostname. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
