### PR TITLE
Upgrade `requests` dependency to 2.28.1

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -88,7 +88,7 @@ requests-ntlm==1.1.0
 requests-toolbelt==0.9.1
 requests-unixsocket==0.3.0
 requests==2.27.1; python_version < '3.0'
-requests==2.27.1; python_version > '3.0'
+requests==2.28.1; python_version > '3.0'
 rethinkdb==2.4.8
 scandir==1.10.0
 securesystemslib[crypto,pynacl]==0.20.1

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -63,7 +63,7 @@ deps = [
     "requests-toolbelt==0.9.1",
     "requests-unixsocket==0.3.0",
     "requests==2.27.1; python_version < '3.0'",
-    "requests==2.27.1; python_version > '3.0'",
+    "requests==2.28.1; python_version > '3.0'",
     "simplejson==3.17.6",
     "six==1.16.0",
     "typing==3.10.0.0; python_version < '3.0'",


### PR DESCRIPTION
### Motivation

https://github.com/psf/requests/pull/6057 to fix https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=105561&view=logs&j=918144f8-7a9b-57ab-9d4d-7700df3d4745&t=a59da3b3-a5df-5321-8288-a128b4ac33fd&l=310