### PR TITLE
Print similar metrics when asserting metric has tag

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -234,9 +234,7 @@ class AggregatorStub(object):
                 + "\n".join(["     {}".format(m) for m in candidates])
             )
         else:
-            expected_stub = MetricStub(
-                metric_name, metric_type=None, value=None, expected_tags=[tag], hostname=None, device=None
-            )
+            expected_stub = MetricStub(metric_name, type=None, value=None, tags=[tag], hostname=None, device=None)
             msg = "Metric '{}' not found".format(metric_name)
             msg = "{}\n{}".format(msg, build_similar_elements_msg(expected_stub, self._metrics))
 

--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -234,7 +234,11 @@ class AggregatorStub(object):
                 + "\n".join(["     {}".format(m) for m in candidates])
             )
         else:
+            expected_stub = MetricStub(
+                metric_name, metric_type=None, value=None, expected_tags=[tag], hostname=None, device=None
+            )
             msg = "Metric '{}' not found".format(metric_name)
+            msg = "{}\n{}".format(msg, build_similar_elements_msg(expected_stub, self._metrics))
 
         if count is not None:
             assert len(candidates_with_tag) == count, msg


### PR DESCRIPTION
When `assert_metric_has_tag` fails because the metric has not been submitted at all we do not print other similar metrics that have been submitted