### PR TITLE
do not update docker compose

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/aggregator.py
@@ -234,7 +234,11 @@ class AggregatorStub(object):
                 + "\n".join(["     {}".format(m) for m in candidates])
             )
         else:
+            expected_stub = MetricStub(
+                metric_name, metric_type=None, value=None, expected_tags=[tag], hostname=None, device=None
+            )
             msg = "Metric '{}' not found".format(metric_name)
+            msg = "{}\n{}".format(msg, build_similar_elements_msg(expected_stub, self._metrics))
 
         if count is not None:
             assert len(candidates_with_tag) == count, msg

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/ci/setup.py
@@ -54,7 +54,7 @@ def setup(checks, changed):
     Run CI setup scripts
     """
     cur_platform = platform.system().lower()
-    upgrade_docker_compose(cur_platform)
+    #upgrade_docker_compose(cur_platform)
     scripts_path = os.path.join(get_root(), '.azure-pipelines', 'scripts')
     echo_info("Run CI setup scripts")
     if checks:


### PR DESCRIPTION
This is causing `requests.exceptions.SSLError: [SSL: DECRYPTION_FAILED_OR_BAD_RECORD_MAC] decryption failed or bad record mac (_ssl.c:2635)` and most integrations use built-in docker compose now.