### PR TITLE
Better print the error on extra startup commands for e2e tests on agent image set up

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -199,8 +199,8 @@ def _run_start_commands(metadata, environment, check, env):
             result = environment.exec_command(command, capture=True)
             if result.code:
                 click.echo()
-                echo_info(result.stdout + result.stderr)
-                echo_failure('An error occurred.')
+                echo_failure('An error occurred running "{}"'.format(str(command)))
+                echo_failure(result.stdout + result.stderr, indent=True)
                 echo_waiting('Stopping the environment...')
                 stop_environment(check, env, metadata=metadata)
                 echo_waiting('Stopping the Agent...')


### PR DESCRIPTION
Print which command failed also indent the output of that command