### PR TITLE
Mark database metrics as optional

### DIFF
--- a/pgbouncer/tests/test_pgbouncer_integration_e2e.py
+++ b/pgbouncer/tests/test_pgbouncer_integration_e2e.py
@@ -177,9 +177,9 @@ def assert_metric_coverage(env_version, aggregator, include_clients=False, inclu
     aggregator.assert_metric('pgbouncer.stats.bytes_received_per_second')
     aggregator.assert_metric('pgbouncer.stats.bytes_sent_per_second')
 
-    aggregator.assert_metric('pgbouncer.databases.pool_size')
-    aggregator.assert_metric('pgbouncer.databases.max_connections')
-    aggregator.assert_metric('pgbouncer.databases.current_connections')
+    aggregator.assert_metric('pgbouncer.databases.pool_size', at_least=0)
+    aggregator.assert_metric('pgbouncer.databases.max_connections', at_least=0)
+    aggregator.assert_metric('pgbouncer.databases.current_connections', at_least=0)
 
     aggregator.assert_metric('pgbouncer.max_client_conn')
 


### PR DESCRIPTION
On https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=105651&view=logs&j=4fa091e2-3df8-50fa-51e5-b414abd4c247&t=533523c5-01ca-59b0-b401-3818cb8b6f7d&l=207

No database metrics were emitted:
```
E   AssertionError: Needed at least 1 candidates for 'pgbouncer.databases.pool_size', got 0
E     Expected:
E             MetricStub(name='pgbouncer.databases.pool_size', type=None, value=None, tags=None, hostname=None, device=None, flush_first_value=None)
E     Similar submitted:
E     Score   Most similar
E     0.65    MetricStub(name='pgbouncer.pools.sv_used', type=0, value=1, tags=['db:datadog_test', 'optional:tag1', 'user:postgres'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.65    MetricStub(name='pgbouncer.pools.sv_used', type=0, value=1, tags=['db:datadog_test', 'optional:tag1', 'user:postgres'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.65    MetricStub(name='pgbouncer.pools.sv_idle', type=0, value=0, tags=['db:datadog_test', 'optional:tag1', 'user:postgres'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.65    MetricStub(name='pgbouncer.pools.sv_idle', type=0, value=0, tags=['db:datadog_test', 'optional:tag1', 'user:postgres'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.63    MetricStub(name='pgbouncer.pools.sv_tested', type=0, value=0, tags=['db:datadog_test', 'optional:tag1', 'user:postgres'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.63    MetricStub(name='pgbouncer.pools.sv_tested', type=0, value=0, tags=['db:datadog_test', 'optional:tag1', 'user:postgres'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.63    MetricStub(name='pgbouncer.pools.sv_active', type=0, value=0, tags=['db:datadog_test', 'optional:tag1', 'user:postgres'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.63    MetricStub(name='pgbouncer.pools.sv_active', type=0, value=0, tags=['db:datadog_test', 'optional:tag1', 'user:postgres'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.63    MetricStub(name='pgbouncer.pools.cl_active', type=0, value=0, tags=['db:datadog_test', 'optional:tag1', 'user:postgres'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.63    MetricStub(name='pgbouncer.pools.cl_active', type=0, value=0, tags=['db:datadog_test', 'optional:tag1', 'user:postgres'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.62    MetricStub(name='pgbouncer.stats.total_query_time', type=0, value=0, tags=['db:datadog_test', 'optional:tag1'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.62    MetricStub(name='pgbouncer.stats.avg_req', type=0, value=0, tags=['db:datadog_test', 'optional:tag1'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.62    MetricStub(name='pgbouncer.stats.avg_req', type=0, value=0, tags=['db:datadog_test', 'optional:tag1'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.62    MetricStub(name='pgbouncer.pools.maxwait', type=0, value=0, tags=['db:datadog_test', 'optional:tag1', 'user:postgres'], hostname='fv-az101-223', device=None, flush_first_value=False)
E     0.62    MetricStub(name='pgbouncer.pools.maxwait', type=0, value=0, tags=['db:datadog_test', 'optional:tag1', 'user:postgres'], hostname='fv-az101-223', device=None, flush_first_value=False)
E   assert False
```