### PR TITLE
[SNMP Traps] Include BITS enums in traps DB 

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_traps_db.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_traps_db.py
@@ -351,6 +351,10 @@ def get_var_metadata(var_name, mib_name, search_locations=None):
 
     # grab enum if it exists in-line
     enum = file_content[var_name].get('syntax', {}).get('constraints', {}).get('enumeration', {})
+    # if there's not an integer enumeration, look for bits
+    if not enum:
+        enum = file_content[var_name].get('syntax', {}).get('bits', {})
+
     # if there is no enum in-line, check for type definition and enum in the same MIB and its imports
     if not enum:
         var_type = file_content[var_name].get('syntax', {}).get('type', '')
@@ -409,6 +413,11 @@ def get_enum(var_name, mib_name, search_locations=None):
             continue
 
         enum = file_content[var_name].get('type', {}).get('constraints', {}).get('enumeration', {})
+
+        # if there's not an integer enum, try for bits
+        if not enum:
+            enum = file_content[var_name].get('type', {}).get('bits', {})
+
         # update variable to the type name in case we have to go another layer down
         var_name = file_content[var_name].get('type', {}).get('type', '')
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_traps_db.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_traps_db.py
@@ -5,6 +5,7 @@
 import json
 import os
 from collections import namedtuple
+from enum import Enum
 from functools import lru_cache
 
 import click
@@ -19,6 +20,9 @@ from .constants import CLEAR_LINE_ESCAPE_CODE, MIB_SOURCE_URL
 NOTIFICATION_TYPE = 'notificationtype'
 ALLOWED_EXTENSIONS_BY_FORMAT = {"json": [".json"], "yaml": [".yml", ".yaml"]}
 
+class MappingType(Enum):
+    INTEGER = 0
+    BITS = 1
 
 class MissingMIBException(Exception):
     pass
@@ -33,7 +37,7 @@ class MultipleTypeDefintionsException(Exception):
 
 
 # namedtuple definition for trap variable metadata
-VarMetadata = namedtuple('VarMetadata', ['oid', 'description', 'enum'])
+VarMetadata = namedtuple('VarMetadata', ['oid', 'description', 'enum', 'bits'])
 
 
 @click.command(
@@ -319,6 +323,8 @@ def generate_trap_db(compiled_mibs, compiled_mibs_sources, no_descr):
                     trap_db["vars"][var_metadata.oid]["descr"] = var_metadata.description
                 if var_metadata.enum:
                     trap_db["vars"][var_metadata.oid]["enum"] = var_metadata.enum
+                if var_metadata.bits:
+                    trap_db["vars"][var_metadata.oid]["bits"] = var_metadata.bits
 
         if trap_db['traps']:
             mib_name = file_content['meta']['module']
@@ -351,16 +357,32 @@ def get_var_metadata(var_name, mib_name, search_locations=None):
 
     # grab enum if it exists in-line
     enum = file_content[var_name].get('syntax', {}).get('constraints', {}).get('enumeration', {})
-    # if there's not an integer enumeration, look for bits
-    if not enum:
-        enum = file_content[var_name].get('syntax', {}).get('bits', {})
 
     # if there is no enum in-line, check for type definition and enum in the same MIB and its imports
     if not enum:
         var_type = file_content[var_name].get('syntax', {}).get('type', '')
         if var_type:
             try:
-                enum = get_enum(var_type, mib_name, search_locations)
+                enum = get_mapping(var_type, mib_name, MappingType.INTEGER, search_locations)
+            except MissingMIBException:
+                echo_warning(
+                    "Variable {} references a type called {}, but the defining MIB is missing. "
+                    "Enum definitions for this variable will be unavailable.".format(var_name, var_type)
+                )
+            except MultipleTypeDefintionsException:
+                echo_warning(
+                    "Variable {} references a type called {}, but this symbol is imported from multiple MIBs. "
+                    "Enum definitions for this variable will be unavailable.".format(var_name, var_type)
+                )
+
+    # grab bits if they exist in-line
+    bits = file_content[var_name].get('syntax', {}).get('bits', {})
+
+    if not bits:
+        var_type = file_content[var_name].get('syntax', {}).get('type', '')
+        if var_type:
+            try:
+                bits = get_mapping(var_type, mib_name, MappingType.BITS, search_locations)
             except MissingMIBException:
                 echo_warning(
                     "Variable {} references a type called {}, but the defining MIB is missing. "
@@ -378,19 +400,23 @@ def get_var_metadata(var_name, mib_name, search_locations=None):
     for k, v in enum.items():
         parsed_enum[v] = k
 
-    return VarMetadata(file_content[var_name]['oid'], file_content[var_name].get('description', ''), parsed_enum)
+    parsed_bits = {}
+    for k, v in bits.items():
+        parsed_bits[v] = k
+
+    return VarMetadata(file_content[var_name]['oid'], file_content[var_name].get('description', ''), parsed_enum, parsed_bits)
 
 
 @lru_cache(maxsize=None)
-def get_enum(var_name, mib_name, search_locations=None):
+def get_mapping(var_name, mib_name, mapping_type: MappingType, search_locations=None):
     """
     Returns the enum of a given variable, even if the enum is not defined in-line or the same MIB.
     :param var_name: Name of the variable to search for
     :param search_locations: Tuple of path to directories containing json-compiled MIB files
     :return: The oid and the description of the variable.
     """
-    enum = {}
-    while mib_name and var_name and not enum:
+    mapping = {}
+    while mib_name and var_name and not mapping:
         for location in search_locations:
             file_name = os.path.join(location, mib_name + '.json')
             if os.path.isfile(file_name):
@@ -412,16 +438,17 @@ def get_enum(var_name, mib_name, search_locations=None):
                 raise MissingMIBException()
             continue
 
-        enum = file_content[var_name].get('type', {}).get('constraints', {}).get('enumeration', {})
-
-        # if there's not an integer enum, try for bits
-        if not enum:
-            enum = file_content[var_name].get('type', {}).get('bits', {})
+        if mapping_type == MappingType.INTEGER:
+            mapping = file_content[var_name].get('type', {}).get('constraints', {}).get('enumeration', {})
+        elif mapping_type == MappingType.BITS:
+            mapping = file_content[var_name].get('type', {}).get('bits', {})
+        else:
+            raise ValueError("invalid mapping type, must be INTEGER or BITS")
 
         # update variable to the type name in case we have to go another layer down
         var_name = file_content[var_name].get('type', {}).get('type', '')
 
-    return enum
+    return mapping
 
 
 @lru_cache(maxsize=None)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_traps_db.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_traps_db.py
@@ -20,9 +20,11 @@ from .constants import CLEAR_LINE_ESCAPE_CODE, MIB_SOURCE_URL
 NOTIFICATION_TYPE = 'notificationtype'
 ALLOWED_EXTENSIONS_BY_FORMAT = {"json": [".json"], "yaml": [".yml", ".yaml"]}
 
+
 class MappingType(Enum):
     INTEGER = 0
     BITS = 1
+
 
 class MissingMIBException(Exception):
     pass
@@ -404,7 +406,9 @@ def get_var_metadata(var_name, mib_name, search_locations=None):
     for k, v in bits.items():
         parsed_bits[v] = k
 
-    return VarMetadata(file_content[var_name]['oid'], file_content[var_name].get('description', ''), parsed_enum, parsed_bits)
+    return VarMetadata(
+        file_content[var_name]['oid'], file_content[var_name].get('description', ''), parsed_enum, parsed_bits
+    )
 
 
 @lru_cache(maxsize=None)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR processes the `BITS` field in MIBs as enums and adds those mappings to the traps database.

### Motivation
<!-- What inspired you to submit this pull request? -->
The team wants to parse BITS enums so that customers are able to more easily understand the data being sent as part of traps directly in the Datadog UI.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
