### PR TITLE
Add back process signatures lost during the V2 migration

### DIFF
--- a/docker_daemon/manifest.json
+++ b/docker_daemon/manifest.json
@@ -28,6 +28,13 @@
   "assets": {
     "integration": {
       "source_type_name": "Docker",
+      "process_signatures": [
+        "dockerd",
+        "docker-containerd",
+        "docker run",
+        "docker daemon",
+        "docker-containerd-shim"
+      ],
       "configuration": {},
       "events": {
         "creates_events": true

--- a/kong/manifest.json
+++ b/kong/manifest.json
@@ -30,6 +30,9 @@
   "assets": {
     "integration": {
       "source_type_name": "Kong",
+      "process_signatures": [
+        "kong start"
+      ],
       "configuration": {
         "spec": "assets/configuration/spec.yaml"
       },

--- a/teamcity/manifest.json
+++ b/teamcity/manifest.json
@@ -30,6 +30,10 @@
   "assets": {
     "integration": {
       "source_type_name": "Teamcity",
+      "process_signatures": [
+        "teamcity-server.sh",
+        "teamcity-server"
+      ],
       "configuration": {
         "spec": "assets/configuration/spec.yaml"
       },

--- a/varnish/manifest.json
+++ b/varnish/manifest.json
@@ -30,6 +30,10 @@
   "assets": {
     "integration": {
       "source_type_name": "Varnish",
+      "process_signatures": [
+        "service varnish start",
+        "varnishd"
+      ],
       "configuration": {
         "spec": "assets/configuration/spec.yaml"
       },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds back `process_signatures` that were lost when we began migrations to manifest V2

### Motivation
<!-- What inspired you to submit this pull request? -->
The original specification of manifest V2 did not account for `process_signatures`. The V2 manifest now supports this under the `assets->integration` key. We've merged 4 migration PRs that unfortunately lost process_signatures during this time, `kong`, `docker_daemon`, `teamcity`, `varnish`. 

This PR re-introduces them. While this never impacted customers (the backend kept its own version of these), we want to re-introduce them before any issues were to arise. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
