### PR TITLE
Make sure process_signatures gets migrated during V2 migrations

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/migration.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/migration.py
@@ -54,6 +54,7 @@ V2_TO_V1_MAP = JSONDict(
         "/assets/integration/metrics/metadata_path": "/assets/metrics_metadata",
         "/assets/integration/service_checks": {},
         "/assets/integration/service_checks/metadata_path": "/assets/service_checks",
+        "/assets/integration/process_signatures": "/process_signatures",
         "/assets/dashboards": "/assets/dashboards",
         "/assets/monitors": "/assets/monitors",
         "/assets/saved_views": "/assets/saved_views",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Make sure that `process_signatures` gets migrated to the manifest V2 format when running the `ddev meta manifest migrate` command

### Motivation
<!-- What inspired you to submit this pull request? -->
Final piece to fully support `process_signatures` in manifest V2

### Additional Notes
<!-- Anything else we should know when reviewing? -->
I confirmed this works locally by running `ddev -x meta manifest migrate activemq 2.0.0`
and confirming the manifest included this section at the bottom of the `integration` asset:

```
...
      "process_signatures": [
        "activemq"
      ]
...
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
