### PR TITLE
Avoid warnings on apt-get install, exit 0

### DIFF
--- a/oracle/tests/scripts/install_instant_client.sh
+++ b/oracle/tests/scripts/install_instant_client.sh
@@ -6,7 +6,7 @@ INSTANT_CLIENT_URL="https://ddintegrations.blob.core.windows.net/oracle/instantc
 
 mkdir -p /opt/oracle
 apt-get update
-apt-get install unzip
+DEBIAN_FRONTEND=noninteractive apt-get install -yq unzip
 
 # Retry necessary due to flaky download that might trigger:
 # curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110

--- a/oracle/tests/scripts/install_instant_client.sh
+++ b/oracle/tests/scripts/install_instant_client.sh
@@ -18,3 +18,4 @@ done
 unzip /opt/oracle/instantclient.zip -d /opt/oracle
 
 set +x
+exit 0

--- a/oracle/tests/scripts/install_instant_client.sh
+++ b/oracle/tests/scripts/install_instant_client.sh
@@ -16,6 +16,7 @@ for i in 2 4 8 16 32; do
 done
 
 unzip /opt/oracle/instantclient.zip -d /opt/oracle
+ls /opt/oracle
 
 set +x
 exit 0


### PR DESCRIPTION
After printing more information on https://github.com/DataDog/integrations-core/pull/12577 and https://github.com/DataDog/integrations-core/pull/12578

On https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=105743&view=logs&j=c3a06451-088b-587c-b2b9-012b146267bb&t=8b8da6bd-8c7d-5c16-284a-eb82cfe91ae0&l=155
we see:
```
+ apt-get install unzip
debconf: delaying package configuration, since apt-utils is not installed
```
Listing the contents of the unzipped directory for debugging purposes
Adding explicit `exit 0` since I don't see any actual errors on the script that could have made it fail.
EDIT: It seems unzip can return non 0 exit code even if extraction is "ok" https://linux.die.net/man/1/unzip