### PR TITLE
TLS check: implement StartTLS protocol for postgres

### DIFF
--- a/tls/assets/configuration/spec.yaml
+++ b/tls/assets/configuration/spec.yaml
@@ -133,5 +133,15 @@ files:
       description: Unique identifier for this instance that is added as a tag to all data emitted.
       value:
         type: string
+    - name: start_tls
+      description: |
+        Send protocol-specific message(s) to switch to TLS for communication.
+        StartTLS is implemented on those protocols: smtp, pop3, imap, ftp, xmpp, xmpp-server,
+        irc, postgres, mysql, lmtp, nntp. sieve and ldap.
+
+        Currently this checks supports only below protocols:
+          postgres
+      value:
+        type: string
     - template: instances/default
     - template: instances/tls

--- a/tls/assets/configuration/spec.yaml
+++ b/tls/assets/configuration/spec.yaml
@@ -136,10 +136,10 @@ files:
     - name: start_tls
       description: |
         Send protocol-specific message(s) to switch to TLS for communication.
-        StartTLS is implemented on those protocols: smtp, pop3, imap, ftp, xmpp, xmpp-server,
-        irc, postgres, mysql, lmtp, nntp. sieve and ldap.
+        StartTLS is implemented on these protocols: smtp, pop3, imap, ftp, xmpp, xmpp-server,
+        irc, postgres, mysql, lmtp, nntp, sieve, and ldap.
 
-        Currently this checks supports only below protocols:
+        Currently this checks supports only the below protocols:
           postgres
       value:
         type: string

--- a/tls/assets/configuration/spec.yaml
+++ b/tls/assets/configuration/spec.yaml
@@ -143,5 +143,7 @@ files:
           postgres
       value:
         type: string
+        enum:
+        - postgres
     - template: instances/default
     - template: instances/tls

--- a/tls/datadog_checks/tls/config_models/defaults.py
+++ b/tls/datadog_checks/tls/config_models/defaults.py
@@ -90,6 +90,10 @@ def instance_service(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_start_tls(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_tags(field, value):
     return get_default_field_value(field, value)
 

--- a/tls/datadog_checks/tls/config_models/instance.py
+++ b/tls/datadog_checks/tls/config_models/instance.py
@@ -9,7 +9,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import Literal, Optional, Sequence
 
 from pydantic import BaseModel, root_validator, validator
 
@@ -49,7 +49,7 @@ class InstanceConfig(BaseModel):
     server: str
     server_hostname: Optional[str]
     service: Optional[str]
-    start_tls: Optional[str]
+    start_tls: Optional[Literal['postgres']]
     tags: Optional[Sequence[str]]
     timeout: Optional[int]
     tls_ca_cert: Optional[str]

--- a/tls/datadog_checks/tls/config_models/instance.py
+++ b/tls/datadog_checks/tls/config_models/instance.py
@@ -49,6 +49,7 @@ class InstanceConfig(BaseModel):
     server: str
     server_hostname: Optional[str]
     service: Optional[str]
+    start_tls: Optional[str]
     tags: Optional[Sequence[str]]
     timeout: Optional[int]
     tls_ca_cert: Optional[str]

--- a/tls/datadog_checks/tls/data/conf.yaml.example
+++ b/tls/datadog_checks/tls/data/conf.yaml.example
@@ -127,6 +127,16 @@ instances:
     #
     # name: <NAME>
 
+    ## @param start_tls - string - optional
+    ## Send protocol-specific message(s) to switch to TLS for communication.
+    ## StartTLS is implemented on those protocols: smtp, pop3, imap, ftp, xmpp, xmpp-server,
+    ## irc, postgres, mysql, lmtp, nntp. sieve and ldap.
+    ##
+    ## Currently this checks supports only below protocols:
+    ##   postgres
+    #
+    # start_tls: <START_TLS>
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/tls/datadog_checks/tls/data/conf.yaml.example
+++ b/tls/datadog_checks/tls/data/conf.yaml.example
@@ -129,10 +129,10 @@ instances:
 
     ## @param start_tls - string - optional
     ## Send protocol-specific message(s) to switch to TLS for communication.
-    ## StartTLS is implemented on those protocols: smtp, pop3, imap, ftp, xmpp, xmpp-server,
-    ## irc, postgres, mysql, lmtp, nntp. sieve and ldap.
+    ## StartTLS is implemented on these protocols: smtp, pop3, imap, ftp, xmpp, xmpp-server,
+    ## irc, postgres, mysql, lmtp, nntp, sieve, and ldap.
     ##
-    ## Currently this checks supports only below protocols:
+    ## Currently this checks supports only the below protocols:
     ##   postgres
     #
     # start_tls: <START_TLS>

--- a/tls/datadog_checks/tls/tls.py
+++ b/tls/datadog_checks/tls/tls.py
@@ -62,6 +62,8 @@ class TLSCheck(AgentCheck):
             self._sock_type = socket.SOCK_STREAM
             self._port = int(self.instance.get('port', parsed_uri.port or 443))
 
+        self._start_tls = self.instance.get('start_tls')
+
         # https://en.wikipedia.org/wiki/Server_Name_Indication
         self._server_hostname = self.instance.get('server_hostname', self._server)
 

--- a/tls/datadog_checks/tls/tls_remote.py
+++ b/tls/datadog_checks/tls/tls_remote.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import ssl
 from hashlib import sha256
+from struct import pack
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509.base import load_der_x509_certificate
@@ -109,6 +110,8 @@ class TLSRemoteCheck(object):
         try:
             self.log.debug('Checking that TLS service check can connect')
             sock = self.agent_check.create_connection()
+            if self.agent_check._start_tls:
+                self._switch_starttls(sock)
         except Exception as e:
             self.log.debug('Error occurred while connecting to socket: %s', str(e))
             self.agent_check.service_check(
@@ -120,10 +123,36 @@ class TLSRemoteCheck(object):
             self.agent_check.service_check(SERVICE_CHECK_CAN_CONNECT, self.agent_check.OK, tags=self.agent_check._tags)
         return sock
 
+    def _switch_starttls(self, sock):
+        protocol = self.agent_check._start_tls
+        if protocol == "postgres":
+            self.log.debug('Switching connection to encrypted for %s protocol', protocol)
+            version_ssl = pack('!I', 1234 << 16 | 5679)
+            length = pack('!I', 8)
+            packet = length + version_ssl
+
+            sock.sendall(packet)
+            data = self._read_n_bytes_from_socket(sock, 1)
+            if data != b'S':
+                raise Exception('Postgres endpoint does not support TLS')
+        else:
+            raise Exception('Unsupported starttls protocol: ' + protocol)
+
+    def _read_n_bytes_from_socket(self, sock, n):
+        buf = bytearray(n)
+        view = memoryview(buf)
+        while n:
+            nbytes = sock.recv_into(view, n)
+            view = view[nbytes:]  # slicing views is cheap
+            n -= nbytes
+        return buf
+
     def fetch_intermediate_certs(self):
         # TODO: prefer stdlib implementation when available, see https://bugs.python.org/issue18617
         try:
             sock = self.agent_check.create_connection()
+            if self.agent_check._start_tls:
+                self._switch_starttls(sock)
         except Exception as e:
             self.log.error('Error occurred while connecting to socket to discover intermediate certificates: %s', e)
             return

--- a/tls/tests/compose/Dockerfile
+++ b/tls/tests/compose/Dockerfile
@@ -31,3 +31,8 @@ ENV DONT_FAKE_MONOTONIC=1
 RUN openssl genrsa -out expired.mock.key 2048 \
  && openssl req -new -sha256 -key expired.mock.key -subj "/C=US/ST=NY/O=foo/CN=expired.mock" -out expired.mock.csr \
  && openssl x509 -req -in expired.mock.csr -CA /root/ca_cert/ca.crt -CAkey /root/ca_cert/ca.key -CAcreateserial -out expired.mock.crt -days 1 -sha256
+
+## Prepare postgresql certificates
+ENV PSQL_UID=70
+ENV PSQL_GUID=70
+RUN for file in valid.mock.key valid.mock.crt; do cp $file postgres.$file; chown $PSQL_UID:$PSQL_GUID postgres.$file; done

--- a/tls/tests/compose/docker-compose.yml
+++ b/tls/tests/compose/docker-compose.yml
@@ -56,5 +56,19 @@ services:
     depends_on:
       - cert-builder
 
+  # postgres serving valid.postgresql.mock
+  starttls-postgres:
+    container_name: postgres-valid
+    image: postgres:12-alpine
+    volumes:
+      - certs:/var/lib/postgresql/certs/:ro
+    ports:
+      - "55432:5432"
+    command: -c ssl=on -c ssl_cert_file=/var/lib/postgresql/certs/postgres.valid.mock.crt -c ssl_key_file=/var/lib/postgresql/certs/postgres.valid.mock.key
+    environment:
+      - POSTGRES_PASSWORD=masterpassw0rd
+    depends_on:
+      - cert-builder
+
 volumes:
   certs:

--- a/tls/tests/conftest.py
+++ b/tls/tests/conftest.py
@@ -252,3 +252,14 @@ def instance_remote_cert_warning_seconds():
         'seconds_warning': days_to_seconds(200),
         'tls_ca_cert': CA_CERT,
     }
+
+
+@pytest.fixture
+def instance_remote_postgresql_valid():
+    return {
+        'server': 'localhost',
+        'port': 55432,
+        'server_hostname': 'valid.mock',
+        'start_tls': 'postgres',
+        'tls_ca_cert': CA_CERT,
+    }

--- a/tls/tests/test_remote.py
+++ b/tls/tests/test_remote.py
@@ -321,3 +321,17 @@ def test_cert_warning_seconds(aggregator, instance_remote_cert_warning_seconds):
     aggregator.assert_metric('tls.days_left', count=1)
     aggregator.assert_metric('tls.seconds_left', count=1)
     aggregator.assert_all_metrics_covered()
+
+
+def test_postgres_ok(aggregator, instance_remote_postgresql_valid):
+    c = TLSCheck('tls', {}, [instance_remote_postgresql_valid])
+    c.check(None)
+
+    aggregator.assert_service_check(SERVICE_CHECK_CAN_CONNECT, status=c.OK, tags=c._tags, count=1)
+    aggregator.assert_service_check(SERVICE_CHECK_VERSION, status=c.OK, tags=c._tags, count=1)
+    aggregator.assert_service_check(SERVICE_CHECK_VALIDATION, status=c.OK, tags=c._tags, count=1)
+    aggregator.assert_service_check(SERVICE_CHECK_EXPIRATION, status=c.OK, tags=c._tags, count=1)
+
+    aggregator.assert_metric('tls.days_left', count=1)
+    aggregator.assert_metric('tls.seconds_left', count=1)
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
This PR adds support for StartTLS implementation of postgresql protocol within `TLS` check.

### Motivation
There are few protocols that works with StartTLS protocol. This is a way to handle both encrypted and unencrypted traffic on the same port. The client needs to send some protocol specific packets to switch the connection to encrypted format. Before that TLS handshake is not possible. Due to that `TLS` check is currently not able to detect certs on these protocols.

### Additional Notes
Protocols implementing StartTLS: smtp, pop3, imap, ftp, xmpp, xmpp-server, irc, postgres, mysql, lmtp, nntp. sieve and ldap.
This PR adds support only for `postgresql` however with the general idea of extension.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
