### PR TITLE
Update Sidekiq integration docs

### DIFF
--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -69,6 +69,8 @@ No additional installation is needed on your server.
            tags:
              worker: "$1"
     ```
+    
+    These parameters can also be set by adding the 'DD_DOGSTATSD_MAPPER_PROFILES' environment variable to the Datadog Agent. 
 
 4. [Restart the Agent][8].
 

--- a/sidekiq/README.md
+++ b/sidekiq/README.md
@@ -70,7 +70,7 @@ No additional installation is needed on your server.
              worker: "$1"
     ```
     
-    These parameters can also be set by adding the 'DD_DOGSTATSD_MAPPER_PROFILES' environment variable to the Datadog Agent. 
+    These parameters can also be set by adding the `DD_DOGSTATSD_MAPPER_PROFILES` environment variable to the Datadog Agent. 
 
 4. [Restart the Agent][8].
 


### PR DESCRIPTION
### What does this PR do?
This PR adds info about an alternative option to configure dogstatsd mapper profiles by mentioning the `DD_DOGSTATSD_MAPPER_PROFILES` environment variable.  This should hopefully cut down on confusion in setting these parameters without directly editing the `datadog.yaml` file.

### Motivation
A few customers have reached out about not understanding how to add these configs to containerized environments (https://datadog.zendesk.com/agent/tickets/801720).

"I didn’t know that the `DD_DOGSTATSD_MAPPER_PROFILES` env var existed. That will totally solve my problem!"

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
