### PR TITLE
Update service_checks.json

### DIFF
--- a/ecs_fargate/assets/service_checks.json
+++ b/ecs_fargate/assets/service_checks.json
@@ -2,13 +2,13 @@
     {
         "agent_version": "6.0.0",
         "integration": "Amazon Fargate",
-        "check": "ecs_fargate.can_connect",
+        "check": "fargate_check",
         "statuses": [
             "ok",
             "critical"
         ],
         "groups": [
-            "enpoint"
+            "endpoint"
         ],
         "name": "Can Connect",
         "description": "Returns `CRITICAL` if the Agent is unable to connect to Fargate, otherwise returns `OK`."


### PR DESCRIPTION
This check name, ecs_fargate.can_connect, is not consistent with the name submitted by the integration ([Reference code](https://github.com/DataDog/integrations-core/blob/7.38.x/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py#L85)). As such, it (public docs) also does not match what we can see in the UI (Check Summary and Monitor pages).
