### PR TITLE
postgres: use readonly connections

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -394,7 +394,7 @@ class PostgreSql(AgentCheck):
                 args['sslpassword'] = self._config.ssl_password
             conn = psycopg2.connect(**args)
         # Autocommit is enabled by default for safety for all new connections (to prevent long-lived transactions).
-        conn.set_session(autocommit=True)
+        conn.set_session(autocommit=True, readonly=True)
         return conn
 
     def _connect(self):
@@ -446,7 +446,6 @@ class PostgreSql(AgentCheck):
             if not db or db.closed:
                 self.log.debug("initializing connection to dbname=%s", dbname)
                 db = self._new_connection(dbname)
-                db.set_session(autocommit=True)
                 self._db_pool[dbname] = db
                 if self._config.dbname == dbname:
                     # reload settings for the main DB only once every time the connection is reestablished


### PR DESCRIPTION
### What does this PR do?
We don't need the agent to perform writes, so we should connect to postgres via read-only connections. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
