### PR TITLE
sqlserver...connection: check for port provided in config

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -214,7 +214,9 @@ class Connection(object):
         self.adoprovider = init_config.get('adoprovider', self.default_adoprovider)
         if self.adoprovider.upper() not in self.valid_adoproviders:
             self.log.error(
-                "Invalid ADODB provider string %s, defaulting to %s", self.adoprovider, self.default_adoprovider
+                "Invalid ADODB provider string %s, defaulting to %s",
+                self.adoprovider,
+                self.default_adoprovider,
             )
             self.adoprovider = self.default_adoprovider
 
@@ -380,7 +382,10 @@ class Connection(object):
                 for row in cursor:
                     # collation_name can be NULL if db offline, in that case assume its case_insensitive
                     case_insensitive = not row.collation_name or 'CI' in row.collation_name
-                    self.existing_databases[row.name.lower()] = case_insensitive, row.name
+                    self.existing_databases[row.name.lower()] = (
+                        case_insensitive,
+                        row.name,
+                    )
 
             except Exception as e:
                 self.log.error("Failed to check if database %s exists: %s", database, e)
@@ -400,20 +405,36 @@ class Connection(object):
         connector = self.instance.get('connector', self.default_connector)
         if connector != self.default_connector:
             if connector.lower() not in self.valid_connectors:
-                self.log.warning("Invalid database connector %s using default %s", connector, self.default_connector)
+                self.log.warning(
+                    "Invalid database connector %s using default %s",
+                    connector,
+                    self.default_connector,
+                )
                 connector = self.default_connector
             else:
-                self.log.debug("Overriding default connector for %s with %s", self.instance['host'], connector)
+                self.log.debug(
+                    "Overriding default connector for %s with %s",
+                    self.instance['host'],
+                    connector,
+                )
         return connector
 
     def _get_adoprovider(self):
         provider = self.instance.get('adoprovider', self.default_adoprovider)
         if provider != self.adoprovider:
             if provider.upper() not in self.valid_adoproviders:
-                self.log.warning("Invalid ADO provider %s using default %s", provider, self.adoprovider)
+                self.log.warning(
+                    "Invalid ADO provider %s using default %s",
+                    provider,
+                    self.adoprovider,
+                )
                 provider = self.adoprovider
             else:
-                self.log.debug("Overriding default ADO provider for %s with %s", self.instance['host'], provider)
+                self.log.debug(
+                    "Overriding default ADO provider for %s with %s",
+                    self.instance['host'],
+                    provider,
+                )
         return provider
 
     def _get_access_info(self, db_key, db_name=None):
@@ -427,9 +448,7 @@ class Connection(object):
 
         if not dsn:
             if not host:
-                self.log.debug(
-                    "No host provided, falling back to defaults: host=127.0.0.1, port=1433"
-                )
+                self.log.debug("No host provided, falling back to defaults: host=127.0.0.1, port=1433")
                 host = "127.0.0.1,1433"
             if not database:
                 self.log.debug(
@@ -514,7 +533,11 @@ class Connection(object):
             for key, value in other_connector_options.items()
             if value not in connector_options.values() and self.instance.get(value) is not None
         }:
-            self.log.warning("%s option will be ignored since %s connection is used", option, self.connector)
+            self.log.warning(
+                "%s option will be ignored since %s connection is used",
+                option,
+                self.connector,
+            )
 
         if cs is None:
             return
@@ -522,7 +545,10 @@ class Connection(object):
         parsed_cs = parse_connection_string_properties(cs)
         lowercased_keys_cs = {k.lower(): v for k, v in parsed_cs.items()}
 
-        if lowercased_keys_cs.get('trusted_connection', "false").lower() in {'yes', 'true'} and (username or password):
+        if lowercased_keys_cs.get('trusted_connection', "false").lower() in {
+            'yes',
+            'true',
+        } and (username or password):
             self.log.warning("Username and password are ignored when using Windows authentication")
 
         for key, value in connector_options.items():

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -158,6 +158,40 @@ def test_will_fail_for_wrong_parameters_in_the_connection_string(instance_minima
         connection._connection_options_validation('somekey', 'somedb')
 
 
+@pytest.mark.parametrize(
+    'host, port, expected_host',
+    [
+        pytest.param('1.2.3.4', '22', '1.2.3.4,22', id='if port provided as a config option, it should be recognized'),
+        pytest.param('1.2.3.4', 'mcnugget', '1.2.3.4,1433', id='if port is not numeric, it should use default port'),
+        pytest.param(
+            '1.2.3.4,mcnugget',
+            None,
+            '1.2.3.4,1433',
+            id='if host port is not numeric, it should use default port',
+        ),
+        pytest.param(
+            '1.2.3.4,22',
+            None,
+            '1.2.3.4,22',
+            id='if port is provided as part of host, it should be recognized',
+        ),
+        pytest.param('1.2.3.4', None, '1.2.3.4,1433', id='if no port is provided anywhere, should default to 1433'),
+        pytest.param(
+            '1.2.3.4,35',
+            22,
+            '1.2.3.4,35',
+            id='if port is provided and included in host string, host port is used',
+        ),
+    ],
+)
+def test_config_with_and_without_port(instance_minimal_defaults, host, port, expected_host):
+    instance_minimal_defaults["host"] = host
+    instance_minimal_defaults["port"] = port
+    connection = Connection({}, instance_minimal_defaults, None)
+    _, result_host, _, _, _, _ = connection._get_access_info('somekey', 'somedb')
+    assert result_host == expected_host
+
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_query_timeout(instance_docker):
@@ -261,7 +295,7 @@ def test_connection_failure(aggregator, dd_run_check, instance_docker):
             {"host": "wrong"},
             {
                 "odbc-windows|MSOLEDBSQL": "TCP-connection\\(ERROR: getaddrinfo failed\\).*"
-                "Named Pipes Provider: Could not open a connection to SQL Server",
+                "TCP Provider: No such host is known",
                 "SQLOLEDB|SQLNCLI11": "TCP-connection\\(ERROR: getaddrinfo failed\\).*"
                 "could not open database requested by login",
                 "odbc-linux": "TCP-connection\\(ERROR: Temporary failure in name resolution\\).*"


### PR DESCRIPTION
### What does this PR do?
Currently, we read the port from the end of the `host` string for sqlserver connections. Let's allow users to pass an explicit `port` config for sqlserver connections, as we do with other databases. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
