### PR TITLE
Pin `pymysql` to `0.10.1`

### DIFF
--- a/cacti/pyproject.toml
+++ b/cacti/pyproject.toml
@@ -9,6 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-cacti"
 description = "The Cacti check"
 readme = "README.md"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",
@@ -33,9 +34,6 @@ dependencies = [
 dynamic = [
     "version",
 ]
-
-[project.license]
-text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [

--- a/cacti/pyproject.toml
+++ b/cacti/pyproject.toml
@@ -9,7 +9,6 @@ build-backend = "hatchling.build"
 name = "datadog-cacti"
 description = "The Cacti check"
 readme = "README.md"
-license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",
@@ -35,10 +34,12 @@ dynamic = [
     "version",
 ]
 
+[project.license]
+text = "BSD-3-Clause"
+
 [project.optional-dependencies]
 deps = [
-    "pymysql==0.10.1; python_version < '3.0'",
-    "pymysql==1.0.2; python_version > '3.0'",
+    "pymysql==0.10.1",
 ]
 
 [project.urls]

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -64,8 +64,7 @@ pyjwt==1.7.1; python_version < '3.0'
 pyjwt==2.4.0; python_version > '3.0'
 pymongo[srv]==3.12.3
 pymqi==1.12.0
-pymysql==0.10.1; python_version < '3.0'
-pymysql==1.0.2; python_version > '3.0'
+pymysql==0.10.1
 pyodbc==4.0.32
 pyro4==4.82; sys_platform == 'win32'
 pysmi==0.3.4

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -9,7 +9,6 @@ build-backend = "hatchling.build"
 name = "datadog-checks-base"
 description = "The Datadog Check Toolkit"
 readme = "README.md"
-license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "agent",
@@ -30,6 +29,9 @@ classifiers = [
 dynamic = [
     "version",
 ]
+
+[project.license]
+text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 db = [

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -9,6 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-checks-base"
 description = "The Datadog Check Toolkit"
 readme = "README.md"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "agent",
@@ -29,9 +30,6 @@ classifiers = [
 dynamic = [
     "version",
 ]
-
-[project.license]
-text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 db = [

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -9,7 +9,6 @@ build-backend = "hatchling.build"
 name = "datadog-mysql"
 description = "The MySQL check"
 readme = "README.md"
-license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",
@@ -35,6 +34,9 @@ dynamic = [
     "version",
 ]
 
+[project.license]
+text = "BSD-3-Clause"
+
 [project.optional-dependencies]
 deps = [
     "cachetools==3.1.1; python_version < '3.0'",
@@ -42,8 +44,7 @@ deps = [
     "cryptography==3.3.2; python_version < '3.0'",
     "cryptography==3.4.8; python_version > '3.0'",
     "futures==3.3.0; python_version < '3.0'",
-    "pymysql==0.10.1; python_version < '3.0'",
-    "pymysql==1.0.2; python_version > '3.0'",
+    "pymysql==0.10.1",
 ]
 
 [project.urls]

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -9,6 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-mysql"
 description = "The MySQL check"
 readme = "README.md"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",
@@ -33,9 +34,6 @@ dependencies = [
 dynamic = [
     "version",
 ]
-
-[project.license]
-text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [

--- a/proxysql/pyproject.toml
+++ b/proxysql/pyproject.toml
@@ -9,6 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-proxysql"
 description = "The ProxySQL check"
 readme = "README.md"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",
@@ -33,9 +34,6 @@ dependencies = [
 dynamic = [
     "version",
 ]
-
-[project.license]
-text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [

--- a/proxysql/pyproject.toml
+++ b/proxysql/pyproject.toml
@@ -9,7 +9,6 @@ build-backend = "hatchling.build"
 name = "datadog-proxysql"
 description = "The ProxySQL check"
 readme = "README.md"
-license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",
@@ -35,10 +34,12 @@ dynamic = [
     "version",
 ]
 
+[project.license]
+text = "BSD-3-Clause"
+
 [project.optional-dependencies]
 deps = [
-    "pymysql==0.10.1; python_version < '3.0'",
-    "pymysql==1.0.2; python_version > '3.0'",
+    "pymysql==0.10.1",
 ]
 
 [project.urls]

--- a/singlestore/pyproject.toml
+++ b/singlestore/pyproject.toml
@@ -9,7 +9,6 @@ build-backend = "hatchling.build"
 name = "datadog-singlestore"
 description = "The SingleStore check"
 readme = "README.md"
-license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",
@@ -35,10 +34,12 @@ dynamic = [
     "version",
 ]
 
+[project.license]
+text = "BSD-3-Clause"
+
 [project.optional-dependencies]
 deps = [
-    "pymysql==0.10.1; python_version < '3.0'",
-    "pymysql==1.0.2; python_version > '3.0'",
+    "pymysql==0.10.1",
 ]
 
 [project.urls]

--- a/singlestore/pyproject.toml
+++ b/singlestore/pyproject.toml
@@ -9,6 +9,7 @@ build-backend = "hatchling.build"
 name = "datadog-singlestore"
 description = "The SingleStore check"
 readme = "README.md"
+license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",
@@ -33,9 +34,6 @@ dependencies = [
 dynamic = [
     "version",
 ]
-
-[project.license]
-text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [


### PR DESCRIPTION
### What does this PR do?
We are currently shipping pymysql version `1.0.2`, but there is a [bug](https://github.com/PyMySQL/PyMySQL/issues/981) in this version, and there is no release with the fix yet. We have to revert this update until there is a new release of the library.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
