### PR TITLE
SQL Server: Use statement_start_offset to extract SQL text being run from Procedure text

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -47,7 +47,11 @@ SELECT
     DB_NAME(sess.database_id) as database_name,
     sess.status as session_status,
     req.status as request_status,
-    text.text as text,
+    SUBSTRING(text.text, (req.statement_start_offset / 2) + 1,
+    ((CASE req.statement_end_offset
+        WHEN -1 THEN DATALENGTH(text.text)
+        ELSE req.statement_end_offset END
+            - req.statement_start_offset) / 2) + 1) AS text,
     c.client_tcp_port as client_port,
     c.client_net_address as client_address,
     sess.host_name as host_name,

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -9,6 +9,7 @@ from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
+from datadog_checks.sqlserver.utils import is_statement_proc
 
 try:
     import datadog_agent
@@ -56,9 +57,6 @@ SELECT
     c.client_tcp_port as client_port,
     c.client_net_address as client_address,
     sess.host_name as host_name,
-    (SELECT IIF (EXISTS
-        (SELECT 1 FROM sys.dm_exec_procedure_stats proc_stats
-            WHERE proc_stats.plan_handle = req.plan_handle), 1, 0)) as is_proc,
     {exec_request_columns}
 FROM sys.dm_exec_sessions sess
     INNER JOIN sys.dm_exec_connections c
@@ -214,7 +212,7 @@ class SqlserverActivity(DBMAsyncJob):
             statement = obfuscate_sql_with_metadata(row['statement_text'], self.check.obfuscator_options)
             procedure_statement = None
             # sqlserver doesn't have a boolean data type so convert integer to boolean
-            row['is_proc'] = row['is_proc'] == 1
+            row['is_proc'] = is_statement_proc(row['text'])
             if row['is_proc'] and 'text' in row:
                 procedure_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             obfuscated_statement = statement['query']

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -211,7 +211,7 @@ class SqlserverActivity(DBMAsyncJob):
         try:
             statement = obfuscate_sql_with_metadata(row['statement_text'], self.check.obfuscator_options)
             procedure_statement = None
-            # sqlserver doesn't have a boolean data type so we use 1 == True
+            # sqlserver doesn't have a boolean data type so convert integer to boolean
             row['is_proc'] = row['is_proc'] == 1
             if row['is_proc'] and 'text' in row:
                 procedure_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -56,7 +56,9 @@ SELECT
     c.client_tcp_port as client_port,
     c.client_net_address as client_address,
     sess.host_name as host_name,
-    (SELECT IIF (EXISTS (SELECT 1 FROM sys.dm_exec_procedure_stats WHERE object_id = qt.objectid), 1, 0)) as is_proc,
+    (SELECT IIF (EXISTS
+        (SELECT 1 FROM sys.dm_exec_procedure_stats proc_stats
+            WHERE proc_stats.plan_handle = req.plan_handle), 1, 0)) as is_proc,
     {exec_request_columns}
 FROM sys.dm_exec_sessions sess
     INNER JOIN sys.dm_exec_connections c

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -211,6 +211,8 @@ class SqlserverActivity(DBMAsyncJob):
         try:
             statement = obfuscate_sql_with_metadata(row['statement_text'], self.check.obfuscator_options)
             procedure_statement = None
+            # sqlserver doesn't have a boolean data type so we use 1 == True
+            row['is_proc'] = row['is_proc'] == 1
             if row['is_proc'] and 'text' in row:
                 procedure_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             obfuscated_statement = statement['query']

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -236,14 +236,16 @@ class SqlserverActivity(DBMAsyncJob):
 
     @staticmethod
     def _sanitize_row(row, obfuscated_statement):
-        row['statement_text'] = obfuscated_statement
+        # rename the statement_text field to 'text' because that
+        # is what our backend is expecting
+        row['text'] = obfuscated_statement
         if 'query_hash' in row:
             row['query_hash'] = _hash_to_hex(row['query_hash'])
         if 'query_plan_hash' in row:
             row['query_plan_hash'] = _hash_to_hex(row['query_plan_hash'])
         # remove deobfuscated sql text from event
-        if 'text' in row:
-            del row['text']
+        if 'statement_text' in row:
+            del row['statement_text']
         return row
 
     @staticmethod

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -81,7 +81,7 @@ select
             - statement_start_offset) / 2) + 1) AS statement_text,
     qt.text,
     encrypted as is_encrypted,
-    (SELECT IIF (EXISTS (SELECT 1 FROM sys.dm_exec_procedure_stats WHERE object_id =qt.objectid), 1, 0)) as is_proc,
+    (SELECT IIF (EXISTS (SELECT 1 FROM sys.dm_exec_procedure_stats proc_stats WHERE proc_stats.plan_handle = qstats_aggr_split.plan_handle), 1, 0)) as is_proc,
     * from qstats_aggr_split
     cross apply sys.dm_exec_sql_text(plan_handle) qt
 """
@@ -114,7 +114,7 @@ select
     END - statement_start_offset) / 2) + 1) AS statement_text,
     qt.text,
     encrypted as is_encrypted,
-    (SELECT IIF (EXISTS (SELECT 1 FROM sys.dm_exec_procedure_stats WHERE object_id = qt.objectid), 1, 0)) as is_proc,
+    (SELECT IIF (EXISTS (SELECT 1 FROM sys.dm_exec_procedure_stats proc_stats WHERE proc_stats.plan_handle = qstats_aggr_split.plan_handle), 1, 0)) as is_proc,
     * from qstats_aggr_split
     cross apply sys.dm_exec_sql_text(plan_handle) qt
 """

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -274,7 +274,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     procedure_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             except Exception as e:
                 # obfuscation errors are relatively common so only log them during debugging
-                self.log.warning("unable to obfuscate query: %s", row['statement_text'])
                 self.log.debug("Failed to obfuscate query: %s", e)
                 self.check.count(
                     "dd.sqlserver.statements.error",
@@ -321,9 +320,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         return row
 
     def _to_metrics_payload(self, rows):
-        sql_rows = [self._to_metrics_payload_row(r) for r in rows]
-        for r in sql_rows:
-            self.log.warning("query: %s", r['statement_text'])
         return {
             'host': self.check.resolved_hostname,
             'timestamp': time.time() * 1000,
@@ -471,7 +467,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                 text_key = 'statement_text'
                 if row['is_proc']:
                     text_key = 'procedure_text'
-                    self.log.warning("proc text: %s", row["procedure_text"])
                 if 'database_name' in row:
                     tags += ["db:{}".format(row['database_name'])]
                 yield {

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -81,7 +81,9 @@ select
             - statement_start_offset) / 2) + 1) AS statement_text,
     qt.text,
     encrypted as is_encrypted,
-    (SELECT IIF (EXISTS (SELECT 1 FROM sys.dm_exec_procedure_stats proc_stats WHERE proc_stats.plan_handle = qstats_aggr_split.plan_handle), 1, 0)) as is_proc,
+    (SELECT IIF (EXISTS
+        (SELECT 1 FROM sys.dm_exec_procedure_stats proc_stats
+            WHERE proc_stats.plan_handle = qstats_aggr_split.plan_handle), 1, 0)) as is_proc,
     * from qstats_aggr_split
     cross apply sys.dm_exec_sql_text(plan_handle) qt
 """
@@ -114,7 +116,9 @@ select
     END - statement_start_offset) / 2) + 1) AS statement_text,
     qt.text,
     encrypted as is_encrypted,
-    (SELECT IIF (EXISTS (SELECT 1 FROM sys.dm_exec_procedure_stats proc_stats WHERE proc_stats.plan_handle = qstats_aggr_split.plan_handle), 1, 0)) as is_proc,
+    (SELECT IIF (EXISTS
+        (SELECT 1 FROM sys.dm_exec_procedure_stats proc_stats
+            WHERE proc_stats.plan_handle = qstats_aggr_split.plan_handle), 1, 0)) as is_proc,
     * from qstats_aggr_split
     cross apply sys.dm_exec_sql_text(plan_handle) qt
 """

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -73,6 +73,7 @@ select
         WHEN -1 THEN DATALENGTH(text)
         ELSE statement_end_offset END
             - statement_start_offset) / 2) + 1) AS statement_text,
+    qt.text,
     encrypted as is_encrypted,
     (SELECT IIF (EXISTS (SELECT 1 FROM sys.dm_exec_procedure_stats WHERE object_id =qt.objectid), 1, 0)) as is_proc,
     * from qstats_aggr
@@ -97,6 +98,7 @@ select
         WHEN -1 THEN DATALENGTH(text)
         ELSE statement_end_offset
     END - statement_start_offset) / 2) + 1) AS statement_text,
+    qt.text,
     encrypted as is_encrypted,
     (SELECT IIF (EXISTS (SELECT 1 FROM sys.dm_exec_procedure_stats WHERE object_id = qt.objectid), 1, 0)) as is_proc,
     * from qstats_aggr

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -17,6 +17,7 @@ from datadog_checks.base.utils.db.utils import (
 )
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
+from datadog_checks.sqlserver.utils import is_statement_proc
 
 try:
     import datadog_agent
@@ -81,9 +82,6 @@ select
             - statement_start_offset) / 2) + 1) AS statement_text,
     qt.text,
     encrypted as is_encrypted,
-    (SELECT IIF (EXISTS
-        (SELECT 1 FROM sys.dm_exec_procedure_stats proc_stats
-            WHERE proc_stats.plan_handle = qstats_aggr_split.plan_handle), 1, 0)) as is_proc,
     * from qstats_aggr_split
     cross apply sys.dm_exec_sql_text(plan_handle) qt
 """
@@ -116,9 +114,6 @@ select
     END - statement_start_offset) / 2) + 1) AS statement_text,
     qt.text,
     encrypted as is_encrypted,
-    (SELECT IIF (EXISTS
-        (SELECT 1 FROM sys.dm_exec_procedure_stats proc_stats
-            WHERE proc_stats.plan_handle = qstats_aggr_split.plan_handle), 1, 0)) as is_proc,
     * from qstats_aggr_split
     cross apply sys.dm_exec_sql_text(plan_handle) qt
 """
@@ -288,7 +283,8 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             try:
                 statement = obfuscate_sql_with_metadata(row['statement_text'], self.check.obfuscator_options)
                 procedure_statement = None
-                if row['is_proc'] and 'text' in row:
+                row['is_proc'] = is_statement_proc(row['text'])
+                if row['is_proc']:
                     procedure_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             except Exception as e:
                 # obfuscation errors are relatively common so only log them during debugging
@@ -446,9 +442,9 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             plan_key = (row['query_signature'], row['query_hash'], row['query_plan_hash'])
             # for stored procedures, we only want to look up plans for the entire procedure
             # not every query that is executed within the proc. In order to accomplish this,
-            # we use the procedure_signature as the plan key
-            if row['is_proc']:
-                plan_key = row['procedure_signature']
+            # we use the plan handle
+            if row['is_proc'] or row['is_encrypted']:
+                plan_key = row['plan_handle']
             if self._seen_plans_ratelimiter.acquire(plan_key):
                 raw_plan, is_plan_encrypted = self._load_plan(row['plan_handle'], cursor)
                 obfuscated_plan, collection_errors = None, None

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -25,6 +25,27 @@ def construct_use_statement(database):
     return 'use [{}]'.format(database)
 
 
+def is_statement_proc(text):
+    if text:
+        # take first 500 chars, upper case and split into string
+        # to get individual keywords
+        t = text[0:500].upper().split()
+        idx_create = _get_index_for_keyword(t, 'CREATE')
+        idx_proc = _get_index_for_keyword(t, 'PROCEDURE')
+        if idx_proc < 0:
+            idx_proc = _get_index_for_keyword(t, 'PROC')
+        # ensure either PROC or PROCEDURE are found and CREATE occurs before PROCEDURE
+        return 0 <= idx_create < idx_proc and idx_proc >= 0
+    return False
+
+
+def _get_index_for_keyword(text, keyword):
+    try:
+        return text.index(keyword)
+    except ValueError:
+        return -1
+
+
 def parse_sqlserver_major_version(version):
     """
     Parses the SQL Server major version out of the full version

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -50,6 +50,15 @@ EXEC sp_addrolemember 'db_datareader', 'fred'
 EXEC sp_addrolemember 'db_datawriter', 'bob'
 GO
 
+CREATE PROCEDURE bobProc AS
+BEGIN
+    SELECT * FROM ϑings;
+END;
+GO
+
+GRANT EXECUTE on bobProc to bob;
+GO
+
 -- create test procedure for metrics loading feature
 USE master;
 GO

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -92,6 +92,19 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on encryptedProc to bob;
+GO
+
+-- create test procedure with multiple queries
+CREATE PROCEDURE multiQueryProc AS
+BEGIN
+    declare @total int = 0;
+    select @total = @total + count(*) from sys.databases where name like '%_';
+    select @total = @total + count(*) from sys.sysobjects where type = 'U';
+    select @total;
+END;
+GO
+GRANT EXECUTE on multiQueryProc to bob;
+GO
 
 -----------------------------------
 -- AGOG setup

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -65,6 +65,7 @@ GO
 
 GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
+GRANT EXECUTE on bobProc to fred;
 GO
 
 -- create test procedure for metrics loading feature

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -56,6 +56,14 @@ BEGIN
 END;
 GO
 
+CREATE PROCEDURE bobProcParams @P1 INT = NULL, @P2 nvarchar(8) = NULL AS
+BEGIN
+    SELECT * FROM ϑings WHERE id = @P1;
+    SELECT id FROM ϑings WHERE name = @P2;
+END;
+GO
+
+GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
 GO
 

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -53,6 +53,15 @@ EXEC sp_addrolemember 'db_datareader', 'fred'
 EXEC sp_addrolemember 'db_datawriter', 'bob'
 GO
 
+CREATE PROCEDURE bobProc AS
+BEGIN
+    SELECT * FROM ϑings;
+END;
+GO
+
+GRANT EXECUTE on bobProc to bob;
+GO
+
 -- create an offline database to have an unavailable database to test with
 CREATE DATABASE unavailable_db;
 GO

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -68,6 +68,7 @@ GO
 
 GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
+GRANT EXECUTE on bobProc to fred;
 GO
 
 -- create an offline database to have an unavailable database to test with

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -108,6 +108,19 @@ select count(*) from sys.databases;
 END;
 GO
 GRANT EXECUTE on encryptedProc to bob;
+GO
+
+-- create test procedure with multiple queries
+CREATE PROCEDURE multiQueryProc AS
+BEGIN
+    declare @total int = 0;
+    select @total = @total + count(*) from sys.databases where name like '%_';
+    select @total = @total + count(*) from sys.sysobjects where type = 'U';
+    select @total;
+END;
+GO
+GRANT EXECUTE on multiQueryProc to bob;
+GO
 
 ------------------------------ HIGH CARDINALITY ENV SETUP ------------------------------
 

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -59,6 +59,14 @@ BEGIN
 END;
 GO
 
+CREATE PROCEDURE bobProcParams @P1 INT = NULL, @P2 nvarchar(8) = NULL AS
+BEGIN
+    SELECT * FROM ϑings WHERE id = @P1;
+    SELECT id FROM ϑings WHERE name = @P2;
+END;
+GO
+
+GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
 GO
 

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -104,6 +104,7 @@ GO
 
 GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
+GRANT EXECUTE on bobProc to fred;
 GO
 
 -- create an offline database to have an unavailable database to test with

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -95,6 +95,14 @@ BEGIN
 END;
 GO
 
+CREATE PROCEDURE bobProcParams @P1 INT = NULL, @P2 nvarchar(8) = NULL AS
+BEGIN
+    SELECT * FROM ϑings WHERE id = @P1;
+    SELECT id FROM ϑings WHERE name = @P2;
+END;
+GO
+
+GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
 GO
 

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -57,6 +57,19 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on encryptedProc to bob;
+GO
+
+-- create test procedure with multiple queries
+CREATE PROCEDURE multiQueryProc AS
+BEGIN
+    declare @total int = 0;
+    select @total = @total + count(*) from sys.databases where name like '%_';
+    select @total = @total + count(*) from sys.sysobjects where type = 'U';
+    select @total;
+END;
+GO
+GRANT EXECUTE on multiQueryProc to bob;
+GO
 
 -- Create test database for integration tests.
 -- Only bob and fred have read/write access to this database.

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -89,6 +89,15 @@ EXEC sp_addrolemember 'db_datawriter', 'bob'
 EXEC sp_addrolemember 'db_datareader', 'fred'
 GO
 
+CREATE PROCEDURE bobProc AS
+BEGIN
+    SELECT * FROM ϑings;
+END;
+GO
+
+GRANT EXECUTE on bobProc to bob;
+GO
+
 -- create an offline database to have an unavailable database to test with
 CREATE DATABASE unavailable_db;
 GO

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -59,12 +59,6 @@ BEGIN
 END;
 GO
 
-CREATE PROCEDURE bobProcParams AS
-BEGIN
-    SELECT * FROM ϑings;
-END;
-GO
-
 CREATE PROCEDURE bobProcParams @P1 INT = NULL, @P2 nvarchar(8) = NULL AS
 BEGIN
     SELECT * FROM ϑings WHERE id = @P1;

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -53,6 +53,14 @@ EXEC sp_addrolemember 'db_datareader', 'fred'
 EXEC sp_addrolemember 'db_datawriter', 'bob'
 GO
 
+CREATE PROCEDURE bobProc AS
+BEGIN
+    SELECT * FROM ϑings;
+END;
+GO
+GRANT EXECUTE on bobProc to bob;
+GO
+
 -- create an offline database to have an unavailable database to test with
 CREATE DATABASE unavailable_db;
 GO
@@ -108,3 +116,16 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on encryptedProc to bob;
+GO
+
+-- create test procedure with multiple queries
+CREATE PROCEDURE multiQueryProc AS
+BEGIN
+    declare @total int = 0;
+    select @total = @total + count(*) from sys.databases where name like '%_';
+    select @total = @total + count(*) from sys.sysobjects where type = 'U';
+    select @total;
+END;
+GO
+GRANT EXECUTE on multiQueryProc to bob;
+GO

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -73,6 +73,7 @@ END;
 GO
 GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
+GRANT EXECUTE on bobProc to fred;
 GO
 
 -- create an offline database to have an unavailable database to test with

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -58,6 +58,7 @@ BEGIN
     SELECT * FROM ϑings;
 END;
 GO
+
 GRANT EXECUTE on bobProc to bob;
 GO
 

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -59,6 +59,19 @@ BEGIN
 END;
 GO
 
+CREATE PROCEDURE bobProcParams AS
+BEGIN
+    SELECT * FROM ϑings;
+END;
+GO
+
+CREATE PROCEDURE bobProcParams @P1 INT = NULL, @P2 nvarchar(8) = NULL AS
+BEGIN
+    SELECT * FROM ϑings WHERE id = @P1;
+    SELECT id FROM ϑings WHERE name = @P2;
+END;
+GO
+GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
 GO
 

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -39,6 +39,14 @@ BEGIN
 END;
 GO
 
+CREATE PROCEDURE bobProcParams @P1 INT = NULL, @P2 nvarchar(8) = NULL AS
+BEGIN
+    SELECT * FROM ϑings WHERE id = @P1;
+    SELECT id FROM ϑings WHERE name = @P2;
+END;
+GO
+
+GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
 GO
 

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -48,6 +48,7 @@ GO
 
 GRANT EXECUTE on bobProcParams to bob;
 GRANT EXECUTE on bobProc to bob;
+GRANT EXECUTE on bobProc to fred;
 GO
 
 -- create an offline database to have an unavailable database to test with

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -88,3 +88,16 @@ BEGIN
 END;
 GO
 GRANT EXECUTE on encryptedProc to bob;
+GO
+
+-- create test procedure with multiple queries
+CREATE PROCEDURE multiQueryProc AS
+BEGIN
+    declare @total int = 0;
+    select @total = @total + count(*) from sys.databases where name like '%_';
+    select @total = @total + count(*) from sys.sysobjects where type = 'U';
+    select @total;
+END;
+GO
+GRANT EXECUTE on multiQueryProc to bob;
+GO

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -33,6 +33,15 @@ EXEC sp_addrolemember 'db_datareader', 'fred'
 EXEC sp_addrolemember 'db_datawriter', 'bob'
 GO
 
+CREATE PROCEDURE bobProc AS
+BEGIN
+    SELECT * FROM ϑings;
+END;
+GO
+
+GRANT EXECUTE on bobProc to bob;
+GO
+
 -- create an offline database to have an unavailable database to test with
 CREATE DATABASE unavailable_db;
 GO

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -71,13 +71,6 @@ test_collect_load_activity_parameterized = (
             "datadog_test",
             "EXEC bobProc",
             r"SELECT \* FROM ϑings",
-            True,
-            True,
-        ],
-        [
-            "datadog_test",
-            "EXEC bobProc",
-            r"SELECT \* FROM ϑings",
             False,
             True,
         ],

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -159,10 +159,10 @@ def test_collect_load_activity(
     assert blocked_row['request_status'] == "suspended", "incorrect request_status"
     assert blocked_row['blocking_session_id'], "missing blocking_session_id"
     assert blocked_row['is_proc'] == is_proc
-    assert 'text' not in blocked_row, "text field should not be forwarded"
+    assert 'statement_text' not in blocked_row, "statement_text field should not be forwarded"
     if is_proc:
         assert blocked_row['procedure_signature'], "missing procedure signature"
-    assert re.match(match_pattern, blocked_row['statement_text'], re.IGNORECASE), "incorrect blocked query"
+    assert re.match(match_pattern, blocked_row['text'], re.IGNORECASE), "incorrect blocked query"
     assert blocked_row['database_name'] == "datadog_test", "incorrect database_name"
     assert blocked_row['id'], "missing session id"
     assert blocked_row['now'], "missing current timestamp"
@@ -328,7 +328,7 @@ def very_old_time():
                     'last_request_start_time': 'suspended',
                     'id': 1,
                     'user_name': 'oldbob',
-                    'statement_text': "something",
+                    'text': "something",
                     'start_time': 2,
                     'query_start': old_time(),
                 },
@@ -336,14 +336,14 @@ def very_old_time():
                     'last_request_start_time': 'suspended',
                     'id': 1,
                     'user_name': 'olderbob',
-                    'statement_text': "something",
+                    'text': "something",
                     'start_time': 2,
                     'query_start': very_old_time(),
                 },
                 {
                     'last_request_start_time': 'suspended',
                     'id': 2,
-                    'statement_text': "something",
+                    'text': "something",
                     'user_name': 'bigbob',
                     'start_time': 2,
                     'query_start': new_time(),
@@ -353,7 +353,7 @@ def very_old_time():
                     'last_request_start_time': 'suspended',
                     'id': 1,
                     'user_name': 'onlytxbob',
-                    'statement_text': "something",
+                    'text': "something",
                     'start_time': 2,
                     'transaction_begin_time': very_old_time(),
                 },
@@ -367,7 +367,7 @@ def very_old_time():
                     'last_request_start_time': 'suspended',
                     'id': 1,
                     'user_name': 'newbob',
-                    'statement_text': "something",
+                    'text': "something",
                     'start_time': 2,
                     'query_start': new_time(),
                 },
@@ -375,14 +375,14 @@ def very_old_time():
                     'last_request_start_time': 'suspended',
                     'id': 1,
                     'user_name': 'oldestbob',
-                    'statement_text': "something",
+                    'text': "something",
                     'start_time': 2,
                     'query_start': very_old_time(),
                 },
                 {
                     'last_request_start_time': 'suspended',
                     'id': 2,
-                    'statement_text': "something",
+                    'text': "something",
                     'user_name': 'bigbob',
                     'start_time': 2,
                     'query_start': old_time(),
@@ -394,9 +394,9 @@ def very_old_time():
         ],
         [
             [
-                {'user_name': 'newbob', 'id': 1, 'statement_text': "something", 'query_start': new_time()},
-                {'user_name': 'oldbob', 'id': 2, 'statement_text': "something", 'query_start': old_time()},
-                {'user_name': 'olderbob', 'id': 2, 'statement_text': "something", 'query_start': very_old_time()},
+                {'user_name': 'newbob', 'id': 1, 'text': "something", 'query_start': new_time()},
+                {'user_name': 'oldbob', 'id': 2, 'text': "something", 'query_start': old_time()},
+                {'user_name': 'olderbob', 'id': 2, 'text': "something", 'query_start': very_old_time()},
             ],
             3,
             ["olderbob", "oldbob", "newbob"],
@@ -406,7 +406,7 @@ def very_old_time():
                 {
                     'user_name': 'bigbob',
                     'id': 1,
-                    'statement_text': "something",
+                    'text': "something",
                     'toobig': "shame" * 10000,
                 },
             ],

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -50,44 +50,26 @@ def dbm_instance(instance_docker):
     return copy(instance_docker)
 
 
-test_collect_load_activity_parameterized = (
-    "database,query,match_pattern,use_autocommit,is_proc",
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize("use_autocommit", [True, False])
+@pytest.mark.parametrize(
+    "database,query,match_pattern,is_proc",
     [
         [
             "datadog_test",
             "SELECT * FROM ϑings",
             r"SELECT \* FROM ϑings",
             False,
-            False,
-        ],
-        [
-            "datadog_test",
-            "SELECT * FROM ϑings",
-            r"SELECT \* FROM ϑings",
-            True,
-            False,
         ],
         [
             "datadog_test",
             "EXEC bobProc",
             r"SELECT \* FROM ϑings",
             True,
-            True,
-        ],
-        [
-            "datadog_test",
-            "EXEC bobProc",
-            r"SELECT \* FROM ϑings",
-            False,
-            True,
-        ],
+        ]
     ],
 )
-
-
-@pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
-@pytest.mark.parametrize(*test_collect_load_activity_parameterized)
 def test_collect_load_activity(
     aggregator,
     instance_docker,

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -67,7 +67,7 @@ def dbm_instance(instance_docker):
             "EXEC bobProc",
             r"SELECT \* FROM ϑings",
             True,
-        ]
+        ],
     ],
 )
 def test_collect_load_activity(
@@ -75,9 +75,9 @@ def test_collect_load_activity(
     instance_docker,
     dd_run_check,
     dbm_instance,
+    use_autocommit,
     database,
     query,
-    use_autocommit,
     match_pattern,
     is_proc,
 ):
@@ -90,6 +90,12 @@ def test_collect_load_activity(
         cur = c.cursor()
         cur.execute("USE {}".format(database))
         cur.execute(q)
+
+    # run the test query once before the blocking test to ensure that if it's
+    # a procedure then it is populated in the sys.dm_exec_procedure_stats table
+    # the first time a procedure is run we won't know it's a procedure because
+    # it won't appear in that stats table
+    run_test_query(fred_conn, query)
 
     # bob's query blocks until the tx is completed
     run_test_query(bob_conn, blocking_query)

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -71,6 +71,13 @@ test_collect_load_activity_parameterized = (
             "datadog_test",
             "EXEC bobProc",
             r"SELECT \* FROM ϑings",
+            True,
+            True,
+        ],
+        [
+            "datadog_test",
+            "EXEC bobProc",
+            r"SELECT \* FROM ϑings",
             False,
             True,
         ],

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -176,7 +176,7 @@ def test_activity_metadata(
     query = '''
     -- Test comment
     SELECT * FROM ϑings'''
-    query_signature = '5ff34f4267b108c6'
+    query_signature = '2fa838aee8217d23'
     blocking_query = "INSERT INTO ϑings WITH (TABLOCK, HOLDLOCK) (name) VALUES ('puppy')"
 
     bob_conn = _get_conn_for_user(instance_docker, 'bob')

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -110,71 +110,171 @@ def test_get_statement_metrics_query_cached(aggregator, dbm_instance, caplog):
 
 
 test_statement_metrics_and_plans_parameterized = (
-    "database,query,match_pattern,param_groups,is_encrypted,disable_secondary_tags",
+    "database,query,expected_queries_patterns,param_groups,exe_count,is_encrypted,is_proc,disable_secondary_tags",
     [
+        [
+            "master",
+            "EXEC multiQueryProc",
+            [
+                r"select @total = @total \+ count\(\*\) from sys\.databases where name like '%_'",
+                r"select @total = @total \+ count\(\*\) from sys\.sysobjects where type = 'U'",
+            ],
+            ((),),
+            1,
+            False,
+            True,
+            True,
+        ],
+        [
+            "master",
+            "EXEC multiQueryProc",
+            [
+                r"select @total = @total \+ count\(\*\) from sys\.databases where name like '%_'",
+                r"select @total = @total \+ count\(\*\) from sys\.sysobjects where type = 'U'",
+            ],
+            ((),),
+            5,
+            False,
+            True,
+            True,
+        ],
+        [
+            "master",
+            "EXEC encryptedProc",
+            [""],
+            ((),),
+            5,
+            True,
+            True,
+            True,
+        ],
         [
             "datadog_test",
             "SELECT * FROM ϑings",
-            r"SELECT \* FROM ϑings",
+            [r"SELECT \* FROM ϑings"],
             ((),),
+            1,
+            False,
             False,
             False,
         ],
         [
             "datadog_test",
             "SELECT * FROM ϑings where id = ?",
-            r"SELECT \* FROM ϑings where id = @P1",
+            [r"SELECT \* FROM ϑings where id = @P1"],
             (
                 (1,),
                 (2,),
                 (3,),
             ),
+            1,
+            False,
             False,
             False,
         ],
         [
+            "datadog_test",
+            "EXEC bobProc",
+            [r"SELECT \* FROM ϑings"],
+            ((),),
+            1,
+            False,
+            True,
+            True,
+        ],
+        [
+            "datadog_test",
+            "EXEC bobProc",
+            [r"SELECT \* FROM ϑings"],
+            ((),),
+            10,
+            False,
+            True,
+            True,
+        ],
+        [
             "master",
             "SELECT * FROM datadog_test.dbo.ϑings where id = ?",
-            r"SELECT \* FROM datadog_test.dbo.ϑings where id = @P1",
+            [r"SELECT \* FROM datadog_test.dbo.ϑings where id = @P1"],
             (
                 (1,),
                 (2,),
                 (3,),
             ),
+            1,
+            False,
             False,
             False,
         ],
         [
             "datadog_test",
             "SELECT * FROM ϑings where id = ? and name = ?",
-            r"SELECT \* FROM ϑings where id = @P1 and name = @P2",
+            [r"SELECT \* FROM ϑings where id = @P1 and name = @P2"],
             (
                 (1, "hello"),
                 (2, "there"),
                 (3, "bill"),
             ),
+            1,
+            False,
             False,
             False,
         ],
         [
             "datadog_test",
             "SELECT * FROM ϑings where id = ?",
-            r"SELECT \* FROM ϑings where id = @P1",
+            [r"SELECT \* FROM ϑings where id = @P1"],
             (
                 (1,),
                 (2,),
                 (3,),
             ),
+            1,
+            False,
             False,
             True,
         ],
         [
             "master",
             "EXEC encryptedProc",
-            None,
+            [""],
             ((),),
+            1,
+            True,
             True,
             False,
+        ],
+        [
+            "datadog_test",
+            "EXEC bobProcParams @P1 = ?, @P2 = ?",
+            [
+                r"SELECT \* FROM ϑings WHERE id = @P1",
+                r"SELECT id FROM ϑings WHERE name = @P2",
+            ],
+            (
+                (1, "foo"),
+                (2, "bar"),
+            ),
+            1,
+            False,
+            True,
+            True,
+        ],
+        [
+            "datadog_test",
+            "EXEC bobProcParams @P1 = ?, @P2 = ?",
+            [
+                r"SELECT \* FROM ϑings WHERE id = @P1",
+                r"SELECT id FROM ϑings WHERE name = @P2",
+            ],
+            (
+                (1, "foo"),
+                (2, "bar"),
+            ),
+            5,
+            False,
+            True,
+            True,
         ],
     ],
 )
@@ -191,9 +291,11 @@ def test_statement_metrics_and_plans(
     database,
     query,
     param_groups,
+    exe_count,
     is_encrypted,
+    is_proc,
     disable_secondary_tags,
-    match_pattern,
+    expected_queries_patterns,
     caplog,
     datadog_agent,
 ):
@@ -208,12 +310,14 @@ def test_statement_metrics_and_plans(
     # 2) load the test queries into the StatementMetrics state
     # 3) emit the query metrics based on the diff of current and last state
     dd_run_check(check)
-    for params in param_groups:
-        bob_conn.execute_with_retries(query, params, database=database)
+    for _ in range(0, exe_count):
+        for params in param_groups:
+            bob_conn.execute_with_retries(query, params, database=database)
     dd_run_check(check)
     aggregator.reset()
-    for params in param_groups:
-        bob_conn.execute_with_retries(query, params, database=database)
+    for _ in range(0, exe_count):
+        for params in param_groups:
+            bob_conn.execute_with_retries(query, params, database=database)
     dd_run_check(check)
 
     _conn_key_prefix = "dbm-"
@@ -239,13 +343,16 @@ def test_statement_metrics_and_plans(
     # metrics rows
     sqlserver_rows = payload.get('sqlserver_rows', [])
     assert sqlserver_rows, "should have collected some sqlserver query metrics rows"
-    if match_pattern:
-        matching_rows = [r for r in sqlserver_rows if re.match(match_pattern, r['statement_text'], re.IGNORECASE)]
-    else:
+    match_pattern = "(" + ")|(".join(expected_queries_patterns) + ")"
+    if is_encrypted:
         matching_rows = [r for r in sqlserver_rows if not r['statement_text']]
-    assert len(matching_rows) >= 1, "expected at least one matching metrics row"
+    else:
+        matching_rows = [r for r in sqlserver_rows if re.match(match_pattern, r['statement_text'], re.IGNORECASE)]
+    assert len(matching_rows) == len(expected_queries_patterns), "missing expected matching rows"
     total_execution_count = sum([r['execution_count'] for r in matching_rows])
-    assert total_execution_count == len(param_groups), "wrong execution count"
+    assert (
+        total_execution_count == len(param_groups) * len(expected_queries_patterns) * exe_count
+    ), "wrong execution count"
     for row in matching_rows:
         if is_encrypted:
             # we get NULL text for encrypted statements so we have no calculated query signature
@@ -253,6 +360,9 @@ def test_statement_metrics_and_plans(
         else:
             assert row['query_signature'], "missing query signature"
         assert row['is_encrypted'] == is_encrypted
+        assert row['is_proc'] == is_proc
+        if is_proc and not is_encrypted:
+            assert row['procedure_signature'], "missing proc signature"
         if disable_secondary_tags:
             assert 'database_name' not in row
         else:
@@ -260,14 +370,18 @@ def test_statement_metrics_and_plans(
         for column in available_query_metrics_columns:
             assert column in row, "missing required metrics column {}".format(column)
             assert type(row[column]) in (float, int), "wrong type for metrics column {}".format(column)
+    if is_proc:
+        # all the plan handles should be the same for the same procedure execution
+        assert all(row['plan_handle'] == matching_rows[0]['plan_handle'] for row in matching_rows)
 
     dbm_samples = aggregator.get_event_platform_events("dbm-samples")
     assert dbm_samples, "should have collected at least one sample"
 
-    if match_pattern:
-        matching_samples = [s for s in dbm_samples if re.match(match_pattern, s['db']['statement'], re.IGNORECASE)]
-    else:
+    if is_encrypted:
         matching_samples = [s for s in dbm_samples if not s['db']['statement']]
+    else:
+        matching_samples = [s for s in dbm_samples if re.search(match_pattern, s['db']['statement'], re.IGNORECASE)]
+
     assert matching_samples, "should have collected some matching samples"
 
     # validate common host fields
@@ -283,7 +397,9 @@ def test_statement_metrics_and_plans(
             ), "wrong instance tags for plan event"
 
     plan_events = [s for s in matching_samples if s['dbm_type'] == "plan"]
-    assert plan_events, "should have collected some plans"
+    # plan sampling should limit the number of plans we collect per query/ proc
+    # to one, despite changing parameters or mult queries in a single proc
+    assert len(plan_events) == 1, "should have collected exactly one plan event"
 
     for event in plan_events:
         if is_encrypted:
@@ -296,9 +412,13 @@ def test_statement_metrics_and_plans(
             assert parsed_plan.tag.endswith("ShowPlanXML"), "plan does not match expected structure"
             assert not event['sqlserver']['is_plan_encrypted']
             assert not event['sqlserver']['is_statement_encrypted']
+        if is_proc and not is_encrypted:
+            assert row['procedure_signature'], "missing proc signature"
 
     fqt_events = [s for s in matching_samples if s['dbm_type'] == "fqt"]
-    assert fqt_events, "should have collected some FQT events"
+    assert len(fqt_events) == len(
+        expected_queries_patterns
+    ), "should have collected an FQT event per unique query signature"
 
     # internal debug metrics
     aggregator.assert_metric(
@@ -306,150 +426,6 @@ def test_statement_metrics_and_plans(
         tags=['agent_hostname:stubbed.hostname', 'operation:collect_statement_metrics_and_plans']
         + _expected_dbm_instance_tags(dbm_instance),
     )
-
-
-test_statement_metrics_procedure_stats_parameterized = (
-    "database,procedure,expected_queries_patterns,execution_count,is_encrypted",
-    [
-        [
-            "master",
-            "EXEC multiQueryProc",
-            [
-                r"select @total = @total \+ count\(\*\) from sys\.databases where name like '%_'",
-                r"select @total = @total \+ count\(\*\) from sys\.sysobjects where type = 'U'",
-            ],
-            1,
-            False,
-        ],
-        [
-            "master",
-            "EXEC multiQueryProc",
-            [
-                r"select @total = @total \+ count\(\*\) from sys\.databases where name like '%_'",
-                r"select @total = @total \+ count\(\*\) from sys\.sysobjects where type = 'U'",
-            ],
-            5,
-            False,
-        ],
-        ["master", "EXEC encryptedProc", [""], 5, True],
-        ["datadog_test", "EXEC bobProc", [r"SELECT \* FROM ϑings"], 1, False],
-        ["datadog_test", "EXEC bobProc", [r"SELECT \* FROM ϑings"], 10, False],
-    ],
-)
-
-
-@pytest.mark.integration
-@pytest.mark.usefixtures('dd_environment')
-@pytest.mark.parametrize(*test_statement_metrics_procedure_stats_parameterized)
-def test_statement_metrics_procedure_stats(
-    database,
-    procedure,
-    expected_queries_patterns,
-    execution_count,
-    is_encrypted,
-    datadog_agent,
-    dbm_instance,
-    bob_conn,
-    aggregator,
-    dd_run_check,
-):
-    # load statement_metrics_query
-    check = SQLServer(CHECK_NAME, {}, [dbm_instance])
-    check.initialize_connection()
-
-    # the check must be run three times:
-    # 1) set _last_stats_query_time (this needs to happen before the 1st test queries to ensure the query time
-    # interval is correct)
-    # 2) load the test queries into the StatementMetrics state
-    # 3) emit the query metrics based on the diff of current and last state
-    dd_run_check(check)
-    for _ in range(0, execution_count):
-        bob_conn.execute_with_retries(procedure, (), database=database)
-    dd_run_check(check)
-    aggregator.reset()
-    for _ in range(0, execution_count):
-        bob_conn.execute_with_retries(procedure, (), database=database)
-    dd_run_check(check)
-
-    _conn_key_prefix = "dbm-"
-    with check.connection.open_managed_default_connection(key_prefix=_conn_key_prefix):
-        with check.connection.get_managed_cursor(key_prefix=_conn_key_prefix) as cursor:
-            available_query_metrics_columns = check.statement_metrics._get_available_query_metrics_columns(
-                cursor, SQL_SERVER_QUERY_METRICS_COLUMNS
-            )
-
-    expected_instance_tags = set(dbm_instance.get('tags', []))
-
-    dbm_metrics = aggregator.get_event_platform_events("dbm-metrics")
-    assert len(dbm_metrics) == 1, "should have collected exactly one dbm-metrics payload"
-    payload = dbm_metrics[0]
-    # host metadata
-    assert payload['sqlserver_version'].startswith("Microsoft SQL Server"), "invalid version"
-    assert payload['host'] == "stubbed.hostname", "wrong hostname"
-    assert payload['ddagenthostname'] == datadog_agent.get_hostname()
-    assert set(payload['tags']) == expected_instance_tags, "wrong instance tags for dbm-metrics event"
-    assert type(payload['min_collection_interval']) in (float, int), "invalid min_collection_interval"
-    # metrics rows
-    sqlserver_rows = payload.get('sqlserver_rows', [])
-    assert sqlserver_rows, "should have collected some sqlserver query metrics rows"
-    if is_encrypted:
-        matching_rows = [r for r in sqlserver_rows if not r['statement_text']]
-    else:
-        match_pattern = "(" + ")|(".join(expected_queries_patterns) + ")"
-        matching_rows = [r for r in sqlserver_rows if re.match(match_pattern, r['statement_text'], re.IGNORECASE)]
-    assert len(matching_rows) == len(expected_queries_patterns)
-    total_execution_count = sum([r['execution_count'] for r in matching_rows])
-    assert total_execution_count == len(expected_queries_patterns) * execution_count, "wrong execution count"
-    for row in matching_rows:
-        if is_encrypted:
-            # we get NULL text for encrypted statements so we have no calculated query signature
-            assert not row['query_signature']
-        else:
-            assert row['query_signature'], "missing query signature"
-        assert row['is_encrypted'] == is_encrypted
-        assert row['is_proc']
-        for column in available_query_metrics_columns:
-            assert column in row, "missing required metrics column {}".format(column)
-            assert type(row[column]) in (float, int), "wrong type for metrics column {}".format(column)
-    # all the plan handles should be the same for the same procedure execution
-    assert all(row['plan_handle'] == matching_rows[0]['plan_handle'] for row in matching_rows)
-
-    # test plan collection
-    dbm_samples = aggregator.get_event_platform_events("dbm-samples")
-    assert dbm_samples, "should have collected at least one sample"
-    if is_encrypted:
-        matching_samples = [s for s in dbm_samples if not s['db']['statement']]
-    else:
-        match_pattern = "(" + ")|(".join(expected_queries_patterns) + ")"
-        matching_samples = [s for s in dbm_samples if re.match(match_pattern, s['db']['statement'], re.IGNORECASE)]
-    assert matching_samples, "should have collected some matching samples"
-
-    # validate common host fields
-    for event in matching_samples:
-        assert event['host'] == "stubbed.hostname", "wrong hostname"
-        assert event['ddsource'] == "sqlserver", "wrong source"
-        assert event['ddagentversion'], "missing ddagentversion"
-
-    plan_events = [s for s in matching_samples if s['dbm_type'] == "plan"]
-    # we should only collect a single plan event per stored procedure
-    # rather than one for each query that runs inside a stored proc
-    assert len(plan_events) == 1, "should have collected exactly one plan event"
-    event = plan_events[0]
-    if is_encrypted:
-        assert not event['db']['plan']['definition']
-        assert event['sqlserver']['is_plan_encrypted']
-        assert event['sqlserver']['is_statement_encrypted']
-    else:
-        assert event['db']['plan']['definition'], "event plan definition missing"
-        parsed_plan = ET.fromstring(event['db']['plan']['definition'])
-        assert parsed_plan.tag.endswith("ShowPlanXML"), "plan does not match expected structure"
-        assert not event['sqlserver']['is_plan_encrypted']
-        assert not event['sqlserver']['is_statement_encrypted']
-
-    fqt_events = [s for s in matching_samples if s['dbm_type'] == "fqt"]
-    assert len(fqt_events) == len(
-        expected_queries_patterns
-    ), "should have collected an FQT event per query in the stored proc"
 
 
 @pytest.mark.integration

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -345,9 +345,9 @@ def test_statement_metrics_and_plans(
     assert sqlserver_rows, "should have collected some sqlserver query metrics rows"
     match_pattern = "(" + ")|(".join(expected_queries_patterns) + ")"
     if is_encrypted:
-        matching_rows = [r for r in sqlserver_rows if not r['statement_text']]
+        matching_rows = [r for r in sqlserver_rows if not r['text']]
     else:
-        matching_rows = [r for r in sqlserver_rows if re.match(match_pattern, r['statement_text'], re.IGNORECASE)]
+        matching_rows = [r for r in sqlserver_rows if re.match(match_pattern, r['text'], re.IGNORECASE)]
     assert len(matching_rows) == len(expected_queries_patterns), "missing expected matching rows"
     total_execution_count = sum([r['execution_count'] for r in matching_rows])
     assert (
@@ -359,7 +359,7 @@ def test_statement_metrics_and_plans(
             assert not row['query_signature']
         else:
             assert row['query_signature'], "missing query signature"
-        assert 'text' not in row, "text field should not be forwarded"
+        assert 'statement_text' not in row, "statement_text field should not be forwarded"
         assert row['is_encrypted'] == is_encrypted
         assert row['is_proc'] == is_proc
         if is_proc and not is_encrypted:

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -359,6 +359,7 @@ def test_statement_metrics_and_plans(
             assert not row['query_signature']
         else:
             assert row['query_signature'], "missing query signature"
+        assert 'text' not in row, "text field should not be forwarded"
         assert row['is_encrypted'] == is_encrypted
         assert row['is_proc'] == is_proc
         if is_proc and not is_encrypted:
@@ -414,6 +415,9 @@ def test_statement_metrics_and_plans(
             assert not event['sqlserver']['is_statement_encrypted']
         if is_proc and not is_encrypted:
             assert row['procedure_signature'], "missing proc signature"
+            assert (
+                row['procedure_signature'] != row['query_signature']
+            ), "proc signature and query sig should be different"
 
     fqt_events = [s for s in matching_samples if s['dbm_type'] == "fqt"]
     assert len(fqt_events) == len(

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -361,7 +361,8 @@ def test_statement_metrics_and_plans(
             assert row['query_signature'], "missing query signature"
         assert 'statement_text' not in row, "statement_text field should not be forwarded"
         assert row['is_encrypted'] == is_encrypted
-        assert row['is_proc'] == is_proc
+        if not is_encrypted:
+            assert row['is_proc'] == is_proc
         if is_proc and not is_encrypted:
             assert row['procedure_signature'], "missing proc signature"
         if disable_secondary_tags:
@@ -371,9 +372,10 @@ def test_statement_metrics_and_plans(
         for column in available_query_metrics_columns:
             assert column in row, "missing required metrics column {}".format(column)
             assert type(row[column]) in (float, int), "wrong type for metrics column {}".format(column)
+    # all the plan handles / proc sigs should be the same for the same procedure execution
     if is_proc:
-        # all the plan handles / proc sigs should be the same for the same procedure execution
         assert all(row['plan_handle'] == matching_rows[0]['plan_handle'] for row in matching_rows)
+    if is_proc and not is_encrypted:
         assert all(row['procedure_signature'] == matching_rows[0]['procedure_signature'] for row in matching_rows)
 
     dbm_samples = aggregator.get_event_platform_events("dbm-samples")


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Updates both the sqlserver activity and metrics queries to use statement offsets when grabbing the sql text output from `sys.dm_exec_requests`/`sys.dm_exec_query_stats` 

Note: this results in the query signatures changing because we are only taking the actual query text. For example, we lose the types for queries that are executed with parameters

Text before: `(@P1 int,@P2 nvarchar(10))SELECT * FROM ϑings where id = @P1 and name = @P2`
... now results in `SELECT * FROM ϑings where id = @P1 and name = @P2`. The execution plan will still contain types so this seems OK.

This means this is a **breaking change** as it will effect our ability to link queries that are reported from existing agent versions. 

### Motivation
<!-- What inspired you to submit this pull request? -->

This change fixes a bug, where we are reporting SQL stored procedure stats incorrectly, the old behavior worked in the following way:

Let us illustrate with an example. Assume the database has the following procedure already created within it, and it is being executed continuously (i.e. by running `EXEC hello`).

```sql
CREATE PROCEDURE hello AS
BEGIN
    insert into foo values (1);
    select count(*) from foo;
END;
```

... in the Query Metrics page the query statement text for samples & metrics related to this stored procedure would be the original SQL that was used to create the stored procedure (`CREATE PROCEDURE hello AS` ... ) **not the SQL which is used to execute it** (`EXEC hello`). This can be confusing because it might look like we keep recreating the stored proc when in reality we're just executing it.

By making this change, `CREATE PROCEDURE...` queries will no longer appear in query metrics or activity. Instead we’ll track for all discrete statements in the procedures themselves.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

In the future, we should also look to utilize the `sys.dm_exec_procedure_stats` table to collect statistics related to the procedure executions 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
