### PR TITLE
Add attempts to voltdb environment

### DIFF
--- a/voltdb/tests/conftest.py
+++ b/voltdb/tests/conftest.py
@@ -46,7 +46,7 @@ def dd_environment(instance):
     else:
         e2e_metadata = {}
 
-    with docker_run(compose_file, conditions=conditions, env_vars=env_vars, mount_logs=True):
+    with docker_run(compose_file, conditions=conditions, env_vars=env_vars, mount_logs=True, attempts=2):
         yield instance, e2e_metadata
 
 


### PR DESCRIPTION
On https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=105973&view=logs&j=b3462493-d129-5a01-f515-8697d319257d&t=5a721fe0-efeb-5b46-79a9-8f4941179cfe the environment failed to start