### PR TITLE
Better failed assertion message, print return code

### DIFF
--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -41,7 +41,10 @@ class DatadogAgentStub(object):
         assert data == actual
 
     def assert_metadata_count(self, count):
-        assert len(self._metadata) == count
+        metadata_items = len(self._metadata)
+        assert metadata_items == count, 'Expected {} metadata items, found {}. Submitted metadata : {}'.format(
+            count, metadata_items, repr(self._metadata)
+        )
 
     def get_hostname(self):
         return self._hostname

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -42,7 +42,7 @@ class DatadogAgentStub(object):
 
     def assert_metadata_count(self, count):
         metadata_items = len(self._metadata)
-        assert metadata_items == count, 'Expected {} metadata items, found {}. Submitted metadata : {}'.format(
+        assert metadata_items == count, 'Expected {} metadata items, found {}. Submitted metadata: {}'.format(
             count, metadata_items, repr(self._metadata)
         )
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -199,7 +199,7 @@ def _run_start_commands(metadata, environment, check, env):
             result = environment.exec_command(command, capture=True)
             if result.code:
                 click.echo()
-                echo_failure('An error occurred running "{}"'.format(str(command)))
+                echo_failure('An error occurred running "{}". Exit code: {}'.format(str(command), result.code))
                 echo_failure(result.stdout + result.stderr, indent=True)
                 echo_waiting('Stopping the environment...')
                 stop_environment(check, env, metadata=metadata)


### PR DESCRIPTION
Print a more comprehensive assertion message on metadata count failure.
Print return code when running additional startup commands on agent image fails