### PR TITLE
Run apt commands in non interactive mode

### DIFF
--- a/oracle/tests/conftest.py
+++ b/oracle/tests/conftest.py
@@ -34,8 +34,6 @@ E2E_METADATA_ORACLE_CLIENT = {
     ],
     'start_commands': [
         'bash /tmp/install_instant_client.sh',
-        'apt-get install libaio1',  # `apt-get update` already ran in install_instant_client.sh
-        'apt-get install gcc g++ -y',
     ],
     'env_vars': {'LD_LIBRARY_PATH': '/opt/oracle/instantclient_19_3', 'TNS_ADMIN': '/opt/oracle/instantclient_19_3'},
 }
@@ -45,7 +43,6 @@ E2E_METADATA_JDBC_CLIENT = {
     # the integration will fallback to JDBC client
     'use_jmx': True,  # Using jmx to have a ready to use java runtime
     'docker_volumes': [
-        '{}/scripts/install_instant_client.sh:/tmp/install_instant_client.sh'.format(HERE),
         '{}/docker/client/client_wallet:/opt/oracle/instantclient_19_3/client_wallet'.format(HERE),
         '{}/docker/client/sqlnet.ora:/opt/oracle/instantclient_19_3/sqlnet.ora'.format(HERE),
         '{}/docker/client/tnsnames.ora:/opt/oracle/instantclient_19_3/tnsnames.ora'.format(HERE),
@@ -55,8 +52,8 @@ E2E_METADATA_JDBC_CLIENT = {
         '{}/docker/client/osdt_core.jar:/opt/oracle/instantclient_19_3/osdt_core.jar'.format(HERE),
     ],
     'start_commands': [
-        'bash /tmp/install_instant_client.sh',
-        'apt-get install gcc g++ -y',  # `apt-get update` already ran in install_instant_client.sh
+        'apt-get update',
+        'DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc g++',
     ],
     'env_vars': {'TNS_ADMIN': '/opt/oracle/instantclient_19_3'},
 }

--- a/oracle/tests/conftest.py
+++ b/oracle/tests/conftest.py
@@ -53,9 +53,12 @@ E2E_METADATA_JDBC_CLIENT = {
     ],
     'start_commands': [
         'apt-get update',
-        'DEBIAN_FRONTEND=noninteractive apt-get install -yq gcc g++',
+        'apt-get install -yq gcc g++',
     ],
-    'env_vars': {'TNS_ADMIN': '/opt/oracle/instantclient_19_3'},
+    'env_vars': {
+        'DEBIAN_FRONTEND': 'noninteractive',
+        'TNS_ADMIN': '/opt/oracle/instantclient_19_3'
+    },
 }
 
 

--- a/oracle/tests/conftest.py
+++ b/oracle/tests/conftest.py
@@ -43,6 +43,7 @@ E2E_METADATA_JDBC_CLIENT = {
     # the integration will fallback to JDBC client
     'use_jmx': True,  # Using jmx to have a ready to use java runtime
     'docker_volumes': [
+        '{}/scripts/install_instant_client.sh:/tmp/install_instant_client.sh'.format(HERE),
         '{}/docker/client/client_wallet:/opt/oracle/instantclient_19_3/client_wallet'.format(HERE),
         '{}/docker/client/sqlnet.ora:/opt/oracle/instantclient_19_3/sqlnet.ora'.format(HERE),
         '{}/docker/client/tnsnames.ora:/opt/oracle/instantclient_19_3/tnsnames.ora'.format(HERE),
@@ -52,10 +53,9 @@ E2E_METADATA_JDBC_CLIENT = {
         '{}/docker/client/osdt_core.jar:/opt/oracle/instantclient_19_3/osdt_core.jar'.format(HERE),
     ],
     'start_commands': [
-        'apt-get update',
-        'apt-get install -yq gcc g++',
+        'bash /tmp/install_instant_client.sh',  # Still needed to set up the database
     ],
-    'env_vars': {'DEBIAN_FRONTEND': 'noninteractive', 'TNS_ADMIN': '/opt/oracle/instantclient_19_3'},
+    'env_vars': {'TNS_ADMIN': '/opt/oracle/instantclient_19_3'},
 }
 
 

--- a/oracle/tests/conftest.py
+++ b/oracle/tests/conftest.py
@@ -55,10 +55,7 @@ E2E_METADATA_JDBC_CLIENT = {
         'apt-get update',
         'apt-get install -yq gcc g++',
     ],
-    'env_vars': {
-        'DEBIAN_FRONTEND': 'noninteractive',
-        'TNS_ADMIN': '/opt/oracle/instantclient_19_3'
-    },
+    'env_vars': {'DEBIAN_FRONTEND': 'noninteractive', 'TNS_ADMIN': '/opt/oracle/instantclient_19_3'},
 }
 
 

--- a/oracle/tests/scripts/install_instant_client.sh
+++ b/oracle/tests/scripts/install_instant_client.sh
@@ -6,7 +6,7 @@ INSTANT_CLIENT_URL="https://ddintegrations.blob.core.windows.net/oracle/instantc
 
 mkdir -p /opt/oracle
 apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -yq unzip
+DEBIAN_FRONTEND=noninteractive apt-get install -yq unzip libaio1 gcc g++
 
 # Retry necessary due to flaky download that might trigger:
 # curl: (56) OpenSSL SSL_read: SSL_ERROR_SYSCALL, errno 110


### PR DESCRIPTION
Datadog agent set up on oracle e2e test is often failing with error code 129, 129 is the typical exit code of a process being killed with SIGHUP. SIGHUP is sent when the tty a process is connected to is closing.
This PR moves all `apt-get install` commands for the CLI environment inside the shell script and makes them non interactive.
