### PR TITLE
Run pip install with --no-input

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -270,7 +270,7 @@ class DockerInterface(object):
     def update_check(self):
         command = ['docker', 'exec', self.container_name]
         command.extend(get_pip_exe(self.python_version, platform=self.container_platform))
-        command.extend(('install', '-e', f'{self.check_mount_dir}[deps]'))
+        command.extend(('install', '--no-input', '-e', f'{self.check_mount_dir}[deps]'))
         run_command(command, capture=True, check=True)
 
     def update_base_package(self):


### PR DESCRIPTION
Related to https://github.com/DataDog/integrations-core/pull/12616

> 129 is the typical exit code of a process being killed with SIGHUP. SIGHUP is sent when the tty a process is connected to is closing.

Seems pip install also fails with exit code 129
https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106088&view=logs&j=557af170-979d-590c-bfc5-807688bfc85b&t=7709c05d-3d8f-5f0b-94ac-78ac839e15d9&l=260

```
datadog_checks.dev.errors.SubprocessError: Command: ['docker', 'exec', 'dd_haproxy_py38-24', '/opt/datadog-agent/embedded/bin/pip3', 'install', '-e', '/home/datadog_checks_base[db,deps,http,json,kube]']
Exit code: 129
Captured Output: 
```