### PR TITLE
[Vault] Mark metric as optional

### DIFF
--- a/vault/tests/metrics.py
+++ b/vault/tests/metrics.py
@@ -81,6 +81,7 @@ METRICS_OPTIONAL = {
     'vault.core.handle.login_request',
     'vault.core.post_unseal',
     'vault.core.unseal',
+    'vault.expire.fetch.lease',
     'vault.expire.register.auth',
     'vault.expire.renew_token',
     'vault.identity.entity',


### PR DESCRIPTION
Metric was missing on https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106024&view=logs&j=70a237a0-2c52-52f8-23f1-657d682c7ecf&t=d85edea3-9fa0-5bee-ebb0-f3a77200749a&l=543 and https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106049&view=logs&j=70a237a0-2c52-52f8-23f1-657d682c7ecf&t=d85edea3-9fa0-5bee-ebb0-f3a77200749a&l=543