### PR TITLE
Check both log patterns

### DIFF
--- a/ibm_ace/tests/conftest.py
+++ b/ibm_ace/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from datadog_checks.dev import docker_run
+from datadog_checks.dev.conditions import CheckDockerLogs
 
 from . import common
 
@@ -15,7 +16,10 @@ def dd_environment(instance_no_subscriptions):
     with docker_run(
         common.COMPOSE_FILE,
         build=True,
-        log_patterns=['Integration server is ready', 'Started web server'],
+        conditions=[
+            CheckDockerLogs(common.COMPOSE_FILE, 'Integration server is ready'),
+            CheckDockerLogs(common.COMPOSE_FILE, 'Started web server'),
+        ],
         env_vars={
             'IBM_ACE_IMAGE': common.DOCKER_IMAGE_VERSIONS[os.environ['IBM_ACE_VERSION']],
             'ACE_SERVER_NAME': common.ACE_SERVER_NAME,


### PR DESCRIPTION
IBM ACE environment starts two docker images. The provided log patterns are one for each but the current behaviour of log_patterns is to match just one of the given list (we should change that).
This PR makes both conditions required