### PR TITLE
Remove legacy compose from E2E

### DIFF
--- a/couchbase/tox.ini
+++ b/couchbase/tox.ini
@@ -20,7 +20,6 @@ deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =
-    LEGACY_DOCKER_COMPOSE = true
     5.5.3: COUCHBASE_VERSION=5.5.3
     7.0.2: COUCHBASE_VERSION=7.0.2
 passenv =


### PR DESCRIPTION
### What does this PR do?
Remove legacy compose from E2E

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
