### PR TITLE
Add pymysql to dependency update exclude list

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -35,6 +35,7 @@ IGNORED_DEPS = {
     # snowflake-connector-python 2.6.0 has requirement cryptography<4.0.0,>=2.5.0
     'cryptography',
     'dnspython',
+    'pymysql',  # https://github.com/DataDog/integrations-core/pull/12612
 }
 
 # Dependencies for the downloader that are security-related and should be updated separately from the others


### PR DESCRIPTION
### What does this PR do?
Adds `pymysql` to the exclude list when updating dependencies 
### Motivation
There is an unfixed bug in pymysql and we do not want to accidentally update it in the future.
https://github.com/DataDog/integrations-core/pull/12612/s
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
