### PR TITLE
Add IPv4-only configuration option

### DIFF
--- a/tcp_check/assets/configuration/spec.yaml
+++ b/tcp_check/assets/configuration/spec.yaml
@@ -53,4 +53,10 @@ files:
         default: false
         example: false
         type: boolean
+    - name: ipv4_only
+      description: Enable to run the check against only IPv4-formatted addresses on every check run.
+      value:
+        default: false
+        example: false
+        type: boolean
     - template: instances/default

--- a/tcp_check/datadog_checks/tcp_check/config_models/defaults.py
+++ b/tcp_check/datadog_checks/tcp_check/config_models/defaults.py
@@ -30,6 +30,10 @@ def instance_ip_cache_duration(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_ipv4_only(field, value):
+    return False
+
+
 def instance_metric_patterns(field, value):
     return get_default_field_value(field, value)
 

--- a/tcp_check/datadog_checks/tcp_check/config_models/instance.py
+++ b/tcp_check/datadog_checks/tcp_check/config_models/instance.py
@@ -36,6 +36,7 @@ class InstanceConfig(BaseModel):
     empty_default_hostname: Optional[bool]
     host: str
     ip_cache_duration: Optional[float]
+    ipv4_only: Optional[bool]
     metric_patterns: Optional[MetricPatterns]
     min_collection_interval: Optional[float]
     multiple_ips: Optional[bool]

--- a/tcp_check/datadog_checks/tcp_check/data/conf.yaml.example
+++ b/tcp_check/datadog_checks/tcp_check/data/conf.yaml.example
@@ -53,6 +53,11 @@ instances:
     #
     # multiple_ips: false
 
+    ## @param ipv4_only - boolean - optional - default: false
+    ## Enable to run the check against only IPv4-formatted addresses on every check run.
+    #
+    # ipv4_only: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/tcp_check/tests/common.py
+++ b/tcp_check/tests/common.py
@@ -16,7 +16,7 @@ INSTANCE_MULTIPLE.update(INSTANCE)
 INSTANCE_IPV6 = {
     'host': 'ip-ranges.datadoghq.com',
     'port': 80,
-    'timeout': 1.5,
+    'timeout': 5,
     'name': 'UpService',
     'tags': ["foo:bar"],
     'multiple_ips': True,
@@ -29,6 +29,7 @@ E2E_METADATA = {'docker_platform': 'windows' if using_windows_containers() else 
 DUAL_STACK_GETADDRINFO_LOCALHOST_IPV6 = [
     (socket.AF_INET6, socket.SOCK_STREAM, 6, '', ('::1', 80, 0, 0)),
     (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('127.0.0.1', 80)),
+    (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('ip3', 80)),
 ]
 
 DUAL_STACK_GETADDRINFO_LOCALHOST_IPV4 = [
@@ -51,6 +52,7 @@ DUAL_STACK_GETADDRINFO_IPV6 = [
     (socket.AF_INET6, socket.SOCK_STREAM, 6, '', ('ip1', 80, 0, 0)),
     (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('ip2', 80)),
     (socket.AF_INET6, socket.SOCK_STREAM, 6, '', ('ip3', 80, 0, 0)),
+    (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('ip4', 80)),
 ]
 
 SINGLE_STACK_GETADDRINFO_IPV4 = [

--- a/tcp_check/tests/test_tcp_check.py
+++ b/tcp_check/tests/test_tcp_check.py
@@ -293,7 +293,9 @@ def test_multiple(aggregator):
 
 def has_ipv6_connectivity():
     try:
-        for sockaddr in socket.getaddrinfo(socket.gethostname(), None, socket.AF_INET6, 0, socket.IPPROTO_TCP):
+        for _, _, _, _, sockaddr in socket.getaddrinfo(
+            socket.gethostname(), None, socket.AF_INET6, 0, socket.IPPROTO_TCP
+        ):
             if not sockaddr[0].startswith('fe80:'):
                 return True
         return False
@@ -318,10 +320,6 @@ def test_ipv6(aggregator, check):
             if has_ipv6_connectivity():
                 aggregator.assert_service_check('tcp.can_connect', status=check.OK, tags=expected_tags)
                 aggregator.assert_metric('network.tcp.can_connect', value=1, tags=expected_tags)
-            elif platform.system() == 'Darwin':
-                # IPv6 connectivity varies when running test locally on macOS, so we do not check status or metric value
-                aggregator.assert_service_check('tcp.can_connect', tags=expected_tags)
-                aggregator.assert_metric('network.tcp.can_connect', tags=expected_tags)
             else:
                 aggregator.assert_service_check('tcp.can_connect', status=check.CRITICAL, tags=expected_tags)
                 aggregator.assert_metric('network.tcp.can_connect', value=0, tags=expected_tags)


### PR DESCRIPTION
### What does this PR do?
Adds option to only check IPv4 addresses. 

### Motivation
A hostname may resolve to both IPv4 and IPv6 addresses despite the host lacking IPv6 connectivity. Enabling this option will check only IPv4 addresses and prevent false alerts from IPv6 addresses returning CRITICAL status due to "Network is unreachable" error returned from the socket. 

### Additional Notes
Also fixes the `has_ipv6_connectivity()` helper function in the tests, which was silently failing in the CI due to an exception from `socket.gethostname()` not getting caught.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
