### PR TITLE
Remove legacy compose from E2E

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -176,7 +176,7 @@ class Redis(AgentCheck):
                 connection_params = dict((k, instance_config[k]) for k in list_params if k in instance_config)
                 # If caching is disabled, we overwrite the dictionary value so the old connection
                 # will be closed as soon as the corresponding Python object gets garbage collected
-                self.connections[key] = redis.Redis(health_check_interval=5, **connection_params)
+                self.connections[key] = redis.Redis(**connection_params)
 
             except TypeError:
                 msg = "You need a redis library that supports authenticated connections. Try `pip install redis`."

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -176,7 +176,7 @@ class Redis(AgentCheck):
                 connection_params = dict((k, instance_config[k]) for k in list_params if k in instance_config)
                 # If caching is disabled, we overwrite the dictionary value so the old connection
                 # will be closed as soon as the corresponding Python object gets garbage collected
-                self.connections[key] = redis.Redis(**connection_params)
+                self.connections[key] = redis.Redis(health_check_interval=10, **connection_params)
 
             except TypeError:
                 msg = "You need a redis library that supports authenticated connections. Try `pip install redis`."

--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -176,7 +176,7 @@ class Redis(AgentCheck):
                 connection_params = dict((k, instance_config[k]) for k in list_params if k in instance_config)
                 # If caching is disabled, we overwrite the dictionary value so the old connection
                 # will be closed as soon as the corresponding Python object gets garbage collected
-                self.connections[key] = redis.Redis(health_check_interval=10, **connection_params)
+                self.connections[key] = redis.Redis(health_check_interval=5, **connection_params)
 
             except TypeError:
                 msg = "You need a redis library that supports authenticated connections. Try `pip install redis`."

--- a/redisdb/tests/compose/1m-2s-cloud.compose
+++ b/redisdb/tests/compose/1m-2s-cloud.compose
@@ -1,4 +1,4 @@
-version: '3.5'
+version: '3.8'
 
 services:
   redis-master:

--- a/redisdb/tests/compose/1m-2s.compose
+++ b/redisdb/tests/compose/1m-2s.compose
@@ -1,4 +1,4 @@
-version: '3.5'
+version: '3.8'
 
 services:
   redis-master:

--- a/redisdb/tests/compose/standalone.compose
+++ b/redisdb/tests/compose/standalone.compose
@@ -1,4 +1,4 @@
-version: '3.5'
+version: '3.8'
 
 services:
   redis-standalone:

--- a/redisdb/tests/conftest.py
+++ b/redisdb/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import redis
 
 from datadog_checks.dev import LazyFunction, RetryError, docker_run
+from datadog_checks.dev.conditions import CheckDockerLogs
 from datadog_checks.redisdb import Redis
 
 from .common import DOCKER_COMPOSE_PATH, HERE, HOST, MASTER_PORT, PASSWORD, PORT, REPLICA_PORT
@@ -53,10 +54,11 @@ def redis_auth():
     If there's any problem executing `docker compose`, let the exception bubble
     up.
     """
+    compose_file = os.path.join(HERE, 'compose', 'standalone.compose')
     with docker_run(
-        os.path.join(HERE, 'compose', 'standalone.compose'),
+        compose_file,
         env_vars={'REDIS_CONFIG': os.path.join(HERE, 'config', 'auth.conf')},
-        sleep=10,
+        conditions=[CheckDockerLogs(compose_file, 'Ready to accept connections', wait=5)],
     ):
         yield
 

--- a/redisdb/tests/conftest.py
+++ b/redisdb/tests/conftest.py
@@ -56,6 +56,7 @@ def redis_auth():
     with docker_run(
         os.path.join(HERE, 'compose', 'standalone.compose'),
         env_vars={'REDIS_CONFIG': os.path.join(HERE, 'config', 'auth.conf')},
+        sleep=10,
     ):
         yield
 

--- a/redisdb/tox.ini
+++ b/redisdb/tox.ini
@@ -25,7 +25,6 @@ deps =
 commands =
     pytest -v {posargs}
 setenv =
-    LEGACY_DOCKER_COMPOSE = true
     CLOUD_ENV=false
     5.0: REDIS_VERSION=5.0
     6.0: REDIS_VERSION=6.0


### PR DESCRIPTION
### What does this PR do?
Bumps the compose file version to the latest 3.8. Adds a docker logs condition to the redis_auth docker_run command to verify that the ports are available, since the auth tests were failing after removing the legacy compose flag.

### Motivation
Use docker compose v2

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
