### PR TITLE
new name for metric rest_client_request_duration_seconds

### DIFF
--- a/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
@@ -47,6 +47,8 @@ NEW_1_14_HISTOGRAMS = {
     'scheduler_scheduling_duration_seconds': 'scheduling.scheduling_duration',
     # (from 1.14) Binding latency in seconds
     'scheduler_binding_duration_seconds': 'binding_duration',
+    # (from 1.14) Request latency in seconds. Broken down by verb and URL (new name)
+    'rest_client_request_duration_seconds': 'client.http.requests_duration',
 }
 
 NEW_1_23_HISTOGRAMS = {


### PR DESCRIPTION
### What does this PR do?
The metric called `rest_client_request_latency_seconds` changed its name to `rest_client_request_duration_seconds` but that was never changed in our integration, so the metric `client.http.requests_duration` is missing

https://github.com/kubernetes/kubernetes/blob/8ac5d4d6a92d59bba70844fbd6e5de2383a08c96/CHANGELOG/CHANGELOG-1.14.md#deprecated-metrics

### Motivation
I am working on updating the Kube Scheduler OOTB dashboard, but I realized that the current one had the HTTP duration histogram widget empty:

https://a.cl.ly/mXuxXrDg

This is because the corresponding metric is not there.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
