### PR TITLE
[gluster] Update compose version

### DIFF
--- a/glusterfs/tests/docker/docker-compose.yaml
+++ b/glusterfs/tests/docker/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
     gs1:
         container_name: gluster-node-1


### PR DESCRIPTION
The environment is failing to start in the last 8 master builds and seems updating the compose version fixes it

- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106095&view=results
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106094&view=results
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106093&view=results
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106092&view=results
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106091&view=results
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106090&view=results
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106089&view=results
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106088&view=results