### PR TITLE
Match all log patterns

### DIFF
--- a/cassandra_nodetool/tests/conftest.py
+++ b/cassandra_nodetool/tests/conftest.py
@@ -8,6 +8,7 @@ import subprocess
 import pytest
 
 from datadog_checks.dev import docker_run
+from datadog_checks.dev.conditions import CheckDockerLogs
 from datadog_checks.dev.docker import get_container_ip
 
 from . import common
@@ -29,16 +30,23 @@ def dd_environment():
     compose_file = os.path.join(common.HERE, 'compose', 'docker-compose.yaml')
     env['CONTAINER_PORT'] = common.PORT
     env['CASSANDRA_SEEDS'] = '0.0.0.0'
+    cassandra_version = int(env['CASSANDRA_VERSION'].split('.')[0])
+    if cassandra_version >= 3:
+        log_patterns = ['Starting listening for CQL clients', 'Startup complete']
+    else:
+        log_patterns = ['Starting listening for CQL clients', 'All sessions completed']
 
     with docker_run(
-        compose_file, service_name=common.CASSANDRA_CONTAINER_NAME, log_patterns=['Listening for thrift clients']
+        compose_file,
+        service_name=common.CASSANDRA_CONTAINER_NAME,
+        log_patterns=['Listening for thrift clients'],
     ):
         cassandra_seed = get_container_ip("{}".format(common.CASSANDRA_CONTAINER_NAME))
         env['CASSANDRA_SEEDS'] = cassandra_seed
         with docker_run(
             compose_file,
             service_name=common.CASSANDRA_CONTAINER_NAME_2,
-            log_patterns=['All sessions completed', 'Starting listening for CQL clients'],
+            conditions=[CheckDockerLogs(compose_file, log_patterns, matches='all', wait=2)],
         ):
             subprocess.check_call(
                 [
@@ -49,6 +57,8 @@ def dd_environment():
                     "-e",
                     "CREATE KEYSPACE IF NOT EXISTS test \
                 WITH REPLICATION={'class':'SimpleStrategy', 'replication_factor':2}",
+                    "--request-timeout",
+                    "20",
                 ]
             )
             yield common.CONFIG_INSTANCE, E2E_METADATA


### PR DESCRIPTION
log_patterns only requires to match 1 of the provided patterns (changing on https://github.com/DataDog/integrations-core/pull/12623).
This PR makes it so all patterns are required and adapts which ones to the cassandra version