### PR TITLE
Fix probe metrics not reported when creds required

### DIFF
--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -320,6 +320,11 @@ class KubeletCheck(
         # Test the kubelet health ASAP
         self._perform_kubelet_check(self.instance_tags)
 
+        # Kubelet credentials handling
+        self.kubelet_credentials.configure_scraper(self.cadvisor_scraper_config)
+        self.kubelet_credentials.configure_scraper(self.kubelet_scraper_config)
+        self.kubelet_credentials.configure_scraper(self.probes_scraper_config)
+
         if 'cadvisor_metrics_endpoint' in instance:
             self.cadvisor_scraper_config['prometheus_url'] = instance.get(
                 'cadvisor_metrics_endpoint', urljoin(endpoint, CADVISOR_METRICS_PATH)
@@ -336,19 +341,15 @@ class KubeletCheck(
             'kubelet_metrics_endpoint', urljoin(endpoint, KUBELET_METRICS_PATH)
         )
 
+        http_handler = self.get_http_handler(self.probes_scraper_config)
         probes_metrics_endpoint = urljoin(endpoint, PROBES_METRICS_PATH)
-        if self.detect_probes(probes_metrics_endpoint):
+        if self.detect_probes(http_handler, probes_metrics_endpoint):
             self.probes_scraper_config['prometheus_url'] = instance.get(
                 'probes_metrics_endpoint', probes_metrics_endpoint
             )
         else:
             # Disable probe metrics collection (k8s 1.15+ required)
             self.probes_scraper_config['prometheus_url'] = ''
-
-        # Kubelet credentials handling
-        self.kubelet_credentials.configure_scraper(self.cadvisor_scraper_config)
-        self.kubelet_credentials.configure_scraper(self.kubelet_scraper_config)
-        self.kubelet_credentials.configure_scraper(self.probes_scraper_config)
 
         # Legacy cadvisor support
         try:

--- a/kubelet/datadog_checks/kubelet/probes.py
+++ b/kubelet/datadog_checks/kubelet/probes.py
@@ -5,8 +5,6 @@ from __future__ import division
 
 from copy import deepcopy
 
-import requests
-
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.utils.tagging import tagger
 

--- a/kubelet/datadog_checks/kubelet/probes.py
+++ b/kubelet/datadog_checks/kubelet/probes.py
@@ -44,7 +44,7 @@ class ProbesPrometheusScraperMixin(object):
         )
         return probes_instance
 
-    def detect_probes(self, url):
+    def detect_probes(self, http_handler, url):
         """
         Whether the probe metrics endpoint is available (k8s 1.15+).
         :return: false if the endpoint throws a 404, true otherwise.
@@ -52,7 +52,7 @@ class ProbesPrometheusScraperMixin(object):
         if self._probes_available is not None:
             return self._probes_available
         try:
-            r = requests.head(url, timeout=5)
+            r = http_handler.head(url)
         except Exception as e:
             self.log.debug("Unable to collect query probes endpoint: %s", e)
             return False

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -1403,8 +1403,11 @@ def mock_request():
 
 def test_detect_probes(monkeypatch, mock_request):
     mock_request.head('http://kubelet:10250/metrics/probes', status_code=200)
-    check = mock_kubelet_check(monkeypatch, [{}])
-    available = check.detect_probes('http://kubelet:10250/metrics/probes')
+    instance = dict({'prometheus_url': 'http://kubelet:10250', 'namespace': 'kubernetes'})
+    check = mock_kubelet_check(monkeypatch, [instance])
+    scraper_config = check.get_scraper_config(instance)
+    http_handler = check.get_http_handler(scraper_config)
+    available = check.detect_probes(http_handler, 'http://kubelet:10250/metrics/probes')
     assert available is True
     assert check._probes_available is True
     assert mock_request.call_count == 1
@@ -1412,12 +1415,15 @@ def test_detect_probes(monkeypatch, mock_request):
 
 def test_detect_probes_cached(monkeypatch, mock_request):
     mock_request.head('http://kubelet:10250/metrics/probes', status_code=200)
-    check = mock_kubelet_check(monkeypatch, [{}])
-    available = check.detect_probes('http://kubelet:10250/metrics/probes')
+    instance = dict({'prometheus_url': 'http://kubelet:10250', 'namespace': 'kubernetes'})
+    check = mock_kubelet_check(monkeypatch, [instance])
+    scraper_config = check.get_scraper_config(instance)
+    http_handler = check.get_http_handler(scraper_config)
+    available = check.detect_probes(http_handler, 'http://kubelet:10250/metrics/probes')
     assert available is True
     assert check._probes_available is True
     assert mock_request.call_count == 1
-    available = check.detect_probes('http://kubelet:10250/metrics/probes')
+    available = check.detect_probes(http_handler, 'http://kubelet:10250/metrics/probes')
     assert available is True
     assert check._probes_available is True
     assert mock_request.call_count == 1
@@ -1425,8 +1431,11 @@ def test_detect_probes_cached(monkeypatch, mock_request):
 
 def test_detect_probes_404(monkeypatch, mock_request):
     mock_request.head('http://kubelet:10250/metrics/probes', status_code=404)
-    check = mock_kubelet_check(monkeypatch, [{}])
-    available = check.detect_probes('http://kubelet:10250/metrics/probes')
+    instance = dict({'prometheus_url': 'http://kubelet:10250', 'namespace': 'kubernetes'})
+    check = mock_kubelet_check(monkeypatch, [instance])
+    scraper_config = check.get_scraper_config(instance)
+    http_handler = check.get_http_handler(scraper_config)
+    available = check.detect_probes(http_handler, 'http://kubelet:10250/metrics/probes')
     assert available is False
     assert check._probes_available is False
     assert mock_request.call_count == 1
@@ -1434,12 +1443,15 @@ def test_detect_probes_404(monkeypatch, mock_request):
 
 def test_detect_probes_404_cached(monkeypatch, mock_request):
     mock_request.head('http://kubelet:10250/metrics/probes', status_code=404)
-    check = mock_kubelet_check(monkeypatch, [{}])
-    available = check.detect_probes('http://kubelet:10250/metrics/probes')
+    instance = dict({'prometheus_url': 'http://kubelet:10250', 'namespace': 'kubernetes'})
+    check = mock_kubelet_check(monkeypatch, [instance])
+    scraper_config = check.get_scraper_config(instance)
+    http_handler = check.get_http_handler(scraper_config)
+    available = check.detect_probes(http_handler, 'http://kubelet:10250/metrics/probes')
     assert available is False
     assert check._probes_available is False
     assert mock_request.call_count == 1
-    available = check.detect_probes('http://kubelet:10250/metrics/probes')
+    available = check.detect_probes(http_handler, 'http://kubelet:10250/metrics/probes')
     assert available is False
     assert check._probes_available is False
     assert mock_request.call_count == 1
@@ -1447,8 +1459,11 @@ def test_detect_probes_404_cached(monkeypatch, mock_request):
 
 def test_detect_probes_req_exception(monkeypatch, mock_request):
     mock_request.head('http://kubelet:10250/metrics/probes', exc=requests.exceptions.ConnectTimeout)
-    check = mock_kubelet_check(monkeypatch, [{}])
-    available = check.detect_probes('http://kubelet:10250/metrics/probes')
+    instance = dict({'prometheus_url': 'http://kubelet:10250', 'namespace': 'kubernetes'})
+    check = mock_kubelet_check(monkeypatch, [instance])
+    scraper_config = check.get_scraper_config(instance)
+    http_handler = check.get_http_handler(scraper_config)
+    available = check.detect_probes(http_handler, 'http://kubelet:10250/metrics/probes')
     assert available is False
     assert check._probes_available is None
     assert mock_request.call_count == 1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Propagate kubelet creds parameters when making the discovery call for `/metrics/probes`

### Motivation
<!-- What inspired you to submit this pull request? -->

Fix `2022-07-29 10:04:48 UTC | CORE | DEBUG | (pkg/collector/python/datadog_agent.go:128 in LogMessage) | - | (probes.py:57) | Unable to collect query probes endpoint: HTTPSConnectionPool(host='10.50.189.37', port=10250): Max retries exceeded with url: /metrics/probes (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1131)')))` 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
