### PR TITLE
[postgres] Fix operator precedence in relation filter

### DIFF
--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -278,7 +278,7 @@ class RelationsManager(object):
             relation_filter.append(')')
             relations_filter.append(' '.join(relation_filter))
 
-        relations_filter = ' OR '.join(relations_filter)
+        relations_filter = '(' + ' OR '.join(relations_filter) + ')'
         self.log.debug("Running query: %s with relations matching: %s", str(query), relations_filter)
         return query.format(relations=relations_filter)
 

--- a/postgres/tests/test_relationsmanager.py
+++ b/postgres/tests/test_relationsmanager.py
@@ -19,15 +19,15 @@ pytestmark = pytest.mark.unit
                 {'relation_regex': 'ibx.*', 'schemas': ['public']},
                 {'relation_regex': 'icx.*', 'schemas': ['public']},
             ],
-            "( relname ~ 'ix.*' AND schemaname = ANY(array['public','s1','s2']::text[]) ) "
+            "(( relname ~ 'ix.*' AND schemaname = ANY(array['public','s1','s2']::text[]) ) "
             "OR ( relname ~ 'ibx.*' AND schemaname = ANY(array['public']::text[]) ) "
-            "OR ( relname ~ 'icx.*' AND schemaname = ANY(array['public']::text[]) )",
+            "OR ( relname ~ 'icx.*' AND schemaname = ANY(array['public']::text[]) ))",
         ),
         (
             [
                 {'relation_regex': '.+_archive'},
             ],
-            "( relname ~ '.+_archive' )",
+            "(( relname ~ '.+_archive' ))",
         ),
         (
             [
@@ -35,13 +35,13 @@ pytestmark = pytest.mark.unit
                 {'relation_name': 'my_table2', 'relkind': ['p', 'r']},  # relkind ignored
                 {'relation_regex': 'table.*'},
             ],
-            "( relname = 'my_table' AND schemaname = ANY(array['public','app']::text[]) ) "
+            "(( relname = 'my_table' AND schemaname = ANY(array['public','app']::text[]) ) "
             "OR ( relname = 'my_table2' ) "
-            "OR ( relname ~ 'table.*' )",
+            "OR ( relname ~ 'table.*' ))",
         ),
         (
             ['table1', 'table2'],
-            "( relname = 'table1' ) OR ( relname = 'table2' )",
+            "(( relname = 'table1' ) OR ( relname = 'table2' ))",
         ),
     ],
 )
@@ -59,7 +59,7 @@ def test_relation_filter():
 
     query_filter = relations.filter_relation_query(query, SCHEMA_NAME)
     assert (
-        query_filter == "Select foo from bar where ( relname = 'breed' AND schemaname = ANY(array['public']::text[]) )"
+        query_filter == "Select foo from bar where (( relname = 'breed' AND schemaname = ANY(array['public']::text[]) ))"
     )
 
 
@@ -69,7 +69,7 @@ def test_relation_filter_no_schemas():
     relations = RelationsManager(relations_config)
 
     query_filter = relations.filter_relation_query(query, SCHEMA_NAME)
-    assert query_filter == "Select foo from bar where ( relname = 'persons' )"
+    assert query_filter == "Select foo from bar where (( relname = 'persons' ))"
 
 
 def test_relation_filter_regex():
@@ -78,7 +78,7 @@ def test_relation_filter_regex():
     relations = RelationsManager(relations_config)
 
     query_filter = relations.filter_relation_query(query, SCHEMA_NAME)
-    assert query_filter == "Select foo from bar where ( relname ~ 'b.*' )"
+    assert query_filter == "Select foo from bar where (( relname ~ 'b.*' ))"
 
 
 def test_relation_filter_relkind():

--- a/postgres/tests/test_relationsmanager.py
+++ b/postgres/tests/test_relationsmanager.py
@@ -59,7 +59,8 @@ def test_relation_filter():
 
     query_filter = relations.filter_relation_query(query, SCHEMA_NAME)
     assert (
-        query_filter == "Select foo from bar where (( relname = 'breed' AND schemaname = ANY(array['public']::text[]) ))"
+        query_filter
+        == "Select foo from bar where (( relname = 'breed' AND schemaname = ANY(array['public']::text[]) ))"
     )
 
 


### PR DESCRIPTION
### What does this PR do?

In the `postgres` integration, add parentheses around the "relations filter" SQL clause to ensure proper operator precedence.

### Motivation

When multiple entries are added in the `relations` config, the precedence of `AND`/`OR`  conditions may give unexpected results, because [AND takes precedence over OR](https://www.postgresql.org/docs/14/sql-syntax-lexical.html#SQL-PRECEDENCE-TABLE).

For instance with the `SIZE_METRICS` query of the form `SELECT [...] WHERE <cond1> AND {relations}`, with multiple relations it becomes:
* Currently: `SELECT [...] WHERE <cond1> AND <rel1> OR <rel2>`
* Expected: `SELECT [...] WHERE <cond1> AND (<rel1> OR <rel2>)`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
