### PR TITLE
Florentclarret/revert downloader

### DIFF
--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -215,27 +215,30 @@ class TUFDownloader:
 
     def __in_toto_verify(self, inspection_packet, target_relpath):
         # Make a temporary directory in a parent directory we control.
-        with tempfile.TemporaryDirectory(dir=REPOSITORIES_DIR) as tempdir:
-            # Copy files over into temp dir.
-            for abs_path in inspection_packet:
-                shutil.copy(abs_path, tempdir)
+        tempdir = tempfile.mkdtemp(dir=REPOSITORIES_DIR)
 
-            # Switch to the temp dir.
-            os.chdir(tempdir)
+        # Copy files over into temp dir.
+        for abs_path in inspection_packet:
+            shutil.copy(abs_path, tempdir)
 
-            # Load the root layout and public keys in this temp dir.
-            root_layout, root_layout_pubkeys, root_layout_params = self.__load_root_layout(target_relpath)
+        # Switch to the temp dir.
+        os.chdir(tempdir)
 
-            try:
-                verifylib.in_toto_verify(root_layout, root_layout_pubkeys, substitution_parameters=root_layout_params)
-            except Exception as e:
-                self.__handle_in_toto_verification_exception(target_relpath, e)
-            else:
-                logger.info('in-toto verified %s', target_relpath)
-            finally:
-                # Switch back to a parent directory we control, so that we can
-                # safely delete temp dir.
-                os.chdir(REPOSITORIES_DIR)
+        # Load the root layout and public keys in this temp dir.
+        root_layout, root_layout_pubkeys, root_layout_params = self.__load_root_layout(target_relpath)
+
+        try:
+            verifylib.in_toto_verify(root_layout, root_layout_pubkeys, substitution_parameters=root_layout_params)
+        except Exception as e:
+            self.__handle_in_toto_verification_exception(target_relpath, e)
+        else:
+            logger.info('in-toto verified %s', target_relpath)
+        finally:
+            # Switch back to a parent directory we control, so that we can
+            # safely delete temp dir.
+            os.chdir(REPOSITORIES_DIR)
+            # Delete temp dir.
+            shutil.rmtree(tempdir)
 
     def __download_and_verify_in_toto_metadata(self, target_relpath, target_abspath, target):
         # First, get our in-toto root layout.

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -217,17 +217,17 @@ class TUFDownloader:
         # Make a temporary directory in a parent directory we control.
         tempdir = tempfile.mkdtemp(dir=REPOSITORIES_DIR)
 
-        # Copy files over into temp dir.
-        for abs_path in inspection_packet:
-            shutil.copy(abs_path, tempdir)
-
-        # Switch to the temp dir.
-        os.chdir(tempdir)
-
-        # Load the root layout and public keys in this temp dir.
-        root_layout, root_layout_pubkeys, root_layout_params = self.__load_root_layout(target_relpath)
-
         try:
+            # Copy files over into temp dir.
+            for abs_path in inspection_packet:
+                shutil.copy(abs_path, tempdir)
+
+            # Switch to the temp dir.
+            os.chdir(tempdir)
+
+            # Load the root layout and public keys in this temp dir.
+            root_layout, root_layout_pubkeys, root_layout_params = self.__load_root_layout(target_relpath)
+
             verifylib.in_toto_verify(root_layout, root_layout_pubkeys, substitution_parameters=root_layout_params)
         except Exception as e:
             self.__handle_in_toto_verification_exception(target_relpath, e)


### PR DESCRIPTION
### What does this PR do?

Reverting https://github.com/DataDog/integrations-core/pull/12559 because it fails with Python 2 and broke the datadog-agent build.

I moved the rest of the code in the try to make it work

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
