### PR TITLE
[kafka check] Handle errors getting producer offset

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -284,8 +284,8 @@ class NewKafkaConsumerCheck(object):
                 if reported_contexts >= contexts_limit:
                     continue
                 timestamps = self._broker_timestamps["{}_{}".format(topic, partition)]
-                # producer_timestamp is set in the same check, so it should never be None
-                producer_timestamp = timestamps[producer_offset]
+                # The producer timestamp can be not set if there was an error fetching broker offsets.
+                producer_timestamp = timestamps.get(producer_offset, None)
                 consumer_timestamp = self._get_interpolated_timestamp(timestamps, consumer_offset)
                 if consumer_timestamp is None or producer_timestamp is None:
                     continue


### PR DESCRIPTION
### What does this PR do?

if there is an error fetching broker offsets, like:
`NoLeaderForPartition` for eg, then, this line:
https://github.com/DataDog/integrations-core/blob/9455227913fd402a012396610d88647cb93ec445/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py#L199
is not called, and there is no producer offset, and it can cause: https://github.com/DataDog/integrations-core/issues/12587

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
