### PR TITLE
Re-add missing metric: pod_preemption.attempts

### DIFF
--- a/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
@@ -25,6 +25,11 @@ DEFAULT_COUNTERS = {
     'scheduler_total_preemption_attempts': 'pod_preemption.attempts',
 }
 
+NEW_1_19_COUNTERS = {
+    # Total preemption attempts in the cluster till now (new name)
+    'scheduler_preemption_attempts_total': 'pod_preemption.attempts',
+}
+
 DEFAULT_HISTOGRAMS = {
     # Request latency in seconds. Broken down by verb and URL.
     'rest_client_request_latency_seconds': 'client.http.requests_duration',
@@ -132,6 +137,7 @@ class KubeSchedulerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
                     'metrics': [
                         DEFAULT_COUNTERS,
                         DEFAULT_HISTOGRAMS,
+                        NEW_1_19_COUNTERS,
                         NEW_1_14_HISTOGRAMS,
                         DEFAULT_GAUGES,
                         DEFAULT_GO_METRICS,

--- a/kube_scheduler/tests/test_kube_scheduler_1_23.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_23.py
@@ -54,6 +54,8 @@ def test_check_metrics_1_23(aggregator, mock_metrics, mock_leader):
         # Wrapper to keep assertions < 120 chars
         aggregator.assert_metric(NAMESPACE + name, **kwargs)
 
+    assert_metric('.pod_preemption.attempts', value=3.0, tags=[])
+
     assert_metric('.scheduling.algorithm_duration.count', value=7, tags=['upper_bound:0.001'])
     assert_metric('.scheduling.algorithm_duration.sum', value=0.002138012)
 


### PR DESCRIPTION
### What does this PR do?
It changes the metric called `scheduler_total_preemption_attempts` to `scheduler_preemption_attempts_total`, from 1.19.

### Motivation
This metric changed its name in 1.19 and the integration was never changed, so the metric `pod_preemption.attempts` was missing in newer versions of Kubernetes

Details in the K8s changelog: https://www-1.muraena.okta-security-dev.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#other-cleanup-or-flake-7

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
