### PR TITLE
Add MySQL user connections metric

### DIFF
--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -20,20 +20,6 @@ try:
 except ImportError:
     from ..stubs import datadog_agent
 
-CONNECTIONS_QUERY = """\
-SELECT
-    processlist_user,
-    processlist_host,
-    processlist_db,
-    processlist_state,
-    COUNT(processlist_user) AS connections
-FROM
-    performance_schema.threads
-WHERE
-    processlist_user IS NOT NULL AND
-    processlist_state IS NOT NULL
-    GROUP BY processlist_user, processlist_host, processlist_db, processlist_state
-"""
 
 ACTIVITY_QUERY = """\
 SELECT
@@ -172,10 +158,9 @@ class MySQLActivity(DBMAsyncJob):
     def _collect_activity(self):
         # type: () -> None
         with closing(self._get_db_connection().cursor(pymysql.cursors.DictCursor)) as cursor:
-            connections = self._get_active_connections(cursor)
             rows = self._get_activity(cursor)
             rows = self._normalize_rows(rows)
-            event = self._create_activity_event(rows, connections)
+            event = self._create_activity_event(rows)
             payload = json.dumps(event, default=self._json_event_encoding)
             self._check.database_monitoring_query_activity(payload)
             self._check.histogram(
@@ -183,15 +168,6 @@ class MySQLActivity(DBMAsyncJob):
                 len(payload),
                 tags=self._tags + self._check._get_debug_tags(),
             )
-
-    @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
-    def _get_active_connections(self, cursor):
-        # type: (pymysql.cursor) -> List[Dict[str]]
-        self._log.debug("Running connections query [%s]", CONNECTIONS_QUERY)
-        cursor.execute(CONNECTIONS_QUERY)
-        rows = cursor.fetchall()
-        self._log.debug("Loaded [%s] current connections", len(rows))
-        return rows
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _get_activity(self, cursor):
@@ -255,7 +231,7 @@ class MySQLActivity(DBMAsyncJob):
         # type: (Dict[str]) -> int
         return len(str(row))
 
-    def _create_activity_event(self, active_sessions, active_connections):
+    def _create_activity_event(self, active_sessions):
         # type: (List[Dict[str]], List[Dict[str]]) -> Dict[str]
         return {
             "host": self._check.resolved_hostname,
@@ -266,7 +242,6 @@ class MySQLActivity(DBMAsyncJob):
             "ddtags": self._tags,
             "timestamp": time.time() * 1000,
             "mysql_activity": active_sessions,
-            "mysql_connections": active_connections,
         }
 
     @staticmethod

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -249,6 +249,10 @@ PERFORMANCE_VARS = {
     'perf_digest_95th_percentile_avg_us': ('mysql.performance.digest_95th_percentile.avg_us', GAUGE),
 }
 
+COMMON_PERFORMANCE_VARS = {
+    'user_connections': ('mysql.performance.user_connections', GAUGE),
+}
+
 SCHEMA_VARS = {'information_schema_size': ('mysql.info.schema.size', GAUGE)}
 
 TABLE_VARS = {

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -249,10 +249,6 @@ PERFORMANCE_VARS = {
     'perf_digest_95th_percentile_avg_us': ('mysql.performance.digest_95th_percentile.avg_us', GAUGE),
 }
 
-COMMON_PERFORMANCE_VARS = {
-    'user_connections': ('mysql.performance.user_connections', GAUGE),
-}
-
 SCHEMA_VARS = {'information_schema_size': ('mysql.info.schema.size', GAUGE)}
 
 TABLE_VARS = {

--- a/mysql/datadog_checks/mysql/queries.py
+++ b/mysql/datadog_checks/mysql/queries.py
@@ -74,6 +74,31 @@ SQL_GROUP_REPLICATION_PLUGIN_STATUS = """\
 SELECT plugin_status
 FROM information_schema.plugins WHERE plugin_name='group_replication'"""
 
+QUERY_USER_CONNECTIONS = {
+    'name': 'performance_schema.threads',
+    'query': """
+        SELECT
+            COUNT(processlist_user) AS connections,
+            processlist_user,
+            processlist_host,
+            processlist_db,
+            processlist_state
+        FROM
+            performance_schema.threads
+        WHERE
+            processlist_user IS NOT NULL AND
+            processlist_state IS NOT NULL
+        GROUP BY processlist_user, processlist_host, processlist_db, processlist_state
+    """.strip(),
+    'columns': [
+        {'name': 'mysql.performance.user_connections', 'type': 'gauge'},
+        {'name': 'processlist_user', 'type': 'tag'},
+        {'name': 'processlist_host', 'type': 'tag'},
+        {'name': 'processlist_db', 'type': 'tag'},
+        {'name': 'processlist_state', 'type': 'tag'},
+    ],
+}
+
 
 def show_replica_status_query(version, is_mariadb, channel=''):
     if version.version_compatible((10, 5, 1)) or not is_mariadb and version.version_compatible((8, 0, 22)):

--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -21,6 +21,7 @@ mysql.innodb.row_lock_waits,gauge,,event,second,The number of times per second a
 mysql.net.connections,gauge,,connection,second,The rate of connections to the server.,0,mysql,conns per s,cpu
 mysql.net.max_connections,gauge,,connection,,The maximum number of connections that have been in use simultaneously since the server started.,-1,mysql,max used conn,
 mysql.net.max_connections_available,gauge,,connection,,The maximum permitted number of simultaneous client connections.,-1,mysql,max used conn avail,
+mysql.performance.user_connections,gauge,,connection,,"The number of user connections. Tags: processlist_db, processlist_host, processlist_state, processlist_user",0,mysql,user conns,
 mysql.performance.com_delete,gauge,,query,second,The rate of delete statements.,0,mysql,deletes,
 mysql.performance.com_delete_multi,gauge,,query,second,The rate of delete-multi statements.,0,mysql,delete multi,
 mysql.performance.com_insert,gauge,,query,second,The rate of insert statements.,0,mysql,inserts,cpu

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -14,6 +14,7 @@ from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.mysql import MySql
 from datadog_checks.mysql.const import (
     BINLOG_VARS,
+    COMMON_PERFORMANCE_VARS,
     GALERA_VARS,
     GROUP_REPLICATION_VARS,
     INNODB_VARS,
@@ -41,7 +42,13 @@ def test_minimal_config(aggregator, dd_run_check, instance_basic):
     aggregator.assert_service_check('mysql.can_connect', status=MySql.OK, tags=tags.SC_TAGS_MIN, count=1)
 
     # Test metrics
-    testable_metrics = variables.STATUS_VARS + variables.VARIABLES_VARS + variables.INNODB_VARS + variables.BINLOG_VARS
+    testable_metrics = (
+        variables.STATUS_VARS
+        + variables.VARIABLES_VARS
+        + variables.INNODB_VARS
+        + variables.BINLOG_VARS
+        + variables.COMMON_PERFORMANCE_VARS
+    )
 
     for mname in testable_metrics:
         aggregator.assert_metric(mname, at_least=1)
@@ -117,7 +124,7 @@ def _assert_complex_config(aggregator, hostname='stubbed.hostname'):
         )
 
     if MYSQL_VERSION_PARSED >= parse_version('5.6'):
-        testable_metrics.extend(variables.PERFORMANCE_VARS)
+        testable_metrics.extend(variables.PERFORMANCE_VARS + variables.COMMON_PERFORMANCE_VARS)
 
     # Test metrics
     for mname in testable_metrics:
@@ -219,7 +226,7 @@ def test_complex_config_replica(aggregator, dd_run_check, instance_complex):
     )
 
     if MYSQL_VERSION_PARSED >= parse_version('5.6') and environ.get('MYSQL_FLAVOR') != 'mariadb':
-        testable_metrics.extend(variables.PERFORMANCE_VARS)
+        testable_metrics.extend(variables.PERFORMANCE_VARS + variables.COMMON_PERFORMANCE_VARS)
 
     # Test metrics
     for mname in testable_metrics:
@@ -279,9 +286,9 @@ def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, agg
     instance_basic['dbm'] = dbm_enabled
     instance_basic['disable_generic_tags'] = False  # This flag also affects the hostname
     instance_basic['reported_hostname'] = reported_hostname
-    mysql_check = MySql(common.CHECK_NAME, {}, [instance_basic])
 
     with mock.patch('datadog_checks.mysql.MySql.resolve_db_host', return_value='resolved.hostname') as resolve_db_host:
+        mysql_check = MySql(common.CHECK_NAME, {}, [instance_basic])
         dd_run_check(mysql_check)
         if reported_hostname:
             assert resolve_db_host.called is False, 'Expected resolve_db_host.called to be False'
@@ -366,6 +373,7 @@ def test_only_custom_queries(aggregator, dd_run_check, instance_custom_queries):
         SYNTHETIC_VARS,
         REPLICA_VARS,
         GROUP_REPLICATION_VARS,
+        COMMON_PERFORMANCE_VARS,
     ]
     for metric_set in standard_metric_sets:
         for metric_def in metric_set.values():

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -14,7 +14,6 @@ from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.mysql import MySql
 from datadog_checks.mysql.const import (
     BINLOG_VARS,
-    COMMON_PERFORMANCE_VARS,
     GALERA_VARS,
     GROUP_REPLICATION_VARS,
     INNODB_VARS,
@@ -373,7 +372,7 @@ def test_only_custom_queries(aggregator, dd_run_check, instance_custom_queries):
         SYNTHETIC_VARS,
         REPLICA_VARS,
         GROUP_REPLICATION_VARS,
-        COMMON_PERFORMANCE_VARS,
+        variables.QUERY_EXECUTOR_METRIC_SETS,
     ]
     for metric_set in standard_metric_sets:
         for metric_def in metric_set.values():

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -137,18 +137,6 @@ def test_collect_activity(aggregator, dbm_instance, dd_run_check, query, query_s
     assert blocked_row['lock_time'], "missing lock time"
     assert blocked_row['query_truncated'] == expected_query_truncated
 
-    connections = activity['mysql_connections']
-    assert len(connections) > 0, "expected to have active connections"
-    fred_conn = None
-    for conn in connections:
-        if conn['processlist_user'] == 'fred':
-            fred_conn = conn
-            break
-
-    assert fred_conn is not None
-    assert fred_conn['connections'] == 1
-    assert fred_conn['processlist_state'], "missing state"
-
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -22,6 +22,7 @@ STATUS_VARS = [
     'mysql.net.max_connections',
     'mysql.net.aborted_clients',
     'mysql.net.aborted_connects',
+    'mysql.performance.user_connections',
     # Table Cache Metrics
     'mysql.performance.open_files',
     'mysql.performance.open_tables',

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -22,7 +22,6 @@ STATUS_VARS = [
     'mysql.net.max_connections',
     'mysql.net.aborted_clients',
     'mysql.net.aborted_connects',
-    'mysql.performance.user_connections',
     # Table Cache Metrics
     'mysql.performance.open_files',
     'mysql.performance.open_tables',
@@ -249,6 +248,8 @@ OPTIONAL_INNODB_VARS = [
 ]
 
 PERFORMANCE_VARS = ['mysql.performance.query_run_time.avg', 'mysql.performance.digest_95th_percentile.avg_us']
+
+COMMON_PERFORMANCE_VARS = ['mysql.performance.user_connections']
 
 SCHEMA_VARS = ['mysql.info.schema.size']
 

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -251,6 +251,11 @@ PERFORMANCE_VARS = ['mysql.performance.query_run_time.avg', 'mysql.performance.d
 
 COMMON_PERFORMANCE_VARS = ['mysql.performance.user_connections']
 
+# This exists to comply with some of the testing patterns with the old API.
+QUERY_EXECUTOR_METRIC_SETS = {
+    'user_connections': ('mysql.performance.user_connections', 'guage'),
+}
+
 SCHEMA_VARS = ['mysql.info.schema.size']
 
 SYNTHETIC_VARS = ['mysql.performance.qcache.utilization', 'mysql.performance.qcache.utilization.instant']


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a new user connections metric `mysql.performance.user_connections` in the standard integration.

![Screen Shot 2022-08-02 at 10 01 49 AM](https://user-images.githubusercontent.com/30381624/182393727-ac193dc6-e202-4c9e-aba8-eb2a7f412c12.png)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
- The new metric is emitted using the new `QueryExecutor` API
- Removes user connections rows from DBM's activity payload because we concluded that it is not necessary to send these to our back-end to be emitted. This provides the additional benefit of reducing the overall payload size.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
