### PR TITLE
Disable cacti e2e

### DIFF
--- a/cacti/tox.ini
+++ b/cacti/tox.ini
@@ -10,8 +10,6 @@ ensure_default_envdir = true
 envdir =
     py27: {toxworkdir}/py27
     py38: {toxworkdir}/py38
-description =
-    py{27,38}: e2e ready
 usedevelop = true
 dd_check_style = true
 platform = linux|darwin|win32


### PR DESCRIPTION
The docker image we rely on has been removed. This PR disables the e2e tests while we create a new one.