### PR TITLE
Bump `lxml` package

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -41,7 +41,7 @@ kazoo==2.8.0
 kubernetes==18.20.0; python_version < '3.0'
 kubernetes==22.6.0; python_version > '3.0'
 ldap3==2.9.1
-lxml==4.8.0
+lxml==4.9.1
 lz4==2.2.1; python_version < '3.0'
 lz4==3.1.3; python_version > '3.0'
 mmh3==2.5.1; python_version < '3.0'

--- a/ibm_was/pyproject.toml
+++ b/ibm_was/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = [
 
 [project.optional-dependencies]
 deps = [
-    "lxml==4.8.0",
+    "lxml==4.9.1",
 ]
 
 [project.urls]

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -38,7 +38,7 @@ dynamic = [
 [project.optional-dependencies]
 deps = [
     "adodbapi==2.6.2.0; sys_platform == 'win32'",
-    "lxml==4.8.0",
+    "lxml==4.9.1",
     "pyodbc==4.0.32",
     "pyro4==4.82; sys_platform == 'win32'",
     "pywin32==228; sys_platform == 'win32' and python_version < '3.0'",


### PR DESCRIPTION
### What does this PR do?

Bump `lxml` version for [CVE-2022-2309](https://avd.aquasec.com/nvd/cve-2022-2309).

### Motivation

Fix DataDog/image-vuln-scans#502.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
