### PR TITLE
Add attempts to mapreduce environment

### DIFF
--- a/mapreduce/tests/conftest.py
+++ b/mapreduce/tests/conftest.py
@@ -35,6 +35,7 @@ def dd_environment():
         compose_file=os.path.join(HERE, "compose", "docker-compose.yaml"),
         conditions=[WaitFor(setup_mapreduce, attempts=5, wait=5)],
         env_vars=env,
+        attempts=2,
     ):
         # 'custom_hosts' in metadata provides native /etc/hosts mappings in the agent's docker container
         yield INSTANCE_INTEGRATION, {'custom_hosts': get_custom_hosts()}


### PR DESCRIPTION
### What does this PR do?

Add attempts to the mapreduce test environment. It's not great but I don't have a better solution right now.

### Motivation

https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106629&view=logs&jobId=44f80fa8-59b4-5eac-d564-3b72739a148c&j=44f80fa8-59b4-5eac-d564-3b72739a148c&t=b3f261fd-6b58-549b-d68a-62dbdf5aafc4

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
