### PR TITLE
Add queue.incoming_pods metric

### DIFF
--- a/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
@@ -25,6 +25,11 @@ DEFAULT_COUNTERS = {
     'scheduler_total_preemption_attempts': 'pod_preemption.attempts',
 }
 
+NEW_1_17_COUNTERS = {
+    # (from 1.17) Number of pods added to scheduling queues by event and queue type
+    'scheduler_queue_incoming_pods_total': 'queue.incoming_pods'
+}
+
 NEW_1_19_COUNTERS = {
     # Total preemption attempts in the cluster till now (new name)
     'scheduler_preemption_attempts_total': 'pod_preemption.attempts',
@@ -142,6 +147,7 @@ class KubeSchedulerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
                     'metrics': [
                         DEFAULT_COUNTERS,
                         DEFAULT_HISTOGRAMS,
+                        NEW_1_17_COUNTERS,
                         NEW_1_19_COUNTERS,
                         NEW_1_14_HISTOGRAMS,
                         NEW_1_19_HISTOGRAMS,

--- a/kube_scheduler/metadata.csv
+++ b/kube_scheduler/metadata.csv
@@ -37,3 +37,4 @@ kube_scheduler.scheduling.pod.scheduling_duration.sum,gauge,,,second,"Total e2e 
 kube_scheduler.scheduling.pod.scheduling_duration.count,gauge,,,,"E2e latency for a pod being scheduled which may include multiple scheduling attempts (requires k8s v1.23+)",0,kube_scheduler,scheduling.pod.scheduling_duration.count,
 kube_scheduler.scheduling.attempt_duration.sum,gauge,,,second,"Total scheduling attempt latency in seconds (scheduling algorithm + binding) (requires k8s v1.23+)",0,kube_scheduler,scheduling.attempt_duration.sum,
 kube_scheduler.scheduling.attempt_duration.count,gauge,,,,"Scheduling attempt latency in seconds (scheduling algorithm + binding) (requires k8s v1.23+)",0,kube_scheduler,scheduling.attempt_duration.count,
+kube_scheduler.queue.incoming_pods,count,,,,"Number of pods added to scheduling queues by event and queue type (requires k8s v1.17+)",0,kube_scheduler,queue.incoming_pods,

--- a/kube_scheduler/tests/test_kube_scheduler_1_23.py
+++ b/kube_scheduler/tests/test_kube_scheduler_1_23.py
@@ -115,6 +115,11 @@ def test_check_metrics_1_23(aggregator, mock_metrics, mock_leader):
         value=2.0,
         tags=[],
     )
+
+    assert_metric('.queue.incoming_pods', value=7.0, tags=['event:PodAdd', 'queue:active'])
+    assert_metric('.queue.incoming_pods', value=3.0, tags=['event:NodeTaintChange', 'queue:active'])
+    assert_metric('.queue.incoming_pods', value=3.0, tags=['event:ScheduleAttemptFailure', 'queue:unschedulable'])
+
     assert_metric('.goroutines')
     assert_metric('.gc_duration_seconds.sum')
     assert_metric('.gc_duration_seconds.count')


### PR DESCRIPTION
### What does this PR do?
This PR adds the `queue.incoming_pods` metric

### Motivation
The `scheduler_queue_incoming_pods` metric was added in Kubernetes 1.17, but was never added to the integration.

https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.17.md#scheduling-1


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
