### PR TITLE
Add tag consul_node to consul service check consul.check from ConsulCheck.Node

### DIFF
--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -372,6 +372,8 @@ class ConsulCheck(OpenMetricsBaseCheck):
                             tags.append('service:{}'.format(check['ServiceName']))
                     if check["ServiceID"]:
                         tags.append("consul_service_id:{}".format(check["ServiceID"]))
+                    if check["Node"]:
+                        tags.append("consul_node:{}".format(check["Node"]))
                     sc[sc_id] = {'status': status, 'tags': tags}
 
                 elif STATUS_SEVERITY[status] > STATUS_SEVERITY[sc[sc_id]['status']]:

--- a/consul/tests/compose/compose.yaml
+++ b/consul/tests/compose/compose.yaml
@@ -9,7 +9,7 @@ services:
       - "${CONSUL_PORT}:8500"
     networks:
       - network1
-    command: agent -dev -bootstrap -bind=0.0.0.0 -client=0.0.0.0
+    command: agent -dev -bootstrap -bind=0.0.0.0 -client=0.0.0.0 -node=node-consul-leader
 
   consul-follower-1:
     image: "consul:${CONSUL_VERSION}"
@@ -19,7 +19,7 @@ services:
       - network1
     depends_on:
       - "consul-leader"
-    command: ["/bin/sh", "-c", "sleep 5 && consul agent -dev -join=consul-leader -bind=0.0.0.0"]
+    command: ["/bin/sh", "-c", "sleep 5 && consul agent -dev -join=consul-leader -bind=0.0.0.0 -node=node-consul-follower-1"]
 
   consul-follower-2:
     image: "consul:${CONSUL_VERSION}"
@@ -29,7 +29,7 @@ services:
       - ${CONSUL_CONFIG_PATH}:/consul/config/server.json:ro
     depends_on:
       - "consul-follower-1"
-    command: ["/bin/sh", "-c", "sleep 5 && consul agent -dev -join=consul-leader -bind=0.0.0.0"]
+    command: ["/bin/sh", "-c", "sleep 5 && consul agent -dev -join=consul-leader -bind=0.0.0.0 -node=node-consul-follower-2"]
 
 
 networks:

--- a/consul/tests/test_e2e.py
+++ b/consul/tests/test_e2e.py
@@ -33,7 +33,11 @@ def test_e2e(dd_agent_check, instance_single_node_install):
     aggregator.assert_service_check(
         'consul.up', ConsulCheck.OK, tags=['consul_datacenter:dc1', 'consul_url:http://{}:8500'.format(common.HOST)]
     )
-    aggregator.assert_service_check('consul.check', ConsulCheck.OK, tags=['check:serfHealth', 'consul_datacenter:dc1'])
+    aggregator.assert_service_check(
+        'consul.check',
+        ConsulCheck.OK,
+        tags=['check:serfHealth', 'consul_datacenter:dc1', 'consul_node:node-consul-follower-1'],
+    )
     aggregator.assert_service_check(
         'consul.can_connect', ConsulCheck.OK, tags=['url:http://{}:8500/v1/status/leader'.format(common.HOST)]
     )

--- a/consul/tests/test_unit.py
+++ b/consul/tests/test_unit.py
@@ -188,6 +188,7 @@ def test_service_checks(aggregator):
         "check:server-loadbalancer",
         "consul_service_id:server-loadbalancer",
         "consul_service:server-loadbalancer",
+        "consul_node:node-1",
     ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.CRITICAL, tags=expected_tags, count=1)
 
@@ -196,6 +197,7 @@ def test_service_checks(aggregator):
         "check:server-api",
         "consul_service_id:server-loadbalancer",
         "consul_service:server-loadbalancer",
+        "consul_node:node-1",
     ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.OK, tags=expected_tags, count=1)
 
@@ -203,10 +205,16 @@ def test_service_checks(aggregator):
         "consul_datacenter:dc1",
         "check:server-api",
         "consul_service:server-loadbalancer",
+        "consul_node:node-1",
     ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.OK, tags=expected_tags, count=1)
 
-    expected_tags = ["consul_datacenter:dc1", "check:server-api", "consul_service_id:server-loadbalancer"]
+    expected_tags = [
+        "consul_datacenter:dc1",
+        "check:server-api",
+        "consul_service_id:server-loadbalancer",
+        "consul_node:node-1",
+    ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.OK, tags=expected_tags, count=1)
 
     expected_tags = [
@@ -214,6 +222,7 @@ def test_service_checks(aggregator):
         "check:server-status-empty",
         "consul_service_id:server-empty",
         "consul_service:server-empty",
+        "consul_node:node-1",
     ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.UNKNOWN, tags=expected_tags, count=1)
 
@@ -232,6 +241,7 @@ def test_service_checks_disable_service_tag(aggregator):
         'check:server-loadbalancer',
         'consul_service_id:server-loadbalancer',
         'consul_service:server-loadbalancer',
+        'consul_node:node-1',
     ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.CRITICAL, tags=expected_tags, count=1)
 
@@ -240,13 +250,24 @@ def test_service_checks_disable_service_tag(aggregator):
         'check:server-api',
         'consul_service_id:server-loadbalancer',
         'consul_service:server-loadbalancer',
+        'consul_node:node-1',
     ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.OK, tags=expected_tags, count=1)
 
-    expected_tags = ['consul_datacenter:dc1', 'check:server-api', 'consul_service:server-loadbalancer']
+    expected_tags = [
+        'consul_datacenter:dc1',
+        'check:server-api',
+        'consul_service:server-loadbalancer',
+        'consul_node:node-1',
+    ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.OK, tags=expected_tags, count=1)
 
-    expected_tags = ['consul_datacenter:dc1', 'check:server-api', 'consul_service_id:server-loadbalancer']
+    expected_tags = [
+        'consul_datacenter:dc1',
+        'check:server-api',
+        'consul_service_id:server-loadbalancer',
+        'consul_node:node-1',
+    ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.OK, tags=expected_tags, count=1)
 
     expected_tags = [
@@ -254,6 +275,7 @@ def test_service_checks_disable_service_tag(aggregator):
         'check:server-status-empty',
         'consul_service_id:server-empty',
         'consul_service:server-empty',
+        'consul_node:node-1',
     ]
     aggregator.assert_service_check('consul.check', status=ConsulCheck.UNKNOWN, tags=expected_tags, count=1)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Resolves #12609 

Implements the tag `consul_node` with data from `ConsulCheck["Node"]` from response data `consul_request('/v1/health/state/any')` for Service Check `consul.check` (health check).

### Motivation
<!-- What inspired you to submit this pull request? -->

See #12609 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I was unsuccessful at getting a tox test env setup with `ddev` after 1-hour spent trying.

I recommend that y'all quickly run the test `ddev test consul` to ensure that I copied the right node names such as `consul_node:node-1` vs. `consul_node:node-2` between the tests and mocks.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
