### PR TITLE
Prevent metadata validation from crashing on missing columns

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -346,7 +346,7 @@ def metadata(check, check_duplicates, show_warnings):
                 missing_headers = ALL_HEADERS.difference(all_keys)
                 if missing_headers:
                     errors = True
-                    display_queue.append(echo_failure(f'{current_check}:{line} Missing columns {missing_headers}'))
+                    display_queue.append((echo_failure, f'{current_check}:{line} Missing columns {missing_headers}'))
                 continue
 
             errors = errors or check_duplicate_values(


### PR DESCRIPTION
### What does this PR do?
Fixes metadata validation so it does not break when finding missing columns 
### Motivation
metadata validation currently breaks when displaying errors for integrations extras (error fixed in https://github.com/DataDog/integrations-extras/pull/1384):
```
/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/console.py", line 35, in annotate_display_queue
    for func, message in display_queue:
TypeError: cannot unpack non-iterable NoneType object
```
### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
