### PR TITLE
Updates GitLab URL documentation

### DIFF
--- a/gitlab/assets/configuration/spec.yaml
+++ b/gitlab/assets/configuration/spec.yaml
@@ -6,9 +6,9 @@ files:
     options:
     - name: gitlab_url
       description: |
-        The master URL to probe for service health status
-        If you are using gitlab CE and not EE, use this URL with
-        the authorization token: http://localhost/?token=<TOKEN>
+        The GitLab external URL to probe for service health status
+        If authentication is required, use this URL with
+        the authorization token: http://localhost/?access_token=<TOKEN>
       value:
         type: string
     - name: api_token

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -4,9 +4,9 @@ instances:
 
   -
     ## @param gitlab_url - string - optional
-    ## The master URL to probe for service health status
-    ## If you are using gitlab CE and not EE, use this URL with
-    ## the authorization token: http://localhost/?token=<TOKEN>
+    ## The GitLab external URL to probe for service health status
+    ## If authentication is required, use this URL with
+    ## the authorization token: http://localhost/?access_token=<TOKEN>
     #
     # gitlab_url: <GITLAB_URL>
 


### PR DESCRIPTION
### What does this PR do?
Update the gitlab documentation with correct instructions for specifying the gitlab url with authentication. 
Per the GitLab documentation, the token url format is supported for all tiers including EE and CE: 
* https://docs.gitlab.com/ee/api/
* https://docs.gitlab.com/ee/api/#authentication

### Motivation
Customer request

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
