### PR TITLE
Do not recreate the tables if they already exists

### DIFF
--- a/clickhouse/tests/docker/init.sql
+++ b/clickhouse/tests/docker/init.sql
@@ -1,3 +1,3 @@
-CREATE TABLE tableau (id Int64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{layer}-{shard}/tableau', '{replica}') PARTITION BY id ORDER BY id;
-CREATE TABLE tableau_distributed as tableau ENGINE = Distributed(cluster_1, default, tableau, rand());
+CREATE TABLE IF EXISTS tableau (id Int64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{layer}-{shard}/tableau', '{replica}') PARTITION BY id ORDER BY id;
+CREATE TABLE IF EXISTS tableau_distributed as tableau ENGINE = Distributed(cluster_1, default, tableau, rand());
 INSERT INTO tableau VALUES (123),(456),(789);

--- a/clickhouse/tests/docker/init.sql
+++ b/clickhouse/tests/docker/init.sql
@@ -1,3 +1,3 @@
-CREATE TABLE IF EXISTS tableau (id Int64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{layer}-{shard}/tableau', '{replica}') PARTITION BY id ORDER BY id;
-CREATE TABLE IF EXISTS tableau_distributed as tableau ENGINE = Distributed(cluster_1, default, tableau, rand());
+CREATE TABLE IF NOT EXISTS tableau (id Int64) ENGINE = ReplicatedMergeTree('/clickhouse/tables/{layer}-{shard}/tableau', '{replica}') PARTITION BY id ORDER BY id;
+CREATE TABLE IF NOT EXISTS tableau_distributed as tableau ENGINE = Distributed(cluster_1, default, tableau, rand());
 INSERT INTO tableau VALUES (123),(456),(789);


### PR DESCRIPTION
### What does this PR do?

Do not recreate the tables if they already exists during the container initialisation. 

### Motivation

The clickhouse tests are flaky. Examples:
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106857&view=logs&jobId=8e96ab15-72b0-549c-5ab8-f9fece94b017&j=8e96ab15-72b0-549c-5ab8-f9fece94b017&t=ec9b40f1-a5eb-523c-a2d7-f48a83ba2f0c
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106829&view=logs&jobId=8e96ab15-72b0-549c-5ab8-f9fece94b017&j=8e96ab15-72b0-549c-5ab8-f9fece94b017&t=ec9b40f1-a5eb-523c-a2d7-f48a83ba2f0c
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106713&view=logs&jobId=8e96ab15-72b0-549c-5ab8-f9fece94b017&j=8e96ab15-72b0-549c-5ab8-f9fece94b017&t=ec9b40f1-a5eb-523c-a2d7-f48a83ba2f0c

The error says:

```
clickhouse-02         | /entrypoint.sh: running /docker-entrypoint-initdb.d/init.sql
clickhouse-02         | Received exception from server (version 21.8.14):
clickhouse-02         | Code: 57. DB::Exception: Received from 127.0.0.1:9000. DB::Exception: Table default.tableau already exists.. 
```

I don't really understand why the tables already exists in a (supposedly) brand new container. I know it's not a perfect solution but I think we could give it a shot, the clickhouse tests are failing fairly often, even with retries.

Edit: Our assumption with @jose-manuel-almaza is that the tables are replicated from one clickhouse instance to the others. 
- https://github.com/DataDog/integrations-core/blob/8375f36e5182763100a1162e4fc277f29f34be9e/clickhouse/tests/docker/override_configs/remote_servers.xml#L2
- https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/replication/

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
