### PR TITLE
Assert the job is running in the test_e2e

### DIFF
--- a/mapreduce/tests/test_mapreduce_integration_e2e.py
+++ b/mapreduce/tests/test_mapreduce_integration_e2e.py
@@ -44,7 +44,7 @@ def test_metadata(aggregator, check, dd_run_check, instance, datadog_agent):
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, instance):
     # trigger a job but wait for it to be in a running state before running check
-    common.setup_mapreduce()
+    assert common.setup_mapreduce()
 
     aggregator = dd_agent_check(instance, rate=True)
     for metric in common.ELAPSED_TIME_BUCKET_METRICS:


### PR DESCRIPTION
### What does this PR do?

Add an assert to the mapreduce `test_e2e`.

### Motivation

This test is failing sometimes. Example:
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=106873&view=logs&jobId=44f80fa8-59b4-5eac-d564-3b72739a148c&j=44f80fa8-59b4-5eac-d564-3b72739a148c&t=37cf5e0d-a62f-5d05-e6eb-b5df035c1060

I'm not sure if this is because the `mapreduce.job.elapsed_time.max` is optional or if it's because the job is not running. I think it is the latter. Adding an assert will let us know if the job is running or not before running the check and assert the metrics are well collected.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
