### PR TITLE
Add the `max_connections` metric

### DIFF
--- a/mcache/datadog_checks/mcache/mcache.py
+++ b/mcache/datadog_checks/mcache/mcache.py
@@ -31,6 +31,7 @@ class Memcache(AgentCheck):
         "uptime",
         "bytes",
         "curr_connections",
+        "max_connections",
         "connection_structures",
         "threads",
         "pointer_size",

--- a/mcache/metadata.csv
+++ b/mcache/metadata.csv
@@ -11,6 +11,7 @@ memcache.cmd_get_rate,gauge,,command,second,"Rate of ""get"" commands.",0,memcac
 memcache.cmd_set_rate,gauge,,command,second,"Rate of ""set"" commands.",0,memcached,cmd set rate,
 memcache.connection_structures,gauge,,,,Number of connection structures allocated by the server.,0,memcached,conn structs,
 memcache.curr_connections,gauge,,connection,,Number of open connections to this server.,0,memcached,curr conns,
+memcache.max_connections,gauge,,connection,,Maximum number of connections to this server.,0,memcached,max conns,
 memcache.curr_items,gauge,,item,,Current number of items stored by the server.,0,memcached,curr items,
 memcache.delete_hits_rate,gauge,,hit,second,Rate at which delete commands result in items being removed.,0,memcached,del hit rate,
 memcache.delete_misses_rate,gauge,,miss,second,Rate at which delete commands result in no items being removed.,0,memcached,del miss rate,

--- a/mcache/tests/metrics.py
+++ b/mcache/tests/metrics.py
@@ -8,6 +8,7 @@ GAUGES = [
     "memcache.uptime",
     "memcache.bytes",
     "memcache.curr_connections",
+    "memcache.max_connections",
     "memcache.connection_structures",
     "memcache.threads",
     "memcache.pointer_size",

--- a/mcache/tests/test_integration_e2e.py
+++ b/mcache/tests/test_integration_e2e.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
+from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.mcache import Memcache
 
 from .common import HOST, PORT, SERVICE_CHECK, requires_socket_support, requires_unix_utils
@@ -39,6 +40,7 @@ def test_e2e(client, dd_agent_check, instance):
     aggregator = dd_agent_check(instance, rate=True)
 
     assert_check_coverage(aggregator)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 @pytest.mark.integration
@@ -72,6 +74,7 @@ def test_metrics(client, instance, aggregator, dd_run_check):
     dd_run_check(check)
 
     assert_check_coverage(aggregator)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 
 
 @pytest.mark.integration

--- a/mcache/tests/test_integration_e2e.py
+++ b/mcache/tests/test_integration_e2e.py
@@ -5,7 +5,6 @@ import pytest
 
 from datadog_checks.mcache import Memcache
 
-from datadog_checks.dev.utils import get_metadata_metrics
 from .common import HOST, PORT, SERVICE_CHECK, requires_socket_support, requires_unix_utils
 from .metrics import GAUGES, ITEMS_GAUGES, ITEMS_RATES, RATES, SLABS_AGGREGATES, SLABS_GAUGES, SLABS_RATES
 from .utils import count_connections, get_host_socket_path
@@ -24,7 +23,6 @@ def assert_check_coverage(aggregator):
         aggregator.assert_metric(m, tags=expected_tags)
 
     aggregator.assert_all_metrics_covered()
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 @pytest.mark.e2e

--- a/mcache/tests/test_integration_e2e.py
+++ b/mcache/tests/test_integration_e2e.py
@@ -5,6 +5,7 @@ import pytest
 
 from datadog_checks.mcache import Memcache
 
+from datadog_checks.dev.utils import get_metadata_metrics
 from .common import HOST, PORT, SERVICE_CHECK, requires_socket_support, requires_unix_utils
 from .metrics import GAUGES, ITEMS_GAUGES, ITEMS_RATES, RATES, SLABS_AGGREGATES, SLABS_GAUGES, SLABS_RATES
 from .utils import count_connections, get_host_socket_path
@@ -23,6 +24,7 @@ def assert_check_coverage(aggregator):
         aggregator.assert_metric(m, tags=expected_tags)
 
     aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
### What does this PR do?

Add the `max_connections` metric to the `mcache` integration.

### Motivation

Resolves https://github.com/DataDog/integrations-core/issues/12684

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
