### PR TITLE
Fix cluster agent version in requirements-agent-release.txt

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -32,7 +32,7 @@ datadog-coredns==2.2.1; sys_platform == 'linux2'
 datadog-couch==5.1.1
 datadog-couchbase==2.1.0
 datadog-crio==2.2.0
-datadog-datadog-cluster-agent==2.2.0
+datadog-datadog-cluster-agent==2.3.0
 datadog-directory==1.13.1
 datadog-disk==4.7.1
 datadog-dns-check==2.3.0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The cluster v2.3.0 was released in [this PR](https://github.com/DataDog/integrations-core/pull/12699/files), although a subsequent [PR](https://github.com/DataDog/integrations-core/pull/12701/files) changed back the version number in `requirements-agent-release.txt`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Failing job: https://github.com/DataDog/integrations-core/runs/7693754240?check_suite_focus=true
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
