### PR TITLE
Install `datadog_checks_dev[cli]` from pypi instead of `ddev`

### DIFF
--- a/.azure-pipelines/templates/install-deps.yml
+++ b/.azure-pipelines/templates/install-deps.yml
@@ -55,7 +55,7 @@ steps:
     displayName: 'Install ddev from local folder'
 
 - ${{ if not(eq(parameters.repo, 'core')) }}:
-  - script: pip install ddev
+  - script: pip install datadog-checks-dev[cli]
     displayName: 'Install ddev from PyPI'
 
 - script: |


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Reverts a change made by a recent PR to use a standalone ddev package. Right now pypi only has a 0.0.1 version of `ddev` that is over a month old - https://pypi.org/project/ddev/#history

Right now, marketplace (and seems extras as well) tries to install this, and then fails to configure with:

```
/bin/bash --noprofile --norc /home/vsts/work/_temp/742379f6-5935-4320-9e99-2278a8da5422.sh
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.13/x64/bin/ddev", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/ddev/cli/__init__.py", line 8, in main
    from datadog_checks.dev.tooling.cli import ddev
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/datadog_checks/dev/tooling/cli.py", line 7, in <module>
    from .commands import ALL_COMMANDS
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/datadog_checks/dev/tooling/commands/__init__.py", line 4, in <module>
    from .agent import agent
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/datadog_checks/dev/tooling/commands/agent/__init__.py", line 9, in <module>
    from .integrations_changelog import integrations_changelog
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/datadog_checks/dev/tooling/commands/agent/integrations_changelog.py", line 31, in <module>
    def integrations_changelog(checks, since, to, write):
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/click/decorators.py", line 287, in decorator
    _param_memo(f, ArgumentClass(param_decls, **attrs))
  File "/opt/hostedtoolcache/Python/3.8.13/x64/lib/python3.8/site-packages/click/core.py", line 2950, in __init__
    super().__init__(param_decls, required=required, **attrs)
TypeError: __init__() got an unexpected keyword argument 'autocompletion'
```

### Motivation
<!-- What inspired you to submit this pull request? -->
Revert this back to installing the pypi package from before to try to get CI running again in extras and marketplace

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
