### PR TITLE
Add back previously deleted `active_tasks` and `timeouts` metrics for the Cassandra integration

### DIFF
--- a/cassandra/datadog_checks/cassandra/data/metrics.yaml
+++ b/cassandra/datadog_checks/cassandra/data/metrics.yaml
@@ -208,6 +208,23 @@ jmx_metrics:
       attribute:
         - DownEndpointCount
         - UpEndpointCount
+  - include:
+      domain: org.apache.cassandra.metrics
+      type: ThreadPools
+      path: request
+      name:
+        - ActiveTasks
+  - include:
+      domain: org.apache.cassandra.metrics
+      type: ClientRequest
+      scope:
+        - Read
+        - Write
+      name:
+        - Timeouts
+      attribute:
+        - Count
+        - OneMinuteRate
   # Young Gen Collectors (Minor Collections)
   - include:
       domain: java.lang

--- a/cassandra/datadog_checks/cassandra/data/metrics.yaml
+++ b/cassandra/datadog_checks/cassandra/data/metrics.yaml
@@ -197,18 +197,6 @@ jmx_metrics:
       attribute:
         - Value
   - include:
-      domain: org.apache.cassandra.db
-      type: Tables
-      attribute:
-        DroppableTombstoneRatio:
-          alias: cassandra.db.droppable_tombstone_ratio
-  - include:
-      domain: org.apache.cassandra.net
-      type: FailureDetector
-      attribute:
-        - DownEndpointCount
-        - UpEndpointCount
-  - include:
       domain: org.apache.cassandra.metrics
       type: ThreadPools
       path: request
@@ -225,6 +213,18 @@ jmx_metrics:
       attribute:
         - Count
         - OneMinuteRate
+  - include:
+      domain: org.apache.cassandra.db
+      type: Tables
+      attribute:
+        DroppableTombstoneRatio:
+          alias: cassandra.db.droppable_tombstone_ratio
+  - include:
+      domain: org.apache.cassandra.net
+      type: FailureDetector
+      attribute:
+        - DownEndpointCount
+        - UpEndpointCount
   # Young Gen Collectors (Minor Collections)
   - include:
       domain: java.lang

--- a/cassandra/metadata.csv
+++ b/cassandra/metadata.csv
@@ -1,4 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
+cassandra.active_tasks,gauge,10,task,,The number of tasks that the thread pool is actively executing.,0,cassandra,actv tsks
 cassandra.bloom_filter_false_ratio,gauge,10,fraction,,The ratio of Bloom filter false positives to total checks.,-1,cassandra,bloom false ratio,
 cassandra.bytes_flushed.count,gauge,10,byte,,The amount of data that was flushed since (re)start.,0,cassandra,bytes flushed,
 cassandra.cas_commit_latency.75th_percentile,gauge,10,microsecond,,The latency of paxos commit round - p75.,-1,cassandra,cas commit latency p75,
@@ -49,6 +50,8 @@ cassandra.row_cache_miss.count,gauge,10,miss,,The number of table row cache miss
 cassandra.snapshots_size,gauge,10,byte,,The disk space truly used by snapshots.,0,cassandra,snapshot size,
 cassandra.ss_tables_per_read_histogram.75th_percentile,gauge,10,file,read,The number of SSTable data files accessed per read - p75.,-1,cassandra,sstables per read p75,
 cassandra.ss_tables_per_read_histogram.95th_percentile,gauge,10,file,read,The number of SSTable data files accessed per read - p95.,-1,cassandra,sstables per read p95,
+cassandra.timeouts.count,gauge,10,timeout,,Count of requests not acknowledged within configurable timeout window.,-1,cassandra,timeout
+cassandra.timeouts.one_minute_rate,gauge,10,timeout,second,"Recent timeout rate, as an exponentially weighted moving average over a one-minute interval.",-1,cassandra,timeout/s
 cassandra.tombstone_scanned_histogram.75th_percentile,gauge,10,record,read,Number of tombstones scanned per read - p75.,-1,cassandra,tombstones per read p75,
 cassandra.tombstone_scanned_histogram.95th_percentile,gauge,10,record,read,Number of tombstones scanned per read - p95.,-1,cassandra,tombstones per read p95,
 cassandra.total_blocked_tasks,gauge,10,task,,Total blocked tasks,0,cassandra,total blocked tasks,

--- a/cassandra/metadata.csv
+++ b/cassandra/metadata.csv
@@ -1,5 +1,5 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
-cassandra.active_tasks,gauge,10,task,,The number of tasks that the thread pool is actively executing.,0,cassandra,actv tsks
+cassandra.active_tasks,gauge,10,task,,The number of tasks that the thread pool is actively executing.,0,cassandra,actv tsks,
 cassandra.bloom_filter_false_ratio,gauge,10,fraction,,The ratio of Bloom filter false positives to total checks.,-1,cassandra,bloom false ratio,
 cassandra.bytes_flushed.count,gauge,10,byte,,The amount of data that was flushed since (re)start.,0,cassandra,bytes flushed,
 cassandra.cas_commit_latency.75th_percentile,gauge,10,microsecond,,The latency of paxos commit round - p75.,-1,cassandra,cas commit latency p75,
@@ -50,8 +50,8 @@ cassandra.row_cache_miss.count,gauge,10,miss,,The number of table row cache miss
 cassandra.snapshots_size,gauge,10,byte,,The disk space truly used by snapshots.,0,cassandra,snapshot size,
 cassandra.ss_tables_per_read_histogram.75th_percentile,gauge,10,file,read,The number of SSTable data files accessed per read - p75.,-1,cassandra,sstables per read p75,
 cassandra.ss_tables_per_read_histogram.95th_percentile,gauge,10,file,read,The number of SSTable data files accessed per read - p95.,-1,cassandra,sstables per read p95,
-cassandra.timeouts.count,gauge,10,timeout,,Count of requests not acknowledged within configurable timeout window.,-1,cassandra,timeout
-cassandra.timeouts.one_minute_rate,gauge,10,timeout,second,"Recent timeout rate, as an exponentially weighted moving average over a one-minute interval.",-1,cassandra,timeout/s
+cassandra.timeouts.count,gauge,10,timeout,,Count of requests not acknowledged within configurable timeout window.,-1,cassandra,timeout,
+cassandra.timeouts.one_minute_rate,gauge,10,timeout,second,"Recent timeout rate, as an exponentially weighted moving average over a one-minute interval.",-1,cassandra,timeout/s,
 cassandra.tombstone_scanned_histogram.75th_percentile,gauge,10,record,read,Number of tombstones scanned per read - p75.,-1,cassandra,tombstones per read p75,
 cassandra.tombstone_scanned_histogram.95th_percentile,gauge,10,record,read,Number of tombstones scanned per read - p95.,-1,cassandra,tombstones per read p95,
 cassandra.total_blocked_tasks,gauge,10,task,,Total blocked tasks,0,cassandra,total blocked tasks,

--- a/cassandra/tests/common.py
+++ b/cassandra/tests/common.py
@@ -24,6 +24,9 @@ CASSANDRA_JVM_E2E_METRICS = list(set(JVM_E2E_METRICS) - CASSANDRA_JVM_METRICS_NO
 
 CASSANDRA_E2E_METRICS = (
     [
+        "cassandra.active_tasks",
+        "cassandra.timeouts.count",
+        "cassandra.timeouts.one_minute_rate",
         "cassandra.bloom_filter_false_ratio",
         "cassandra.bytes_flushed.count",
         "cassandra.cas_commit_latency.75th_percentile",


### PR DESCRIPTION
### What does this PR do?
This PR adds back 3 previously deleted metrics

### Motivation
Escalation/requested by customer 
