### PR TITLE
Update instructions to include Fork

### DIFF
--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -34,7 +34,7 @@ mkdir $HOME/dd && cd $HOME/dd       # optional
 git clone https://github.com/DataDog/integrations-extras.git
 ```
 
-**Note** A Fork is required if you intend on publishing the check to the [integrations-extras repository][3].
+**Note** A Fork is required if you intend on publishing the check or contributing to [integrations-extras repository][3].
 
 ### Developer toolkit
 

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -27,12 +27,14 @@ Creating and activating [Python virtual environments][1] to isolate the developm
 
 ## Setup
 
-Clone the [integrations-extras repository][3]. By default, that tooling expects you to be working in the `$HOME/dd/` directory—this is optional and can be adjusted with configuration later.
+Fork* and Clone the [integrations-extras repository][3]. By default, that tooling expects you to be working in the `$HOME/dd/` directory—this is optional and can be adjusted with configuration later.
 
 ```shell
 mkdir $HOME/dd && cd $HOME/dd       # optional
 git clone https://github.com/DataDog/integrations-extras.git
 ```
+
+**Note** A Fork is required if you intend on publishing the check to the [integrations-extras repository][3].
 
 ### Developer toolkit
 

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -27,7 +27,7 @@ Creating and activating [Python virtual environments][1] to isolate the developm
 
 ## Setup
 
-Fork* and Clone the [integrations-extras repository][3]. By default, that tooling expects you to be working in the `$HOME/dd/` directory—this is optional and can be adjusted with configuration later.
+**Fork** and clone the [integrations-extras repository][3]. By default, the tooling expects you to be working in the `$HOME/dd/` directory. This is optional and can be adjusted with configuration later.
 
 ```shell
 mkdir $HOME/dd && cd $HOME/dd       # optional

--- a/docs/dev/new_check_howto.md
+++ b/docs/dev/new_check_howto.md
@@ -34,7 +34,7 @@ mkdir $HOME/dd && cd $HOME/dd       # optional
 git clone https://github.com/DataDog/integrations-extras.git
 ```
 
-**Note** A Fork is required if you intend on publishing the check or contributing to [integrations-extras repository][3].
+If you intend on publishing the check or contributing to [integrations-extras repository][3], you must create a fork.
 
 ### Developer toolkit
 


### PR DESCRIPTION
We don't allow outside contributors to directly push to the integrations-extras repo. If they would like to contribute to it, they would have to fork the repo and then make a PR using the fork.

### What does this PR do?
Was a bit unclear
