### PR TITLE
Add ignore_metrics to Prometheus scraper

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/base_check.py
@@ -160,6 +160,7 @@ class GenericPrometheusCheck(AgentCheck):
         scraper.type_overrides = default_instance.get("type_overrides", {})
         scraper.type_overrides.update(instance.get("type_overrides", {}))
         scraper.exclude_labels = default_instance.get("exclude_labels", []) + instance.get("exclude_labels", [])
+        scraper.ignore_metrics = instance.get("ignore_metrics", [])
         scraper.extra_headers = default_instance.get("extra_headers", {})
         scraper.extra_headers.update(instance.get("extra_headers", {}))
         # For simple values instance settings overrides optional defaults

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -501,7 +501,7 @@ class PrometheusScraperMixin(object):
 
         for im in self.ignore_metrics:
             if search(im, message.name):
-                return
+                return # Ignore metric
 
         # Filter metric to see if we can enrich with joined labels
         self.join_labels(message)

--- a/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/prometheus/mixins.py
@@ -499,8 +499,9 @@ class PrometheusScraperMixin(object):
         # If targeted metric, store labels
         self.store_labels(message)
 
-        if message.name in self.ignore_metrics:
-            return  # Ignore the metric
+        for im in self.ignore_metrics:
+            if search(im, message.name):
+                return
 
         # Filter metric to see if we can enrich with joined labels
         self.join_labels(message)

--- a/prometheus/datadog_checks/prometheus/data/conf.yaml.example
+++ b/prometheus/datadog_checks/prometheus/data/conf.yaml.example
@@ -52,6 +52,13 @@ instances:
     # labels_mapper:
     #   flavor: origin
 
+    ## @param ignore_metrics - list of metrics to ignore - optional
+    ## List of metrics to ignore.
+    ## Format is <METRIC_TO_IGNORE> like `default*`, `^default`. Library re https://docs.python.org/3/library/re.html
+    #
+    # ignore_metrics:
+    #   - <METRIC_TO_IGNORE>
+
     ## @param type_overrides - list of key:value element - optional
     ## Type override allows you to override a type in the prometheus payload
     ## or type an untyped metrics (they're ignored by default)


### PR DESCRIPTION
### What does this PR do?
Add ability to ignore metrics via Prometheus integration. 

### Motivation
Have the possibility to drop metrics that you do not want to send to Datadog.

### Additional Notes
Nothing

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
