### PR TITLE
Add Citrix Hypervisor link to integration README

### DIFF
--- a/citrix_hypervisor/README.md
+++ b/citrix_hypervisor/README.md
@@ -69,6 +69,11 @@ See [service_checks.json][9] for a list of service checks provided by this integ
 
 Need help? Contact [Datadog support][10].
 
+## Further reading
+
+Additional helpful documentation, links, and articles:
+
+- [Monitor Citrix Hypervisor performance with Datadog][11]
 
 [1]: https://www.citrix.com/products/citrix-hypervisor/
 [2]: https://docs.datadoghq.com/agent/kubernetes/integrations/
@@ -80,3 +85,4 @@ Need help? Contact [Datadog support][10].
 [8]: https://github.com/DataDog/integrations-core/blob/master/citrix_hypervisor/metadata.csv
 [9]: https://github.com/DataDog/integrations-core/blob/master/citrix_hypervisor/assets/service_checks.json
 [10]: https://docs.datadoghq.com/help/
+[11]: https://www.datadoghq.com/blog/monitor-citrix-hypervisor-datadog/


### PR DESCRIPTION
### What does this PR do?
Adds the Citrix Hypervisor blog link to its doc page.

### Motivation
Docs team Tuesday task. Improves the SEO of the blog.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
