### PR TITLE
Mention that `instance` tag is normalized

### DIFF
--- a/datadog_checks_base/tests/base/checks/test_agent_check.py
+++ b/datadog_checks_base/tests/base/checks/test_agent_check.py
@@ -419,7 +419,7 @@ class TestMetricNormalization:
     [
         ('nothing to normalize', 'abc:123', 'abc:123'),
         ('unicode', u'Klüft inför på fédéral', 'Klüft_inför_på_fédéral'),
-        ('invalid chars', 'foo,+*-/()[]{}  \t\nbar:123', 'foo_bar:123'),
+        ('invalid chars', 'foo,+*-/()[]{}-  \t\nbar:123', 'foo_bar:123'),
         ('leading and trailing underscores', '__abc:123__', 'abc:123'),
         ('redundant underscore', 'foo_____bar', 'foo_bar'),
         ('invalid chars and underscore', 'foo++__bar', 'foo_bar'),

--- a/http_check/assets/configuration/spec.yaml
+++ b/http_check/assets/configuration/spec.yaml
@@ -11,7 +11,7 @@ files:
     - name: name
       required: true
       description: |
-        Name of your Http check instance.
+        Name of your HTTP check instance.
 
         Note: The `instance` tag takes the value of this parameter and normalizes all `,+*-/()[]{}` into `_`.
       value:

--- a/http_check/assets/configuration/spec.yaml
+++ b/http_check/assets/configuration/spec.yaml
@@ -13,7 +13,7 @@ files:
       description: |
         Name of your HTTP check instance.
 
-        Note: The `instance` tag takes the value of this parameter and normalizes all `,+*-/()[]{}` into `_`.
+        Note: The `instance` tag takes the value of this parameter and normalizes all `,+*-/()[]{}` characters into `_`.
       value:
         example: My first service
         type: string

--- a/http_check/assets/configuration/spec.yaml
+++ b/http_check/assets/configuration/spec.yaml
@@ -10,7 +10,10 @@ files:
     options:
     - name: name
       required: true
-      description: Name of your Http check instance.
+      description: |
+        Name of your Http check instance.
+
+        Note: The `instance` tag takes the value of this parameter and normalizes all `,+*-/()[]{}` into `_`.
       value:
         example: My first service
         type: string

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -47,6 +47,8 @@ instances:
 
     ## @param name - string - required
     ## Name of your Http check instance.
+    ##
+    ## Note: The `instance` tag takes the value of this parameter and normalizes all `,+*-/()[]{}` into `_`.
     #
   - name: My first service
 

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -48,7 +48,7 @@ instances:
     ## @param name - string - required
     ## Name of your HTTP check instance.
     ##
-    ## Note: The `instance` tag takes the value of this parameter and normalizes all `,+*-/()[]{}` into `_`.
+    ## Note: The `instance` tag takes the value of this parameter and normalizes all `,+*-/()[]{}` characters into `_`.
     #
   - name: My first service
 

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -46,7 +46,7 @@ init_config:
 instances:
 
     ## @param name - string - required
-    ## Name of your Http check instance.
+    ## Name of your HTTP check instance.
     ##
     ## Note: The `instance` tag takes the value of this parameter and normalizes all `,+*-/()[]{}` into `_`.
     #


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The `http_check`'s `instance` tag is being normalized, and therefore all `instance:test-instance` is converted into `instance:test_instance`, even though the [public docs](https://docs.datadoghq.com/getting_started/tagging/#define-tags) mention that `-` are valid for tags. 

This PR adds a note in the `name` config option to mention that this is happening, since this is where `instance` tag pulls its data.

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
