### PR TITLE
(DOCS-3777) Update Pivotal PKS setup

### DIFF
--- a/pivotal_pks/README.md
+++ b/pivotal_pks/README.md
@@ -6,7 +6,9 @@ This integration monitors [Pivotal Container Service][1] clusters.
 
 ## Setup
 
-Since Datadog already integrates with Kubernetes, it is ready-made to monitor PKS.
+Since Datadog already integrates with Kubernetes, it is ready-made to monitor Pivotal Kubernetes Service (PKS). You can use the Datadog [Cluster Monitoring tile][7] along with this integration to monitor your cluster.
+
+Install the Datadog Agent on each non-worker VM in your PKS environment. In environments without PAS installed, select the `Resource Config` section of the tile and set `instances` of the `datadog-firehose-nozzle` to `0`.
 
 ### Metric collection
 
@@ -33,3 +35,4 @@ Need help? Contact [Datadog support][6].
 [4]: https://docs.datadoghq.com/agent/basic_agent_usage/kubernetes/#container-installation
 [5]: https://docs.datadoghq.com/logs/log_collection/docker/#option-2-container-installation
 [6]: https://docs.datadoghq.com/help/
+[7]: https://network.pivotal.io/products/datadog

--- a/pivotal_pks/README.md
+++ b/pivotal_pks/README.md
@@ -8,7 +8,7 @@ This integration monitors [Pivotal Container Service][1] clusters.
 
 Since Datadog already integrates with Kubernetes, it is ready-made to monitor Pivotal Kubernetes Service (PKS). You can use the Datadog [Cluster Monitoring tile][7] along with this integration to monitor your cluster.
 
-Install the Datadog Agent on each non-worker VM in your PKS environment. In environments without PAS installed, select the `Resource Config` section of the tile and set `instances` of the `datadog-firehose-nozzle` to `0`.
+Install the Datadog Agent on each non-worker VM in your PKS environment. In environments without Pivotal Application Service (PAS) installed, select the `Resource Config` section of the tile and set `instances` of the `datadog-firehose-nozzle` to `0`.
 
 ### Metric collection
 


### PR DESCRIPTION
### What does this PR do?
Add information to the Pivotal PKS documentation setup section, which was removed from the main Pivotal Platform documentation in the following documentation repo PR:
https://github.com/DataDog/documentation/pull/14955

### Motivation
DOCS-3777

### Additional Notes
Preview link:
https://docs-staging.datadoghq.com/docs3777/update-pull-config-preview/integrations/pivotal_pks/#setup

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
