### PR TITLE
Re-enable the 2.3 tests

### DIFF
--- a/harbor/tox.ini
+++ b/harbor/tox.ini
@@ -4,7 +4,7 @@ minversion = 2.0
 skip_missing_interpreters = true
 basepython = py38
 envlist =
-    py{27,38}-{1.10,2.0}
+    py{27,38}-{1.10,2.0,2.3}
 
 [testenv]
 ensure_default_envdir = true
@@ -12,7 +12,7 @@ envdir =
     py27: {toxworkdir}/py27
     py38: {toxworkdir}/py38
 description =
-    py{27,38}-{1.10,2.0}: e2e ready
+    py{27,38}-{1.10,2.0,2.3}: e2e ready
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32


### PR DESCRIPTION
### What does this PR do?

The test env for the 2.3 version was disabled. This PR enable it again.

### Motivation

This env was disabled because it was flaky (https://github.com/DataDog/integrations-core/pull/10141). I would like to re-enable it to see what the errors are and try to fix them if possible.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
