### PR TITLE
Bumps base check requirement to v25.4.0

### DIFF
--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=25.2.2",
+    "datadog-checks-base>=25.4.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
Bumps base check requirement to v25.4.0

### Motivation
Fix CI

New QueryExecutor class added in https://github.com/DataDog/integrations-core/pull/12657: 
https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/CHANGELOG.md#2540--2022-05-10

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
