### PR TITLE
Get a connection every check run

### DIFF
--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -63,18 +63,17 @@ class IbmDb2Check(AgentCheck):
         )
 
     def check(self, instance):
-        if self._conn is None:
-            connection = self.get_connection()
-            if connection is None:
-                self.service_check(
-                    self.SERVICE_CHECK_CONNECT,
-                    self.CRITICAL,
-                    tags=self._tags,
-                    message="Unable to create new connection to database: {}".format(self._db),
-                )
-                return
+        connection = self.get_connection()
+        if connection is None:
+            self.service_check(
+                self.SERVICE_CHECK_CONNECT,
+                self.CRITICAL,
+                tags=self._tags,
+                message="Unable to create new connection to database: {}".format(self._db),
+            )
+            return
 
-            self._conn = connection
+        self._conn = connection
 
         self.service_check(self.SERVICE_CHECK_CONNECT, self.OK, tags=self._tags)
         self.collect_metadata()

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -561,6 +561,7 @@ class IbmDb2Check(AgentCheck):
         connection_options = {ibm_db.ATTR_CASE: ibm_db.CASE_LOWER}
 
         try:
+            self.log.debug("Attempting to connect to Db2 with `%s`...", scrub_connection_string(target))
             connection = ibm_db.connect(target, username, password, connection_options)
         except Exception as e:
             if self._host:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR changes the Db2 check to get a valid connection in each check run. Originally, the check would call `get_connection()` only if `self._conn` was `None`. However, this only happened the first check run, so all subsequent runs would always return an `OK` for `can_connect` service check, even if the connection itself was disabled.

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Another option could be to add a connection refresh option (similar to [VSphere check](https://github.com/DataDog/integrations-core/pull/11507)) so you only need to get a new connection after a certain timeout. 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
