### PR TITLE
Fix logs integration validation

### DIFF
--- a/.gitlab/validate-logs-intgs/validate_log_intgs.py
+++ b/.gitlab/validate-logs-intgs/validate_log_intgs.py
@@ -71,11 +71,11 @@ class CheckDefinition(object):
         with open(os.path.join(INTEGRATIONS_CORE, dir_name, "manifest.json"), 'r') as manifest:
             content = json.load(manifest)
             # name of the integration
-            self.name: str = content['name']
+            self.name: str = content['app_id']
             # boolean: whether or not the integration supports log collection
-            self.log_collection: bool = 'log collection' in content['categories']
+            self.log_collection: bool = 'Category::Log Collection' in content.get('tile', {}).get('classifier_tags', [])
             # boolean: whether or not the integration has public facing docs
-            self.is_public: bool = content['is_public']
+            self.is_public: bool = content['display_on_public_website']
             # Log source defined in the manifest.json of the integration
             self.log_source: Optional[str] = content.get("assets", {}).get("logs", {}).get("source")
 


### PR DESCRIPTION
### What does this PR do?
The weekly logs integration validation gitlab job broke after manifest.json files migrated to v2. Now that V2 migration has completed, we need to update the validation script to reference the updated manifest fields. 

### Motivation
Broken CI validation

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
