### PR TITLE
Fixing in-app display of twistlock integration docs

### DIFF
--- a/twistlock/README.md
+++ b/twistlock/README.md
@@ -40,6 +40,9 @@ For containerized environments, see the [Autodiscovery Integration Templates][5]
 | `<INIT_CONFIG>`      | blank or `{}`                                                                       |
 | `<INSTANCE_CONFIG>`  | `{"url":"http://%%host%%:8083", "username":"<USERNAME>", "password": "<PASSWORD>"}` |
 
+<!-- xxz tab xxx -->
+<!-- xxx tab "Kubernetes" xxx -->
+
 ###### Kubernetes
 
 If you're using Kubernetes, add the config to replication controller section of twistlock_console.yaml before deploying:

--- a/twistlock/README.md
+++ b/twistlock/README.md
@@ -40,15 +40,11 @@ For containerized environments, see the [Autodiscovery Integration Templates][5]
 | `<INIT_CONFIG>`      | blank or `{}`                                                                       |
 | `<INSTANCE_CONFIG>`  | `{"url":"http://%%host%%:8083", "username":"<USERNAME>", "password": "<PASSWORD>"}` |
 
-<!-- xxz tab xxx -->
-<!-- xxx tab "Kubernetes" xxx -->
-
 ###### Kubernetes
 
 If you're using Kubernetes, add the config to replication controller section of twistlock_console.yaml before deploying:
 
 ```yaml
----
 apiVersion: v1
 kind: ReplicationController
 metadata:


### PR DESCRIPTION
### What does this PR do?
Fixes (?) the yaml example where the in-app docs are breaking 

### Motivation
noticed it was breaking

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
