### PR TITLE
Re-enable public docs

### DIFF
--- a/teradata/manifest.json
+++ b/teradata/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "8cac0599-64ca-4a46-8c68-1c5db6cc65ca",
   "app_id": "teradata",
-  "display_on_public_website": false,
+  "display_on_public_website": true,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?
Re-enable public docs. It was mistakenly disabled during the manifest v2 migration. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
