### PR TITLE
Update the statsd config example

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -52,8 +52,10 @@ Connect Airflow to DogStatsD (included in the Datadog Agent) by using the Airflo
    ```conf
    [scheduler]
    statsd_on = True
-   statsd_host = localhost  # Hostname or IP of server running the Datadog Agent
-   statsd_port = 8125       # DogStatsD port configured in the Datadog Agent
+   # Hostname or IP of server running the Datadog Agent
+   statsd_host = localhost  
+   # DogStatsD port configured in the Datadog Agent
+   statsd_port = 8125
    statsd_prefix = airflow
    ```
 


### PR DESCRIPTION
### What does this PR do?
Update the statsd config example so the comments are not on the same line as the properties. 

### Motivation

Support case. Running airflow using this config:

```
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 25, in <module>
    from airflow.configuration import conf
  File "/usr/local/lib/python3.8/site-packages/airflow/__init__.py", line 31, in <module>
    from airflow.utils.log.logging_mixin import LoggingMixin
  File "/usr/local/lib/python3.8/site-packages/airflow/utils/__init__.py", line 24, in <module>
    from .decorators import apply_defaults as _apply_defaults
  File "/usr/local/lib/python3.8/site-packages/airflow/utils/decorators.py", line 36, in <module>
    from airflow import settings
  File "/usr/local/lib/python3.8/site-packages/airflow/settings.py", line 121, in <module>
    port=conf.getint('scheduler', 'statsd_port'),
  File "/usr/local/lib/python3.8/site-packages/airflow/configuration.py", line 418, in getint
    return int(self.get(section, key, **kwargs))
ValueError: invalid literal for int() with base 10: '8125       # DogStatsD port configured in the Datadog Agent'
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
