### PR TITLE
Add virtualdomain_index tag to fgFwPolStatsTable

### DIFF
--- a/snmp/datadog_checks/snmp/data/profiles/fortinet-fortigate.yaml
+++ b/snmp/datadog_checks/snmp/data/profiles/fortinet-fortigate.yaml
@@ -266,12 +266,12 @@ metrics:
       - OID: 1.3.6.1.4.1.12356.101.5.1.2.1.1.3
         name: fgFwPolByteCount
     metric_tags:
+      # Internal virtual domain index used to uniquely identify rows in this table. This index is also used by other tables referencing a virtual domain.
+      - index: 1
+        tag: virtualdomain_index
       # Firewall policy ID. Only enabled policies are present in this table. Policy IDs are only unique within a virtual domain.
-      - tag: policy_index
-        column:
-          OID: 1.3.6.1.4.1.12356.101.5.1.2.1.1.1
-          name: fgFwPolID
-
+      - index: 2
+        tag: policy_index
   # Firewall policy6 statistics table.
   - MIB: FORTINET-FORTIGATE-MIB
     table:
@@ -286,8 +286,9 @@ metrics:
       - OID: 1.3.6.1.4.1.12356.101.5.1.2.2.1.3
         name: fgFwPol6ByteCount
     metric_tags:
+      # Internal virtual domain index used to uniquely identify rows in this table. This index is also used by other tables referencing a virtual domain.
+      - index: 1
+        tag: virtualdomain_index
       # Firewall policy6 ID. Only enabled policies are present in this table. Policy IDs are only unique within a virtual domain.
-      - tag: policy6_index
-        column:
-          OID: 1.3.6.1.4.1.12356.101.5.1.2.2.1.1
-          name: fgFwPol6ID
+      - index: 2
+        tag: policy6_index

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -2415,7 +2415,7 @@ def test_fortinet_fortigate(aggregator):
     aggregator.assert_metric('snmp.fgIntfEntVdom', metric_type=aggregator.GAUGE, count=1)
 
     # Firewall
-    firewall_tags = common_tags + ['policy_index:22']
+    firewall_tags = common_tags + ['policy_index:22', 'virtualdomain_index:2']
     for metric in ['fgFwPolPktCount', 'fgFwPolByteCount']:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=firewall_tags, count=1
@@ -2425,7 +2425,7 @@ def test_fortinet_fortigate(aggregator):
         )
 
     # Firewall 6
-    firewall6_tags = common_tags + ['policy6_index:29']
+    firewall6_tags = common_tags + ['policy6_index:29', 'virtualdomain_index:5']
     for metric in ['fgFwPol6PktCount', 'fgFwPol6ByteCount']:
         aggregator.assert_metric(
             'snmp.{}'.format(metric), metric_type=aggregator.MONOTONIC_COUNT, tags=firewall6_tags, count=1


### PR DESCRIPTION
snmpwalk extract:
```
.1.3.6.1.4.1.12356.101.5.1.2.1.1.3.1.0,Counter32,0
.1.3.6.1.4.1.12356.101.5.1.2.1.1.3.1.1,Counter32,0
.1.3.6.1.4.1.12356.101.5.1.2.1.1.3.2.0,Counter32,12345
.1.3.6.1.4.1.12356.101.5.1.2.1.1.3.2.2,Counter32,2591
.1.3.6.1.4.1.12356.101.5.1.2.1.1.3.2.3,Counter32,25822
.1.3.6.1.4.1.12356.101.5.1.2.1.1.3.2.6,Counter32,201
.1.3.6.1.4.1.12356.101.5.1.2.1.1.3.2.7,Counter32,0
.1.3.6.1.4.1.12356.101.5.1.2.1.1.3.2.8,Counter32,0
```

Each row is `1.3.6.1.4.1.12356.101.5.1.2.1.1.3.X.Y` where `X` is the `virtualdomain_index` and `Y` is the `policy_index`.
The latter can be found under the OID `1.3.6.1.4.1.12356.101.5.1.2.1.1.1` but not the former. Because both are simple numerical ID, we can instead directly extract the value from each row OID using `index`.

This change is required as currently we only look at the policy index, which is not enough to uniquely identify a row. This leads to agent warnings of the kind "Rate value is negative, dropping it"