### PR TITLE
Use the `client_token` option with the openmetrics v2 implementation

### DIFF
--- a/vault/datadog_checks/vault/check.py
+++ b/vault/datadog_checks/vault/check.py
@@ -237,7 +237,7 @@ class VaultCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
         super().configure_scrapers()
 
         # TODO How could we move this in the configure_scrapers method?
-        for _, scraper in self.scrapers.items():
+        for scraper in self.scrapers.values():
             if not self.config.no_token and self.config.client_token:
                 scraper.http.options['headers']['X-Vault-Token'] = self.config.client_token
 

--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -317,7 +317,7 @@ class Vault(OpenMetricsBaseCheck):
                 else:
                     self.set_client_token(self._client_token)
 
-        # https://www.vaultproject.io/api/overview#the-x-vault-request-header
+        # https://www.vaultproject.io/api-docs#the-x-vault-request-header
         self._set_header(self.http, 'X-Vault-Request', 'true')
 
     def set_client_token(self, client_token):
@@ -330,7 +330,7 @@ class Vault(OpenMetricsBaseCheck):
             self.set_client_token(f.read().decode('utf-8'))
 
     def poll(self, scraper_config, headers=None):
-        # https://www.vaultproject.io/api/overview#the-x-vault-request-header
+        # https://www.vaultproject.io/api-docs#the-x-vault-request-header
         headers = {'X-Vault-Request': 'true'}
         if self._client_token:
             headers['X-Vault-Token'] = self._client_token

--- a/vault/tests/test_e2e.py
+++ b/vault/tests/test_e2e.py
@@ -1,0 +1,20 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+
+from .common import auth_required
+from .utils import assert_collection
+
+
+@auth_required
+@pytest.mark.e2e
+@pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
+@pytest.mark.parametrize('use_auth_file', [False, True])
+def test_e2e(dd_agent_check, e2e_instance, global_tags, use_openmetrics, use_auth_file):
+    instance = dict(e2e_instance(use_auth_file))
+    instance['use_openmetrics'] = use_openmetrics
+    aggregator = dd_agent_check(instance, rate=True)
+
+    assert_collection(aggregator, global_tags, use_openmetrics, runs=2)

--- a/vault/tests/test_integration.py
+++ b/vault/tests/test_integration.py
@@ -17,9 +17,11 @@ from .metrics import KNOWN_COUNTERS, METRICS, METRICS_OPTIONAL
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.integration
 @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
-def test_integration(aggregator, dd_run_check, check, instance, global_tags, use_openmetrics):
-    instance = dict(instance())
+@pytest.mark.parametrize('use_auth_file', [False, True])
+def test_integration(aggregator, dd_run_check, check, instance, global_tags, use_openmetrics, use_auth_file):
+    instance = dict(instance(use_auth_file))
     instance['use_openmetrics'] = use_openmetrics
+
     check = check(instance)
     dd_run_check(check)
 
@@ -42,8 +44,9 @@ def test_integration_noauth(aggregator, dd_run_check, check, no_token_instance, 
 @auth_required
 @pytest.mark.e2e
 @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
-def test_e2e(dd_agent_check, e2e_instance, global_tags, use_openmetrics):
-    instance = dict(e2e_instance)
+@pytest.mark.parametrize('use_auth_file', [False, True])
+def test_e2e(dd_agent_check, e2e_instance, global_tags, use_openmetrics, use_auth_file):
+    instance = dict(e2e_instance(use_auth_file))
     instance['use_openmetrics'] = use_openmetrics
     aggregator = dd_agent_check(instance, rate=True)
 

--- a/vault/tests/test_integration.py
+++ b/vault/tests/test_integration.py
@@ -1,16 +1,11 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import re
-from collections import defaultdict
 
 import pytest
 
-from datadog_checks.dev.utils import get_metadata_metrics
-from datadog_checks.vault import Vault
-
 from .common import auth_required, noauth_required
-from .metrics import KNOWN_COUNTERS, METRICS, METRICS_OPTIONAL
+from .utils import assert_collection
 
 
 @auth_required
@@ -35,102 +30,8 @@ def test_integration(aggregator, dd_run_check, check, instance, global_tags, use
 def test_integration_noauth(aggregator, dd_run_check, check, no_token_instance, global_tags, use_openmetrics):
     instance = dict(no_token_instance)
     instance['use_openmetrics'] = use_openmetrics
+
     check = check(instance)
     dd_run_check(check)
 
     assert_collection(aggregator, global_tags, use_openmetrics)
-
-
-@auth_required
-@pytest.mark.e2e
-@pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
-@pytest.mark.parametrize('use_auth_file', [False, True])
-def test_e2e(dd_agent_check, e2e_instance, global_tags, use_openmetrics, use_auth_file):
-    instance = dict(e2e_instance(use_auth_file))
-    instance['use_openmetrics'] = use_openmetrics
-    aggregator = dd_agent_check(instance, rate=True)
-
-    assert_collection(aggregator, global_tags, use_openmetrics, runs=2)
-
-
-def assert_collection(aggregator, tags, use_openmetrics, runs=1):
-    metrics = set(METRICS)
-    metrics.update(METRICS_OPTIONAL)
-    metrics.add('is_leader')
-
-    # Summaries
-    summaries = {'go.gc.duration.seconds'}
-    summaries.update(metric for metric in metrics if metric.startswith(('vault.', 'route.')))
-
-    # Remove everything that either is not a summary or summaries for which we're getting all 3 as NaN
-    for metric in (
-        'vault.audit.log.request.failure',
-        'vault.audit.log.response.failure',
-        'vault.expire.num_leases',
-        'vault.identity.entity.creation',
-        'vault.runtime.alloc.bytes',
-        'vault.runtime.free.count',
-        'vault.runtime.heap.objects',
-        'vault.runtime.malloc.count',
-        'vault.runtime.num_goroutines',
-        'vault.runtime.sys.bytes',
-        'vault.runtime.total.gc.runs',
-        'vault.runtime.total.gc.pause_ns',
-        'vault.token.count.by_policy',
-        'vault.token.creation',
-    ):
-        summaries.remove(metric)
-
-    summaries = {metric for metric in summaries if not metric.startswith('vault.cache.')}
-
-    for metric in summaries:
-        metrics.remove(metric)
-        metrics.update({'{}.count'.format(metric), '{}.quantile'.format(metric), '{}.sum'.format(metric)})
-
-    if use_openmetrics:
-        for metric in list(metrics):
-            if metric.endswith('.total'):
-                metrics.discard(metric)
-                metrics.add('{}.count'.format(metric[:-6]))
-            elif metric in KNOWN_COUNTERS:
-                metrics.discard(metric)
-                metrics.add('{}.count'.format(metric))
-            elif metric.startswith('vault.route.rollback.') and not metric.endswith(('.count', '.quantile', '.sum')):
-                metrics.discard(metric)
-
-    missing_summaries = defaultdict(set)
-    for metric in sorted(metrics):
-        at_least = 1
-        if metric.startswith(tuple(METRICS_OPTIONAL)):
-            at_least = 0
-        metric = 'vault.{}'.format(metric)
-
-        for tag in tags:
-            try:
-                aggregator.assert_metric_has_tag(metric, tag, at_least=at_least)
-            # For some reason explicitly handling AssertionError does not catch AssertionError
-            except Exception:
-                possible_summary = re.sub(r'^vault\.|(\.count|\.quantile|\.sum)$', '', metric)
-                if possible_summary in summaries:
-                    missing_summaries[possible_summary].add(metric)
-                else:
-                    raise
-            else:
-                aggregator.assert_metric_has_tag_prefix(metric, 'is_leader:', at_least=at_least)
-                aggregator.assert_metric_has_tag_prefix(metric, 'vault_cluster:', at_least=at_least)
-                aggregator.assert_metric_has_tag_prefix(metric, 'vault_version:', at_least=at_least)
-                if not use_openmetrics:
-                    aggregator.assert_metric_has_tag_prefix(metric, 'cluster_name:', at_least=at_least)
-
-    for _, summaries in sorted(missing_summaries.items()):
-        if len(summaries) > 2:
-            raise AssertionError('Missing: {}'.format(' | '.join(sorted(summaries))))
-
-    aggregator.assert_all_metrics_covered()
-
-    if use_openmetrics:
-        aggregator.assert_metrics_using_metadata(get_metadata_metrics())
-
-    aggregator.assert_service_check(Vault.SERVICE_CHECK_CONNECT, Vault.OK, count=runs)
-    aggregator.assert_service_check(Vault.SERVICE_CHECK_UNSEALED, Vault.OK, count=runs)
-    aggregator.assert_service_check(Vault.SERVICE_CHECK_INITIALIZED, Vault.OK, count=runs)

--- a/vault/tests/utils.py
+++ b/vault/tests/utils.py
@@ -2,10 +2,14 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+import re
+from collections import defaultdict
 
 from datadog_checks.dev.utils import get_metadata_metrics
+from datadog_checks.vault import Vault
 
 from .common import HERE
+from .metrics import KNOWN_COUNTERS, METRICS, METRICS_OPTIONAL
 
 
 def get_fixture_path(filename):
@@ -16,3 +20,86 @@ def assert_all_metrics(aggregator):
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
     aggregator.assert_no_duplicate_metrics()
+
+
+def assert_collection(aggregator, tags, use_openmetrics, runs=1):
+    metrics = set(METRICS)
+    metrics.update(METRICS_OPTIONAL)
+    metrics.add('is_leader')
+
+    # Summaries
+    summaries = {'go.gc.duration.seconds'}
+    summaries.update(metric for metric in metrics if metric.startswith(('vault.', 'route.')))
+
+    # Remove everything that either is not a summary or summaries for which we're getting all 3 as NaN
+    for metric in (
+        'vault.audit.log.request.failure',
+        'vault.audit.log.response.failure',
+        'vault.expire.num_leases',
+        'vault.identity.entity.creation',
+        'vault.runtime.alloc.bytes',
+        'vault.runtime.free.count',
+        'vault.runtime.heap.objects',
+        'vault.runtime.malloc.count',
+        'vault.runtime.num_goroutines',
+        'vault.runtime.sys.bytes',
+        'vault.runtime.total.gc.runs',
+        'vault.runtime.total.gc.pause_ns',
+        'vault.token.count.by_policy',
+        'vault.token.creation',
+    ):
+        summaries.remove(metric)
+
+    summaries = {metric for metric in summaries if not metric.startswith('vault.cache.')}
+
+    for metric in summaries:
+        metrics.remove(metric)
+        metrics.update({'{}.count'.format(metric), '{}.quantile'.format(metric), '{}.sum'.format(metric)})
+
+    if use_openmetrics:
+        for metric in list(metrics):
+            if metric.endswith('.total'):
+                metrics.discard(metric)
+                metrics.add('{}.count'.format(metric[:-6]))
+            elif metric in KNOWN_COUNTERS:
+                metrics.discard(metric)
+                metrics.add('{}.count'.format(metric))
+            elif metric.startswith('vault.route.rollback.') and not metric.endswith(('.count', '.quantile', '.sum')):
+                metrics.discard(metric)
+
+    missing_summaries = defaultdict(set)
+    for metric in sorted(metrics):
+        at_least = 1
+        if metric.startswith(tuple(METRICS_OPTIONAL)):
+            at_least = 0
+        metric = 'vault.{}'.format(metric)
+
+        for tag in tags:
+            try:
+                aggregator.assert_metric_has_tag(metric, tag, at_least=at_least)
+            # For some reason explicitly handling AssertionError does not catch AssertionError
+            except Exception:
+                possible_summary = re.sub(r'^vault\.|(\.count|\.quantile|\.sum)$', '', metric)
+                if possible_summary in summaries:
+                    missing_summaries[possible_summary].add(metric)
+                else:
+                    raise
+            else:
+                aggregator.assert_metric_has_tag_prefix(metric, 'is_leader:', at_least=at_least)
+                aggregator.assert_metric_has_tag_prefix(metric, 'vault_cluster:', at_least=at_least)
+                aggregator.assert_metric_has_tag_prefix(metric, 'vault_version:', at_least=at_least)
+                if not use_openmetrics:
+                    aggregator.assert_metric_has_tag_prefix(metric, 'cluster_name:', at_least=at_least)
+
+    for _, summaries in sorted(missing_summaries.items()):
+        if len(summaries) > 2:
+            raise AssertionError('Missing: {}'.format(' | '.join(sorted(summaries))))
+
+    aggregator.assert_all_metrics_covered()
+
+    if use_openmetrics:
+        aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+
+    aggregator.assert_service_check(Vault.SERVICE_CHECK_CONNECT, Vault.OK, count=runs)
+    aggregator.assert_service_check(Vault.SERVICE_CHECK_UNSEALED, Vault.OK, count=runs)
+    aggregator.assert_service_check(Vault.SERVICE_CHECK_INITIALIZED, Vault.OK, count=runs)


### PR DESCRIPTION
### What does this PR do?

Use the `client_token` option and set the `X-Vault-Request` header to the scrapers' request wrappers instead of the check request wrapper. 

Update the tests.

### Motivation

Support case. The `client_token` option and the `X-Vault-Request` header are set to the `http` attribute of the check itself. However, it is not used because another request wrapper is created in each scraper, so the `client_token` option is not working and the client gets an error 400. 

### Additional Notes

- I did not find a way to set the header through the `super().configure_scrapers()` method. If you have any idea, let me know :)
- We missed this case because we have no test using the `client_token` option, we only have tests with the `client_token_path`. I added some tests that read the token from this file and add it as the `client_token` option instead.
- Fixing this bug, I found another one related to the `client_token` and the `no_token` options. I will fix it in [follow up PR](https://github.com/DataDog/integrations-core/pull/12776) depending on this one (because I need the test setup). This is why this PR does not update the `test_auth_needed_but_no_token` test.
- I also built the wheel manually and it fixed the issue.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
