### PR TITLE
Do not use the `client_token` if `no_token` is true with the openmetrics v1 implementation

### DIFF
--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -332,7 +332,7 @@ class Vault(OpenMetricsBaseCheck):
     def poll(self, scraper_config, headers=None):
         # https://www.vaultproject.io/api-docs#the-x-vault-request-header
         headers = {'X-Vault-Request': 'true'}
-        if self._client_token:
+        if self._client_token and not self._no_token:
             headers['X-Vault-Token'] = self._client_token
 
         return super(Vault, self).poll(scraper_config, headers=headers)

--- a/vault/tests/test_vault.py
+++ b/vault/tests/test_vault.py
@@ -698,8 +698,11 @@ class TestVault:
 
     @auth_required
     @pytest.mark.parametrize('use_openmetrics', [False, True], indirect=True)
-    def test_auth_needed_but_no_token(self, aggregator, dd_run_check, instance, global_tags, use_openmetrics):
-        instance = instance()
+    @pytest.mark.parametrize('use_auth_file', [False, True])
+    def test_auth_needed_but_no_token(
+        self, aggregator, dd_run_check, instance, global_tags, use_openmetrics, use_auth_file
+    ):
+        instance = instance(use_auth_file)
         instance['no_token'] = True
         instance['use_openmetrics'] = use_openmetrics
         c = Vault(Vault.CHECK_NAME, {}, [instance])


### PR DESCRIPTION
### What does this PR do?

Do not use the `client_token` if `no_token` is true with the openmetrics v1 implementation.

### Motivation
Found this issue working on https://github.com/DataDog/integrations-core/pull/12764 and updating the `test_auth_needed_but_no_token` tests. The `client_token` was used even though the `no_token` option was set and no exceptions were raised. 

### Additional Notes
- This PR is based on https://github.com/DataDog/integrations-core/pull/12764. I do not target master yet so you can review the changes without being polluted by the other one. I will merge this one to master after.
- Tested locally building the wheel

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
