### PR TITLE
[IBM WAS] Add attempts, increase logs waiting time

### DIFF
--- a/ibm_was/tests/conftest.py
+++ b/ibm_was/tests/conftest.py
@@ -32,6 +32,7 @@ def dd_environment():
             StartPerfServlet(),
             CheckEndpoints(common.INSTANCE['servlet_url']),
         ],
+        attempts=2,
     ):
         yield common.INSTANCE
 

--- a/ibm_was/tests/conftest.py
+++ b/ibm_was/tests/conftest.py
@@ -28,7 +28,7 @@ def dd_environment():
     with docker_run(
         compose_file,
         conditions=[
-            CheckDockerLogs(compose_file, 'Server server1 open for e-business', attempts=120),
+            CheckDockerLogs(compose_file, 'Server server1 open for e-business', attempts=80, wait=2),
             StartPerfServlet(),
             CheckEndpoints(common.INSTANCE['servlet_url']),
         ],


### PR DESCRIPTION
Environment failed to start on https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=107537&view=logs&j=203178a3-a7e8-53ac-1b4d-4f9b986b112a&t=3703a3cd-697a-5590-dc54-67db3e8cff7a&l=1072

```
datadog_checks.dev.errors.RetryError: Command: ['docker', 'compose', '-f', '/home/vsts/work/1/s/ibm_was/tests/docker/docker-compose.yaml', 'logs']
E   Failed to match `1` of the patterns.
E   Provided patterns: 	- re.compile('Server server1 open for e-business', re.MULTILINE)
E   Missing patterns: 	- re.compile('Server server1 open for e-business', re.MULTILINE)
```
