### PR TITLE
Add attempts, increase waiting time for docker logs

### DIFF
--- a/ibm_ace/tests/conftest.py
+++ b/ibm_ace/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 import pytest
 
 from datadog_checks.dev import docker_run
+from datadog_checks.dev.conditions import CheckDockerLogs
 
 from . import common
 
@@ -15,11 +16,20 @@ def dd_environment(instance_no_subscriptions):
     with docker_run(
         common.COMPOSE_FILE,
         build=True,
-        log_patterns=['Integration server is ready', 'Started web server'],
+        conditions=[
+            CheckDockerLogs(
+                common.COMPOSE_FILE,
+                ['Integration server is ready', 'Started web server'],
+                matches='all',
+                attempts=35,
+                wait=2,
+            ),
+        ],
         env_vars={
             'IBM_ACE_IMAGE': common.DOCKER_IMAGE_VERSIONS[os.environ['IBM_ACE_VERSION']],
             'ACE_SERVER_NAME': common.ACE_SERVER_NAME,
         },
+        attempts=2,
     ):
         yield instance_no_subscriptions, common.E2E_METADATA
 


### PR DESCRIPTION
Default log patterns behaviour is `wait=1, attempts=60`
Set up failed on https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=107538&view=logs&j=dd4b56be-071e-57b4-2a5e-8eda93907f10&t=de2bf97c-09ab-578d-74d6-50a77c38a36d&l=1784

```
E   datadog_checks.dev.errors.RetryError: Command: ['docker', 'compose', '-f', '/home/vsts/work/1/s/ibm_ace/tests/docker/docker-compose.yaml', 'logs']
E   Failed to match `2` of the patterns.
E   Provided patterns: 	- re.compile('Integration server is ready', re.MULTILINE)	- re.compile('Started web server', re.MULTILINE)
E   Missing patterns: 	- re.compile('Started web server', re.MULTILINE)
```