### PR TITLE
Refactor e2e tests, add missing assertions

### DIFF
--- a/marklogic/tests/metrics.py
+++ b/marklogic/tests/metrics.py
@@ -66,14 +66,18 @@ FOREST_STATUS_TREE_CACHE_METRICS = [
     'marklogic.forests.compressed-tree-cache-ratio',
 ]
 
-HOST_STATUS_METRICS_SPECIFIC = [
+HOST_STATUS_METRICS_SPECIFIC_OPTIONAL = [
     # TODO: needs preprocessing to be available
-    # 'marklogic.hosts.memory-process-huge-pages-size',
-    # 'marklogic.hosts.memory-process-rss',
-    # 'marklogic.hosts.memory-system-free',
-    # 'marklogic.hosts.memory-system-total',
-    # 'marklogic.hosts.total-cpu-stat-system',
-    # 'marklogic.hosts.total-cpu-stat-user',
+    'marklogic.hosts.memory-process-huge-pages-size',
+    'marklogic.hosts.memory-process-rss',
+    'marklogic.hosts.memory-system-free',
+    'marklogic.hosts.memory-system-total',
+    'marklogic.hosts.total-cpu-stat-system',
+    'marklogic.hosts.total-cpu-stat-user',
+]
+
+
+HOST_STATUS_METRICS_SPECIFIC = [
     'marklogic.hosts.memory-process-swap-rate',
     'marklogic.hosts.total-hosts',
     'marklogic.hosts.total-hosts-offline',
@@ -275,3 +279,5 @@ GLOBAL_METRICS = (
     + SERVER_STATUS_METRICS
     + TRANSACTION_STATUS_METRICS
 )
+
+OPTIONAL_METRICS = HOST_STATUS_METRICS_SPECIFIC_OPTIONAL

--- a/marklogic/tests/test_e2e.py
+++ b/marklogic/tests/test_e2e.py
@@ -1,0 +1,25 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from typing import Any
+
+import pytest
+
+from datadog_checks.dev.utils import get_metadata_metrics
+
+from .common import COMMON_TAGS, INSTANCE, assert_metrics, assert_service_checks
+
+
+@pytest.mark.e2e
+def test_e2e(dd_agent_check):
+    # type: (Any) -> None
+    aggregator = dd_agent_check(INSTANCE, rate=True)
+
+    assert_metrics(aggregator, COMMON_TAGS)
+
+    aggregator.assert_all_metrics_covered()
+
+    # Service checks
+    assert_service_checks(aggregator, COMMON_TAGS, count=2)
+
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())

--- a/marklogic/tests/test_marklogic.py
+++ b/marklogic/tests/test_marklogic.py
@@ -1,70 +1,19 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from typing import Any, List
+from typing import Any
 
 import mock
 import pytest
 from packaging import version
+from tests.assertions import assert_service_checks
 
 from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.marklogic import MarklogicCheck
 
-from .common import (
-    COMMON_TAGS,
-    INSTANCE,
-    INSTANCE_FILTERS,
-    INSTANCE_SIMPLE_USER,
-    MARKLOGIC_VERSION,
-    SERVICE_CHECKS_HEALTH_TAG,
-)
-from .metrics import (
-    FOREST_STATUS_TREE_CACHE_METRICS,
-    GLOBAL_METRICS,
-    RESOURCE_STATUS_DATABASE_METRICS,
-    RESOURCE_STORAGE_FOREST_METRICS,
-    STORAGE_FOREST_METRICS,
-    STORAGE_HOST_METRICS,
-)
-
-
-def _assert_metrics(aggregator, tags):
-    # type: (AggregatorStub, List[str]) -> None
-    for metric in GLOBAL_METRICS:
-        aggregator.assert_metric(metric, tags=tags)
-
-    # May take some time to be available
-    for metric in FOREST_STATUS_TREE_CACHE_METRICS:
-        aggregator.assert_metric(metric, tags=tags, at_least=0)
-
-    storage_tag_prefixes = ['storage_path', 'marklogic_host_name', 'marklogic_host_id']
-    for metric in STORAGE_HOST_METRICS:
-        for tag in tags:
-            aggregator.assert_metric_has_tag(metric, tag)
-        for prefix in storage_tag_prefixes:
-            aggregator.assert_metric_has_tag_prefix(metric, prefix)
-    for metric in STORAGE_FOREST_METRICS:
-        for tag in tags:
-            aggregator.assert_metric_has_tag(metric, tag)
-        for prefix in storage_tag_prefixes + ['forest_id', 'forest_name']:
-            aggregator.assert_metric_has_tag_prefix(metric, prefix)
-
-
-def _assert_service_checks(aggregator, tags, count=1, include_health_checks=True):
-    # type: (AggregatorStub, List[str], int, bool) -> None
-    aggregator.assert_service_check('marklogic.can_connect', MarklogicCheck.OK, count=count)
-
-    if include_health_checks:
-        for database_tag in SERVICE_CHECKS_HEALTH_TAG['database']:
-            aggregator.assert_service_check(
-                'marklogic.database.health', MarklogicCheck.OK, tags=tags + [database_tag], count=count
-            )
-
-        for forest_tag in SERVICE_CHECKS_HEALTH_TAG['forest']:
-            aggregator.assert_service_check(
-                'marklogic.forest.health', MarklogicCheck.OK, tags=tags + [forest_tag], count=count
-            )
+from .common import COMMON_TAGS, INSTANCE, INSTANCE_FILTERS, INSTANCE_SIMPLE_USER, MARKLOGIC_VERSION, assert_metrics
+from .metrics import RESOURCE_STATUS_DATABASE_METRICS, RESOURCE_STORAGE_FOREST_METRICS, STORAGE_HOST_METRICS
 
 
 @pytest.mark.integration
@@ -75,12 +24,12 @@ def test_check(aggregator):
 
     check.check(INSTANCE)
 
-    _assert_metrics(aggregator, COMMON_TAGS)
+    assert_metrics(aggregator, COMMON_TAGS)
 
     aggregator.assert_all_metrics_covered()
 
     # Service checks
-    _assert_service_checks(aggregator, COMMON_TAGS)
+    assert_service_checks(aggregator, COMMON_TAGS)
 
     aggregator.assert_no_duplicate_all()
 
@@ -95,12 +44,12 @@ def test_check_simple_user(aggregator):
 
     check.check(INSTANCE_SIMPLE_USER)
 
-    _assert_metrics(aggregator, COMMON_TAGS)
+    assert_metrics(aggregator, COMMON_TAGS)
 
     aggregator.assert_all_metrics_covered()
 
     # Service checks
-    _assert_service_checks(aggregator, COMMON_TAGS, include_health_checks=False)
+    assert_service_checks(aggregator, COMMON_TAGS, include_health_checks=False)
 
     len(aggregator._service_checks) == 1  # can_connect service check only
 
@@ -117,7 +66,7 @@ def test_check_with_filters(aggregator):
 
     check.check(INSTANCE_FILTERS)
 
-    _assert_metrics(aggregator, COMMON_TAGS)
+    assert_metrics(aggregator, COMMON_TAGS)
 
     # Resource filter only
     for metric in STORAGE_HOST_METRICS + RESOURCE_STORAGE_FOREST_METRICS:
@@ -134,7 +83,7 @@ def test_check_with_filters(aggregator):
     aggregator.assert_all_metrics_covered()
 
     # Service checks
-    _assert_service_checks(aggregator, COMMON_TAGS)
+    assert_service_checks(aggregator, COMMON_TAGS)
 
     aggregator.assert_no_duplicate_all()
 
@@ -162,22 +111,7 @@ def test_metadata_integration(aggregator, datadog_agent):
     datadog_agent.assert_metadata_count(len(version_metadata))
 
     # Service checks
-    _assert_service_checks(aggregator, COMMON_TAGS)
-
-
-@pytest.mark.e2e
-def test_e2e(dd_agent_check):
-    # type: (Any) -> None
-    aggregator = dd_agent_check(INSTANCE, rate=True)
-
-    _assert_metrics(aggregator, COMMON_TAGS)
-
-    aggregator.assert_all_metrics_covered()
-
-    # Service checks
-    _assert_service_checks(aggregator, COMMON_TAGS, count=2)
-
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+    assert_service_checks(aggregator, COMMON_TAGS)
 
 
 def test_submit_health_service_checks(aggregator, caplog):

--- a/marklogic/tests/test_marklogic.py
+++ b/marklogic/tests/test_marklogic.py
@@ -6,13 +6,20 @@ from typing import Any
 import mock
 import pytest
 from packaging import version
-from tests.assertions import assert_service_checks
 
 from datadog_checks.base.stubs.aggregator import AggregatorStub
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.marklogic import MarklogicCheck
 
-from .common import COMMON_TAGS, INSTANCE, INSTANCE_FILTERS, INSTANCE_SIMPLE_USER, MARKLOGIC_VERSION, assert_metrics
+from .common import (
+    COMMON_TAGS,
+    INSTANCE,
+    INSTANCE_FILTERS,
+    INSTANCE_SIMPLE_USER,
+    MARKLOGIC_VERSION,
+    assert_metrics,
+    assert_service_checks,
+)
 from .metrics import RESOURCE_STATUS_DATABASE_METRICS, RESOURCE_STORAGE_FOREST_METRICS, STORAGE_HOST_METRICS
 
 


### PR DESCRIPTION
Move e2e tests to a separate file.
Move assertions to `common`
Added assertion for optional metrics as this build was failing because of that 
https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=107820&view=logs&j=71710f82-a700-5025-04de-9315f9265e29&t=60755dd0-fa1f-5e19-668b-97bd6488bfaf&l=211

```
E   Found metrics that are not asserted:
E   	- marklogic.hosts.memory-process-huge-pages-size
E   	- marklogic.hosts.memory-process-rss
E   	- marklogic.hosts.memory-system-free
E   	- marklogic.hosts.memory-system-total
E   	- marklogic.hosts.total-cpu-stat-system
E   	- marklogic.hosts.total-cpu-stat-user
```