### PR TITLE
Allow customers to enable profiling in the postgres integration

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -12,7 +12,7 @@ from ddtrace.profiling import Profiler
 import psycopg2
 from six import iteritems
 
-from datadog_checks.base import AgentCheck
+from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.db.utils import resolve_db_host as agent_host_resolver
 from datadog_checks.postgres.metrics_cache import PostgresMetricsCache
 from datadog_checks.postgres.relationsmanager import INDEX_BLOAT, RELATION_METRICS, TABLE_BLOAT, RelationsManager
@@ -578,9 +578,9 @@ class PostgreSql(AgentCheck):
 
     def check(self, _):
         tags = copy.copy(self._config.tags)
-        # start profiler
-        prof = Profiler()
-        prof.start()
+        if is_affirmative(os.environ.get('DD_PROFILING_ENABLED')):
+            prof = Profiler(service='{}_check'.format(self.name))
+            prof.start()
         # Collect metrics
         try:
             # Check version

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -7,6 +7,8 @@ import threading
 from contextlib import closing
 from time import time
 
+from ddtrace.profiling import Profiler
+
 import psycopg2
 from six import iteritems
 
@@ -576,6 +578,9 @@ class PostgreSql(AgentCheck):
 
     def check(self, _):
         tags = copy.copy(self._config.tags)
+        # start profiler
+        prof = Profiler()
+        prof.start()
         # Collect metrics
         try:
             # Check version


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Allows customers to set the `DD_PROFILING_ENABLED` environment variable and enable the DD python profiling agent, if desired. This will allow us to easily collect memory profile data from customers when issues (such as potential memory leaks) arise. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
