### PR TITLE
Remove the `tox_base_dep` variable from the create command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -27,15 +27,15 @@ def tree():
 def construct_output_info(path, depth, last, is_dir=False):
     if depth == 0:
         return '', path, is_dir
-    else:
-        if depth == 1:
-            return (f'{PIPE_END if last else PIPE_MIDDLE}{HYPHEN} ', path, is_dir)
-        else:
-            return (
-                f"{PIPE}   {' ' * 4 * (depth - 2)}{PIPE_END if last or is_dir else PIPE_MIDDLE}{HYPHEN} ",
-                path,
-                is_dir,
-            )
+
+    if depth == 1:
+        return f'{PIPE_END if last else PIPE_MIDDLE}{HYPHEN} ', path, is_dir
+
+    return (
+        f"{PIPE}   {' ' * 4 * (depth - 2)}{PIPE_END if last or is_dir else PIPE_MIDDLE}{HYPHEN} ",
+        path,
+        is_dir,
+    )
 
 
 def path_tree_output(path_tree, depth=0):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -38,7 +38,6 @@ def construct_template_fields(integration_name, repo_choice, integration_type, *
     normalized_integration_name = normalize_package_name(integration_name)
     check_name_kebab = kebab_case_name(integration_name)
 
-    datadog_checks_base_req = 'datadog-checks-base[deps]>=6.6.0'
     third_party_install_info = f"""\
 To install the {integration_name} check on your host:
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -67,7 +67,6 @@ To install the {integration_name} check on your host:
         license_header = get_license_header()
         support_type = 'core'
         test_dev_dep = '-e ../datadog_checks_dev'
-        tox_base_dep = '-e../datadog_checks_base[deps]'
         integration_links = integration_type_links.get(integration_type).format(name=normalized_integration_name)
     elif repo_choice == 'marketplace':
         check_name = normalize_package_name(f"{kwargs.get('author')}_{normalized_integration_name}")
@@ -80,7 +79,6 @@ To install the {integration_name} check on your host:
         license_header = ''
         support_type = 'partner'
         test_dev_dep = 'datadog-checks-dev'
-        tox_base_dep = datadog_checks_base_req
         integration_links = ''
     else:
         check_name = normalized_integration_name
@@ -90,7 +88,6 @@ To install the {integration_name} check on your host:
         license_header = ''
         support_type = 'contrib'
         test_dev_dep = 'datadog-checks-dev'
-        tox_base_dep = datadog_checks_base_req
         integration_links = integration_type_links.get(integration_type)
 
     config = {
@@ -110,7 +107,6 @@ To install the {integration_name} check on your host:
         'repo_name': REPO_CHOICES[repo_choice],
         'support_type': support_type,
         'test_dev_dep': test_dev_dep,
-        'tox_base_dep': tox_base_dep,
         'integration_links': integration_links,
     }
     config.update(kwargs)


### PR DESCRIPTION
### What does this PR do?
Remove the `tox_base_dep` variable from the create command.

### Motivation
We now use `hatch` by default. This is not used

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
