### PR TITLE
Remove the `requirements-dev.txt` files from the `ddev create` integration template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/requirements-dev.txt
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/requirements-dev.txt
@@ -1,1 +1,0 @@
-{test_dev_dep}


### PR DESCRIPTION
### What does this PR do?
Remove the `requirements-dev.txt` files from the `ddev create` integration template

### Motivation
We now use `hatch` by default. This is not used

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
