### PR TITLE
Add a validator for the manifest version

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -10,7 +10,7 @@ from ....fs import file_exists, read_file, write_file
 from ...constants import get_root
 from ...datastructures import JSONDict
 from ...manifest_validator import get_all_validators
-from ...manifest_validator.constants import V1_STRING, V2_STRING
+from ...manifest_validator.constants import V2_STRING
 from ...testing import process_checks_option
 from ...utils import complete_valid_checks
 from ..console import (

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -75,10 +75,6 @@ def manifest(ctx, check, fix):
             continue
 
         version = decoded.get('manifest_version', V2_STRING)
-        if version == V1_STRING:
-            file_failures += 1
-            display_queue.append((echo_failure, 'Manifest version must be >= 2.0.0'))
-
         all_validators = get_all_validators(ctx, version, is_extras, is_marketplace)
 
         for validator in all_validators:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/__init__.py
@@ -1,8 +1,15 @@
 #  (C) Datadog, Inc. 2021-present
 #  All rights reserved
 #  Licensed under a 3-clause BSD style license (see LICENSE)
+from .common.validator import VersionValidator
+from .constants import V2_STRING
 from .v2.validator import get_v2_validators
 
 
 def get_all_validators(ctx, version_string, is_extras=False, is_marketplace=False):
-    return get_v2_validators(ctx, is_extras, is_marketplace)
+    validators = [VersionValidator()]
+
+    if version_string == V2_STRING:
+        validators.extend(get_v2_validators(ctx, is_extras, is_marketplace))
+
+    return validators

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/common/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/common/validator.py
@@ -12,7 +12,7 @@ import six
 from ...datastructures import JSONDict
 from ...git import git_show_file
 from ...utils import get_metadata_file, has_logs, is_metric_in_metadata_file, read_metadata_rows
-from ..constants import V1, V2
+from ..constants import V1, V1_STRING, V2, V2_STRING
 
 
 class ValidationResult(object):
@@ -311,3 +311,9 @@ class LogsCategoryValidator(BaseManifestValidator):
                 + ' or define the logs properly'
             )
             self.fail(output)
+
+
+class VersionValidator(BaseManifestValidator):
+    def validate(self, check_name, decoded, fix):
+        if decoded.get('manifest_version', V2_STRING) == V1_STRING:
+            self.fail('Manifest version must be >= 2.0.0')


### PR DESCRIPTION
### What does this PR do?

Stop running the v2 validators for manifest v1 files and add a validator for the version.

### Motivation
We are only running v2 validators: https://github.com/DataDog/integrations-core/blob/2d86725d7ec6b83719c82ec40ab74dc45f9e0e64/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/__init__.py#L8

Because of that, I got the following trying to validate a v1 file (that was created a few weeks ago on a [branch](https://github.com/DataDog/integrations-core/pull/12548)):

```
  File "/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/common/validator.py", line 102, in validate
    if not maintainer.isascii():
AttributeError: 'NoneType' object has no attribute 'isascii'
```

With this fix, we have:

```
╰─❯ ddev validate manifest impala                                                                                                                                                                                                                                                                                       ─╯
Validating manifest.json files for 1 checks ...
impala/manifest.json... FAILED
Manifest version must be >= 2.0.0
1 invalid files
```


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
