### PR TITLE
Make the manifest validation fail if the file is not found

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/manifest.py
@@ -53,74 +53,78 @@ def manifest(ctx, check, fix):
 
         manifest_file = os.path.join(root, check_name, 'manifest.json')
 
-        if file_exists(manifest_file):
-            display_queue = []
-            file_failures = 0
-            file_warnings = 0
-            file_fixed = False
+        if not file_exists(manifest_file):
+            failed_checks += 1
+            echo_failure(f"{check_name}/manifest.json does not exist.")
+            continue
 
-            try:
-                decoded = json.loads(read_file(manifest_file).strip())
-                decoded = JSONDict(decoded)
-            except json.JSONDecodeError as e:
+        display_queue = []
+        file_failures = 0
+        file_warnings = 0
+        file_fixed = False
+
+        try:
+            decoded = json.loads(read_file(manifest_file).strip())
+            decoded = JSONDict(decoded)
+        except json.JSONDecodeError as e:
+            failed_checks += 1
+            echo_info(f"{check_name}/manifest.json... ", nl=False)
+            echo_failure("FAILED")
+            echo_failure(f'  invalid json: {e}')
+            annotate_error(manifest_file, f"Invalid json: {e}")
+            continue
+
+        version = decoded.get('manifest_version', V2_STRING)
+        if version == V1_STRING:
+            file_failures += 1
+            display_queue.append((echo_failure, 'Manifest version must be >= 2.0.0'))
+
+        all_validators = get_all_validators(ctx, version, is_extras, is_marketplace)
+
+        for validator in all_validators:
+            if validator.skip_if_errors and file_failures > 0:
+                echo_info(f'Skipping validation {validator} since errors have already been found.')
+                continue
+            validator.validate(check_name, decoded, fix)
+            file_failures += 1 if validator.result.failed else 0
+            file_fixed += 1 if validator.result.fixed else 0
+            file_warnings += 1 if validator.result.warning else 0
+            for msg_type, messages in validator.result.messages.items():
+                for message in messages:
+                    display_queue.append((message_methods[msg_type], message))
+
+        if file_failures > 0 or file_warnings > 0:
+            annotate_display_queue(manifest_file, display_queue)
+            if file_failures > 0:
                 failed_checks += 1
+                # Display detailed info if file invalid
                 echo_info(f"{check_name}/manifest.json... ", nl=False)
                 echo_failure("FAILED")
-                echo_failure(f'  invalid json: {e}')
-                annotate_error(manifest_file, f"Invalid json: {e}")
-                continue
+                for display_func, message in display_queue:
+                    display_func(message)
+            elif not file_fixed:
+                ok_checks += 1
 
-            version = decoded.get('manifest_version', V2_STRING)
-            if version == V1_STRING:
-                file_failures += 1
-                display_queue.append((echo_failure, 'Manifest version must be >= 2.0.0'))
-
-            all_validators = get_all_validators(ctx, version, is_extras, is_marketplace)
-
-            for validator in all_validators:
-                if validator.skip_if_errors and file_failures > 0:
-                    echo_info(f'Skipping validation {validator} since errors have already been found.')
-                    continue
-                validator.validate(check_name, decoded, fix)
-                file_failures += 1 if validator.result.failed else 0
-                file_fixed += 1 if validator.result.fixed else 0
-                file_warnings += 1 if validator.result.warning else 0
-                for msg_type, messages in validator.result.messages.items():
-                    for message in messages:
-                        display_queue.append((message_methods[msg_type], message))
-
-            if file_failures > 0 or file_warnings > 0:
-                annotate_display_queue(manifest_file, display_queue)
-                if file_failures > 0:
-                    failed_checks += 1
-                    # Display detailed info if file invalid
-                    echo_info(f"{check_name}/manifest.json... ", nl=False)
-                    echo_failure("FAILED")
-                    for display_func, message in display_queue:
-                        display_func(message)
-                elif not file_fixed:
-                    ok_checks += 1
-
-                if file_warnings > 0:
-                    warning_checks += 1
-                    # Don't redisplay the display_queue if there were errors,
-                    # warnings are already shown if there were errors
-                    if file_failures == 0:
-                        echo_info(f"{check_name}/manifest.json... ", nl=False)
-                        echo_warning("WARNING")
-                        for display_func, message in display_queue:
-                            display_func(message)
-
-            if fix and file_fixed:
-                new_manifest = f"{json.dumps(decoded, indent=2, separators=(',', ': '))}\n"
-                write_file(manifest_file, new_manifest)
-                # Display detailed info if file has been completely fixed
+            if file_warnings > 0:
+                warning_checks += 1
+                # Don't redisplay the display_queue if there were errors,
+                # warnings are already shown if there were errors
                 if file_failures == 0:
-                    fixed_checks += 1
                     echo_info(f"{check_name}/manifest.json... ", nl=False)
-                    echo_success("FIXED")
+                    echo_warning("WARNING")
                     for display_func, message in display_queue:
                         display_func(message)
+
+        if fix and file_fixed:
+            new_manifest = f"{json.dumps(decoded, indent=2, separators=(',', ': '))}\n"
+            write_file(manifest_file, new_manifest)
+            # Display detailed info if file has been completely fixed
+            if file_failures == 0:
+                fixed_checks += 1
+                echo_info(f"{check_name}/manifest.json... ", nl=False)
+                echo_success("FIXED")
+                for display_func, message in display_queue:
+                    display_func(message)
 
     if ok_checks:
         echo_success(f"{ok_checks} valid files")


### PR DESCRIPTION
### What does this PR do?
Fail the manifest validation if the manifest file is not found.

### Motivation
I was not on the correct branch and ran the validation. Took me a few minutes to understand why the command succeeded locally but did not on the CI.

Example:
```
╰─❯ ddev validate manifest check                                                                                                                                                                                                                                                                                        ─╯
Validating manifest.json files for 1 checks ...
check/manifest.json does not exist.
1 invalid files
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
