### PR TITLE
Add missing metadata

### DIFF
--- a/mysql/metadata.csv
+++ b/mysql/metadata.csv
@@ -80,6 +80,8 @@ mysql.innodb.ibuf_merged_inserts,gauge,,operation,,"Insert buffer and adaptative
 mysql.innodb.ibuf_merged,gauge,,operation,,"Insert buffer and adaptative hash index merged",0,mysql,mysql innodb merged,
 mysql.innodb.ibuf_merges,gauge,,operation,,"Insert buffer and adaptative hash index merges",0,mysql,mysql innodb merges,
 mysql.innodb.lock_structs,gauge,,operation,,"Lock structs",0,mysql,mysql innodb lock structs,
+mysql.innodb.locked_tables,gauge,,operation,,"Locked tables",0,mysql,mysql innodb locked tables,
+mysql.innodb.tables_in_use,gauge,,operation,,"Tables in use",0,mysql,mysql innodb used tables,
 mysql.innodb.os_file_fsyncs,gauge,,operation,,"(Delta) The total number of fsync() operations performed by InnoDB.",0,mysql,mysql innodb os file fsyncs,
 mysql.innodb.os_file_reads,gauge,,operation,,"(Delta) The total number of files reads performed by read threads within InnoDB.",0,mysql,mysql innodb os file reads,
 mysql.innodb.os_file_writes,gauge,,operation,,"(Delta) The total number of file writes performed by write threads within InnoDB.",0,mysql,mysql innodb os file writes,


### PR DESCRIPTION
These metrics were missing from the metadata file.
Detected on https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=109477&view=logs&j=d74967ea-228d-5634-fe5f-5bd874cd0575&t=41dabac0-8a87-53de-65b2-c4ce3c459938&l=185

```
=================================== FAILURES ===================================
___________________________________ test_e2e ___________________________________
tests/test_mysql.py:84: in test_e2e
    aggregator.assert_metrics_using_metadata(
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:477: in assert_metrics_using_metadata
    assert not errors, "Metadata assertion errors using metadata.csv:" + "\n\t- ".join([''] + sorted(errors))
E   AssertionError: Metadata assertion errors using metadata.csv:
E   	- Expect `mysql.innodb.locked_tables` to be in metadata.csv.
E   	- Expect `mysql.innodb.tables_in_use` to be in metadata.csv.
- generated xml file: /home/vsts/work/1/s/mysql/.junit/test-e2e-$HATCH_ENV_ACTIVEpy38-maria10.2.xml 
```