### PR TITLE
Skip test_query_timeout on 2019 windows

### DIFF
--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -11,14 +11,14 @@ import pyodbc
 import pytest
 
 from datadog_checks.base import ConfigurationError
+from datadog_checks.dev.utils import running_on_windows_ci
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import Connection, SQLConnectionError, parse_connection_string_properties
 
-from .common import CHECK_NAME
-
-pytestmark = pytest.mark.unit
+from .common import CHECK_NAME, SQLSERVER_MAJOR_VERSION
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     'cs,parsed',
     [
@@ -53,6 +53,7 @@ def test_parse_connection_string_properties(cs, parsed):
         parse_connection_string_properties(cs)
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     'cs,username,password,expect_warning',
     [
@@ -76,6 +77,7 @@ def test_warn_trusted_connection_username_pass(instance_minimal_defaults, cs, us
         connection.log.warning.assert_not_called()
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     'connector, param',
     [
@@ -94,6 +96,7 @@ def test_will_warn_parameters_for_the_wrong_connection(instance_minimal_defaults
     )
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     'connector, cs, param, should_fail',
     [
@@ -130,6 +133,7 @@ def test_will_fail_for_duplicate_parameters(instance_minimal_defaults, connector
         connection._connection_options_validation('somekey', 'somedb')
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     'connector, cs',
     [
@@ -158,6 +162,7 @@ def test_will_fail_for_wrong_parameters_in_the_connection_string(instance_minima
         connection._connection_options_validation('somekey', 'somedb')
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     'host, port, expected_host',
     [
@@ -194,6 +199,7 @@ def test_config_with_and_without_port(instance_minimal_defaults, host, port, exp
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
+@pytest.mark.skipif(running_on_windows_ci() and SQLSERVER_MAJOR_VERSION == 2019, reason='Test flakes on this set up')
 def test_query_timeout(instance_docker):
     instance_docker['command_timeout'] = 1
     check = SQLServer(CHECK_NAME, {}, [instance_docker])
@@ -282,6 +288,7 @@ def test_connection_failure(aggregator, dd_run_check, instance_docker):
     )
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "test_case_name, instance_overrides, expected_error_patterns",
     [


### PR DESCRIPTION
Also categorise tests independently since not all tests in the file are unit tests.

Example failures:
* [https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=109408&vie[…]fd3-e4d77a183e2d&t=69858a7d-83bd-5a0d-66ce-9165e8b8a6f9&l=1204](https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=109408&view=logs&j=8d9df12f-f2bb-5103-9fd3-e4d77a183e2d&t=69858a7d-83bd-5a0d-66ce-9165e8b8a6f9&l=1204)
* [https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=109333&vie[…]fd3-e4d77a183e2d&t=69858a7d-83bd-5a0d-66ce-9165e8b8a6f9&l=1221](https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=109333&view=logs&j=8d9df12f-f2bb-5103-9fd3-e4d77a183e2d&t=69858a7d-83bd-5a0d-66ce-9165e8b8a6f9&l=1221)
* https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=109408&view=logs&j=8d9df12f-f2bb-5103-9fd3-e4d77a183e2d&t=69858a7d-83bd-5a0d-66ce-9165e8b8a6f9&l=1204

![image](https://user-images.githubusercontent.com/611228/185963790-c7e0e857-ca89-43de-a11e-5a2f254b890f.png)
