### PR TITLE
Update Ubuntu image for Linux CI jobs

### DIFF
--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -29,7 +29,7 @@ jobs:
       dd_agent: dd_agent
 
   pool:
-    vmImage: 'ubuntu-18.04'
+    vmImage: 'ubuntu-20.04'
 
   variables:
     ${{ if not(eq(parameters.run_py2_tests, 'true')) }}:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Ubuntu 18.04 is being [deprecated on Dec 2, 2022](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software). Some Linux CI jobs may be canceled to remind us to update the image: 

![image](https://user-images.githubusercontent.com/31313038/185975356-55853ede-3461-46e1-8459-bf8854ecedc8.png)

This PR updates the Ubuntu environment from 18.04 to 20.04.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
