### PR TITLE
Keep cache of stored procedure plan_handles 

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -56,9 +56,6 @@ SELECT
     c.client_tcp_port as client_port,
     c.client_net_address as client_address,
     sess.host_name as host_name,
-    (SELECT IIF (EXISTS
-        (SELECT 1 FROM sys.dm_exec_procedure_stats proc_stats
-            WHERE proc_stats.plan_handle = req.plan_handle), 1, 0)) as is_proc,
     {exec_request_columns}
 FROM sys.dm_exec_sessions sess
     INNER JOIN sys.dm_exec_connections c
@@ -213,8 +210,7 @@ class SqlserverActivity(DBMAsyncJob):
         try:
             statement = obfuscate_sql_with_metadata(row['statement_text'], self.check.obfuscator_options)
             procedure_statement = None
-            # sqlserver doesn't have a boolean data type so convert integer to boolean
-            row['is_proc'] = row['is_proc'] == 1
+            row['is_proc'] = self._get_stmt_is_proc(row['text'])
             if row['is_proc'] and 'text' in row:
                 procedure_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             obfuscated_statement = statement['query']
@@ -233,6 +229,13 @@ class SqlserverActivity(DBMAsyncJob):
             obfuscated_statement = "ERROR: failed to obfuscate"
         row = self._sanitize_row(row, obfuscated_statement)
         return row
+
+    # checks if statement_text is part of a stored procedure
+    @staticmethod
+    def _get_stmt_is_proc(text):
+        if text:
+            return "CREATE PROCEDURE" in text
+        return False
 
     @staticmethod
     def _remove_null_vals(row):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Regularly reads the `plan_handle` field out of `sys.dm_exec_procedure_stats` table && caches them in a TTL cache for 5 minutes, which allows us to remove the extra JOIN on this table in the query metrics query. This adds extra complexity to the code base, but eventually we might want to read out of this table anyways to emit stored procedure specific metrics. 

The result of this is a fairly negligible change in performance between the updated metrics/activity queries and the 7.38 agent version:

![Screen Shot 2022-08-22 at 5 51 36 PM](https://user-images.githubusercontent.com/14317240/186025190-ee2208f5-8b81-4852-acd6-4b535bc14cb4.png)
   

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
