### PR TITLE
Increase SQL Server docker start attempts

### DIFF
--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -302,5 +302,5 @@ def dd_environment(full_e2e_config):
 
     conditions += [CheckDockerLogs(compose_file, completion_message)]
 
-    with docker_run(compose_file=compose_file, conditions=conditions, mount_logs=True, build=True, attempts=2):
+    with docker_run(compose_file=compose_file, conditions=conditions, mount_logs=True, build=True, attempts=3):
         yield full_e2e_config, E2E_METADATA


### PR DESCRIPTION
Docker compose failed after two attempts https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=109662&view=logs&j=1844037c-5a79-57cd-fd15-36c50f4dfdba&t=c5ebbd8d-d13a-587b-7a74-3442ff24c769&l=1505. It seems to be in a bad state `[HADR TRANSPORT] AR[39E3BAD5-39E9-489F-AD00-8B7BBD061A67]->[93B6F4E5-BB41-46B8-985E-A1C1AD672A8F] Transport is not in a connected state, unable to send packet
`