### PR TITLE
Change agent build notification channel

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ variables:
   TAGGER_EMAIL: packages@datadoghq.com
   TAGGER_NAME: ci.integrations-core
   NOTIFICATIONS_SLACK_CHANNEL: agent-integrations
+  AGENT_BUILD_NOTIFICATIONS_SLACK_CHANNEL: agent-integrations-ops
 
 # Uncomment when/if we modify script to use Jira
 #
@@ -83,7 +84,7 @@ trigger-agent-build:
           # Get slack user
           if [[ $GITLAB_USER_LOGIN = "gitsync" ]]; then EMAIL=$(git show -s --format="%ae" "$CI_COMMIT_SHA"); else EMAIL=$GITLAB_USER_EMAIL; fi
           SLACK_AUTHOR=$(echo $EMAIL | email2slackid)
-          if [ -z "$SLACK_AUTHOR" ]; then echo "${EMAIL} cannot be translated into a Slack user, defaulting to ${NOTIFICATIONS_SLACK_CHANNEL}"; SLACK_AUTHOR=$NOTIFICATIONS_SLACK_CHANNEL; fi
+          if [ -z "$SLACK_AUTHOR" ]; then echo "${EMAIL} cannot be translated into a Slack user, defaulting to ${AGENT_BUILD_NOTIFICATIONS_SLACK_CHANNEL}"; SLACK_AUTHOR=$AGENT_BUILD_NOTIFICATIONS_SLACK_CHANNEL; fi
 
           MESSAGE="Starting a build of the agent, watch ${CI_PIPELINE_URL}."
           postmessage "$SLACK_AUTHOR" "$MESSAGE"
@@ -116,7 +117,7 @@ validate-agent-build:
           # Get slack user
           if [[ $GITLAB_USER_LOGIN = "gitsync" ]]; then EMAIL=$(git show -s --format="%ae" "$CI_COMMIT_SHA"); else EMAIL=$GITLAB_USER_EMAIL; fi
           SLACK_AUTHOR=$(echo $EMAIL | email2slackid)
-          if [ -z "$SLACK_AUTHOR" ]; then echo "${EMAIL} cannot be translated into a Slack user, defaulting to ${NOTIFICATIONS_SLACK_CHANNEL}"; SLACK_AUTHOR=$NOTIFICATIONS_SLACK_CHANNEL; fi
+          if [ -z "$SLACK_AUTHOR" ]; then echo "${EMAIL} cannot be translated into a Slack user, defaulting to ${AGENT_BUILD_NOTIFICATIONS_SLACK_CHANNEL}"; SLACK_AUTHOR=$AGENT_BUILD_NOTIFICATIONS_SLACK_CHANNEL; fi
 
           # Wait for the agent build to complete
           export BUILD_SUCCESS="true"


### PR DESCRIPTION
### What does this PR do?
Changes the channel where agent build notifications are sent to

### Motivation
The messages are noisy
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
