### PR TITLE
Deprecate Kong table metrics

### DIFF
--- a/kong/assets/dashboards/kong_overview.json
+++ b/kong/assets/dashboards/kong_overview.json
@@ -1,250 +1,260 @@
 {
-    "title": "Kong Overview [Legacy]",
-    "description": "## Kong\n\nThis dashboard provides a high-level overview of your Kong instances so you can monitor metrics related to connections, table counts, and total requests.\n\nFor further reading on monitoring Kong, see:\n[Official Kong integration docs](https://docs.datadoghq.com/integrations/kong/)\n\nClone this template to make changes and add your own graphs and widgets.",
-    "widgets": [
-        {
-            "id": 0,
-            "definition": {
-                "type": "image",
-                "url": "/static/images/logos/kong_large.svg",
-                "sizing": "fit"
+  "title": "Kong Overview [Legacy]",
+  "description": "## Kong\n\nThis dashboard provides a high-level overview of your Kong instances so you can monitor metrics related to connections, table counts, and total requests.\n\nFor further reading on monitoring Kong, see:\n[Official Kong integration docs](https://docs.datadoghq.com/integrations/kong/)\n\nClone this template to make changes and add your own graphs and widgets.",
+  "widgets": [
+    {
+      "id": 0,
+      "layout": {
+        "x": 2,
+        "y": 2,
+        "width": 38,
+        "height": 23
+      },
+      "definition": {
+        "type": "image",
+        "url": "/static/images/logos/kong_large.svg",
+        "sizing": "fit"
+      }
+    },
+    {
+      "id": 1,
+      "layout": {
+        "x": 20,
+        "y": 26,
+        "width": 20,
+        "height": 15
+      },
+      "definition": {
+        "title": "Total requests rate (per minute)",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "type": "timeseries",
+        "requests": [
+          {
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "data_source": "metrics",
+                "name": "query1",
+                "query": "avg:kong.total_requests{$scope} by {host}"
+              }
+            ],
+            "formulas": [
+              {
+                "formula": "per_minute(query1)"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
             },
-            "layout": {
-                "x": 1,
-                "y": 1,
-                "width": 13,
-                "height": 8
-            }
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "include_zero": true,
+          "scale": "linear",
+          "label": "",
+          "min": "auto",
+          "max": "auto"
         },
-        {
-            "id": 1,
-            "definition": {
-                "type": "timeseries",
-                "requests": [
-                    {
-                        "q": "per_minute(avg:kong.total_requests{$scope} by {host})",
-                        "display_type": "bars",
-                        "style": {
-                            "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        }
-                    }
-                ],
-                "custom_links": [],
-                "yaxis": {
-                    "label": "",
-                    "scale": "linear",
-                    "min": "auto",
-                    "max": "auto",
-                    "include_zero": true
-                },
-                "title": "Total requests rate (per minute)",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": false
+        "custom_links": []
+      }
+    },
+    {
+      "id": 2,
+      "layout": {
+        "x": 2,
+        "y": 26,
+        "width": 17,
+        "height": 15
+      },
+      "definition": {
+        "title": "Status",
+        "title_size": "16",
+        "title_align": "center",
+        "type": "check_status",
+        "check": "kong.can_connect",
+        "grouping": "cluster",
+        "group_by": [],
+        "tags": [
+          "*"
+        ]
+      }
+    },
+    {
+      "id": 3,
+      "layout": {
+        "x": 41,
+        "y": 2,
+        "width": 71,
+        "height": 6
+      },
+      "definition": {
+        "type": "note",
+        "content": "Connections",
+        "background_color": "gray",
+        "font_size": "24",
+        "text_align": "center",
+        "show_tick": true,
+        "tick_pos": "50%",
+        "tick_edge": "bottom"
+      }
+    },
+    {
+      "id": 5,
+      "layout": {
+        "x": 41,
+        "y": 10,
+        "width": 35,
+        "height": 15
+      },
+      "definition": {
+        "title": "Active connections",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0",
+        "type": "timeseries",
+        "requests": [
+          {
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "data_source": "metrics",
+                "name": "query1",
+                "query": "avg:kong.connections_active{$scope} by {host}"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
             },
-            "layout": {
-                "x": 1,
-                "y": 26,
-                "width": 39,
-                "height": 15
-            }
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "include_zero": true,
+          "scale": "linear",
+          "label": "",
+          "min": "auto",
+          "max": "auto"
         },
-        {
-            "id": 2,
-            "definition": {
-                "type": "check_status",
-                "title": "Status",
-                "title_size": "16",
-                "title_align": "center",
-                "check": "kong.can_connect",
-                "grouping": "cluster",
-                "group_by": [],
-                "tags": [
-                    "*"
-                ]
+        "custom_links": []
+      }
+    },
+    {
+      "id": 6,
+      "layout": {
+        "x": 77,
+        "y": 10,
+        "width": 35,
+        "height": 15
+      },
+      "definition": {
+        "title": "Idle connections",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0",
+        "type": "timeseries",
+        "requests": [
+          {
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "data_source": "metrics",
+                "name": "query1",
+                "query": "avg:kong.connections_waiting{$scope} by {host}"
+              }
+            ],
+            "style": {
+              "palette": "dog_classic",
+              "line_type": "solid",
+              "line_width": "normal"
             },
-            "layout": {
-                "x": 15,
-                "y": 1,
-                "width": 24,
-                "height": 8
-            }
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "include_zero": true,
+          "scale": "linear",
+          "label": "",
+          "min": "auto",
+          "max": "auto"
         },
-        {
-            "id": 3,
-            "definition": {
-                "type": "note",
-                "content": "Connections",
-                "background_color": "gray",
-                "font_size": "24",
-                "text_align": "center",
-                "show_tick": true,
-                "tick_pos": "50%",
-                "tick_edge": "bottom"
+        "custom_links": []
+      }
+    },
+    {
+      "id": 7,
+      "layout": {
+        "x": 41,
+        "y": 26,
+        "width": 71,
+        "height": 15
+      },
+      "definition": {
+        "title": "Rate of accepted and handled connections",
+        "title_size": "16",
+        "title_align": "left",
+        "show_legend": false,
+        "legend_size": "0",
+        "type": "timeseries",
+        "requests": [
+          {
+            "response_format": "timeseries",
+            "queries": [
+              {
+                "data_source": "metrics",
+                "name": "query1",
+                "query": "avg:kong.connections_handled{$scope} by {host}"
+              },
+              {
+                "data_source": "metrics",
+                "name": "query2",
+                "query": "avg:kong.connections_accepted{$scope} by {host}"
+              }
+            ],
+            "formulas": [
+              {
+                "formula": "per_minute(query1)"
+              },
+              {
+                "formula": "per_minute(query2)"
+              }
+            ],
+            "style": {
+              "palette": "cool",
+              "line_type": "solid",
+              "line_width": "normal"
             },
-            "layout": {
-                "x": 41,
-                "y": 2,
-                "width": 71,
-                "height": 6
-            }
+            "display_type": "bars"
+          }
+        ],
+        "yaxis": {
+          "include_zero": true,
+          "scale": "linear",
+          "label": "",
+          "min": "auto",
+          "max": "auto"
         },
-        {
-            "id": 4,
-            "definition": {
-                "type": "timeseries",
-                "requests": [
-                    {
-                        "q": "avg:kong.table.items{$scope} by {table}",
-                        "display_type": "bars",
-                        "style": {
-                            "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        }
-                    }
-                ],
-                "custom_links": [],
-                "yaxis": {
-                    "label": "",
-                    "scale": "linear",
-                    "min": "auto",
-                    "max": "auto",
-                    "include_zero": true
-                },
-                "title": "Items per table",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": false,
-                "legend_size": "0"
-            },
-            "layout": {
-                "x": 1,
-                "y": 10,
-                "width": 39,
-                "height": 15
-            }
-        },
-        {
-            "id": 5,
-            "definition": {
-                "type": "timeseries",
-                "requests": [
-                    {
-                        "q": "avg:kong.connections_active{$scope} by {host}",
-                        "display_type": "bars",
-                        "style": {
-                            "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        }
-                    }
-                ],
-                "custom_links": [],
-                "yaxis": {
-                    "label": "",
-                    "scale": "linear",
-                    "min": "auto",
-                    "max": "auto",
-                    "include_zero": true
-                },
-                "title": "Active connections",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": false,
-                "legend_size": "0"
-            },
-            "layout": {
-                "x": 41,
-                "y": 10,
-                "width": 35,
-                "height": 15
-            }
-        },
-        {
-            "id": 6,
-            "definition": {
-                "type": "timeseries",
-                "requests": [
-                    {
-                        "q": "avg:kong.connections_waiting{$scope} by {host}",
-                        "display_type": "bars",
-                        "style": {
-                            "palette": "dog_classic",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        }
-                    }
-                ],
-                "custom_links": [],
-                "yaxis": {
-                    "label": "",
-                    "scale": "linear",
-                    "min": "auto",
-                    "max": "auto",
-                    "include_zero": true
-                },
-                "title": "Idle connections",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": false,
-                "legend_size": "0"
-            },
-            "layout": {
-                "x": 77,
-                "y": 10,
-                "width": 35,
-                "height": 15
-            }
-        },
-        {
-            "id": 7,
-            "definition": {
-                "type": "timeseries",
-                "requests": [
-                    {
-                        "q": "per_minute(avg:kong.connections_handled{$scope} by {host}), per_minute(avg:kong.connections_accepted{$scope} by {host})",
-                        "display_type": "bars",
-                        "style": {
-                            "palette": "cool",
-                            "line_type": "solid",
-                            "line_width": "normal"
-                        }
-                    }
-                ],
-                "custom_links": [],
-                "yaxis": {
-                    "label": "",
-                    "scale": "linear",
-                    "min": "auto",
-                    "max": "auto",
-                    "include_zero": true
-                },
-                "title": "Rate of accepted and handled connections",
-                "title_size": "16",
-                "title_align": "left",
-                "show_legend": false,
-                "legend_size": "0"
-            },
-            "layout": {
-                "x": 41,
-                "y": 26,
-                "width": 71,
-                "height": 15
-            }
-        }
-    ],
-    "template_variables": [
-        {
-            "default": "*",
-            "prefix": null,
-            "name": "scope"
-        }
-    ],
-    "layout_type": "free",
-    "is_read_only": true,
-    "notify_list": [],
-    "id": 30262
+        "custom_links": []
+      }
+    }
+  ],
+  "template_variables": [
+    {
+      "name": "scope",
+      "available_values": [],
+      "default": "*"
+    }
+  ],
+  "layout_type": "free",
+  "is_read_only": true,
+  "notify_list": [],
+  "id": 30304
 }

--- a/kong/assets/dashboards/kong_overview.json
+++ b/kong/assets/dashboards/kong_overview.json
@@ -68,7 +68,7 @@
             "layout": {
                 "x": 15,
                 "y": 1,
-                "width": 12,
+                "width": 24,
                 "height": 8
             }
         },
@@ -233,29 +233,6 @@
                 "y": 26,
                 "width": 71,
                 "height": 15
-            }
-        },
-        {
-            "id": 8,
-            "definition": {
-                "type": "query_value",
-                "requests": [
-                    {
-                        "q": "avg:kong.table.count{$scope}",
-                        "aggregator": "avg"
-                    }
-                ],
-                "custom_links": [],
-                "title": "Number of Tables",
-                "title_size": "16",
-                "title_align": "left",
-                "precision": 0
-            },
-            "layout": {
-                "x": 28,
-                "y": 1,
-                "width": 12,
-                "height": 8
             }
         }
     ],

--- a/kong/datadog_checks/kong/kong.py
+++ b/kong/datadog_checks/kong/kong.py
@@ -79,15 +79,9 @@ class Kong(AgentCheck):
         parsed = json.loads(raw)
         output = []
 
-        # First get the server stats
+        # Get the server stats
         for name, value in parsed.get('server').items():
             metric_name = self.METRIC_PREFIX + name
             output.append((metric_name, value, tags))
-
-        # Then the database metrics
-        databases_metrics = parsed.get('database').items()
-        output.append((self.METRIC_PREFIX + 'table.count', len(databases_metrics), tags))
-        for name, items in databases_metrics:
-            output.append((self.METRIC_PREFIX + 'table.items', items, tags + ['table:{}'.format(name)]))
 
         return output

--- a/kong/metadata.csv
+++ b/kong/metadata.csv
@@ -11,8 +11,6 @@ kong.memory.workers.lua.vms.bytes,gauge,,byte,,[OpenMetrics V2] The allocated by
 kong.nginx.http.current_connections,gauge,,connection,,[OpenMetrics V2] The number of HTTP connections,0,kong,,
 kong.nginx.stream.current_connections,gauge,,connection,,[OpenMetrics V2] The number of stream connections,0,kong,,
 kong.stream.status.count,count,,request,,[OpenMetrics V2] The stream status codes per service/route in Kong,0,kong,,
-kong.table.count,gauge,,table,,[Legacy]Total number of tables in the database.,0,kong,table count,
-kong.table.items,gauge,,row,,[Legacy] Number of items in each table of the database.,0,kong,items count,
 kong.connections_accepted,gauge,,connection,,[Legacy] Total number of accepted client connections.,-1,kong,srvr conn accepted,
 kong.connections_active,gauge,,connection,,[Legacy] Current number of active client connections including Waiting connections.,-1,kong,srvr conn active,
 kong.connections_handled,gauge,,connection,,[Legacy] Total number of handled connections. (Same as accepts unless resource limits were reached).,-1,kong,srvr conn handled,

--- a/kong/tests/test_integration_e2e.py
+++ b/kong/tests/test_integration_e2e.py
@@ -57,12 +57,6 @@ def _assert_check(aggregator):
         for mname in GAUGES:
             aggregator.assert_metric(mname, tags=expected_tags, count=1)
 
-        aggregator.assert_metric('kong.table.count', len(DATABASES), tags=expected_tags, count=1)
-
-        for name in DATABASES:
-            tags = expected_tags + ['table:{}'.format(name)]
-            aggregator.assert_metric('kong.table.items', tags=tags, count=1)
-
         aggregator.assert_service_check(
             'kong.can_connect', status=Kong.OK, tags=['kong_host:localhost', 'kong_port:8001'] + expected_tags, count=1
         )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`kong.table.*` metrics are calculated by counting the number of entries under `database` in the `/status` endpoint. However, the `database` value only contains 1 entry every time, so both `kong.table.count` and `kong.table.items` return a constant of 1 regardless of actual number of databases.

This PR deprecates this metric since it is not accurate and always returns 1.

Note: the `kong_overview.json` dashboard has been updated from
![image](https://user-images.githubusercontent.com/31313038/186745357-512e191d-d5f0-4344-ab04-898ea7b239d2.png)

to 
![image](https://user-images.githubusercontent.com/31313038/186745447-5abe5282-d026-424e-b346-5a0c09448e90.png)

due to the removed table metrics.

Stg: https://dd.datad0g.com/screen/integration/30262/kong-overview-legacy?from_ts=1661450084896&to_ts=1661453684896&live=true
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
