### PR TITLE
Initial pass at moving the IAM Access Analyzer Integration to this repo

### DIFF
--- a/iam_access_analyzer/CHANGELOG.md
+++ b/iam_access_analyzer/CHANGELOG.md
@@ -1,0 +1,1 @@
+# CHANGELOG - Iam Access Analyzer

--- a/iam_access_analyzer/README.md
+++ b/iam_access_analyzer/README.md
@@ -1,0 +1,39 @@
+# Agent Check: AWS IAM Access Analyzer
+
+## Overview
+
+Collect AWS IAM Access Analyzer Logs.
+
+## Setup
+
+Datadog uses Datadog lambda log collector to forward AWS IAM Access Analyzer logs from cloudwatch events.
+Find details on how to set it up in [documentation][1]
+
+### Installation
+
+No installation is needed on your server.
+
+## Data Collected
+
+### Metrics
+
+This integration does not not collect metrics 
+
+### Service Checks
+
+This integration does not include any service checks.
+
+### Logs
+
+This integration can be configured to send Logs.
+
+### Events
+
+This integration does not send events
+
+## Troubleshooting
+
+Need help? Contact [Datadog support][7].
+
+[1]: https://docs.datadoghq.com/integrations/iam_access_analyzer/
+[7]: https://docs.datadoghq.com/help

--- a/iam_access_analyzer/manifest.json
+++ b/iam_access_analyzer/manifest.json
@@ -1,0 +1,30 @@
+{
+  "manifest_version": "2.0.0",
+  "app_uuid": "13a88901-3d20-43b3-9a3c-3b20b2adf1cc",
+  "app_id": "iam-access-analyzer",
+  "display_on_public_website": true,
+  "tile": {
+    "overview": "README.md#Overview",
+    "configuration": "README.md#Setup",
+    "support": "README.md#Support",
+    "changelog": "CHANGELOG.md",
+    "description": "AWS IAM Access Analyzer identifies publicly accessible resources",
+    "title": "AWS IAM Access Analyzer",
+    "media": [],
+    "classifier_tags": [
+      "Category::Log Collection",
+      "Category::Security",
+      "Supported OS::Linux",
+      "Supported OS::Windows",
+      "Supported OS::macOS"
+    ]
+  },
+  "assets": {},
+  "author": {
+    "support_email": "help@datadoghq.com",
+    "name": "Datadog",
+    "homepage": "https://www.datadoghq.com",
+    "sales_email": "info@datadoghq.com"
+  },
+  "oauth": {}
+}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Move the IAM Access Analyzer Integration from the private repo - https://github.com/DataDog/integrations-internal/pull/35/files to this repo. 
Also migrates it to Manifest V2

### Motivation
<!-- What inspired you to submit this pull request? -->
Trying to get everything onto Manifest V2 (that has a tile)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
