### PR TITLE
Fix legacy tooling initialization when using the --here flag

### DIFF
--- a/ddev/src/ddev/cli/application.py
+++ b/ddev/src/ddev/cli/application.py
@@ -78,7 +78,7 @@ class Application(Terminal):
         self.__config['dd_api_key'] = self.config.orgs.get('default', {}).get('api_key', '')
         self.__config['dd_app_key'] = self.config.orgs.get('default', {}).get('app_key', '')
 
-        kwargs = {'here' if self.config.repo.name == 'local' else self.repo.name: True}
+        kwargs = {'here' if self.repo.name == 'local' else self.repo.name: True}
         initialize_root(self.__config, **kwargs)
 
     def copy(self):


### PR DESCRIPTION
### Motivation

```
│ C:\Users\ofek\Desktop\code\integrations-core\ddev\src\ddev\cli\application.py:82 in              │
│ initialize_old_cli                                                                               │
│                                                                                                  │
│   79 │   │   self.__config['dd_app_key'] = self.config.orgs.get('default', {}).get('app_key',    │
│   80 │   │                                                                                       │
│   81 │   │   kwargs = {'here' if self.config.repo.name == 'local' else self.repo.name: True}     │
│ ❱ 82 │   │   initialize_root(self.__config, **kwargs)                                            │
│   83 │                                                                                           │
│   84 │   def copy(self):                                                                         │
│   85 │   │   return self.__config.copy()                                                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: initialize_root() got an unexpected keyword argument 'local'
```