### PR TITLE
Validate the `changelog` field in the manifest file

### DIFF
--- a/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import mock
 import pytest
+from click.testing import CliRunner
 import tests.tooling.manifest_validator.input_constants as input_constants
 
 import datadog_checks.dev.tooling.manifest_validator.common.validator as common
@@ -476,3 +477,33 @@ def test_manifest_v2_tile_description_validator_invalid(setup_route):
     # Assert test case
     assert validator.result.failed, validator.result
     assert not validator.result.fixed
+
+
+def test_manifest_v2_changelog_found(setup_route):
+    manifest = JSONDict(
+        {
+            "tile": {
+                "changelog": "CHANGELOG.md",
+            },
+        }
+    )
+
+    validator = v2_validators.ChangelogValidator(version=V2)
+    validator.validate('datadog_checks_dev', manifest, False)
+
+    assert not validator.result.failed
+
+
+def test_manifest_v2_changelog_not_found(setup_route):
+    manifest = JSONDict(
+        {
+            "tile": {
+                "changelog": "CHANGELOG_NOT_FOUND.md",
+            },
+        }
+    )
+
+    validator = v2_validators.ChangelogValidator(version=V2)
+    validator.validate('datadog_checks_dev', manifest, False)
+
+    assert validator.result.failed

--- a/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import mock
 import pytest
-from click.testing import CliRunner
 import tests.tooling.manifest_validator.input_constants as input_constants
 
 import datadog_checks.dev.tooling.manifest_validator.common.validator as common


### PR DESCRIPTION
### What does this PR do?
Validate the `changelog` field references an existing file if provided in the manifest file.

### Motivation
AI-2388

### Additional Notes

- I don't think we should create a separate command for this validation because we are not validating the content of the changelog file, but that the manifest contains valid data.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
