### PR TITLE
Increase memory

### DIFF
--- a/.azure-pipelines/scripts/sap_hana/linux/50_set_up_sysctl.sh
+++ b/.azure-pipelines/scripts/sap_hana/linux/50_set_up_sysctl.sh
@@ -2,14 +2,10 @@
 
 set -ex
 
-# 6GB is proven to be enough for SAP HANA to run.
-# The default number of memory addresses is 65536, i.e. 512MB (Linux 64-bit).
-# => To get 6GB, we multiply that amount by 12.
-sudo sysctl -w vm.max_map_count=$(expr 16 \* 65536)
-
 # Recommended settings on https://developers.sap.com/tutorials/hxe-ua-install-using-docker.html
 sudo sysctl -w fs.file-max=20000000
 sudo sysctl -w fs.aio-max-nr=262144
+sudo sysctl -w  vm.max_map_count=135217728
 sudo sysctl -w vm.memory_failure_early_kill=1
 
 set +ex


### PR DESCRIPTION
Use the actual recommended memory.
Seems atm is timing out some times

```
ERROR    datadog_checks.base.checks.base.sap_hana:sap_hana.py:109 Error querying SYS_DATABASES.M_DISK_USAGE: (-10807, 'Connection down: [89012] Socket recv timeout (recv took longer than 10000 ms; timeout configured by communicationTimeout or heartbeat)')
ERROR    datadog_checks.base.checks.base.sap_hana:sap_hana.py:109 Error querying SYS_DATABASES.M_SERVICE_MEMORY: (-10807, 'Connection down: [89012] Socket recv timeout (recv took longer than 10000 ms; timeout configured by communicationTimeout or heartbeat)')
- generated xml file: /home/vsts/work/1/s/sap_hana/.junit/test-unit-$HATCH_ENV_ACTIVEpy38-2.xml -
```