### PR TITLE
Perf improvement for `is_proc` lookup in sql server metrics query

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -10,7 +10,7 @@ from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_e
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 
-from .utils import get_stmt_is_proc
+from datadog_checks.sqlserver.utils import is_statement_proc
 
 try:
     import datadog_agent
@@ -213,7 +213,7 @@ class SqlserverActivity(DBMAsyncJob):
             statement = obfuscate_sql_with_metadata(row['statement_text'], self.check.obfuscator_options)
             procedure_statement = None
             # sqlserver doesn't have a boolean data type so convert integer to boolean
-            row['is_proc'] = get_stmt_is_proc(row['text'])
+            row['is_proc'] = is_statement_proc(row['text'])
             if row['is_proc'] and 'text' in row:
                 procedure_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             obfuscated_statement = statement['query']

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -9,7 +9,6 @@ from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding, obfuscate_sql_with_metadata
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
-
 from datadog_checks.sqlserver.utils import is_statement_proc
 
 try:

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -18,7 +18,7 @@ from datadog_checks.base.utils.db.utils import (
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 
-from .utils import get_stmt_is_proc
+from datadog_checks.sqlserver.utils import is_statement_proc
 
 try:
     import datadog_agent
@@ -284,7 +284,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             try:
                 statement = obfuscate_sql_with_metadata(row['statement_text'], self.check.obfuscator_options)
                 procedure_statement = None
-                row['is_proc'] = get_stmt_is_proc(row['text'])
+                row['is_proc'] = is_statement_proc(row['text'])
                 if row['is_proc']:
                     procedure_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             except Exception as e:

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -442,10 +442,9 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             plan_key = (row['query_signature'], row['query_hash'], row['query_plan_hash'])
             # for stored procedures, we only want to look up plans for the entire procedure
             # not every query that is executed within the proc. In order to accomplish this,
-            # we use the first 16 bytes of the plan handle, which is unique enough to differentiate
-            # between plans and saves us space (plan handles are ~64 bytes total)
+            # we use the plan handle
             if row['is_proc'] or row['is_encrypted']:
-                plan_key = row['plan_handle'][0:16]
+                plan_key = row['plan_handle']
             if self._seen_plans_ratelimiter.acquire(plan_key):
                 raw_plan, is_plan_encrypted = self._load_plan(row['plan_handle'], cursor)
                 obfuscated_plan, collection_errors = None, None

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -443,7 +443,8 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             plan_key = (row['query_signature'], row['query_hash'], row['query_plan_hash'])
             # for stored procedures, we only want to look up plans for the entire procedure
             # not every query that is executed within the proc. In order to accomplish this,
-            # we use the procedure_signature as the plan key
+            # we use the first 16 bytes of the plan handle, which is unique enough to differentiate
+            # between plans and saves us space (plan handles are ~64 bytes total)
             if row['is_proc'] or row['is_encrypted']:
                 plan_key = row['plan_handle'][0:16]
             if self._seen_plans_ratelimiter.acquire(plan_key):

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -18,6 +18,8 @@ from datadog_checks.base.utils.db.utils import (
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 
+from .utils import get_stmt_is_proc
+
 try:
     import datadog_agent
 except ImportError:
@@ -81,9 +83,6 @@ select
             - statement_start_offset) / 2) + 1) AS statement_text,
     qt.text,
     encrypted as is_encrypted,
-    (SELECT IIF (EXISTS
-        (SELECT 1 FROM sys.dm_exec_procedure_stats proc_stats
-            WHERE proc_stats.plan_handle = qstats_aggr_split.plan_handle), 1, 0)) as is_proc,
     * from qstats_aggr_split
     cross apply sys.dm_exec_sql_text(plan_handle) qt
 """
@@ -116,9 +115,6 @@ select
     END - statement_start_offset) / 2) + 1) AS statement_text,
     qt.text,
     encrypted as is_encrypted,
-    (SELECT IIF (EXISTS
-        (SELECT 1 FROM sys.dm_exec_procedure_stats proc_stats
-            WHERE proc_stats.plan_handle = qstats_aggr_split.plan_handle), 1, 0)) as is_proc,
     * from qstats_aggr_split
     cross apply sys.dm_exec_sql_text(plan_handle) qt
 """
@@ -288,7 +284,8 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             try:
                 statement = obfuscate_sql_with_metadata(row['statement_text'], self.check.obfuscator_options)
                 procedure_statement = None
-                if row['is_proc'] and 'text' in row:
+                row['is_proc'] = get_stmt_is_proc(row['text'])
+                if row['is_proc']:
                     procedure_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             except Exception as e:
                 # obfuscation errors are relatively common so only log them during debugging
@@ -447,8 +444,8 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             # for stored procedures, we only want to look up plans for the entire procedure
             # not every query that is executed within the proc. In order to accomplish this,
             # we use the procedure_signature as the plan key
-            if row['is_proc']:
-                plan_key = row['procedure_signature']
+            if row['is_proc'] or row['is_encrypted']:
+                plan_key = row['plan_handle'][0:16]
             if self._seen_plans_ratelimiter.acquire(plan_key):
                 raw_plan, is_plan_encrypted = self._load_plan(row['plan_handle'], cursor)
                 obfuscated_plan, collection_errors = None, None

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -17,7 +17,6 @@ from datadog_checks.base.utils.db.utils import (
 )
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
-
 from datadog_checks.sqlserver.utils import is_statement_proc
 
 try:

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -25,6 +25,13 @@ def construct_use_statement(database):
     return 'use [{}]'.format(database)
 
 
+def get_stmt_is_proc(text):
+    if text:
+        t = text.upper()
+        return ("CREATE" in t) and (("PROC" or "PROCEDURE") in t)
+    return False
+
+
 def parse_sqlserver_major_version(version):
     """
     Parses the SQL Server major version out of the full version

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -27,7 +27,9 @@ def construct_use_statement(database):
 
 def is_statement_proc(text):
     if text:
-        t = text.upper().split()
+        # take first 500 chars, upper case and split into string
+        # to get individual keywords
+        t = text[0:500].upper().split()
         idx_create = _get_index_for_keyword(t, 'CREATE')
         idx_proc = _get_index_for_keyword(t, 'PROCEDURE')
         if idx_proc < 0:

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -28,14 +28,20 @@ def construct_use_statement(database):
 def is_statement_proc(text):
     if text:
         t = text.upper().split()
-        idx_create = t.index('CREATE') if 'CREATE' in t else -1
-        procedure = t.index('PROCEDURE') if 'PROCEDURE' in t else -1
-        proc = t.index('PROC') if 'PROC' in t else -1
-        idx_proc = procedure if procedure > 0 else proc
-
+        idx_create = _get_index_for_keyword(t, 'CREATE')
+        idx_proc = _get_index_for_keyword(t, 'PROCEDURE')
+        if idx_proc < 0:
+            idx_proc = _get_index_for_keyword(t, 'PROC')
         # ensure either PROC or PROCEDURE are found and CREATE occurs before PROCEDURE
         return 0 <= idx_create < idx_proc and idx_proc >= 0
     return False
+
+
+def _get_index_for_keyword(text, keyword):
+    try:
+        return text.index(keyword)
+    except ValueError:
+        return -1
 
 
 def parse_sqlserver_major_version(version):

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -25,10 +25,16 @@ def construct_use_statement(database):
     return 'use [{}]'.format(database)
 
 
-def get_stmt_is_proc(text):
+def is_statement_proc(text):
     if text:
-        t = text.upper()
-        return ("CREATE" in t) and (("PROC" or "PROCEDURE") in t)
+        t = text.upper().split()
+        idx_create = t.index('CREATE') if 'CREATE' in t else -1
+        procedure = t.index('PROCEDURE') if 'PROCEDURE' in t else -1
+        proc = t.index('PROC') if 'PROC' in t else -1
+        idx_proc = procedure if procedure > 0 else proc
+
+        # ensure either PROC or PROCEDURE are found and CREATE occurs before PROCEDURE
+        return 0 <= idx_create < idx_proc and idx_proc >= 0
     return False
 
 

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -17,7 +17,7 @@ from dateutil import parser
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.activity import DM_EXEC_REQUESTS_COLS
-from datadog_checks.sqlserver.utils import get_stmt_is_proc
+from datadog_checks.sqlserver.utils import is_statement_proc
 
 from .common import CHECK_NAME
 from .conftest import DEFAULT_TIMEOUT
@@ -494,21 +494,25 @@ def test_get_estimated_row_size_bytes(dbm_instance, file):
             True,
         ],
         [
-            """\
-            CREATE TABLE bob_table
-            """,
+            "CREATE TABLE bob_table",
             False,
         ],
         [
-            """\
-            Exec procedure
-            """,
+            "Exec procedure",
+            False,
+        ],
+        [
+            "CREATEprocedure",
+            False,
+        ],
+        [
+            "procedure create",
             False,
         ],
     ],
 )
-def test_get_stmt_is_procedure(query, is_proc):
-    assert get_stmt_is_proc(query) == is_proc
+def test_is_statement_procedure(query, is_proc):
+    assert is_statement_proc(query) == is_proc
 
 
 def test_activity_collection_rate_limit(aggregator, dd_run_check, dbm_instance):

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -17,6 +17,7 @@ from dateutil import parser
 from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_encoding
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.activity import DM_EXEC_REQUESTS_COLS
+from datadog_checks.sqlserver.utils import get_stmt_is_proc
 
 from .common import CHECK_NAME
 from .conftest import DEFAULT_TIMEOUT
@@ -429,6 +430,85 @@ def test_get_estimated_row_size_bytes(dbm_instance, file):
         computed_size += check.activity._get_estimated_row_size_bytes(a)
 
     assert abs((actual_size - computed_size) / float(actual_size)) <= 0.10
+
+
+@pytest.mark.parametrize(
+    "query,is_proc",
+    [
+        [
+            """\
+            CREATE PROCEDURE bobProcedure
+            BEGIN
+                SELECT name FROM bob
+            END;
+            """,
+            True,
+        ],
+        [
+            """\
+            CREATE PROC bobProcedure
+            BEGIN
+                SELECT name FROM bob
+            END;
+            """,
+            True,
+        ],
+        [
+            """\
+            create procedure bobProcedureLowercase
+            begin
+                select name from bob
+            end;
+            """,
+            True,
+        ],
+        [
+            """\
+            /* my sql is very fun */
+            CREATE PROCEDURE bobProcedure
+            BEGIN
+                SELECT name FROM bob
+            END;
+            """,
+            True,
+        ],
+        [
+            """\
+            CREATE /* this is fun! */ PROC bobProcedure
+            BEGIN
+                SELECT name FROM bob
+            END;
+            """,
+            True,
+        ],
+        [
+            """\
+            -- this is a comment!
+            CREATE
+            -- additional comment here!
+            PROCEDURE bobProcedure
+            BEGIN
+                SELECT name FROM bob
+            END;
+            """,
+            True,
+        ],
+        [
+            """\
+            CREATE TABLE bob_table
+            """,
+            False,
+        ],
+        [
+            """\
+            Exec procedure
+            """,
+            False,
+        ],
+    ],
+)
+def test_get_stmt_is_procedure(query, is_proc):
+    assert get_stmt_is_proc(query) == is_proc
 
 
 def test_activity_collection_rate_limit(aggregator, dd_run_check, dbm_instance):

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -361,7 +361,8 @@ def test_statement_metrics_and_plans(
             assert row['query_signature'], "missing query signature"
         assert 'statement_text' not in row, "statement_text field should not be forwarded"
         assert row['is_encrypted'] == is_encrypted
-        assert row['is_proc'] == is_proc
+        if not is_encrypted:
+            assert row['is_proc'] == is_proc
         if is_proc and not is_encrypted:
             assert row['procedure_signature'], "missing proc signature"
         if disable_secondary_tags:
@@ -371,9 +372,10 @@ def test_statement_metrics_and_plans(
         for column in available_query_metrics_columns:
             assert column in row, "missing required metrics column {}".format(column)
             assert type(row[column]) in (float, int), "wrong type for metrics column {}".format(column)
+    # all the plan handles / proc sigs should be the same for the same procedure execution
     if is_proc:
-        # all the plan handles / proc sigs should be the same for the same procedure execution
         assert all(row['plan_handle'] == matching_rows[0]['plan_handle'] for row in matching_rows)
+    if is_proc and not is_encrypted:
         assert all(row['procedure_signature'] == matching_rows[0]['procedure_signature'] for row in matching_rows)
 
     dbm_samples = aggregator.get_event_platform_events("dbm-samples")


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Instead of looking up if the text comes from a procedure via `sys.dm_exec_procedure_stats`, we can simply check if the full text contains `CREATE PROCEDURE/PROC` as per the [sql server docs](https://docs.microsoft.com/en-us/sql/t-sql/statements/create-procedure-transact-sql?view=sql-server-ver16). Note: this doesn't work for encrypted stored procedures (obviously), but in order to prevent extra plan lookups for encrypted stored procedures, we can use the `plan_handle` as the plan key in our RL cache. 

The result of this is a negligible change in performance  between the updated metrics/activity queries and the 7.38 agent version: 

![Screen Shot 2022-08-26 at 9 02 09 AM](https://user-images.githubusercontent.com/14317240/186966290-bca15038-974a-4eb7-a645-433fac932236.png)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
