### PR TITLE
Update wording around collection interval

### DIFF
--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -110,7 +110,7 @@ datadog-agent integration install datadog-snowflake==2.0.1
         # disable_generic_tags: true
     ```
 
-    <div class="alert alert-info">By default, the <code>min_collection_interval</code> is 1 hour. 
+    <div class="alert alert-info">In the default `conf.yaml`, the <code>min_collection_interval</code> is 1 hour. 
     Snowflake metrics are aggregated by day, you can increase the interval to reduce the number of queries.<br>
     <bold>Note</bold>: Snowflake ACCOUNT_USAGE views have a <a href="https://docs.snowflake.com/en/sql-reference/account-usage.html#data-latency">known latency</a> of 45 minutes to 3 hours.</div>
 

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -95,7 +95,7 @@ datadog-agent integration install datadog-snowflake==2.0.1
         #
         role: <ROLE>
    
-        ## @param min_collection_interval - number - optional - default: 3600
+        ## @param min_collection_interval - number - optional - default: 15
         ## This changes the collection interval of the check. For more information, see:
         ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
         ##

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -100,7 +100,7 @@ datadog-agent integration install datadog-snowflake==2.0.1
         ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
         ##
         ## NOTE: Most Snowflake ACCOUNT_USAGE views are populated on an hourly basis,
-        ## so to minimize unnecessary queries the `min_collection_interval` defaults to 1 hour.
+        ## so to minimize unnecessary queries, set the `min_collection_interval` to 1 hour.
         #
         min_collection_interval: 3600
    

--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -210,8 +210,9 @@ files:
             so to minimize unnecessary queries, set the `min_collection_interval` to 1 hour.
 
             Most metrics are aggregated by day, you can increase the interval to reduce the number of queries.
-          min_collection_interval.display_default: 15
+          min_collection_interval.value.display_default: 15
+          min_collection_interval.value.default: 3600
           min_collection_interval.value.example: 3600
-          min_collection_interval.enabled: 3600
+          min_collection_interval.enabled: true
           disable_generic_tags.hidden: False
           disable_generic_tags.enabled: True

--- a/snowflake/assets/configuration/spec.yaml
+++ b/snowflake/assets/configuration/spec.yaml
@@ -207,10 +207,10 @@ files:
             https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
 
             NOTE: Most Snowflake ACCOUNT_USAGE views are populated on an hourly basis,
-            so to minimize unnecessary queries the `min_collection_interval` defaults to 1 hour.
+            so to minimize unnecessary queries, set the `min_collection_interval` to 1 hour.
 
             Most metrics are aggregated by day, you can increase the interval to reduce the number of queries.
-          min_collection_interval.display_default: 3600
+          min_collection_interval.display_default: 15
           min_collection_interval.value.example: 3600
           min_collection_interval.enabled: 3600
           disable_generic_tags.hidden: False

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -254,7 +254,7 @@ instances:
     ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
     ##
     ## NOTE: Most Snowflake ACCOUNT_USAGE views are populated on an hourly basis,
-    ## so to minimize unnecessary queries the `min_collection_interval` defaults to 1 hour.
+    ## so to minimize unnecessary queries, set the `min_collection_interval` to 1 hour.
     ##
     ## Most metrics are aggregated by day, you can increase the interval to reduce the number of queries.
     #

--- a/snowflake/datadog_checks/snowflake/data/conf.yaml.example
+++ b/snowflake/datadog_checks/snowflake/data/conf.yaml.example
@@ -249,7 +249,7 @@ instances:
     #
     # service: <SERVICE>
 
-    ## @param min_collection_interval - number - optional - default: 3600
+    ## @param min_collection_interval - number - optional - default: 15
     ## This changes the collection interval of the check. For more information, see:
     ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
     ##


### PR DESCRIPTION
### What does this PR do?
Updates readme and configuration docs to make it more clear that `min_collection_interval` needs to be explicitly set to `3600` in the `conf.yaml` and that the default is 15s.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
