### PR TITLE
Run test_check_invalid_schema until stable

### DIFF
--- a/sap_hana/tests/conftest.py
+++ b/sap_hana/tests/conftest.py
@@ -89,6 +89,7 @@ def dd_environment(schema="SYS_DATABASES"):
             CheckDockerLogs(COMPOSE_FILE, ['Startup finished!'], wait=5, attempts=120),
             WaitFor(db.connect),
             db.initialize,
+            #CheckDockerLogs()
         ],
         env_vars={'PASSWORD': ADMIN_CONFIG['password']},
     ):

--- a/sap_hana/tests/conftest.py
+++ b/sap_hana/tests/conftest.py
@@ -89,7 +89,6 @@ def dd_environment(schema="SYS_DATABASES"):
             CheckDockerLogs(COMPOSE_FILE, ['Startup finished!'], wait=5, attempts=120),
             WaitFor(db.connect),
             db.initialize,
-            #CheckDockerLogs()
         ],
         env_vars={'PASSWORD': ADMIN_CONFIG['password']},
     ):

--- a/sap_hana/tests/test_integration.py
+++ b/sap_hana/tests/test_integration.py
@@ -24,8 +24,7 @@ def test_check(aggregator, instance, dd_run_check):
 def test_check_invalid_schema(aggregator, instance, dd_run_check):
     instance["schema"] = "UNKNOWN_SCHEMA"
     check = SapHanaCheck('sap_hana', {}, [instance])
-    check.log = mock.MagicMock()
-    dd_run_check(check)
+    _run_until_stable(dd_run_check, check, aggregator, mock_log=True)
 
     check.log.error.assert_has_calls(
         calls=[
@@ -48,10 +47,14 @@ def test_check_invalid_schema(aggregator, instance, dd_run_check):
         assert "invalid schema name: UNKNOWN_SCHEMA" in call_args[0][2]
 
 
-def _run_until_stable(dd_run_check, check, aggregator):
+def _run_until_stable(dd_run_check, check, aggregator, mock_log=False):
     retries = 3
+    if mock_log:
+        check.log = mock.MagicMock()
     dd_run_check(check)
     while retries and connection_flaked(aggregator):
+        if mock_log:
+            check.log.reset_mock()
         aggregator.reset()
         dd_run_check(check)
         retries -= 1


### PR DESCRIPTION
Otherwise the check might have more errors than asserted in the logs
https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=110242&view=logs&j=b0ed5827-5770-56e3-9f82-70059854e6d2&t=879ef9f2-95c3-5e11-5b66-404511e0691a&l=54