### PR TITLE
Remove tox related references from the `ddev create` template files

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -65,7 +65,6 @@ To install the {integration_name} check on your host:
         )
         license_header = get_license_header()
         support_type = 'core'
-        test_dev_dep = '-e ../datadog_checks_dev'
         integration_links = integration_type_links.get(integration_type).format(name=normalized_integration_name)
     elif repo_choice == 'marketplace':
         check_name = normalize_package_name(f"{kwargs.get('author')}_{normalized_integration_name}")
@@ -77,7 +76,6 @@ To install the {integration_name} check on your host:
         # Static fields
         license_header = ''
         support_type = 'partner'
-        test_dev_dep = 'datadog-checks-dev'
         integration_links = ''
     else:
         check_name = normalized_integration_name
@@ -86,7 +84,6 @@ To install the {integration_name} check on your host:
         install_info = third_party_install_info
         license_header = ''
         support_type = 'contrib'
-        test_dev_dep = 'datadog-checks-dev'
         integration_links = integration_type_links.get(integration_type)
 
     config = {
@@ -105,7 +102,6 @@ To install the {integration_name} check on your host:
         'repo_choice': repo_choice,
         'repo_name': REPO_CHOICES[repo_choice],
         'support_type': support_type,
-        'test_dev_dep': test_dev_dep,
         'integration_links': integration_links,
     }
     config.update(kwargs)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
@@ -50,8 +50,6 @@ include = [
     "/datadog_checks",
     "/tests",
     "/manifest.json",
-    "/requirements-dev.txt",
-    "/tox.ini",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
@@ -50,8 +50,6 @@ include = [
     "/datadog_checks",
     "/tests",
     "/manifest.json",
-    "/requirements-dev.txt",
-    "/tox.ini",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
@@ -50,8 +50,6 @@ include = [
     "/datadog_checks",
     "/tests",
     "/manifest.json",
-    "/requirements-dev.txt",
-    "/tox.ini",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/requirements-dev.txt
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/requirements-dev.txt
@@ -1,1 +1,0 @@
-{test_dev_dep}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Remove `requirements-dev.txt` from the `pyproject.toml` template file
- Remove `tox.ini` from the `pyproject.toml` template file
- Remove the `requirements-dev.txt` from the log template files
- Remove the `test_dev_dep` template variable since it's not used anymore

### Motivation
<!-- What inspired you to submit this pull request? -->

We do not use tox anymore. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
