### PR TITLE
Increase memory for hana

### DIFF
--- a/.azure-pipelines/scripts/sap_hana/linux/50_set_up_sysctl.sh
+++ b/.azure-pipelines/scripts/sap_hana/linux/50_set_up_sysctl.sh
@@ -5,7 +5,7 @@ set -ex
 # Recommended settings on https://developers.sap.com/tutorials/hxe-ua-install-using-docker.html
 sudo sysctl -w fs.file-max=20000000
 sudo sysctl -w fs.aio-max-nr=262144
-sudo sysctl -w  vm.max_map_count=135217728
+sudo sysctl -w  vm.max_map_count=270435456  # Doubling the recommended value
 sudo sysctl -w vm.memory_failure_early_kill=1
 
 set +ex

--- a/sap_hana/datadog_checks/sap_hana/sap_hana.py
+++ b/sap_hana/datadog_checks/sap_hana/sap_hana.py
@@ -88,7 +88,6 @@ class SapHanaCheck(AgentCheck):
         self.check_initializations.append(self.set_default_methods)
 
     def check(self, _):
-
         if self._only_custom_queries:
             query_methods = [self.query_custom]
         else:


### PR DESCRIPTION
Although all recent changes to HANA have made it more stable on CI it is still failing quite often.

Recent changes:
https://github.com/DataDog/integrations-core/pull/12848
https://github.com/DataDog/integrations-core/pull/12826
https://github.com/DataDog/integrations-core/pull/12528
