### PR TITLE
[rabbitmq] Add new metric to track size of queues in bytes

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/const.py
+++ b/rabbitmq/datadog_checks/rabbitmq/const.py
@@ -44,6 +44,7 @@ QUEUE_ATTRIBUTES = [
     ('messages_details/rate', 'messages.rate', float),
     ('messages_ready', 'messages_ready', float),
     ('messages_ready_details/rate', 'messages_ready.rate', float),
+    ('message_bytes', 'message_bytes', float),
     ('messages_unacknowledged', 'messages_unacknowledged', float),
     ('messages_unacknowledged_details/rate', 'messages_unacknowledged.rate', float),
     ('message_stats/ack', 'messages.ack.count', float),

--- a/rabbitmq/metadata.csv
+++ b/rabbitmq/metadata.csv
@@ -35,6 +35,7 @@ rabbitmq.queue.messages,gauge,,message,,Count of the total messages in the queue
 rabbitmq.queue.messages.rate,gauge,,message,second,Count per second of the total messages in the queue,0,rabbitmq,msgs rate,
 rabbitmq.queue.messages_ready,gauge,,message,,Number of messages ready to be delivered to clients,0,rabbitmq,msgs rdy,
 rabbitmq.queue.messages_ready.rate,gauge,,message,second,Number per second of messages ready to be delivered to clients,0,rabbitmq,msgs rdy rate,
+rabbitmq.queue.message_bytes,gauge,,message,,Number of bytes of messages ready to be delivered to clients,0,rabbitmq,msgs rdy,
 rabbitmq.queue.messages_unacknowledged,gauge,,message,,Number of messages delivered to clients but not yet acknowledged,0,rabbitmq,msgs unack,
 rabbitmq.queue.messages_unacknowledged.rate,gauge,,message,second,Number per second of messages delivered to clients but not yet acknowledged,0,rabbitmq,msgs unack rate,
 rabbitmq.queue.messages.ack.count,gauge,,message,,Number of messages in queues delivered to clients and acknowledged,0,rabbitmq,msgs ack,

--- a/rabbitmq/tests/metrics.py
+++ b/rabbitmq/tests/metrics.py
@@ -45,6 +45,7 @@ Q_METRICS = [
     'rabbitmq.queue.messages.rate',
     'rabbitmq.queue.messages_ready',
     'rabbitmq.queue.messages_ready.rate',
+    'rabbitmq.queue.message_bytes',
     'rabbitmq.queue.messages_unacknowledged',
     'rabbitmq.queue.messages_unacknowledged.rate',
     'rabbitmq.queue.messages.publish.count',


### PR DESCRIPTION
### What does this PR do?
Adds new metric to track number of bytes of each queue in rabbitmq.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
