### PR TITLE
Clarify mysql config steps

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -29,10 +29,17 @@ On each MySQL server, create a database user for the Datadog Agent.
 
 The following instructions grant the Agent permission to login from any host using `datadog@'%'`. You can restrict the `datadog` user to be allowed to login only from localhost by using `datadog@'localhost'`. See [MySQL Adding Accounts, Assigning Privileges, and Dropping Accounts][5] for more info.
 
-For MySQL versions 5.6 and 5.7, create the `datadog` user with the following command:
+For MySQL 5.6, MySQL 5.7 or MariaDB, create the `datadog` user with the following command:
 
 ```shell
 mysql> CREATE USER 'datadog'@'%' IDENTIFIED BY '<UNIQUEPASSWORD>';
+Query OK, 0 rows affected (0.00 sec)
+```
+
+For MariaDB, create another `datadog` user `@localhost`, otherwise you will see `Error 1045, "Access denied for user 'datadog'@'localhost' (using password: YES)"`:
+
+```shell
+mysql> CREATE USER 'datadog'@'localhost' IDENTIFIED BY '<UNIQUEPASSWORD>';
 Query OK, 0 rows affected (0.00 sec)
 ```
 

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -29,17 +29,10 @@ On each MySQL server, create a database user for the Datadog Agent.
 
 The following instructions grant the Agent permission to login from any host using `datadog@'%'`. You can restrict the `datadog` user to be allowed to login only from localhost by using `datadog@'localhost'`. See [MySQL Adding Accounts, Assigning Privileges, and Dropping Accounts][5] for more info.
 
-For MySQL 5.6, MySQL 5.7 or MariaDB, create the `datadog` user with the following command:
+For MySQL 5.6 or MySQL 5.7 create the `datadog` user with the following command:
 
 ```shell
 mysql> CREATE USER 'datadog'@'%' IDENTIFIED BY '<UNIQUEPASSWORD>';
-Query OK, 0 rows affected (0.00 sec)
-```
-
-For MariaDB, create another `datadog` user `@localhost`, otherwise you will see `Error 1045, "Access denied for user 'datadog'@'localhost' (using password: YES)"`:
-
-```shell
-mysql> CREATE USER 'datadog'@'localhost' IDENTIFIED BY '<UNIQUEPASSWORD>';
 Query OK, 0 rows affected (0.00 sec)
 ```
 
@@ -60,16 +53,18 @@ echo -e "\033[0;31mCannot connect to MySQL\033[0m"
 
 The Agent needs a few privileges to collect metrics. Grant the `datadog` user only the following limited privileges.
 
-For MySQL versions 5.6 and 5.7, set `max_user_connections` with the following command:
+For MySQL versions 5.6 and 5.7, grant `replication client` and set `max_user_connections` with the following command:
 
 ```shell
 mysql> GRANT REPLICATION CLIENT ON *.* TO 'datadog'@'%' WITH MAX_USER_CONNECTIONS 5;
 Query OK, 0 rows affected, 1 warning (0.00 sec)
 ```
 
-For MySQL 8.0 or greater, set `max_user_connections` with the following command:
+For MySQL 8.0 or greater, grant `replication client` and set `max_user_connections` with the following commands:
 
 ```shell
+mysql> GRANT REPLICATION CLIENT ON *.* TO 'datadog'@'%'
+Query OK, 0 rows affected (0.00 sec)
 mysql> ALTER USER 'datadog'@'%' WITH MAX_USER_CONNECTIONS 5;
 Query OK, 0 rows affected (0.00 sec)
 ```

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -29,12 +29,14 @@ On each MySQL server, create a database user for the Datadog Agent.
 
 The following instructions grant the Agent permission to login from any host using `datadog@'%'`. You can restrict the `datadog` user to be allowed to login only from localhost by using `datadog@'localhost'`. See [MySQL Adding Accounts, Assigning Privileges, and Dropping Accounts][5] for more info.
 
+For MySQL versions 5.6 and 5.7, create the `datadog` user with the following command:
+
 ```shell
 mysql> CREATE USER 'datadog'@'%' IDENTIFIED BY '<UNIQUEPASSWORD>';
 Query OK, 0 rows affected (0.00 sec)
 ```
 
-For mySQL 8.0+ create the `datadog` user with the native password hashing method:
+For MySQL 8.0 or greater, create the `datadog` user with the native password hashing method:
 
 ```shell
 mysql> CREATE USER 'datadog'@'%' IDENTIFIED WITH mysql_native_password by '<UNIQUEPASSWORD>';
@@ -49,27 +51,35 @@ grep Uptime && echo -e "\033[0;32mMySQL user - OK\033[0m" || \
 echo -e "\033[0;31mCannot connect to MySQL\033[0m"
 ```
 
-```shell
-mysql -u datadog --password=<UNIQUEPASSWORD> -e "show slave status" && \
-echo -e "\033[0;32mMySQL grant - OK\033[0m" || \
-echo -e "\033[0;31mMissing REPLICATION CLIENT grant\033[0m"
-```
+The Agent needs a few privileges to collect metrics. Grant the `datadog` user only the following limited privileges.
 
-The Agent needs a few privileges to collect metrics. Grant the user the following limited privileges ONLY:
+For MySQL versions 5.6 and 5.7, set `max_user_connections` with the following command:
 
 ```shell
 mysql> GRANT REPLICATION CLIENT ON *.* TO 'datadog'@'%' WITH MAX_USER_CONNECTIONS 5;
 Query OK, 0 rows affected, 1 warning (0.00 sec)
-
-mysql> GRANT PROCESS ON *.* TO 'datadog'@'%';
-Query OK, 0 rows affected (0.00 sec)
 ```
 
-For MySQL 8.0+ set `max_user_connections` with:
+For MySQL 8.0 or greater, set `max_user_connections` with the following command:
 
 ```shell
 mysql> ALTER USER 'datadog'@'%' WITH MAX_USER_CONNECTIONS 5;
 Query OK, 0 rows affected (0.00 sec)
+```
+
+Grant the `datadog` user the process privilege:
+
+```shell
+mysql> GRANT PROCESS ON *.* TO 'datadog'@'%';
+Query OK, 0 rows affected (0.00 sec)
+```
+
+Verify the replication client. Replace `<UNIQUEPASSWORD>` with the password you created above:
+
+```shell
+mysql -u datadog --password=<UNIQUEPASSWORD> -e "show slave status" && \
+echo -e "\033[0;32mMySQL grant - OK\033[0m" || \
+echo -e "\033[0;31mMissing REPLICATION CLIENT grant\033[0m"
 ```
 
 If enabled, metrics can be collected from the `performance_schema` database by granting an additional privilege:


### PR DESCRIPTION
One step was out of order and mysql versions needed to be clearer.  New steps were tested on MySQL 8.0.30 on Mac (m1) and Datadog Agent status collector is green afterwards.

