### PR TITLE
Skip sock5 tests on py2

### DIFF
--- a/datadog_checks_base/tests/base/utils/http/test_socks5_proxy.py
+++ b/datadog_checks_base/tests/base/utils/http/test_socks5_proxy.py
@@ -3,11 +3,11 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 from requests.exceptions import ConnectTimeout, ProxyError
+from six import PY2
 
 from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.dev.ci import running_on_windows_ci
-from six import PY2
 
 pytestmark = [
     pytest.mark.integration,

--- a/datadog_checks_base/tests/base/utils/http/test_socks5_proxy.py
+++ b/datadog_checks_base/tests/base/utils/http/test_socks5_proxy.py
@@ -7,9 +7,11 @@ from requests.exceptions import ConnectTimeout, ProxyError
 from datadog_checks.base.utils.http import RequestsWrapper
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.dev.ci import running_on_windows_ci
+from six import PY2
 
 pytestmark = [
     pytest.mark.integration,
+    pytest.mark.skipif(PY2, reason='Test flakes on py2'),
     pytest.mark.skipif(running_on_windows_ci(), reason='Test cannot be run on Windows CI'),
 ]
 


### PR DESCRIPTION
These tests often fail on py2 with `ConnectionError: ('Connection aborted.', error(104, 'Connection reset by peer'))` or `ConnectionError: SOCKSHTTPConnectionPool(host='nginx', port=80): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.contrib.socks.SOCKSConnection object at 0x7f844f302090>: Failed to establish a new connection: 0x05: Connection refused',))`

Examples:

* https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=111441&view=logs&j=762a2123-1c7c-5bf0-0e62-04885c3ecd74&t=e42a329a-2791-53f4-67fc-ce0c85b45aed&l=1251
* https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=111116&view=logs&j=762a2123-1c7c-5bf0-0e62-04885c3ecd74&t=e42a329a-2791-53f4-67fc-ce0c85b45aed&l=1253
* https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=111001&view=logs&j=762a2123-1c7c-5bf0-0e62-04885c3ecd74&t=e42a329a-2791-53f4-67fc-ce0c85b45aed&l=1248
* https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=110957&view=logs&j=762a2123-1c7c-5bf0-0e62-04885c3ecd74&t=e42a329a-2791-53f4-67fc-ce0c85b45aed&l=1143