### PR TITLE
Convert regex patterns to glob patterns in PR labeler config

### DIFF
--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -3,7 +3,8 @@ base_package:
 changelog/no-changelog:
 - requirements-agent-release.txt
 - datadog_checks_dev/datadog_checks/dev/__about__.py
-- all:['*/!(datadog_checks)/**', '*/!(pyproject.toml)', '*/tests/**']
+- '*/!(datadog_checks)/**'
+- '*/!(pyproject.toml)'
 ddev:
 - ddev/**/*
 dependencies:
@@ -25,6 +26,7 @@ documentation:
 - '*/manifest.json'
 - '*/assets/configuration/**'
 - '*/CHANGELOG.md'
+- '*/README.md'
 - docs/**
 downloader:
 - datadog_checks_downloader/**/*

--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -3,7 +3,7 @@ base_package:
 changelog/no-changelog:
 - requirements-agent-release.txt
 - datadog_checks_dev/datadog_checks/dev/__about__.py
-- all:^(?![^/]+/datadog_checks/.*|[^/]+/pyproject\.toml).*
+- all:['*/!(datadog_checks)/**', '*/!(pyproject.toml)', '*/tests/**']
 ddev:
 - ddev/**/*
 dependencies:
@@ -24,7 +24,7 @@ dev_package:
 documentation:
 - '*/manifest.json'
 - '*/assets/configuration/**'
-- (?<!CHANGELOG)\.md$
+- '*/CHANGELOG.md'
 - docs/**
 downloader:
 - datadog_checks_downloader/**/*


### PR DESCRIPTION
### What does this PR do?
Fixes the PR labeler config to use glob patterns instead of regex patterns. The official labeler GH action does not support regex patterns. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
