### PR TITLE
Fix exception thrown when database is null in config

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -394,7 +394,7 @@ class Connection(object):
                 self.close_cursor(cursor)
 
         exists = False
-        if database.lower() in self.existing_databases:
+        if database and database.lower() in self.existing_databases:
             case_insensitive, cased_name = self.existing_databases[database.lower()]
             if case_insensitive or database == cased_name:
                 exists = True


### PR DESCRIPTION
### What does this PR do?

Fixes a type check error:

```
error: sqlserver:6342f67680de647e | (sqlserver.py:316) | Initialization exception 'NoneType' object has no attribute 'lower'
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sqlserver/sqlserver.py", line 289, in initialize_connection
    db_exists, context = self.connection.check_database()
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sqlserver/connection.py", line 261, in check_database
    db_exists, context = self._check_db_exists()
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/sqlserver/connection.py", line 397, in _check_db_exists
    if database.lower() in self.existing_databases:
AttributeError: 'NoneType' object has no attribute 'lower'
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
