### PR TITLE
Bump dependencies for 7.40

### DIFF
--- a/aerospike/pyproject.toml
+++ b/aerospike/pyproject.toml
@@ -40,7 +40,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "aerospike==4.0.0; sys_platform != 'win32' and sys_platform != 'darwin' and python_version < '3.0'",
-    "aerospike==7.0.2; sys_platform != 'win32' and sys_platform != 'darwin' and python_version > '3.0'",
+    "aerospike==7.1.0; sys_platform != 'win32' and sys_platform != 'darwin' and python_version > '3.0'",
 ]
 
 [project.urls]

--- a/amazon_msk/pyproject.toml
+++ b/amazon_msk/pyproject.toml
@@ -40,7 +40,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "boto3==1.17.112; python_version < '3.0'",
-    "boto3==1.24.70; python_version > '3.0'",
+    "boto3==1.24.71; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/amazon_msk/pyproject.toml
+++ b/amazon_msk/pyproject.toml
@@ -40,7 +40,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "boto3==1.17.112; python_version < '3.0'",
-    "boto3==1.24.44; python_version > '3.0'",
+    "boto3==1.24.70; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -6,10 +6,10 @@ beautifulsoup4==4.11.1; python_version > '3.0'
 beautifulsoup4==4.9.3; python_version < '3.0'
 binary==1.0.0
 boto3==1.17.112; python_version < '3.0'
-boto3==1.24.70; python_version > '3.0'
+boto3==1.24.71; python_version > '3.0'
 boto==2.49.0
 botocore==1.20.112; python_version < '3.0'
-botocore==1.27.70; python_version > '3.0'
+botocore==1.27.71; python_version > '3.0'
 cachetools==3.1.1; python_version < '3.0'
 cachetools==5.2.0; python_version > '3.0'
 clickhouse-cityhash==1.0.2.3

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -1,15 +1,15 @@
 adodbapi==2.6.2.0; sys_platform == 'win32'
 aerospike==4.0.0; sys_platform != 'win32' and sys_platform != 'darwin' and python_version < '3.0'
-aerospike==7.0.2; sys_platform != 'win32' and sys_platform != 'darwin' and python_version > '3.0'
+aerospike==7.1.0; sys_platform != 'win32' and sys_platform != 'darwin' and python_version > '3.0'
 aws-requests-auth==0.4.3
 beautifulsoup4==4.11.1; python_version > '3.0'
 beautifulsoup4==4.9.3; python_version < '3.0'
 binary==1.0.0
 boto3==1.17.112; python_version < '3.0'
-boto3==1.24.44; python_version > '3.0'
+boto3==1.24.70; python_version > '3.0'
 boto==2.49.0
 botocore==1.20.112; python_version < '3.0'
-botocore==1.27.44; python_version > '3.0'
+botocore==1.27.70; python_version > '3.0'
 cachetools==3.1.1; python_version < '3.0'
 cachetools==5.2.0; python_version > '3.0'
 clickhouse-cityhash==1.0.2.3
@@ -28,7 +28,7 @@ foundationdb==6.3.24; python_version > '3.0'
 futures==3.3.0; python_version < '3.0'
 gearman==2.0.2; sys_platform != 'win32' and python_version < '3.0'
 gssapi==1.6.1; python_version < '3.0'
-gssapi==1.7.3; python_version > '3.0'
+gssapi==1.8.1; python_version > '3.0'
 immutables==0.18; python_version > '3.0'
 in-toto==1.0.1
 ipaddress==1.0.23; python_version < '3.0'
@@ -47,10 +47,10 @@ lz4==3.1.3; python_version > '3.0'
 mmh3==2.5.1; python_version < '3.0'
 mmh3==3.0.0; python_version > '3.0'
 oauthlib==3.1.0; python_version < '3.0'
-oauthlib==3.2.0; python_version > '3.0'
+oauthlib==3.2.1; python_version > '3.0'
 openstacksdk==0.39.0; python_version < '3.0'
 openstacksdk==0.61.0; python_version > '3.0'
-orjson==3.7.11; python_version > '3.0'
+orjson==3.8.0; python_version > '3.0'
 packaging==20.9; python_version < '3.0'
 packaging==21.3; python_version > '3.0'
 paramiko==2.11.0
@@ -63,7 +63,7 @@ psutil==5.9.0
 psycopg2-binary==2.8.6
 pyasn1==0.4.6
 pycryptodomex==3.10.1
-pydantic==1.9.1; python_version > '3.0'
+pydantic==1.10.2; python_version > '3.0'
 pyjwt==1.7.1; python_version < '3.0'
 pyjwt==2.4.0; python_version > '3.0'
 pymongo[srv]==4.2.0; python_version >= '3.8'
@@ -104,7 +104,7 @@ serpent==1.41; sys_platform == 'win32' and python_version > '3.0'
 service-identity[idna]==21.1.0
 simplejson==3.17.6
 six==1.16.0
-snowflake-connector-python==2.7.11; python_version > '3.0'
+snowflake-connector-python==2.7.12; python_version > '3.0'
 supervisor==4.2.4
 tuf==0.17.0; python_version < '3.0'
 tuf==0.19.0; python_version > '3.0'

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -55,7 +55,7 @@ deps = [
     "prometheus-client==0.14.1; python_version > '3.0'",
     "protobuf==3.17.3; python_version < '3.0'",
     "protobuf==3.20.1; python_version > '3.0'",
-    "pydantic==1.9.1; python_version > '3.0'",
+    "pydantic==1.10.2; python_version > '3.0'",
     "python-dateutil==2.8.2",
     "pywin32==228; sys_platform == 'win32' and python_version < '3.0'",
     "pywin32==304; sys_platform == 'win32' and python_version > '3.0'",
@@ -74,9 +74,9 @@ deps = [
 http = [
     "aws-requests-auth==0.4.3",
     "botocore==1.20.112; python_version < '3.0'",
-    "botocore==1.27.44; python_version > '3.0'",
+    "botocore==1.27.70; python_version > '3.0'",
     "oauthlib==3.1.0; python_version < '3.0'",
-    "oauthlib==3.2.0; python_version > '3.0'",
+    "oauthlib==3.2.1; python_version > '3.0'",
     "pyjwt==1.7.1; python_version < '3.0'",
     "pyjwt==2.4.0; python_version > '3.0'",
     "pysocks==1.7.1",
@@ -87,7 +87,7 @@ http = [
     "win-inet-pton==1.1.0; sys_platform == 'win32' and python_version < '3.0'",
 ]
 json = [
-    "orjson==3.7.11; python_version > '3.0'",
+    "orjson==3.8.0; python_version > '3.0'",
 ]
 kube = [
     "kubernetes==18.20.0; python_version < '3.0'",

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -74,7 +74,7 @@ deps = [
 http = [
     "aws-requests-auth==0.4.3",
     "botocore==1.20.112; python_version < '3.0'",
-    "botocore==1.27.70; python_version > '3.0'",
+    "botocore==1.27.71; python_version > '3.0'",
     "oauthlib==3.1.0; python_version < '3.0'",
     "oauthlib==3.2.1; python_version > '3.0'",
     "pyjwt==1.7.1; python_version < '3.0'",

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -20,14 +20,10 @@ FIX_DEFAULT_ENVDIR_FLAG = 'ensure_default_envdir'
 # Style deps:
 # We pin deps in order to make CI more stable/reliable.
 ISORT_DEP = 'isort==5.10.1'
-BLACK_DEP = 'black==22.6.0'
-FLAKE8_DEP = 'flake8==5.0.3'
-FLAKE8_BUGBEAR_DEP = 'flake8-bugbear==22.7.1'
-# TODO: update when fix is released https://github.com/globality-corp/flake8-logging-format/pull/33
-FLAKE8_LOGGING_FORMAT_DEP = (
-    'flake8-logging-format @ git+https://github.com/globality-corp/flake8-logging-format.git'
-    '@f3cdb24468241ebe85e41b0bd2e8958c76b4dec6 '
-)
+BLACK_DEP = 'black==22.8.0'
+FLAKE8_DEP = 'flake8==5.0.4'
+FLAKE8_BUGBEAR_DEP = 'flake8-bugbear==22.9.11'
+FLAKE8_LOGGING_FORMAT_DEP = 'flake8-logging-format==0.7.5'
 # TODO: remove extra when we drop Python 2
 MYPY_DEP = 'mypy[python2]==0.910'
 # TODO: when we drop Python 2 and replace with --install-types --non-interactive
@@ -38,7 +34,7 @@ TYPES_DEPS = [
     'types_six==1.16.2',
     'types-simplejson==3.17.5',
 ]
-PYDANTIC_DEP = 'pydantic==1.9.1'  # Keep in sync with: /datadog_checks_base/requirements.in
+PYDANTIC_DEP = 'pydantic==1.10.2'  # Keep in sync with: /datadog_checks_base/datadog_checks/data/agent_requirements.in
 
 
 @tox.hookimpl

--- a/kafka_consumer/pyproject.toml
+++ b/kafka_consumer/pyproject.toml
@@ -9,7 +9,6 @@ build-backend = "hatchling.build"
 name = "datadog-kafka-consumer"
 description = "The Kafka Consumer check"
 readme = "README.md"
-license = {text = "BSD-3-Clause"}
 keywords = [
     "datadog",
     "datadog agent",
@@ -35,10 +34,13 @@ dynamic = [
     "version",
 ]
 
+[project.license]
+text = "BSD-3-Clause"
+
 [project.optional-dependencies]
 deps = [
     "gssapi==1.6.1; python_version < '3.0'",
-    "gssapi==1.7.3; python_version > '3.0'",
+    "gssapi==1.8.1; python_version > '3.0'",
     "kafka-python==2.0.2",
     "kazoo==2.8.0",
 ]

--- a/snowflake/pyproject.toml
+++ b/snowflake/pyproject.toml
@@ -38,7 +38,7 @@ text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "snowflake-connector-python==2.7.11; python_version > '3.0'",
+    "snowflake-connector-python==2.7.12; python_version > '3.0'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
Bump the dependencies before the freeze 

```
╰─❯ ddev dep updates --sync --batch-size 10                                                                                                                                                                                                                                                                             ─╯
Files updated: 5
Updated 8 dependencies
```

Only one batch is needed this time.

### Motivation
Freeze at the end of the week.

### Additional Notes
- https://github.com/globality-corp/flake8-logging-format/pull/33 has been shipped with the 0.7.0

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
