### PR TITLE
Make the `validate metadata` command fail if the metric prefix is invalid

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -498,6 +498,7 @@ def metadata(check, check_duplicates, show_warnings):
             display_queue.append((echo_failure, f'{current_check}: {header} is empty in {count} rows.'))
 
         for prefix, count in metric_prefix_count.items():
+            errors = True
             display_queue.append(
                 (
                     echo_failure,

--- a/datadog_checks_dev/tests/tooling/commands/validate/test_metadata.py
+++ b/datadog_checks_dev/tests/tooling/commands/validate/test_metadata.py
@@ -1,0 +1,70 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+import shutil
+import sys
+
+import pytest
+from click.testing import CliRunner
+
+from datadog_checks.dev import run_command
+
+# E501: line too long (XXX > 120 characters)
+# flake8: noqa: E501
+HEADER = "metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric"
+
+
+@pytest.mark.parametrize(
+    'code,output,metric_lines',
+    [
+        (
+            0,
+            "Validated!",
+            ["my_check.broker_offset,gauge,,offset,,Current message offset on broker.,0,my_check,broker offset,"],
+        ),
+        (
+            1,
+            "my_check:2 integration: `check` should be: my_check",
+            ["my_check.broker_offset,gauge,,offset,,Current message offset on broker.,0,check,broker offset,"],
+        ),
+        (
+            1,
+            "my_check: `check` appears 1 time(s) and does not match metric_prefix defined in the manifest.",
+            ["check.broker_offset,gauge,,offset,,Current message offset on broker.,0,my_check,broker offset,"],
+        ),
+        (
+            1,
+            "my_check:2 `unknown` is an invalid metric_type.",
+            ["my_check.broker_offset,unknown,,offset,,Current message offset on broker.,0,my_check,broker offset,"],
+        ),
+        (
+            1,
+            "my_check:2 `2` is an invalid orientation.",
+            ["my_check.broker_offset,gauge,,offset,,Current message offset on broker.,2,my_check,broker offset,"],
+        ),
+        (
+            1,
+            "my_check:3 `my_check.broker_offset` is a duplicate metric_name",
+            [
+                "my_check.broker_offset,gauge,,offset,,Current message offset on broker.,0,my_check,broker offset,",
+                "my_check.broker_offset,gauge,,offset,,Current message offset on broker.,0,my_check,broker offset,",
+            ],
+        ),
+    ],
+)
+def test_validate_invalid_metadata_file(code, output, metric_lines):
+    with CliRunner().isolated_filesystem():
+        shutil.copytree(os.path.dirname(os.path.realpath(__file__)) + "/data/my_check", "./my_check")
+
+        with open("./my_check/metadata.csv", "w") as metadata_file:
+            metadata_file.write(HEADER + "\n")
+            metadata_file.write("\n".join(metric_lines))
+
+        result = run_command(
+            [sys.executable, "-m", "datadog_checks.dev", "--here", "validate", "metadata", "my_check"],
+            capture=True,
+        )
+
+        assert result.code == code
+        assert output in result.stdout, result.stdout


### PR DESCRIPTION
### What does this PR do?

- Return an error code if the prefix is invalid in the `metadata.csv` file.
- Add tests

### Motivation

I was working on AI-2500, did not find the bug mentioned so I wrote a test to make sure and spotted this one instead.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
