### PR TITLE
Update app id exceptions in logs validation

### DIFF
--- a/.gitlab/validate-logs-intgs/validate_log_intgs.py
+++ b/.gitlab/validate-logs-intgs/validate_log_intgs.py
@@ -18,9 +18,9 @@ ERR_MULTIPLE_SOURCES = "The check has a log pipeline but documents multiple sour
 ERR_NOT_DEFINED_WEB_UI = "The check has a log pipeline but does not have a corresponding entry defined in web-ui."
 
 EXCEPTIONS = {
-    'amazon_eks': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # eks is just a tile
+    'amazon-eks': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # eks is just a tile
     'aspdotnet': [ERR_MISSING_LOG_DOC], # Use iis pipeline
-    'azure_active_directory': [
+    'azure-active-directory': [
         ERR_MISSING_LOG_DOC,  # This is a tile only integration, the source is populated by azure directly.
         ERR_NOT_DEFINED_WEB_UI,  # The integration does not have any metrics.
     ],
@@ -28,14 +28,14 @@ EXCEPTIONS = {
         ERR_UNEXPECTED_LOG_COLLECTION_CAT,  # cilium does not need a pipeline to automatically parse the logs
         ERR_UNEXPECTED_LOG_DOC  # The documentation says to use 'source: cilium'
     ],
-    'consul_connect': [ERR_MISSING_LOG_DOC], # Use envoy pipeline
-    'docker_daemon': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # Tile only integration
-    'ecs_fargate': [
+    'consul-connect': [ERR_MISSING_LOG_DOC], # Use envoy pipeline
+    'docker': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # Tile only integration
+    'ecs-fargate': [
         ERR_UNEXPECTED_LOG_COLLECTION_CAT, # Log collection but not from the agent
         ERR_UNEXPECTED_LOG_DOC, # Not collecting logs directly, but has example in its readme
     ],
-    'eks_anywhere': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # Works with amazon_eks
-    'eks_fargate': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # Log collection but not from the agent
+    'eks-anywhere': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # Works with amazon_eks
+    'eks-fargate': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # Log collection but not from the agent
     'fluentd': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # Fluentd is about log collection but we don't collect fluentd logs
     'jmeter': [ERR_MISSING_LOG_DOC], # Tile only in integrations-core, logs collected in DataDog/jmeter-datadog-backend-listener
     'journald': [
@@ -43,14 +43,14 @@ EXCEPTIONS = {
         ERR_UNEXPECTED_LOG_COLLECTION_CAT,
     ],
     'kubernetes': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # The agent collects logs from kubernetes environment but there is no pipeline per se
-    'mesos_master': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # We do support log collection for mesos environments
+    'mesos-master': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # We do support log collection for mesos environments
     'linkerd': [
         ERR_UNEXPECTED_LOG_COLLECTION_CAT,  # linkerd does not need a pipeline to automatically parse the logs
         ERR_UNEXPECTED_LOG_DOC
     ],
     'openshift': [ERR_UNEXPECTED_LOG_COLLECTION_CAT],  # The agent collects logs from openshift environment but there is no pipeline
-    'pan_firewall': [ERR_NOT_DEFINED_WEB_UI], # The integration doesn't emit metric
-    'pivotal_pks': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # Using kubernetes pipeline
+    'pan-firewall': [ERR_NOT_DEFINED_WEB_UI], # The integration doesn't emit metric
+    'pivotal-pks': [ERR_UNEXPECTED_LOG_COLLECTION_CAT], # Using kubernetes pipeline
 }
 
 


### PR DESCRIPTION
### What does this PR do?
Now that we've [migrated](https://github.com/DataDog/integrations-core/pull/12745) to manifest v2 there is no notion of integration name, so the exceptions we have defined in the validation need to correspond to `app_id`s. This PR updates the exception map to use the `app_id`s so these integrations don't fail validation anymore

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
