### PR TITLE
warn that concurrent SSL connections won't work

### DIFF
--- a/ibm_mq/assets/configuration/spec.yaml
+++ b/ibm_mq/assets/configuration/spec.yaml
@@ -199,7 +199,11 @@ files:
           example: 5
           type: integer
       - name: ssl_auth
-        description: Whether or not to use SSL auth while connecting to the channel.
+        description: |
+          Whether or not to use SSL auth while connecting to the channel.
+          Note: Multiple concurrent SSL connections from the same process to the same or different queue managers
+          are not permitted. If you define multiple check instances using ssl_auth you may experience
+          MQRC_SSL_INITIALIZATION_ERROR or MQRC_SSL_ALREADY_INITIALIZED errors.
         value:
           example: False
           type: boolean

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -177,6 +177,9 @@ instances:
 
     ## @param ssl_auth - boolean - optional - default: false
     ## Whether or not to use SSL auth while connecting to the channel.
+    ## Note: Multiple concurrent SSL connections from the same process to the same or different queue managers
+    ## are not permitted. If you define multiple check instances using ssl_auth you may experience
+    ## MQRC_SSL_INITIALIZATION_ERROR or MQRC_SSL_ALREADY_INITIALIZED errors.
     #
     # ssl_auth: false
 


### PR DESCRIPTION
From IBM documentation https://www.ibm.com/docs/en/ibm-mq/9.0?topic=applications-secure-connections-mq-queue-manager

> If you use the IBM WebSphere MQ 6.0 and later client libraries, then you can create a SSL connection only if you close any previous SSL connection first. Multiple concurrent SSL connections from the same process to the same or different queue managers are not permitted. If you attempt more than one request, you get the warning MQRC_SSL_ALREADY_INITIALIZED, which might mean that some requested parameters for the SSL connection were ignored.