### PR TITLE
Stop asserting metadata during e2e tests

### DIFF
--- a/avi_vantage/tests/test_avi_vantage.py
+++ b/avi_vantage/tests/test_avi_vantage.py
@@ -39,12 +39,12 @@ def test_integration(
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, datadog_agent, integration_instance, get_expected_metrics):
+def test_e2e(dd_agent_check, integration_instance, get_expected_metrics):
     aggregator = dd_agent_check(integration_instance)
 
     aggregator.assert_service_check("avi_vantage.can_connect", AviVantageCheck.OK)
     for metric in get_expected_metrics(endpoint='http://localhost:5000/'):
         aggregator.assert_metric(metric['name'], metric['value'], metric['tags'], metric_type=metric['type'])
+
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
-    datadog_agent.assert_metadata_count(5)

--- a/proxysql/tests/test_e2e.py
+++ b/proxysql/tests/test_e2e.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
-from .conftest import _assert_all_metrics, _assert_metadata
+from .conftest import _assert_all_metrics
 
 
 @pytest.mark.e2e

--- a/proxysql/tests/test_e2e.py
+++ b/proxysql/tests/test_e2e.py
@@ -7,7 +7,6 @@ from .conftest import _assert_all_metrics, _assert_metadata
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, datadog_agent):
+def test_e2e(dd_agent_check):
     aggregator = dd_agent_check(rate=True)
-    _assert_metadata(datadog_agent, check_id='proxysql')
     _assert_all_metrics(aggregator)

--- a/singlestore/tests/test_e2e.py
+++ b/singlestore/tests/test_e2e.py
@@ -9,7 +9,7 @@ from .common import EXPECTED_INTEGRATION_METRICS
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, datadog_agent):
+def test_e2e(dd_agent_check):
     aggregator = dd_agent_check(rate=True)
     for m in EXPECTED_INTEGRATION_METRICS:
         aggregator.assert_metric(m)
@@ -17,11 +17,3 @@ def test_e2e(dd_agent_check, datadog_agent):
     aggregator.assert_service_check(
         'singlestore.can_connect', AgentCheck.OK, tags=['singlestore_endpoint:localhost:3306']
     )
-    version_metadata = {
-        'version.scheme': 'semver',
-        'version.major': '7',
-        'version.minor': '5',
-        'version.patch': '9',
-        'version.raw': '7.5.9',
-    }
-    datadog_agent.assert_metadata('singlestore', version_metadata)

--- a/snowflake/tests/test_e2e.py
+++ b/snowflake/tests/test_e2e.py
@@ -8,7 +8,7 @@ from .common import EXPECTED_TAGS
 pytestmark = pytest.mark.e2e
 
 
-def test_account_usage_mock_data(dd_agent_check, datadog_agent, instance):
+def test_account_usage_mock_data(dd_agent_check, instance):
     instance['metric_groups'] = [
         'snowflake.billing',
         'snowflake.logins',
@@ -111,19 +111,8 @@ def test_account_usage_mock_data(dd_agent_check, datadog_agent, instance):
         tags=EXPECTED_TAGS + ['warehouse:COMPUTE_WH', 'database:SNOWFLAKE', 'schema:None', 'query_type:USE'],
     )
 
-    datadog_agent.assert_metadata(
-        'snowflake',
-        {
-            'version.major': '4',
-            'version.minor': '30',
-            'version.patch': '2',
-            'version.raw': '4.30.2',
-            'version.scheme': 'semver',
-        },
-    )
 
-
-def test_org_usage_mock_data(dd_agent_check, datadog_agent, instance):
+def test_org_usage_mock_data(dd_agent_check, instance):
     instance['schema'] = 'ORGANIZATION_USAGE'
     instance['metric_groups'] = [
         'snowflake.organization.contracts',


### PR DESCRIPTION
### What does this PR do?
Remove the assertions on metadata in the e2e test.

### Motivation

Following [this PR](https://github.com/DataDog/datadog-agent/pull/13376), the metadata are not sent by the agent if the check is not scheduled, which is our case in our tests. Since we are getting the data from the agent, the metadata are gone. 

I took a look at the unit/integration and made sure they still validate the metadata (because they are not using the agent so we have the data).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
