### PR TITLE
Updating adoprovider parameter details 2

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -188,8 +188,8 @@ files:
       description: |
         Choose the ADO provider.  Note that the (default) provider
         SQLOLEDB is being deprecated.  To use the newer MSOLEDBSQL
-        provider, set the adoprovider to "MSOLEDBSQL" below. You will also need
-        to download the new provider from
+        provider, set the adoprovider to "MSOLEDBSQL" below or "MSOLEDBSQL19" for version 19 of the driver. 
+        You will also need to download the new provider from
         https://docs.microsoft.com/en-us/sql/connect/oledb/oledb-driver-for-sql-server?view=sql-server-2017
       value:
         type: string


### PR DESCRIPTION
If client is using version 19 of the Microsoft OLE DB Driver the adoprovider: parameter needs to be set to "MSOLEDBSQL19" instead of "MSOLEDBSQL".

### What does this PR do?
Adds additional setting for adoprovider: parameter

### Motivation
Zendesk ticket:
https://datadog.zendesk.com/agent/tickets/906248

### Additional Notes
Change was suggested under different PR:
https://github.com/DataDog/integrations-core/pull/12916

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
