### PR TITLE
Fix tile-only README template generation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -127,7 +127,7 @@ def create_template_files(template_name, new_root, config, read=False):
 
                     # Custom README for tile apps
                     elif config.get('support_type') == 'contrib':
-                        template_path = path_join(TEMPLATES_DIR, 'tile_v2/', 'README.md')
+                        template_path = path_join(TEMPLATES_DIR, 'tile/{check_name}', 'README.md')
                         file_path = path_join(config.get('check_name'), "README.md")
                     else:
                         template_path = path_join(root, template_file)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR changes the template path for generating the README of a contributor tile-only integration.

### Motivation
<!-- What inspired you to submit this pull request? -->
There is no directory called `tile_v2`, so generating a tile-only contributor integration will fail.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
