### PR TITLE
fix(kubernetes): return the proper number of job's pod

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_jobs.json
+++ b/kubernetes/assets/dashboards/kubernetes_jobs.json
@@ -127,7 +127,7 @@
                             "precision": 0,
                             "requests": [
                                 {
-                                    "aggregator": "sum",
+                                    "aggregator": "avg",
                                     "conditional_formats": [
                                         {
                                             "comparator": ">",


### PR DESCRIPTION
### What does this PR do?

change the aggregator function to `avg` instead of `sum` to get the proper number of pods attached to jobs or cronjobs.

### Motivation

fix the `Successful Job Pods` widget in the OOTB dashboard "Kubernetes Jobs and CronJobs Overview" linked to the `kubernetes` integration.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
