### PR TITLE
Add case sensitive changelog validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
@@ -8,7 +8,6 @@ import jsonschema
 import requests
 
 import datadog_checks.dev.tooling.manifest_validator.common.validator as common
-from datadog_checks.dev.fs import file_exists
 
 from ...constants import get_root
 from ...manifest_validator.common.validator import BaseManifestValidator

--- a/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/manifest_validator/v2/validator.py
@@ -241,9 +241,8 @@ class ChangelogValidator(BaseManifestValidator):
         changelog = tile.get("changelog", None)
 
         if changelog:
-            path = os.path.join(get_root(), check_name, changelog)
-
-            if not file_exists(path):
+            check_dir = os.path.join(get_root(), check_name)
+            if changelog not in os.listdir(check_dir):
                 self.fail(f"{os.path.join(check_name, changelog)} does not exist.")
 
 

--- a/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/test_v2_validator.py
@@ -506,3 +506,18 @@ def test_manifest_v2_changelog_not_found(setup_route):
     validator.validate('datadog_checks_dev', manifest, False)
 
     assert validator.result.failed
+
+
+def test_manifest_v2_changelog_case_sensitive(setup_route):
+    manifest = JSONDict(
+        {
+            "tile": {
+                "changelog": "CHANGELOG.MD",
+            },
+        }
+    )
+
+    validator = v2_validators.ChangelogValidator(version=V2)
+    validator.validate('datadog_checks_dev', manifest, False)
+
+    assert validator.result.failed


### PR DESCRIPTION
### What does this PR do?
Make changelog validation case sensitive
### Motivation
Changelog validation was not failing with a file named CHANGELOG.MD

### Additional Notes
We may want to do this case sensitive validation in more places 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
