### PR TITLE
Add docker_platform windows to win32_event_log env

### DIFF
--- a/win32_event_log/tests/conftest.py
+++ b/win32_event_log/tests/conftest.py
@@ -95,4 +95,4 @@ def instance():
 
 @pytest.fixture(scope='session')
 def dd_environment():  # no cov
-    yield common.INSTANCE
+    yield common.INSTANCE, {'docker_platform': 'windows'}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add dd_environment metadata to use windows containers.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
