### PR TITLE
Recover from EvtNext error when EvtSubscribe handle fails

### DIFF
--- a/win32_event_log/tests/conftest.py
+++ b/win32_event_log/tests/conftest.py
@@ -95,4 +95,4 @@ def instance():
 
 @pytest.fixture(scope='session')
 def dd_environment():  # no cov
-    yield common.INSTANCE
+    yield common.INSTANCE, {'docker_platform': 'windows'}

--- a/win32_event_log/tests/test_check.py
+++ b/win32_event_log/tests/test_check.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 import win32evtlog
+import logging
 
 from . import common
 
@@ -51,7 +52,9 @@ def test_recover_from_broken_subscribe(aggregator, dd_run_check, new_check, inst
     check._subscription = None
 
     # Run the check to initiate the reset
-    dd_run_check(check)
+    # Enable debug logging so we see expected error message
+    with caplog.at_level(logging.DEBUG):
+        dd_run_check(check)
 
     # Run the check again to collect the event we missed
     dd_run_check(check)

--- a/win32_event_log/tests/test_check.py
+++ b/win32_event_log/tests/test_check.py
@@ -1,9 +1,10 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
+
 import pytest
 import win32evtlog
-import logging
 
 from . import common
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

If `EvtNext` fails due to an issue with the `EvtSubsribe` handle the check will recreate the subscription and allow events to continue to be collected.

This can happen when an event publisher is removed while we are subscribed to it. This sometimes happens during software updates.

### Motivation
<!-- What inspired you to submit this pull request? -->

xref https://datadoghq.atlassian.net/browse/WA-71

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
