### PR TITLE
[Postgres] Added Agent settings to log original unobfuscated strings

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -537,7 +537,7 @@ files:
       hidden: true
       description: |
         Set to `true` to enable logging of original unobfuscated SQL queries when obfuscation errors occur.
-        For security purposes, it is recommended to use this option for debugging only.
+        For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
         Note: This option only applies when `dbm` is enabled.
       value:
         type: boolean
@@ -547,7 +547,7 @@ files:
       hidden: true
       description: |
         Set to `true` to enable logging of original unobfuscated SQL plans when obfuscation errors occur.
-        For security purposes, it is recommended to use this option for debugging only.
+        For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
         Note: This option only applies when `dbm` is enabled.
       value:
         type: boolean

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -533,6 +533,26 @@ files:
             type: boolean
             example: true
             display_default: true
+    - name: log_unobfuscated_queries
+      hidden: true
+      description: |
+        Set to `true` to enable logging of original unobfuscated SQL queries when obfuscation errors occur.
+        For security purposes, it is recommended to use this option for debugging only.
+        Note: This option only applies when `dbm` is enabled.
+      value:
+        type: boolean
+        example: false
+        display_default: false
+    - name: log_unobfuscated_plans
+      hidden: true
+      description: |
+        Set to `true` to enable logging of original unobfuscated SQL plans when obfuscation errors occur.
+        For security purposes, it is recommended to use this option for debugging only.
+        Note: This option only applies when `dbm` is enabled.
+      value:
+        type: boolean
+        example: false
+        display_default: false
     - template: instances/default
       overrides:
         disable_generic_tags.hidden: False

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -117,6 +117,8 @@ class PostgresConfig:
             'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),
             'collect_comments': is_affirmative(obfuscator_options_config.get('collect_comments', True)),
         }
+        self.log_unobfuscated_queries = is_affirmative(instance.get('log_unobfuscated_queries', False))
+        self.log_unobfuscated_plans = is_affirmative(instance.get('log_unobfuscated_plans', False))
 
     def _build_tags(self, custom_tags):
         # Clean up tags in case there was a None entry in the instance

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -90,6 +90,14 @@ def instance_ignore_databases(field, value):
     return ['template%', 'rdsadmin', 'azure_maintenance', 'postgres']
 
 
+def instance_log_unobfuscated_plans(field, value):
+    return False
+
+
+def instance_log_unobfuscated_queries(field, value):
+    return False
+
+
 def instance_max_relations(field, value):
     return 300
 

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -128,6 +128,8 @@ class InstanceConfig(BaseModel):
     gcp: Optional[Gcp]
     host: str
     ignore_databases: Optional[Sequence[str]]
+    log_unobfuscated_plans: Optional[bool]
+    log_unobfuscated_queries: Optional[bool]
     max_relations: Optional[int]
     metric_patterns: Optional[MetricPatterns]
     min_collection_interval: Optional[float]

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -329,7 +329,10 @@ class PostgresStatementSamples(DBMAsyncJob):
             normalized_row['dd_commands'] = metadata.get('commands', None)
             normalized_row['dd_comments'] = metadata.get('comments', None)
         except Exception as e:
-            self._log.debug("Failed to obfuscate statement: %s", e)
+            if self._config.log_unobfuscated_queries:
+                self._log.info("Failed to obfuscate statement '%s': %s", row['query'], e)
+            else:
+                self._log.debug("Failed to obfuscate statement: %s", e)
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 1,
@@ -610,8 +613,15 @@ class PostgresStatementSamples(DBMAsyncJob):
             plan = json.dumps(plan_dict)
             # if we're using the orjson implementation then json.dumps returns bytes
             plan = plan.decode('utf-8') if isinstance(plan, bytes) else plan
-            normalized_plan = datadog_agent.obfuscate_sql_exec_plan(plan, normalize=True)
-            obfuscated_plan = datadog_agent.obfuscate_sql_exec_plan(plan)
+            try:
+                normalized_plan = datadog_agent.obfuscate_sql_exec_plan(plan, normalize=True)
+                obfuscated_plan = datadog_agent.obfuscate_sql_exec_plan(plan)
+                raise RuntimeError("Mock failure")
+            except Exception as e:
+                if self._config.log_unobfuscated_plans:
+                    self._log.info("Failed to obfuscate plan '%s': %s", plan, e)
+                raise e
+
             plan_signature = compute_exec_plan_signature(normalized_plan)
 
         statement_plan_sig = (row['query_signature'], plan_signature)

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -330,7 +330,7 @@ class PostgresStatementSamples(DBMAsyncJob):
             normalized_row['dd_comments'] = metadata.get('comments', None)
         except Exception as e:
             if self._config.log_unobfuscated_queries:
-                self._log.info("Failed to obfuscate statement '%s': %s", row['query'], e)
+                self._log.warning("Failed to obfuscate statement '%s': %s", row['query'], e)
             else:
                 self._log.debug("Failed to obfuscate statement: %s", e)
             self._check.count(
@@ -616,10 +616,9 @@ class PostgresStatementSamples(DBMAsyncJob):
             try:
                 normalized_plan = datadog_agent.obfuscate_sql_exec_plan(plan, normalize=True)
                 obfuscated_plan = datadog_agent.obfuscate_sql_exec_plan(plan)
-                raise RuntimeError("Mock failure")
             except Exception as e:
                 if self._config.log_unobfuscated_plans:
-                    self._log.info("Failed to obfuscate plan '%s': %s", plan, e)
+                    self._log.warning("Failed to obfuscate plan '%s': %s", plan, e)
                 raise e
 
             plan_signature = compute_exec_plan_signature(normalized_plan)

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -330,9 +330,9 @@ class PostgresStatementSamples(DBMAsyncJob):
             normalized_row['dd_comments'] = metadata.get('comments', None)
         except Exception as e:
             if self._config.log_unobfuscated_queries:
-                self._log.warning("Failed to obfuscate statement '%s': %s", row['query'], e)
+                self._log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['query'], e)
             else:
-                self._log.debug("Failed to obfuscate statement: %s", e)
+                self._log.debug("Failed to obfuscate query | err=[%s]", e)
             self._check.count(
                 "dd.postgres.statement_samples.error",
                 1,
@@ -618,7 +618,7 @@ class PostgresStatementSamples(DBMAsyncJob):
                 obfuscated_plan = datadog_agent.obfuscate_sql_exec_plan(plan)
             except Exception as e:
                 if self._config.log_unobfuscated_plans:
-                    self._log.warning("Failed to obfuscate plan '%s': %s", plan, e)
+                    self._log.warning("Failed to obfuscate plan=[%s] | err=[%s]", plan, e)
                 raise e
 
             plan_signature = compute_exec_plan_signature(normalized_plan)

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -360,9 +360,9 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 statement = obfuscate_sql_with_metadata(row['query'], self._obfuscate_options)
             except Exception as e:
                 if self._config.log_unobfuscated_queries:
-                    self._log.warning("Failed to obfuscate query '%s': %s", row['query'], e)
+                    self._log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['query'], e)
                 else:
-                    self._log.debug("Failed to obfuscate query: %s", e)
+                    self._log.debug("Failed to obfuscate query | err=[%s]", e)
                 continue
 
             obfuscated_query = statement['query']

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -360,7 +360,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 statement = obfuscate_sql_with_metadata(row['query'], self._obfuscate_options)
             except Exception as e:
                 if self._config.log_unobfuscated_queries:
-                    self._log.info("Failed to obfuscate query '%s': %s", row['query'], e)
+                    self._log.warning("Failed to obfuscate query '%s': %s", row['query'], e)
                 else:
                     self._log.debug("Failed to obfuscate query: %s", e)
                 continue

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -359,8 +359,10 @@ class PostgresStatementMetrics(DBMAsyncJob):
             try:
                 statement = obfuscate_sql_with_metadata(row['query'], self._obfuscate_options)
             except Exception as e:
-                # obfuscation errors are relatively common so only log them during debugging
-                self._log.debug("Failed to obfuscate query '%s': %s", row['query'], e)
+                if self._config.log_unobfuscated_queries:
+                    self._log.info("Failed to obfuscate query '%s': %s", row['query'], e)
+                else:
+                    self._log.debug("Failed to obfuscate query: %s", e)
                 continue
 
             obfuscated_query = statement['query']


### PR DESCRIPTION
### What does this PR do?
Adds two hidden options `log_unobfuscated_queries` and `log_unobfuscated_plans` which will log the original unobfuscated SQL queries and plans respectively if an obfuscation error occurs. These options will simplify the debugging process when dealing with obfuscation errors.

### Motivation

### Additional Notes
The original code in `postgres/datadog_checks/postgres/statements.py` already had a [logging line that logs the original unobfuscated query](https://github.com/DataDog/integrations-core/blob/a5e1ce3d8bda06018f6ecd3876c1005f9c5c2bd6/postgres/datadog_checks/postgres/statements.py#L363), with no configuration parameter required. This PR changes the code to only log the query when the `log_unobfuscated_queries` parameter is enabled.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
