### PR TITLE
Add recommended monitor for Vertica

### DIFF
--- a/vertica/assets/monitors/vertica_replication_safety.json
+++ b/vertica/assets/monitors/vertica_replication_safety.json
@@ -29,6 +29,6 @@
 	"priority": null,
 	"restricted_roles": null,
 	"recommended_monitor_metadata": {
-		"description": "Get notified when the query load is high."
+		"description": "Get notified when the database is at risk of becoming unsafe."
 	}
 }

--- a/vertica/assets/monitors/vertica_replication_safety.json
+++ b/vertica/assets/monitors/vertica_replication_safety.json
@@ -1,0 +1,34 @@
+{
+	"name": "[Vertica] Nodes down above K-safety level",
+	"type": "query alert",
+	"query": "max(last_5m):avg:vertica.node.down{*} - avg:vertica.ksafety.current{*} > 1",
+	"message": "Number of nodes down is above the K-safety, which may lead to data becoming unavailable.",
+	"tags": [
+		"integration:vertica"
+	],
+	"options": {
+		"notify_audit": false,
+		"locked": null,
+		"timeout_h": 0,
+		"new_host_delay": 300,
+		"require_full_window": false,
+		"notify_no_data": false,
+		"renotify_interval": "0",
+		"renotify_occurrences": null,
+		"renotify_statuses": null,
+		"escalation_message": "",
+		"no_data_timeframe": null,
+		"include_tags": true,
+		"thresholds": {
+			"critical": 1,
+			"warning": 0,
+			"critical_recovery": 0,
+			"warning_recovery": 0
+		}
+	},
+	"priority": null,
+	"restricted_roles": null,
+	"recommended_monitor_metadata": {
+		"description": "Get notified when the query load is high."
+	}
+}

--- a/vertica/manifest.json
+++ b/vertica/manifest.json
@@ -47,6 +47,9 @@
     "dashboards": {
       "Vertica Overview": "assets/dashboards/overview.json"
     },
+    "monitors": {
+      "[Vertica] Nodes down above K-safety level": "assets/monitors/vertica_replication_safety.json"
+    },
     "logs": {
       "source": "vertica"
     }


### PR DESCRIPTION
### What does this PR do?

Add a recommended monitor for Vertica. This monitor warns about when the database may become unsafe due to the number of failed nodes exceeding the k-safety value. See [official docs](https://www.vertica.com/docs/12.0.x/HTML/Content/Authoring/ConceptsGuide/Components/K-Safety.htm).

### Motivation

[AI-2670](https://datadoghq.atlassian.net/browse/AI-2670)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
