### PR TITLE
Templatize the repository in the README links

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -87,11 +87,11 @@ CHECK_LINKS = """\
 [1]: **LINK_TO_INTEGRATION_SITE**
 [2]: https://app.datadoghq.com/account/settings#agent
 [3]: https://docs.datadoghq.com/agent/kubernetes/integrations/
-[4]: https://github.com/DataDog/integrations-core/blob/master/{name}/datadog_checks/{name}/data/conf.yaml.example
+[4]: https://github.com/DataDog/{repository}/blob/master/{name}/datadog_checks/{name}/data/conf.yaml.example
 [5]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
-[7]: https://github.com/DataDog/integrations-core/blob/master/{name}/metadata.csv
-[8]: https://github.com/DataDog/integrations-core/blob/master/{name}/assets/service_checks.json
+[7]: https://github.com/DataDog/{repository}/blob/master/{name}/metadata.csv
+[8]: https://github.com/DataDog/{repository}/blob/master/{name}/assets/service_checks.json
 [9]: https://docs.datadoghq.com/help/
 """
 
@@ -100,24 +100,24 @@ LOGS_LINKS = """\
 [2]: https://app.datadoghq.com/account/settings#agent
 [3]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
 [4]: **LINK_TO_INTEGRATION_SITE**
-[5]: https://github.com/DataDog/integrations-core/blob/master/logs/assets/service_checks.json
+[5]: https://github.com/DataDog/{repository}/blob/master/{name}/assets/service_checks.json
 """
 
 JMX_LINKS = """\
 [1]: **LINK_TO_INTEGERATION_SITE**
 [2]: https://app.datadoghq.com/account/settings#agent
-[3]: https://github.com/DataDog/integrations-core/blob/master/jmx/datadog_checks/jmx/data/conf.yaml.example
+[3]: https://github.com/DataDog/{repository}/blob/master/{name}/datadog_checks/{name}/data/conf.yaml.example
 [4]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [5]: https://docs.datadoghq.com/integrations/java/
 [6]: https://docs.datadoghq.com/help/
 [7]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[8]: https://github.com/DataDog/integrations-core/blob/master/jmx/assets/service_checks.json
+[8]: https://github.com/DataDog/{repository}/blob/master/{name}/assets/service_checks.json
 """
 
 SNMP_TILE_LINKS = """\
 [1]: https://docs.datadoghq.com/network_performance_monitoring/devices/data
 [2]: https://docs.datadoghq.com/network_performance_monitoring/devices/setup
-[3]: https://github.com/DataDog/integrations-core/blob/master/snmp_tile/assets/service_checks.json
+[3]: https://github.com/DataDog/{repository}/blob/master/snmp_{name}/assets/service_checks.json
 [4]: https://docs.datadoghq.com/help/
 [5]: https://www.datadoghq.com/blog/monitor-snmp-with-datadog/
 """

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -65,7 +65,9 @@ To install the {integration_name} check on your host:
         )
         license_header = get_license_header()
         support_type = 'core'
-        integration_links = integration_type_links.get(integration_type).format(name=normalized_integration_name)
+        integration_links = integration_type_links.get(integration_type).format(
+            name=normalized_integration_name, repository="integrations-core"
+        )
     elif repo_choice == 'marketplace':
         check_name = normalize_package_name(f"{kwargs.get('author')}_{normalized_integration_name}")
         # Updated by the kwargs passed in
@@ -85,6 +87,15 @@ To install the {integration_name} check on your host:
         license_header = ''
         support_type = 'contrib'
         integration_links = integration_type_links.get(integration_type)
+
+        if repo_choice == 'internal':
+            integration_links = integration_links.format(
+                name=normalized_integration_name, repository="integrations-internal"
+            )
+        else:
+            integration_links = integration_links.format(
+                name=normalized_integration_name, repository="integrations-extras"
+            )
 
     config = {
         'author': author,


### PR DESCRIPTION
### What does this PR do?
Update the default README links to include a `repository` variable. 

### Motivation
Before, `integrations-core` was hardcoded and we had to update it. 

A part of the job was done in this PR https://github.com/DataDog/integrations-core/pull/12742

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
