### PR TITLE
Add optional windows_service_startup_type tag

### DIFF
--- a/windows_service/assets/configuration/spec.yaml
+++ b/windows_service/assets/configuration/spec.yaml
@@ -31,4 +31,18 @@ files:
             value:
               type: boolean
               example: false
+          - name: windows_service_startup_type_tag
+            description: |
+              Whether or not to submit the `windows_service_startup_type` tag along
+              with each service check.
+              This tag indicates the Windows service startup type as shown in a service's properties,
+              and can be used as a filter/scope in Monitors.
+              Possible values for this tag are:
+                - disabled
+                - manual
+                - automatic
+                - automatic_delayed_start
+            value:
+              type: boolean
+              example: false
           - template: instances/default

--- a/windows_service/datadog_checks/windows_service/config_models/defaults.py
+++ b/windows_service/datadog_checks/windows_service/config_models/defaults.py
@@ -22,10 +22,6 @@ def instance_disable_legacy_service_tag(field, value):
     return False
 
 
-def instance_windows_service_startup_type_tag(field, value):
-    return False
-
-
 def instance_empty_default_hostname(field, value):
     return False
 
@@ -44,3 +40,7 @@ def instance_service(field, value):
 
 def instance_tags(field, value):
     return get_default_field_value(field, value)
+
+
+def instance_windows_service_startup_type_tag(field, value):
+    return False

--- a/windows_service/datadog_checks/windows_service/config_models/defaults.py
+++ b/windows_service/datadog_checks/windows_service/config_models/defaults.py
@@ -22,6 +22,10 @@ def instance_disable_legacy_service_tag(field, value):
     return False
 
 
+def instance_windows_service_startup_type_tag(field, value):
+    return False
+
+
 def instance_empty_default_hostname(field, value):
     return False
 

--- a/windows_service/datadog_checks/windows_service/config_models/instance.py
+++ b/windows_service/datadog_checks/windows_service/config_models/instance.py
@@ -33,6 +33,7 @@ class InstanceConfig(BaseModel):
 
     disable_generic_tags: Optional[bool]
     disable_legacy_service_tag: Optional[bool]
+    windows_service_startup_type_tag: Optional[bool]
     empty_default_hostname: Optional[bool]
     metric_patterns: Optional[MetricPatterns]
     min_collection_interval: Optional[float]

--- a/windows_service/datadog_checks/windows_service/config_models/instance.py
+++ b/windows_service/datadog_checks/windows_service/config_models/instance.py
@@ -33,13 +33,13 @@ class InstanceConfig(BaseModel):
 
     disable_generic_tags: Optional[bool]
     disable_legacy_service_tag: Optional[bool]
-    windows_service_startup_type_tag: Optional[bool]
     empty_default_hostname: Optional[bool]
     metric_patterns: Optional[MetricPatterns]
     min_collection_interval: Optional[float]
     service: Optional[str]
     services: Sequence[str]
     tags: Optional[Sequence[str]]
+    windows_service_startup_type_tag: Optional[bool]
 
     @root_validator(pre=True)
     def _initial_validation(cls, values):

--- a/windows_service/datadog_checks/windows_service/data/conf.yaml.example
+++ b/windows_service/datadog_checks/windows_service/data/conf.yaml.example
@@ -31,6 +31,19 @@ instances:
     #
     # disable_legacy_service_tag: false
 
+    ## @param windows_service_startup_type_tag - boolean - optional - default: false
+    ## Whether or not to submit the `windows_service_startup_type` tag along
+    ## with each service check.
+    ## This tag indicates the Windows service startup type as shown in a service's properties,
+    ## and can be used as a filter/scope in Monitors.
+    ## Possible values for this tag are:
+    ##   - disabled
+    ##   - manual
+    ##   - automatic
+    ##   - automatic_delayed_start
+    #
+    # windows_service_startup_type_tag: false
+
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.
     ##

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -30,6 +30,14 @@ class WindowsService(AgentCheck):
         # PAUSED
         7: AgentCheck.WARNING,
     }
+    # windows_service_startup_type tag values
+    STARTUP_TYPE_TO_STRING = {
+        win32service.SERVICE_AUTO_START: "automatic",
+        win32service.SERVICE_DEMAND_START: "manual",
+        win32service.SERVICE_DISABLED: "disabled",
+    }
+    STARTUP_TYPE_DELAYED_AUTO = "automatic_delayed_start"
+    STARTUP_TYPE_UNKNOWN = "unknown"
 
     def check(self, instance):
         services = set(instance.get('services', []))
@@ -73,6 +81,10 @@ class WindowsService(AgentCheck):
             tags = ['windows_service:{}'.format(short_name)]
             tags.extend(custom_tags)
 
+            if instance.get('windows_service_startup_type_tag', False):
+                startup_type_string = self._get_service_startup_type_tag(scm_handle, short_name)
+                tags.append('windows_service_startup_type:{}'.format(startup_type_string))
+
             if not instance.get('disable_legacy_service_tag', False):
                 self._log_deprecation('service_tag', 'windows_service')
                 tags.append('service:{}'.format(short_name))
@@ -84,9 +96,14 @@ class WindowsService(AgentCheck):
             for service in services_unseen:
                 # if a name doesn't match anything (wrong name or no permission to access the service), report UNKNOWN
                 status = self.UNKNOWN
+                startup_type_string = self.STARTUP_TYPE_UNKNOWN
 
                 tags = ['windows_service:{}'.format(service)]
+
                 tags.extend(custom_tags)
+
+                if instance.get('windows_service_startup_type_tag', False):
+                    tags.append('windows_service_startup_type:{}'.format(startup_type_string))
 
                 if not instance.get('disable_legacy_service_tag', False):
                     self._log_deprecation('service_tag', 'windows_service')
@@ -94,3 +111,33 @@ class WindowsService(AgentCheck):
 
                 self.service_check(self.SERVICE_CHECK_NAME, status, tags=tags)
                 self.log.debug('service state for %s %s', service, status)
+
+    def _get_service_startup_type(self, scm_handle, service_name):
+        """
+        Returns a tuple that describes the startup type for the service
+          - QUERY_SERVICE_CONFIG.dwStartType
+          - SERVICE_CONFIG_DELAYED_AUTO_START_INFO.fDelayedAutostart
+        """
+        hSvc = win32service.OpenService(scm_handle, service_name, win32service.SERVICE_QUERY_CONFIG)
+        service_config = win32service.QueryServiceConfig(hSvc)
+        startup_type = service_config[1]
+        if startup_type == win32service.SERVICE_AUTO_START:
+            # Query if auto start is delayed
+            is_delayed_auto = win32service.QueryServiceConfig2(
+                hSvc, win32service.SERVICE_CONFIG_DELAYED_AUTO_START_INFO
+            )
+        else:
+            is_delayed_auto = False
+        return startup_type, is_delayed_auto
+
+    def _get_service_startup_type_tag(self, scm_handle, service_name):
+        try:
+            startup_type, is_delayed_auto = self._get_service_startup_type(scm_handle, service_name)
+            startup_type_string = self.STARTUP_TYPE_TO_STRING.get(startup_type, self.STARTUP_TYPE_UNKNOWN)
+            if startup_type == win32service.SERVICE_AUTO_START and is_delayed_auto:
+                startup_type_string = self.STARTUP_TYPE_DELAYED_AUTO
+        except Exception as e:
+            self.warning("Failed to query service config for %s: %s", service_name, str(e))
+            startup_type_string = self.STARTUP_TYPE_UNKNOWN
+
+        return startup_type_string

--- a/windows_service/tests/test_bench.py
+++ b/windows_service/tests/test_bench.py
@@ -11,3 +11,13 @@ def test_run(benchmark, instance_all):
     check.check(instance_all)
 
     benchmark(check.check, instance_all)
+
+
+def test_all_startup_type_tag(benchmark, instance_all):
+    instance_all['windows_service_startup_type_tag'] = True
+    check = WindowsService('windows_service', {}, [instance_all])
+
+    # Run once to get any set up out of the way.
+    check.check(instance_all)
+
+    benchmark(check.check, instance_all)

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -79,6 +79,45 @@ def test_basic_disable_service_tag(aggregator, check, instance_basic_disable_ser
     )
 
 
+def test_startup_type(aggregator, check, instance_basic):
+    instance_basic['windows_service_startup_type_tag'] = True
+    c = check(instance_basic)
+    c.check(instance_basic)
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME,
+        status=c.OK,
+        tags=[
+            'service:EventLog',
+            'windows_service:EventLog',
+            'windows_service_startup_type:automatic',
+            'optional:tag1',
+        ],
+        count=1,
+    )
+    aggregator.assert_service_check(
+        c.SERVICE_CHECK_NAME,
+        status=c.OK,
+        tags=[
+            'service:Dnscache',
+            'windows_service:Dnscache',
+            'windows_service_startup_type:automatic',
+            'optional:tag1',
+        ],
+        count=1,
+    )
+    aggregator.assert_service_check(
+        WindowsService.SERVICE_CHECK_NAME,
+        status=WindowsService.UNKNOWN,
+        tags=[
+            'service:NonExistentService',
+            'windows_service:NonExistentService',
+            'windows_service_startup_type:unknown',
+            'optional:tag1',
+        ],
+        count=1,
+    )
+
+
 @pytest.mark.e2e
 def test_basic_e2e(dd_agent_check, check, instance_basic):
     aggregator = dd_agent_check(instance_basic)

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -106,8 +106,8 @@ def test_startup_type(aggregator, check, instance_basic):
         count=1,
     )
     aggregator.assert_service_check(
-        WindowsService.SERVICE_CHECK_NAME,
-        status=WindowsService.UNKNOWN,
+        c.SERVICE_CHECK_NAME,
+        status=c.UNKNOWN,
         tags=[
             'service:NonExistentService',
             'windows_service:NonExistentService',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add a new tag to each windows_service service check that indicates that service's startup type.
Add a `windows_service_startup_type_tag` option to control presence/absence of the tag.

### Motivation
<!-- What inspired you to submit this pull request? -->

customer requests https://datadoghq.atlassian.net/browse/WA-77

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
