### PR TITLE
Remove tox files references in some pyproject.toml files

### DIFF
--- a/activemq/pyproject.toml
+++ b/activemq/pyproject.toml
@@ -49,8 +49,6 @@ include = [
     "/datadog_checks",
     "/tests",
     "/manifest.json",
-    "/requirements-dev.txt",
-    "/tox.ini",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/activemq_xml/pyproject.toml
+++ b/activemq_xml/pyproject.toml
@@ -49,8 +49,6 @@ include = [
     "/datadog_checks",
     "/tests",
     "/manifest.json",
-    "/requirements-dev.txt",
-    "/tox.ini",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/ambari/pyproject.toml
+++ b/ambari/pyproject.toml
@@ -49,8 +49,6 @@ include = [
     "/datadog_checks",
     "/tests",
     "/manifest.json",
-    "/requirements-dev.txt",
-    "/tox.ini",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/apache/pyproject.toml
+++ b/apache/pyproject.toml
@@ -49,8 +49,6 @@ include = [
     "/datadog_checks",
     "/tests",
     "/manifest.json",
-    "/requirements-dev.txt",
-    "/tox.ini",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/avi_vantage/pyproject.toml
+++ b/avi_vantage/pyproject.toml
@@ -49,8 +49,6 @@ include = [
     "/datadog_checks",
     "/tests",
     "/manifest.json",
-    "/requirements-dev.txt",
-    "/tox.ini",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -107,8 +107,6 @@ path = "datadog_checks/dev/__about__.py"
 include = [
     "/datadog_checks",
     "/tests",
-    "/requirements-dev.txt",
-    "/tox.ini",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/gitlab_runner/pyproject.toml
+++ b/gitlab_runner/pyproject.toml
@@ -54,8 +54,6 @@ include = [
     "/datadog_checks",
     "/tests",
     "/manifest.json",
-    "/requirements-dev.txt",
-    "/tox.ini",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/openmetrics/pyproject.toml
+++ b/openmetrics/pyproject.toml
@@ -49,8 +49,6 @@ include = [
     "/datadog_checks",
     "/tests",
     "/manifest.json",
-    "/requirements-dev.txt",
-    "/tox.ini",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/vault/pyproject.toml
+++ b/vault/pyproject.toml
@@ -49,8 +49,6 @@ include = [
     "/datadog_checks",
     "/tests",
     "/manifest.json",
-    "/requirements-dev.txt",
-    "/tox.ini",
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
### What does this PR do?
Remove tox files references in some pyproject.toml files.

### Motivation
Those integrations do not have those files anymore because they have been migrated to hatch. We forgot to update this file. 

Spotted by @yzhan289 [here](https://github.com/DataDog/integrations-core/pull/12928#pullrequestreview-1107884199)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
