### PR TITLE
[datadog_cluster_agent] Add kubernetes_apiserver metrics

### DIFF
--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -43,6 +43,8 @@ DEFAULT_METRICS = {
     'autodiscovery_poll_duration': 'autodiscovery.poll_duration',
     'autodiscovery_watched_resources': 'autodiscovery.watched_resources',
     'autodiscovery_errors': 'autodiscovery.errors',
+    'kubernetes_apiserver_kube_events': 'kubernetes_apiserver.kube_events',
+    'kubernetes_apiserver_emitted_events': 'kubernetes_apiserver.emitted_events',
 }
 
 

--- a/datadog_cluster_agent/metadata.csv
+++ b/datadog_cluster_agent/metadata.csv
@@ -38,6 +38,6 @@ datadog.cluster_agent.autodiscovery.poll_duration.count,count,,,,Autodiscovery p
 datadog.cluster_agent.autodiscovery.poll_duration.sum,count,,,,Autodiscovery poll duration sum,0,datadog_cluster_agent,AD poll duration sum,
 datadog.cluster_agent.admission_webhooks.library_injection_attempts,count,,,,"Number of library injection attempts by language",0,datadog_cluster_agent,library injection attempts,
 datadog.cluster_agent.admission_webhooks.library_injection_errors,count,,,,"Number of library injection failures by language",0,datadog_cluster_agent,library injection errors,
-datadog.cluster_agent.kubernetes_apiserver_kube_events,count,,,,"Kubernetes events processed by the kubernetes_apiserver check",0,datadog_cluster_agent,apiserver events,
-datadog.cluster_agent.kubernetes_apiserver_emitted_events,count,,,,"Datadog events emitted by the kubernetes_apiserver check",0,datadog_cluster_agent,datadog events events,
+datadog.cluster_agent.kubernetes_apiserver.kube_events,count,,,,"Kubernetes events processed by the kubernetes_apiserver check",0,datadog_cluster_agent,apiserver events,
+datadog.cluster_agent.kubernetes_apiserver.emitted_events,count,,,,"Datadog events emitted by the kubernetes_apiserver check",0,datadog_cluster_agent,datadog events events,
 

--- a/datadog_cluster_agent/metadata.csv
+++ b/datadog_cluster_agent/metadata.csv
@@ -38,3 +38,6 @@ datadog.cluster_agent.autodiscovery.poll_duration.count,count,,,,Autodiscovery p
 datadog.cluster_agent.autodiscovery.poll_duration.sum,count,,,,Autodiscovery poll duration sum,0,datadog_cluster_agent,AD poll duration sum,
 datadog.cluster_agent.admission_webhooks.library_injection_attempts,count,,,,"Number of library injection attempts by language",0,datadog_cluster_agent,library injection attempts,
 datadog.cluster_agent.admission_webhooks.library_injection_errors,count,,,,"Number of library injection failures by language",0,datadog_cluster_agent,library injection errors,
+datadog.cluster_agent.kubernetes_apiserver_kube_events,count,,,,"Kubernetes events processed by the kubernetes_apiserver check",0,datadog_cluster_agent,apiserver events,
+datadog.cluster_agent.kubernetes_apiserver_emitted_events,count,,,,"Datadog events emitted by the kubernetes_apiserver check",0,datadog_cluster_agent,datadog events events,
+

--- a/datadog_cluster_agent/tests/fixtures/metrics.txt
+++ b/datadog_cluster_agent/tests/fixtures/metrics.txt
@@ -366,3 +366,9 @@ admission_webhooks_library_injection_attempts{injected="true",language="java"} 4
 # HELP admission_webhooks_library_injection_errors Number of library injection failures by language
 # TYPE admission_webhooks_library_injection_errors counter
 admission_webhooks_library_injection_errors{language="java"} 1
+# HELP kubernetes_apiserver_emitted_events Number of events emitted by the check.
+# TYPE kubernetes_apiserver_emitted_events counter
+kubernetes_apiserver_emitted_events{kind="ConfigMap",type="Normal"} 7
+# HELP kubernetes_apiserver_kube_events Number of Kubernetes events received by the check.
+# TYPE kubernetes_apiserver_kube_events counter
+kubernetes_apiserver_kube_events{component="",kind="Pod",reason="FailedScheduling",type="Warning"} 10424

--- a/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
+++ b/datadog_cluster_agent/tests/test_datadog_cluster_agent.py
@@ -52,6 +52,8 @@ METRICS = [
     'autodiscovery.poll_duration.sum',
     'autodiscovery.watched_resources',
     'autodiscovery.errors',
+    'kubernetes_apiserver.kube_events',
+    'kubernetes_apiserver.emitted_events',
 ]
 
 


### PR DESCRIPTION
### What does this PR do?

Adds the following metrics to the `datadog_cluster_agent` integration:

* kubernetes_apiserver.kube_events
* kubernetes_apiserver.emitted_events

### Motivation

These metrics were introduced in https://github.com/DataDog/datadog-agent/pull/13158

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
