### PR TITLE
Update calico to v3.24 for tests and reactivate e2e tests

### DIFF
--- a/calico/metadata.csv
+++ b/calico/metadata.csv
@@ -2,7 +2,7 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 calico.felix.active.local_endpoints,gauge,,,,Number of active endpoints on this host,0,calico,calico.felix.active.local_endpoints,
 calico.felix.active.local_policies,gauge,,,,Number of policies on this host,0,calico,calico.felix.active.local_policies,
 calico.felix.active.local_selectors,gauge,,,,Number of active selectors on this host,0,calico,calico.felix.active.local_selectors,
-calico.felix.active.local_tags,gauge,,,,Number of active tags on this host (deprecated in Calico v3.23+),0,calico,calico.felix.active.local_tags,
+calico.felix.active.local_tags,gauge,,,,Number of active tags on this host [versions < Calico v3.23],0,calico,calico.felix.active.local_tags,
 calico.felix.cluster.num_host_endpoints,gauge,,,,Total number of host endpoints cluster-wide,0,calico,calico.felix.cluster.num_host_endpoints,
 calico.felix.cluster.num_hosts,gauge,,,,Total number of Calico hosts in the cluster,0,calico,calico.felix.cluster.num_hosts,
 calico.felix.cluster.num_workload_endpoints,gauge,,,,Total number of workload endpoints cluster-wide,0,calico,calico.felix.cluster.num_workload_endpoints,

--- a/calico/tests/common.py
+++ b/calico/tests/common.py
@@ -27,7 +27,6 @@ FORMATTED_EXTRA_METRICS = [
     "calico.felix.active.local_endpoints",
     "calico.felix.active.local_policies",
     "calico.felix.active.local_selectors",
-    "calico.felix.active.local_tags",
     "calico.felix.cluster.num_host_endpoints",
     "calico.felix.cluster.num_hosts",
     "calico.felix.cluster.num_workload_endpoints",

--- a/calico/tests/conftest.py
+++ b/calico/tests/conftest.py
@@ -23,13 +23,11 @@ HERE = path.dirname(path.abspath(__file__))
 
 def setup_calico():
     # Deploy calico
-    # Pinned the test manifests to v3.22. v3.23 deprecated a metric that we check for `felix_active_local_tags`
-    # https://projectcalico.docs.tigera.io/archive/v3.22/reference/felix/prometheus
-    run_command(["kubectl", "apply", "-f", "https://projectcalico.docs.tigera.io/archive/v3.22/manifests/calico.yaml"])
+    run_command(["kubectl", "apply", "-f", "https://projectcalico.docs.tigera.io/archive/v3.24/manifests/calico.yaml"])
 
     # Install calicoctl as a pod
     run_command(
-        ["kubectl", "apply", "-f", "https://projectcalico.docs.tigera.io/archive/v3.22/manifests/calicoctl.yaml"]
+        ["kubectl", "apply", "-f", "https://projectcalico.docs.tigera.io/archive/v3.24/manifests/calicoctl.yaml"]
     )
 
     # Create felix metrics service

--- a/calico/tox.ini
+++ b/calico/tox.ini
@@ -10,6 +10,8 @@ envlist =
 ensure_default_envdir = true
 envdir =
     py38: {toxworkdir}/py38
+description =
+    py38: e2e ready
 dd_check_style = true
 usedevelop = true
 platform = linux|darwin|win32


### PR DESCRIPTION
### What does this PR do?

Fix calico e2e test by updating calico version used in tests to v3.24.

### Motivation

[AI-2676](https://datadoghq.atlassian.net/browse/AI-2676), Calico e2e test was failing.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
