### PR TITLE
Add Windows service `startup_type` filter to config

### DIFF
--- a/windows_service/assets/configuration/spec.yaml
+++ b/windows_service/assets/configuration/spec.yaml
@@ -13,7 +13,7 @@ files:
               List of services to monitor e.g. Dnscache, wmiApSrv, etc.
 
               Services can also be selectively monitored by their startup type.
-              Possible values for the `startup_type` pattern:
+              The possible values for `startup_type` are:
                 - disabled
                 - manual
                 - automatic
@@ -22,9 +22,9 @@ files:
               If any service is set to `ALL`, all services registered with the SCM will be monitored, and
               all other patterns provided in this instance will be ignored.
 
-              Patterns are case insensitive. `ALL` is case sensitive.
+              Service name patterns are case insensitive. `ALL` is case sensitive.
 
-              NOTE: The configured patterns will match all services starting with the pattern. For example,
+              NOTE: The service name patterns will match all services starting with the pattern. For example,
               if `service` is provided, it will match all services starting with `service` as if service.* is configured.
               For an exact match, use ^service$
             required: true
@@ -36,8 +36,8 @@ files:
                   - type: object
               example:
                 - <SERVICE_NAME_1>
-                - <SERVICE_NAME_2>
-                - startup_type: ^automatic$
+                - name: <SERVICE_NAME_2>
+                - startup_type: automatic
           - name: disable_legacy_service_tag
             description: |
               Whether or not to stop submitting the tag `service` that has been renamed

--- a/windows_service/assets/configuration/spec.yaml
+++ b/windows_service/assets/configuration/spec.yaml
@@ -12,18 +12,32 @@ files:
             description: |
               List of services to monitor e.g. Dnscache, wmiApSrv, etc.
 
-              If any service is set to `ALL`, all services registered with the SCM will be monitored.
+              Services can also be selectively monitored by their startup type.
+              Possible values for the `startup_type` pattern:
+                - disabled
+                - manual
+                - automatic
+                - automatic_delayed_start
 
-              This matches all services starting with service, as if service.* is configured.
+              If any service is set to `ALL`, all services registered with the SCM will be monitored, and
+              all other patterns provided in this instance will be ignored.
+
+              Patterns are case insensitive. `ALL` is case sensitive.
+
+              NOTE: The configured patterns will match all services starting with the pattern. For example,
+              if `service` is provided, it will match all services starting with `service` as if service.* is configured.
               For an exact match, use ^service$
             required: true
             value:
               type: array
               items:
-                type: string
+                anyOf:
+                  - type: string
+                  - type: object
               example:
                 - <SERVICE_NAME_1>
                 - <SERVICE_NAME_2>
+                - startup_type: ^automatic$
           - name: disable_legacy_service_tag
             description: |
               Whether or not to stop submitting the tag `service` that has been renamed

--- a/windows_service/datadog_checks/windows_service/config_models/instance.py
+++ b/windows_service/datadog_checks/windows_service/config_models/instance.py
@@ -9,7 +9,7 @@
 
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence, Union
 
 from pydantic import BaseModel, root_validator, validator
 
@@ -37,7 +37,7 @@ class InstanceConfig(BaseModel):
     metric_patterns: Optional[MetricPatterns]
     min_collection_interval: Optional[float]
     service: Optional[str]
-    services: Sequence[str]
+    services: Sequence[Union[str, Mapping[str, Any]]]
     tags: Optional[Sequence[str]]
     windows_service_startup_type_tag: Optional[bool]
 

--- a/windows_service/datadog_checks/windows_service/data/conf.yaml.example
+++ b/windows_service/datadog_checks/windows_service/data/conf.yaml.example
@@ -17,7 +17,7 @@ instances:
     ## List of services to monitor e.g. Dnscache, wmiApSrv, etc.
     ##
     ## Services can also be selectively monitored by their startup type.
-    ## Possible values for the `startup_type` pattern:
+    ## The possible values for `startup_type` are:
     ##   - disabled
     ##   - manual
     ##   - automatic
@@ -26,16 +26,16 @@ instances:
     ## If any service is set to `ALL`, all services registered with the SCM will be monitored, and
     ## all other patterns provided in this instance will be ignored.
     ##
-    ## Patterns are case insensitive. `ALL` is case sensitive.
+    ## Service name patterns are case insensitive. `ALL` is case sensitive.
     ##
-    ## NOTE: The configured patterns will match all services starting with the pattern. For example,
+    ## NOTE: The service name patterns will match all services starting with the pattern. For example,
     ## if `service` is provided, it will match all services starting with `service` as if service.* is configured.
     ## For an exact match, use ^service$
     #
   - services:
       - <SERVICE_NAME_1>
-      - <SERVICE_NAME_2>
-      - startup_type: ^automatic$
+      - name: <SERVICE_NAME_2>
+      - startup_type: automatic
 
     ## @param disable_legacy_service_tag - boolean - optional - default: false
     ## Whether or not to stop submitting the tag `service` that has been renamed

--- a/windows_service/datadog_checks/windows_service/data/conf.yaml.example
+++ b/windows_service/datadog_checks/windows_service/data/conf.yaml.example
@@ -13,17 +13,29 @@ init_config:
 #
 instances:
 
-    ## @param services - list of strings - required
+    ## @param services - (list of string or mapping) - required
     ## List of services to monitor e.g. Dnscache, wmiApSrv, etc.
     ##
-    ## If any service is set to `ALL`, all services registered with the SCM will be monitored.
+    ## Services can also be selectively monitored by their startup type.
+    ## Possible values for the `startup_type` pattern:
+    ##   - disabled
+    ##   - manual
+    ##   - automatic
+    ##   - automatic_delayed_start
     ##
-    ## This matches all services starting with service, as if service.* is configured.
+    ## If any service is set to `ALL`, all services registered with the SCM will be monitored, and
+    ## all other patterns provided in this instance will be ignored.
+    ##
+    ## Patterns are case insensitive. `ALL` is case sensitive.
+    ##
+    ## NOTE: The configured patterns will match all services starting with the pattern. For example,
+    ## if `service` is provided, it will match all services starting with `service` as if service.* is configured.
     ## For an exact match, use ^service$
     #
   - services:
       - <SERVICE_NAME_1>
       - <SERVICE_NAME_2>
+      - startup_type: ^automatic$
 
     ## @param disable_legacy_service_tag - boolean - optional - default: false
     ## Whether or not to stop submitting the tag `service` that has been renamed

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -24,9 +24,6 @@ class ServiceFilter(object):
             if self.name is not None:
                 pattern = self.name
                 self._name_re = re.compile(pattern, SERVICE_PATTERN_FLAGS)
-            if self.startup_type is not None:
-                pattern = self.startup_type
-                self._startup_type_re = re.compile(pattern, SERVICE_PATTERN_FLAGS)
         except re.error as e:
             raise_from(Exception("Regular expression syntax error in '{}': {}".format(pattern, str(e))), None)
 
@@ -35,7 +32,7 @@ class ServiceFilter(object):
             if not self._name_re.match(service_view.name):
                 return False
         if self.startup_type is not None:
-            if not self._startup_type_re.match(service_view.startup_type_string()):
+            if self.startup_type.lower() != service_view.startup_type_string().lower():
                 return False
         return True
 
@@ -44,7 +41,7 @@ class ServiceFilter(object):
         if self.name is not None:
             vals.append('name={}'.format(self._name_re.pattern))
         if self.startup_type is not None:
-            vals.append('startup_type={}'.format(self._startup_type_re.pattern))
+            vals.append('startup_type={}'.format(self.startup_type))
         # Example:
         #   - ServiceFilter(name=EventLog)
         #   - ServiceFilter(startup_type=automatic)

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -42,7 +42,7 @@ class ServiceFilter(object):
         # Example:
         #   - ServiceFilter(name=EventLog)
         #   - ServiceFilter(startup_type=automatic)
-        return '{}({})'.format(self.__name__, ', '.join(vals))
+        return '{}({})'.format(type(self).__name__, ', '.join(vals))
 
     @classmethod
     def _wmi_compat_name(cls, name):

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -22,11 +22,13 @@ class ServiceFilter(object):
     def _init_patterns(self):
         try:
             if self.name is not None:
-                self._name_re = re.compile(self.name, SERVICE_PATTERN_FLAGS)
+                pattern = self.name
+                self._name_re = re.compile(pattern, SERVICE_PATTERN_FLAGS)
             if self.startup_type is not None:
-                self._startup_type_re = re.compile(self.startup_type, SERVICE_PATTERN_FLAGS)
+                pattern = self.startup_type
+                self._startup_type_re = re.compile(pattern, SERVICE_PATTERN_FLAGS)
         except re.error as e:
-            raise_from(Exception("Regular expression syntax error in '{}': {}".format(e.pattern, str(e))), None)
+            raise_from(Exception("Regular expression syntax error in '{}': {}".format(pattern, str(e))), None)
 
     def match(self, service_view):
         if self.name is not None:

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -3,12 +3,132 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
 
+import pywintypes
 import win32service
-from six import iteritems
 
 from datadog_checks.base import AgentCheck
 
 SERVICE_PATTERN_FLAGS = re.IGNORECASE
+
+
+class ServiceFilter(object):
+    def __init__(self, name=None, startup_type=None):
+        self.name = name
+        self.startup_type = startup_type
+
+        self._init_patterns()
+
+    def _init_patterns(self):
+        if self.name is not None:
+            self._name_re = re.compile(self.name, SERVICE_PATTERN_FLAGS)
+        if self.startup_type is not None:
+            self._startup_type_re = re.compile(self.startup_type, SERVICE_PATTERN_FLAGS)
+
+    def match(self, service_view):
+        if self.name is not None:
+            if not self._name_re.match(service_view.name):
+                return False
+        if self.startup_type is not None:
+            if not self._startup_type_re.match(service_view.startup_type_string()):
+                return False
+        return True
+
+    def __str__(self):
+        vals = []
+        if self.name is not None:
+            vals.append('name={}'.format(self._name_re.pattern))
+        if self.startup_type is not None:
+            vals.append('startup_type={}'.format(self._startup_type_re.pattern))
+        # Example:
+        #   - ServiceFilter(name=EventLog)
+        #   - ServiceFilter(startup_type=automatic)
+        return '{}({})'.format(self.__name__, ', '.join(vals))
+
+    @classmethod
+    def _wmi_compat_name(cls, name):
+        # Old-style WMI wildcards
+        return name.replace('%', '.*')
+
+    @classmethod
+    def from_config(cls, item, wmi_compat=False):
+        if isinstance(item, str):
+            # Example config
+            '''
+            services:
+              - service_name
+            '''
+            name = item
+            if wmi_compat:
+                name = cls._wmi_compat_name(name)
+            obj = cls(name=name)
+        elif isinstance(item, dict):
+            # Example config
+            '''
+            services:
+              - name: service_name
+              - startup_type: automatic
+            '''
+            name = item.get('name', None)
+            if name is not None and wmi_compat:
+                name = cls._wmi_compat_name(name)
+            startup_type = item.get('startup_type', None)
+            obj = cls(name=name, startup_type=startup_type)
+        else:
+            raise Exception("Invalid type '{}' for service".format(type(item).__name__))
+        return obj
+
+
+class ServiceView(object):
+    # map service startup types to strings for ServiceFilter and windows_service_startup_type tag values
+    STARTUP_TYPE_TO_STRING = {
+        win32service.SERVICE_AUTO_START: "automatic",
+        win32service.SERVICE_DEMAND_START: "manual",
+        win32service.SERVICE_DISABLED: "disabled",
+    }
+    STARTUP_TYPE_DELAYED_AUTO = "automatic_delayed_start"
+    STARTUP_TYPE_UNKNOWN = "unknown"
+
+    def __init__(self, scm_handle, name):
+        self.scm_handle = scm_handle
+        self.name = name
+
+        self._hSvc = None
+        self._startup_type = None
+        self._service_config = None
+        self._is_delayed_auto = None
+
+    @property
+    def hSvc(self):
+        if self._hSvc is None:
+            self._hSvc = win32service.OpenService(self.scm_handle, self.name, win32service.SERVICE_QUERY_CONFIG)
+        return self._hSvc
+
+    @property
+    def service_config(self):
+        if self._service_config is None:
+            self._service_config = win32service.QueryServiceConfig(self.hSvc)
+        return self._service_config
+
+    @property
+    def startup_type(self):
+        if self._startup_type is None:
+            self._startup_type = self.service_config[1]
+        return self._startup_type
+
+    @property
+    def is_delayed_auto(self):
+        if self._is_delayed_auto is None:
+            self._is_delayed_auto = win32service.QueryServiceConfig2(
+                self.hSvc, win32service.SERVICE_CONFIG_DELAYED_AUTO_START_INFO
+            )
+        return self._is_delayed_auto
+
+    def startup_type_string(self):
+        startup_type_string = ''
+        startup_type_string = self.STARTUP_TYPE_TO_STRING.get(self.startup_type, self.STARTUP_TYPE_UNKNOWN)
+        if self.startup_type == win32service.SERVICE_AUTO_START and self.is_delayed_auto:
+            startup_type_string = self.STARTUP_TYPE_DELAYED_AUTO
+        return startup_type_string
 
 
 class WindowsService(AgentCheck):
@@ -30,17 +150,9 @@ class WindowsService(AgentCheck):
         # PAUSED
         7: AgentCheck.WARNING,
     }
-    # windows_service_startup_type tag values
-    STARTUP_TYPE_TO_STRING = {
-        win32service.SERVICE_AUTO_START: "automatic",
-        win32service.SERVICE_DEMAND_START: "manual",
-        win32service.SERVICE_DISABLED: "disabled",
-    }
-    STARTUP_TYPE_DELAYED_AUTO = "automatic_delayed_start"
-    STARTUP_TYPE_UNKNOWN = "unknown"
 
     def check(self, instance):
-        services = set(instance.get('services', []))
+        services = instance.get('services', [])
         custom_tags = instance.get('tags', [])
 
         if not services:
@@ -48,10 +160,12 @@ class WindowsService(AgentCheck):
 
         # Old-style WMI wildcards
         if 'host' in instance:
-            services = set(service.replace('%', '.*') for service in services)
+            wmi_compat = True
+        else:
+            wmi_compat = False
 
-        service_patterns = {service: re.compile(service, SERVICE_PATTERN_FLAGS) for service in services}
-        services_unseen = set(services)
+        service_filters = [ServiceFilter.from_config(item, wmi_compat=wmi_compat) for item in services]
+        services_unseen = set(f.name for f in service_filters if f.name is not None)
 
         try:
             scm_handle = win32service.OpenSCManager(None, None, win32service.SC_MANAGER_ENUMERATE_SERVICE)
@@ -64,14 +178,20 @@ class WindowsService(AgentCheck):
         service_statuses = win32service.EnumServicesStatus(scm_handle, type_filter, state_filter)
 
         for short_name, _, service_status in service_statuses:
+            service_view = ServiceView(scm_handle, short_name)
+
             if 'ALL' not in services:
-                for service, service_pattern in sorted(iteritems(service_patterns), reverse=True):
-                    self.log.debug(
-                        'Service: %s with Short Name: %s and Pattern: %s', service, short_name, service_pattern.pattern
-                    )
-                    if service_pattern.match(short_name):
-                        services_unseen.discard(service)
-                        break
+                for service_filter in service_filters:
+                    self.log.debug('Service Short Name: %s and Filter: %s', short_name, service_filter)
+                    try:
+                        if service_filter.match(service_view):
+                            services_unseen.discard(service_filter.name)
+                            break
+                    except pywintypes.error as e:
+                        self.log.exception("Exception at service match for %s", service_filter)
+                        self.warning(
+                            "Failed to query %s service config for filter %s: %s", short_name, service_filter, str(e)
+                        )
                 else:
                     continue
 
@@ -82,8 +202,13 @@ class WindowsService(AgentCheck):
             tags.extend(custom_tags)
 
             if instance.get('windows_service_startup_type_tag', False):
-                startup_type_string = self._get_service_startup_type_tag(scm_handle, short_name)
-                tags.append('windows_service_startup_type:{}'.format(startup_type_string))
+                try:
+                    tags.append('windows_service_startup_type:{}'.format(service_view.startup_type_string()))
+                except pywintypes.error as e:
+                    self.log.exception("Exception at windows_service_startup_type tag for %s", service_filter)
+                    self.warning(
+                        "Failed to query %s service config for filter %s: %s", short_name, service_filter, str(e)
+                    )
 
             if not instance.get('disable_legacy_service_tag', False):
                 self._log_deprecation('service_tag', 'windows_service')
@@ -96,7 +221,7 @@ class WindowsService(AgentCheck):
             for service in services_unseen:
                 # if a name doesn't match anything (wrong name or no permission to access the service), report UNKNOWN
                 status = self.UNKNOWN
-                startup_type_string = self.STARTUP_TYPE_UNKNOWN
+                startup_type_string = ServiceView.STARTUP_TYPE_UNKNOWN
 
                 tags = ['windows_service:{}'.format(service)]
 
@@ -111,33 +236,3 @@ class WindowsService(AgentCheck):
 
                 self.service_check(self.SERVICE_CHECK_NAME, status, tags=tags)
                 self.log.debug('service state for %s %s', service, status)
-
-    def _get_service_startup_type(self, scm_handle, service_name):
-        """
-        Returns a tuple that describes the startup type for the service
-          - QUERY_SERVICE_CONFIG.dwStartType
-          - SERVICE_CONFIG_DELAYED_AUTO_START_INFO.fDelayedAutostart
-        """
-        hSvc = win32service.OpenService(scm_handle, service_name, win32service.SERVICE_QUERY_CONFIG)
-        service_config = win32service.QueryServiceConfig(hSvc)
-        startup_type = service_config[1]
-        if startup_type == win32service.SERVICE_AUTO_START:
-            # Query if auto start is delayed
-            is_delayed_auto = win32service.QueryServiceConfig2(
-                hSvc, win32service.SERVICE_CONFIG_DELAYED_AUTO_START_INFO
-            )
-        else:
-            is_delayed_auto = False
-        return startup_type, is_delayed_auto
-
-    def _get_service_startup_type_tag(self, scm_handle, service_name):
-        try:
-            startup_type, is_delayed_auto = self._get_service_startup_type(scm_handle, service_name)
-            startup_type_string = self.STARTUP_TYPE_TO_STRING.get(startup_type, self.STARTUP_TYPE_UNKNOWN)
-            if startup_type == win32service.SERVICE_AUTO_START and is_delayed_auto:
-                startup_type_string = self.STARTUP_TYPE_DELAYED_AUTO
-        except Exception as e:
-            self.warning("Failed to query service config for %s: %s", service_name, str(e))
-            startup_type_string = self.STARTUP_TYPE_UNKNOWN
-
-        return startup_type_string

--- a/windows_service/datadog_checks/windows_service/windows_service.py
+++ b/windows_service/datadog_checks/windows_service/windows_service.py
@@ -5,6 +5,7 @@ import re
 
 import pywintypes
 import win32service
+from six import raise_from
 
 from datadog_checks.base import AgentCheck
 
@@ -19,10 +20,13 @@ class ServiceFilter(object):
         self._init_patterns()
 
     def _init_patterns(self):
-        if self.name is not None:
-            self._name_re = re.compile(self.name, SERVICE_PATTERN_FLAGS)
-        if self.startup_type is not None:
-            self._startup_type_re = re.compile(self.startup_type, SERVICE_PATTERN_FLAGS)
+        try:
+            if self.name is not None:
+                self._name_re = re.compile(self.name, SERVICE_PATTERN_FLAGS)
+            if self.startup_type is not None:
+                self._startup_type_re = re.compile(self.startup_type, SERVICE_PATTERN_FLAGS)
+        except re.error as e:
+            raise_from(Exception("Regular expression syntax error in '{}': {}".format(e.pattern, str(e))), None)
 
     def match(self, service_view):
         if self.name is not None:

--- a/windows_service/tests/common.py
+++ b/windows_service/tests/common.py
@@ -2,10 +2,31 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 INSTANCE_BASIC = {'services': ['eventlog', 'Dnscache', 'NonExistentService'], 'tags': ['optional:tag1']}
+INSTANCE_BASIC_DICT = {
+    'services': [
+        {'name': 'eventlog'},
+        {'name': 'Dnscache'},
+        {'name': 'NonExistentService'},
+    ],
+    'tags': ['optional:tag1'],
+    'disable_legacy_service_tag': True,
+}
 INSTANCE_BASIC_DISABLE_SERVICE_TAG = {
     'services': ['eventlog', 'Dnscache', 'NonExistentService'],
     'tags': ['optional:tag1'],
     'disable_legacy_service_tag': True,
 }
+INSTANCE_STARTUP_TYPE_FILTER = {
+    'windows_service_startup_type_tag': True,
+    'disable_legacy_service_tag': True,
+}
 INSTANCE_WILDCARD = {'host': '.', 'services': ['Event.*', 'Dns%']}
+INSTANCE_WILDCARD_DICT = {
+    'host': '.',
+    'services': [
+        {'name': 'Event.*'},
+        {'name': 'Dns%'},
+    ],
+    'disable_legacy_service_tag': True,
+}
 INSTANCE_ALL = {'services': ['ALL']}

--- a/windows_service/tests/conftest.py
+++ b/windows_service/tests/conftest.py
@@ -31,6 +31,11 @@ def instance_basic():
 
 
 @pytest.fixture
+def instance_basic_dict():
+    return deepcopy(common.INSTANCE_BASIC_DICT)
+
+
+@pytest.fixture
 def instance_basic_disable_service_tag():
     return deepcopy(common.INSTANCE_BASIC_DISABLE_SERVICE_TAG)
 
@@ -41,5 +46,15 @@ def instance_wildcard():
 
 
 @pytest.fixture
+def instance_wildcard_dict():
+    return deepcopy(common.INSTANCE_WILDCARD_DICT)
+
+
+@pytest.fixture
 def instance_all():
     return deepcopy(common.INSTANCE_ALL)
+
+
+@pytest.fixture
+def instance_startup_type_filter():
+    return deepcopy(common.INSTANCE_STARTUP_TYPE_FILTER)

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -2,6 +2,8 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
+import pywintypes
+from mock import patch
 
 from datadog_checks.windows_service import WindowsService
 
@@ -230,6 +232,16 @@ def test_startup_type_tag(aggregator, check, instance_basic):
         ],
         count=1,
     )
+
+
+def test_openservice_failure(aggregator, check, instance_basic, caplog):
+    instance_basic['windows_service_startup_type_tag'] = True
+    c = check(instance_basic)
+
+    with patch('win32service.OpenService', side_effect=pywintypes.error('mocked error')):
+        c.check(instance_basic)
+
+    assert 'Failed to query EventLog service config' in caplog.text
 
 
 @pytest.mark.e2e

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -69,7 +69,7 @@ def test_all(aggregator, check, instance_all):
 
 def test_startup_type_filter_automatic(aggregator, check, instance_startup_type_filter):
     instance_startup_type_filter['services'] = [
-        {'startup_type': '^automatic$'},
+        {'startup_type': 'automatic'},
     ]
     c = check(instance_startup_type_filter)
     c.check(instance_startup_type_filter)
@@ -83,25 +83,8 @@ def test_startup_type_filter_automatic(aggregator, check, instance_startup_type_
 
 def test_startup_type_filter_automatic_and_delayed(aggregator, check, instance_startup_type_filter):
     instance_startup_type_filter['services'] = [
-        {'startup_type': '^automatic$'},
-        {'startup_type': 'automatic_delayed_start'},
-    ]
-    c = check(instance_startup_type_filter)
-    c.check(instance_startup_type_filter)
-
-    # Make sure we got at least one
-    aggregator.assert_service_check(c.SERVICE_CHECK_NAME, status=c.OK, at_least=1)
-    # Assert all found were automatic or delayed
-    for sc in aggregator.service_checks(c.SERVICE_CHECK_NAME):
-        assert (
-            'windows_service_startup_type:automatic' in sc.tags
-            or 'windows_service_startup_type:automatic_delayed_start' in sc.tags
-        )
-
-
-def test_startup_type_filter_automatic_and_delayed_pattern(aggregator, check, instance_startup_type_filter):
-    instance_startup_type_filter['services'] = [
         {'startup_type': 'automatic'},
+        {'startup_type': 'automatic_delayed_start'},
     ]
     c = check(instance_startup_type_filter)
     c.check(instance_startup_type_filter)

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -268,7 +268,7 @@ def test_invalid_pattern_regex(aggregator, check, instance_basic_dict):
     instance_basic_dict['windows_service_startup_type_tag'] = True
     c = check(instance_basic_dict)
 
-    with pytest.raises(Exception, match=r"Regular expression syntax error in '\(foo': missing \)"):
+    with pytest.raises(Exception, match=r"Regular expression syntax error in '\(foo':"):
         c.check(instance_basic_dict)
 
 

--- a/windows_service/tests/test_windows_service.py
+++ b/windows_service/tests/test_windows_service.py
@@ -258,10 +258,18 @@ def test_invalid_pattern_type(aggregator, check, instance_basic_dict):
     instance_basic_dict['windows_service_startup_type_tag'] = True
     c = check(instance_basic_dict)
 
-    with pytest.raises(Exception) as e_info:
+    with pytest.raises(Exception, match="Invalid type 'list' for service"):
         c.check(instance_basic_dict)
 
-    assert "Invalid type 'list' for service" in str(e_info)
+
+def test_invalid_pattern_regex(aggregator, check, instance_basic_dict):
+    instance_basic_dict['services'].append('(foo')
+
+    instance_basic_dict['windows_service_startup_type_tag'] = True
+    c = check(instance_basic_dict)
+
+    with pytest.raises(Exception, match=r"Regular expression syntax error in '\(foo': missing \)"):
+        c.check(instance_basic_dict)
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds a new `startup_type` pattern to the windows_service `services` config entry that enables users to filter services by their startup type at the agent.

This new pattern combines with the existing patterns

```
# Matches the EventLog service
services:
  - EventLog
services:
  - name: EventLog

# Matches all services with an automatic startup type
services:
  - startup_type: automatic

# Only matches EventLog service when its startup type is automatic
services:
  - name: EventLog
    startup_type: automatic
 ```

### Motivation
<!-- What inspired you to submit this pull request? -->

https://datadoghq.atlassian.net/browse/WA-77

builds upon https://github.com/DataDog/integrations-core/pull/12932 by providing a way to filter the startup type at the agent to reduce bandwidth usage and unwanted service checks from showing in the dashboard.

Combining this with the `windows_service_startup_type` tag can be useful for separating service checks by their startup type in Monitors, for an example like the following
```
# Matches all services with an automatic startup type as well as remoteregistry regardless of it's startup type
services:
  - name: remoteregistry
  - startup_type: automatic
```
 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
