### PR TITLE
[MySQL] Added Agent settings to log original unobfuscated strings

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -603,6 +603,26 @@ files:
                   type: boolean
                   example: true
                   display_default: true
+          - name: log_unobfuscated_queries
+            hidden: true
+            description: |
+              Set to `true` to enable logging of original unobfuscated SQL queries when obfuscation errors occur.
+              For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
+              Note: This option only applies when `dbm` is enabled.
+            value:
+              type: boolean
+              example: false
+              display_default: false
+          - name: log_unobfuscated_plans
+            hidden: true
+            description: |
+              Set to `true` to enable logging of original unobfuscated SQL plans when obfuscation errors occur.
+              For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
+              Note: This option only applies when `dbm` is enabled.
+            value:
+              type: boolean
+              example: false
+              display_default: false
           - template: instances/default
             overrides:
               disable_generic_tags.hidden: false

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -205,8 +205,11 @@ class MySQLActivity(DBMAsyncJob):
         try:
             self._finalize_row(row, obfuscate_sql_with_metadata(row["sql_text"], self._obfuscator_options))
         except Exception as e:
+            if self._config.log_unobfuscated_queries:
+                self._log.warning("Failed to obfuscate query '%s' | err=[%s]", row["sql_text"], e)
+            else:
+                self._log.debug("Failed to obfuscate | err=[%s]", e)
             row["sql_text"] = "ERROR: failed to obfuscate"
-            self._log.debug("Failed to obfuscate | err=[%s]", e)
         return row
 
     @staticmethod

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -206,9 +206,9 @@ class MySQLActivity(DBMAsyncJob):
             self._finalize_row(row, obfuscate_sql_with_metadata(row["sql_text"], self._obfuscator_options))
         except Exception as e:
             if self._config.log_unobfuscated_queries:
-                self._log.warning("Failed to obfuscate query '%s' | err=[%s]", row["sql_text"], e)
+                self._log.warning("Failed to obfuscate query=[%s] | err=[%s]", row["sql_text"], e)
             else:
-                self._log.debug("Failed to obfuscate | err=[%s]", e)
+                self._log.debug("Failed to obfuscate query | err=[%s]", e)
             row["sql_text"] = "ERROR: failed to obfuscate"
         return row
 

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -69,6 +69,8 @@ class MySQLConfig(object):
             'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),
             'collect_comments': is_affirmative(obfuscator_options_config.get('collect_comments', True)),
         }
+        self.log_unobfuscated_queries = is_affirmative(instance.get('log_unobfuscated_queries', False))
+        self.log_unobfuscated_plans = is_affirmative(instance.get('log_unobfuscated_plans', False))
         self.configuration_checks()
 
     def _build_tags(self, custom_tags):

--- a/mysql/datadog_checks/mysql/config_models/defaults.py
+++ b/mysql/datadog_checks/mysql/config_models/defaults.py
@@ -70,6 +70,14 @@ def instance_host(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_log_unobfuscated_plans(field, value):
+    return False
+
+
+def instance_log_unobfuscated_queries(field, value):
+    return False
+
+
 def instance_max_custom_queries(field, value):
     return 20
 

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -152,6 +152,8 @@ class InstanceConfig(BaseModel):
     empty_default_hostname: Optional[bool]
     gcp: Optional[Gcp]
     host: Optional[str]
+    log_unobfuscated_plans: Optional[bool]
+    log_unobfuscated_queries: Optional[bool]
     max_custom_queries: Optional[int]
     metric_patterns: Optional[MetricPatterns]
     min_collection_interval: Optional[float]

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -491,13 +491,13 @@ class MySQLStatementSamples(DBMAsyncJob):
         try:
             statement = obfuscate_sql_with_metadata(row['sql_text'], self._obfuscate_options)
             statement_digest_text = obfuscate_sql_with_metadata(row['digest_text'], self._obfuscate_options)
-        except Exception:
+        except Exception as e:
             # do not log raw sql_text to avoid leaking sensitive data into logs unless log_unobfuscated_queries is set
             # digest_text is safe as parameters are obfuscated by the database
             if self._config.log_unobfuscated_queries:
-                self._log.warning("Failed to obfuscate statement: %s", row['sql_text'])
+                self._log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['sql_text'], e)
             else:
-                self._log.debug("Failed to obfuscate statement: %s", row['digest_text'])
+                self._log.debug("Failed to obfuscate query=[%s] | err=[%s]", row['digest_text'], e)
             self._check.count(
                 "dd.mysql.query_samples.error",
                 1,
@@ -545,7 +545,7 @@ class MySQLStatementSamples(DBMAsyncJob):
                 obfuscated_plan = datadog_agent.obfuscate_sql_exec_plan(plan)
             except Exception as e:
                 if self._config.log_unobfuscated_plans:
-                    self._log.warning("Failed to obfuscate plan '%s': %s", plan, e)
+                    self._log.warning("Failed to obfuscate plan=[%s] | err=[%s]", plan, e)
                 raise e
             plan_signature = compute_exec_plan_signature(normalized_plan)
 

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -202,7 +202,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
                 statement = obfuscate_sql_with_metadata(row['digest_text'], self._obfuscate_options)
                 obfuscated_statement = statement['query'] if row['digest_text'] is not None else None
             except Exception as e:
-                self.log.warning("Failed to obfuscate query '%s': %s", row['digest_text'], e)
+                self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['digest_text'], e)
                 continue
 
             normalized_row['digest_text'] = obfuscated_statement


### PR DESCRIPTION
### What does this PR do?
Adds two hidden options `log_unobfuscated_queries` and `log_unobfuscated_plans` which will log the original unobfuscated SQL queries and plans respectively if an obfuscation error occurs. These options will simplify the debugging process when dealing with obfuscation errors.

### Motivation


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
