### PR TITLE
[kafka consumer integration] Put lag in seconds behind a feature flag

### DIFF
--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -241,3 +241,10 @@ files:
           type: boolean
           example: false
         display_default: false
+      - name: data_streams_enabled
+        description: |
+          Beta feature to get a lag metric in Seconds. It's part of the Data Streams Monitoring Product
+        value:
+          type: boolean
+          example: false
+        display_default: false

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
@@ -30,6 +30,10 @@ def instance_consumer_groups(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_data_streams_enabled(field, value):
+    return False
+
+
 def instance_disable_generic_tags(field, value):
     return False
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
@@ -42,6 +42,7 @@ class InstanceConfig(BaseModel):
 
     broker_requests_batch_size: Optional[int]
     consumer_groups: Optional[Mapping[str, Any]]
+    data_streams_enabled: Optional[bool]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]
     kafka_client_api_version: Optional[str]

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -295,3 +295,8 @@ instances:
     ## Set to false to fetch consumer offsets only from Zookeeper.
     #
     # kafka_consumer_offsets: false
+
+    ## @param data_streams_enabled - boolean - optional - default: false
+    ## Beta feature to get a lag metric in Seconds. It's part of the Data Streams Monitoring Product
+    #
+    # data_streams_enabled: false

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -42,6 +42,7 @@ class KafkaCheck(AgentCheck):
         super(KafkaCheck, self).__init__(name, init_config, instances)
         self.sub_check = None
         self._context_limit = int(self.init_config.get('max_partition_contexts', CONTEXT_UPPER_BOUND))
+        self._data_streams_enabled = is_affirmative(self.instance.get('data_streams_enabled', False))
         self._custom_tags = self.instance.get('tags', [])
         self._monitor_unlisted_consumer_groups = is_affirmative(
             self.instance.get('monitor_unlisted_consumer_groups', False)

--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -197,11 +197,12 @@ class NewKafkaConsumerCheck(object):
                 error_type = kafka_errors.for_code(error_code)
                 if error_type is kafka_errors.NoError:
                     self._highwater_offsets[(topic, partition)] = offsets[0]
-                    timestamps = self._broker_timestamps["{}_{}".format(topic, partition)]
-                    timestamps[offsets[0]] = time()
-                    # If there's too many timestamps, we delete the oldest
-                    if len(timestamps) > MAX_TIMESTAMPS:
-                        del timestamps[min(timestamps)]
+                    if self._data_streams_enabled:
+                        timestamps = self._broker_timestamps["{}_{}".format(topic, partition)]
+                        timestamps[offsets[0]] = time()
+                        # If there's too many timestamps, we delete the oldest
+                        if len(timestamps) > MAX_TIMESTAMPS:
+                            del timestamps[min(timestamps)]
                 elif error_type is kafka_errors.NotLeaderForPartitionError:
                     self.log.warning(
                         "Kafka broker returned %s (error_code %s) for topic %s, partition: %s. This should only happen "

--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -66,7 +66,8 @@ class NewKafkaConsumerCheck(object):
             self.log.exception("There was a problem collecting consumer offsets from Kafka.")
             # don't raise because we might get valid broker offsets
 
-        self._load_broker_timestamps()
+        if self._data_streams_enabled:
+            self._load_broker_timestamps()
         # Fetch the broker highwater offsets
         try:
             if len(self._consumer_offsets) < self._context_limit:
@@ -88,7 +89,8 @@ class NewKafkaConsumerCheck(object):
                 self._context_limit,
             )
 
-        self._save_broker_timestamps()
+        if self._data_streams_enabled:
+            self._save_broker_timestamps()
 
         # Report the metrics
         self._report_highwater_offsets(self._context_limit)
@@ -282,6 +284,8 @@ class NewKafkaConsumerCheck(object):
                     self.log.debug(message)
 
                 if reported_contexts >= contexts_limit:
+                    continue
+                if not self._data_streams_enabled:
                     continue
                 timestamps = self._broker_timestamps["{}_{}".format(topic, partition)]
                 # The producer timestamp can be not set if there was an error fetching broker offsets.

--- a/kafka_consumer/metadata.csv
+++ b/kafka_consumer/metadata.csv
@@ -2,4 +2,3 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 kafka.broker_offset,gauge,,offset,,Current message offset on broker.,0,kafka_consumer,broker offset,
 kafka.consumer_lag,gauge,,offset,,Lag in messages between consumer and broker.,-1,kafka_consumer,consumer lag,
 kafka.consumer_offset,gauge,,offset,,Current message offset on consumer.,0,kafka_consumer,consumer offset,
-kafka.consumer_lag_seconds,gauge,,second,,Lag in seconds between consumer and broker.,-1,kafka_consumer,consumer time lag,


### PR DESCRIPTION
### What does this PR do?
Puts the lag in seconds metric behind a feature flag.

### Motivation


### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
