### PR TITLE
Do not include `ddev` in the `requirements-agent-release.txt` file

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/requirements.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/requirements.py
@@ -24,7 +24,9 @@ def requirements(ctx):
     """
     echo_info('Freezing check releases')
     checks = get_valid_checks()
+
     checks.remove('datadog_checks_dev')
+    checks.remove('ddev')
 
     entries = []
     for check in checks:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/requirements.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/requirements.py
@@ -25,8 +25,7 @@ def requirements(ctx):
     echo_info('Freezing check releases')
     checks = get_valid_checks()
 
-    checks.remove('datadog_checks_dev')
-    checks.remove('ddev')
+    checks -= {'datadog_checks_dev', 'ddev'}
 
     entries = []
     for check in checks:


### PR DESCRIPTION
### What does this PR do?
Avoid adding the `ddev` check to the requirements-agent-release.txt file, just like `datadog_checks_dev`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

No need ton include this in the current release, we can wait for the mergefreeze to be lifted

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
