### PR TITLE
Update the classifier for macOS

### DIFF
--- a/cert_manager/manifest.json
+++ b/cert_manager/manifest.json
@@ -13,7 +13,7 @@
     "media": [],
     "classifier_tags": [
       "Supported OS::Linux",
-      "Supported OS::Mac OS",
+      "Supported OS::macOS",
       "Supported OS::Windows",
       "Category::Security",
       "Category::Configuration & Deployment",


### PR DESCRIPTION
### What does this PR do?
Update the Supported OS classifier to `macOS`

### Motivation
<!-- What inspired you to submit this pull request? -->

`Mac OS` is not supported by the `ddev agent requirements` command https://github.com/DataDog/integrations-core/blob/34767476bae373ef8778ce46b64b34458ea618bf/datadog_checks_dev/datadog_checks/dev/tooling/release.py#L93-L94. Because of that, we append `; sys_platform != 'darwin'` to the dep, which should not be

### Additional Notes
<!-- Anything else we should know when reviewing? -->

We should add a validation in the `ddev validate manifest` command, adding a [card](https://datadoghq.atlassian.net/browse/AI-2687) to our board. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
