### PR TITLE
Fix setup.py keywords in datadog-checks-downloader

### DIFF
--- a/datadog_checks_downloader/setup.py
+++ b/datadog_checks_downloader/setup.py
@@ -49,7 +49,7 @@ setup(
     description='The Datadog Checks Downloader',
     long_description=LONG_DESC,
     long_description_content_type='text/markdown',
-    keywords='datadog agent checks',
+    keywords='datadog,agent,checks',
     url='https://github.com/DataDog/integrations-core',
     author='Datadog',
     author_email='packages@datadoghq.com',


### PR DESCRIPTION
### What does this PR do?

Fix keywords in setup.py, see [keywords section](https://setuptools.pypa.io/en/latest/references/keywords.html). Originally spotted by @cedricvanrompay-datadog.