### PR TITLE
Update codeowners for Agent Platform-owned integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -100,26 +100,26 @@ assets/               @DataDog/agent-integrations
 /datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/ @DataDog/infrastructure-integrations @DataDog/agent-integrations
 /docs/developer/tutorials/snmp/                                    @DataDog/infrastructure-integrations @DataDog/agent-integrations @DataDog/documentation
 
+# System checks
+/disk/                                    @DataDog/agent-integrations @DataDog/windows-agent
+/disk/*.md                                @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation
+/disk/manifest.json                       @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation
+/network/                                 @DataDog/agent-integrations @DataDog/windows-agent
+/network/*.md                             @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation
+/network/manifest.json                    @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation
+/process/                                 @DataDog/agent-integrations @DataDog/windows-agent
+/process/*.md                             @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation
+/process/manifest.json                    @DataDog/agent-integrations @DataDog/windows-agent @DataDog/documentation
+
+# OpenTelemetry
+/otel/                                    @DataDog/opentelemetry @DataDog/agent-integrations
+/otel/*.md                                @DataDog/opentelemetry @DataDog/agent-integrations @DataDog/documentation
+/otel/manifest.json                       @DataDog/opentelemetry @DataDog/agent-integrations @DataDog/documentation
+
 # Agent Platform
-/disk/                                    @DataDog/agent-platform @DataDog/agent-integrations
-/disk/*.md                                @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
-/disk/manifest.json                       @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
-/network/                                 @DataDog/agent-platform @DataDog/agent-integrations
-/network/*.md                             @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
-/network/manifest.json                    @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
-/process/                                 @DataDog/agent-platform @DataDog/agent-integrations
-/process/*.md                             @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
-/process/manifest.json                    @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
-/otel/                                    @DataDog/agent-platform @DataDog/agent-integrations
-/otel/*.md                                @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
-/otel/manifest.json                       @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
 /nvidia_jetson/                           @DataDog/agent-platform @DataDog/agent-integrations
 /nvidia_jetson/*.md                       @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
 /nvidia_jetson/manifest.json              @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
-/ibm_i/                                   @DataDog/agent-platform @DataDog/agent-integrations
-/ibm_i/*.md                               @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
-/ibm_i/manifest.json                      @DataDog/agent-platform @DataDog/agent-integrations @DataDog/documentation
-
 
 # Database monitoring
 **/base/utils/db/utils.py                           @DataDog/agent-integrations @DataDog/database-monitoring


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Updates the owners of integrations previously owned by Agent Platform in the `CODEOWNERS` file:
- System integrations (process, disk and network) are now owned by Agent Integrations. The Windows Agent team is listed as a secondary owner, to help with the Windows bits of these checks.
- The IBM i integration is now owned by Agent Integrations.
- The OTel integration is now owned by the OpenTelemetry team.

To be merged on October 10th, 2022.

### Motivation
<!-- What inspired you to submit this pull request? -->

Ownership updates.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
