### PR TITLE
Add minimal e2e test for ecs_fargate integration

### DIFF
--- a/ecs_fargate/tests/conftest.py
+++ b/ecs_fargate/tests/conftest.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+from copy import deepcopy
 
 import pytest
 
@@ -152,3 +153,13 @@ INSTANCE = {'timeout': '2', 'tags': INSTANCE_TAGS}
 @pytest.fixture
 def check():
     return FargateCheck('ecs_fargate', {}, [INSTANCE])
+
+
+@pytest.fixture(scope="session")
+def dd_environment():
+    yield INSTANCE
+
+
+@pytest.fixture
+def instance():
+    return deepcopy(INSTANCE)

--- a/ecs_fargate/tests/test_e2e.py
+++ b/ecs_fargate/tests/test_e2e.py
@@ -1,0 +1,13 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+import pytest
+
+from datadog_checks.ecs_fargate import FargateCheck
+
+
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, aggregator, instance):
+    aggregator = dd_agent_check(instance)
+    aggregator.assert_service_check("fargate_check", status=FargateCheck.CRITICAL, tags=[], count=1)

--- a/ecs_fargate/tox.ini
+++ b/ecs_fargate/tox.ini
@@ -11,6 +11,8 @@ envdir =
     py27: {toxworkdir}/py27
     py38: {toxworkdir}/py38
 dd_check_style = true
+description =
+    py{27,38}: e2e ready
 usedevelop = true
 platform = linux|darwin|win32
 extras = deps


### PR DESCRIPTION
### What does this PR do?

Adds an e2e test to `ecs_fargate` that asserts that a critical check is emitted, as there's no service running.

### Motivation
[AI-2508](https://datadoghq.atlassian.net/browse/AI-2508)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
