### PR TITLE
[SQL Server] Added Agent settings to log original unobfuscated strings

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -432,6 +432,26 @@ files:
             type: boolean
             example: true
             display_default: true
+    - name: log_unobfuscated_queries
+      hidden: true
+      description: |
+        Set to `true` to enable logging of original unobfuscated SQL queries when obfuscation errors occur.
+        For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
+        Note: This option only applies when `dbm` is enabled.
+      value:
+        type: boolean
+        example: false
+        display_default: false
+    - name: log_unobfuscated_plans
+      hidden: true
+      description: |
+        Set to `true` to enable logging of original unobfuscated SQL plans when obfuscation errors occur.
+        For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
+        Note: This option only applies when `dbm` is enabled.
+      value:
+        type: boolean
+        example: false
+        display_default: false
     - name: command_timeout
       description: Timeout in seconds for the connection and each command run
       value:

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -227,8 +227,8 @@ class SqlserverActivity(DBMAsyncJob):
                 row['procedure_signature'] = compute_sql_signature(procedure_statement['query'])
         except Exception as e:
             if self.check.log_unobfuscated_queries:
-                failed_obfuscation = row['text'] if row.get('is_proc', False) else row['statement_text']
-                self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", failed_obfuscation, e)
+                raw_query_text = row['text'] if row.get('is_proc', False) else row['statement_text']
+                self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", raw_query_text, e)
             else:
                 self.log.debug("Failed to obfuscate query | err=[%s]", e)
             obfuscated_statement = "ERROR: failed to obfuscate"

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -227,7 +227,7 @@ class SqlserverActivity(DBMAsyncJob):
                 row['procedure_signature'] = compute_sql_signature(procedure_statement['query'])
         except Exception as e:
             if self.check.log_unobfuscated_queries:
-                failed_obfuscation = row['text'] if row['is_proc'] else row['statement_text']
+                failed_obfuscation = row['text'] if row.get('is_proc', False) else row['statement_text']
                 self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", failed_obfuscation, e)
             else:
                 self.log.debug("Failed to obfuscate query | err=[%s]", e)

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -226,8 +226,11 @@ class SqlserverActivity(DBMAsyncJob):
             if procedure_statement:
                 row['procedure_signature'] = compute_sql_signature(procedure_statement['query'])
         except Exception as e:
-            # obfuscation errors are relatively common so only log them during debugging
-            self.log.debug("Failed to obfuscate query: %s", e)
+            if self.check.log_unobfuscated_queries:
+                failed_obfuscation = row['text'] if row['is_proc'] else row['statement_text']
+                self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", failed_obfuscation, e)
+            else:
+                self.log.debug("Failed to obfuscate query | err=[%s]", e)
             obfuscated_statement = "ERROR: failed to obfuscate"
         row = self._sanitize_row(row, obfuscated_statement)
         return row

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -138,6 +138,14 @@ def instance_include_task_scheduler_metrics(field, value):
     return False
 
 
+def instance_log_unobfuscated_plans(field, value):
+    return False
+
+
+def instance_log_unobfuscated_queries(field, value):
+    return False
+
+
 def instance_metric_patterns(field, value):
     return get_default_field_value(field, value)
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -125,6 +125,8 @@ class InstanceConfig(BaseModel):
     include_instance_metrics: Optional[bool]
     include_master_files_metrics: Optional[bool]
     include_task_scheduler_metrics: Optional[bool]
+    log_unobfuscated_plans: Optional[bool]
+    log_unobfuscated_queries: Optional[bool]
     metric_patterns: Optional[MetricPatterns]
     min_collection_interval: Optional[float]
     obfuscator_options: Optional[ObfuscatorOptions]

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -150,6 +150,8 @@ class SQLServer(AgentCheck):
                 }
             )
         )
+        self.log_unobfuscated_queries = is_affirmative(self.instance.get('log_unobfuscated_queries', False))
+        self.log_unobfuscated_plans = is_affirmative(self.instance.get('log_unobfuscated_plans', False))
 
         self.static_info_cache = TTLCache(
             maxsize=100,

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -288,7 +288,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     procedure_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             except Exception as e:
                 if self.check.log_unobfuscated_queries:
-                    failed_obfuscation = row['text'] if row['is_proc'] else row['statement_text']
+                    failed_obfuscation = row['text'] if row.get('is_proc', False) else row['statement_text']
                     self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", failed_obfuscation, e)
                 else:
                     self.log.debug("Failed to obfuscate query | err=[%s]", e)

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -288,8 +288,8 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     procedure_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             except Exception as e:
                 if self.check.log_unobfuscated_queries:
-                    failed_obfuscation = row['text'] if row.get('is_proc', False) else row['statement_text']
-                    self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", failed_obfuscation, e)
+                    raw_query_text = row['text'] if row.get('is_proc', False) else row['statement_text']
+                    self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", raw_query_text, e)
                 else:
                     self.log.debug("Failed to obfuscate query | err=[%s]", e)
                 self.check.count(

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -456,11 +456,9 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     if raw_plan:
                         obfuscated_plan = obfuscate_xml_plan(raw_plan, self.check.obfuscator_options)
                 except Exception as e:
-                    context = ("query_signature=[{0}] query_hash=[{1}] "
-                               "query_plan_hash=[{2}] plan_handle=[{3}] err=[{4}]"
-                               ).format(
-                        row['query_signature'], row['query_hash'], row['query_plan_hash'], row['plan_handle'], e
-                    )
+                    context = (
+                        "query_signature=[{0}] query_hash=[{1}] query_plan_hash=[{2}] plan_handle=[{3}] err=[{4}]"
+                    ).format(row['query_signature'], row['query_hash'], row['query_plan_hash'], row['plan_handle'], e)
                     if self.check.log_unobfuscated_plans:
                         self.log.warning("Failed to obfuscate plan=[%s] | %s", raw_plan, context)
                     else:


### PR DESCRIPTION
### What does this PR do?
Adds two hidden options `log_unobfuscated_queries` and `log_unobfuscated_plans` which will log the original unobfuscated SQL queries and plans respectively if an obfuscation error occurs. These options will simplify the debugging process when dealing with obfuscation errors.

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
