### PR TITLE
MariaDB 10.2 minimum for window functions

### DIFF
--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -333,7 +333,10 @@ class MySQLStatementSamples(DBMAsyncJob):
 
     def _read_version_info(self):
         if not self._version_processed and self._check.version:
-            self._has_window_functions = self._check.version.version_compatible((8, 0, 0))
+            if self._check.version.flavor == "MariaDB":
+                self._has_window_functions = self._check.version.version_compatible((10, 2, 0))
+            else:
+                self._has_window_functions = self._check.version.version_compatible((8, 0, 0))
             if self._check.version.flavor == "MariaDB" or not self._check.version.version_compatible((5, 7, 0)):
                 self._global_status_table = "information_schema.global_status"
             else:


### PR DESCRIPTION
### What does this PR do?
This fixes statement sample collection on MariaDB 10.1. 

[Per the MariaDB docs](https://mariadb.com/kb/en/window-functions/), they're only supported on 10.2.0+.

### Motivation
Couldn't collect samples on MariaDB 10.1.

### Additional Notes
Discovered through a Datadog support case (Request #854033).


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
