### PR TITLE
Add the Windows-Agent team to the `trello testable` command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -270,6 +270,7 @@ def testable(
             '5': 'Platform',
             '6': 'Tools and Libraries',
             '7': 'Database Monitoring',
+            '8': 'Windows-Agent',
             's': 'Skip',
             'q': 'Quit',
         }
@@ -286,6 +287,7 @@ def testable(
             '9': 'Infra-Integrations',
             '10': 'Tools and Libraries',
             '11': 'Database Monitoring',
+            '12': 'Windows-Agent',
             's': 'Skip',
             'q': 'Quit',
         }


### PR DESCRIPTION
### What does this PR do?
Add the Windows-Agent team to the `testable` command

### Motivation
This team was missing, I manually moved the card to the right column

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
