### PR TITLE
Do not fail the validation if `pr_labels_config_relative_path` is not defined

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/ci.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/ci.py
@@ -393,7 +393,7 @@ def validate_coverage_flags(fix, repo_data, testable_checks, cached_display_name
 
 
 def validate_integration_pr_labels(fix, repo_data, valid_integrations):
-    pr_labels_config_relative_path = repo_data['pr_labels_config_relative_path']
+    pr_labels_config_relative_path = repo_data.get('pr_labels_config_relative_path')
     if not pr_labels_config_relative_path:
         echo_info("Skipping since PR Labels config path isn't defined")
         return


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not fail the validation if the `pr_labels_config_relative_path` key is not defined for the repository.

### Motivation
<!-- What inspired you to submit this pull request? -->

CI is failing in -extras:
- https://github.com/DataDog/integrations-extras/pull/1539
- https://github.com/DataDog/integrations-extras/actions/runs/3080683701/jobs/4978322219

We will probably have this error for marketplace too

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
