### PR TITLE
Update SSL connection configs used for determining SSL auth

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -126,16 +126,21 @@ class IBMMQConfig:
             'ssl_key_repository_location', '/var/mqm/ssl-db/client/KeyringClient'
         )  # type: str
         self.ssl_certificate_label = instance.get('ssl_certificate_label')  # type: str
-        if instance.get('ssl_auth') is None and (
-            instance.get('ssl_cipher_spec') or instance.get('ssl_key_repository_location') or self.ssl_certificate_label
-        ):
-            self.log.info(
-                "ssl_auth has not been explicitly enabled but other SSL options have been provided. "
-                "SSL will be used for connecting"
-            )
-            self.ssl = True
+
+        ssl_options = ['ssl_cipher_spec', 'ssl_key_repository_location', 'ssl_certificate_label']
+
+        # Implicitly enable SSL auth connection if SSL options are used and `ssl_auth` isn't set
+        if instance.get('ssl_auth') is None:
+            for option in ssl_options:
+                if instance.get(option):
+                    self.log.info(
+                        "ssl_auth has not been explicitly enabled but other SSL options have been provided. "
+                        "SSL will be used for connecting"
+                    )
+                    self.ssl = True
+
+        # Explicitly disable SSL auth connection if SSL options are used but `ssl_auth` is False
         if instance.get('ssl_auth') is False:
-            ssl_options = ['ssl_cipher_spec', 'ssl_key_repository_location']
             for option in ssl_options:
                 if instance.get(option):
                     self.log.warning(

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -131,21 +131,20 @@ class IBMMQConfig:
 
         # Implicitly enable SSL auth connection if SSL options are used and `ssl_auth` isn't set
         if instance.get('ssl_auth') is None:
-            for option in ssl_options:
-                if instance.get(option):
-                    self.log.info(
-                        "ssl_auth has not been explicitly enabled but other SSL options have been provided. "
-                        "SSL will be used for connecting"
-                    )
-                    self.ssl = True
+            if any([instance.get(o) for o in ssl_options]):
+                self.log.info(
+                    "`ssl_auth` has not been explicitly enabled but other SSL options have been provided. "
+                    "SSL will be used for connecting"
+                )
+                self.ssl = True
 
         # Explicitly disable SSL auth connection if SSL options are used but `ssl_auth` is False
         if instance.get('ssl_auth') is False:
-            for option in ssl_options:
-                if instance.get(option):
-                    self.log.warning(
-                        "'%s' has been provided but will be ignored since 'ssl_auth' is explicitly disabled", option
-                    )
+            if any([instance.get(o) for o in ssl_options]):
+                self.log.warning(
+                    "`ssl_auth` is explicitly disabled but SSL options are being used. "
+                    "SSL will not be used for connecting."
+                )
 
         self.mq_installation_dir = instance.get('mq_installation_dir', '/opt/mqm/')
 

--- a/ibm_mq/tests/test_config.py
+++ b/ibm_mq/tests/test_config.py
@@ -113,3 +113,56 @@ def test_min_properties_queue_tags_channel_status(instance, get_check, dd_run_ch
             dd_run_check(check)
         except Exception as e:
             AssertionError("`{}` contains empty mapping. Error is: {}".format(param, e))
+
+
+@pytest.mark.parametrize(
+    'ssl_explicit_disable, ssl_option, expected_ssl',
+    [
+        pytest.param(
+            False,
+            'ssl_cipher_spec',
+            True,
+            id="ssl_cipher_spec enabled, SSL implicitly enabled",
+        ),
+        pytest.param(
+            False,
+            'ssl_key_repository_location',
+            True,
+            id="ssl_key_repository_location enabled, SSL implicitly enabled",
+        ),
+        pytest.param(
+            False,
+            'ssl_certificate_label',
+            True,
+            id="ssl_certificate_label enabled, SSL implicitly enabled",
+        ),
+        pytest.param(
+            True,
+            'ssl_cipher_spec',
+            False,
+            id="ssl_cipher_spec enabled but ssl_auth disabled, SSL explicitly disabled",
+        ),
+        pytest.param(
+            True,
+            'ssl_key_repository_location',
+            False,
+            id="ssl_key_repository_location enabled but ssl_auth disabled, SSL explicitly disabled",
+        ),
+        pytest.param(
+            True,
+            'ssl_certificate_label',
+            False,
+            id="ssl_certificate_label enabled but ssl_auth disabled, SSL explicitly disabled",
+        ),
+    ],
+)
+def test_ssl_auth_implicit_enable(instance, ssl_explicit_disable, ssl_option, expected_ssl):
+    if ssl_explicit_disable:
+        instance['ssl_auth'] = False
+
+    # We only care that the option is enabled
+    instance[ssl_option] = "dummy_value"
+
+    config = IBMMQConfig(instance)
+
+    assert config.ssl == expected_ssl


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR does two things:
- Refactors the code determining if SSL should be enabled for the IBM MQ check.
- Adds `ssl_certificate_label` as an SSL config option used when determining SSL auth status.

### Motivation
<!-- What inspired you to submit this pull request? -->
Clarify when SSL is enabled.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
