### PR TITLE
Remove unnecessary `poll` method

### DIFF
--- a/vault/datadog_checks/vault/vault.py
+++ b/vault/datadog_checks/vault/vault.py
@@ -329,14 +329,6 @@ class Vault(OpenMetricsBaseCheck):
         with open(self._client_token_path, 'rb') as f:
             self.set_client_token(f.read().decode('utf-8'))
 
-    def poll(self, scraper_config, headers=None):
-        # https://www.vaultproject.io/api-docs#the-x-vault-request-header
-        headers = {'X-Vault-Request': 'true'}
-        if self._client_token and not self._no_token:
-            headers['X-Vault-Token'] = self._client_token
-
-        return super(Vault, self).poll(scraper_config, headers=headers)
-
     def _set_header(self, http_wrapper, header, value):
         http_wrapper.options['headers'][header] = value
 


### PR DESCRIPTION

### What does this PR do?

Removes `poll` method as it's redundant.

### Motivation

QA for #12776.

The headers are already being set on `parse_config` which also includes the logic to add the token to the header only if the `no_token` config is set to `false`. `poll` was overwriting the headers and therefore has duplicate logic.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
