### PR TITLE
Add entry for skipping QA in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,3 +13,4 @@
 - [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
 - [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
 - [ ] PR must have `changelog/` and `integration/` labels attached
+- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update the Github PR template to include using the `qa/skip-qa` label.

### Motivation
<!-- What inspired you to submit this pull request? -->
This label lets the release script directly skip labeled PRs from having trello cards generated rather than having a prompt.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Credit to @FlorentClarret for finding this in the script

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
