### PR TITLE
Fix sensitive client_secret config specification

### DIFF
--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -168,6 +168,7 @@ files:
           value:
             type: string
         - name: client_secret
+          secret: true
           required: true
           enabled: false
           description: |


### PR DESCRIPTION
### What does this PR do?
Fix the `client_secret` config option to mark the field as sensitive. 

### Motivation
QA https://github.com/DataDog/integrations-core/pull/12891

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
