### PR TITLE
Avoid assigning QA cards to the main reviewers

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -181,8 +181,7 @@ def pick_card_member(
         random.shuffle(team_members)
         card_assignments[team] = dict.fromkeys(team_members, 0)
 
-    potential_testers = [member for member in card_assignments[team] if
-                         member != author and member not in approvers]
+    potential_testers = [member for member in card_assignments[team] if member != author and member not in approvers]
 
     if not potential_testers:
         return None, None

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -181,10 +181,13 @@ def pick_card_member(
         random.shuffle(team_members)
         card_assignments[team] = dict.fromkeys(team_members, 0)
 
-    member = min(
-        [member for member in card_assignments[team] if member != author and member not in approvers],
-        key=card_assignments[team].get,
-    )
+    potential_testers = [member for member in card_assignments[team] if
+                         member != author and member not in approvers]
+
+    if not potential_testers:
+        return None, None
+
+    member = min(users, key=card_assignments[team].get)
     card_assignments[team][member] += 1
     return member, users[member]
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -12,7 +12,7 @@ from .....subprocess import SubprocessError, run_command
 from .....utils import get_next
 from ....config import APP_DIR
 from ....constants import CHANGELOG_LABEL_PREFIX, CHANGELOG_TYPE_NONE, get_root
-from ....github import get_pr, get_pr_from_hash, get_pr_labels, get_pr_milestone, parse_pr_number
+from ....github import get_pr, get_pr_approvers, get_pr_from_hash, get_pr_labels, get_pr_milestone, parse_pr_number
 from ....trello import TrelloClient
 from ....utils import format_commit_id
 from ...console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_waiting, echo_warning
@@ -34,6 +34,7 @@ def create_trello_card(
     pr_author: str,
     config: dict,
     card_assignments: dict,
+    pr_approvers: List[str] = None,
 ) -> None:
     labels = ', '.join(f'`{label}`' for label in sorted(pr_labels))
     body = f'''\
@@ -43,7 +44,7 @@ Labels: {labels}
 
 {pr_body}'''
     for team in teams:
-        tester_name, member = pick_card_member(config, pr_author, team.lower(), card_assignments)
+        tester_name, member = pick_card_member(config, pr_author, team.lower(), card_assignments, pr_approvers)
         if member is None:
             tester = _select_trello_tester(client, testerSelector, team, pr_author, pr_num, pr_url)
             if tester:
@@ -154,9 +155,11 @@ def get_commits_between(base_ref: str, target_ref: str, *, root: str) -> List[Tu
             raise click.Abort
 
 
-def pick_card_member(config: dict, author: str, team: str, card_assignments: dict) -> Tuple[Any, Any]:
+def pick_card_member(
+    config: dict, author: str, team: str, card_assignments: dict, approvers: List[str] = None
+) -> Tuple[Any, Any]:
     """Return a member to assign to the created issue.
-    In practice, it returns one trello user which is not the PR author, for the given team.
+    In practice, it returns one trello user which is not the PR author or an approver, for the given team.
     For it to work, you need a `trello_users_$team` table in your ddev configuration,
     with keys being github users and values being their corresponding trello IDs (not names).
 
@@ -165,6 +168,10 @@ def pick_card_member(config: dict, author: str, team: str, card_assignments: dic
         john = "xxxxxxxxxxxxxxxxxxxxx"
         alice = "yyyyyyyyyyyyyyyyyyyy"
     """
+
+    if approvers is None:
+        approvers = []
+
     users = config.get(f'trello_users_{team}')
     if not users:
         return None, None
@@ -174,7 +181,10 @@ def pick_card_member(config: dict, author: str, team: str, card_assignments: dic
         random.shuffle(team_members)
         card_assignments[team] = dict.fromkeys(team_members, 0)
 
-    member = min([member for member in card_assignments[team] if member != author], key=card_assignments[team].get)
+    member = min(
+        [member for member in card_assignments[team] if member != author and member not in approvers],
+        key=card_assignments[team].get,
+    )
     card_assignments[team][member] += 1
     return member, users[member]
 
@@ -388,6 +398,7 @@ def testable(
         pr_author = pr_data.get('user', {}).get('login', '')
         pr_body = pr_data.get('body', '')
         pr_num = pr_data.get('number', 0)
+        pr_approvers = get_pr_approvers(repo, pr_num, user_config)
 
         trello_config = user_config['trello']
         if not (trello_config['key'] and trello_config['token']):
@@ -410,6 +421,7 @@ def testable(
                 pr_author,
                 user_config,
                 card_assignments,
+                pr_approvers,
             )
             continue
 
@@ -483,6 +495,7 @@ def testable(
                     pr_author,
                     user_config,
                     card_assignments,
+                    pr_approvers,
                 )
 
             finished = True

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -181,9 +181,11 @@ def pick_card_member(
         random.shuffle(team_members)
         card_assignments[team] = dict.fromkeys(team_members, 0)
 
+    # try to find someone who did not approve the PR
     potential_testers = [member for member in card_assignments[team] if member != author and member not in approvers]
 
     if not potential_testers:
+        # try to find someone in the team, even if they approve
         potential_testers = [member for member in card_assignments[team] if member != author]
 
         if not potential_testers:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -34,7 +34,7 @@ def create_trello_card(
     pr_author: str,
     config: dict,
     card_assignments: dict,
-    pr_approvers: List[str] = None,
+    pr_approvers: Optional[List[str]] = None,
 ) -> None:
     labels = ', '.join(f'`{label}`' for label in sorted(pr_labels))
     body = f'''\
@@ -156,7 +156,7 @@ def get_commits_between(base_ref: str, target_ref: str, *, root: str) -> List[Tu
 
 
 def pick_card_member(
-    config: dict, author: str, team: str, card_assignments: dict, approvers: List[str] = None
+    config: dict, author: str, team: str, card_assignments: dict, approvers: Optional[List[str]] = None
 ) -> Tuple[Any, Any]:
     """Return a member to assign to the created issue.
     In practice, it returns one trello user which is not the PR author or an approver, for the given team.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/testable.py
@@ -184,9 +184,12 @@ def pick_card_member(
     potential_testers = [member for member in card_assignments[team] if member != author and member not in approvers]
 
     if not potential_testers:
-        return None, None
+        potential_testers = [member for member in card_assignments[team] if member != author]
 
-    member = min(users, key=card_assignments[team].get)
+        if not potential_testers:
+            return None, None
+
+    member = min(potential_testers, key=card_assignments[team].get)
     card_assignments[team][member] += 1
     return member, users[member]
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/github.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/github.py
@@ -4,7 +4,7 @@
 import os
 import re
 import time
-from typing import Optional
+from typing import List, Optional
 
 import requests
 
@@ -51,6 +51,14 @@ def get_tags(repo, config):
 
     response.raise_for_status()
     return response.json()
+
+
+def get_pr_approvers(repo: str, pr_id: str, config: dict) -> List[str]:
+    response = requests.get(
+        f'https://api.github.com/repos/DataDog/{repo}/pulls/{pr_id}/reviews', auth=get_auth_info(config)
+    )
+    response.raise_for_status()
+    return [review['user']['login'] for review in response.json() if review['state'] == "APPROVED"]
 
 
 def get_pr_labels(pr_payload):

--- a/datadog_checks_dev/tests/tooling/test_github.py
+++ b/datadog_checks_dev/tests/tooling/test_github.py
@@ -14,7 +14,10 @@ from datadog_checks.dev.tooling.github import get_pr_approvers
         ([], []),
         ([{"user": {"login": "user1"}, "state": "APPROVED"}], ["user1"]),
         ([{"user": {"login": "user1"}, "state": "PENDING"}], []),
-        ([{"user": {"login": "user1"}, "state": "APPROVED"}, {"user": {"login": "user2"}, "state": "PENDING"}], ["user1"]),
+        (
+            [{"user": {"login": "user1"}, "state": "APPROVED"}, {"user": {"login": "user2"}, "state": "PENDING"}],
+            ["user1"],
+        ),
     ],
 )
 def test_get_pr_approvers(github_response, expected_approvers):
@@ -24,8 +27,7 @@ def test_get_pr_approvers(github_response, expected_approvers):
     mock_response.json.return_value = github_response
 
     with mock.patch(
-            "requests.get",
-            return_value=mock_response,
+        "requests.get",
+        return_value=mock_response,
     ):
         assert get_pr_approvers("integrations-core", "42", {}) == expected_approvers
-

--- a/datadog_checks_dev/tests/tooling/test_github.py
+++ b/datadog_checks_dev/tests/tooling/test_github.py
@@ -1,0 +1,31 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import mock
+import pytest
+
+from datadog_checks.dev.tooling.github import get_pr_approvers
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    'github_response, expected_approvers',
+    [
+        ([], []),
+        ([{"user": {"login": "user1"}, "state": "APPROVED"}], ["user1"]),
+        ([{"user": {"login": "user1"}, "state": "PENDING"}], []),
+        ([{"user": {"login": "user1"}, "state": "APPROVED"}, {"user": {"login": "user2"}, "state": "PENDING"}], ["user1"]),
+    ],
+)
+def test_get_pr_approvers(github_response, expected_approvers):
+    mock_response = mock.MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {"Content-Type": "text/plain"}
+    mock_response.json.return_value = github_response
+
+    with mock.patch(
+            "requests.get",
+            return_value=mock_response,
+    ):
+        assert get_pr_approvers("integrations-core", "42", {}) == expected_approvers
+


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the `trello testable` command to:

1. Get the main reviewers of a PR. By main, I pick only the one who approved.
2. Avoid assigning the trello cards to the main reviewers.

### Motivation
<!-- What inspired you to submit this pull request? -->

Ideally, we should not QA a PR we already reviewed.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Not sure if `approvers` actually means something. Also, we could update the condition if you think we should not filter on the review status

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
