### PR TITLE
Emit service checks every time it reconnects, add metadata entrypoint

### DIFF
--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -63,6 +63,8 @@ class IbmDb2Check(AgentCheck):
         )
 
     def check(self, instance):
+        # The reason this connection is not cached between check runs is because in the event of the credentials
+        # becoming invalid DB2 would still consider the existing open connection to be a valid one.
         self._conn = self.get_connection()
         if self._conn is None:
             return

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -598,12 +598,10 @@ class IbmDb2Check(AgentCheck):
         except Exception as e:
             error = str(e)
             self.log.error("Error executing query: %s.\nAttempting to reconnect", error)
-            connection = self.get_connection()
-
-            if connection is None:
+            self._conn = self.get_connection()
+            if self._conn is None:
                 raise ConnectionError("Unable to create new connection")
 
-            self._conn = connection
             cursor = ibm_db.exec_immediate(self._conn, query)
 
         row = method(cursor)


### PR DESCRIPTION
QA for https://github.com/DataDog/integrations-core/pull/12736

There are two instances where this integration attempts connection:
* At the beginning of the check run
* In case of an error on the middle of the checkrun

I think both should emit a critical service check in case of failure so I moved the service check emitting inside the get_connection method.

Aside from that the metadata method was missing the entrypoint annotation that allows disabling the feature.