### PR TITLE
Emit critical service check when connection is lost

### DIFF
--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -63,6 +63,8 @@ class IbmDb2Check(AgentCheck):
         )
 
     def check(self, instance):
+        # The reason this connection is not cached between check runs is because in the event of the credentials
+        # becoming invalid DB2 would still consider the existing open connection to be a valid one.
         self._conn = self.get_connection()
         if self._conn is None:
             return

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -63,11 +63,10 @@ class IbmDb2Check(AgentCheck):
         )
 
     def check(self, instance):
-        # The reason this connection is not cached between check runs is because in the event of the credentials
-        # becoming invalid DB2 would still consider the existing open connection to be a valid one.
-        self._conn = self.get_connection()
         if self._conn is None:
-            return
+            self._conn = self.get_connection()
+            if self._conn is None:
+                return
 
         self.collect_metadata()
         for query_method in self._query_methods:

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -575,7 +575,6 @@ class IbmDb2Check(AgentCheck):
         else:
             self.service_check(self.SERVICE_CHECK_CONNECT, self.OK, tags=self._tags)
 
-
     @classmethod
     def get_connection_data(cls, db, username, password, host, port, security, tls_cert):
         if host:

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -65,7 +65,7 @@ class IbmDb2Check(AgentCheck):
     def check(self, instance):
         if self._conn is None:
             self._conn = self.get_connection()
-        self.emmit_connection_service_checks()
+        self.emit_connection_service_checks()
         if self._conn is None:
             return
 
@@ -564,7 +564,7 @@ class IbmDb2Check(AgentCheck):
             connection = None
         return connection
 
-    def emmit_connection_service_checks(self):
+    def emit_connection_service_checks(self):
         if self._conn is None:
             self.service_check(
                 self.SERVICE_CHECK_CONNECT,
@@ -602,7 +602,7 @@ class IbmDb2Check(AgentCheck):
             # ToDo: Probably the best strategy here would be to just set self._conn = None, abort the current check run
             # and retry on the next check run.
             self._conn = self.get_connection()
-            self.emmit_connection_service_checks()
+            self.emit_connection_service_checks()
             if self._conn is None:
                 raise ConnectionError("Unable to create new connection")
 

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -597,6 +597,8 @@ class IbmDb2Check(AgentCheck):
         except Exception as e:
             error = str(e)
             self.log.error("Error executing query: %s.\nAttempting to reconnect", error)
+            # ToDo: Probably the best strategy here would be to just set self._conn = None, abort the current check run
+            # and retry on the next check run.
             self._conn = self.get_connection()
             if self._conn is None:
                 raise ConnectionError("Unable to create new connection")

--- a/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
+++ b/ibm_db2/datadog_checks/ibm_db2/ibm_db2.py
@@ -598,12 +598,10 @@ class IbmDb2Check(AgentCheck):
         except Exception as e:
             error = str(e)
             self.log.error("Error executing query: %s.\nAttempting to reconnect", error)
-            connection = self.get_connection()
-
-            if connection is None:
+            self._conn = self.get_connection()
+            if self._conn is None:
                 raise ConnectionError("Unable to create new connection")
 
-            self._conn = connection
             cursor = ibm_db.exec_immediate(self._conn, query)
 
         row = method(cursor)

--- a/ibm_db2/tests/test_unit.py
+++ b/ibm_db2/tests/test_unit.py
@@ -62,6 +62,14 @@ def test_fails_to_reconnect(aggregator, instance):
     aggregator.assert_service_check(IbmDb2Check.SERVICE_CHECK_CONNECT, IbmDb2Check.CRITICAL)
 
 
+def test_ok_service_check_is_emitted_on_every_check_run(instance, aggregator):
+    ibmdb2 = IbmDb2Check('ibm_db2', {}, [instance])
+    ibmdb2._conn = mock.MagicMock()
+    with mock.patch('ibm_db.exec_immediate'):
+        ibmdb2.check(instance)
+    aggregator.assert_service_check(IbmDb2Check.SERVICE_CHECK_CONNECT, IbmDb2Check.OK)
+
+
 def test_query_function_error(aggregator, instance):
     exception_msg = (
         '[IBM][CLI Driver][DB2/NT64] SQL0440N  No authorized routine named "MON_GET_INSTANCE" of type '

--- a/ibm_db2/tests/test_unit.py
+++ b/ibm_db2/tests/test_unit.py
@@ -32,19 +32,34 @@ def test_retry_connection(aggregator, instance):
     ibmdb2 = IbmDb2Check('ibm_db2', {}, [instance])
     conn1 = mock.MagicMock()
     ibmdb2._conn = conn1
-    ibmdb2.get_connection = mock.MagicMock()
-
-    exception_msg = "[IBM][CLI Driver] CLI0106E  Connection is closed. SQLSTATE=08003"
 
     def mock_exception(*args, **kwargs):
-        raise ConnectionError(exception_msg)
+        raise ConnectionError("[IBM][CLI Driver] CLI0106E  Connection is closed. SQLSTATE=08003")
 
     with mock.patch('ibm_db.exec_immediate', side_effect=mock_exception):
-
-        with pytest.raises(ConnectionError, match='CLI0106E  Connection is closed. SQLSTATE=08003'):
-            ibmdb2.check(instance)
+        with mock.patch('ibm_db.connect', return_value=mock.MagicMock()):
+            with pytest.raises(ConnectionError, match='CLI0106E  Connection is closed. SQLSTATE=08003'):
+                ibmdb2.check(instance)
         # new connection made
         assert ibmdb2._conn != conn1
+    aggregator.assert_service_check(IbmDb2Check.SERVICE_CHECK_CONNECT, IbmDb2Check.OK)
+
+
+def test_fails_to_reconnect(aggregator, instance):
+    ibmdb2 = IbmDb2Check('ibm_db2', {}, [instance])
+    conn1 = mock.MagicMock()
+    ibmdb2._conn = conn1
+
+    def mock_exception(*args, **kwargs):
+        raise ConnectionError("[IBM][CLI Driver] CLI0106E  Connection is closed. SQLSTATE=08003")
+
+    with mock.patch('ibm_db.exec_immediate', side_effect=mock_exception):
+        with mock.patch('ibm_db.connect', side_effect=mock_exception):
+            with pytest.raises(ConnectionError, match='Unable to create new connection'):
+                ibmdb2.check(instance)
+        # new connection could not be made
+        assert ibmdb2._conn is None
+    aggregator.assert_service_check(IbmDb2Check.SERVICE_CHECK_CONNECT, IbmDb2Check.CRITICAL)
 
 
 def test_query_function_error(aggregator, instance):


### PR DESCRIPTION
QA for https://github.com/DataDog/integrations-core/pull/12736
The original PR addressed a customer concern about the integration keeping emitting an OK service check even if the integration was failing to connect and showing errors in the agent status. It did so by stopping to cache the connection all toghether.

There are two instances where this integration attempts to create a new connection:
* At the beginning of the check run
* In case of an error on the middle of the check run. In this case we were failing to both reassign the connection and emit a critical service check and this is the bug that is being fixed here.

This PR fixes the bug mentioned before and reverts the changes about connection caching done in the original PR.
Aside from that the metadata method was missing the entrypoint annotation that allows disabling the feature.