### PR TITLE
Honor ignore_databases in query metrics collection

### DIFF
--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -239,6 +239,9 @@ class PostgresStatementMetrics(DBMAsyncJob):
             if self._config.dbstrict:
                 filters = "AND pg_database.datname = %s"
                 params = (self._config.dbname,)
+            elif self._config.ignore_databases:
+                filters = " AND " + " AND ".join("pg_database.datname NOT ILIKE %s" for _ in self._config.ignore_databases)
+                params = params + tuple(self._config.ignore_databases)
             return self._execute_query(
                 self._check._get_db(self._config.dbname).cursor(cursor_factory=psycopg2.extras.DictCursor),
                 STATEMENTS_QUERY.format(

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -240,7 +240,9 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 filters = "AND pg_database.datname = %s"
                 params = (self._config.dbname,)
             elif self._config.ignore_databases:
-                filters = " AND " + " AND ".join("pg_database.datname NOT ILIKE %s" for _ in self._config.ignore_databases)
+                filters = " AND " + " AND ".join(
+                    "pg_database.datname NOT ILIKE %s" for _ in self._config.ignore_databases
+                )
                 params = params + tuple(self._config.ignore_databases)
             return self._execute_query(
                 self._check._get_db(self._config.dbname).cursor(cursor_factory=psycopg2.extras.DictCursor),

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -101,7 +101,7 @@ def test_statement_metrics_version(integration_check, dbm_instance, version, exp
             assert check.statement_metrics._payload_pg_version() == expected_payload_version
 
 
-@pytest.mark.parametrize("dbstrict", [True, False])
+@pytest.mark.parametrize("dbstrict,ignore_databases", [(True, []), (False, ['dogs']), (False, [])])
 @pytest.mark.parametrize("pg_stat_statements_view", ["pg_stat_statements", "datadog.pg_stat_statements()"])
 @pytest.mark.parametrize("track_io_timing_enabled", [True, False])
 def test_statement_metrics(
@@ -109,11 +109,13 @@ def test_statement_metrics(
     integration_check,
     dbm_instance,
     dbstrict,
+    ignore_databases,
     pg_stat_statements_view,
     datadog_agent,
     track_io_timing_enabled,
 ):
     dbm_instance['dbstrict'] = dbstrict
+    dbm_instance['ignore_databases'] = ignore_databases
     dbm_instance['pg_stat_statements_view'] = pg_stat_statements_view
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}
@@ -148,7 +150,7 @@ def test_statement_metrics(
             # cannot catch any queries from other users
             # only can see own queries
             return False
-        if dbstrict and dbname != dbm_instance['dbname']:
+        if dbstrict and dbname != dbm_instance['dbname'] or dbname in ignore_databases:
             return False
         return True
 


### PR DESCRIPTION
### What does this PR do?
This PR aims to address confusion that comes up related to inconsistent treatment the `ignore_databases` configuration: 
* Query samples/activity and core metrics honored the `ignore_databases` while query metrics collection ignored it.

### Motivation

### Additional Notes
I validated the performance and impact of this on our integration environment. Note that I tested this change along with https://github.com/DataDog/integrations-core/pull/12999 because they are both related to the same goal of reducing confusion regarding our data collection, going out at the same time. The material impact is that prior to both changes, query samples/activity was not collected on the default `postgres` database. With the two changes, they now are. And because query metric collection didn't honor the `ignore_databases` configuration before, query metrics on the default `postgres` database remains unchanged with the new default configuration. And, more importantly, when setting `collect_default_database` to false with this change, we now see that no query metrics are collected on the `postgres` database.

<img width="1527" alt="Screen Shot 2022-09-23 at 9 24 24 AM" src="https://user-images.githubusercontent.com/788439/192007760-f612bffd-46c5-463d-9d2a-37e84463256f.png">
<img width="1532" alt="Screen Shot 2022-09-23 at 9 24 32 AM" src="https://user-images.githubusercontent.com/788439/192007774-5dbb9a44-2091-4e01-8770-65421477f60b.png">
<img width="1526" alt="Screen Shot 2022-09-23 at 9 24 39 AM" src="https://user-images.githubusercontent.com/788439/192007785-eb1205ac-abfe-43f4-9a60-a8e3444ceee9.png">

Here's a clearer way to see the impact. This shows the different behavior of 7.39.0 vs the version with the changes with one deployment using the default config and another one setting `collect_default_database` to false. 
<img width="1006" alt="Screen Shot 2022-09-23 at 9 30 19 AM" src="https://user-images.githubusercontent.com/788439/192008817-1c9284d8-564f-4ea1-a940-23a31055b1ce.png">

<img width="987" alt="Screen Shot 2022-09-23 at 9 25 56 AM" src="https://user-images.githubusercontent.com/788439/192008068-3ce1554f-031b-4118-ac14-27f7b7be6f6a.png">
<img width="1022" alt="Screen Shot 2022-09-23 at 9 26 04 AM" src="https://user-images.githubusercontent.com/788439/192008077-1ee0932a-96e2-4bf1-b649-ae14a3d69265.png">


### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
