### PR TITLE
Change the path to the default log folder

### DIFF
--- a/impala/assets/configuration/spec.yaml
+++ b/impala/assets/configuration/spec.yaml
@@ -32,7 +32,7 @@ files:
       - template: logs
         example:
           - type: file
-            path: /opt/impala/logs/impalad.INFO
+            path: /var/log/impala/impalad.INFO
             source: impala
             tags:
               - service_type:daemon
@@ -41,7 +41,7 @@ files:
                 pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
                 name: new_log_start_with_log_level_and_date
           - type: file
-            path: /opt/impala/logs/impalad.WARNING
+            path: /var/log/impala/impalad.WARNING
             source: impala
             tags:
               - service_type:daemon
@@ -50,7 +50,7 @@ files:
                 pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
                 name: new_log_start_with_log_level_and_date
           - type: file
-            path: /opt/impala/logs/impalad.ERROR
+            path: /var/log/impala/impalad.ERROR
             source: impala
             tags:
               - service_type:daemon
@@ -59,7 +59,7 @@ files:
                 pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
                 name: new_log_start_with_log_level_and_date
           - type: file
-            path: /opt/impala/logs/impalad.FATAL
+            path: /var/log/impala/impalad.FATAL
             source: impala
             tags:
               - service_type:daemon
@@ -68,7 +68,7 @@ files:
                 pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
                 name: new_log_start_with_log_level_and_date
           - type: file
-            path: /opt/impala/logs/catalogd.INFO
+            path: /var/log/impala/catalogd.INFO
             source: impala
             tags:
               - service_type:catalog
@@ -77,7 +77,7 @@ files:
                 pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
                 name: new_log_start_with_log_level_and_date
           - type: file
-            path: /opt/impala/logs/catalogd.WARNING
+            path: /var/log/impala/catalogd.WARNING
             source: impala
             tags:
               - service_type:catalog
@@ -86,7 +86,7 @@ files:
                 pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
                 name: new_log_start_with_log_level_and_date
           - type: file
-            path: /opt/impala/logs/catalogd.ERROR
+            path: /var/log/impala/catalogd.ERROR
             source: impala
             tags:
               - service_type:catalog
@@ -95,7 +95,7 @@ files:
                 pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
                 name: new_log_start_with_log_level_and_date
           - type: file
-            path: /opt/impala/logs/catalogd.FATAL
+            path: /var/log/impala/catalogd.FATAL
             source: impala
             tags:
               - service_type:catalog
@@ -104,7 +104,7 @@ files:
                 pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
                 name: new_log_start_with_log_level_and_date
           - type: file
-            path: /opt/impala/logs/statestored.INFO
+            path: /var/log/impala/statestored.INFO
             source: impala
             tags:
               - service_type:statestore
@@ -113,7 +113,7 @@ files:
                 pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
                 name: new_log_start_with_log_level_and_date
           - type: file
-            path: /opt/impala/logs/statestored.WARNING
+            path: /var/log/impala/statestored.WARNING
             source: impala
             tags:
               - service_type:statestore
@@ -122,7 +122,7 @@ files:
                 pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
                 name: new_log_start_with_log_level_and_date
           - type: file
-            path: /opt/impala/logs/statestored.ERROR
+            path: /var/log/impala/statestored.ERROR
             source: impala
             tags:
               - service_type:statestore
@@ -131,7 +131,7 @@ files:
                 pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
                 name: new_log_start_with_log_level_and_date
           - type: file
-            path: /opt/impala/logs/statestored.FATAL
+            path: /var/log/impala/statestored.FATAL
             source: impala
             tags:
               - service_type:statestore

--- a/impala/datadog_checks/impala/data/conf.yaml.example
+++ b/impala/datadog_checks/impala/data/conf.yaml.example
@@ -646,7 +646,7 @@ instances:
 #
 # logs:
 #   - type: file
-#     path: /opt/impala/logs/impalad.INFO
+#     path: /var/log/impala/impalad.INFO
 #     source: impala
 #     tags:
 #     - service_type:daemon
@@ -655,7 +655,7 @@ instances:
 #       pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
 #       name: new_log_start_with_log_level_and_date
 #   - type: file
-#     path: /opt/impala/logs/impalad.WARNING
+#     path: /var/log/impala/impalad.WARNING
 #     source: impala
 #     tags:
 #     - service_type:daemon
@@ -664,7 +664,7 @@ instances:
 #       pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
 #       name: new_log_start_with_log_level_and_date
 #   - type: file
-#     path: /opt/impala/logs/impalad.ERROR
+#     path: /var/log/impala/impalad.ERROR
 #     source: impala
 #     tags:
 #     - service_type:daemon
@@ -673,7 +673,7 @@ instances:
 #       pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
 #       name: new_log_start_with_log_level_and_date
 #   - type: file
-#     path: /opt/impala/logs/impalad.FATAL
+#     path: /var/log/impala/impalad.FATAL
 #     source: impala
 #     tags:
 #     - service_type:daemon
@@ -682,7 +682,7 @@ instances:
 #       pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
 #       name: new_log_start_with_log_level_and_date
 #   - type: file
-#     path: /opt/impala/logs/catalogd.INFO
+#     path: /var/log/impala/catalogd.INFO
 #     source: impala
 #     tags:
 #     - service_type:catalog
@@ -691,7 +691,7 @@ instances:
 #       pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
 #       name: new_log_start_with_log_level_and_date
 #   - type: file
-#     path: /opt/impala/logs/catalogd.WARNING
+#     path: /var/log/impala/catalogd.WARNING
 #     source: impala
 #     tags:
 #     - service_type:catalog
@@ -700,7 +700,7 @@ instances:
 #       pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
 #       name: new_log_start_with_log_level_and_date
 #   - type: file
-#     path: /opt/impala/logs/catalogd.ERROR
+#     path: /var/log/impala/catalogd.ERROR
 #     source: impala
 #     tags:
 #     - service_type:catalog
@@ -709,7 +709,7 @@ instances:
 #       pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
 #       name: new_log_start_with_log_level_and_date
 #   - type: file
-#     path: /opt/impala/logs/catalogd.FATAL
+#     path: /var/log/impala/catalogd.FATAL
 #     source: impala
 #     tags:
 #     - service_type:catalog
@@ -718,7 +718,7 @@ instances:
 #       pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
 #       name: new_log_start_with_log_level_and_date
 #   - type: file
-#     path: /opt/impala/logs/statestored.INFO
+#     path: /var/log/impala/statestored.INFO
 #     source: impala
 #     tags:
 #     - service_type:statestore
@@ -727,7 +727,7 @@ instances:
 #       pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
 #       name: new_log_start_with_log_level_and_date
 #   - type: file
-#     path: /opt/impala/logs/statestored.WARNING
+#     path: /var/log/impala/statestored.WARNING
 #     source: impala
 #     tags:
 #     - service_type:statestore
@@ -736,7 +736,7 @@ instances:
 #       pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
 #       name: new_log_start_with_log_level_and_date
 #   - type: file
-#     path: /opt/impala/logs/statestored.ERROR
+#     path: /var/log/impala/statestored.ERROR
 #     source: impala
 #     tags:
 #     - service_type:statestore
@@ -745,7 +745,7 @@ instances:
 #       pattern: ^[IWEF]\d{4} (\d{2}:){2}\d{2}
 #       name: new_log_start_with_log_level_and_date
 #   - type: file
-#     path: /opt/impala/logs/statestored.FATAL
+#     path: /var/log/impala/statestored.FATAL
 #     source: impala
 #     tags:
 #     - service_type:statestore


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update the impala log default location

### Motivation
<!-- What inspired you to submit this pull request? -->
Pair QAing the new Impala integration with @yzhan289. `/opt/impala/logs` is used only in the test docker image. Default log location is `/var/log/impala`. More info [here](https://impala.apache.org/docs/build/html/topics/impala_logging.html)

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Already updated the RFC accordingly
Should be shipped with 7.40

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
