### PR TITLE
Collect logs in the e2e environment

### DIFF
--- a/impala/tests/compose/docker-compose.yaml
+++ b/impala/tests/compose/docker-compose.yaml
@@ -38,8 +38,7 @@ services:
     ports:
       # Web debug UI
       - "0.0.0.0:25020:25020"
-    command: ["-v=1",
-              "-hms_event_polling_interval_s=1", "-invalidate_tables_timeout_s=999999"]
+    command: ["-v=1", "-hms_event_polling_interval_s=1", "-invalidate_tables_timeout_s=999999"]
     volumes:
       # Warehouse directory. Catalog does file operations so needs access to the
       # shared volume.
@@ -63,8 +62,7 @@ services:
       - "0.0.0.0:25000:25000"
       # HS2 over HTTP endpoint.
       - "0.0.0.0:28000:28000"
-    command: [ "-v=1",
-              "-kudu_master_hosts=kudu-master-1:7051",
+    command: [ "-v=1", "-kudu_master_hosts=kudu-master-1:7051",
               "-mt_dop_auto_fallback=true",
               "-default_query_options=mt_dop=4,default_file_format=parquet,default_transactional_type=insert_only",
               "-mem_limit=4gb"]

--- a/impala/tests/compose/docker-compose.yaml
+++ b/impala/tests/compose/docker-compose.yaml
@@ -23,9 +23,10 @@ services:
     ports:
       # Web debug UI
       - "0.0.0.0:25010:25010"
-    command: ["-redirect_stdout_stderr=false", "-logtostderr", "-v=1"]
+    command: ["-v=1"]
     volumes:
       - ./conf:/opt/impala/conf:ro
+      - ${STATESTORED_LOG_FOLDER}:/opt/impala/logs
     networks:
       - impala-network
   catalogd:
@@ -37,13 +38,14 @@ services:
     ports:
       # Web debug UI
       - "0.0.0.0:25020:25020"
-    command: ["-redirect_stdout_stderr=false", "-logtostderr", "-v=1",
+    command: ["-v=1",
               "-hms_event_polling_interval_s=1", "-invalidate_tables_timeout_s=999999"]
     volumes:
       # Warehouse directory. Catalog does file operations so needs access to the
       # shared volume.
       - impala-warehouse:/user/hive/warehouse
       - ./conf:/opt/impala/conf:ro
+      - ${CATALOGD_LOG_FOLDER}:/opt/impala/logs
     networks:
       - impala-network
   impalad:
@@ -62,7 +64,6 @@ services:
       # HS2 over HTTP endpoint.
       - "0.0.0.0:28000:28000"
     command: [ "-v=1",
-              "-redirect_stdout_stderr=false", "-logtostderr",
               "-kudu_master_hosts=kudu-master-1:7051",
               "-mt_dop_auto_fallback=true",
               "-default_query_options=mt_dop=4,default_file_format=parquet,default_transactional_type=insert_only",
@@ -70,6 +71,7 @@ services:
     volumes:
       - impala-warehouse:/user/hive/warehouse
       - ./conf:/opt/impala/conf:ro
+      - ${IMPALAD_LOG_FOLDER}:/opt/impala/logs
     networks:
       - impala-network
 

--- a/impala/tests/conftest.py
+++ b/impala/tests/conftest.py
@@ -2,12 +2,14 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+from contextlib import ExitStack
 from unittest import mock
 
 import pytest
 
-from datadog_checks.dev import docker_run, get_docker_hostname, get_here
-from datadog_checks.dev.conditions import CheckDockerLogs
+from datadog_checks.dev import TempDir, docker_run, get_docker_hostname, get_here
+from datadog_checks.dev._env import get_state, save_state
+from datadog_checks.dev.conditions import CheckEndpoints
 from datadog_checks.impala import ImpalaCheck
 
 
@@ -20,43 +22,42 @@ def pytest_configure(config):
 @pytest.fixture(scope="session")
 def dd_environment():
     compose_file = os.path.join(get_here(), "compose", "docker-compose.yaml")
-    with docker_run(
-        compose_file=compose_file,
-        conditions=[
-            CheckDockerLogs(
-                identifier=compose_file,
-                patterns=[
-                    "Connected to metastore.",  # Statestore
-                    "Impala has started.",  # Daemon
-                    "CatalogService started",  # Catalog
-                ],
-                matches='all',
-                wait=5,
-                attempts=20,
-            )
-        ],
-        endpoints=[
-            f"http://{get_docker_hostname()}:25000/metrics_prometheus",  # Daemon
-            f"http://{get_docker_hostname()}:25010/metrics_prometheus",  # Statestore
-            f"http://{get_docker_hostname()}:25020/metrics_prometheus",  # Catalog
-        ],
-    ):
-        yield {
-            'instances': [
-                {
-                    "openmetrics_endpoint": f"http://{get_docker_hostname()}:25000/metrics_prometheus",
-                    "service_type": "daemon",
-                },
-                {
-                    "openmetrics_endpoint": f"http://{get_docker_hostname()}:25010/metrics_prometheus",
-                    "service_type": "statestore",
-                },
-                {
-                    "openmetrics_endpoint": f"http://{get_docker_hostname()}:25020/metrics_prometheus",
-                    "service_type": "catalog",
-                },
-            ]
-        }
+
+    with ExitStack() as stack:
+
+        save_state('logs_config', get_logs_config())
+
+        conditions = []
+
+        # daemon, statestore, catalog
+        for port in [25000, 25010, 25020]:
+            conditions.append(CheckEndpoints(f"http://{get_docker_hostname()}:{port}/metrics_prometheus", wait=10))
+
+        with docker_run(
+            compose_file=compose_file,
+            conditions=conditions,
+            env_vars={
+                "IMPALAD_LOG_FOLDER": create_log_volume(stack, "impalad"),
+                "CATALOGD_LOG_FOLDER": create_log_volume(stack, "catalogd"),
+                "STATESTORED_LOG_FOLDER": create_log_volume(stack, "statestored"),
+            },
+        ):
+            yield {
+                'instances': [
+                    {
+                        "openmetrics_endpoint": f"http://{get_docker_hostname()}:25000/metrics_prometheus",
+                        "service_type": "daemon",
+                    },
+                    {
+                        "openmetrics_endpoint": f"http://{get_docker_hostname()}:25010/metrics_prometheus",
+                        "service_type": "statestore",
+                    },
+                    {
+                        "openmetrics_endpoint": f"http://{get_docker_hostname()}:25020/metrics_prometheus",
+                        "service_type": "catalog",
+                    },
+                ]
+            }
 
 
 @pytest.fixture
@@ -115,3 +116,39 @@ def mock_metrics(request):
         ),
     ):
         yield
+
+
+def create_log_volume(stack, name):
+    docker_volumes = get_state('docker_volumes', [])
+    d = stack.enter_context(TempDir(name))
+    docker_volumes.append('{}:{}'.format(d, f"/var/log/{name}"))
+    save_state('docker_volumes', docker_volumes)
+    return d
+
+
+def get_logs_config():
+    config = []
+    for service in [
+        {"name": "impalad", "type": "daemon"},
+        {"name": "catalogd", "type": "catalog"},
+        {"name": "statestored", "type": "statestore"},
+    ]:
+        for level in ["WARNING", "ERROR", "INFO", "FATAL"]:
+            config.append(
+                {
+                    'type': 'file',
+                    'path': f'/var/log/{service["name"]}/{service["name"]}.{level}',
+                    'source': 'impala',
+                    'service': service["name"],
+                    'tags': [f'service_type:{service["type"]}'],
+                    'log_processing_rules': [
+                        {
+                            'type': 'multi_line',
+                            'pattern': '^[IWEF]\\d{4} (\\d{2}:){2}\\d{2}',
+                            'name': 'new_log_start_with_log_level_and_date',
+                        }
+                    ],
+                },
+            )
+
+    return config

--- a/impala/tests/conftest.py
+++ b/impala/tests/conftest.py
@@ -32,7 +32,7 @@ def dd_environment():
         compose_file=compose_file,
         conditions=conditions,
         wrappers=[create_log_volumes()],
-        sleep=5,
+        sleep=10,
     ):
 
         yield {
@@ -119,6 +119,7 @@ def create_log_volumes():
     with ExitStack() as stack:
         for service in ["impalad", "catalogd", "statestored"]:
             d = stack.enter_context(TempDir(service))
+            os.chmod(d, 0o777)
             docker_volumes.append(f'{d}:/var/log/{service}')
             env_vars[f"{service.upper()}_LOG_FOLDER"] = d
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Mount and collect the logs in the agent container to collect them.

### Motivation
<!-- What inspired you to submit this pull request? -->
The impala integration collects logs but the e2e was not configured to do so.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This needs some explanations:

1. Impala is composed of three different services: daemon, catalog and statestore
2. Each of those services generate 4 file, one per log level. For instance `impalad.c38ed8616270.invalid-user.log.ERROR.20220922-100840.1` and we can not predict the name of this file. Impala provide a symlink, `impalad.ERROR` in this case which references the latest log file. 
3. Impala writes directly to the destination log file and does not use the symlink. Because of that, if I use the `mount_logs=True` option, a 'impalad.INFO' file is created and we can not collect the logs, because the file is never opened by Impala.
4. Here what I do is that I mount the whole log folder from the three different services in the agent and manualy configure it to use this folder.

- To start the env: `ddev env start -a datadog/agent:7.40.0-rc.1 -o staging -e DD_LOGS_ENABLED=true impala py38-4.0.0`
- Example in staging: https://dd.datad0g.com/logs?cols=host%2Cservice&event&from_ts=1663840658530&index=&live=false&messageDisplay=inline&query=source%3Aimpala&stream_sort=time%2Cdesc&to_ts=1663840697660&viz=stream

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
