### PR TITLE
add missing debug tags for internal mysql run_explain metric

### DIFF
--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -828,7 +828,7 @@ class MySQLStatementSamples(DBMAsyncJob):
                     self._check.histogram(
                         "dd.mysql.run_explain.time",
                         (time.time() - start_time) * 1000,
-                        tags=self._tags + ["strategy:{}".format(strategy)],
+                        tags=self._tags + ["strategy:{}".format(strategy)] + self._check._get_debug_tags(),
                         hostname=self._check.resolved_hostname,
                     )
                     return plan, None


### PR DESCRIPTION
### What does this PR do?
These debug tags are expected to be present for all internal integration performance metrics. They were missing from this specific metric only.

### Motivation

Improve tagging of internal performance metrics.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
