### PR TITLE
Ensure X-Vault-Request header is set to `true` on all requests

### DIFF
--- a/vault/datadog_checks/vault/check.py
+++ b/vault/datadog_checks/vault/check.py
@@ -220,29 +220,24 @@ class VaultCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
             config['openmetrics_endpoint'] = self._metrics_url
             config['tags'] = list(self._tags)
 
-            if not self.config.no_token and self.config.client_token_path:
-                self.HTTP_CONFIG_REMAPPER = {
-                    'auth_token': {
-                        'name': 'auth_token',
-                        'default': {
-                            'reader': {'type': 'file', 'path': self.config.client_token_path},
-                            'writer': {'type': 'header', 'name': 'X-Vault-Token'},
-                        },
+            if not self.config.no_token:
+                if self.config.client_token_path:
+                    self.HTTP_CONFIG_REMAPPER = {
+                        'auth_token': {
+                            'name': 'auth_token',
+                            'default': {
+                                'reader': {'type': 'file', 'path': self.config.client_token_path},
+                                'writer': {'type': 'header', 'name': 'X-Vault-Token'},
+                            },
+                        }
                     }
-                }
+                if self.config.client_token:
+                    config.setdefault('headers', {})['X-Vault-Token'] = self.config.client_token
 
             self.scraper_configs.clear()
             self.scraper_configs.append(config)
 
         super().configure_scrapers()
-
-        # TODO How could we move this in the configure_scrapers method?
-        for scraper in self.scrapers.values():
-            if not self.config.no_token and self.config.client_token:
-                scraper.http.options['headers']['X-Vault-Token'] = self.config.client_token
-
-            # https://www.vaultproject.io/api-docs#the-x-vault-request-header
-            scraper.http.options['headers']['X-Vault-Request'] = 'true'
 
     def get_default_config(self):
         return {'metrics': construct_metrics_config(METRIC_MAP, {})}

--- a/vault/datadog_checks/vault/check.py
+++ b/vault/datadog_checks/vault/check.py
@@ -220,6 +220,9 @@ class VaultCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
             config['openmetrics_endpoint'] = self._metrics_url
             config['tags'] = list(self._tags)
 
+            # https://www.vaultproject.io/api-docs#the-x-vault-request-header
+            config.setdefault('headers', {})['X-Vault-Request'] = 'true'
+
             if not self.config.no_token:
                 if self.config.client_token_path:
                     self.HTTP_CONFIG_REMAPPER = {
@@ -232,7 +235,7 @@ class VaultCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
                         }
                     }
                 if self.config.client_token:
-                    config.setdefault('headers', {})['X-Vault-Token'] = self.config.client_token
+                    config['headers']['X-Vault-Token'] = self.config.client_token
 
             self.scraper_configs.clear()
             self.scraper_configs.append(config)

--- a/vault/datadog_checks/vault/check.py
+++ b/vault/datadog_checks/vault/check.py
@@ -42,6 +42,9 @@ class VaultCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
         # Might not be configured for metric collection
         self.scraper_configs.clear()
 
+        # https://www.vaultproject.io/api-docs#the-x-vault-request-header
+        self.http.options['headers']['X-Vault-Request'] = 'true'
+
         # Before scrapers are configured
         self.check_initializations.insert(-1, self.parse_config)
 


### PR DESCRIPTION
### What does this PR do?

Simplifies code by setting up the scraper configurator to pick up the header instead of setting it ad-hoc after configuration.

### Motivation

Found while QA'ing #12764.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
