### PR TITLE
Fix check failing when missing unnecessary SELECT grant on perf schema

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -168,6 +168,9 @@ class MySql(AgentCheck):
         return self.userstat_enabled
 
     def _check_events_wait_current_enabled(self, db):
+        if not self._config.dbm_enabled or not self._config.activity_config.get("enabled", True):
+            self.log.debug("skipping _check_events_wait_current_enabled because dbm activity collection is not enabled")
+            return
         if not self._check_performance_schema_enabled(db):
             self.log.debug('`performance_schema` is required to enable `events_waits_current`')
             return


### PR DESCRIPTION
### What does this PR do?
https://github.com/DataDog/integrations-core/pull/12343 introduced a method to validate that `events_waits_current` is an enabled consumer by doing a query on `performance_schema.setup_consumers`. This is fine for dbm users or the core integration users that have had to `grant select` on the performance_schema for core metrics collection but some users don't need to grant select on the performance schema because they don't use any features that require it otherwise. 

For those users, the mysql integration would break if that grant was missing. This PR addresses this by limiting the execution of that SELECT to find if `events_waits_current` is enabled only to users of dbm activity collection.

For reference, here's an example of the error users would have been getting before:
```
[ERROR]: [{"message": "(1142, u\"SELECT command denied to user 'datadog_user'@'localhost' for table 'setup_consumers'\")", "traceback": "Traceback (most recent call last):\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/base/checks/base.py\", line 1120, in run\n self.check(instance)\n File \"/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/mysql/mysql.py\", line 225, in check\n raise e\nOperationalError: (1142, u\"SELECT command denied to user 'datadog_user'@'localhost' for table 'setup_consumers'\")\n"}]
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
I validated this change by building the agent and testing end-to-end. I validated on a setup with the select grant missing and confirmed the behavior when dbm was disabled as well as dbm enabled with activity collection disabled. With this change, the new behavior is that the `_check_events_wait_current_enabled` is skipped and a debug statement is logged explaining why. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attachedd
