### PR TITLE
Don't set any default algorithm for `ssl_cipher_spec`

### DIFF
--- a/ibm_mq/assets/configuration/spec.yaml
+++ b/ibm_mq/assets/configuration/spec.yaml
@@ -214,10 +214,8 @@ files:
           type: boolean
           display_default: true
       - name: ssl_cipher_spec
-        type: string
         description: The ssl cipher to use. It should match the value of the channels SSLCIPH attribute.
         value:
-          example: 'TLS_RSA_WITH_AES_256_CBC_SHA'
           type: string
       - name: ssl_key_repository_location
         description: |

--- a/ibm_mq/assets/configuration/spec.yaml
+++ b/ibm_mq/assets/configuration/spec.yaml
@@ -214,7 +214,9 @@ files:
           type: boolean
           display_default: true
       - name: ssl_cipher_spec
-        description: The ssl cipher to use. It should match the value of the channels SSLCIPH attribute.
+        description: |
+          The TLS/SSL cipher to use. It should match the value of the channels SSLCIPH attribute. For an enumeration
+          see: https://www.ibm.com/docs/en/ibm-mq/9.3?topic=jms-tls-cipherspecs-ciphersuites-in-mq-classes
         value:
           type: string
       - name: ssl_key_repository_location

--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -121,7 +121,7 @@ class IBMMQConfig:
         # SSL options
         self.ssl = is_affirmative(instance.get('ssl_auth', False))  # type: bool
         self.try_basic_auth = is_affirmative(instance.get('try_basic_auth', True))  # type: bool
-        self.ssl_cipher_spec = instance.get('ssl_cipher_spec', 'TLS_RSA_WITH_AES_256_CBC_SHA')  # type: str
+        self.ssl_cipher_spec = instance.get('ssl_cipher_spec', '')  # type: str
         self.ssl_key_repository_location = instance.get(
             'ssl_key_repository_location', '/var/mqm/ssl-db/client/KeyringClient'
         )  # type: str

--- a/ibm_mq/datadog_checks/ibm_mq/config_models/defaults.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config_models/defaults.py
@@ -115,7 +115,7 @@ def instance_ssl_certificate_label(field, value):
 
 
 def instance_ssl_cipher_spec(field, value):
-    return 'TLS_RSA_WITH_AES_256_CBC_SHA'
+    return get_default_field_value(field, value)
 
 
 def instance_ssl_key_repository_location(field, value):

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -188,10 +188,10 @@ instances:
     #
     # try_basic_auth: false
 
-    ## @param ssl_cipher_spec - string - optional - default: TLS_RSA_WITH_AES_256_CBC_SHA
+    ## @param ssl_cipher_spec - string - optional
     ## The ssl cipher to use. It should match the value of the channels SSLCIPH attribute.
     #
-    # ssl_cipher_spec: TLS_RSA_WITH_AES_256_CBC_SHA
+    # ssl_cipher_spec: <SSL_CIPHER_SPEC>
 
     ## @param ssl_key_repository_location - string - optional - default: /var/mqm/ssl-db/client/KeyringClient
     ## It specifies the location of the key database file in which keys and certificates are stored.

--- a/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
+++ b/ibm_mq/datadog_checks/ibm_mq/data/conf.yaml.example
@@ -189,7 +189,8 @@ instances:
     # try_basic_auth: false
 
     ## @param ssl_cipher_spec - string - optional
-    ## The ssl cipher to use. It should match the value of the channels SSLCIPH attribute.
+    ## The TLS/SSL cipher to use. It should match the value of the channels SSLCIPH attribute. For an enumeration
+    ## see: https://www.ibm.com/docs/en/ibm-mq/9.3?topic=jms-tls-cipherspecs-ciphersuites-in-mq-classes
     #
     # ssl_cipher_spec: <SSL_CIPHER_SPEC>
 


### PR DESCRIPTION
### Motivation

None is desirable if TLS is not required, see https://github.com/dsuch/pymqi/blob/3c5453200ff5a3c2b1476e4fbb56b979eb378cf4/code/pymqi/__init__.py#L1604-L1608