### PR TITLE
Use workaround for labeler `sync-labels` bug

### DIFF
--- a/.github/workflows/labeler-reusable.yml
+++ b/.github/workflows/labeler-reusable.yml
@@ -18,4 +18,5 @@ jobs:
         with:
           configuration-path: .github/workflows/config/labeler.yml
           repo-token: "${{ secrets.repo-token }}"
-          sync-labels: "false"
+          sync-labels: ""   # workaround for sync-labels bug:
+                            # https://github.com/actions/labeler/issues/112#issuecomment-1000491676


### PR DESCRIPTION
### What does this PR do?
Sets config `sync-labels` to `""` in order to workaround bug in the labeler action.

https://github.com/actions/labeler/issues/112#issuecomment-1000491676

### Motivation
Fix PR labeler action from removing manually added labels. 

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
