### PR TITLE
Pass SSL related parameters when obtaining OAuth token

### DIFF
--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -174,6 +174,33 @@ files:
             The client secret.
           value:
             type: string
+        - name: tls_verify
+          value:
+            example: true
+            type: boolean
+          description: |
+            Instructs the check to validate the TLS certificate(s) of the service(s).
+        - name: tls_ca_cert
+          value:
+            example: <CA_CERT_PATH>
+            type: string
+          description: |
+            The path to a file of concatenated CA certificates in PEM format or a directory
+            containing several CA certificates in PEM format. If a directory, the directory
+            must have been processed using the c_rehash utility supplied with OpenSSL. See:
+            https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+
+            Setting this implicitly sets `tls_verify` to true.
+        - name: tls_cert
+          value:
+            example: <CERT_PATH>
+            type: string
+          description: |
+            The path to a single file in PEM format containing a certificate as well as any
+            number of CA certificates needed to establish the certificate's authenticity for
+            use when connecting to services. It may also contain an unencrypted private key to use.
+
+            Setting this implicitly sets `tls_verify` to true.    
       - template: instances/tls
       - name: tls_crlfile
         description: |

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
@@ -33,6 +33,9 @@ class SaslOauthTokenProvider(BaseModel):
 
     client_id: Optional[str]
     client_secret: Optional[str]
+    tls_ca_cert: Optional[str]
+    tls_cert: Optional[str]
+    tls_verify: Optional[bool]
     url: Optional[str]
 
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -157,6 +157,30 @@ instances:
         #
         # client_secret: <CLIENT_SECRET>
 
+        ## @param tls_verify - boolean - optional - default: true
+        ## Instructs the check to validate the TLS certificate(s) of the service(s).
+        #
+        # tls_verify: true
+
+        ## @param tls_ca_cert - string - optional
+        ## The path to a file of concatenated CA certificates in PEM format or a directory
+        ## containing several CA certificates in PEM format. If a directory, the directory
+        ## must have been processed using the c_rehash utility supplied with OpenSSL. See:
+        ## https://www.openssl.org/docs/manmaster/man3/SSL_CTX_load_verify_locations.html
+        ##
+        ## Setting this implicitly sets `tls_verify` to true.
+        #
+        # tls_ca_cert: <CA_CERT_PATH>
+
+        ## @param tls_cert - string - optional
+        ## The path to a single file in PEM format containing a certificate as well as any
+        ## number of CA certificates needed to establish the certificate's authenticity for
+        ## use when connecting to services. It may also contain an unencrypted private key to use.
+        ##
+        ## Setting this implicitly sets `tls_verify` to true.    
+        #
+        # tls_cert: <CERT_PATH>
+
     ## @param tls_verify - boolean - optional - default: true
     ## Instructs the check to validate the TLS certificate(s) of the service(s).
     #

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -9,11 +9,11 @@ from kafka.oauth.abstract import AbstractTokenProvider
 from six import string_types
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
-from datadog_checks.base.utils.http import AuthTokenOAuthReader
 
 from .constants import CONTEXT_UPPER_BOUND, DEFAULT_KAFKA_TIMEOUT
 from .legacy_0_10_2 import LegacyKafkaCheck_0_10_2
 from .new_kafka_consumer import NewKafkaConsumerCheck
+from .oauth_token_reader import AuthTokenOAuthReader
 
 
 class OAuthTokenProvider(AbstractTokenProvider):

--- a/kafka_consumer/datadog_checks/kafka_consumer/oauth_token_reader.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/oauth_token_reader.py
@@ -1,0 +1,83 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+from requests import auth as requests_auth
+from six import string_types
+
+from datadog_checks.base.config import is_affirmative
+from datadog_checks.base.errors import ConfigurationError
+from datadog_checks.base.utils.time import get_timestamp
+
+
+class AuthTokenOAuthReader(object):
+    def __init__(self, config):
+        self._url = config.get('url', '')
+        if not isinstance(self._url, str):
+            raise ConfigurationError('The `url` setting of `auth_token` reader must be a string')
+        elif not self._url:
+            raise ConfigurationError('The `url` setting of `auth_token` reader is required')
+
+        self._client_id = config.get('client_id', '')
+        if not isinstance(self._client_id, str):
+            raise ConfigurationError('The `client_id` setting of `auth_token` reader must be a string')
+        elif not self._client_id:
+            raise ConfigurationError('The `client_id` setting of `auth_token` reader is required')
+
+        self._client_secret = config.get('client_secret', '')
+        if not isinstance(self._client_secret, str):
+            raise ConfigurationError('The `client_secret` setting of `auth_token` reader must be a string')
+        elif not self._client_secret:
+            raise ConfigurationError('The `client_secret` setting of `auth_token` reader is required')
+
+        self._basic_auth = config.get('basic_auth', False)
+        if not isinstance(self._basic_auth, bool):
+            raise ConfigurationError('The `basic_auth` setting of `auth_token` reader must be a boolean')
+
+        self._fetch_options = {'token_url': self._url}
+        if self._basic_auth:
+            self._fetch_options['auth'] = requests_auth.HTTPBasicAuth(self._client_id, self._client_secret)
+        else:
+            self._fetch_options['client_id'] = self._client_id
+            self._fetch_options['client_secret'] = self._client_secret
+
+        if 'tls_ca_cert' in config:
+            if isinstance(config['tls_ca_cert'], string_types):
+                self._fetch_options['verify'] = config['tls_ca_cert']
+            else:
+                raise ConfigurationError('The `tls_ca_cert` setting of `auth_token` reader must be a string')
+        else:
+            self._fetch_options['verify'] = is_affirmative(config.get('tls_verify', True))
+
+        if 'tls_cert' in config:
+            if isinstance(config['tls_cert'], string_types):
+                self._fetch_options['cert'] = config['tls_cert']
+            else:
+                raise ConfigurationError('The `tls_cert` setting of `auth_token` reader must be a string')
+
+        self._token = None
+        self._expiration = None
+
+    def read(self, **request):
+        if self._token is None or get_timestamp() >= self._expiration or 'error' in request:
+            global oauth2
+            if oauth2 is None:
+                from oauthlib import oauth2
+
+            global requests_oauthlib
+            if requests_oauthlib is None:
+                import requests_oauthlib
+
+            client = oauth2.BackendApplicationClient(client_id=self._client_id)
+            oauth = requests_oauthlib.OAuth2Session(client=client)
+            response = oauth.fetch_token(**self._fetch_options)
+
+            # https://www.rfc-editor.org/rfc/rfc6749#section-5.2
+            if 'error' in response:
+                raise Exception('OAuth2 client credentials grant error: {}'.format(response['error']))
+
+            # https://www.rfc-editor.org/rfc/rfc6749#section-4.4.3
+            self._token = response['access_token']
+            self._expiration = get_timestamp() + response['expires_in']
+
+            return self._token

--- a/kafka_consumer/datadog_checks/kafka_consumer/oauth_token_reader.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/oauth_token_reader.py
@@ -60,13 +60,8 @@ class AuthTokenOAuthReader(object):
 
     def read(self, **request):
         if self._token is None or get_timestamp() >= self._expiration or 'error' in request:
-            global oauth2
-            if oauth2 is None:
-                from oauthlib import oauth2
-
-            global requests_oauthlib
-            if requests_oauthlib is None:
-                import requests_oauthlib
+            from oauthlib import oauth2
+            import requests_oauthlib
 
             client = oauth2.BackendApplicationClient(client_id=self._client_id)
             oauth = requests_oauthlib.OAuth2Session(client=client)


### PR DESCRIPTION
### What does this PR do?

It passes `tls_*` config parameters when making requests to obtain OAuth tokens.

It includes a modified copy of the `AuthTokenOAuthReader` class from the base package. I don't intend to merge this as is, but it should be a proof of concept before updating this directly in the base package.

### Motivation

Support case.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
