### PR TITLE
Fix collection of `fsyncLocked` metric when configured database is not `admin`

### DIFF
--- a/mongo/datadog_checks/mongo/collectors/fsynclock.py
+++ b/mongo/datadog_checks/mongo/collectors/fsynclock.py
@@ -6,9 +6,8 @@ class FsyncLockCollector(MongoCollector):
     """Collects the mongodb.fsyncLock metric by checking the output of the 'currentOp' command.
     Useful to know if the selected database is currently write-locked."""
 
-    def __init__(self, check, db_name, tags):
+    def __init__(self, check, tags):
         super(FsyncLockCollector, self).__init__(check, tags)
-        self.db_name = db_name
 
     def compatible_with(self, deployment):
         # Can be run on any mongod instance excepts arbiters.

--- a/mongo/datadog_checks/mongo/collectors/fsynclock.py
+++ b/mongo/datadog_checks/mongo/collectors/fsynclock.py
@@ -19,7 +19,7 @@ class FsyncLockCollector(MongoCollector):
         return True
 
     def collect(self, api):
-        db = api[self.db_name]
+        db = api['admin']
         ops = db.aggregate([{"$currentOp": {}}])
         for op in ops:
             payload = {'fsyncLocked': 1 if op.get('fsyncLock') else 0}

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -91,7 +91,7 @@ class MongoDb(AgentCheck):
         potential_collectors = [
             ConnPoolStatsCollector(self, tags),
             ReplicationOpLogCollector(self, tags),
-            FsyncLockCollector(self, self._config.db_name, tags),
+            FsyncLockCollector(self, tags),
             CollStatsCollector(self, self._config.db_name, tags, coll_names=self._config.coll_names),
             ServerStatusCollector(self, self._config.db_name, tags, tcmalloc=collect_tcmalloc_metrics),
         ]

--- a/mongo/tests/mocked_api.py
+++ b/mongo/tests/mocked_api.py
@@ -7,6 +7,8 @@ from mock import MagicMock
 
 from .common import HERE
 
+import pymongo.errors
+
 
 class MockedCollection(object):
     def __init__(self, db_name, coll_name):
@@ -45,7 +47,12 @@ class MockedDB(object):
     def __getitem__(self, coll_name):
         return MockedCollection(self._db_name, coll_name)
 
-    def aggregate(self, *_):
+    def aggregate(self, pipeline, **kwargs):
+        assert pipeline == [{"$currentOp": {}}], "Unexpected input to mocked DB method"
+
+        if self._db_name != "admin":
+            raise pymongo.errors.OperationFailure("$currentOp must be run against the 'admin' database with {aggregate: 1}")
+
         with open(os.path.join(HERE, "fixtures", "current_op"), 'r') as f:
             return json.load(f, object_hook=json_util.object_hook)
 

--- a/mongo/tests/mocked_api.py
+++ b/mongo/tests/mocked_api.py
@@ -2,12 +2,11 @@ import itertools
 import json
 import os
 
+import pymongo.errors
 from bson import Timestamp, json_util
 from mock import MagicMock
 
 from .common import HERE
-
-import pymongo.errors
 
 
 class MockedCollection(object):
@@ -51,7 +50,9 @@ class MockedDB(object):
         assert pipeline == [{"$currentOp": {}}], "Unexpected input to mocked DB method"
 
         if self._db_name != "admin":
-            raise pymongo.errors.OperationFailure("$currentOp must be run against the 'admin' database with {aggregate: 1}")
+            raise pymongo.errors.OperationFailure(
+                "$currentOp must be run against the 'admin' database with {aggregate: 1}"
+            )
 
         with open(os.path.join(HERE, "fixtures", "current_op"), 'r') as f:
             return json.load(f, object_hook=json_util.object_hook)

--- a/mongo/tests/test_e2e.py
+++ b/mongo/tests/test_e2e.py
@@ -58,7 +58,7 @@ MONGOD_METRICS = BASE_METRICS + [
 @standalone
 @pytest.mark.e2e
 def test_e2e_mongo_standalone(dd_agent_check):
-    instance = {'hosts': ['{}:{}'.format(HOST, PORT1)], 'username': 'testUser', 'password': 'testPass'}
+    instance = {'hosts': ['{}:{}'.format(HOST, PORT1)], 'database': 'test', 'username': 'testUser2', 'password': 'testPass2'}
     aggregator = dd_agent_check(instance, rate=True)
     for metric in MONGOD_METRICS:
         aggregator.assert_metric(metric)
@@ -79,6 +79,7 @@ def test_e2e_mongo_shard(dd_agent_check, instance_authdb):
 def test_e2e_mongo_auth(dd_agent_check):
     instance = {
         'hosts': ['{}:{}'.format(HOST, PORT1)],
+        'database': 'test',
         'username': 'testUser',
         'password': 'testPass',
         'options': {'authSource': 'authDB'},
@@ -94,6 +95,7 @@ def test_e2e_mongo_auth(dd_agent_check):
 def test_e2e_mongo_tls(dd_agent_check):
     instance = {
         'hosts': ['{}:{}'.format(HOST, PORT1)],
+        'database': 'test',
         'tls': True,
         'tls_allow_invalid_certificates': True,
         'tls_certificate_key_file': '/certs/client1.pem',

--- a/mongo/tests/test_e2e.py
+++ b/mongo/tests/test_e2e.py
@@ -57,9 +57,8 @@ MONGOD_METRICS = BASE_METRICS + [
 
 @standalone
 @pytest.mark.e2e
-def test_e2e_mongo_standalone(dd_agent_check):
-    instance = {'hosts': ['{}:{}'.format(HOST, PORT1)], 'database': 'test', 'username': 'testUser2', 'password': 'testPass2'}
-    aggregator = dd_agent_check(instance, rate=True)
+def test_e2e_mongo_standalone(dd_agent_check, instance_user):
+    aggregator = dd_agent_check(instance_user, rate=True)
     for metric in MONGOD_METRICS:
         aggregator.assert_metric(metric)
     aggregator.assert_service_check('mongodb.can_connect', status=MongoDb.OK)
@@ -76,15 +75,8 @@ def test_e2e_mongo_shard(dd_agent_check, instance_authdb):
 
 @auth
 @pytest.mark.e2e
-def test_e2e_mongo_auth(dd_agent_check):
-    instance = {
-        'hosts': ['{}:{}'.format(HOST, PORT1)],
-        'database': 'test',
-        'username': 'testUser',
-        'password': 'testPass',
-        'options': {'authSource': 'authDB'},
-    }
-    aggregator = dd_agent_check(instance, rate=True)
+def test_e2e_mongo_auth(dd_agent_check, instance_authdb):
+    aggregator = dd_agent_check(instance_authdb, rate=True)
     for metric in MONGOD_METRICS:
         aggregator.assert_metric(metric)
     aggregator.assert_service_check('mongodb.can_connect', status=MongoDb.OK)


### PR DESCRIPTION
### What does this PR do?

It forces `db.aggregate([{"$currentOp": {}}])` to be always called on the `admin` database regardless of what's configured. This is required as per [mongo's docs](https://www.mongodb.com/docs/manual/reference/operator/aggregation/currentOp/) (and also appears on the error message when you call it on an arbitrary database). This also matches the behavior that we had when we were using pymongo 3.x (as [that ran against `admin` under the hood](https://github.com/mongodb/mongo-python-driver/blob/ee262d680fc4ea369a4a982cf5a8f15a3aa9cddf/pymongo/database.py#L1129-L1131)).

### Motivation

Support case. An unexpected behavior change coming from updating from pymongo 3.x to 4.x.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
