### PR TITLE
Allow creating integrations with `--here` in an arbitrary folder

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -163,6 +163,8 @@ def create(ctx, name, integration_type, location, non_interactive, quiet, dry_ru
     "sales_email": "info@datadoghq.com"
   },"""
             else:
+                prompt_and_update_if_missing(template_fields, 'email', 'Email used for support requests')
+                prompt_and_update_if_missing(template_fields, 'author', 'Your name')
                 template_fields[
                     'author_info'
                 ] = f"""
@@ -206,3 +208,8 @@ def create(ctx, name, integration_type, location, non_interactive, quiet, dry_ru
     else:
         echo_info(f'Created in `{root}`:')
         display_path_tree(path_tree)
+
+
+def prompt_and_update_if_missing(mapping, field, prompt):
+    if mapping.get(field) is None:
+        mapping[field] = click.prompt(prompt)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -122,7 +122,7 @@ To install the {integration_name} check on your host:
         'license_header': license_header,
         'install_info': install_info,
         'repo_choice': repo_choice,
-        'repo_name': REPO_CHOICES[repo_choice],
+        'repo_name': REPO_CHOICES.get(repo_choice, ''),
         'support_type': support_type,
         'integration_links': integration_links,
     }


### PR DESCRIPTION
### What does this PR do?

It enables the creation of new integrations in arbitrary locations, by ensuring that all necessary fields are prompted for in a catch-all case.

### Motivation

It was reported internally that running `ddev --here create <INTEGRATION-NAME>` was failing, which I could confirm happens when running it in an arbitrary folder.

### Additional Notes

Was only tested manually.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
