### PR TITLE
[cockroachdb] Increase `max_returned_metrics` in test to get expected metric

### DIFF
--- a/cockroachdb/tests/conftest.py
+++ b/cockroachdb/tests/conftest.py
@@ -27,7 +27,7 @@ def dd_environment(instance):
 
 @pytest.fixture(scope='session')
 def instance_legacy():
-    return {'prometheus_url': 'http://{}:{}/_status/vars'.format(HOST, PORT)}
+    return {'prometheus_url': 'http://{}:{}/_status/vars'.format(HOST, PORT), 'max_returned_metrics': 20000}
 
 
 @pytest.fixture(scope='session')

--- a/cockroachdb/tests/test_cockroachdb.py
+++ b/cockroachdb/tests/test_cockroachdb.py
@@ -22,7 +22,6 @@ def test_integration(aggregator, instance_legacy, dd_run_check):
 @pytest.mark.integration
 @pytest.mark.usefixtures("dd_environment")
 def test_version_metadata(aggregator, instance_legacy, datadog_agent, dd_run_check):
-
     check_instance = CockroachdbCheck('cockroachdb', {}, [instance_legacy])
     check_instance.check_id = 'test:123'
     dd_run_check(check_instance)


### PR DESCRIPTION
It looks like the integration hits the default limit of 2000 metrics which results in not always getting the `cockroach.build.timestamp` metric that's used in a test to dynamically get the version.

### Motivation

Tests failing in CI.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
