### PR TITLE
Remove metrics limit from legacy version of the integration

### DIFF
--- a/cockroachdb/datadog_checks/cockroachdb/cockroachdb.py
+++ b/cockroachdb/datadog_checks/cockroachdb/cockroachdb.py
@@ -9,6 +9,9 @@ from .metrics import METRIC_MAP
 
 
 class CockroachdbCheck(OpenMetricsBaseCheck):
+
+    DEFAULT_METRIC_LIMIT = 0
+
     def __new__(cls, name, init_config, instances):
         instance = instances[0]
 

--- a/cockroachdb/tests/conftest.py
+++ b/cockroachdb/tests/conftest.py
@@ -27,7 +27,7 @@ def dd_environment(instance):
 
 @pytest.fixture(scope='session')
 def instance_legacy():
-    return {'prometheus_url': 'http://{}:{}/_status/vars'.format(HOST, PORT), 'max_returned_metrics': 20000}
+    return {'prometheus_url': 'http://{}:{}/_status/vars'.format(HOST, PORT)}
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
### What does this PR do?

### Motivation

Core integrations shouldn't have a limit.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
