### PR TITLE
[DOCS] Fix typo in SNMP metrics

### DIFF
--- a/snmp/metadata.csv
+++ b/snmp/metadata.csv
@@ -520,7 +520,7 @@ snmp.ltmVirtualServConnLimit,gauge,,,,[F5 BIG-IP] The maximum number of connecti
 snmp.ltmVirtualServStatClientPktsIn,rate,,,,[F5 BIG-IP] The number of packets received per second by a given virtual server.,0,snmp,,
 snmp.ltmVirtualServStatClientBytesIn,rate,,,,[F5 BIG-IP] The number of bytes received per second by a given virtual server.,0,snmp,,
 snmp.ltmVirtualServStatClientPktsOut,rate,,,,[F5 BIG-IP] The number of packets sent per second by a given virtual server.,0,snmp,,
-snmp.ltmVirtualServStatClientBytesOut,rate,,,,[F5 BIG-IP The number of bytes sent per second by a given virtual server.,0,snmp,,
+snmp.ltmVirtualServStatClientBytesOut,rate,,,,[F5 BIG-IP] The number of bytes sent per second by a given virtual server.,0,snmp,,
 snmp.ltmVirtualServStatNoNodesErrors,count,,,,[F5 BIG-IP] The total number of times the number of active nodes went to zero.,0,snmp,,
 snmp.ltmVirtualServStatClientTotConns,count,,,,[F5 BIG-IP] The total number of client connections on a given virtual server.,0,snmp,,
 snmp.ltmVirtualServStatTotRequests,count,,,,[F5 BIG-IP] The total number of requests on a given virtual server.,0,snmp,,


### PR DESCRIPTION
### What does this PR do?

Add missing closing bracket (`]`)

### Motivation

Typo originally mentioned here: https://github.com/DataDog/documentation/pull/15450 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
