### PR TITLE
Exclude loopback interface from ethtool

### DIFF
--- a/network/assets/configuration/spec.yaml
+++ b/network/assets/configuration/spec.yaml
@@ -148,6 +148,8 @@ files:
               The queue and cpu will be used as a tag when submitting metrics.
               For example, 'queue_0_tx_cnt' will be submitted as 'system.net.ena.queue.tx_cnt' with tag 'queue:0'
 
+              Loopback interfaces 'lo' and 'lo0' are excluded as they don't support SIOCETHTOOL.
+
               Currently supported drivers:
               - ena
               - virtio_net

--- a/network/datadog_checks/network/data/conf.yaml.default
+++ b/network/datadog_checks/network/data/conf.yaml.default
@@ -126,6 +126,8 @@ instances:
     ## The queue and cpu will be used as a tag when submitting metrics.
     ## For example, 'queue_0_tx_cnt' will be submitted as 'system.net.ena.queue.tx_cnt' with tag 'queue:0'
     ##
+    ## Loopback interfaces 'lo' and 'lo0' are excluded as they don't support SIOCETHTOOL.
+    ##
     ## Currently supported drivers:
     ## - ena
     ## - virtio_net

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -1064,6 +1064,10 @@ class Network(AgentCheck):
         if iface in self._excluded_ifaces or (self._exclude_iface_re and self._exclude_iface_re.match(iface)):
             # Skip this network interface.
             return
+        if iface in ['lo', 'lo0']:
+            # Skip loopback ifaces as they don't support SIOCETHTOOL
+            return
+
         driver_name, driver_version, ethtool_stats_names, ethtool_stats = self._fetch_ethtool_stats(iface)
         tags = [] if custom_tags is None else custom_tags[:]
         tags.append('driver_name:{}'.format(driver_name))


### PR DESCRIPTION
### What does this PR do?
Loopback interfaces don't support ethtool ioctl call and they are not gonna expose driver specific informations. 
Exclude them so that we don't generate error logs.

### Motivation
We want to avoid error logs. While they don't have an impact, they certainly are noisy.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
