### PR TITLE
Use variable groups on azure pipelines

### DIFF
--- a/.azure-pipelines/agent.yml
+++ b/.azure-pipelines/agent.yml
@@ -29,13 +29,21 @@ parameters:
   default: datadog/agent-dev:master-py2-win-servercore
 
 variables:
-  DDEV_E2E_AGENT: ${{ parameters.agent_image }}
-  DDEV_E2E_AGENT_PY2: ${{ parameters.agent_image_py2 }}
-  DDEV_E2E_AGENT_WIN: ${{ parameters.agent_windows_image }}
-  DDEV_E2E_AGENT_WIN_PY2: ${{ parameters.agent_windows_image_py2 }}
-  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
-  DDEV_COLOR: 1
-  DD_TRACE_AGENT_PORT: 8127
+  - group: core-variables
+  - name: DDEV_E2E_AGENT
+    value: ${{ parameters.agent_image }}
+  - name: DDEV_E2E_AGENT_PY2
+    value: ${{ parameters.agent_image_py2 }}
+  - name: DDEV_E2E_AGENT_WIN
+    value: ${{ parameters.agent_windows_image }}
+  - name: DDEV_E2E_AGENT_WIN_PY2
+    value: ${{ parameters.agent_windows_image_py2 }}
+  - name: PIP_CACHE_DIR
+    value: $(Pipeline.Workspace)/.cache/pip
+  - name: DDEV_COLOR
+    value: 1
+  - name: DD_TRACE_AGENT_PORT
+    value: 8127
 
 resources:
   containers:

--- a/.azure-pipelines/agent.yml
+++ b/.azure-pipelines/agent.yml
@@ -29,7 +29,7 @@ parameters:
   default: datadog/agent-dev:master-py2-win-servercore
 
 variables:
-  - group: core-variables
+  - template: './templates/common-variables.yml'
   - name: DDEV_E2E_AGENT
     value: ${{ parameters.agent_image }}
   - name: DDEV_E2E_AGENT_PY2
@@ -38,12 +38,6 @@ variables:
     value: ${{ parameters.agent_windows_image }}
   - name: DDEV_E2E_AGENT_WIN_PY2
     value: ${{ parameters.agent_windows_image_py2 }}
-  - name: PIP_CACHE_DIR
-    value: $(Pipeline.Workspace)/.cache/pip
-  - name: DDEV_COLOR
-    value: 1
-  - name: DD_TRACE_AGENT_PORT
-    value: 8127
 
 resources:
   containers:

--- a/.azure-pipelines/all_comment.yml
+++ b/.azure-pipelines/all_comment.yml
@@ -6,13 +6,7 @@ pr:
 trigger: none
 
 variables:
-  - group: core-variables
-  - name: PIP_CACHE_DIR
-    value: $(Pipeline.Workspace)/.cache/pip
-  - name: DDEV_COLOR
-    value: 1
-  - name: DD_TRACE_AGENT_PORT
-    value: 8127
+  - template: './templates/common-variables.yml'
 
 resources:
   containers:

--- a/.azure-pipelines/all_comment.yml
+++ b/.azure-pipelines/all_comment.yml
@@ -6,9 +6,13 @@ pr:
 trigger: none
 
 variables:
-  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
-  DDEV_COLOR: 1
-  DD_TRACE_AGENT_PORT: 8127
+  - group: core-variables
+  - name: PIP_CACHE_DIR
+    value: $(Pipeline.Workspace)/.cache/pip
+  - name: DDEV_COLOR
+    value: 1
+  - name: DD_TRACE_AGENT_PORT
+    value: 8127
 
 resources:
   containers:

--- a/.azure-pipelines/all_master.yml
+++ b/.azure-pipelines/all_master.yml
@@ -6,9 +6,13 @@ trigger:
 pr: none
 
 variables:
-  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
-  DDEV_COLOR: 1
-  DD_TRACE_AGENT_PORT: 8127
+  - group: core-variables
+  - name: PIP_CACHE_DIR
+    value: $(Pipeline.Workspace)/.cache/pip
+  - name: DDEV_COLOR
+    value: 1
+  - name: DD_TRACE_AGENT_PORT
+    value: 8127
 
 resources:
   containers:

--- a/.azure-pipelines/all_master.yml
+++ b/.azure-pipelines/all_master.yml
@@ -6,13 +6,7 @@ trigger:
 pr: none
 
 variables:
-  - group: core-variables
-  - name: PIP_CACHE_DIR
-    value: $(Pipeline.Workspace)/.cache/pip
-  - name: DDEV_COLOR
-    value: 1
-  - name: DD_TRACE_AGENT_PORT
-    value: 8127
+  - template: './templates/common-variables.yml'
 
 resources:
   containers:

--- a/.azure-pipelines/all_pr.yml
+++ b/.azure-pipelines/all_pr.yml
@@ -12,13 +12,7 @@ pr:
 trigger: none
 
 variables:
-  - group: core-variables
-  - name: PIP_CACHE_DIR
-    value: $(Pipeline.Workspace)/.cache/pip
-  - name: DDEV_COLOR
-    value: 1
-  - name: DD_TRACE_AGENT_PORT
-    value: 8127
+  - template: './templates/common-variables.yml'
 
 resources:
   containers:

--- a/.azure-pipelines/all_pr.yml
+++ b/.azure-pipelines/all_pr.yml
@@ -12,9 +12,13 @@ pr:
 trigger: none
 
 variables:
-  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
-  DDEV_COLOR: 1
-  DD_TRACE_AGENT_PORT: 8127
+  - group: core-variables
+  - name: PIP_CACHE_DIR
+    value: $(Pipeline.Workspace)/.cache/pip
+  - name: DDEV_COLOR
+    value: 1
+  - name: DD_TRACE_AGENT_PORT
+    value: 8127
 
 resources:
   containers:

--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -10,9 +10,13 @@ pr:
     - datadog_checks_dev/datadog_checks/dev/*.py
 
 variables:
-  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
-  DDEV_COLOR: 1
-  DD_TRACE_AGENT_PORT: 8127
+  - group: core-variables
+  - name: PIP_CACHE_DIR
+    value: $(Pipeline.Workspace)/.cache/pip
+  - name: DDEV_COLOR
+    value: 1
+  - name: DD_TRACE_AGENT_PORT
+    value: 8127
 
 resources:
   containers:

--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -10,13 +10,7 @@ pr:
     - datadog_checks_dev/datadog_checks/dev/*.py
 
 variables:
-  - group: core-variables
-  - name: PIP_CACHE_DIR
-    value: $(Pipeline.Workspace)/.cache/pip
-  - name: DDEV_COLOR
-    value: 1
-  - name: DD_TRACE_AGENT_PORT
-    value: 8127
+  - template: './templates/common-variables.yml'
 
 resources:
   containers:

--- a/.azure-pipelines/latest.yml
+++ b/.azure-pipelines/latest.yml
@@ -11,13 +11,7 @@ pr: none
 trigger: none
 
 variables:
-  - group: core-variables
-  - name: PIP_CACHE_DIR
-    value: $(Pipeline.Workspace)/.cache/pip
-  - name: DDEV_COLOR
-    value: 1
-  - name: DD_TRACE_AGENT_PORT
-    value: 8127
+  - template: './templates/common-variables.yml'
 
 resources:
   containers:

--- a/.azure-pipelines/latest.yml
+++ b/.azure-pipelines/latest.yml
@@ -11,9 +11,13 @@ pr: none
 trigger: none
 
 variables:
-  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
-  DDEV_COLOR: 1
-  DD_TRACE_AGENT_PORT: 8127
+  - group: core-variables
+  - name: PIP_CACHE_DIR
+    value: $(Pipeline.Workspace)/.cache/pip
+  - name: DDEV_COLOR
+    value: 1
+  - name: DD_TRACE_AGENT_PORT
+    value: 8127
 
 resources:
   containers:

--- a/.azure-pipelines/nightly_latest_base.yml
+++ b/.azure-pipelines/nightly_latest_base.yml
@@ -14,9 +14,13 @@ pr: none
 trigger: none
 
 variables:
-  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
-  DDEV_COLOR: 1
-  DD_TRACE_AGENT_PORT: 8127
+  - group: core-variables
+  - name: PIP_CACHE_DIR
+    value: $(Pipeline.Workspace)/.cache/pip
+  - name: DDEV_COLOR
+    value: 1
+  - name: DD_TRACE_AGENT_PORT
+    value: 8127
 
 resources:
   containers:

--- a/.azure-pipelines/nightly_latest_base.yml
+++ b/.azure-pipelines/nightly_latest_base.yml
@@ -14,13 +14,7 @@ pr: none
 trigger: none
 
 variables:
-  - group: core-variables
-  - name: PIP_CACHE_DIR
-    value: $(Pipeline.Workspace)/.cache/pip
-  - name: DDEV_COLOR
-    value: 1
-  - name: DD_TRACE_AGENT_PORT
-    value: 8127
+  - template: './templates/common-variables.yml'
 
 resources:
   containers:

--- a/.azure-pipelines/nightly_py2.yml
+++ b/.azure-pipelines/nightly_py2.yml
@@ -15,13 +15,7 @@ pr: none
 trigger: none
 
 variables:
-  - group: core-variables
-  - name: PIP_CACHE_DIR
-    value: $(Pipeline.Workspace)/.cache/pip
-  - name: DDEV_COLOR
-    value: 1
-  - name: DD_TRACE_AGENT_PORT
-    value: 8127
+  - template: './templates/common-variables.yml'
 
 resources:
   containers:

--- a/.azure-pipelines/nightly_py2.yml
+++ b/.azure-pipelines/nightly_py2.yml
@@ -15,9 +15,13 @@ pr: none
 trigger: none
 
 variables:
-  PIP_CACHE_DIR: $(Pipeline.Workspace)/.cache/pip
-  DDEV_COLOR: 1
-  DD_TRACE_AGENT_PORT: 8127
+  - group: core-variables
+  - name: PIP_CACHE_DIR
+    value: $(Pipeline.Workspace)/.cache/pip
+  - name: DDEV_COLOR
+    value: 1
+  - name: DD_TRACE_AGENT_PORT
+    value: 8127
 
 resources:
   containers:

--- a/.azure-pipelines/templates/common-variables.yml
+++ b/.azure-pipelines/templates/common-variables.yml
@@ -1,0 +1,8 @@
+variables:
+  - group: core-variables
+  - name: PIP_CACHE_DIR
+    value: $(Pipeline.Workspace)/.cache/pip
+  - name: DDEV_COLOR
+    value: 1
+  - name: DD_TRACE_AGENT_PORT
+    value: 8127


### PR DESCRIPTION
### What does this PR do?

Adds a reference to the `core-variables` variable group on Azure Pipelines to all of our pipelines so that we don't need to maintain secrets and variables individually for every pipeline. In the process, it also factors out all variables that are used in all pipelines to a separate template for reuse.

### Motivation

[AI-2094](https://datadoghq.atlassian.net/browse/AI-2094)

### Additional Notes

This change will only have an effect once the aforementioned variable group is properly populated and corresponding variables deleted from individual pipelines (needs to be done on the az's UI).

Reference:
- https://learn.microsoft.com/en-us/azure/devops/pipelines/library/variable-groups?view=azure-devops&tabs=yaml

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
