### PR TITLE
sqlserver/connection: always cast provided port to str

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -474,7 +474,7 @@ class Connection(object):
         if not host:
             return None
 
-        port = str(DEFAULT_CONN_PORT)
+        port = DEFAULT_CONN_PORT
         split_host, split_port = split_sqlserver_host_port(host)
         config_port = self.instance.get("port")
 
@@ -486,9 +486,9 @@ class Connection(object):
             int(port)
         except ValueError:
             self.log.warning("Invalid port %s; falling back to default 1433", port)
-            port = str(DEFAULT_CONN_PORT)
+            port = DEFAULT_CONN_PORT
 
-        return split_host + "," + port
+        return split_host + "," + str(port)
 
     def _conn_key(self, db_key, db_name=None, key_prefix=None):
         """Return a key to use for the connection cache"""

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -166,7 +166,12 @@ def test_will_fail_for_wrong_parameters_in_the_connection_string(instance_minima
 @pytest.mark.parametrize(
     'host, port, expected_host',
     [
-        pytest.param('1.2.3.4', '22', '1.2.3.4,22', id='if port provided as a config option, it should be recognized'),
+        pytest.param(
+            '1.2.3.4', 22, '1.2.3.4,22', id='if port provided as a config option as an int, it should be recognized'
+        ),
+        pytest.param(
+            '1.2.3.4', '22', '1.2.3.4,22', id='if port provided as a config option as a string, it should be recognized'
+        ),
         pytest.param('1.2.3.4', 'mcnugget', '1.2.3.4,1433', id='if port is not numeric, it should use default port'),
         pytest.param(
             '1.2.3.4,mcnugget',


### PR DESCRIPTION
### What does this PR do?
We received a [bug report](https://github.com/DataDog/integrations-core/issues/13051) that we are not properly casting customer-provided ports to a string. This fixes the issue by always casting the port to a string during string concatenation. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
