### PR TITLE
Revert "pin tagger image (#12943)"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,6 @@
 variables:
   REMINDER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/integrations-core:reminder
   TAGGER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/integrations-core:tagger
-  TAGGER_IMAGE_SHA: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/integrations-core:tagger@sha256:5f9cd17c4af0007cf8e9a72dd8880b65a43d3948dec59ccdc87df437b133bd18
   VALIDATE_LOG_INTGS: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/integrations-core:validate_log_intgs
   VALIDATE_AGENT_BUILD: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/integrations-core:validate_agent_build
   NOTIFIER_IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/slack-notifier:latest
@@ -177,7 +176,7 @@ notify-failed-pipeline:
 
 release-auto:
   stage: release
-  image: $TAGGER_IMAGE_SHA
+  image: $TAGGER_IMAGE
   only:
     - master
   except:
@@ -191,7 +190,7 @@ release-auto:
 
 release-manual:
   stage: release
-  image: $TAGGER_IMAGE_SHA
+  image: $TAGGER_IMAGE
   only:
     # Integration release tags e.g. any_check-X.Y.Z-rc.N
     - /.*-\d+\.\d+\.\d+(-(rc|pre|alpha|beta)\.\d+)?$/


### PR DESCRIPTION
### What does this PR do?
This reverts commit 99ab510798257730b1a2b0373f32a21bc0afec65
 
### Motivation
After https://github.com/DataDog/integrations-core/pull/12956, we can rely on the latest tagger image since we know the dependencies are pinned to the correct ones

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.