### PR TITLE
Add unit tests in case no running apps are found

### DIFF
--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -1106,7 +1106,9 @@ def test_do_not_crash_on_single_app_failure():
 )
 def test_no_running_apps(aggregator, dd_run_check, instance, service_check):
     with mock.patch('requests.get', return_value=MockResponse("{}")):
-        dd_run_check(SparkCheck('spark', {}, [instance]))
+        check = SparkCheck('spark', {}, [instance])
+        check.log = mock.MagicMock()
+        dd_run_check(check)
 
         # no metrics sent in this case
         aggregator.assert_all_metrics_covered()
@@ -1115,6 +1117,7 @@ def test_no_running_apps(aggregator, dd_run_check, instance, service_check):
             status=SparkCheck.OK,
             tags=['url:{}'.format(instance['spark_url'])] + CLUSTER_TAGS + instance.get('tags', []),
         )
+        check.log.warning.assert_called_once_with('No running apps found. No metrics will be collected.')
 
 
 class StandaloneAppsResponseHandler(BaseHTTPServer.BaseHTTPRequestHandler):

--- a/spark/tests/test_spark.py
+++ b/spark/tests/test_spark.py
@@ -56,8 +56,8 @@ TEST_PASSWORD = 'password'
 
 CUSTOM_TAGS = ['optional:tag1']
 COMMON_TAGS = [
-                  'app_name:' + APP_NAME,
-              ] + CLUSTER_TAGS
+    'app_name:' + APP_NAME,
+] + CLUSTER_TAGS
 
 
 def join_url_dir(url, *args):
@@ -405,11 +405,11 @@ SPARK_JOB_RUNNING_METRIC_VALUES = {
 }
 
 SPARK_JOB_RUNNING_METRIC_TAGS = [
-                                    'status:running',
-                                    'job_id:0',
-                                    'stage_id:0',
-                                    'stage_id:1',
-                                ] + COMMON_TAGS
+    'status:running',
+    'job_id:0',
+    'stage_id:0',
+    'stage_id:1',
+] + COMMON_TAGS
 
 SPARK_JOB_SUCCEEDED_METRIC_VALUES = {
     'spark.job.count': 3,
@@ -425,11 +425,11 @@ SPARK_JOB_SUCCEEDED_METRIC_VALUES = {
 }
 
 SPARK_JOB_SUCCEEDED_METRIC_TAGS = [
-                                      'status:succeeded',
-                                      'job_id:0',
-                                      'stage_id:0',
-                                      'stage_id:1',
-                                  ] + COMMON_TAGS
+    'status:succeeded',
+    'job_id:0',
+    'stage_id:0',
+    'stage_id:1',
+] + COMMON_TAGS
 
 SPARK_STAGE_RUNNING_METRIC_VALUES = {
     'spark.stage.count': 3,
@@ -450,9 +450,9 @@ SPARK_STAGE_RUNNING_METRIC_VALUES = {
 }
 
 SPARK_STAGE_RUNNING_METRIC_TAGS = [
-                                      'status:running',
-                                      'stage_id:1',
-                                  ] + COMMON_TAGS
+    'status:running',
+    'stage_id:1',
+] + COMMON_TAGS
 
 SPARK_STAGE_COMPLETE_METRIC_VALUES = {
     'spark.stage.count': 2,
@@ -473,9 +473,9 @@ SPARK_STAGE_COMPLETE_METRIC_VALUES = {
 }
 
 SPARK_STAGE_COMPLETE_METRIC_TAGS = [
-                                       'status:complete',
-                                       'stage_id:0',
-                                   ] + COMMON_TAGS
+    'status:complete',
+    'stage_id:0',
+] + COMMON_TAGS
 
 SPARK_DRIVER_METRIC_VALUES = {
     'spark.driver.rdd_blocks': 99,
@@ -524,8 +524,8 @@ SPARK_EXECUTOR_LEVEL_METRIC_VALUES = {
 }
 
 SPARK_EXECUTOR_LEVEL_METRIC_TAGS = [
-                                       'executor_id:1',
-                                   ] + COMMON_TAGS
+    'executor_id:1',
+] + COMMON_TAGS
 
 SPARK_RDD_METRIC_VALUES = {
     'spark.rdd.count': 1,
@@ -1024,7 +1024,7 @@ def test_disable_legacy_cluster_tags(aggregator, dd_run_check):
     ids=["driver", "yarn", "mesos", "standalone", "standalone_pre_20"],
 )
 def test_enable_query_name_tag_for_structured_streaming(
-        aggregator, dd_run_check, instance, requests_get_mock, base_tags
+    aggregator, dd_run_check, instance, requests_get_mock, base_tags
 ):
     instance['enable_query_name_tag'] = True
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add unit tests in case no running apps are found.

### Motivation
<!-- What inspired you to submit this pull request? -->

Saw the test were missing working on https://github.com/DataDog/integrations-core/pull/13067

### Additional Notes
<!-- Anything else we should know when reviewing? -->

@alopezz: The service check is submitted during the `_get_running_apps` call. For example https://github.com/DataDog/integrations-core/blob/master/spark/datadog_checks/spark/spark.py#L263-L268

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.