### PR TITLE
Remove the legacy docker-compose

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/conditions.py
+++ b/datadog_checks_dev/datadog_checks/dev/conditions.py
@@ -13,7 +13,7 @@ from six.moves.urllib.request import urlopen
 from .errors import RetryError
 from .structures import LazyFunction
 from .subprocess import run_command
-from .utils import file_exists, using_legacy_docker_compose
+from .utils import file_exists
 
 
 class WaitFor(LazyFunction):
@@ -204,10 +204,7 @@ class CheckDockerLogs(CheckCommandOutput):
         :param wait: How long, in seconds, to wait between attempts
         """
         if file_exists(identifier):
-            if using_legacy_docker_compose():
-                command = ['docker-compose', '-f', identifier, 'logs']
-            else:
-                command = ['docker', 'compose', '-f', identifier, 'logs']
+            command = ['docker', 'compose', '-f', identifier, 'logs']
         else:
             command = ['docker', 'logs', identifier]
 

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -14,7 +14,7 @@ from .fs import create_file, file_exists
 from .spec import load_spec
 from .structures import EnvVars, LazyFunction, TempDir
 from .subprocess import run_command
-from .utils import find_check_root, using_legacy_docker_compose
+from .utils import find_check_root
 
 try:
     from contextlib import ExitStack
@@ -48,20 +48,10 @@ def compose_file_active(compose_file):
     """
     Returns a `bool` indicating whether or not a compose file has any active services.
     """
-    if using_legacy_docker_compose():
-        command = ['docker-compose', '-f', compose_file, 'ps']
-        lines = run_command(command, capture='out', check=True).stdout.splitlines()
+    command = ['docker', 'compose', '--compatibility', '-f', compose_file, 'ps']
+    lines = run_command(command, capture='out', check=True).stdout.strip().splitlines()
 
-        for i, line in enumerate(lines, 1):
-            if set(line.strip()) == {'-'}:
-                return len(lines[i:]) >= 1
-
-        return False
-    else:
-        command = ['docker', 'compose', '--compatibility', '-f', compose_file, 'ps']
-        lines = run_command(command, capture='out', check=True).stdout.strip().splitlines()
-
-        return len(lines) > 1
+    return len(lines) > 1
 
 
 def using_windows_containers():
@@ -230,10 +220,7 @@ class ComposeFileUp(LazyFunction):
         self.compose_file = compose_file
         self.build = build
         self.service_name = service_name
-        if using_legacy_docker_compose():
-            self.command = ['docker-compose', '-f', self.compose_file, 'up', '-d']
-        else:
-            self.command = ['docker', 'compose', '--compatibility', '-f', self.compose_file, 'up', '-d']
+        self.command = ['docker', 'compose', '--compatibility', '-f', self.compose_file, 'up', '-d']
 
         if self.build:
             self.command.append('--build')
@@ -249,10 +236,7 @@ class ComposeFileLogs(LazyFunction):
     def __init__(self, compose_file, check=True):
         self.compose_file = compose_file
         self.check = check
-        if using_legacy_docker_compose():
-            self.command = ['docker-compose', '-f', self.compose_file, 'logs']
-        else:
-            self.command = ['docker', 'compose', '--compatibility', '-f', self.compose_file, 'logs']
+        self.command = ['docker', 'compose', '--compatibility', '-f', self.compose_file, 'logs']
 
     def __call__(self, exception):
         return run_command(self.command, capture=False, check=self.check)
@@ -262,30 +246,18 @@ class ComposeFileDown(LazyFunction):
     def __init__(self, compose_file, check=True):
         self.compose_file = compose_file
         self.check = check
-        if using_legacy_docker_compose():
-            self.command = [
-                'docker-compose',
-                '-f',
-                self.compose_file,
-                'down',
-                '--volumes',
-                '--remove-orphans',
-                '-t',
-                '0',
-            ]
-        else:
-            self.command = [
-                'docker',
-                'compose',
-                '--compatibility',
-                '-f',
-                self.compose_file,
-                'down',
-                '--volumes',
-                '--remove-orphans',
-                '-t',
-                '0',
-            ]
+        self.command = [
+            'docker',
+            'compose',
+            '--compatibility',
+            '-f',
+            self.compose_file,
+            'down',
+            '--volumes',
+            '--remove-orphans',
+            '-t',
+            '0',
+        ]
 
     def __call__(self):
         return run_command(self.command, check=self.check)
@@ -305,12 +277,8 @@ def _read_example_logs_config(check_root):
 @contextmanager
 def temporarily_stop_service(service, compose_file, check=True):
     # type: (str, str, bool) -> Iterator[None]
-    if using_legacy_docker_compose():
-        stop_command = ['docker-compose', '-f', compose_file, 'stop', service]
-        start_command = ['docker-compose', '-f', compose_file, 'start', service]
-    else:
-        stop_command = ['docker', 'compose', '--compatibility', '-f', compose_file, 'stop', service]
-        start_command = ['docker', 'compose', '--compatibility', '-f', compose_file, 'start', service]
+    stop_command = ['docker', 'compose', '--compatibility', '-f', compose_file, 'stop', service]
+    start_command = ['docker', 'compose', '--compatibility', '-f', compose_file, 'start', service]
 
     run_command(stop_command, capture=False, check=check)
     yield

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -48,7 +48,7 @@ def compose_file_active(compose_file):
     """
     Returns a `bool` indicating whether or not a compose file has any active services.
     """
-    command = ['docker', 'compose', '--compatibility', '-f', compose_file, 'ps']
+    command = ['docker', 'compose', '-f', compose_file, 'ps']
     lines = run_command(command, capture='out', check=True).stdout.strip().splitlines()
 
     return len(lines) > 1
@@ -220,7 +220,7 @@ class ComposeFileUp(LazyFunction):
         self.compose_file = compose_file
         self.build = build
         self.service_name = service_name
-        self.command = ['docker', 'compose', '--compatibility', '-f', self.compose_file, 'up', '-d']
+        self.command = ['docker', 'compose', '-f', self.compose_file, 'up', '-d']
 
         if self.build:
             self.command.append('--build')
@@ -236,7 +236,7 @@ class ComposeFileLogs(LazyFunction):
     def __init__(self, compose_file, check=True):
         self.compose_file = compose_file
         self.check = check
-        self.command = ['docker', 'compose', '--compatibility', '-f', self.compose_file, 'logs']
+        self.command = ['docker', 'compose', '-f', self.compose_file, 'logs']
 
     def __call__(self, exception):
         return run_command(self.command, capture=False, check=self.check)
@@ -249,7 +249,6 @@ class ComposeFileDown(LazyFunction):
         self.command = [
             'docker',
             'compose',
-            '--compatibility',
             '-f',
             self.compose_file,
             'down',
@@ -277,8 +276,8 @@ def _read_example_logs_config(check_root):
 @contextmanager
 def temporarily_stop_service(service, compose_file, check=True):
     # type: (str, str, bool) -> Iterator[None]
-    stop_command = ['docker', 'compose', '--compatibility', '-f', compose_file, 'stop', service]
-    start_command = ['docker', 'compose', '--compatibility', '-f', compose_file, 'start', service]
+    stop_command = ['docker', 'compose', '-f', compose_file, 'stop', service]
+    start_command = ['docker', 'compose', '-f', compose_file, 'start', service]
 
     run_command(stop_command, capture=False, check=check)
     yield

--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -48,7 +48,7 @@ def compose_file_active(compose_file):
     """
     Returns a `bool` indicating whether or not a compose file has any active services.
     """
-    command = ['docker', 'compose', '-f', compose_file, 'ps']
+    command = ['docker', 'compose', '--compatibility', '-f', compose_file, 'ps']
     lines = run_command(command, capture='out', check=True).stdout.strip().splitlines()
 
     return len(lines) > 1
@@ -220,7 +220,7 @@ class ComposeFileUp(LazyFunction):
         self.compose_file = compose_file
         self.build = build
         self.service_name = service_name
-        self.command = ['docker', 'compose', '-f', self.compose_file, 'up', '-d']
+        self.command = ['docker', 'compose', '--compatibility', '-f', self.compose_file, 'up', '-d']
 
         if self.build:
             self.command.append('--build')
@@ -236,7 +236,7 @@ class ComposeFileLogs(LazyFunction):
     def __init__(self, compose_file, check=True):
         self.compose_file = compose_file
         self.check = check
-        self.command = ['docker', 'compose', '-f', self.compose_file, 'logs']
+        self.command = ['docker', 'compose', '--compatibility', '-f', self.compose_file, 'logs']
 
     def __call__(self, exception):
         return run_command(self.command, capture=False, check=self.check)
@@ -249,6 +249,7 @@ class ComposeFileDown(LazyFunction):
         self.command = [
             'docker',
             'compose',
+            '--compatibility',
             '-f',
             self.compose_file,
             'down',
@@ -276,8 +277,8 @@ def _read_example_logs_config(check_root):
 @contextmanager
 def temporarily_stop_service(service, compose_file, check=True):
     # type: (str, str, bool) -> Iterator[None]
-    stop_command = ['docker', 'compose', '-f', compose_file, 'stop', service]
-    start_command = ['docker', 'compose', '-f', compose_file, 'start', service]
+    stop_command = ['docker', 'compose', '--compatibility', '-f', compose_file, 'stop', service]
+    start_command = ['docker', 'compose', '--compatibility', '-f', compose_file, 'start', service]
 
     run_command(stop_command, capture=False, check=check)
     yield

--- a/datadog_checks_dev/datadog_checks/dev/utils.py
+++ b/datadog_checks_dev/datadog_checks/dev/utils.py
@@ -30,10 +30,6 @@ def get_active_env():
     return os.environ.get('TOX_ENV_NAME') or os.environ['HATCH_ENV_ACTIVE']
 
 
-def using_legacy_docker_compose():
-    return os.environ.get('LEGACY_DOCKER_COMPOSE', 'false') == 'true'
-
-
 def ensure_bytes(s):
     if not isinstance(s, bytes):
         s = s.encode('utf-8')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove the legacy docker-compose.

### Motivation
<!-- What inspired you to submit this pull request? -->

https://datadoghq.atlassian.net/browse/AITOOLS-65

We do not use `docker-compose` anymore.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.