### PR TITLE
Use specific endpoint to get all members from trello board at once

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_trello_user_matcher.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/github_trello_user_matcher.py
@@ -4,9 +4,9 @@
 
 import string
 import unicodedata
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
-from .trello_users import TrelloUser, TrelloUsers
+from .trello_users import TrelloUser
 
 
 class GithubTrelloUserMatcher:
@@ -17,10 +17,9 @@ class GithubTrelloUserMatcher:
     `__normalize_trello_name` for Trello name normalization
     """
 
-    def __init__(self, trello_users: TrelloUsers):
-        users = trello_users.get_users()
+    def __init__(self, trello_users: List[TrelloUser]):
         self.__normalized_trello_users: Dict[str, TrelloUser] = {}
-        for user in users:
+        for user in trello_users:
             self.__add_trello_user(user.full_name, user)
             self.__add_trello_user(user.username, user)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/tester_selector.py
@@ -11,14 +11,14 @@ from ....console import echo_info, echo_warning
 from .github_trello_user_matcher import GithubTrelloUserMatcher
 from .github_users import GithubUser, GithubUsers, pr_date_str_to_date
 from .tester_selector_team import TesterSelectorTeam
-from .trello_users import TrelloUser, TrelloUsers
+from .trello_users import TrelloUser
 
 
 def create_tester_selector(trello: TrelloClient, repo: str, github_teams: List[str], user_config, app_dir: str):
     github = Github(user_config, 5, repo, 'DataDog')
     now = datetime.utcnow()
     user_cache_expiration = now + timedelta(days=-7)
-    trello_users = TrelloUsers(trello, app_dir, user_cache_expiration)
+    trello_users = [TrelloUser(member) for member in trello.get_board_members()]
     github_users = GithubUsers(github, app_dir, user_cache_expiration)
     userMatcher = GithubTrelloUserMatcher(trello_users)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/trello_users.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/trello_users.py
@@ -2,12 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from datetime import datetime
-from typing import Dict, List, cast
-
-from .....trello import TrelloClient
-from ....console import echo_info
-from .cache import Cache
+from typing import Dict, cast
 
 
 class TrelloUser:
@@ -15,34 +10,3 @@ class TrelloUser:
         self.id = cast(str, data['id_member'])
         self.full_name = cast(str, data['full_name'])
         self.username = cast(str, data['username'])
-
-
-class TrelloUsers:
-    """
-    Store a collection of Trello users
-    """
-
-    def __init__(self, trello: TrelloClient, app_dir: str, cache_expiration: datetime):
-        self.__trello = trello
-        # Use a cache to avoid API Rate Limits
-        self.__user_cache = Cache(app_dir, 'trello_user', cache_expiration)
-
-    def get_users(self) -> List[TrelloUser]:
-        trello_users = cast(Dict[str, Dict[str, object]], self.__user_cache.get_value())
-        if not trello_users:
-            trello_users = {}
-        membership = self.__trello.get_membership()
-        for m in membership:
-            if not m['deactivated']:
-                id_member = m['idMember']
-                if id_member not in trello_users:
-                    member = self.__trello.get_member(id_member)
-                    fullname = member['fullName']
-                    echo_info(f'Getting information for user {fullname}')
-                    trello_users[id_member] = {
-                        'id_member': id_member,
-                        'full_name': fullname,
-                        'username': member['username'],
-                    }
-        self.__user_cache.set_value(trello_users)
-        return [TrelloUser(user) for user in trello_users.values()]

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/trello_users.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/tester_selector/trello_users.py
@@ -7,6 +7,6 @@ from typing import Dict, cast
 
 class TrelloUser:
     def __init__(self, data: Dict[str, object]):
-        self.id = cast(str, data['id_member'])
-        self.full_name = cast(str, data['full_name'])
+        self.id = cast(str, data['id'])
+        self.full_name = cast(str, data['fullName'])
         self.username = cast(str, data['username'])

--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -253,11 +253,7 @@ class TrelloClient:
         memberships = memberships.json()
         deactivated_users = {m['idMember'] for m in memberships if m['deactivated']}
 
-        return [
-            {'id_member': member['id'], 'full_name': member['fullName'], 'username': member['username']}
-            for member in members
-            if member['id'] not in deactivated_users
-        ]
+        return [member for member in members if member['id'] not in deactivated_users]
 
     def get_list(self, list_id):
         return self.__request(self.API_URL + f'/1/lists/{list_id}/cards')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -13,7 +13,7 @@ class TrelloClient:
     LABELS_ENDPOINT = API_URL + '/1/boards/ICjijxr4/labels'
     CARDS_ENDPOINT = API_URL + '/1/cards'
     MEMBERSHIP_ENDPOINT = API_URL + '/1/boards/ICjijxr4/memberships'
-    MEMBER_ENPOINT = API_URL + '/1/members'
+    BOARD_MEMBERS_ENDPOINT = API_URL + '/1/boards/ICjijxr4/members'
     HAVE_BUG_FIXE_ME_COLUMN = '58f0c271cbf2d534bd626916'
     FIXED_READY_TO_REBUILD_COLUMN = '5d5a8a50ca7a0189ae8ac5ac'
     RC_BUILDS_COLUMN = '5727778db5367f8b4cb520ca'
@@ -239,28 +239,25 @@ class TrelloClient:
         response.raise_for_status()
         return response.json()
 
-    def get_membership(self):
+    def get_board_members(self):
         """
-        Get the members.
+        Get the members from the board.
         """
-        membership = requests.get(self.MEMBERSHIP_ENDPOINT, params=self.auth)
-        membership.raise_for_status()
-        return membership.json()
+        members = requests.get(self.BOARD_MEMBERS_ENDPOINT, params=self.auth)
+        members.raise_for_status()
+        members = members.json()
 
-    def get_member(self, id_member):
-        """
-        Get the member.
-        """
-        try:
-            membership = requests.get(f'{self.MEMBER_ENPOINT}/{id_member}', params=self.auth)
-            membership.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 429:
-                raise Exception('Timeout, please try in 900 secondes') from e
-            else:
-                raise e
+        # We need the memberships to filter out deactivated users
+        memberships = requests.get(self.MEMBERSHIP_ENDPOINT, params=self.auth)
+        memberships.raise_for_status()
+        memberships = memberships.json()
+        deactivated_users = {m['idMember'] for m in memberships if m['deactivated']}
 
-        return membership.json()
+        return [
+            {'id_member': member['id'], 'full_name': member['fullName'], 'username': member['username']}
+            for member in members
+            if member['id'] not in deactivated_users
+        ]
 
     def get_list(self, list_id):
         return self.__request(self.API_URL + f'/1/lists/{list_id}/cards')

--- a/datadog_checks_dev/tests/tooling/test_trello.py
+++ b/datadog_checks_dev/tests/tooling/test_trello.py
@@ -1,0 +1,41 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from mock import MagicMock
+
+from datadog_checks.dev.tooling.trello import TrelloClient
+
+
+def test_get_board_members(monkeypatch):
+    client = TrelloClient({'trello': {'token': 'my-token', 'key': 'my-key'}})
+
+    mock_response_memberships = MagicMock()
+    mock_response_memberships.json.return_value = [
+        {"deactivated": False, "idMember": "id1", "memberType": "normal", "unconfirmed": False},
+        {"deactivated": False, "idMember": "id2", "memberType": "normal", "unconfirmed": False},
+        {"deactivated": True, "idMember": "id3", "memberType": "normal", "unconfirmed": False},
+    ]
+    mock_response_memberships.headers = {"Content-Type": "application/json"}
+
+    mock_response_members = MagicMock()
+    mock_response_members.json.return_value = [
+        {"fullName": "first.user", "id": "id1", "username": "first_user"},
+        {"fullName": "sec.user", "id": "id2", "username": "second_user"},
+        {"fullName": "d.user", "id": "id3", "username": "deactivated_user"},
+    ]
+    mock_response_members.headers = {"Content-Type": "application/json"}
+
+    def mock_request(url, *args, **kwargs):
+        if url == client.MEMBERSHIP_ENDPOINT:
+            return mock_response_memberships
+        elif url == client.BOARD_MEMBERS_ENDPOINT:
+            return mock_response_members
+
+    monkeypatch.setattr('requests.get', MagicMock(side_effect=mock_request))
+
+    members = client.get_board_members()
+
+    assert members == [
+        {"fullName": "first.user", "id": "id1", "username": "first_user"},
+        {"fullName": "sec.user", "id": "id2", "username": "second_user"},
+    ]


### PR DESCRIPTION
### What does this PR do?

Replaces the existing member-by-member fetching strategy with the use of [an endpoint](https://developer.atlassian.com/cloud/trello/rest/api-group-boards/#api-boards-id-members-get) that returns the same data in a single call.

### Motivation

[AITOOLS-66](https://datadoghq.atlassian.net/browse/AITOOLS-66). Would also close https://github.com/DataDog/integrations-core/pull/13024.

### Additional Notes

I haven't been able to test this thoroughly, an attempt at a dry run at least shows it's not completely broken.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.