### PR TITLE
Ignore aberrant values for `kubernetes.memory.rss`

### DIFF
--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -553,6 +553,8 @@ class CadvisorPrometheusScraperMixin(object):
 
     def container_memory_rss(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.memory.rss'
+        # Filter out aberrant values
+        metric.samples = [sample for sample in metric.samples if sample[self.SAMPLE_VALUE] < 2**63]
         self._process_container_metric('gauge', metric_name, metric, scraper_config)
 
     def container_memory_swap(self, metric, scraper_config):

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -18,7 +18,7 @@ METRIC_TYPES = ['counter', 'gauge', 'summary']
 PRE_1_16_CONTAINER_LABELS = set(['namespace', 'name', 'image', 'id', 'container_name', 'pod_name'])
 POST_1_16_CONTAINER_LABELS = set(['namespace', 'name', 'image', 'id', 'container', 'pod'])
 
-# Value above which the figure can be discarded because it’s an aberrant transient value
+# Value above which the figure can be discarded because it's an aberrant transient value
 MAX_MEMORY_RSS = 2**63
 
 

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -18,6 +18,9 @@ METRIC_TYPES = ['counter', 'gauge', 'summary']
 PRE_1_16_CONTAINER_LABELS = set(['namespace', 'name', 'image', 'id', 'container_name', 'pod_name'])
 POST_1_16_CONTAINER_LABELS = set(['namespace', 'name', 'image', 'id', 'container', 'pod'])
 
+# Value above which the figure can be discarded because it’s an aberrant transient value
+MAX_MEMORY_RSS = 2**63
+
 
 class CadvisorPrometheusScraperMixin(object):
     """
@@ -554,7 +557,7 @@ class CadvisorPrometheusScraperMixin(object):
     def container_memory_rss(self, metric, scraper_config):
         metric_name = scraper_config['namespace'] + '.memory.rss'
         # Filter out aberrant values
-        metric.samples = [sample for sample in metric.samples if sample[self.SAMPLE_VALUE] < 2**63]
+        metric.samples = [sample for sample in metric.samples if sample[self.SAMPLE_VALUE] < MAX_MEMORY_RSS]
         self._process_container_metric('gauge', metric_name, metric, scraper_config)
 
     def container_memory_swap(self, metric, scraper_config):


### PR DESCRIPTION
### What does this PR do?

Ignore aberrant values (close to 18 EiB) for `kubernetes.memory.rss`.

### Motivation

Under some circumstances, the `memory.stat` cgroup file shows super high value for `total_rss` like for ex.:

```
/host/sys/fs/cgroup/memory/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1cbe9fde_6ee9_445f_8f59_7298e66618f5.slice/cri-containerd-38fe097c37a933d8d2f5d3fe50e751bb64d3001e07217529349a9446a2944946.scope/memory.stat
```
```
cache 1622016
rss 1409024
rss_huge 0
shmem 0
mapped_file 159744
dirty 0
writeback 0
swap 0
pgpgin 231327950
pgpgout 231327210
pgfault 347344261
pgmajfault 75
inactive_anon 1404928
active_anon 4096
inactive_file 204800
active_file 1417216
unevictable 0
hierarchical_memory_limit 268435456
hierarchical_memsw_limit 9223372036854771712
total_cache 1622016
total_rss 18446744073706844160
total_rss_huge 0
total_shmem 0
total_mapped_file 159744
total_dirty 0
total_writeback 0
total_swap 0
total_pgpgin 231326246
total_pgpgout 231326507
total_pgfault 347341748
total_pgmajfault 75
total_inactive_anon 18446744073706860544
total_active_anon 0
total_inactive_file 204800
total_active_file 1417216
total_unevictable 0
```

In this case, the RSS value must be ignored to avoid triggering some “high memory” monitors.

### Additional Notes

* DataDog/datadog-agent#13824

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.