### PR TITLE
Migrate to new codecov uploader

### DIFF
--- a/.azure-pipelines/templates/install-deps.yml
+++ b/.azure-pipelines/templates/install-deps.yml
@@ -45,9 +45,6 @@ steps:
 - script: python -m pip install --disable-pip-version-check --upgrade pip setuptools wheel
   displayName: 'Upgrade Python packaging tools'
 
-- script: pip install --disable-pip-version-check git+https://github.com/ofek/codecov-python.git@datadog
-  displayName: 'Install Codecov'
-
 - ${{ if eq(parameters.repo, 'core') }}:
   - script: |
       pip install ./datadog_checks_dev[cli]

--- a/.azure-pipelines/templates/run-tests.yml
+++ b/.azure-pipelines/templates/run-tests.yml
@@ -14,8 +14,6 @@ steps:
 - ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.force_base_package, 'false')) }}:
   - script: ddev test --cov --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}
     displayName: 'Run Unit/Integration tests'
-    env:
-      CODECOV_TOKEN: $(CODECOV_TOKEN)
 
 - ${{ if and(eq(parameters.test, 'true'), not(eq(parameters.coverage, 'true'))) }}:
     - script: ddev test --junit ${{ parameters.ddtrace_flag }} ${{ parameters.check }}

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -78,7 +78,7 @@ jobs:
       coverage: ${{ parameters.coverage }}
       force_base_package: ${{ parameters.force_base_package }}
 
-  - ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.force_base_package, 'false')) }}:
+  - ${{ if and(eq(parameters.repo, 'core'), eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.force_base_package, 'false')) }}:
     # https://docs.codecov.com/docs/codecov-uploader
     - script: |
         curl -O https://uploader.codecov.io/v0.3.2/linux/codecov

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -81,7 +81,10 @@ jobs:
   - ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.force_base_package, 'false')) }}:
     # https://docs.codecov.com/docs/codecov-uploader
     - script: |
-        curl -O https://uploader.codecov.io/latest/linux/codecov
+        curl -O https://uploader.codecov.io/v0.3.2/linux/codecov
+        # Verify checksum
+        printf '20f9c9d78483fce977b6cc39e231a734a23bcd36f4d536bb7355222fb88d02bc  codecov' > codecov.SHA256SUM
+        shasum -a 256 -c codecov.SHA256SUM
         chmod +x codecov
       displayName: 'Install Codecov'
     - script: |

--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -77,3 +77,18 @@ jobs:
       repo: ${{ parameters.repo }}
       coverage: ${{ parameters.coverage }}
       force_base_package: ${{ parameters.force_base_package }}
+
+  - ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.force_base_package, 'false')) }}:
+    # https://docs.codecov.com/docs/codecov-uploader
+    - script: |
+        curl -O https://uploader.codecov.io/latest/linux/codecov
+        chmod +x codecov
+      displayName: 'Install Codecov'
+    - script: |
+        for cov_file in */coverage.xml; do
+          echo "Uploading $cov_file with flag $(dirname $cov_file)"
+          ./codecov --F $(dirname $cov_file) -f $cov_file
+        done
+      displayName: 'Upload coverage data'
+      env:
+        CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -95,7 +95,10 @@ jobs:
   - ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.force_base_package, 'false')) }}:
     # https://docs.codecov.com/docs/codecov-uploader
     - powershell: |
-        Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
+        Invoke-WebRequest -Uri https://uploader.codecov.io/v0.3.2/windows/codecov.exe -Outfile codecov.exe
+        # Verify checksum
+        "9dce1ac2d35f550d96d46f8a1116b4f03740d61ca4508bfccdbf1ea1dfeabe4d  codecov.exe" > codecov.exe.SHA256SUM
+        If ($(Compare-Object -ReferenceObject  $(($(certUtil -hashfile codecov.exe SHA256)[1], "codecov.exe") -join "  ") -DifferenceObject $(Get-Content codecov.exe.SHA256SUM)).length -eq 0) { echo "SHASUM verified" } Else {exit 1}
       displayName: 'Install Codecov'
     - bash: |        
         for cov_file in */coverage.xml; do

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -91,3 +91,17 @@ jobs:
       repo: ${{ parameters.repo }}
       coverage: ${{ parameters.coverage }}
       force_base_package: ${{ parameters.force_base_package }}
+
+  - ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.force_base_package, 'false')) }}:
+    # https://docs.codecov.com/docs/codecov-uploader
+    - powershell: |
+        Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile codecov.exe
+      displayName: 'Install Codecov'
+    - bash: |        
+        for cov_file in */coverage.xml; do
+          echo "Uploading $cov_file with flag $(dirname $cov_file)"
+          ./codecov --F $(dirname $cov_file) -f $cov_file
+        done
+      displayName: 'Upload coverage data'
+      env:
+        CODECOV_TOKEN: $(CODECOV_TOKEN)

--- a/.azure-pipelines/templates/test-single-windows.yml
+++ b/.azure-pipelines/templates/test-single-windows.yml
@@ -92,7 +92,7 @@ jobs:
       coverage: ${{ parameters.coverage }}
       force_base_package: ${{ parameters.force_base_package }}
 
-  - ${{ if and(eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.force_base_package, 'false')) }}:
+  - ${{ if and(eq(parameters.repo, 'core'), eq(parameters.test, 'true'), eq(parameters.coverage, 'true'), eq(parameters.force_base_package, 'false')) }}:
     # https://docs.codecov.com/docs/codecov-uploader
     - powershell: |
         Invoke-WebRequest -Uri https://uploader.codecov.io/v0.3.2/windows/codecov.exe -Outfile codecov.exe

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -94,7 +94,6 @@ def test(
     root = get_root()
     testing_on_ci = running_on_ci()
     color = ctx.obj['color']
-    repo = ctx.obj['repo_name']
 
     # Implicitly track coverage
     if cov_missing:
@@ -263,8 +262,6 @@ def test(
 
                     fix_coverage_report(check, 'coverage.xml')
 
-                    if repo == 'integrations-core':
-                        run_command(['codecov', '-X', 'gcov', '--root', root, '-F', check, '-f', 'coverage.xml'])
                 else:
                     if not cov_keep:
                         remove_path('.coverage')


### PR DESCRIPTION
### What does this PR do?

Replaces installation of unsupported python uploader fork with new binary uploader.

It also moves the invocation of `codecov` outside of `ddev` and into a CI step, next to the step where the codecov uploader is installed, so that it's easier to track the dependency of this step on the binary. It also moves the installation of the codecov uploader to after tests have run (saves time in case tests fail).

### Motivation

[AITOOLS-1](https://datadoghq.atlassian.net/browse/AITOOLS-1)

### Additional Notes

I've pinned the version of the uploader to the current latest version (0.3.2), so that I could add SHASUM based verification. That should be good enough to be confident that we get the right binary.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.