### PR TITLE
Fix Query Metrics query to correct for over-inflated / incorrect SQL Server metrics 

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -28,7 +28,6 @@ from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_IN
 
 DEFAULT_COLLECTION_INTERVAL = 10
 
-
 SQL_SERVER_QUERY_METRICS_COLUMNS = [
     "execution_count",
     "total_worker_time",
@@ -48,7 +47,6 @@ SQL_SERVER_QUERY_METRICS_COLUMNS = [
     "total_columnstore_segment_skips",
     "total_spills",
 ]
-
 
 STATEMENT_METRICS_QUERY = """\
 with qstats as (

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -28,6 +28,7 @@ from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_IN
 
 DEFAULT_COLLECTION_INTERVAL = 10
 
+
 SQL_SERVER_QUERY_METRICS_COLUMNS = [
     "execution_count",
     "total_worker_time",
@@ -48,9 +49,10 @@ SQL_SERVER_QUERY_METRICS_COLUMNS = [
     "total_spills",
 ]
 
+
 STATEMENT_METRICS_QUERY = """\
 with qstats as (
-    select TOP {limit} query_hash, query_plan_hash, last_execution_time,
+    select query_hash, query_plan_hash, last_execution_time,
             CONCAT(
                 CONVERT(binary(64), plan_handle),
                 CONVERT(binary(4), statement_start_offset),
@@ -58,21 +60,22 @@ with qstats as (
            (select value from sys.dm_exec_plan_attributes(plan_handle) where attribute = 'dbid') as dbid,
            {query_metrics_columns}
     from sys.dm_exec_query_stats
-    where last_execution_time > dateadd(second, -?, getdate())
 ),
 qstats_aggr as (
     select query_hash, query_plan_hash, CAST(S.dbid as int) as dbid,
        D.name as database_name, max(plan_handle_and_offsets) as plan_handle_and_offsets,
+       max(last_execution_time) as last_execution_time,
     {query_metrics_column_sums}
     from qstats S
     left join sys.databases D on S.dbid = D.database_id
     group by query_hash, query_plan_hash, S.dbid, D.name
 ),
-qstats_aggr_split as (select
+qstats_aggr_split as (select TOP {limit}
     convert(varbinary(64), substring(plan_handle_and_offsets, 1, 64)) as plan_handle,
     convert(int, convert(varbinary(4), substring(plan_handle_and_offsets, 64+1, 4))) as statement_start_offset,
     convert(int, convert(varbinary(4), substring(plan_handle_and_offsets, 64+6, 4))) as statement_end_offset,
     * from qstats_aggr
+    where last_execution_time > dateadd(second, -?, getdate())
 )
 select
     SUBSTRING(text, (statement_start_offset / 2) + 1,

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -235,16 +235,6 @@ test_statement_metrics_and_plans_parameterized = (
             True,
         ],
         [
-            "master",
-            "EXEC encryptedProc",
-            [""],
-            ((),),
-            1,
-            True,
-            True,
-            False,
-        ],
-        [
             "datadog_test",
             "EXEC bobProcParams @P1 = ?, @P2 = ?",
             [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR updates the query the agent runs to produce DD Query Metrics for sqlserver (e.g.: `sqlserver.queries.count`) in the following way:

1. Moves the filter `where last_execution_time > dateadd(second, -?, getdate())` from the pre-aggregation part of the query to post aggregation (`qstats` CTE -> `qstats_aggr_split` CTE) 
2. Moves the `TOP 10000` limit to the `qstats_aggr_split` CTE

By doing this, we are able to accurately calculate sums for each of the relevant rows in `sys.dm_exec_query_stats` (e.g.: `execution_count`)

### Motivation
<!-- What inspired you to submit this pull request? -->

Prior to this change, a bug existed in which we could sometimes inaccurately calculate sqlserver query metrics. This would result in certain metrics looking wrong in our UI. For example, for a query with constant throughput, the `sqlserver.queries.count` metric looked like the following:

![Screen Shot 2022-10-12 at 5 42 36 PM](https://user-images.githubusercontent.com/14317240/195453573-df437e60-fb6c-49ed-95e3-0a7e375d7d9a.png)

In order to understand this change & for extra context, the agent works like this:

1. Runs query metrics query once every 10 secs
2. This query grabs execution related statistics from the `sys.dm_exec_query_stats` DMV table in sqlserver & sums over all rows, which have the same `query_hash`, `query_plan_hash` & database ID. 
3. The relationship between `query_hash`, `query_plan_hash` & `plan_handle` is 1 to many, where many different plan_handles can exist for the same query. This is why we have to sum the stats for each query across many different rows in the table. 
4. Once the agent query finishes, we calculate the difference in execution stats for each relevant metric column per query compared with the last time the check ran. For example:

Check runs at T0: for the tuple `query_hash,query_plan_hash,dbid` X the `execution_count` was 10 -> check emits nothing
Check runs at T10: for the tuple `query_hash,query_plan_hash,dbid` X the `execution_count` was 15 -> check emits 5     
Check runs at T20: for the tuple `query_hash,query_plan_hash,dbid` X the `execution_count` was 100 -> check emits 75
... and so on

If at any point the value for `execution_count` is _less than_ what was stored in the prior check run, the agent will essentially emit a 0 value for that metric.     

The reason why the metrics became inflated over time is due to the fact that prior to this change, the query had the following filter  `where last_execution_time > dateadd(second, -?, getdate())` (where the param is 2 * the check coll interval) in the part of the query where we grab the initial data from the `sys.dm_exec_query_stats` table. The `qstats` CTE 
```sql
--- Get query metric data from the query stats DMV & filter rows where the last_execution_time is less than 20 seconds old
with qstats as (
    select TOP {limit} query_hash, query_plan_hash, last_execution_time,
            CONCAT(
                CONVERT(binary(64), plan_handle),
                CONVERT(binary(4), statement_start_offset),
                CONVERT(binary(4), statement_end_offset)) as plan_handle_and_offsets,
           (select value from sys.dm_exec_plan_attributes(plan_handle) where attribute = 'dbid') as dbid,
          execution_count, 
          --- other query stats columns
    from sys.dm_exec_query_stats
    where last_execution_time > dateadd(second, -?, getdate())
),
```
By adding this filter, we are introducing the possibility of missing rows that should be used to calculate the sum of the stat columns. For example, consider the following scenario where for the same query_hash & query_plan_hash we get 3 different rows (because they happen to have different `plan_handle`s) 

<img width="791" alt="image (4)" src="https://user-images.githubusercontent.com/14317240/195454682-510dfe06-bec3-41aa-83f2-0f1e81a52596.png">

... each with its own `execution_count`. Normally, we would simply sum all 3 rows & produce the correct number for `execution_count`. However, say that the 3rd row `last_execution_time` value on the next iteration of the check falls outside of the 20s filter & causes the sum to be `3293604` _less than_ it was on the previous run so when the agent goes to calculate the diff between runs we get a negative count. 

... but on the next check run, the 3rd row _does_ fall within the filter's time range & so we increase the count by  `3293604` + any additional executions that happened for that plan_handle in the meantime. This results in the `sqlserver.queries.count` metric jumping seemingly out of no where.

In order to fix this, we must scan all rows in the query stats table in order to calculate the sums correctly. That is why moving the filter to this part of the query (post aggregation) fixes the issue 

```sql
--- Collect data from sys.dm_exec_query_stats
with qstats as (
    select query_hash, query_plan_hash, last_execution_time,
            CONCAT(
                CONVERT(binary(64), plan_handle),
                CONVERT(binary(4), statement_start_offset),
                CONVERT(binary(4), statement_end_offset)) as plan_handle_and_offsets,
           (select value from sys.dm_exec_plan_attributes(plan_handle) where attribute = 'dbid') as dbid,
           execution_count, 
           --- other query_stats columns
    from sys.dm_exec_query_stats
),
--- Calculate sum for each row per query_hash, query_plan_hash & dbid
qstats_aggr as (
    select query_hash, query_plan_hash, CAST(S.dbid as int) as dbid,
       D.name as database_name, max(plan_handle_and_offsets) as plan_handle_and_offsets,
       max(last_execution_time) as last_execution_time,
    SUM(execution_count),
    --- sum all other query stat columns
    from qstats S
    left join sys.databases D on S.dbid = D.database_id
    group by query_hash, query_plan_hash, S.dbid, D.name
),
--- Now that columns have been sum'd, take top 10k rows for only queries that have executed in the past 20 seconds
qstats_aggr_split as (select TOP 10000
    convert(varbinary(64), substring(plan_handle_and_offsets, 1, 64)) as plan_handle,
    convert(int, convert(varbinary(4), substring(plan_handle_and_offsets, 64+1, 4))) as statement_start_offset,
    convert(int, convert(varbinary(4), substring(plan_handle_and_offsets, 64+6, 4))) as statement_end_offset,
    * from qstats_aggr
    where last_execution_time > dateadd(second, -?, getdate())
)
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Due to the fact that this change requires the query now scan all rows in `sys.dm_exec_query_stats`, there is a performance impact on the agent's runtime. 

The query now takes about 30% longer than before on average (to run the entire check `collect_statement_metrics_and_plans`), but runs in about the same amount of time during bursts of many high cardinality (ad-hoc) queries:
![Screen Shot 2022-10-12 at 6 25 05 PM](https://user-images.githubusercontent.com/14317240/195459311-10bac079-fdc7-4b58-829c-1865ddebc2f1.png)

View during cardinality bursts:
![Screen Shot 2022-10-12 at 6 26 18 PM](https://user-images.githubusercontent.com/14317240/195459413-40cd4964-4923-4789-8752-41a13b43e12f.png)

This could be an issue for customers who have **very high cardinality** databases, but the performance trade off here is worth getting the correct metric values.

All other import metrics such as agent CPU/Mem and database CPU/Mem were stable  



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.