### PR TITLE
Prevent fork bomb when defining the experimental `process_isolation` option globally in the `init_config` section

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/replay/execute.py
+++ b/datadog_checks_base/datadog_checks/base/utils/replay/execute.py
@@ -13,15 +13,17 @@ from .constants import KNOWN_DATADOG_AGENT_SETTER_METHODS, EnvVars
 def run_with_isolation(check, aggregator, datadog_agent):
     message_indicator = os.urandom(8).hex()
     instance = dict(check.instance)
+    init_config = dict(check.init_config)
 
     # Prevent fork bomb
     instance.pop('process_isolation', None)
+    init_config.pop('process_isolation', None)
 
     env_vars = dict(os.environ)
     env_vars[EnvVars.MESSAGE_INDICATOR] = message_indicator
     env_vars[EnvVars.CHECK_NAME] = check.name
     env_vars[EnvVars.CHECK_ID] = check.check_id
-    env_vars[EnvVars.INIT_CONFIG] = to_native_string(json.dumps(check.init_config))
+    env_vars[EnvVars.INIT_CONFIG] = to_native_string(json.dumps(init_config))
     env_vars[EnvVars.INSTANCE] = to_native_string(json.dumps(instance))
 
     check_module = check.__module__


### PR DESCRIPTION
### What does this PR do?
Fixes fork bomb and CPU overconsumption when using `process_isolation: true` in the init_config.

### Motivation
QA https://github.com/DataDog/integrations-core/pull/12986

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.