### PR TITLE
directory: Improve error message

### DIFF
--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -135,7 +135,8 @@ class DirectoryCheck(AgentCheck):
                             self.gauge('system.disk.directory.file.bytes', file_stat.st_size, tags=filetags)
                             self.gauge(
                                 'system.disk.directory.file.modified_sec_ago',
-                                time() - file_stat.st_mtime, tags=filetags,
+                                time() - file_stat.st_mtime,
+                                tags=filetags,
                             )
                             self.gauge(
                                 'system.disk.directory.file.created_sec_ago', time() - file_stat.st_ctime, tags=filetags

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -78,7 +78,11 @@ class DirectoryCheck(AgentCheck):
         walker = walk(self._config.abs_directory, self._config.follow_symlinks)
         if not self._config.recursive:
             # Only visit the first directory.
-            walker = [next(walker)]
+            try:
+                walker = [next(walker)]
+            except Exception as e:
+                self.log.error("failed to visit %s: %s", self._config.abs_directory, e)
+                return
 
         # Avoid repeated global lookups.
         get_length = len

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -134,7 +134,8 @@ class DirectoryCheck(AgentCheck):
                             filetags.extend(dirtags)
                             self.gauge('system.disk.directory.file.bytes', file_stat.st_size, tags=filetags)
                             self.gauge(
-                                'system.disk.directory.file.modified_sec_ago', time() - file_stat.st_mtime, tags=filetags
+                                'system.disk.directory.file.modified_sec_ago',
+                                time() - file_stat.st_mtime, tags=filetags,
                             )
                             self.gauge(
                                 'system.disk.directory.file.created_sec_ago', time() - file_stat.st_ctime, tags=filetags

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -80,8 +80,7 @@ class DirectoryCheck(AgentCheck):
             # Only visit the first directory.
             try:
                 walker = [next(walker)]
-            except Exception as e:
-                self.log.error("failed to visit %s: %s", self._config.abs_directory, e)
+            except StopIteration:
                 return
 
         # Avoid repeated global lookups.

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -80,87 +80,91 @@ class DirectoryCheck(AgentCheck):
             # Only visit the first directory.
             try:
                 walker = [next(walker)]
-            except StopIteration:
+            except OSError as e:
+                self.log.error("Failed to scan %s: %s", self._config.abs_directory, e)
                 return
 
         # Avoid repeated global lookups.
         get_length = len
 
-        for root, dirs, files in walker:
-            matched_files = []
-            adjust_max_filegauge = False
+        try:
+            for root, dirs, files in walker:
+                matched_files = []
+                adjust_max_filegauge = False
 
-            if self._config.exclude_dirs_pattern is not None:
-                if self._config.dirs_patterns_full:
-                    dirs[:] = [d for d in dirs if not self._config.exclude_dirs_pattern.search(d.path)]
+                if self._config.exclude_dirs_pattern is not None:
+                    if self._config.dirs_patterns_full:
+                        dirs[:] = [d for d in dirs if not self._config.exclude_dirs_pattern.search(d.path)]
+                    else:
+                        dirs[:] = [d for d in dirs if not self._config.exclude_dirs_pattern.search(d.name)]
+                    self.log.debug('Directories: %s', str(dirs))
+                if self._config.pattern is not None:
+                    # Check if the path of the file relative to the directory
+                    # matches the pattern. Also check if the absolute path of the
+                    # filename matches the pattern, for compatibility with previous
+                    # agent versions.
+                    for file_entry in files:
+                        filename = join(root, file_entry.name)
+                        if fnmatch(filename, self._config.pattern) or fnmatch(
+                            relpath(filename, self._config.abs_directory), self._config.pattern
+                        ):
+                            matched_files.append(file_entry)
                 else:
-                    dirs[:] = [d for d in dirs if not self._config.exclude_dirs_pattern.search(d.name)]
-                self.log.debug('Directories: %s', str(dirs))
-            if self._config.pattern is not None:
-                # Check if the path of the file relative to the directory
-                # matches the pattern. Also check if the absolute path of the
-                # filename matches the pattern, for compatibility with previous
-                # agent versions.
-                for file_entry in files:
-                    filename = join(root, file_entry.name)
-                    if fnmatch(filename, self._config.pattern) or fnmatch(
-                        relpath(filename, self._config.abs_directory), self._config.pattern
-                    ):
-                        matched_files.append(file_entry)
-            else:
-                matched_files = list(files)
+                    matched_files = list(files)
 
-            matched_files_length = get_length(matched_files)
-            directory_files += matched_files_length
+                matched_files_length = get_length(matched_files)
+                directory_files += matched_files_length
 
-            # We're just looking to count the files.
-            if self._config.countonly:
-                continue
+                # We're just looking to count the files.
+                if self._config.countonly:
+                    continue
 
-            for file_entry in matched_files:
-                try:
-                    self.log.debug('File entries in matched files: %s', str(file_entry))
-                    file_stat = file_entry.stat(follow_symlinks=self._config.stat_follow_symlinks)
-                except OSError as ose:
-                    self.warning('DirectoryCheck: could not stat file %s - %s', join(root, file_entry.name), ose)
-                else:
-                    # file specific metrics
-                    directory_bytes += file_stat.st_size
-                    if self._config.filegauges and matched_files_length <= max_filegauge_balance:
-                        self.log.debug('Matched files length: %s', matched_files_length)
-                        filetags = ['{}:{}'.format(self._config.filetagname, join(root, file_entry.name))]
-                        filetags.extend(dirtags)
-                        self.gauge('system.disk.directory.file.bytes', file_stat.st_size, tags=filetags)
-                        self.gauge(
-                            'system.disk.directory.file.modified_sec_ago', time() - file_stat.st_mtime, tags=filetags
-                        )
-                        self.gauge(
-                            'system.disk.directory.file.created_sec_ago', time() - file_stat.st_ctime, tags=filetags
-                        )
-                        adjust_max_filegauge = True
-                        self.log.debug(
-                            'File stat output - size:%s mtime:%s ctime:%s',
-                            str(file_stat.st_size),
-                            str(file_stat.st_mtime),
-                            str(file_stat.st_ctime),
-                        )
-                    elif submit_histograms:
-                        self.histogram('system.disk.directory.file.bytes', file_stat.st_size, tags=dirtags)
-                        self.histogram(
-                            'system.disk.directory.file.modified_sec_ago', time() - file_stat.st_mtime, tags=dirtags
-                        )
-                        self.histogram(
-                            'system.disk.directory.file.created_sec_ago', time() - file_stat.st_ctime, tags=dirtags
-                        )
-                        self.log.debug(
-                            'File stat output histogram - size:%s mtime:%s ctime:%s',
-                            str(file_stat.st_size),
-                            str(file_stat.st_mtime),
-                            str(file_stat.st_ctime),
-                        )
+                for file_entry in matched_files:
+                    try:
+                        self.log.debug('File entries in matched files: %s', str(file_entry))
+                        file_stat = file_entry.stat(follow_symlinks=self._config.stat_follow_symlinks)
+                    except OSError as ose:
+                        self.warning('DirectoryCheck: could not stat file %s - %s', join(root, file_entry.name), ose)
+                    else:
+                        # file specific metrics
+                        directory_bytes += file_stat.st_size
+                        if self._config.filegauges and matched_files_length <= max_filegauge_balance:
+                            self.log.debug('Matched files length: %s', matched_files_length)
+                            filetags = ['{}:{}'.format(self._config.filetagname, join(root, file_entry.name))]
+                            filetags.extend(dirtags)
+                            self.gauge('system.disk.directory.file.bytes', file_stat.st_size, tags=filetags)
+                            self.gauge(
+                                'system.disk.directory.file.modified_sec_ago', time() - file_stat.st_mtime, tags=filetags
+                            )
+                            self.gauge(
+                                'system.disk.directory.file.created_sec_ago', time() - file_stat.st_ctime, tags=filetags
+                            )
+                            adjust_max_filegauge = True
+                            self.log.debug(
+                                'File stat output - size:%s mtime:%s ctime:%s',
+                                str(file_stat.st_size),
+                                str(file_stat.st_mtime),
+                                str(file_stat.st_ctime),
+                            )
+                        elif submit_histograms:
+                            self.histogram('system.disk.directory.file.bytes', file_stat.st_size, tags=dirtags)
+                            self.histogram(
+                                'system.disk.directory.file.modified_sec_ago', time() - file_stat.st_mtime, tags=dirtags
+                            )
+                            self.histogram(
+                                'system.disk.directory.file.created_sec_ago', time() - file_stat.st_ctime, tags=dirtags
+                            )
+                            self.log.debug(
+                                'File stat output histogram - size:%s mtime:%s ctime:%s',
+                                str(file_stat.st_size),
+                                str(file_stat.st_mtime),
+                                str(file_stat.st_ctime),
+                            )
 
-            if adjust_max_filegauge:
-                max_filegauge_balance -= matched_files_length
+                if adjust_max_filegauge:
+                    max_filegauge_balance -= matched_files_length
+        except OSError as e:
+            self.log.error("Error when traversing %s: %s", self._config.abs_directory, e)
 
         # number of files
         self.gauge('system.disk.directory.files', directory_files, tags=dirtags)

--- a/directory/datadog_checks/directory/traverse.py
+++ b/directory/datadog_checks/directory/traverse.py
@@ -16,10 +16,7 @@ def _walk(top, follow_symlinks):
     dirs = []
     nondirs = []
 
-    try:
-        scandir_iter = scandir(top)
-    except OSError:
-        return
+    scandir_iter = scandir(top)
 
     # Avoid repeated global lookups.
     get_next = next

--- a/directory/datadog_checks/directory/traverse.py
+++ b/directory/datadog_checks/directory/traverse.py
@@ -47,7 +47,7 @@ def _walk(top, follow_symlinks, log):
     yield top, dirs, nondirs
 
     for dir_entry in dirs:
-        for entry in walk(dir_entry.path, follow_symlinks=follow_symlinks, log):
+        for entry in walk(dir_entry.path, follow_symlinks=follow_symlinks):
             yield entry
 
 
@@ -61,4 +61,4 @@ else:
     def walk(top, follow_symlinks):
         if isinstance(top, bytes):
             top = top.decode(file_system_encoding)
-        return _walk(top, follow_symlinks)
+        return _walk(top, follow_symlinks, log)

--- a/directory/datadog_checks/directory/traverse.py
+++ b/directory/datadog_checks/directory/traverse.py
@@ -8,19 +8,15 @@ import six
 from scandir import scandir
 
 
-def _walk(top, follow_symlinks, log):
-    """Modified version of https://docs.python.org/3/library/os.html#os.scandir
+def _walk(top, follow_symlinks):
+    """Modified version of https://docs.python.org/3/library/os.html#os.scandirkkk
     that returns https://docs.python.org/3/library/os.html#os.DirEntry for files
     directly to take advantage of possible cached os.stat calls.
     """
     dirs = []
     nondirs = []
 
-    try:
-        scandir_iter = scandir(top)
-    except OSError as e:
-        log.error("Failed to scan %s: %s", top, e)
-        return
+    scandir_iter = scandir(top)
 
     # Avoid repeated global lookups.
     get_next = next
@@ -30,9 +26,6 @@ def _walk(top, follow_symlinks, log):
             entry = get_next(scandir_iter)
         except StopIteration:
             break
-        except OSError:
-            log.error("Failed to scan: %s", e)
-            return
 
         try:
             is_dir = entry.is_dir(follow_symlinks=follow_symlinks)
@@ -61,4 +54,4 @@ else:
     def walk(top, follow_symlinks):
         if isinstance(top, bytes):
             top = top.decode(file_system_encoding)
-        return _walk(top, follow_symlinks, log)
+        return _walk(top, follow_symlinks)

--- a/directory/datadog_checks/directory/traverse.py
+++ b/directory/datadog_checks/directory/traverse.py
@@ -9,7 +9,7 @@ from scandir import scandir
 
 
 def _walk(top, follow_symlinks):
-    """Modified version of https://docs.python.org/3/library/os.html#os.scandirkkk
+    """Modified version of https://docs.python.org/3/library/os.html#os.scandir
     that returns https://docs.python.org/3/library/os.html#os.DirEntry for files
     directly to take advantage of possible cached os.stat calls.
     """


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Improve the error handling when Agent tries to read the not allowed directory.

### Motivation
<!-- What inspired you to submit this pull request? -->

#### `StopIteration` doesn't suggest next actions

Suppose we have the following directory and `conf.yaml`.

```
vagrant@vagrant:~$ whoami
vagrant
vagrant@vagrant:~$ mkdir -p test/foo
vagrant@vagrant:~$ mkdir -p test/bar
vagrant@vagrant:~$ chmod 700 test
vagrant@vagrant:~$ ls -la test
total 16
drwx------  4 vagrant vagrant 4096 Oct 12 04:38 .
drwxr-x--- 15 vagrant vagrant 4096 Oct 12 04:38 ..
drwxrwxr-x  2 vagrant vagrant 4096 Oct 12 04:38 bar
drwxrwxr-x  2 vagrant vagrant 4096 Oct 12 04:38 foo
```

```yaml
init_config:
instances:
  - directory: /home/vagrant/test
```

When we run this command,

```bash
sudo -u dd-agent datadog-agent check directory -l error
```

We have the non-actionable message.

```
    directory (1.13.1)
    ------------------
      Instance ID: directory:2e7e27b6b9a8ee26 [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/directory.d/conf.yaml
      Total Runs: 2
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 2
      Average Execution Time : 5ms
      Last Execution Date : 2022-10-12 05:34:21 CEST / 2022-10-12 03:34:21 UTC (1665545661000)
      Last Successful Execution Date : Never
      Error:
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 1116, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/directory/directory.py", line 67, in check
          self._get_stats()
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/directory/directory.py", line 81, in _get_stats
          walker = [next(walker)]
      StopIteration
```

#### Hard to notice directories that are failing to scan

Suppose we have the following directories and `conf.yaml`,

```
vagrant@vagrant:~$ whoami
vagrant
vagrant@vagrant:~$ mkdir -p test/not_allowed
vagrant@vagrant:~$ chmod 700 test/not_allowed
vagrant@vagrant:~$ namei -mon test/not_allowed
f: test/not_allowed
 drwxrwxr-x vagrant vagrant test
 drwx------ vagrant vagrant not_allowed
```

```yaml
init_config:
instances:
  - directory: /home/vagrant/test
    recursive: true
```

We have no errors and exceptions.

```bash
sudo -u dd-agent datadog-agent check directory -l error
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.