### PR TITLE
Updates Confluent Platform dashboard to use the correct service check

### DIFF
--- a/confluent_platform/assets/dashboards/overview.json
+++ b/confluent_platform/assets/dashboards/overview.json
@@ -757,7 +757,7 @@
                 "title": "Connected Hosts",
                 "title_size": "16",
                 "title_align": "center",
-                "check": "confluentplatform.can_connect",
+                "check": "confluent.can_connect",
                 "grouping": "cluster",
                 "group_by": [],
                 "tags": [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Updates the default dashboard to use `confluent.can_connect` instead of `confluentplatform.can_connect` to align with the service check provided by Confluent Platform
### Motivation
<!-- What inspired you to submit this pull request? -->
* Customer mentioning the widget is empty despite having connected hosts
* The service check is `confluent.can_connect` as shown in https://github.com/DataDog/integrations-core/blob/master/confluent_platform/assets/service_checks.json which I confirmed on the customer's account as well
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.