### PR TITLE
Add the ability to retry kind environments

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/env.py
+++ b/datadog_checks_dev/datadog_checks/dev/env.py
@@ -90,7 +90,7 @@ def environment_run(
 
     if attempts is not None:
         # This is only called in case the function failed
-        def after(_):
+        def after(retry_state):
             down()
 
         @retry(wait=wait_fixed(attempts_wait), stop=stop_after_attempt(attempts), after=after)

--- a/datadog_checks_dev/datadog_checks/dev/env.py
+++ b/datadog_checks_dev/datadog_checks/dev/env.py
@@ -89,8 +89,11 @@ def environment_run(
         attempts = 2
 
     if attempts is not None:
+        # This is only called in case the function failed
+        def after(_):
+            down()
 
-        @retry(wait=wait_fixed(attempts_wait), stop=stop_after_attempt(attempts))
+        @retry(wait=wait_fixed(attempts_wait), stop=stop_after_attempt(attempts), after=after)
         def set_up_with_retry():
             return set_up()
 

--- a/datadog_checks_dev/datadog_checks/dev/kind.py
+++ b/datadog_checks_dev/datadog_checks/dev/kind.py
@@ -19,7 +19,16 @@ else:
 
 
 @contextmanager
-def kind_run(sleep=None, endpoints=None, conditions=None, env_vars=None, wrappers=None, kind_config=None):
+def kind_run(
+    sleep=None,
+    endpoints=None,
+    conditions=None,
+    env_vars=None,
+    wrappers=None,
+    kind_config=None,
+    attempts=None,
+    attempts_wait=1,
+):
     """
     This utility provides a convenient way to safely set up and tear down Kind environments.
 
@@ -35,6 +44,10 @@ def kind_run(sleep=None, endpoints=None, conditions=None, env_vars=None, wrapper
     :param wrappers: A list of context managers to use during execution.
     :param kind_config: A path to a yaml file that contains the configuration for creating the kind cluster.
     :type kind_config: ``str``
+    :param attempts: Number of attempts to run `up` and the `conditions` successfully. Defaults to 2 in CI.
+    :type attempts: ``int``
+    :param attempts_wait: Time to wait between attempts.
+    :type attempts_wait: ``int``
     """
     if not which('kind'):
         pytest.skip('Kind not available')
@@ -63,6 +76,8 @@ def kind_run(sleep=None, endpoints=None, conditions=None, env_vars=None, wrapper
                 conditions=conditions,
                 env_vars=env_vars,
                 wrappers=wrappers,
+                attempts=attempts,
+                attempts_wait=attempts_wait,
             ):
                 yield kubeconfig_path
 

--- a/datadog_checks_dev/tests/test_kind.py
+++ b/datadog_checks_dev/tests/test_kind.py
@@ -6,6 +6,7 @@ import mock
 import pytest
 import tenacity
 
+from common import not_windows_ci
 from datadog_checks.dev import RetryError
 from datadog_checks.dev.ci import running_on_ci
 from datadog_checks.dev.kind import kind_run
@@ -21,6 +22,7 @@ class TestKindRun:
             (3, 3),
         ],
     )
+    @not_windows_ci
     def test_retry_on_failed_conditions(self, attempts, expected_call_count):
         condition = mock.MagicMock()
         condition.side_effect = RetryError("error")
@@ -38,6 +40,7 @@ class TestKindRun:
 
         assert condition.call_count == expected_call_count
 
+    @not_windows_ci
     def test_retry_condition_failed_only_on_first_run(self):
         condition = mock.MagicMock()
         condition.side_effect = [RetryError("error"), None, None]

--- a/datadog_checks_dev/tests/test_kind.py
+++ b/datadog_checks_dev/tests/test_kind.py
@@ -5,8 +5,8 @@
 import mock
 import pytest
 import tenacity
-
 from common import not_windows_ci
+
 from datadog_checks.dev import RetryError
 from datadog_checks.dev.ci import running_on_ci
 from datadog_checks.dev.kind import kind_run

--- a/datadog_checks_dev/tests/test_kind.py
+++ b/datadog_checks_dev/tests/test_kind.py
@@ -5,11 +5,12 @@
 import mock
 import pytest
 import tenacity
-from common import not_windows_ci
 
 from datadog_checks.dev import RetryError
 from datadog_checks.dev.ci import running_on_ci
 from datadog_checks.dev.kind import kind_run
+
+from .common import not_windows_ci
 
 
 class TestKindRun:

--- a/datadog_checks_dev/tests/test_kind.py
+++ b/datadog_checks_dev/tests/test_kind.py
@@ -6,7 +6,6 @@ import mock
 import pytest
 import tenacity
 
-from datadog_checks.dev import RetryError
 from datadog_checks.dev.ci import running_on_ci
 from datadog_checks.dev.kind import kind_run
 

--- a/datadog_checks_dev/tests/test_kind.py
+++ b/datadog_checks_dev/tests/test_kind.py
@@ -1,0 +1,46 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import mock
+import pytest
+import tenacity
+
+from datadog_checks.dev import RetryError
+from datadog_checks.dev.ci import running_on_ci
+from datadog_checks.dev.kind import kind_run
+
+
+class TestKindRun:
+    @pytest.mark.parametrize(
+        "attempts,expected_call_count",
+        [
+            (None, 1),
+            (0, 1),
+            (1, 1),
+            (3, 3),
+        ],
+    )
+    def test_retry_on_failed_conditions(self, attempts, expected_call_count):
+        condition = mock.MagicMock()
+        condition.side_effect = RetryError("error")
+
+        expected_exception = tenacity.RetryError
+        if attempts is None:
+            if running_on_ci():
+                expected_call_count = 2
+            else:
+                expected_exception = RetryError
+
+        with pytest.raises(expected_exception):
+            with kind_run(attempts=attempts, conditions=[condition]):
+                pass
+
+        assert condition.call_count == expected_call_count
+
+    def test_retry_condition_failed_only_on_first_run(self):
+        condition = mock.MagicMock()
+        condition.side_effect = [RetryError("error"), None, None]
+
+        with kind_run(attempts=3, conditions=[condition]):
+            assert condition.call_count == 2

--- a/datadog_checks_dev/tests/test_kind.py
+++ b/datadog_checks_dev/tests/test_kind.py
@@ -26,14 +26,14 @@ class TestKindRun:
     @not_windows_ci
     def test_retry_on_failed_conditions(self, attempts, expected_call_count):
         condition = mock.MagicMock()
-        condition.side_effect = RetryError("error")
+        condition.side_effect = Exception("exception")
 
         expected_exception = tenacity.RetryError
         if attempts is None:
             if running_on_ci():
                 expected_call_count = 2
             else:
-                expected_exception = RetryError
+                expected_exception = Exception
 
         with pytest.raises(expected_exception):
             with kind_run(attempts=attempts, conditions=[condition]):
@@ -44,7 +44,7 @@ class TestKindRun:
     @not_windows_ci
     def test_retry_condition_failed_only_on_first_run(self):
         condition = mock.MagicMock()
-        condition.side_effect = [RetryError("error"), None, None]
+        condition.side_effect = [Exception("exception"), None, None]
 
         with kind_run(attempts=3, conditions=[condition]):
             assert condition.call_count == 2


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add the ability to retry `kind` environments

### Motivation
<!-- What inspired you to submit this pull request? -->

https://datadoghq.atlassian.net/browse/AITOOLS-37

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I get this error on windows:

```
failed to pull image "kindest/node:v1.25.2@sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace": command "docker pull kindest/node:v1.25.2@sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace" failed with error: exit status 1\n\nCommand Output: docker.io/kindest/node@sha256:9be91e9e9cdf116809841fc77ebdb8845443c4c72fe5218f3ae9eb57fdb4bace: Pulling from kindest/node\nno matching manifest for windows/amd64 10.0.17763 in the manifest list entries
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.