### PR TITLE
[network] Refactor: split check_linux methods into different class

### DIFF
--- a/network/datadog_checks/network/check_linux.py
+++ b/network/datadog_checks/network/check_linux.py
@@ -1,0 +1,510 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+import os
+import socket
+
+from six import PY3, iteritems
+
+from datadog_checks.base import is_affirmative
+from datadog_checks.base.utils.common import pattern_filter
+from datadog_checks.base.utils.subprocess_output import SubprocessOutputEmptyError, get_subprocess_output
+from datadog_checks.network import ethtool
+from datadog_checks.network.const import ENA_METRIC_NAMES, ENA_METRIC_PREFIX
+
+from . import Network
+
+try:
+    import datadog_agent
+except ImportError:
+    from datadog_checks.base.stubs import datadog_agent
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+if PY3:
+    long = int
+
+
+class LinuxNetwork(Network):
+    def __init__(self, name, init_config, instances):
+        super(LinuxNetwork, self).__init__(name, init_config, instances)
+
+    def check(self, _):
+        """
+        _check_linux can be run inside a container and still collects the network metrics from the host
+        For that procfs_path can be set to something like "/host/proc"
+        When a custom procfs_path is set, the collect_connection_state option is ignored
+        """
+        proc_location = datadog_agent.get_config('procfs_path')
+        if not proc_location:
+            proc_location = '/proc'
+        proc_location = proc_location.rstrip('/')
+        custom_tags = self.instance.get('tags', [])
+
+        self._get_iface_sys_metrics(custom_tags)
+        net_proc_base_location = self.get_net_proc_base_location(proc_location)
+
+        if self.is_collect_cx_state_runnable(net_proc_base_location):
+            try:
+                self.log.debug("Using `ss` to collect connection state")
+                # Try using `ss` for increased performance over `netstat`
+                ss_env = {"PROC_ROOT": net_proc_base_location}
+
+                # By providing the environment variables in ss_env, the PATH will be overridden. In CentOS,
+                # datadog-agent PATH is "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin", while sh PATH
+                # will be '/usr/local/bin:/usr/bin'. In CentOS, ss is located in /sbin and /usr/sbin, not
+                # in the sh PATH, which will result in network metric collection failure.
+                #
+                # The line below will set sh PATH explicitly as the datadog-agent PATH to fix that issue.
+                if "PATH" in os.environ:
+                    ss_env["PATH"] = os.environ["PATH"]
+
+                metrics = self._get_metrics()
+                for ip_version in ['4', '6']:
+                    # Call `ss` for each IP version because there's no built-in way of distinguishing
+                    # between the IP versions in the output
+                    # Also calls `ss` for each protocol, because on some systems (e.g. Ubuntu 14.04), there is a
+                    # bug that print `tcp` even if it's `udp`
+                    # The `-H` flag isn't available on old versions of `ss`.
+                    cmd = "ss --numeric --tcp --all --ipv{} | cut -d ' ' -f 1 | sort | uniq -c".format(ip_version)
+                    output, _, _ = get_subprocess_output(["sh", "-c", cmd], self.log, env=ss_env)
+
+                    # 7624 CLOSE-WAIT
+                    #   72 ESTAB
+                    #    9 LISTEN
+                    #    1 State
+                    #   37 TIME-WAIT
+                    lines = output.splitlines()
+
+                    self._parse_short_state_lines(lines, metrics, self.tcp_states['ss'], ip_version=ip_version)
+
+                    cmd = "ss --numeric --udp --all --ipv{} | wc -l".format(ip_version)
+                    output, _, _ = get_subprocess_output(["sh", "-c", cmd], self.log, env=ss_env)
+                    metric = self.cx_state_gauge[('udp{}'.format(ip_version), 'connections')]
+                    metrics[metric] = int(output) - 1  # Remove header
+
+                    if self._collect_cx_queues:
+                        cmd = "ss --numeric --tcp --all --ipv{}".format(ip_version)
+                        output, _, _ = get_subprocess_output(["sh", "-c", cmd], self.log, env=ss_env)
+                        for (state, recvq, sendq) in self._parse_queues("ss", output):
+                            self.histogram('system.net.tcp.recv_q', recvq, custom_tags + ["state:" + state])
+                            self.histogram('system.net.tcp.send_q', sendq, custom_tags + ["state:" + state])
+
+                for metric, value in iteritems(metrics):
+                    self.gauge(metric, value, tags=custom_tags)
+
+            except OSError as e:
+                self.log.info("`ss` invocation failed: %s. Using `netstat` as a fallback", str(e))
+                output, _, _ = get_subprocess_output(["netstat", "-n", "-u", "-t", "-a"], self.log)
+                lines = output.splitlines()
+                # Active Internet connections (w/o servers)
+                # Proto Recv-Q Send-Q Local Address           Foreign Address         State
+                # tcp        0      0 46.105.75.4:80          79.220.227.193:2032     SYN_RECV
+                # tcp        0      0 46.105.75.4:143         90.56.111.177:56867     ESTABLISHED
+                # tcp        0      0 46.105.75.4:50468       107.20.207.175:443      TIME_WAIT
+                # tcp6       0      0 46.105.75.4:80          93.15.237.188:58038     FIN_WAIT2
+                # tcp6       0      0 46.105.75.4:80          79.220.227.193:2029     ESTABLISHED
+                # udp        0      0 0.0.0.0:123             0.0.0.0:*
+                # udp6       0      0 :::41458                :::*
+
+                metrics = self.parse_cx_state(lines[2:], self.tcp_states['netstat'], 5)
+                for metric, value in iteritems(metrics):
+                    self.gauge(metric, value, tags=custom_tags)
+
+                if self._collect_cx_queues:
+                    for (state, recvq, sendq) in self._parse_queues("netstat", output):
+                        self.histogram('system.net.tcp.recv_q', recvq, custom_tags + ["state:" + state])
+                        self.histogram('system.net.tcp.send_q', sendq, custom_tags + ["state:" + state])
+
+            except SubprocessOutputEmptyError:
+                self.log.exception("Error collecting connection states.")
+
+        proc_dev_path = "{}/net/dev".format(net_proc_base_location)
+        try:
+            with open(proc_dev_path, 'r') as proc:
+                lines = proc.readlines()
+        except IOError:
+            # On Openshift, /proc/net/snmp is only readable by root
+            self.log.debug("Unable to read %s.", proc_dev_path)
+            lines = []
+
+        # Inter-|   Receive                                                 |  Transmit
+        #  face |bytes     packets errs drop fifo frame compressed multicast|bytes       packets errs drop fifo colls carrier compressed # noqa: E501
+        #     lo:45890956   112797   0    0    0     0          0         0    45890956   112797    0    0    0     0       0          0 # noqa: E501
+        #   eth0:631947052 1042233   0   19    0   184          0      1206  1208625538  1320529    0    0    0     0       0          0 # noqa: E501
+        #   eth1:       0        0   0    0    0     0          0         0           0        0    0    0    0     0       0          0 # noqa: E501
+        for line in lines[2:]:
+            cols = line.split(':', 1)
+            x = cols[1].split()
+            # Filter inactive interfaces
+            if self.parse_long(x[0]) or self.parse_long(x[8]):
+                iface = cols[0].strip()
+                metrics = {
+                    'bytes_rcvd': self.parse_long(x[0]),
+                    'bytes_sent': self.parse_long(x[8]),
+                    'packets_in.count': self.parse_long(x[1]),
+                    'packets_in.drop': self.parse_long(x[3]),
+                    'packets_in.error': self.parse_long(x[2]) + self.parse_long(x[3]),
+                    'packets_out.count': self.parse_long(x[9]),
+                    'packets_out.drop': self.parse_long(x[11]),
+                    'packets_out.error': self.parse_long(x[10]) + self.parse_long(x[11]),
+                }
+                self.submit_devicemetrics(iface, metrics, custom_tags)
+                self._handle_ethtool_stats(iface, custom_tags)
+
+        netstat_data = {}
+        for f in ['netstat', 'snmp']:
+            proc_data_path = "{}/net/{}".format(net_proc_base_location, f)
+            try:
+                with open(proc_data_path, 'r') as netstat:
+                    while True:
+                        n_header = netstat.readline()
+                        if not n_header:
+                            break  # No more? Abort!
+                        n_data = netstat.readline()
+
+                        h_parts = n_header.strip().split(' ')
+                        h_values = n_data.strip().split(' ')
+                        ns_category = h_parts[0][:-1]
+                        netstat_data[ns_category] = {}
+                        # Turn the data into a dictionary
+                        for idx, hpart in enumerate(h_parts[1:]):
+                            netstat_data[ns_category][hpart] = h_values[idx + 1]
+            except IOError:
+                # On Openshift, /proc/net/snmp is only readable by root
+                self.log.debug("Unable to read %s.", proc_data_path)
+
+        nstat_metrics_names = {
+            'Ip': {
+                'InReceives': 'system.net.ip.in_receives',
+                'InHdrErrors': 'system.net.ip.in_header_errors',
+                'InAddrErrors': 'system.net.ip.in_addr_errors',
+                'InUnknownProtos': 'system.net.ip.in_unknown_protos',
+                'InDiscards': 'system.net.ip.in_discards',
+                'InDelivers': 'system.net.ip.in_delivers',
+                'OutRequests': 'system.net.ip.out_requests',
+                'OutDiscards': 'system.net.ip.out_discards',
+                'OutNoRoutes': 'system.net.ip.out_no_routes',
+                'ForwDatagrams': 'system.net.ip.forwarded_datagrams',
+                'ReasmTimeout': 'system.net.ip.reassembly_timeouts',
+                'ReasmReqds': 'system.net.ip.reassembly_requests',
+                'ReasmOKs': 'system.net.ip.reassembly_oks',
+                'ReasmFails': 'system.net.ip.reassembly_fails',
+                'FragOKs': 'system.net.ip.fragmentation_oks',
+                'FragFails': 'system.net.ip.fragmentation_fails',
+                'FragCreates': 'system.net.ip.fragmentation_creates',
+            },
+            'IpExt': {
+                'InNoRoutes': 'system.net.ip.in_no_routes',
+                'InTruncatedPkts': 'system.net.ip.in_truncated_pkts',
+                'InCsumErrors': 'system.net.ip.in_csum_errors',
+                'ReasmOverlaps': 'system.net.ip.reassembly_overlaps',
+            },
+            'Tcp': {
+                'RetransSegs': 'system.net.tcp.retrans_segs',
+                'InSegs': 'system.net.tcp.in_segs',
+                'OutSegs': 'system.net.tcp.out_segs',
+                'ActiveOpens': 'system.net.tcp.active_opens',
+                'PassiveOpens': 'system.net.tcp.passive_opens',
+                'AttemptFails': 'system.net.tcp.attempt_fails',
+                'EstabResets': 'system.net.tcp.established_resets',
+                'InErrs': 'system.net.tcp.in_errors',
+                'OutRsts': 'system.net.tcp.out_resets',
+                'InCsumErrors': 'system.net.tcp.in_csum_errors',
+            },
+            'TcpExt': {
+                'ListenOverflows': 'system.net.tcp.listen_overflows',
+                'ListenDrops': 'system.net.tcp.listen_drops',
+                'TCPBacklogDrop': 'system.net.tcp.backlog_drops',
+                'TCPRetransFail': 'system.net.tcp.failed_retransmits',
+                'IPReversePathFilter': 'system.net.ip.reverse_path_filter',
+                'PruneCalled': 'system.net.tcp.prune_called',
+                'RcvPruned': 'system.net.tcp.prune_rcv_drops',
+                'OfoPruned': 'system.net.tcp.prune_ofo_called',
+                'PAWSActive': 'system.net.tcp.paws_connection_drops',
+                'PAWSEstab': 'system.net.tcp.paws_established_drops',
+                'SyncookiesSent': 'system.net.tcp.syn_cookies_sent',
+                'SyncookiesRecv': 'system.net.tcp.syn_cookies_recv',
+                'SyncookiesFailed': 'system.net.tcp.syn_cookies_failed',
+                'TCPAbortOnTimeout': 'system.net.tcp.abort_on_timeout',
+                'TCPSynRetrans': 'system.net.tcp.syn_retrans',
+                'TCPFromZeroWindowAdv': 'system.net.tcp.from_zero_window',
+                'TCPToZeroWindowAdv': 'system.net.tcp.to_zero_window',
+                'TWRecycled': 'system.net.tcp.tw_reused',
+            },
+            'Udp': {
+                'InDatagrams': 'system.net.udp.in_datagrams',
+                'NoPorts': 'system.net.udp.no_ports',
+                'InErrors': 'system.net.udp.in_errors',
+                'OutDatagrams': 'system.net.udp.out_datagrams',
+                'RcvbufErrors': 'system.net.udp.rcv_buf_errors',
+                'SndbufErrors': 'system.net.udp.snd_buf_errors',
+                'InCsumErrors': 'system.net.udp.in_csum_errors',
+            },
+        }
+        nstat_metrics_gauge_names = {
+            'Tcp': {
+                'CurrEstab': 'system.net.tcp.current_established',
+            },
+        }
+
+        for k in nstat_metrics_names:
+            for met in nstat_metrics_names[k]:
+                if met in netstat_data.get(k, {}):
+                    self._submit_netmetric(
+                        nstat_metrics_names[k][met], self.parse_long(netstat_data[k][met]), tags=custom_tags
+                    )
+
+        for k in nstat_metrics_gauge_names:
+            for met in nstat_metrics_gauge_names[k]:
+                if met in netstat_data.get(k, {}):
+                    self._submit_netmetric_gauge(
+                        nstat_metrics_gauge_names[k][met], self.parse_long(netstat_data[k][met]), tags=custom_tags
+                    )
+
+        # Get the conntrack -S information
+        conntrack_path = self.instance.get('conntrack_path')
+        use_sudo_conntrack = is_affirmative(self.instance.get('use_sudo_conntrack', True))
+        if conntrack_path is not None:
+            self._add_conntrack_stats_metrics(conntrack_path, use_sudo_conntrack, custom_tags)
+
+        # Get the rest of the metric by reading the files. Metrics available since kernel 3.6
+        conntrack_files_location = os.path.join(proc_location, 'sys', 'net', 'netfilter')
+        # By default, only max and count are reported. However if the blacklist is set,
+        # the whitelist is losing its default value
+        blacklisted_files = self.instance.get('blacklist_conntrack_metrics')
+        whitelisted_files = self.instance.get('whitelist_conntrack_metrics')
+        if blacklisted_files is None and whitelisted_files is None:
+            whitelisted_files = ['max', 'count']
+
+        available_files = []
+
+        # Get the metrics to read
+        try:
+            for metric_file in os.listdir(conntrack_files_location):
+                if (
+                    os.path.isfile(os.path.join(conntrack_files_location, metric_file))
+                    and 'nf_conntrack_' in metric_file
+                ):
+                    available_files.append(metric_file[len('nf_conntrack_') :])
+        except Exception as e:
+            self.log.debug("Unable to list the files in %s. %s", conntrack_files_location, e)
+
+        filtered_available_files = pattern_filter(
+            available_files, whitelist=whitelisted_files, blacklist=blacklisted_files
+        )
+
+        for metric_name in filtered_available_files:
+            metric_file_location = os.path.join(conntrack_files_location, 'nf_conntrack_{}'.format(metric_name))
+            value = self._read_int_file(metric_file_location)
+            if value is not None:
+                self.gauge('system.net.conntrack.{}'.format(metric_name), value, tags=custom_tags)
+
+    def get_expected_metrics(self):
+        expected_metrics = super(LinuxNetwork, self).get_expected_metrics()
+        expected_metrics.extend(
+            [
+                'packets_in.drop',
+                'packets_out.drop',
+            ]
+        )
+        return expected_metrics
+
+    def _submit_netmetric(self, metric, value, tags=None):
+        if self._collect_rate_metrics:
+            self.rate(metric, value, tags=tags)
+        if self._collect_count_metrics:
+            self.monotonic_count('{}.count'.format(metric), value, tags=tags)
+
+    def _submit_netmetric_gauge(self, metric, value, tags=None):
+        self.gauge(metric, value, tags=tags)
+
+    def _read_int_file(self, file_location):
+        try:
+            with open(file_location, 'r') as f:
+                try:
+                    value = int(f.read().rstrip())
+                    return value
+                except ValueError:
+                    self.log.debug("Content of %s is not an integer", file_location)
+        except IOError as e:
+            self.log.debug("Unable to read %s, skipping %s.", file_location, e)
+            return None
+
+    def _get_iface_sys_metrics(self, custom_tags):
+        sys_net_location = '/sys/class/net'
+        sys_net_metrics = ['mtu', 'tx_queue_len']
+        try:
+            ifaces = os.listdir(sys_net_location)
+        except OSError as e:
+            self.log.debug("Unable to list %s, skipping system iface metrics: %s.", sys_net_location, e)
+            return None
+        for iface in ifaces:
+            for metric_name in sys_net_metrics:
+                metric_file_location = os.path.join(sys_net_location, iface, metric_name)
+                value = self._read_int_file(metric_file_location)
+                if value is not None:
+                    self.gauge('system.net.iface.{}'.format(metric_name), value, tags=custom_tags + ["iface:" + iface])
+            iface_queues_location = os.path.join(sys_net_location, iface, 'queues')
+            self._collect_iface_queue_metrics(iface, iface_queues_location, custom_tags)
+
+    def _collect_iface_queue_metrics(self, iface, iface_queues_location, custom_tags):
+        try:
+            iface_queues = os.listdir(iface_queues_location)
+        except OSError as e:
+            self.log.debug("Unable to list %s, skipping %s.", iface_queues_location, e)
+            return
+        num_rx_queues = len([q for q in iface_queues if q.startswith('rx-')])
+        num_tx_queues = len([q for q in iface_queues if q.startswith('tx-')])
+        self.gauge('system.net.iface.num_tx_queues', num_tx_queues, tags=custom_tags + ["iface:" + iface])
+        self.gauge('system.net.iface.num_rx_queues', num_rx_queues, tags=custom_tags + ["iface:" + iface])
+
+    def _add_conntrack_stats_metrics(self, conntrack_path, use_sudo_conntrack, tags):
+        """
+        Parse the output of conntrack -S
+        Add the parsed metrics
+        """
+        try:
+            cmd = [conntrack_path, "-S"]
+            if use_sudo_conntrack:
+                cmd.insert(0, "sudo")
+            output, _, _ = get_subprocess_output(cmd, self.log)
+            # conntrack -S sample:
+            # cpu=0 found=27644 invalid=19060 ignore=485633411 insert=0 insert_failed=1 \
+            #       drop=1 early_drop=0 error=0 search_restart=39936711
+            # cpu=1 found=21960 invalid=17288 ignore=475938848 insert=0 insert_failed=1 \
+            #       drop=1 early_drop=0 error=0 search_restart=36983181
+
+            lines = output.splitlines()
+
+            for line in lines:
+                cols = line.split()
+                cpu_num = cols[0].split('=')[-1]
+                cpu_tag = ['cpu:{}'.format(cpu_num)]
+                cols = cols[1:]
+
+                for cell in cols:
+                    metric, value = cell.split('=')
+                    self.monotonic_count('system.net.conntrack.{}'.format(metric), int(value), tags=tags + cpu_tag)
+        except SubprocessOutputEmptyError:
+            self.log.debug("Couldn't use %s to get conntrack stats", conntrack_path)
+
+    def _parse_short_state_lines(self, lines, metrics, tcp_states, ip_version):
+        for line in lines:
+            value, state = line.split()
+            proto = "tcp{0}".format(ip_version)
+            if state in tcp_states:
+                metric = self.cx_state_gauge[proto, tcp_states[state]]
+                metrics[metric] += int(value)
+
+    def _parse_queues(self, tool, ss_output):
+        """
+        for each line of `ss_output`, returns a triplet with:
+        * a connection state (`established`, `listening`)
+        * the receive queue size
+        * the send queue size
+        """
+        for line in ss_output.splitlines():
+            fields = line.split()
+
+            if len(fields) < (6 if tool == "netstat" else 3):
+                continue
+
+            state_column = 0 if tool == "ss" else 5
+
+            try:
+                state = self.tcp_states[tool][fields[state_column]]
+            except KeyError:
+                continue
+
+            yield (state, fields[1], fields[2])
+
+    def _handle_ethtool_stats(self, iface, custom_tags):
+        # read Ethtool metrics, if configured and available
+        if not self._collect_ethtool_stats:
+            return
+        if iface in self._excluded_ifaces or (self._exclude_iface_re and self._exclude_iface_re.match(iface)):
+            # Skip this network interface.
+            return
+        if iface in ['lo', 'lo0']:
+            # Skip loopback ifaces as they don't support SIOCETHTOOL
+            return
+
+        driver_name, driver_version, ethtool_stats_names, ethtool_stats = self._fetch_ethtool_stats(iface)
+        tags = [] if custom_tags is None else custom_tags[:]
+        tags.append('driver_name:{}'.format(driver_name))
+        tags.append('driver_version:{}'.format(driver_version))
+        if self._collect_ena_metrics:
+            ena_metrics = ethtool.get_ena_metrics(ethtool_stats_names, ethtool_stats)
+            self._submit_ena_metrics(iface, ena_metrics, tags)
+        if self._collect_ethtool_metrics:
+            ethtool_metrics = ethtool.get_ethtool_metrics(driver_name, ethtool_stats_names, ethtool_stats)
+            self._submit_ethtool_metrics(iface, ethtool_metrics, tags)
+
+    def _submit_ena_metrics(self, iface, vals_by_metric, tags):
+        if not vals_by_metric:
+            return
+        if iface in self._excluded_ifaces or (self._exclude_iface_re and self._exclude_iface_re.match(iface)):
+            # Skip this network interface.
+            return
+
+        metric_tags = [] if tags is None else tags[:]
+        metric_tags.append('device:{}'.format(iface))
+
+        allowed = [ENA_METRIC_PREFIX + m for m in ENA_METRIC_NAMES]
+        for m in vals_by_metric:
+            assert m in allowed
+
+        count = 0
+        for metric, val in iteritems(vals_by_metric):
+            self.gauge('system.net.%s' % metric, val, tags=metric_tags)
+            count += 1
+        self.log.debug("tracked %s network ena metrics for interface %s", count, iface)
+
+    def _submit_ethtool_metrics(self, iface, ethtool_metrics, base_tags):
+        if not ethtool_metrics:
+            return
+        if iface in self._excluded_ifaces or (self._exclude_iface_re and self._exclude_iface_re.match(iface)):
+            # Skip this network interface.
+            return
+
+        base_tags_with_device = [] if base_tags is None else base_tags[:]
+        base_tags_with_device.append('device:{}'.format(iface))
+
+        count = 0
+        for ethtool_tag, metric_map in iteritems(ethtool_metrics):
+            tags = base_tags_with_device + [ethtool_tag]
+            for metric, val in iteritems(metric_map):
+                self.monotonic_count('system.net.%s' % metric, val, tags=tags)
+                count += 1
+        self.log.debug("tracked %s network ethtool metrics for interface %s", count, iface)
+
+    def _fetch_ethtool_stats(self, iface):
+        """
+        Collect ethtool metrics for given interface.
+
+        Ethtool metrics are collected via the ioctl SIOCETHTOOL call. At the time of writing
+        this method, there are no maintained Python libraries that do this. The solution
+        is based on:
+
+        * https://github.com/safchain/ethtool
+        * https://gist.github.com/yunazuno/d7cd7e1e127a39192834c75d85d45df9
+        """
+        ethtool_socket = None
+        try:
+            ethtool_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, 0)
+            driver_name, driver_version = ethtool.get_ethtool_drvinfo(iface, ethtool_socket)
+            stats_names, stats = ethtool.get_ethtool_stats(iface, ethtool_socket)
+            return driver_name, driver_version, stats_names, stats
+        except OSError as e:
+            # this will happen for interfaces that don't support SIOCETHTOOL - e.g. loopback or docker
+            self.log.debug('OSError while trying to collect ethtool metrics for interface %s: %s', iface, str(e))
+        except Exception:
+            self.log.exception('Unable to collect ethtool metrics for interface %s', iface)
+        finally:
+            if ethtool_socket is not None:
+                ethtool_socket.close()
+        return None, None, [], []

--- a/network/datadog_checks/network/check_linux.py
+++ b/network/datadog_checks/network/check_linux.py
@@ -19,11 +19,6 @@ try:
 except ImportError:
     from datadog_checks.base.stubs import datadog_agent
 
-try:
-    import fcntl
-except ImportError:
-    fcntl = None
-
 if PY3:
     long = int
 
@@ -34,7 +29,7 @@ class LinuxNetwork(Network):
 
     def check(self, _):
         """
-        _check_linux can be run inside a container and still collects the network metrics from the host
+        check can be run inside a container and still collects the network metrics from the host
         For that procfs_path can be set to something like "/host/proc"
         When a custom procfs_path is set, the collect_connection_state option is ignored
         """

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -226,7 +226,7 @@ class Network(AgentCheck):
                 },
             }
 
-    def _submit_devicemetrics(self, iface, vals_by_metric, tags):
+    def submit_devicemetrics(self, iface, vals_by_metric, tags):
         if iface in self._excluded_ifaces or (self._exclude_iface_re and self._exclude_iface_re.match(iface)):
             # Skip this network interface.
             return
@@ -443,7 +443,7 @@ class Network(AgentCheck):
                         'packets_out.count': self.parse_long(x[-4]),
                         'packets_out.error': self.parse_long(x[-3]),
                     }
-                    self._submit_devicemetrics(iface, metrics, custom_tags)
+                    self.submit_devicemetrics(iface, metrics, custom_tags)
         except SubprocessOutputEmptyError:
             self.log.exception("Error collecting connection stats.")
 
@@ -505,7 +505,7 @@ class Network(AgentCheck):
             netstat, _, _ = get_subprocess_output(["kstat", "-p", "link:0:"], self.log)
             metrics_by_interface = self._parse_solaris_netstat(netstat)
             for interface, metrics in iteritems(metrics_by_interface):
-                self._submit_devicemetrics(interface, metrics, custom_tags)
+                self.submit_devicemetrics(interface, metrics, custom_tags)
         except SubprocessOutputEmptyError:
             self.log.exception("Error collecting kstat stats.")
 
@@ -665,7 +665,7 @@ class Network(AgentCheck):
                 'packets_out.drop': counters.dropout,
                 'packets_out.error': counters.errout,
             }
-            self._submit_devicemetrics(iface, metrics, tags)
+            self.submit_devicemetrics(iface, metrics, tags)
 
     def _parse_protocol_psutil(self, conn):
         """

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -7,7 +7,6 @@ Collects network metrics.
 """
 
 import distutils.spawn
-import os
 import re
 import socket
 from collections import defaultdict
@@ -15,18 +14,11 @@ from collections import defaultdict
 import psutil
 from six import PY3, iteritems, itervalues
 
-from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
-from datadog_checks.base.utils.common import pattern_filter
+from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.base.utils.subprocess_output import SubprocessOutputEmptyError, get_subprocess_output
 
-from . import ethtool
 from .const import BSD_TCP_METRICS, ENA_METRIC_NAMES, ENA_METRIC_PREFIX, SOLARIS_TCP_METRICS
-
-try:
-    import datadog_agent
-except ImportError:
-    from datadog_checks.base.stubs import datadog_agent
 
 try:
     import fcntl
@@ -42,6 +34,18 @@ class Network(AgentCheck):
     SOURCE_TYPE_NAME = 'system'
     PSUTIL_TYPE_MAPPING = {socket.SOCK_STREAM: 'tcp', socket.SOCK_DGRAM: 'udp'}
     PSUTIL_FAMILY_MAPPING = {socket.AF_INET: '4', socket.AF_INET6: '6'}
+
+    def __new__(cls, name, init_config, instances):
+        if cls is not Network:
+            # avoid infinite recursion
+            return super(Network, cls).__new__(cls)
+        if Platform.is_linux():
+            from .check_linux import LinuxNetwork
+
+            return LinuxNetwork(name, init_config, instances)
+        else:
+            # Todo: remove later in the refactor
+            return super(Network, cls).__new__(cls)
 
     def __init__(self, name, init_config, instances):
         super(Network, self).__init__(name, init_config, instances)
@@ -81,9 +85,7 @@ class Network(AgentCheck):
                 )
 
     def check(self, _):
-        if Platform.is_linux():
-            self._check_linux(self.instance)
-        elif Platform.is_bsd():
+        if Platform.is_bsd():
             self._check_bsd(self.instance)
         elif Platform.is_solaris():
             self._check_solaris(self.instance)
@@ -224,15 +226,6 @@ class Network(AgentCheck):
                 },
             }
 
-    def _submit_netmetric(self, metric, value, tags=None):
-        if self._collect_rate_metrics:
-            self.rate(metric, value, tags=tags)
-        if self._collect_count_metrics:
-            self.monotonic_count('{}.count'.format(metric), value, tags=tags)
-
-    def _submit_netmetric_gauge(self, metric, value, tags=None):
-        self.gauge(metric, value, tags=tags)
-
     def _submit_devicemetrics(self, iface, vals_by_metric, tags):
         if iface in self._excluded_ifaces or (self._exclude_iface_re and self._exclude_iface_re.match(iface)):
             # Skip this network interface.
@@ -242,7 +235,7 @@ class Network(AgentCheck):
         metric_tags = [] if tags is None else tags[:]
         metric_tags.append('device:{}'.format(iface))
 
-        expected_metrics = self._get_expected_metrics()
+        expected_metrics = self.get_expected_metrics()
         for m in expected_metrics:
             assert m in vals_by_metric
         assert len(vals_by_metric) == len(expected_metrics)
@@ -253,7 +246,7 @@ class Network(AgentCheck):
             count += 1
         self.log.debug("tracked %s network metrics for interface %s", count, iface)
 
-    def _get_expected_metrics(self):
+    def get_expected_metrics(self):
         expected_metrics = [
             'bytes_rcvd',
             'bytes_sent',
@@ -262,7 +255,7 @@ class Network(AgentCheck):
             'packets_out.count',
             'packets_out.error',
         ]
-        if Platform.is_linux() or Platform.is_windows():
+        if Platform.is_windows():
             expected_metrics.extend(
                 [
                     'packets_in.drop',
@@ -309,7 +302,7 @@ class Network(AgentCheck):
                 count += 1
         self.log.debug("tracked %s network ethtool metrics for interface %s", count, iface)
 
-    def _parse_value(self, v):
+    def parse_long(self, v):
         try:
             return long(v)
         except ValueError:
@@ -321,9 +314,9 @@ class Network(AgentCheck):
             for regex, metric in regex_list:
                 value = re.match(regex, line)
                 if value:
-                    self._submit_netmetric(metric, self._parse_value(value.group(1)), tags=tags)
+                    self._submit_netmetric(metric, self.parse_long(value.group(1)), tags=tags)
 
-    def _is_collect_cx_state_runnable(self, proc_location):
+    def is_collect_cx_state_runnable(self, proc_location):
         """
         Determine if collect_connection_state is set and can effectively run.
         If self._collect_cx_state is True and a custom proc_location is provided, the system cannot
@@ -348,367 +341,18 @@ class Network(AgentCheck):
 
         return True
 
-    def _check_linux(self, instance):
-        """
-        _check_linux can be run inside a container and still collects the network metrics from the host
-        For that procfs_path can be set to something like "/host/proc"
-        When a custom procfs_path is set, the collect_connection_state option is ignored
-        """
-        proc_location = datadog_agent.get_config('procfs_path')
-        if not proc_location:
-            proc_location = '/proc'
-        proc_location = proc_location.rstrip('/')
-        custom_tags = instance.get('tags', [])
-
-        self._get_iface_sys_metrics(custom_tags)
-        net_proc_base_location = self._get_net_proc_base_location(proc_location)
-
-        if self._is_collect_cx_state_runnable(net_proc_base_location):
-            try:
-                self.log.debug("Using `ss` to collect connection state")
-                # Try using `ss` for increased performance over `netstat`
-                ss_env = {"PROC_ROOT": net_proc_base_location}
-
-                # By providing the environment variables in ss_env, the PATH will be overridden. In CentOS,
-                # datadog-agent PATH is "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin", while sh PATH
-                # will be '/usr/local/bin:/usr/bin'. In CentOS, ss is located in /sbin and /usr/sbin, not
-                # in the sh PATH, which will result in network metric collection failure.
-                #
-                # The line below will set sh PATH explicitly as the datadog-agent PATH to fix that issue.
-                if "PATH" in os.environ:
-                    ss_env["PATH"] = os.environ["PATH"]
-
-                metrics = self._get_metrics()
-                for ip_version in ['4', '6']:
-                    # Call `ss` for each IP version because there's no built-in way of distinguishing
-                    # between the IP versions in the output
-                    # Also calls `ss` for each protocol, because on some systems (e.g. Ubuntu 14.04), there is a
-                    # bug that print `tcp` even if it's `udp`
-                    # The `-H` flag isn't available on old versions of `ss`.
-                    cmd = "ss --numeric --tcp --all --ipv{} | cut -d ' ' -f 1 | sort | uniq -c".format(ip_version)
-                    output, _, _ = get_subprocess_output(["sh", "-c", cmd], self.log, env=ss_env)
-
-                    # 7624 CLOSE-WAIT
-                    #   72 ESTAB
-                    #    9 LISTEN
-                    #    1 State
-                    #   37 TIME-WAIT
-                    lines = output.splitlines()
-
-                    self._parse_short_state_lines(lines, metrics, self.tcp_states['ss'], ip_version=ip_version)
-
-                    cmd = "ss --numeric --udp --all --ipv{} | wc -l".format(ip_version)
-                    output, _, _ = get_subprocess_output(["sh", "-c", cmd], self.log, env=ss_env)
-                    metric = self.cx_state_gauge[('udp{}'.format(ip_version), 'connections')]
-                    metrics[metric] = int(output) - 1  # Remove header
-
-                    if self._collect_cx_queues:
-                        cmd = "ss --numeric --tcp --all --ipv{}".format(ip_version)
-                        output, _, _ = get_subprocess_output(["sh", "-c", cmd], self.log, env=ss_env)
-                        for (state, recvq, sendq) in self._parse_queues("ss", output):
-                            self.histogram('system.net.tcp.recv_q', recvq, custom_tags + ["state:" + state])
-                            self.histogram('system.net.tcp.send_q', sendq, custom_tags + ["state:" + state])
-
-                for metric, value in iteritems(metrics):
-                    self.gauge(metric, value, tags=custom_tags)
-
-            except OSError as e:
-                self.log.info("`ss` invocation failed: %s. Using `netstat` as a fallback", str(e))
-                output, _, _ = get_subprocess_output(["netstat", "-n", "-u", "-t", "-a"], self.log)
-                lines = output.splitlines()
-                # Active Internet connections (w/o servers)
-                # Proto Recv-Q Send-Q Local Address           Foreign Address         State
-                # tcp        0      0 46.105.75.4:80          79.220.227.193:2032     SYN_RECV
-                # tcp        0      0 46.105.75.4:143         90.56.111.177:56867     ESTABLISHED
-                # tcp        0      0 46.105.75.4:50468       107.20.207.175:443      TIME_WAIT
-                # tcp6       0      0 46.105.75.4:80          93.15.237.188:58038     FIN_WAIT2
-                # tcp6       0      0 46.105.75.4:80          79.220.227.193:2029     ESTABLISHED
-                # udp        0      0 0.0.0.0:123             0.0.0.0:*
-                # udp6       0      0 :::41458                :::*
-
-                metrics = self._parse_linux_cx_state(lines[2:], self.tcp_states['netstat'], 5)
-                for metric, value in iteritems(metrics):
-                    self.gauge(metric, value, tags=custom_tags)
-
-                if self._collect_cx_queues:
-                    for (state, recvq, sendq) in self._parse_queues("netstat", output):
-                        self.histogram('system.net.tcp.recv_q', recvq, custom_tags + ["state:" + state])
-                        self.histogram('system.net.tcp.send_q', sendq, custom_tags + ["state:" + state])
-
-            except SubprocessOutputEmptyError:
-                self.log.exception("Error collecting connection states.")
-
-        proc_dev_path = "{}/net/dev".format(net_proc_base_location)
-        try:
-            with open(proc_dev_path, 'r') as proc:
-                lines = proc.readlines()
-        except IOError:
-            # On Openshift, /proc/net/snmp is only readable by root
-            self.log.debug("Unable to read %s.", proc_dev_path)
-            lines = []
-
-        # Inter-|   Receive                                                 |  Transmit
-        #  face |bytes     packets errs drop fifo frame compressed multicast|bytes       packets errs drop fifo colls carrier compressed # noqa: E501
-        #     lo:45890956   112797   0    0    0     0          0         0    45890956   112797    0    0    0     0       0          0 # noqa: E501
-        #   eth0:631947052 1042233   0   19    0   184          0      1206  1208625538  1320529    0    0    0     0       0          0 # noqa: E501
-        #   eth1:       0        0   0    0    0     0          0         0           0        0    0    0    0     0       0          0 # noqa: E501
-        for line in lines[2:]:
-            cols = line.split(':', 1)
-            x = cols[1].split()
-            # Filter inactive interfaces
-            if self._parse_value(x[0]) or self._parse_value(x[8]):
-                iface = cols[0].strip()
-                metrics = {
-                    'bytes_rcvd': self._parse_value(x[0]),
-                    'bytes_sent': self._parse_value(x[8]),
-                    'packets_in.count': self._parse_value(x[1]),
-                    'packets_in.drop': self._parse_value(x[3]),
-                    'packets_in.error': self._parse_value(x[2]) + self._parse_value(x[3]),
-                    'packets_out.count': self._parse_value(x[9]),
-                    'packets_out.drop': self._parse_value(x[11]),
-                    'packets_out.error': self._parse_value(x[10]) + self._parse_value(x[11]),
-                }
-                self._submit_devicemetrics(iface, metrics, custom_tags)
-                self._handle_ethtool_stats(iface, custom_tags)
-
-        netstat_data = {}
-        for f in ['netstat', 'snmp']:
-            proc_data_path = "{}/net/{}".format(net_proc_base_location, f)
-            try:
-                with open(proc_data_path, 'r') as netstat:
-                    while True:
-                        n_header = netstat.readline()
-                        if not n_header:
-                            break  # No more? Abort!
-                        n_data = netstat.readline()
-
-                        h_parts = n_header.strip().split(' ')
-                        h_values = n_data.strip().split(' ')
-                        ns_category = h_parts[0][:-1]
-                        netstat_data[ns_category] = {}
-                        # Turn the data into a dictionary
-                        for idx, hpart in enumerate(h_parts[1:]):
-                            netstat_data[ns_category][hpart] = h_values[idx + 1]
-            except IOError:
-                # On Openshift, /proc/net/snmp is only readable by root
-                self.log.debug("Unable to read %s.", proc_data_path)
-
-        nstat_metrics_names = {
-            'Ip': {
-                'InReceives': 'system.net.ip.in_receives',
-                'InHdrErrors': 'system.net.ip.in_header_errors',
-                'InAddrErrors': 'system.net.ip.in_addr_errors',
-                'InUnknownProtos': 'system.net.ip.in_unknown_protos',
-                'InDiscards': 'system.net.ip.in_discards',
-                'InDelivers': 'system.net.ip.in_delivers',
-                'OutRequests': 'system.net.ip.out_requests',
-                'OutDiscards': 'system.net.ip.out_discards',
-                'OutNoRoutes': 'system.net.ip.out_no_routes',
-                'ForwDatagrams': 'system.net.ip.forwarded_datagrams',
-                'ReasmTimeout': 'system.net.ip.reassembly_timeouts',
-                'ReasmReqds': 'system.net.ip.reassembly_requests',
-                'ReasmOKs': 'system.net.ip.reassembly_oks',
-                'ReasmFails': 'system.net.ip.reassembly_fails',
-                'FragOKs': 'system.net.ip.fragmentation_oks',
-                'FragFails': 'system.net.ip.fragmentation_fails',
-                'FragCreates': 'system.net.ip.fragmentation_creates',
-            },
-            'IpExt': {
-                'InNoRoutes': 'system.net.ip.in_no_routes',
-                'InTruncatedPkts': 'system.net.ip.in_truncated_pkts',
-                'InCsumErrors': 'system.net.ip.in_csum_errors',
-                'ReasmOverlaps': 'system.net.ip.reassembly_overlaps',
-            },
-            'Tcp': {
-                'RetransSegs': 'system.net.tcp.retrans_segs',
-                'InSegs': 'system.net.tcp.in_segs',
-                'OutSegs': 'system.net.tcp.out_segs',
-                'ActiveOpens': 'system.net.tcp.active_opens',
-                'PassiveOpens': 'system.net.tcp.passive_opens',
-                'AttemptFails': 'system.net.tcp.attempt_fails',
-                'EstabResets': 'system.net.tcp.established_resets',
-                'InErrs': 'system.net.tcp.in_errors',
-                'OutRsts': 'system.net.tcp.out_resets',
-                'InCsumErrors': 'system.net.tcp.in_csum_errors',
-            },
-            'TcpExt': {
-                'ListenOverflows': 'system.net.tcp.listen_overflows',
-                'ListenDrops': 'system.net.tcp.listen_drops',
-                'TCPBacklogDrop': 'system.net.tcp.backlog_drops',
-                'TCPRetransFail': 'system.net.tcp.failed_retransmits',
-                'IPReversePathFilter': 'system.net.ip.reverse_path_filter',
-                'PruneCalled': 'system.net.tcp.prune_called',
-                'RcvPruned': 'system.net.tcp.prune_rcv_drops',
-                'OfoPruned': 'system.net.tcp.prune_ofo_called',
-                'PAWSActive': 'system.net.tcp.paws_connection_drops',
-                'PAWSEstab': 'system.net.tcp.paws_established_drops',
-                'SyncookiesSent': 'system.net.tcp.syn_cookies_sent',
-                'SyncookiesRecv': 'system.net.tcp.syn_cookies_recv',
-                'SyncookiesFailed': 'system.net.tcp.syn_cookies_failed',
-                'TCPAbortOnTimeout': 'system.net.tcp.abort_on_timeout',
-                'TCPSynRetrans': 'system.net.tcp.syn_retrans',
-                'TCPFromZeroWindowAdv': 'system.net.tcp.from_zero_window',
-                'TCPToZeroWindowAdv': 'system.net.tcp.to_zero_window',
-                'TWRecycled': 'system.net.tcp.tw_reused',
-            },
-            'Udp': {
-                'InDatagrams': 'system.net.udp.in_datagrams',
-                'NoPorts': 'system.net.udp.no_ports',
-                'InErrors': 'system.net.udp.in_errors',
-                'OutDatagrams': 'system.net.udp.out_datagrams',
-                'RcvbufErrors': 'system.net.udp.rcv_buf_errors',
-                'SndbufErrors': 'system.net.udp.snd_buf_errors',
-                'InCsumErrors': 'system.net.udp.in_csum_errors',
-            },
-        }
-        nstat_metrics_gauge_names = {
-            'Tcp': {
-                'CurrEstab': 'system.net.tcp.current_established',
-            },
-        }
-
-        for k in nstat_metrics_names:
-            for met in nstat_metrics_names[k]:
-                if met in netstat_data.get(k, {}):
-                    self._submit_netmetric(
-                        nstat_metrics_names[k][met], self._parse_value(netstat_data[k][met]), tags=custom_tags
-                    )
-
-        for k in nstat_metrics_gauge_names:
-            for met in nstat_metrics_gauge_names[k]:
-                if met in netstat_data.get(k, {}):
-                    self._submit_netmetric_gauge(
-                        nstat_metrics_gauge_names[k][met], self._parse_value(netstat_data[k][met]), tags=custom_tags
-                    )
-
-        # Get the conntrack -S information
-        conntrack_path = instance.get('conntrack_path')
-        use_sudo_conntrack = is_affirmative(instance.get('use_sudo_conntrack', True))
-        if conntrack_path is not None:
-            self._add_conntrack_stats_metrics(conntrack_path, use_sudo_conntrack, custom_tags)
-
-        # Get the rest of the metric by reading the files. Metrics available since kernel 3.6
-        conntrack_files_location = os.path.join(proc_location, 'sys', 'net', 'netfilter')
-        # By default, only max and count are reported. However if the blacklist is set,
-        # the whitelist is losing its default value
-        blacklisted_files = instance.get('blacklist_conntrack_metrics')
-        whitelisted_files = instance.get('whitelist_conntrack_metrics')
-        if blacklisted_files is None and whitelisted_files is None:
-            whitelisted_files = ['max', 'count']
-
-        available_files = []
-
-        # Get the metrics to read
-        try:
-            for metric_file in os.listdir(conntrack_files_location):
-                if (
-                    os.path.isfile(os.path.join(conntrack_files_location, metric_file))
-                    and 'nf_conntrack_' in metric_file
-                ):
-                    available_files.append(metric_file[len('nf_conntrack_') :])
-        except Exception as e:
-            self.log.debug("Unable to list the files in %s. %s", conntrack_files_location, e)
-
-        filtered_available_files = pattern_filter(
-            available_files, whitelist=whitelisted_files, blacklist=blacklisted_files
-        )
-
-        for metric_name in filtered_available_files:
-            metric_file_location = os.path.join(conntrack_files_location, 'nf_conntrack_{}'.format(metric_name))
-            value = self._read_int_file(metric_file_location)
-            if value is not None:
-                self.gauge('system.net.conntrack.{}'.format(metric_name), value, tags=custom_tags)
-
     @staticmethod
-    def _get_net_proc_base_location(proc_location):
+    def get_net_proc_base_location(proc_location):
         if Platform.is_containerized() and proc_location != "/proc":
             net_proc_base_location = "%s/1" % proc_location
         else:
             net_proc_base_location = proc_location
         return net_proc_base_location
 
-    def _read_int_file(self, file_location):
-        try:
-            with open(file_location, 'r') as f:
-                try:
-                    value = int(f.read().rstrip())
-                    return value
-                except ValueError:
-                    self.log.debug("Content of %s is not an integer", file_location)
-        except IOError as e:
-            self.log.debug("Unable to read %s, skipping %s.", file_location, e)
-            return None
-
-    def _get_iface_sys_metrics(self, custom_tags):
-        sys_net_location = '/sys/class/net'
-        sys_net_metrics = ['mtu', 'tx_queue_len']
-        try:
-            ifaces = os.listdir(sys_net_location)
-        except OSError as e:
-            self.log.debug("Unable to list %s, skipping system iface metrics: %s.", sys_net_location, e)
-            return None
-        for iface in ifaces:
-            for metric_name in sys_net_metrics:
-                metric_file_location = os.path.join(sys_net_location, iface, metric_name)
-                value = self._read_int_file(metric_file_location)
-                if value is not None:
-                    self.gauge('system.net.iface.{}'.format(metric_name), value, tags=custom_tags + ["iface:" + iface])
-            iface_queues_location = os.path.join(sys_net_location, iface, 'queues')
-            self._collect_iface_queue_metrics(iface, iface_queues_location, custom_tags)
-
-    def _collect_iface_queue_metrics(self, iface, iface_queues_location, custom_tags):
-        try:
-            iface_queues = os.listdir(iface_queues_location)
-        except OSError as e:
-            self.log.debug("Unable to list %s, skipping %s.", iface_queues_location, e)
-            return
-        num_rx_queues = len([q for q in iface_queues if q.startswith('rx-')])
-        num_tx_queues = len([q for q in iface_queues if q.startswith('tx-')])
-        self.gauge('system.net.iface.num_tx_queues', num_tx_queues, tags=custom_tags + ["iface:" + iface])
-        self.gauge('system.net.iface.num_rx_queues', num_rx_queues, tags=custom_tags + ["iface:" + iface])
-
-    def _add_conntrack_stats_metrics(self, conntrack_path, use_sudo_conntrack, tags):
-        """
-        Parse the output of conntrack -S
-        Add the parsed metrics
-        """
-        try:
-            cmd = [conntrack_path, "-S"]
-            if use_sudo_conntrack:
-                cmd.insert(0, "sudo")
-            output, _, _ = get_subprocess_output(cmd, self.log)
-            # conntrack -S sample:
-            # cpu=0 found=27644 invalid=19060 ignore=485633411 insert=0 insert_failed=1 \
-            #       drop=1 early_drop=0 error=0 search_restart=39936711
-            # cpu=1 found=21960 invalid=17288 ignore=475938848 insert=0 insert_failed=1 \
-            #       drop=1 early_drop=0 error=0 search_restart=36983181
-
-            lines = output.splitlines()
-
-            for line in lines:
-                cols = line.split()
-                cpu_num = cols[0].split('=')[-1]
-                cpu_tag = ['cpu:{}'.format(cpu_num)]
-                cols = cols[1:]
-
-                for cell in cols:
-                    metric, value = cell.split('=')
-                    self.monotonic_count('system.net.conntrack.{}'.format(metric), int(value), tags=tags + cpu_tag)
-        except SubprocessOutputEmptyError:
-            self.log.debug("Couldn't use %s to get conntrack stats", conntrack_path)
-
     def _get_metrics(self):
         return {val: 0 for val in itervalues(self.cx_state_gauge)}
 
-    def _parse_short_state_lines(self, lines, metrics, tcp_states, ip_version):
-        for line in lines:
-            value, state = line.split()
-            proto = "tcp{0}".format(ip_version)
-            if state in tcp_states:
-                metric = self.cx_state_gauge[proto, tcp_states[state]]
-                metrics[metric] += int(value)
-
-    def _parse_linux_cx_state(self, lines, tcp_states, state_col, protocol=None, ip_version=None):
+    def parse_cx_state(self, lines, tcp_states, state_col, protocol=None, ip_version=None):
         """
         Parse the output of the command that retrieves the connection state (either `ss` or `netstat`)
         Returns a dict metric_name -> value
@@ -789,15 +433,15 @@ class Network(AgentCheck):
                     current = iface
 
                 # Filter inactive interfaces
-                if self._parse_value(x[-5]) or self._parse_value(x[-2]):
+                if self.parse_long(x[-5]) or self.parse_long(x[-2]):
                     iface = current
                     metrics = {
-                        'bytes_rcvd': self._parse_value(x[-5]),
-                        'bytes_sent': self._parse_value(x[-2]),
-                        'packets_in.count': self._parse_value(x[-7]),
-                        'packets_in.error': self._parse_value(x[-6]),
-                        'packets_out.count': self._parse_value(x[-4]),
-                        'packets_out.error': self._parse_value(x[-3]),
+                        'bytes_rcvd': self.parse_long(x[-5]),
+                        'bytes_sent': self.parse_long(x[-2]),
+                        'packets_in.count': self.parse_long(x[-7]),
+                        'packets_in.error': self.parse_long(x[-6]),
+                        'packets_out.count': self.parse_long(x[-4]),
+                        'packets_out.error': self.parse_long(x[-3]),
                     }
                     self._submit_devicemetrics(iface, metrics, custom_tags)
         except SubprocessOutputEmptyError:
@@ -829,9 +473,9 @@ class Network(AgentCheck):
 
         proc_location = self.agentConfig.get('procfs_path', '/proc').rstrip('/')
 
-        net_proc_base_location = self._get_net_proc_base_location(proc_location)
+        net_proc_base_location = self.get_net_proc_base_location(proc_location)
 
-        if self._is_collect_cx_state_runnable(net_proc_base_location):
+        if self.is_collect_cx_state_runnable(net_proc_base_location):
             try:
                 self.log.debug("Using `netstat` to collect connection state")
                 output_TCP, _, _ = get_subprocess_output(["netstat", "-n", "-a", "-p", "tcp"], self.log)
@@ -847,7 +491,7 @@ class Network(AgentCheck):
                 # udp        0      0 0.0.0.0:123             0.0.0.0:*
                 # udp6       0      0 :::41458                :::*
 
-                metrics = self._parse_linux_cx_state(lines[2:], self.tcp_states['netstat'], 5)
+                metrics = self.parse_cx_state(lines[2:], self.tcp_states['netstat'], 5)
                 for metric, value in iteritems(metrics):
                     self.gauge(metric, value, tags=custom_tags)
             except SubprocessOutputEmptyError:
@@ -971,7 +615,7 @@ class Network(AgentCheck):
 
             # Add it to this interface's list of metrics.
             metrics = metrics_by_interface.get(iface, {})
-            metrics[ddname] = self._parse_value(cols[1])
+            metrics[ddname] = self.parse_long(cols[1])
             metrics_by_interface[iface] = metrics
 
         return metrics_by_interface
@@ -1031,74 +675,3 @@ class Network(AgentCheck):
         protocol = self.PSUTIL_TYPE_MAPPING.get(conn.type, '')
         family = self.PSUTIL_FAMILY_MAPPING.get(conn.family, '')
         return '{}{}'.format(protocol, family)
-
-    def _parse_queues(self, tool, ss_output):
-        """
-        for each line of `ss_output`, returns a triplet with:
-        * a connection state (`established`, `listening`)
-        * the receive queue size
-        * the send queue size
-        """
-        for line in ss_output.splitlines():
-            fields = line.split()
-
-            if len(fields) < (6 if tool == "netstat" else 3):
-                continue
-
-            state_column = 0 if tool == "ss" else 5
-
-            try:
-                state = self.tcp_states[tool][fields[state_column]]
-            except KeyError:
-                continue
-
-            yield (state, fields[1], fields[2])
-
-    def _handle_ethtool_stats(self, iface, custom_tags):
-        # read Ethtool metrics, if configured and available
-        if not self._collect_ethtool_stats:
-            return
-        if iface in self._excluded_ifaces or (self._exclude_iface_re and self._exclude_iface_re.match(iface)):
-            # Skip this network interface.
-            return
-        if iface in ['lo', 'lo0']:
-            # Skip loopback ifaces as they don't support SIOCETHTOOL
-            return
-
-        driver_name, driver_version, ethtool_stats_names, ethtool_stats = self._fetch_ethtool_stats(iface)
-        tags = [] if custom_tags is None else custom_tags[:]
-        tags.append('driver_name:{}'.format(driver_name))
-        tags.append('driver_version:{}'.format(driver_version))
-        if self._collect_ena_metrics:
-            ena_metrics = ethtool.get_ena_metrics(ethtool_stats_names, ethtool_stats)
-            self._submit_ena_metrics(iface, ena_metrics, tags)
-        if self._collect_ethtool_metrics:
-            ethtool_metrics = ethtool.get_ethtool_metrics(driver_name, ethtool_stats_names, ethtool_stats)
-            self._submit_ethtool_metrics(iface, ethtool_metrics, tags)
-
-    def _fetch_ethtool_stats(self, iface):
-        """
-        Collect ethtool metrics for given interface.
-
-        Ethtool metrics are collected via the ioctl SIOCETHTOOL call. At the time of writing
-        this method, there are no maintained Python libraries that do this. The solution
-        is based on:
-
-        * https://github.com/safchain/ethtool
-        * https://gist.github.com/yunazuno/d7cd7e1e127a39192834c75d85d45df9
-        """
-        ethtool_socket = None
-        try:
-            ethtool_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, 0)
-            driver_name, driver_version = ethtool.get_ethtool_drvinfo(iface, ethtool_socket)
-            stats_names, stats = ethtool.get_ethtool_stats(iface, ethtool_socket)
-            return driver_name, driver_version, stats_names, stats
-        except OSError as e:
-            # this will happen for interfaces that don't support SIOCETHTOOL - e.g. loopback or docker
-            self.log.debug('OSError while trying to collect ethtool metrics for interface %s: %s', iface, str(e))
-        except Exception:
-            self.log.exception('Unable to collect ethtool metrics for interface %s', iface)
-        finally:
-            if ethtool_socket is not None:
-                ethtool_socket.close()
-        return (None, None, [], [])

--- a/network/tests/test_ethtool.py
+++ b/network/tests/test_ethtool.py
@@ -453,7 +453,9 @@ def send_ethtool_ioctl_mock(iface, sckt, data):
 
 @pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('datadog_checks.network.ethtool._send_ethtool_ioctl')
-def test_collect_ena(send_ethtool_ioctl, check):
+@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
+def test_collect_ena(is_linux, is_bsd, send_ethtool_ioctl, check):
     check_instance = check(common.INSTANCE)
     send_ethtool_ioctl.side_effect = send_ethtool_ioctl_mock
     driver_name, driver_version, stats_names, stats = check_instance._fetch_ethtool_stats('eth0')
@@ -469,7 +471,9 @@ def test_collect_ena(send_ethtool_ioctl, check):
 
 @pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('datadog_checks.network.ethtool._send_ethtool_ioctl')
-def test_collect_ethtool_metrics_ena(send_ethtool_ioctl, check):
+@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
+def test_collect_ethtool_metrics_ena(is_linux, is_bsd, send_ethtool_ioctl, check):
     check_instance = check(common.INSTANCE)
     send_ethtool_ioctl.side_effect = send_ethtool_ioctl_mock
     driver_name, driver_version, stats_names, stats = check_instance._fetch_ethtool_stats('eth0')
@@ -479,7 +483,9 @@ def test_collect_ethtool_metrics_ena(send_ethtool_ioctl, check):
 
 @pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('datadog_checks.network.ethtool._send_ethtool_ioctl')
-def test_collect_ethtool_metrics_virtio(send_ethtool_ioctl, check):
+@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
+def test_collect_ethtool_metrics_virtio(is_linux, is_bsd, send_ethtool_ioctl, check):
     check_instance = check(common.INSTANCE)
     send_ethtool_ioctl.side_effect = send_ethtool_ioctl_mock
     driver_name, driver_version, stats_names, stats = check_instance._fetch_ethtool_stats('virtio')
@@ -489,7 +495,9 @@ def test_collect_ethtool_metrics_virtio(send_ethtool_ioctl, check):
 
 @pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('datadog_checks.network.ethtool._send_ethtool_ioctl')
-def test_collect_ethtool_metrics_hv_netvsc(send_ethtool_ioctl, check):
+@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
+def test_collect_ethtool_metrics_hv_netvsc(is_linu, is_bsd, send_ethtool_ioctl, check):
     check_instance = check(common.INSTANCE)
     send_ethtool_ioctl.side_effect = send_ethtool_ioctl_mock
     driver_name, driver_version, stats_names, stats = check_instance._fetch_ethtool_stats('hv_netvsc')
@@ -499,7 +507,9 @@ def test_collect_ethtool_metrics_hv_netvsc(send_ethtool_ioctl, check):
 
 @pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('datadog_checks.network.ethtool._send_ethtool_ioctl')
-def test_collect_ethtool_metrics_gve(send_ethtool_ioctl, check):
+@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
+def test_collect_ethtool_metrics_gve(is_linux, is_bsd, send_ethtool_ioctl, check):
     check_instance = check(common.INSTANCE)
     send_ethtool_ioctl.side_effect = send_ethtool_ioctl_mock
     driver_name, driver_version, stats_names, stats = check_instance._fetch_ethtool_stats('gve')
@@ -509,7 +519,9 @@ def test_collect_ethtool_metrics_gve(send_ethtool_ioctl, check):
 
 @pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('datadog_checks.network.ethtool._send_ethtool_ioctl')
-def test_submit_ena(send_ethtool_ioctl, check, aggregator):
+@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
+def test_submit_ena(is_linux, is_bsd, send_ethtool_ioctl, check, aggregator):
     instance = copy.deepcopy(common.INSTANCE)
     instance['collect_aws_ena_metrics'] = True
     check_instance = check(instance)
@@ -532,7 +544,9 @@ def test_submit_ena(send_ethtool_ioctl, check, aggregator):
 
 @pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('datadog_checks.network.ethtool._send_ethtool_ioctl')
-def test_submit_ena_ethtool_metrics(send_ethtool_ioctl, check, aggregator):
+@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
+def test_submit_ena_ethtool_metrics(is_linux, is_bsd, send_ethtool_ioctl, check, aggregator):
     instance = copy.deepcopy(common.INSTANCE)
     instance['collect_ethtool_metrics'] = True
     check_instance = check(instance)
@@ -552,7 +566,9 @@ def test_submit_ena_ethtool_metrics(send_ethtool_ioctl, check, aggregator):
 
 @pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('datadog_checks.network.ethtool._send_ethtool_ioctl')
-def test_submit_hv_netvsc_ethtool_metrics(send_ethtool_ioctl, check, aggregator):
+@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
+def test_submit_hv_netvsc_ethtool_metrics(is_linux, is_bsd, send_ethtool_ioctl, check, aggregator):
     instance = copy.deepcopy(common.INSTANCE)
     instance['collect_ethtool_metrics'] = True
     check_instance = check(instance)
@@ -572,7 +588,9 @@ def test_submit_hv_netvsc_ethtool_metrics(send_ethtool_ioctl, check, aggregator)
 
 @pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('datadog_checks.network.ethtool._send_ethtool_ioctl')
-def test_submit_gve_ethtool_metrics(send_ethtool_ioctl, check, aggregator):
+@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
+def test_submit_gve_ethtool_metrics(is_linux, is_bsd, send_ethtool_ioctl, check, aggregator):
     instance = copy.deepcopy(common.INSTANCE)
     instance['collect_ethtool_metrics'] = True
     check_instance = check(instance)
@@ -592,7 +610,9 @@ def test_submit_gve_ethtool_metrics(send_ethtool_ioctl, check, aggregator):
 
 @pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('datadog_checks.network.ethtool._send_ethtool_ioctl')
-def test_collect_ena_values_not_present(send_ethtool_ioctl, check):
+@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
+def test_collect_ena_values_not_present(is_linux, is_bsd, send_ethtool_ioctl, check):
     check_instance = check(common.INSTANCE)
 
     send_ethtool_ioctl.side_effect = send_ethtool_ioctl_mock
@@ -603,7 +623,9 @@ def test_collect_ena_values_not_present(send_ethtool_ioctl, check):
 
 @pytest.mark.skipif(platform.system() == 'Windows', reason="Only runs on Unix systems")
 @mock.patch('fcntl.ioctl')
-def test_collect_ena_unsupported_on_iface(ioctl_mock, check, caplog):
+@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
+def test_collect_ena_unsupported_on_iface(is_linux, is_bsd, ioctl_mock, check, caplog):
     check_instance = check(common.INSTANCE)
     caplog.set_level(logging.DEBUG)
     ioctl_mock.side_effect = OSError('mock error')

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -405,9 +405,10 @@ def test_cx_state_psutil(aggregator, check):
             assert results[m[0].name] == m[0].value
 
 
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=False)
 @mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
 @mock.patch('datadog_checks.network.network.Platform.is_windows', return_value=True)
-def test_cx_counters_psutil(is_linux, is_bsd, aggregator, check):
+def test_cx_counters_psutil(is_linux, is_bsd, is_windows, aggregator, check):
     snetio = namedtuple(
         'snetio', ['bytes_sent', 'bytes_recv', 'packets_sent', 'packets_recv', 'errin', 'errout', 'dropin', 'dropout']
     )

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -405,8 +405,9 @@ def test_cx_state_psutil(aggregator, check):
             assert results[m[0].name] == m[0].value
 
 
-@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=True)
-def test_cx_counters_psutil(aggregator, check):
+@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_windows', return_value=True)
+def test_cx_counters_psutil(is_linux, is_bsd, aggregator, check):
     snetio = namedtuple(
         'snetio', ['bytes_sent', 'bytes_recv', 'packets_sent', 'packets_recv', 'errin', 'errout', 'dropin', 'dropout']
     )


### PR DESCRIPTION
split of https://github.com/DataDog/integrations-core/pull/13102 only extracting the linux check for easier review

Extract check linux into a different class
Rename methods that will remain in the parent class
Noticed that some parts of the linux check have no coverage, working on it on a separate PR https://github.com/DataDog/integrations-core/pull/13117