### PR TITLE
Rebuild images when ci file is updated

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -216,6 +216,7 @@ reminder-image-builder:
   only:
     changes:
       - .gitlab/reminder/**/*
+      - .gitlab-ci.yaml
     refs:
       - master
   script:
@@ -232,6 +233,7 @@ tagger-image-builder:
     changes:
       - .gitlab/tagger/**/*
       - datadog_checks_dev/**/*
+      - .gitlab-ci.yaml
     refs:
       - master
   script:
@@ -247,6 +249,7 @@ validate-log-intgs-builder:
   only:
     changes:
       - .gitlab/validate-logs-intgs/**/*
+      - .gitlab-ci.yaml
     refs:
       - master
   script:
@@ -262,6 +265,7 @@ validate-agent-build-builder:
   only:
     changes:
       - .gitlab/validate-agent-build/**/*
+      - .gitlab-ci.yaml
     refs:
       - master
   script:


### PR DESCRIPTION
### What does this PR do?
Rebuild all images when the `.gitlab-ci.yaml` file is updated

### Motivation
We want to pick up changes to the jobs that happen in the 'script' section of the `.gitlab-ci.yaml` file

This change was never applied because of this limitation: https://github.com/DataDog/integrations-core/pull/12806
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.