### PR TITLE
Add back channels_to_skip for channel status metrics

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
+++ b/ibm_mq/datadog_checks/ibm_mq/collectors/channel_metric_collector.py
@@ -76,7 +76,7 @@ class ChannelMetricCollector(object):
 
         # Grab all the discoverable channels
         if self.config.auto_discover_channels:
-            self._submit_channel_status(queue_manager, '*', self.config.tags_no_channel)
+            self._submit_channel_status(queue_manager, '*', self.config.tags_no_channel, self.config.channels)
 
     def _discover_channels(self, queue_manager):
         """Discover all channels"""

--- a/ibm_mq/tests/test_ibm_mq_int.py
+++ b/ibm_mq/tests/test_ibm_mq_int.py
@@ -377,3 +377,20 @@ def test_stats_metrics(aggregator, get_check, instance, dd_run_check):
 
     assert_all_metrics(aggregator)
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+
+
+def test_channel_status_no_duplicates(aggregator, get_check, instance, dd_run_check):
+    check = get_check(instance)
+    dd_run_check(check)
+
+    tags = [
+        'queue_manager:{}'.format(common.QUEUE_MANAGER),
+        'mq_host:{}'.format(common.HOST),
+        'port:{}'.format(common.PORT),
+        'connection_name:{}({})'.format(common.HOST, common.PORT),
+        'foo:bar',
+        'channel:{}'.format(common.CHANNEL)
+    ]
+
+    aggregator.assert_service_check("ibm_mq.channel.status", check.OK, tags=tags, count=1)
+


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds back the use of the `channels_to_skip` parameter in `_submit_channel_status` to eliminate duplicate channel status metrics and service checks.

This was likely removed accidentally during a [refactor](https://github.com/DataDog/integrations-core/pull/5902/files#diff-c13bdfbdf64a9b350dba96c6d9517932e3aeea07345fe9fc77c088392cae42b2L260).
### Motivation
<!-- What inspired you to submit this pull request? -->
[AI-2306](https://datadoghq.atlassian.net/browse/AI-2306)
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.