### PR TITLE
ibm_i integration produces CRITICAL service check if it cannot connect

### DIFF
--- a/ibm_i/datadog_checks/ibm_i/check.py
+++ b/ibm_i/datadog_checks/ibm_i/check.py
@@ -37,12 +37,15 @@ class IbmICheck(AgentCheck, ConfigMixin):
         try:
             self.query_manager.execute()
             check_status = AgentCheck.OK
+            hostname = self._query_manager.hostname
         except AttributeError as e:
             self.warning('Could not set up query manager, skipping check run: %s', e)
-            check_status = None
+            check_status = AgentCheck.CRITICAL
+            hostname = self.config.hostname if self.config else None
         except Exception as e:
             self._delete_connection_subprocess(e)
             check_status = AgentCheck.CRITICAL
+            hostname = self.config.hostname if self.config else None
 
         # At least one query failed, set the service check as failing
         if self._current_errors:
@@ -52,8 +55,8 @@ class IbmICheck(AgentCheck, ConfigMixin):
             self.service_check(
                 self.SERVICE_CHECK_NAME,
                 check_status,
-                tags=self.config.tags,
-                hostname=self._query_manager.hostname,
+                tags=self.config.tags if self.config else None,
+                hostname=hostname,
             )
 
     def cancel(self):

--- a/ibm_i/datadog_checks/ibm_i/check.py
+++ b/ibm_i/datadog_checks/ibm_i/check.py
@@ -55,7 +55,7 @@ class IbmICheck(AgentCheck, ConfigMixin):
             self.service_check(
                 self.SERVICE_CHECK_NAME,
                 check_status,
-                tags=self.config.tags if self.config else None,
+                tags=self.config.tags if self.config else [],
                 hostname=hostname,
             )
 

--- a/ibm_i/tests/conftest.py
+++ b/ibm_i/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    yield
+    yield {}
 
 
 @pytest.fixture

--- a/ibm_i/tests/conftest.py
+++ b/ibm_i/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    yield {}
+    yield {'tags': ['foo:bar']}
 
 
 @pytest.fixture

--- a/ibm_i/tests/test_e2e.py
+++ b/ibm_i/tests/test_e2e.py
@@ -6,4 +6,4 @@ from datadog_checks.ibm_i import IbmICheck
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, aggregator, instance):
     aggregator = dd_agent_check(instance)
-    aggregator.assert_service_check('ibm_i', IbmICheck.CRITICAL)
+    aggregator.assert_service_check("ibm_i.can_connect", IbmICheck.CRITICAL)

--- a/ibm_i/tests/test_e2e.py
+++ b/ibm_i/tests/test_e2e.py
@@ -6,4 +6,4 @@ from datadog_checks.ibm_i import IbmICheck
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, aggregator, instance):
     aggregator = dd_agent_check(instance)
-    aggregator.assert_service_check("ibm_i.can_connect", IbmICheck.CRITICAL)
+    aggregator.assert_service_check("ibm_i.can_connect", IbmICheck.CRITICAL, tags=['foo:bar'])

--- a/ibm_i/tests/test_e2e.py
+++ b/ibm_i/tests/test_e2e.py
@@ -1,11 +1,9 @@
 import pytest
 
-from datadog_checks.dev.testing import requires_py3
 from datadog_checks.ibm_i import IbmICheck
 
 
 @pytest.mark.e2e
-@requires_py3
 def test_e2e(dd_agent_check, aggregator, instance):
     aggregator = dd_agent_check(instance)
-    aggregator.assert_service_check('ibm_i', IbmCheck.CRITICAL)
+    aggregator.assert_service_check('ibm_i', IbmICheck.CRITICAL)

--- a/ibm_i/tests/test_e2e.py
+++ b/ibm_i/tests/test_e2e.py
@@ -1,0 +1,11 @@
+import pytest
+
+from datadog_checks.dev.testing import requires_py3
+from datadog_checks.ibm_i import IbmICheck
+
+
+@pytest.mark.e2e
+@requires_py3
+def test_e2e(dd_agent_check, aggregator, instance):
+    aggregator = dd_agent_check(instance)
+    aggregator.assert_service_check('ibm_i', IbmCheck.CRITICAL)

--- a/ibm_i/tox.ini
+++ b/ibm_i/tox.ini
@@ -8,6 +8,8 @@ envlist =
 
 [testenv]
 dd_check_style = true
+description=
+    py38: e2e ready
 usedevelop = true
 platform = linux|darwin|win32
 extras = deps


### PR DESCRIPTION
### What does this PR do?
As part of adding e2e tests for the ibm_i integration, we change it to emit a CRITICAL service check in case we cannot connect to an IBM-I machine.

### Motivation
Part of work on this:
https://datadoghq.atlassian.net/browse/AI-1760

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.