### PR TITLE
Allow 1e to have email-based codeowners

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/codeowners.py
@@ -12,6 +12,7 @@ DIRECTORY_REGEX = re.compile(r"\/(.*)\/$")
 
 # Integrations that are known to be tiles and have email-based codeowners
 IGNORE_TILES = {
+    '1e',
     'auth0',
     'bluematador',
     'bonsai',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Allow the 1e tile to have an email-based codeowner.

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-extras/pull/1569

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.