### PR TITLE
Fix `release make` to include new integrations in the agent requirements file

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/release.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/release.py
@@ -127,6 +127,9 @@ def update_agent_requirements(req_file, check, newline):
         if current_package_name == package_name:
             lines[i] = f'{newline}\n'
             break
+    else:
+        # If this is a new integration
+        lines.append(f'{newline}\n')
 
     write_file_lines(req_file, sorted(lines))
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `release make` to include new integrations in the agent requirements file. 

### Motivation
<!-- What inspired you to submit this pull request? -->

https://datadoghq.atlassian.net/browse/AITOOLS-12

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.