### PR TITLE
Emma/sqlserver port 0

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -26,7 +26,11 @@ files:
       Note: All '%' characters must be escaped as '%%'.
     options:
     - name: host
-      description: Host and port of your SQL server.
+      description: | 
+        Host and port of your SQL server. If a port is ommitted, a default port of 1433 will be used. 
+        If you use Sql Server Browser Service or a similar port autodiscovery service, pass in a port
+        of 0 to omit port from your connection string. This should allow SSBS to autodiscover the 
+        correct database port. 
       required: true
       value:
         type: string

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -37,7 +37,10 @@ init_config:
 instances:
 
     ## @param host - string - required
-    ## Host and port of your SQL server.
+    ## Host and port of your SQL server. If a port is ommitted, a default port of 1433 will be used. 
+    ## If you use Sql Server Browser Service or a similar port autodiscovery service, pass in a port
+    ## of 0 to omit port from your connection string. This should allow SSBS to autodiscover the 
+    ## correct database port. 
     #
   - host: <HOST>,<PORT>
 

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -185,12 +185,29 @@ def test_will_fail_for_wrong_parameters_in_the_connection_string(instance_minima
             '1.2.3.4,22',
             id='if port is provided as part of host, it should be recognized',
         ),
-        pytest.param('1.2.3.4', None, '1.2.3.4,1433', id='if no port is provided anywhere, should default to 1433'),
+        pytest.param(
+            '1.2.3.4',
+            None,
+            '1.2.3.4,1433',
+            id='if no port is provided anywhere, should default to 1433',
+        ),
         pytest.param(
             '1.2.3.4,35',
             22,
             '1.2.3.4,35',
             id='if port is provided and included in host string, host port is used',
+        ),
+        pytest.param(
+            '1.2.3.4,0',
+            None,
+            '1.2.3.4',
+            id='if port provided in host string is 0, return a string with only host',
+        ),
+        pytest.param(
+            '1.2.3.4',
+            0,
+            '1.2.3.4',
+            id='if port provided via port config option is 0, return a string with only host',
         ),
     ],
 )


### PR DESCRIPTION
### What does this PR do?
Currently, when a user does not provide a port for a sqlserver connection, we autofill a default port `1433`. This was a change in 7.39.0.

This breaks a workflow for some of our users who are using port autodiscovery with sqlserver through services like [Sql Server Browser Service](https://learn.microsoft.com/en-us/sql/tools/configuration-manager/sql-server-browser-service?view=sql-server-ver16). To accommodate these users, we are adding the option for a user to pass in a port `0`, either through the host string or a standalone port config line, that will signal that we should not append a port to the host string that is included in the connection string. 

There is a current workaround for this: users can manually specify the port in their sqlserver config, as if they weren't using autodiscovery. 

### Motivation
Two users have reported this issue. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.