### PR TITLE
Extract windows check to separate class

### DIFF
--- a/network/datadog_checks/network/check_windows.py
+++ b/network/datadog_checks/network/check_windows.py
@@ -1,0 +1,89 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+from collections import defaultdict
+
+import psutil
+from six import PY3, iteritems
+
+from . import Network
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+if PY3:
+    long = int
+
+
+class WindowsNetwork(Network):
+    """
+    Gather metrics about connections states and interfaces counters
+    using psutil facilities
+    """
+
+    def __init__(self, name, init_config, instances):
+        super(WindowsNetwork, self).__init__(name, init_config, instances)
+
+    def check(self, _):
+        custom_tags = self.instance.get('tags', [])
+        if self._collect_cx_state:
+            self._cx_state_psutil(tags=custom_tags)
+
+        self._cx_counters_psutil(tags=custom_tags)
+
+    def get_expected_metrics(self):
+        expected_metrics = super(WindowsNetwork, self).get_expected_metrics()
+        expected_metrics.extend(
+            [
+                'packets_in.drop',
+                'packets_out.drop',
+            ]
+        )
+        return expected_metrics
+
+    def _cx_state_psutil(self, tags=None):
+        """
+        Collect metrics about connections state using psutil
+        """
+        metrics = defaultdict(int)
+        tags = [] if tags is None else tags
+        for conn in psutil.net_connections():
+            protocol = self._parse_protocol_psutil(conn)
+            status = self.tcp_states['psutil'].get(conn.status)
+            metric = self.cx_state_gauge.get((protocol, status))
+            if metric is None:
+                self.log.warning('Metric not found for: %s,%s', protocol, status)
+            else:
+                metrics[metric] += 1
+
+        for metric, value in iteritems(metrics):
+            self.gauge(metric, value, tags=tags)
+
+    def _cx_counters_psutil(self, tags=None):
+        """
+        Collect metrics about interfaces counters using psutil
+        """
+        tags = [] if tags is None else tags
+        for iface, counters in iteritems(psutil.net_io_counters(pernic=True)):
+            metrics = {
+                'bytes_rcvd': counters.bytes_recv,
+                'bytes_sent': counters.bytes_sent,
+                'packets_in.count': counters.packets_recv,
+                'packets_in.drop': counters.dropin,
+                'packets_in.error': counters.errin,
+                'packets_out.count': counters.packets_sent,
+                'packets_out.drop': counters.dropout,
+                'packets_out.error': counters.errout,
+            }
+            self.submit_devicemetrics(iface, metrics, tags)
+
+    def _parse_protocol_psutil(self, conn):
+        """
+        Returns a string describing the protocol for the given connection
+        in the form `tcp4`, 'udp4` as in `self.cx_state_gauge`
+        """
+        protocol = self.PSUTIL_TYPE_MAPPING.get(conn.type, '')
+        family = self.PSUTIL_FAMILY_MAPPING.get(conn.family, '')
+        return '{}{}'.format(protocol, family)

--- a/network/datadog_checks/network/check_windows.py
+++ b/network/datadog_checks/network/check_windows.py
@@ -8,11 +8,6 @@ from six import PY3, iteritems
 
 from . import Network
 
-try:
-    import fcntl
-except ImportError:
-    fcntl = None
-
 if PY3:
     long = int
 

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -17,18 +17,7 @@ if PY3:
     long = int
 
 
-@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=False)
-@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
-@mock.patch('datadog_checks.network.network.Platform.is_solaris', return_value=False)
 @mock.patch('datadog_checks.network.network.Platform.is_windows', return_value=True)
-def test_win_uses_psutil(is_linux, is_bsd, is_solaris, is_windows, check):
-    check_instance = check({})
-    with mock.patch.object(check_instance, '_check_psutil') as _check_psutil:
-        check_instance.check({})
-        check._check_psutil = mock.MagicMock()
-        _check_psutil.assert_called_once_with({})
-
-
 def test_check_psutil_no_collect_connection_state(aggregator, check):
     instance = copy.deepcopy(common.INSTANCE)
     instance['collect_connection_state'] = False
@@ -37,12 +26,13 @@ def test_check_psutil_no_collect_connection_state(aggregator, check):
     with mock.patch.object(check_instance, '_cx_state_psutil') as _cx_state_psutil, mock.patch.object(
         check_instance, '_cx_counters_psutil'
     ) as _cx_counters_psutil:
-        check_instance._check_psutil({})
+        check_instance.check({})
 
         _cx_state_psutil.assert_not_called()
         _cx_counters_psutil.assert_called_once_with(tags=[])
 
 
+@mock.patch('datadog_checks.network.network.Platform.is_windows', return_value=True)
 def test_check_psutil_collect_connection_state(aggregator, check):
     instance = copy.deepcopy(common.INSTANCE)
     instance['collect_connection_state'] = True
@@ -52,11 +42,12 @@ def test_check_psutil_collect_connection_state(aggregator, check):
         check_instance, '_cx_counters_psutil'
     ) as _cx_counters_psutil:
         check_instance._collect_cx_state = True
-        check_instance._check_psutil({})
+        check_instance.check({})
         _cx_state_psutil.assert_called_once_with(tags=[])
         _cx_counters_psutil.assert_called_once_with(tags=[])
 
 
+@mock.patch('datadog_checks.network.network.Platform.is_windows', return_value=True)
 def test_cx_state_psutil(aggregator, check):
     sconn = namedtuple('sconn', ['fd', 'family', 'type', 'laddr', 'raddr', 'status', 'pid'])
     conn = [
@@ -144,7 +135,7 @@ def test_cx_state_psutil(aggregator, check):
     }
 
     check_instance = check(common.INSTANCE)
-    with mock.patch('datadog_checks.network.network.psutil') as mock_psutil:
+    with mock.patch('datadog_checks.network.check_windows.psutil') as mock_psutil:
         mock_psutil.net_connections.return_value = conn
         check_instance._setup_metrics({})
         check_instance._cx_state_psutil()
@@ -180,7 +171,7 @@ def test_cx_counters_psutil(is_linux, is_bsd, is_windows, aggregator, check):
     instance['excluded_interface_re'] = ''
     check_instance = check(instance)
 
-    with mock.patch('datadog_checks.network.network.psutil') as mock_psutil:
+    with mock.patch('datadog_checks.network.check_windows.psutil') as mock_psutil:
         mock_psutil.net_io_counters.return_value = counters
         check_instance._cx_counters_psutil()
         for _, m in iteritems(aggregator._metrics):
@@ -189,6 +180,7 @@ def test_cx_counters_psutil(is_linux, is_bsd, is_windows, aggregator, check):
                 assert m[0].value == 3280598526
 
 
+@mock.patch('datadog_checks.network.network.Platform.is_windows', return_value=True)
 def test_parse_protocol_psutil(aggregator, check):
     import socket
 

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -17,8 +17,9 @@ if PY3:
     long = int
 
 
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=False)
 @mock.patch('datadog_checks.network.network.Platform.is_windows', return_value=True)
-def test_check_psutil_no_collect_connection_state(aggregator, check):
+def test_check_psutil_no_collect_connection_state(is_windows, is_linux, aggregator, check):
     instance = copy.deepcopy(common.INSTANCE)
     instance['collect_connection_state'] = False
     check_instance = check(instance)
@@ -32,8 +33,9 @@ def test_check_psutil_no_collect_connection_state(aggregator, check):
         _cx_counters_psutil.assert_called_once_with(tags=[])
 
 
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=False)
 @mock.patch('datadog_checks.network.network.Platform.is_windows', return_value=True)
-def test_check_psutil_collect_connection_state(aggregator, check):
+def test_check_psutil_collect_connection_state(is_windows, is_linux, aggregator, check):
     instance = copy.deepcopy(common.INSTANCE)
     instance['collect_connection_state'] = True
     check_instance = check(instance)
@@ -47,8 +49,9 @@ def test_check_psutil_collect_connection_state(aggregator, check):
         _cx_counters_psutil.assert_called_once_with(tags=[])
 
 
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=False)
 @mock.patch('datadog_checks.network.network.Platform.is_windows', return_value=True)
-def test_cx_state_psutil(aggregator, check):
+def test_cx_state_psutil(is_windows, is_linux, aggregator, check):
     sconn = namedtuple('sconn', ['fd', 'family', 'type', 'laddr', 'raddr', 'status', 'pid'])
     conn = [
         sconn(
@@ -180,8 +183,9 @@ def test_cx_counters_psutil(is_linux, is_bsd, is_windows, aggregator, check):
                 assert m[0].value == 3280598526
 
 
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=False)
 @mock.patch('datadog_checks.network.network.Platform.is_windows', return_value=True)
-def test_parse_protocol_psutil(aggregator, check):
+def test_parse_protocol_psutil(is_windows, is_linux, aggregator, check):
     import socket
 
     conn = mock.MagicMock()

--- a/network/tests/test_windows.py
+++ b/network/tests/test_windows.py
@@ -1,0 +1,19 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+import mock
+from six import PY3
+
+from datadog_checks.network.check_windows import WindowsNetwork
+
+if PY3:
+    long = int
+
+
+@mock.patch('datadog_checks.network.network.Platform.is_linux', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_bsd', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_solaris', return_value=False)
+@mock.patch('datadog_checks.network.network.Platform.is_windows', return_value=True)
+def test_win_uses_psutil(is_linux, is_bsd, is_solaris, is_windows, check):
+    check_instance = check({})
+    isinstance(check_instance, WindowsNetwork)

--- a/network/tests/test_windows.py
+++ b/network/tests/test_windows.py
@@ -16,4 +16,4 @@ if PY3:
 @mock.patch('datadog_checks.network.network.Platform.is_windows', return_value=True)
 def test_win_uses_psutil(is_linux, is_bsd, is_solaris, is_windows, check):
     check_instance = check({})
-    isinstance(check_instance, WindowsNetwork)
+    assert isinstance(check_instance, WindowsNetwork)


### PR DESCRIPTION
Split of https://github.com/DataDog/integrations-core/pull/13102

* Moves all windows related code to a separate class.
* Creates a new test module with a single test that asserts the right class is instantiated.
* The remaining tests will be moved in a followup PR.
* Small fix on main module asserts to include a more descriptive error message

* Splitting tests on a separate PR: https://github.com/DataDog/integrations-core/pull/13145