### PR TITLE
Added section to SQL intergration

### DIFF
--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -78,7 +78,7 @@ instances:
    reported_hostname:<host>\<name instance> # add this line
 ```
 
-   **Note**: The (default) provider `SQLOLEDB` is being deprecated. To use the newer `MSOLEDBSQL` provider, set the `adoprovider` variable to `MSOLEDBSQL` in your `sqlserver.d/conf.yaml` file after having downloaded the new provider from [Microsoft][7]. It is also possible to use the Windows Authentication and not specify the username/password with:
+   **Note**: The (default) provider `SQLOLEDB` is deprecated. To use the newer `MSOLEDBSQL` provider, set the `adoprovider` variable to `MSOLEDBSQL` in your `sqlserver.d/conf.yaml` file after having downloaded the new provider from [Microsoft][7]. It is also possible to use the Windows Authentication and not specify the username/password with:
 
       ```yaml
       connection_string: "Trusted_Connection=yes"

--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -69,7 +69,7 @@ To configure this check for an Agent running on a host:
 
     See the [example check configuration][6] for a comprehensive description of all options, including how to use custom queries to create your own metrics.
 
-For hosts that are configured with the `<hostname\instance name>`, add `reported_hostname:` to the `sqlserver.d/conf.yaml` file, in the `conf.d/` at the root of the [Agent’s configuration directory][5]:
+For hosts that are configured with the `<hostname\instance name>`, add `reported_hostname:` to the `sqlserver.d/conf.yaml` file, in the `conf.d/` at the root of the [Agent's configuration directory][5]:
 
 ```yaml
 init_config:

--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -69,7 +69,16 @@ To configure this check for an Agent running on a host:
 
     See the [example check configuration][6] for a comprehensive description of all options, including how to use custom queries to create your own metrics.
 
-    **Note**: The (default) provider `SQLOLEDB` is being deprecated. To use the newer `MSOLEDBSQL` provider, set the `adoprovider` variable to `MSOLEDBSQL` in your `sqlserver.d/conf.yaml` file after having downloaded the new provider from [Microsoft][7]. It is also possible to use the Windows Authentication and not specify the username/password with:
+For hosts that are configured with the `<hostname\instance name>`, add `reported_hostname:` to the `sqlserver.d/conf.yaml` file, in the `conf.d/` at the root of the [Agent’s configuration directory][5]:
+
+```yaml
+init_config:
+instances:
+ - host:<host>\<name instance>
+   reported_hostname:<host>\<name instance> # add this line
+```
+
+   **Note**: The (default) provider `SQLOLEDB` is being deprecated. To use the newer `MSOLEDBSQL` provider, set the `adoprovider` variable to `MSOLEDBSQL` in your `sqlserver.d/conf.yaml` file after having downloaded the new provider from [Microsoft][7]. It is also possible to use the Windows Authentication and not specify the username/password with:
 
       ```yaml
       connection_string: "Trusted_Connection=yes"


### PR DESCRIPTION
Added a another configuration for our SQL server integration that for when customers have their host configured with a host and instance name, instead of just the SQL host and port.

### What does this PR do?
Adds a section to the SQL server documentation that includes a use case for of setting up your instance with a `hostname\instance name`

### Motivation
This was a suggestion of a Premier Customer to have this added. There has also been multiple tickets on this. This will prevent future tickets and as customers will not need to contact support for assistance on setting up the integration.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.