### PR TITLE
Allow dashboards to be removed from the manifest file

### DIFF
--- a/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
+++ b/datadog_checks_dev/tests/tooling/manifest_validator/input_constants.py
@@ -10,7 +10,12 @@ ORACLE_METADATA_CSV_EXAMPLE = [(0, {"metric_name": "oracle.session_count"})]
 V2_VALID_MANIFEST = {
     "app_id": "datadog-oracle",
     "assets": {
-        "dashboards": {"oracle": "assets/dashboards/example.json"},
+        "dashboards": {
+            "oracle": "assets/dashboards/example.json",
+        },
+        "monitors": {
+            "monitor": "assets/monitors/monitor.json",
+        },
         "integration": {
             "configuration": {"spec": "assets/configuration/spec.yaml"},
             "events": {"creates_events": True},


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

We currently raise an error if a dashboard is modified. It is actually allowed but requires manual modifications on our side. This PR allows dashboards to be removed be raise a warning so the author will know. 

### Motivation
<!-- What inspired you to submit this pull request? -->

https://datadoghq.atlassian.net/browse/AITOOLS-54

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.