### PR TITLE
Add the memray option to the `test` command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -49,6 +49,7 @@ from .console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, echo_succes
 @click.option('--force-base-unpinned', is_flag=True, help='Force using datadog-checks-base as specified by check dep')
 @click.option('--force-base-min', is_flag=True, help='Force using lowest viable release version of datadog-checks-base')
 @click.option('--force-env-rebuild', is_flag=True, help='Force creating a new env')
+@click.option('--memray', is_flag=True, help='Run memray to measure memory usage')
 @click.pass_context
 def test(
     ctx,
@@ -76,6 +77,7 @@ def test(
     force_base_unpinned,
     force_base_min,
     force_env_rebuild,
+    memray,
 ):
     """Run tests for Agent-based checks.
 
@@ -199,6 +201,7 @@ def test(
             pytest_args=pytest_args,
             e2e=e2e,
             ddtrace=ddtrace_check,
+            memray=memray,
         )
         if coverage:
             pytest_options = pytest_options.format(pytest_coverage_sources(check))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -556,7 +556,7 @@ def construct_pytest_options(
 
     if memray:
         if platform.system().lower() not in ('linux', 'darwin'):
-            abort('\nThe `--memray` option can only be used on linux or MacOs!')
+            abort('\nThe `--memray` option can only be used on Linux or MacOS!')
 
         pytest_options += ' --memray'
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import json
 import os
+import platform
 import re
 from fnmatch import fnmatch
 
@@ -499,6 +500,7 @@ def construct_pytest_options(
     pytest_args='',
     e2e=False,
     ddtrace=False,
+    memray=False,
 ):
     # Prevent no verbosity
     pytest_options = f'--verbosity={verbose or 1}'
@@ -551,6 +553,12 @@ def construct_pytest_options(
             # This will be formatted to the appropriate coverage paths for each package
             ' {}'
         )
+
+    if memray:
+        if platform.system().lower() not in ('linux', 'darwin'):
+            abort('\nThe `--memray` option can only be used on linux or MacOs!')
+
+        pytest_options += ' --memray'
 
     if marker:
         pytest_options += f' -m "{marker}"'

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "pytest",
     "pytest-benchmark[histogram]>=3.2.1",
     "pytest-cov>=2.6.1",
+    "pytest-memray>=1.3.0; python_version > '3.0' and (platform_system=='Linux' or platform_system=='Darwin')",
     "pytest-mock",
     "pyyaml>=5.4.1",
     "requests>=2.22.0",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add memray to the test suite. 

- https://github.com/bloomberg/memray
- https://github.com/bloomberg/pytest-memray

Note: only works on linux and MacOs and with py3
### Motivation
<!-- What inspired you to submit this pull request? -->

https://datadoghq.atlassian.net/browse/AITOOLS-26

First step for memory testing in the CI. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Output example: 

```
ddev test --memray impala 

...

============================================================================================================================================================================ MEMRAY REPORT =============================================================================================================================================================================
Allocations results for tests/daemon/test_integration.py::test_daemon_check_integration_assert_metrics

         📦 Total memory allocated: 1.1MiB
         📏 Total allocations: 8226
         📊 Histogram of allocation sizes: |▄ ▆ ▂ ▂ █|
         🥇 Biggest allocating functions:
                - _parse_sample:/Users/florent.clarret/Library/Application Support/hatch/env/virtual/datadog-impala-qyAqD2CG/py38-4.0.0/lib/python3.8/site-packages/prometheus_client/parser.py:116 -> 256.0KiB
                - _deepcopy_dict:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/copy.py:230 -> 256.0KiB
                - stub_to_key_fn:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/stubs/aggregator.py:502 -> 256.0KiB
                - iter_lines:/Users/florent.clarret/Library/Application Support/hatch/env/virtual/datadog-impala-qyAqD2CG/py38-4.0.0/lib/python3.8/site-packages/requests/models.py:875 -> 256.0KiB
                - _assert_no_duplicate_stub:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/stubs/aggregator.py:528 -> 54.1KiB


Allocations results for tests/catalog/test_check.py::test_catalog_mock_assert_metrics_using_metadata

         📦 Total memory allocated: 611.6KiB
         📏 Total allocations: 3341
         📊 Histogram of allocation sizes: |█ ▂      |
         🥇 Biggest allocating functions:
                - __next__:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/csv.py:111 -> 256.0KiB
                - get_gauge:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transformers/gauge.py:13 -> 256.0KiB
                - get_metadata_metrics:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/utils.py:138 -> 27.1KiB
                - fieldnames:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/csv.py:97 -> 16.0KiB
                - decode:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/codecs.py:322 -> 8.0KiB


Allocations results for tests/daemon/test_integration.py::test_daemon_check_integration_assert_metrics_using_metadata

         📦 Total memory allocated: 593.1KiB
         📏 Total allocations: 24329
         📊 Histogram of allocation sizes: |█ ▆     ▁|
         🥇 Biggest allocating functions:
                - __next__:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/csv.py:119 -> 512.0KiB
                - get:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transform.py:73 -> 18.0KiB
                - get_metadata_metrics:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/utils.py:138 -> 18.0KiB
                - fieldnames:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/csv.py:97 -> 16.0KiB
                - submit_metric:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/stubs/aggregator.py:110 -> 9.0KiB


Allocations results for tests/catalog/test_integration.py::test_catalog_check_integration_assert_metrics_using_metadata

         📦 Total memory allocated: 570.2KiB
         📏 Total allocations: 3509
         📊 Histogram of allocation sizes: |▁ █ ▃   ▁|
         🥇 Biggest allocating functions:
                - __next__:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/csv.py:111 -> 516.2KiB
                - get_metadata_metrics:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/utils.py:138 -> 18.0KiB
                - fieldnames:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/csv.py:97 -> 16.0KiB
                - __init__:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transform.py:53 -> 4.5KiB
                - submit_metric:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/stubs/aggregator.py:110 -> 4.5KiB


Allocations results for tests/daemon/test_check.py::test_daemon_mock_assert_metrics_using_metadata

         📦 Total memory allocated: 351.3KiB
         📏 Total allocations: 7577
         📊 Histogram of allocation sizes: |█ ▁ ▁    |
         🥇 Biggest allocating functions:
                - __next__:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/csv.py:119 -> 256.0KiB
                - get_metadata_metrics:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/utils.py:138 -> 27.1KiB
                - fieldnames:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/csv.py:97 -> 16.0KiB
                - __init__:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transform.py:53 -> 9.0KiB
                - submit_metric:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/stubs/aggregator.py:110 -> 9.0KiB


```

We can also define memory limit for a test using the `limit_memory` marker (e.g. `@pytest.mark.limit_memory("24 MB")`) which would make it fail in this case. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.