### PR TITLE
sqlserver: mark stored_procedure as deprecated

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -464,9 +464,10 @@ files:
     - template: instances/db
     - name: stored_procedure
       description: |
+        DEPRECATED - use `custom_queries` instead. For guidance, see:
+        https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/
         Get metrics from custom proc in MyDB but only if the database is writable
         (i.e. it's the master in an availability group) Note: Custom proc must be defined in its own instance
-        See https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/
       value:
         type: string
         example: <PROCEDURE_NAME>

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -436,9 +436,10 @@ instances:
     #     - test:<INTEGRATION>
 
     ## @param stored_procedure - string - optional
+    ## DEPRECATED - use `custom_queries` instead. For guidance, see:
+    ## https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/
     ## Get metrics from custom proc in MyDB but only if the database is writable
     ## (i.e. it's the master in an availability group) Note: Custom proc must be defined in its own instance
-    ## See https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/
     #
     # stored_procedure: <PROCEDURE_NAME>
 


### PR DESCRIPTION
### What does this PR do?
We no longer recommend using stored procedures to collect custom metrics. However, some users currently use stored procedures, so we don't want to vanish the examples all at once. 
Instead, we are updating documentation to remove mention of stored procedures; once that has deployed, we will merge this deprecation notice. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.