### PR TITLE
Remove the manifest v2 progress

### DIFF
--- a/docs/developer/.scripts/33_render_status.py
+++ b/docs/developer/.scripts/33_render_status.py
@@ -21,7 +21,6 @@ from datadog_checks.dev.tooling.utils import (
     is_tile_only,
     is_logs_only,
     get_available_recommended_monitors_integrations,
-    is_manifest_v2,
 )
 
 MARKER = '<docs-insert-status>'
@@ -36,7 +35,6 @@ def patch(lines):
     new_lines = lines[:marker_index]
 
     for renderer in (
-        render_manifest_v2_progress,
         render_dashboard_progress,
         render_logs_progress,
         render_recommended_monitors_progress,
@@ -320,30 +318,6 @@ def render_recommended_monitors_progress():
     formatted_percent = f'{percent:.2f}'
     lines[2] = f'[={formatted_percent}% "{formatted_percent}%"]'
     lines[4] = f'??? check "Completed {checks_with_rm}/{total_checks}"'
-    return lines
-
-
-def render_manifest_v2_progress():
-    valid_checks = sorted(get_valid_integrations())
-
-    total_checks = len(valid_checks)
-    checks_v2_manifest = 0
-
-    lines = ['## Manifest V2', '', None, '', '??? check "Completed"']
-
-    for check in valid_checks:
-        if is_manifest_v2(check):
-            checks_v2_manifest += 1
-            status = 'X'
-        else:
-            status = ' '
-
-        lines.append(f'    - [{status}] {check}')
-
-    percent = checks_v2_manifest / total_checks * 100
-    formatted_percent = f'{percent:.2f}'
-    lines[2] = f'[={formatted_percent}% "{formatted_percent}%"]'
-    lines[4] = f'??? check "Completed {checks_v2_manifest}/{total_checks}"'
     return lines
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Drop the manifest v2 migration status

### Motivation
<!-- What inspired you to submit this pull request? -->

Migration done and the validations do not allow manifests v1 anymore

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.