### PR TITLE
Exclude non-python checks from the hatch migration status

### DIFF
--- a/docs/developer/.scripts/33_render_status.py
+++ b/docs/developer/.scripts/33_render_status.py
@@ -371,7 +371,7 @@ def render_config_validation_progress():
 
 
 def render_hatch_migration_progress():
-    valid_checks = sorted(get_valid_integrations())
+    valid_checks = sorted(get_valid_checks())
     total_checks = len(valid_checks)
     checks_migrated = 0
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not include non-python migration in the hatch migration progress.

### Motivation
<!-- What inspired you to submit this pull request? -->

They do not have a `tox` file to migrate. Some example:

- agent_metrics
- databricks

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.