### PR TITLE
Make version parsing more flexible to increase compatibility

### DIFF
--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -101,7 +101,7 @@ class ZookeeperCheck(AgentCheck):
     # example match:
     # "Zookeeper version: 3.4.10-39d3a4f269333c922ed3db283be479f9deacaa0f, built on 03/23/2017 10:13 GMT"
     # This regex matches the entire version rather than <major>.<minor>.<patch>
-    METADATA_VERSION_PATTERN = re.compile('Zookeeper version: ([^,]+)')
+    METADATA_VERSION_PATTERN = re.compile('\w+ version: v?([^,]+)')
     METRIC_TAGGED_PATTERN = re.compile(r'(\w+){(\w+)="(.+)"}\s+(\S+)')
 
     SOURCE_TYPE_NAME = 'zookeeper'

--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -101,7 +101,7 @@ class ZookeeperCheck(AgentCheck):
     # example match:
     # "Zookeeper version: 3.4.10-39d3a4f269333c922ed3db283be479f9deacaa0f, built on 03/23/2017 10:13 GMT"
     # This regex matches the entire version rather than <major>.<minor>.<patch>
-    METADATA_VERSION_PATTERN = re.compile('\w+ version: v?([^,]+)')
+    METADATA_VERSION_PATTERN = re.compile(r'\w+ version: v?([^,]+)')
     METRIC_TAGGED_PATTERN = re.compile(r'(\w+){(\w+)="(.+)"}\s+(\S+)')
 
     SOURCE_TYPE_NAME = 'zookeeper'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR changes METADATA_VERSION_PATTERN in a way that it will be compatible with alternative zookeeper implementations with their own versioning.
For example with clickhouse-keeper line that contains version information differs a bit with original zookeeper:
```
# echo stat | nc 127.0.0.1 2181 | head -1
ClickHouse Keeper version: v22.9.1.15416-testing-6156f9cd99b5efd5fe1eeab391571deb4176e2af
```

vs

```
Zookeeper version: 3.2.2--1, built on 03/16/2010 07:31 GMT
```

### Motivation
<!-- What inspired you to submit this pull request? -->
Desire to use this integration with alternative zookeeper implementations, for example https://clickhouse.com/docs/en/operations/clickhouse-keeper

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.