### PR TITLE
README.md: add shareProcessNamespace parameter to agent container spec

### DIFF
--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -382,8 +382,8 @@ spec:
      name: "<POD_NAME>"
    spec:
      serviceAccountName: datadog-agent
-     ## Enabling host pid namespace for origin detection with cgroup v2
-     hostPID: true
+     ## Putting the agent in the same namespace as the application for origin detection with cgroup v2
+     shareProcessNamespace: true
      containers:
      - name: "<APPLICATION_NAME>"
        image: "<APPLICATION_IMAGE>"

--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -388,6 +388,8 @@ spec:
      ## Running the Agent as a side-car
      - image: datadog/agent
        name: datadog-agent
+       ## Enabling host pid namespace for origin detection with cgroup v2
+       hostPID: true
        ## Enabling port 8126 for Trace collection
        ports:
         - containerPort: 8126

--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -382,14 +382,14 @@ spec:
      name: "<POD_NAME>"
    spec:
      serviceAccountName: datadog-agent
+     ## Enabling host pid namespace for origin detection with cgroup v2
+     hostPID: true
      containers:
      - name: "<APPLICATION_NAME>"
        image: "<APPLICATION_IMAGE>"
      ## Running the Agent as a side-car
      - image: datadog/agent
        name: datadog-agent
-       ## Enabling host pid namespace for origin detection with cgroup v2
-       hostPID: true
        ## Enabling port 8126 for Trace collection
        ports:
         - containerPort: 8126


### PR DESCRIPTION
### What does this PR do?
This PR adds the `shareProcessNamespace` parameter to the spec for the agent container. Running in the host's or the application's pid namespace is required for origin detection to work with cgroup v2.

### Motivation
Cgroup v2 support for origin detection has been merged into the Trace Agent, but it is necessary for the trace agent to be run in the host's or the application's PID namespace for it to work. We want this to be working by default, so this change is necessary.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.