### PR TITLE
Skip offline downloader tests for now

### DIFF
--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -191,6 +191,7 @@ def test_non_datadog_distribution():
 )
 @pytest.mark.skipif(PY2, reason="tuf builds for Python 2 do not provide required information in exception")
 @mock.patch("time.time", mock.MagicMock(return_value=_LOCAL_TESTS_DATA_TIMESTAMP))
+@pytest.mark.skip(reason="currently failing since offline metadata was generated with v9 ceremony but currently on v10")
 def test_local_download(capfd, distribution_name, distribution_version, target):
     """Test local verification of a wheel file."""
     with local_http_server("{}-{}".format(distribution_name, distribution_version)) as http_url:
@@ -211,6 +212,7 @@ def test_local_download(capfd, distribution_name, distribution_version, target):
 
 
 @pytest.mark.local_dir
+@pytest.mark.skip(reason="currently failing since offline metadata was generated with v9 ceremony but currently on v10")
 def test_local_dir_download(capfd, local_dir, distribution_name, distribution_version):
     """Test local verification of a wheel file."""
     if local_dir is None:
@@ -242,6 +244,7 @@ def test_local_dir_download(capfd, local_dir, distribution_name, distribution_ve
         ("datadog-active-directory", "1.10.0"),
     ],
 )
+@pytest.mark.skip(reason="currently failing since offline metadata was generated with v9 ceremony but currently on v10")
 @pytest.mark.skipif(PY2, reason="tuf builds for Python 2 do not provide required information in exception")
 def test_local_expired_metadata_error(distribution_name, distribution_version):
     """Test expiration of metadata raises an exception."""
@@ -266,6 +269,7 @@ def test_local_expired_metadata_error(distribution_name, distribution_version):
 
 
 @pytest.mark.offline
+@pytest.mark.skip(reason="currently failing since offline metadata was generated with v9 ceremony but currently on v10")
 @pytest.mark.skipif(PY2, reason="tuf builds for Python 2 do not provide required information in exception")
 def test_local_unreachable_repository():
     """Test unreachable repository raises an exception."""
@@ -292,6 +296,7 @@ def test_local_unreachable_repository():
     ],
 )
 @pytest.mark.skipif(PY2, reason="tuf builds for Python 2 do not provide required information in exception")
+@pytest.mark.skip(reason="currently failing since offline metadata was generated with v9 ceremony but currently on v10")
 @mock.patch("time.time", mock.MagicMock(return_value=_LOCAL_TESTS_DATA_TIMESTAMP))
 def test_local_wheels_signer_signature_leaf_error(distribution_name, distribution_version):
     """Test failure in verifying wheels-signer signature.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Temporarily skip offline downloader tests since they are failing after the v10 ceremony.

### Motivation
<!-- What inspired you to submit this pull request? -->
When the downloader executes, it also updates the `root.json` in `downloader/data/repo/metadata/current`. This also happens in tests for the downloader. After running the recent v10 ceremony, the `root.json` file has been updated on the S3 repository. However, the offline tests rely on a zipped file with dummy metadata generated during the v9 ceremony and expects the `root.json` to still be v9. For now, we will skip the offline tests until we can fix this behavior.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
To fix the behavior, these two conditions should be met:
- Do not modify the state of `root.json` in tests in the first place. We should implement a way to change the `root.json` to the original value after a test is conducted, or some other way to prevent it from being modified.
- Use a v9 `root.json` during the offline tests. When an offline test tries to get the `root.json` in `downloader/data/repo/metadata/current`, we can substitute it with a pinned v9 `root.json` file instead.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.