### PR TITLE
Force pytest<7.2.0 to avoid test breakage

### DIFF
--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "flaky",
     "mock",
     "psutil",
-    "pytest",
+    "pytest<7.2.0",  # pytest 7.2.0 has broken our tests
     "pytest-benchmark[histogram]>=3.2.1",
     "pytest-cov>=2.6.1",
     "pytest-mock",


### PR DESCRIPTION
### What does this PR do?

Adds an upper bound to prevent tests from running under a pytest version that is currently broken for us.

### Motivation

pytest not running properly after update to 7.2.0 ([example](https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=116478&view=logs&jobId=e68def02-528b-569b-6f8b-ee3f97480a3a&j=8157d5c0-6574-55bb-ebb7-ea0affeefc23&t=576db4fb-ad6e-58ed-028c-734dacbb6401)).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.