### PR TITLE
Add port for merged telemetry endpoint in Istio auto_conf

### DIFF
--- a/istio/assets/configuration/spec.yaml
+++ b/istio/assets/configuration/spec.yaml
@@ -35,7 +35,7 @@ files:
             istio_mesh_endpoint: http://istio-telemetry.istio-system:42422/metrics
           value:
             display_default: null
-            example: http://istio-proxy.istio-system:15090/stats/prometheus
+            example: http://istio-proxy.istio-system:15020/stats/prometheus
             type: string
         - template: instances/openmetrics
           overrides:

--- a/istio/assets/configuration/spec.yaml
+++ b/istio/assets/configuration/spec.yaml
@@ -97,7 +97,7 @@ files:
         enabled: true
         value:
           display_default: null
-          example: http://%%host%%:15090/stats/prometheus
+          example: http://%%host%%:15020/stats/prometheus
           type: string
       - name: tag_by_endpoint
         description: Wether to include an endpoint tag or not. This only applies if `use openmentrics` is enabled.

--- a/istio/datadog_checks/istio/data/auto_conf.yaml
+++ b/istio/datadog_checks/istio/data/auto_conf.yaml
@@ -30,7 +30,7 @@ instances:
     ## @param istio_mesh_endpoint - string - optional
     ## To enable Istio metrics you must specify the url exposing the API.
     #
-    istio_mesh_endpoint: http://%%host%%:15090/stats/prometheus
+    istio_mesh_endpoint: http://%%host%%:15020/stats/prometheus
 
     ## @param tag_by_endpoint - boolean - optional - default: true
     ## Wether to include an endpoint tag or not. This only applies if `use openmentrics` is enabled.

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -66,7 +66,7 @@ instances:
     ## When collecting mesh metrics in Istio < v1.5, use
     ## istio_mesh_endpoint: http://istio-telemetry.istio-system:42422/metrics
     #
-    # istio_mesh_endpoint: http://istio-proxy.istio-system:15090/stats/prometheus
+    # istio_mesh_endpoint: http://istio-proxy.istio-system:15020/stats/prometheus
 
     ## @param raw_metric_prefix - string - optional
     ## A prefix that will be removed from all exposed metric names, if present.


### PR DESCRIPTION
### What does this PR do?
Updates the port in the Istio auto_conf.yaml to port 15020, the merged telemetry endpoint: [Istio docs ](https://istio.io/latest/docs/ops/deployment/requirements/#server-first-protocols:~:text=No-,15020,-HTTP)

### Motivation
Customer request: https://github.com/DataDog/integrations-core/issues/13047

### Additional Notes
N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.