### PR TITLE
Remove postgres tag truncation for metrics

### DIFF
--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -184,9 +184,6 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 return
             for event in self._rows_to_fqt_events(rows):
                 self._check.database_monitoring_query_sample(json.dumps(event, default=default_json_event_encoding))
-            # truncate query text to the maximum length supported by metrics tags
-            for row in rows:
-                row['query'] = row['query'][0:200]
             payload = {
                 'host': self._check.resolved_hostname,
                 'timestamp': time.time() * 1000,

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -186,7 +186,7 @@ def test_statement_metrics(
         assert row['calls'] == 1
         assert row['datname'] == dbname
         assert row['rolname'] == username
-        assert row['query'] == expected_query[0:200], "query should be truncated when sending to metrics"
+        assert row['query'] == expected_query
         available_columns = set(row.keys())
         metric_columns = available_columns & PG_STAT_STATEMENTS_METRICS_COLUMNS
         if track_io_timing_enabled:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We're moving the logic to the backend, and metrics is also allowing us to make tag lengths longer.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.