### PR TITLE
Remove mysql tag truncation for metrics

### DIFF
--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -133,10 +133,6 @@ class MySQLStatementMetrics(DBMAsyncJob):
         for event in self._rows_to_fqt_events(rows):
             self._check.database_monitoring_query_sample(json.dumps(event, default=default_json_event_encoding))
 
-        # truncate query text to the maximum length supported by metrics tags
-        for row in rows:
-            row['digest_text'] = row['digest_text'][0:200] if row['digest_text'] is not None else None
-
         payload = {
             'host': self._check.resolved_hostname,
             'timestamp': time.time() * 1000,

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -149,7 +149,7 @@ def test_statement_metrics(
 
     assert row['digest']
     assert row['schema_name'] == default_schema
-    assert row['digest_text'].strip() == query.strip()[0:200]
+    assert row['digest_text'].strip() == query.strip()
 
     for col in statements.METRICS_COLUMNS:
         assert type(row[col]) in (float, int)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We're moving the logic to the backend, and metrics is also allowing us to make tag lengths longer.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.