### PR TITLE
Fix non-specific troubleshooting link on explain_plan_procedure_missing configuration error

### DIFF
--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -132,7 +132,8 @@ class MySQLActivity(DBMAsyncJob):
                     'Query activity and wait event collection is disabled on this host. To enable it, the setup '
                     'consumer `performance-schema-consumer-events-waits-current` must be enabled on the MySQL server. '
                     'Please refer to the troubleshooting documentation: '
-                    'https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting/',
+                    'https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting#%s',
+                    DatabaseConfigurationError.events_waits_current_not_enabled.value,
                     code=DatabaseConfigurationError.events_waits_current_not_enabled.value,
                     host=self._check.resolved_hostname,
                 ),


### PR DESCRIPTION
### What does this PR do?
For known configuration issues, we want troubleshooting links to be the code-specific permanent URLs but I found one warning that had a generic troubleshooting url even though the specific permanent link exists: https://docs.datadoghq.com/database_monitoring/setup_mysql/troubleshooting#events-waits-current-not-enabled

This updates the message to include the correct specific link.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.