### PR TITLE
Fix gunicorn test environments

### DIFF
--- a/gunicorn/tests/compose/Dockerfile
+++ b/gunicorn/tests/compose/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3.10-alpine3.16
 ARG PROC_NAME
 ARG GUNICORN_VERSION
 ENV proc_name_env=${PROC_NAME}

--- a/gunicorn/tox.ini
+++ b/gunicorn/tox.ini
@@ -3,7 +3,7 @@ isolated_build = true
 minversion = 2.0
 basepython = py38
 envlist =
-    py{27,38}-{19.2,19.9,latest}
+    py27-19.9,py38-{19.9,20.1}
 
 [testenv]
 ensure_default_envdir = true
@@ -23,8 +23,7 @@ deps =
     -e../datadog_checks_base[deps]
     -rrequirements-dev.txt
 setenv =
-    latest: GUNICORN_VERSION=
     19.9: GUNICORN_VERSION=19.9.0
-    19.2: GUNICORN_VERSION=19.2.0
+    20.1: GUNICORN_VERSION=20.1.0
 commands =
     pytest -v {posargs}


### PR DESCRIPTION
### What does this PR do?

- Remove old gunicorn environment and replace it with a more current one.
- Remove sources of unreproducibility (pinned Docker base image, removed `latest` env).

### Motivation

Failing tests in CI.

### Additional Notes

The reason for the failure on gunicorn 19.2 was the release of Python 3.11, which has deprecated `inspect.getargspec`, which apparently that version of gunicorn was using. Since we weren't pinning the Docker base image, we got Python 3.11 there as soon as it was released, causing the error.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.