### PR TITLE
Disable socket wakeup when sending requests

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -192,6 +192,10 @@ class NewKafkaConsumerCheck(object):
             # Loop until all futures resolved.
             self.kafka_client._wait_for_futures(highwater_futures)
 
+    # FIXME: This is using a workaround to skip socket wakeup, which causes blocking
+    # (see https://github.com/dpkp/kafka-python/issues/2286).
+    # Once https://github.com/dpkp/kafka-python/pull/2335 is merged in, we can use the official
+    # implementation for this function instead.
     def _send_request_to_node(self, node_id, request, wakeup=True):
         while not self.kafka_client._client.ready(node_id):
             # poll until the connection to broker is ready, otherwise send()
@@ -376,6 +380,10 @@ class NewKafkaConsumerCheck(object):
 
         if self._monitor_unlisted_consumer_groups:
             for broker in self.kafka_client._client.cluster.brokers():
+                # FIXME: This is using a workaround to skip socket wakeup, which causes blocking
+                # (see https://github.com/dpkp/kafka-python/issues/2286).
+                # Once https://github.com/dpkp/kafka-python/pull/2335 is merged in, we can use the official
+                # implementation for this function instead.
                 list_groups_future = self._list_consumer_groups_send_request(broker.nodeId)
                 list_groups_future.add_callback(self._list_groups_callback, broker.nodeId)
                 self._consumer_futures.append(list_groups_future)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR disables socket wakeup when sending requests to the kafka-python library we use for the kafka_consumer check. Since our check runs in a single thread, it doesn't need to do a socket wakeup. This was also causing issues for set ups with high number of brokers per cluster:

```
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/kafka_consumer/new_kafka_consumer.py", line 64, in check
    self._get_consumer_offsets()
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/kafka_consumer/new_kafka_consumer.py", line 363, in _get_consumer_offsets
    list_groups_future = self.kafka_client._list_consumer_groups_send_request(broker.nodeId)
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/kafka/admin/client.py", line 1116, in _list_consumer_groups_send_request
    return self._send_request_to_node(broker_id, request)
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/kafka/admin/client.py", line 368, in _send_request_to_node
    return self._client.send(node_id, request)
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/kafka/client_async.py", line 546, in send
    self.wakeup()
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/kafka/client_async.py", line 935, in wakeup
    raise Errors.KafkaTimeoutError()
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->
https://github.com/dpkp/kafka-python/pull/1761 added the ability to disable socket wakeups with the `wakeup` argument to fix the `KafkaTimeoutError` error, although the fix wasn't being applied to the kafka-python function `_send_request_to_node()` which we use, so we needed to reimplement it by hand.

Here is the original Github issue: https://github.com/dpkp/kafka-python/issues/1760

I've also opened a Github PR on kafka-python to add the `wakeup` argument to the `_send_request_to_node()` function: https://github.com/dpkp/kafka-python/pull/2335

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.