### PR TITLE
Fix kafka request metrics due to KIP 272

### DIFF
--- a/kafka/datadog_checks/kafka/data/metrics.yaml
+++ b/kafka/datadog_checks/kafka/data/metrics.yaml
@@ -428,14 +428,14 @@ jmx_metrics:
             alias: kafka.request.produce.time.99percentile
     - include:
         domain: 'kafka.network'
-        bean_regex: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchConsumer.*'
+        bean_regex: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchConsumer(?:,version=.*)?'
         attribute:
           Count:
             metric_type: rate
             alias: kafka.request.fetch_consumer.rate
     - include:
         domain: 'kafka.network'
-        bean_regex: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchFollower.*'
+        bean_regex: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchFollower(?:,version=.*)?'
         attribute:
           Count:
             metric_type: rate

--- a/kafka/datadog_checks/kafka/data/metrics.yaml
+++ b/kafka/datadog_checks/kafka/data/metrics.yaml
@@ -411,7 +411,7 @@ jmx_metrics:
             alias: kafka.request.produce.failed.rate
     - include:
         domain: 'kafka.network'
-        bean_regex: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=Produce.*'
+        bean_regex: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=Produce(?:,version=.*)?'
         attribute:
           Count:
             metric_type: rate

--- a/kafka/datadog_checks/kafka/data/metrics.yaml
+++ b/kafka/datadog_checks/kafka/data/metrics.yaml
@@ -411,7 +411,7 @@ jmx_metrics:
             alias: kafka.request.produce.failed.rate
     - include:
         domain: 'kafka.network'
-        bean: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=Produce'
+        bean_regex: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=Produce.*'
         attribute:
           Count:
             metric_type: rate
@@ -428,14 +428,14 @@ jmx_metrics:
             alias: kafka.request.produce.time.99percentile
     - include:
         domain: 'kafka.network'
-        bean: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchConsumer'
+        bean_regex: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchConsumer.*'
         attribute:
           Count:
             metric_type: rate
             alias: kafka.request.fetch_consumer.rate
     - include:
         domain: 'kafka.network'
-        bean: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchFollower'
+        bean_regex: 'kafka.network:type=RequestMetrics,name=RequestsPerSec,request=FetchFollower.*'
         attribute:
           Count:
             metric_type: rate

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -6,18 +6,18 @@ kafka.net.processor.avg.idle.pct.rate,gauge,10,fraction,,Average fraction of tim
 kafka.messages_in.rate,gauge,10,message,,Incoming message rate.,0,kafka,messages in,cpu
 kafka.request.channel.queue.size,gauge,10,request,,Number of queued requests.,-1,kafka,req channel queue size,
 kafka.request.fetch_consumer.time.avg,gauge,10,millisecond,,Total time in ms to serve the specified request.,0,kafka,req fetch time avg,memory
-kafka.request.fetch_consumer.rate,gauge,10,request,,Number of fetch consumer requests.,0,kafka,req fetch consumer,
+kafka.request.fetch_consumer.rate,gauge,10,request,,Fetch consumer requests rate.,0,kafka,req fetch consumer,
 kafka.request.fetch_consumer.time.99percentile,gauge,10,millisecond,,Total time in ms to serve the specified request.,0,kafka,req fetch time 99,
-kafka.request.fetch.failed.rate,gauge,10,request,,Number of client fetch request failures.,-1,kafka,req fetch fail,
+kafka.request.fetch.failed.rate,gauge,10,request,,Client fetch request failures rate.,-1,kafka,req fetch fail,
 kafka.request.fetch_follower.time.avg,gauge,10,millisecond,,Total time in ms to serve the specified request.,-1,kafka,req fetch follower avg,
 kafka.request.fetch_follower.time.99percentile,gauge,10,millisecond,,Total time in ms to serve the specified request.,-1,kafka,req fetch follower 99,
-kafka.request.fetch_follower.rate,gauge,10,request,,Number of fetch follower requests.,0,kafka,req fetch follower,
+kafka.request.fetch_follower.rate,gauge,10,request,,Fetch follower requests rate.,0,kafka,req fetch follower,
 kafka.request.fetch_request_purgatory.size,gauge,10,request,,Number of requests waiting in the producer purgatory.,0,kafka,req fetch purgatory,
 kafka.request.handler.avg.idle.pct.rate,gauge,10,fraction,,Average fraction of time the request handler threads are idle.,1,kafka,req handle avg idle,
 kafka.request.produce.time.avg,gauge,10,millisecond,,Average time for a produce request.,0,kafka,req prod time avg,cpu
 kafka.request.produce.time.99percentile,gauge,10,millisecond,,Time for produce requests for 99th percentile.,0,kafka,req prod time 99,cpu
-kafka.request.produce.failed.rate,gauge,10,request,,Number of failed produce requests.,-1,kafka,req prod fail,
-kafka.request.produce.rate,gauge,10,request,,Number of produce requests.,0,kafka,req prod,
+kafka.request.produce.failed.rate,gauge,10,request,,Failed produce requests rate.,-1,kafka,req prod fail,
+kafka.request.produce.rate,gauge,10,request,,Produce requests rate.,0,kafka,req prod,
 kafka.request.producer_request_purgatory.size,gauge,10,request,,Number of requests waiting in the producer purgatory,0,kafka,req prod purgatory,
 kafka.request.update_metadata.time.avg,gauge,10,millisecond,,Average time for a request to update metadata.,0,kafka,req update meta time avg,
 kafka.request.update_metadata.time.99percentile,gauge,10,millisecond,,Time for update metadata requests for 99th percentile.,0,kafka,req update meta time 99,

--- a/kafka/metadata.csv
+++ b/kafka/metadata.csv
@@ -6,15 +6,18 @@ kafka.net.processor.avg.idle.pct.rate,gauge,10,fraction,,Average fraction of tim
 kafka.messages_in.rate,gauge,10,message,,Incoming message rate.,0,kafka,messages in,cpu
 kafka.request.channel.queue.size,gauge,10,request,,Number of queued requests.,-1,kafka,req channel queue size,
 kafka.request.fetch_consumer.time.avg,gauge,10,millisecond,,Total time in ms to serve the specified request.,0,kafka,req fetch time avg,memory
+kafka.request.fetch_consumer.rate,gauge,10,request,,Number of fetch consumer requests.,0,kafka,req fetch consumer,
 kafka.request.fetch_consumer.time.99percentile,gauge,10,millisecond,,Total time in ms to serve the specified request.,0,kafka,req fetch time 99,
 kafka.request.fetch.failed.rate,gauge,10,request,,Number of client fetch request failures.,-1,kafka,req fetch fail,
 kafka.request.fetch_follower.time.avg,gauge,10,millisecond,,Total time in ms to serve the specified request.,-1,kafka,req fetch follower avg,
 kafka.request.fetch_follower.time.99percentile,gauge,10,millisecond,,Total time in ms to serve the specified request.,-1,kafka,req fetch follower 99,
+kafka.request.fetch_follower.rate,gauge,10,request,,Number of fetch follower requests.,0,kafka,req fetch follower,
 kafka.request.fetch_request_purgatory.size,gauge,10,request,,Number of requests waiting in the producer purgatory.,0,kafka,req fetch purgatory,
 kafka.request.handler.avg.idle.pct.rate,gauge,10,fraction,,Average fraction of time the request handler threads are idle.,1,kafka,req handle avg idle,
 kafka.request.produce.time.avg,gauge,10,millisecond,,Average time for a produce request.,0,kafka,req prod time avg,cpu
 kafka.request.produce.time.99percentile,gauge,10,millisecond,,Time for produce requests for 99th percentile.,0,kafka,req prod time 99,cpu
 kafka.request.produce.failed.rate,gauge,10,request,,Number of failed produce requests.,-1,kafka,req prod fail,
+kafka.request.produce.rate,gauge,10,request,,Number of produce requests.,0,kafka,req prod,
 kafka.request.producer_request_purgatory.size,gauge,10,request,,Number of requests waiting in the producer purgatory,0,kafka,req prod purgatory,
 kafka.request.update_metadata.time.avg,gauge,10,millisecond,,Average time for a request to update metadata.,0,kafka,req update meta time avg,
 kafka.request.update_metadata.time.99percentile,gauge,10,millisecond,,Time for update metadata requests for 99th percentile.,0,kafka,req update meta time 99,

--- a/kafka/tests/common.py
+++ b/kafka/tests/common.py
@@ -18,6 +18,9 @@ Metrics that do not work in our e2e:
     "kafka.consumer.kafka_commits",
     "kafka.consumer.messages_in",
     "kafka.consumer.zookeeper_commits",
+    "kafka.request.produce.rate",
+    "kafka.request.fetch_follower.rate",
+    "kafka.request.fetch_consumer.rate",
 """
 
 KAFKA_E2E_METRICS = [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
In [KIP-272](https://cwiki.apache.org/confluence/display/KAFKA/KIP-272%3A+Add+API+version+tag+to+broker%27s+RequestsPerSec+metric), all `RequestsPerSec` metric bean names were changed from 
`kafka.network:type=RequestMetrics,name=RequestsPerSec,request={Produce|FetchConsumer|FetchFollower|...}` 

to 
`kafka.network:type=RequestMetrics,name=RequestsPerSec,request={Produce|FetchConsumer|FetchFollower|...},version=INTEGER`

This caused our current `RequestsPerSec` metrics to no longer be collected. This wasn't discovered until recently because our current e2e environment doesn't collect the missing metrics in the first place. 

This PR updates the bean name to be a regex and allow it to collect the version number if it exists, but retains backwards compatibility with the original style.

### Motivation
<!-- What inspired you to submit this pull request? -->
Support case
### Additional Notes
<!-- Anything else we should know when reviewing? -->
We should consider using a more official Kafka image, since [our version](https://hub.docker.com/r/wurstmeister/kafka/) is a major version release behind the current version of Kafka. Here's an [alternate image](https://hub.docker.com/r/bitnami/kafka) we can consider using.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.