### PR TITLE
Allow device-specific tags for all device-specific metrics

### DIFF
--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -169,6 +169,10 @@ class Disk(AgentCheck):
         tags = [part.fstype, 'filesystem:{}'.format(part.fstype)] if self._tag_by_filesystem else []
         tags.extend(self._custom_tags)
 
+        # apply device-specific tags
+        device_specific_tags = self._get_device_specific_tags(device_name)
+        tags.extend(device_specific_tags)
+
         # apply device/mountpoint specific tags
         for regex, device_tags in self._device_tag_re:
             if regex.match(device_name):
@@ -321,6 +325,10 @@ class Disk(AgentCheck):
             self.log.debug('IO Counters: %s -> %s', disk_name, disk)
             try:
                 metric_tags = [] if self._custom_tags is None else self._custom_tags[:]
+
+                device_specific_tags = self._get_device_specific_tags(disk_name)
+                metric_tags.extend(device_specific_tags)
+
                 metric_tags.append('device:{}'.format(disk_name))
                 metric_tags.append('device_name:{}'.format(_base_device_name(disk_name)))
                 if self.devices_label.get(disk_name):
@@ -490,6 +498,15 @@ class Disk(AgentCheck):
                 )
 
         return devices_label
+
+    def _get_device_specific_tags(self, device_name):
+        device_specific_tags = []
+
+        # apply device/mountpoint specific tags
+        for regex, device_tags in self._device_tag_re:
+            if regex.match(device_name):
+                device_specific_tags.extend(device_tags)
+        return device_specific_tags
 
     def _create_manual_mounts(self):
         """

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -173,11 +173,6 @@ class Disk(AgentCheck):
         device_specific_tags = self._get_device_specific_tags(device_name)
         tags.extend(device_specific_tags)
 
-        # apply device/mountpoint specific tags
-        for regex, device_tags in self._device_tag_re:
-            if regex.match(device_name):
-                tags.extend(device_tags)
-
         # apply device labels as tags (from blkid or lsblk).
         # we want to use the real device name and not the device_name (which can be the mountpoint)
         if self.devices_label.get(part.device):

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -153,20 +153,11 @@ def test_device_tagging(aggregator, gauge_metrics, rate_metrics, count_metrics, 
         'device_label:mylab',
     ]
 
-    for name, value in iteritems(gauge_metrics):
-        aggregator.assert_metric(name, value=value, tags=tags)
-
-    for name, value in chain(iteritems(rate_metrics), iteritems(count_metrics)):
+    for name, value in chain(iteritems(gauge_metrics), iteritems(rate_metrics), iteritems(count_metrics)):
         aggregator.assert_metric(
             name,
             value=value,
-            tags=[
-                'device:{}'.format(DEFAULT_DEVICE_NAME),
-                'device_name:{}'.format(DEFAULT_DEVICE_BASE_NAME),
-                'optional:tags1',
-                'label:mylab',
-                'device_label:mylab',
-            ],
+            tags=tags,
         )
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR allows device-specific tags declared in `device_tag_re` to apply to all metrics that already tag by `device_name` or `device`. 

Originally this was skipped for latency metrics (`read_time`, `write_time`, `read_time_pct`, and `write_time_pct`).

### Motivation
<!-- What inspired you to submit this pull request? -->
Customer request.
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.