### PR TITLE
Skip empty columns when metric_prefix is used for custom queries

### DIFF
--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -101,7 +101,11 @@ class Oracle(AgentCheck):
                 if prefix.startswith(self.__NAMESPACE__ + '.'):
                     prefix = prefix[len(self.__NAMESPACE__) + 1 :]
                 for column in query.get('columns', []):
-                    if column.get('type') != 'tag':
+                    # if the column is supposed to be skipped
+                    if not column.get('type') and not column.get('name'):
+                        continue
+
+                    elif column.get('type') != 'tag':
                         column['name'] = '{}.{}'.format(prefix, column['name'])
 
     def validate_config(self):

--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -102,10 +102,7 @@ class Oracle(AgentCheck):
                     prefix = prefix[len(self.__NAMESPACE__) + 1 :]
                 for column in query.get('columns', []):
                     # if the column is supposed to be skipped
-                    if not (column.get('type') or column.get('name')):
-                        continue
-
-                    elif column.get('type') != 'tag':
+                    if column.get('type') != 'tag' and column.get('name'):
                         column['name'] = '{}.{}'.format(prefix, column['name'])
 
     def validate_config(self):

--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -102,7 +102,7 @@ class Oracle(AgentCheck):
                     prefix = prefix[len(self.__NAMESPACE__) + 1 :]
                 for column in query.get('columns', []):
                     # if the column is supposed to be skipped
-                    if not column.get('type') and not column.get('name'):
+                    if not (column.get('type') or column.get('name')):
                         continue
 
                     elif column.get('type') != 'tag':

--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -101,7 +101,6 @@ class Oracle(AgentCheck):
                 if prefix.startswith(self.__NAMESPACE__ + '.'):
                     prefix = prefix[len(self.__NAMESPACE__) + 1 :]
                 for column in query.get('columns', []):
-                    # if the column is supposed to be skipped
                     if column.get('type') != 'tag' and column.get('name'):
                         column['name'] = '{}.{}'.format(prefix, column['name'])
 

--- a/oracle/tests/test_custom_queries.py
+++ b/oracle/tests/test_custom_queries.py
@@ -120,9 +120,7 @@ def test_custom_queries_metric_prefix_skip_column(aggregator, check, dd_run_chec
         {
             "metric_prefix": "oracle.test1",
             "query": "mocked",
-            "columns": [{},  # skip `tag_value1` column
-                        {"name": "metric", "type": "gauge"}
-                        ],
+            "columns": [{}, {"name": "metric", "type": "gauge"}],  # skip `tag_value1` column
             "tags": ["query_tags1"],
         },
     ]
@@ -134,6 +132,4 @@ def test_custom_queries_metric_prefix_skip_column(aggregator, check, dd_run_chec
         connection.return_value = con
         dd_run_check(check)
 
-    aggregator.assert_metric(
-        "oracle.test1.metric", value=1, count=1, tags=["query_tags1", "optional:tag1"]
-    )
+    aggregator.assert_metric("oracle.test1.metric", value=1, count=1, tags=["query_tags1", "optional:tag1"])

--- a/oracle/tests/test_custom_queries.py
+++ b/oracle/tests/test_custom_queries.py
@@ -108,6 +108,7 @@ def test_custom_queries_multiple_results(aggregator, check):
         "oracle.test1.metric", value=2, count=1, tags=["tag_name:tag_value2", "query_tags1", "custom_tag"]
     )
 
+
 def test_custom_queries_metric_prefix_skip_column(aggregator, check):
     con = mock.MagicMock()
     cursor = mock.MagicMock()

--- a/oracle/tests/test_unit.py
+++ b/oracle/tests/test_unit.py
@@ -137,20 +137,3 @@ def test_handle_query_error_when_connected_disconnects_and_resets_connection(ins
     assert error == 'foo'
     assert oracle_check._cached_connection is None
     cached_connection.assert_has_calls([mock.call.close()])
-
-
-def test_custom_query_metric_prefix_skip_column():
-    instance = {
-        'custom_queries': [
-            {
-                'metric_prefix': 'test',
-                'query': 'select foo',
-                'columns': [
-                    {'name': "test", 'type': 'test'},
-                    {},  # empty entry
-                ],
-            }
-        ]
-    }
-    c = Oracle(CHECK_NAME, {}, [instance])
-    c._fix_custom_queries()

--- a/oracle/tests/test_unit.py
+++ b/oracle/tests/test_unit.py
@@ -137,3 +137,20 @@ def test_handle_query_error_when_connected_disconnects_and_resets_connection(ins
     assert error == 'foo'
     assert oracle_check._cached_connection is None
     cached_connection.assert_has_calls([mock.call.close()])
+
+
+def test_custom_query_metric_prefix_skip_column():
+    instance = {
+        'custom_queries': [
+            {
+                'metric_prefix': 'test',
+                'query': 'select foo',
+                'columns': [
+                    {'name': "test", 'type': 'test'},
+                    {},  # empty entry
+                ],
+            }
+        ]
+    }
+    c = Oracle(CHECK_NAME, {}, [instance])
+    c._fix_custom_queries()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
`metric_prefix` is a deprecated config option that would attach a metric prefix to custom queries. In these custom queries, specific columns may be skipped, although currently any custom metric prefix will still be attempted to be added to the skipped columns. This PR will stop attempting to append a custom metric prefix to skipped columns.


### Motivation
<!-- What inspired you to submit this pull request? -->
Customer request

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Example where this may happen:

```
init_config:
instances:
...
    custom_queries:
  - metric_prefix: custom_metric_prefix
    query: |
      select foo, bar, baz, etc;
    columns:
      - {}
      - name: metric1
        type: gauge
      - name: tag1
        type: tag
      - name: metric2
        type: count
    tags:
      - tester:oracle
```

This will result in the error message:
```
Check Initialization Errors
  ===========================
      oracle (3.5.0)
      --------------
      instance 0:
        could not invoke 'oracle' python check constructor. New constructor API returned:
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/oracle/oracle.py", line 55, in __init__
    self._fix_custom_queries()
  File "/opt/datadog-agent/embedded/lib/python2.7/site-packages/datadog_checks/oracle/oracle.py", line 85, in _fix_custom_queries
    column['name'] = '{}.{}'.format(prefix, column['name'])
KeyError: 'name'
Deprecated constructor API returned:
__init__() got an unexpected keyword argument 'agentConfig'
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.