### PR TITLE
Allow punctuation marks in query name when publishing spark structured streaming metrics

### DIFF
--- a/spark/datadog_checks/spark/constants.py
+++ b/spark/datadog_checks/spark/constants.py
@@ -37,7 +37,7 @@ MESOS_MASTER_APP_PATH = '/frameworks'
 
 # Extract the application name and the dd metric name from the structured streams metrics.
 STRUCTURED_STREAMS_METRICS_REGEX = re.compile(
-    r"^[\w-]+\.driver\.spark\.streaming\.(?P<query_name>[\w/\\|!.,@-]+)\.(?P<metric_name>[\w-]+)$"
+    r"^[\w-]+\.driver\.spark\.streaming\.(?P<query_name>.+)\.(?P<metric_name>[\w-]+)$"
 )
 
 # Tests if the query_name is a UUID to determine whether to add it as a tag

--- a/spark/datadog_checks/spark/constants.py
+++ b/spark/datadog_checks/spark/constants.py
@@ -37,7 +37,7 @@ MESOS_MASTER_APP_PATH = '/frameworks'
 
 # Extract the application name and the dd metric name from the structured streams metrics.
 STRUCTURED_STREAMS_METRICS_REGEX = re.compile(
-    r"^[\w-]+\.driver\.spark\.streaming\.(?P<query_name>[\w-]+)\.(?P<metric_name>[\w-]+)$"
+    r"^[\w-]+\.driver\.spark\.streaming\.(?P<query_name>[\w/\\|!.,@-]+)\.(?P<metric_name>[\w-]+)$"
 )
 
 # Tests if the query_name is a UUID to determine whether to add it as a tag


### PR DESCRIPTION
### What does this PR do?

Updates regex used for extracting spark structured streaming metrics to allow punctuation characters in the query name.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.