### PR TITLE
Add the CHANGELOG.md template file to the new integration scaffolds

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/CHANGELOG.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/snmp_tile/snmp_{check_name}/CHANGELOG.md
@@ -1,0 +1,2 @@
+# CHANGELOG - {integration_name}
+

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/CHANGELOG.md
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/tile/{check_name}/CHANGELOG.md
@@ -1,0 +1,2 @@
+# CHANGELOG - {integration_name}
+


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Make sure that the CHANGELOG.md file is present when running `ddev create` against _all_ types of integrations

### Motivation
<!-- What inspired you to submit this pull request? -->
This was missing for SNMP and TILE type integrations but its required for all integrations to have a CHANGELOG.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.