### PR TITLE
Disable socket wakeup when listing consumer groups and send request

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -376,7 +376,7 @@ class NewKafkaConsumerCheck(object):
 
         if self._monitor_unlisted_consumer_groups:
             for broker in self.kafka_client._client.cluster.brokers():
-                list_groups_future = self.kafka_client._list_consumer_groups_send_request(broker.nodeId)
+                list_groups_future = self._list_consumer_groups_send_request(broker.nodeId)
                 list_groups_future.add_callback(self._list_groups_callback, broker.nodeId)
                 self._consumer_futures.append(list_groups_future)
         elif self._consumer_groups:
@@ -400,7 +400,7 @@ class NewKafkaConsumerCheck(object):
         :param broker_id: The broker's node_id.
         :return: A message future
         """
-        kafka_version = self.kafka_client._matching_api_version
+        kafka_version = self.kafka_client.config['api_version']
         if kafka_version <= 2:
             request = ListGroupsRequest[kafka_version]()
         else:

--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -396,10 +396,6 @@ class NewKafkaConsumerCheck(object):
         del self._consumer_futures  # since it's reset on every check run, no sense holding the reference between runs
 
     def _list_consumer_groups_send_request(self, broker_id):
-        """Send a ListGroupsRequest to a broker.
-        :param broker_id: The broker's node_id.
-        :return: A message future
-        """
         kafka_version = self.kafka_client.config['api_version']
         if kafka_version <= 2:
             request = ListGroupsRequest[kafka_version]()

--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -396,7 +396,7 @@ class NewKafkaConsumerCheck(object):
         del self._consumer_futures  # since it's reset on every check run, no sense holding the reference between runs
 
     def _list_consumer_groups_send_request(self, broker_id):
-        kafka_version = self.kafka_client.config['api_version']
+        kafka_version = self.kafka_client._matching_api_version(ListGroupsRequest)
         if kafka_version <= 2:
             request = ListGroupsRequest[kafka_version]()
         else:

--- a/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/new_kafka_consumer.py
@@ -407,6 +407,7 @@ class NewKafkaConsumerCheck(object):
             raise NotImplementedError(
                 "Support for ListGroupsRequest_v{} has not yet been added to KafkaAdminClient.".format(kafka_version)
             )
+        # Disable wakeup when sending request to prevent blocking send requests
         return self._send_request_to_node(broker_id, request, wakeup=False)
 
     def _list_groups_callback(self, broker_id, response):


### PR DESCRIPTION
### What does this PR do?
Re-implements the kafka-python `_list_consumer_groups_send_request` [method](https://github.com/dpkp/kafka-python/blob/4d598055dab7da99e41bfcceffa8462b32931cdd/kafka/admin/client.py#L1107-L1120) to use the patched `_send_request_to_node` method to disable socket wakeup.

### Motivation
Support case

### Additional Notes
Adding onto https://github.com/DataDog/integrations-core/pull/13221

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.