### PR TITLE
Bump protobuf version to 3.20.1

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -58,7 +58,7 @@ ply==3.11
 prometheus-client==0.12.0; python_version < '3.0'
 prometheus-client==0.14.1; python_version > '3.0'
 protobuf==3.17.3; python_version < '3.0'
-protobuf==3.20.1; python_version > '3.0'
+protobuf==3.20.2; python_version > '3.0'
 psutil==5.9.0
 psycopg2-binary==2.8.6
 pyasn1==0.4.6

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -54,7 +54,7 @@ deps = [
     "prometheus-client==0.12.0; python_version < '3.0'",
     "prometheus-client==0.14.1; python_version > '3.0'",
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
     "pydantic==1.10.2; python_version > '3.0'",
     "python-dateutil==2.8.2",
     "pywin32==228; sys_platform == 'win32' and python_version < '3.0'",

--- a/gitlab/pyproject.toml
+++ b/gitlab/pyproject.toml
@@ -40,7 +40,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/gitlab_runner/pyproject.toml
+++ b/gitlab_runner/pyproject.toml
@@ -40,7 +40,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/kube_dns/pyproject.toml
+++ b/kube_dns/pyproject.toml
@@ -40,7 +40,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/kubernetes_state/pyproject.toml
+++ b/kubernetes_state/pyproject.toml
@@ -40,7 +40,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Backport of https://github.com/DataDog/integrations-core/pull/13262

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/image-vuln-scans/issues/547

Will be shipped with the agent 7.40.1 as discussed with Brian (Kacper being OOO) 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.