### PR TITLE
Bump protobuf version to 3.20.1

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -58,7 +58,7 @@ ply==3.11
 prometheus-client==0.12.0; python_version < '3.0'
 prometheus-client==0.15.0; python_version > '3.0'
 protobuf==3.17.3; python_version < '3.0'
-protobuf==3.20.1; python_version > '3.0'
+protobuf==3.20.2; python_version > '3.0'
 psutil==5.9.0
 psycopg2-binary==2.8.6
 pyasn1==0.4.6

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -55,7 +55,7 @@ deps = [
     "prometheus-client==0.12.0; python_version < '3.0'",
     "prometheus-client==0.15.0; python_version > '3.0'",
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
     "pydantic==1.10.2; python_version > '3.0'",
     "python-dateutil==2.8.2",
     "pywin32==228; sys_platform == 'win32' and python_version < '3.0'",

--- a/gitlab/CHANGELOG.md
+++ b/gitlab/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - gitlab
 
+## 5.3.1 / 2022-11-07
+
+* [Fixed] Bump protobuf version to 3.20.1. See [#13269](https://github.com/DataDog/integrations-core/pull/13269).
+
 ## 5.3.0 / 2022-09-16
 
 * [Added] Update HTTP config spec templates. See [#12890](https://github.com/DataDog/integrations-core/pull/12890).

--- a/gitlab/datadog_checks/gitlab/__about__.py
+++ b/gitlab/datadog_checks/gitlab/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '5.3.0'
+__version__ = '5.3.1'

--- a/gitlab/pyproject.toml
+++ b/gitlab/pyproject.toml
@@ -41,7 +41,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/gitlab_runner/CHANGELOG.md
+++ b/gitlab_runner/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - gitlab_runner
 
+## 3.3.1 / 2022-11-07
+
+* [Fixed] Bump protobuf version to 3.20.1. See [#13269](https://github.com/DataDog/integrations-core/pull/13269).
+
 ## 3.3.0 / 2022-09-16
 
 * [Added] Update HTTP config spec templates. See [#12890](https://github.com/DataDog/integrations-core/pull/12890).

--- a/gitlab_runner/datadog_checks/gitlab_runner/__about__.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '3.3.0'
+__version__ = '3.3.1'

--- a/gitlab_runner/pyproject.toml
+++ b/gitlab_runner/pyproject.toml
@@ -41,7 +41,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/kube_dns/CHANGELOG.md
+++ b/kube_dns/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - Kube-dns
 
+## 3.3.1 / 2022-11-07
+
+* [Fixed] Bump protobuf version to 3.20.1. See [#13269](https://github.com/DataDog/integrations-core/pull/13269).
+
 ## 3.3.0 / 2022-09-16
 
 * [Added] Update HTTP config spec templates. See [#12890](https://github.com/DataDog/integrations-core/pull/12890).

--- a/kube_dns/datadog_checks/kube_dns/__about__.py
+++ b/kube_dns/datadog_checks/kube_dns/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '3.3.0'
+__version__ = '3.3.1'

--- a/kube_dns/pyproject.toml
+++ b/kube_dns/pyproject.toml
@@ -41,7 +41,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/kubernetes_state/CHANGELOG.md
+++ b/kubernetes_state/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * [Added] Add documentation for `kubernetes_state_core` core check. See [#12552](https://github.com/DataDog/integrations-core/pull/12552).
 
+## 7.3.1 / 2022-11-07
+
+* [Fixed] Bump protobuf version to 3.20.1. See [#13269](https://github.com/DataDog/integrations-core/pull/13269).
+
 ## 7.3.0 / 2022-09-16
 
 * [Added] Update HTTP config spec templates. See [#12890](https://github.com/DataDog/integrations-core/pull/12890).

--- a/kubernetes_state/pyproject.toml
+++ b/kubernetes_state/pyproject.toml
@@ -41,7 +41,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==3.20.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -50,8 +50,8 @@ datadog-flink==1.4.0
 datadog-fluentd==2.2.0
 datadog-foundationdb==1.2.0
 datadog-gearmand==2.3.0; sys_platform != 'win32'
-datadog-gitlab-runner==3.3.0
-datadog-gitlab==5.3.0
+datadog-gitlab-runner==3.3.1
+datadog-gitlab==5.3.1
 datadog-glusterfs==1.5.0; sys_platform == 'linux2'
 datadog-go-expvar==2.2.0
 datadog-gunicorn==2.3.1; sys_platform != 'win32'
@@ -81,7 +81,7 @@ datadog-kafka==2.13.0
 datadog-kong==2.2.0
 datadog-kube-apiserver-metrics==3.3.0
 datadog-kube-controller-manager==4.3.0
-datadog-kube-dns==3.3.0
+datadog-kube-dns==3.3.1
 datadog-kube-metrics-server==2.3.0
 datadog-kube-proxy==5.3.0
 datadog-kube-scheduler==4.5.0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Port those PRs: 

- https://github.com/DataDog/integrations-core/pull/13269
- https://github.com/DataDog/integrations-core/pull/13270

### Motivation
<!-- What inspired you to submit this pull request? -->

It needs to be included in agent 7.41

### Additional Notes
<!-- Anything else we should know when reviewing? -->

kubernetes_sate is 7.4.0 on this branch so I will have to release a 7.4.1 after that 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.