### PR TITLE
Add deprecation notice for `extra_performance_metrics` option

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -423,6 +423,9 @@ class MySql(AgentCheck):
             and above_560
             and self.performance_schema_enabled
         ):
+            self.warning(
+                "[Deprecated] The `extra_performance_metrics` option will be removed in a future release."
+            )
             results['perf_digest_95th_percentile_avg_us'] = self._get_query_exec_time_95th_us(db)
             results['query_run_time_avg'] = self._query_exec_time_per_schema(db)
             metrics.update(PERFORMANCE_VARS)

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -424,7 +424,8 @@ class MySql(AgentCheck):
             and self.performance_schema_enabled
         ):
             self.warning(
-                "[Deprecated] The `extra_performance_metrics` option will be removed in a future release."
+                "[Deprecated] The `extra_performance_metrics` option will be removed in a future release. "
+                "Utilize the `custom_queries` feature if the functionality is needed.",
             )
             results['perf_digest_95th_percentile_avg_us'] = self._get_query_exec_time_95th_us(db)
             results['query_run_time_avg'] = self._query_exec_time_per_schema(db)

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -476,6 +476,9 @@ def test_statement_samples_collect(
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_missing_explain_procedure(dbm_instance, dd_run_check, aggregator, statement, schema, expected_warnings):
+    # This feature is being deprecated, it's disabled here because otherwise this warning gets surfaced before the
+    # explain procedure warning.
+    dbm_instance['options']['extra_performance_metrics'] = False
     # Disable query samples to avoid interference from query samples getting picked up from db and triggering
     # explain plans
     dbm_instance['query_samples']['enabled'] = False


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds a notice for the deprecation of the `extra_performance_metrics` option 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.