### PR TITLE
Use an access token to log in dockerhub

### DIFF
--- a/.azure-pipelines/scripts/sap_hana/linux/55_docker_login.sh
+++ b/.azure-pipelines/scripts/sap_hana/linux/55_docker_login.sh
@@ -3,6 +3,6 @@ set -euo pipefail
 
 set +x
 
-echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+echo "$DOCKER_ACCESS_TOKEN" | docker login --username "$DOCKER_USERNAME" --password-stdin
 
 set -x

--- a/sap_hana/datadog_checks/sap_hana/queries.py
+++ b/sap_hana/datadog_checks/sap_hana/queries.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
-
 """
 https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.02/en-US/20cbb10c75191014b47ba845bfe499fe.html
 

--- a/sap_hana/datadog_checks/sap_hana/queries.py
+++ b/sap_hana/datadog_checks/sap_hana/queries.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
+
 """
 https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.02/en-US/20cbb10c75191014b47ba845bfe499fe.html
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Stop using the password and use an access token to log in docker hub.

I added the token to our variable group.

### Motivation
<!-- What inspired you to submit this pull request? -->

Password authentication is now disabled. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

We have to be logged in to get sap hana images. More info [here](https://developers.sap.com/tutorials/hxe-ua-install-using-docker.html)

Worked here https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=117732&view=logs&j=b9b61b1e-e7ad-5a75-8bb3-f1445ef55317&t=4df15724-c42a-51be-f807-8fc596bf2a13

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.