### PR TITLE
Set the DOCKER_ACCESS_TOKEN as a secret

### DIFF
--- a/.azure-pipelines/templates/set-up-integrations.yml
+++ b/.azure-pipelines/templates/set-up-integrations.yml
@@ -7,5 +7,7 @@ steps:
   env:
     # Need unbuffered IO, see: https://github.com/Microsoft/azure-pipelines-yaml/issues/106
     PYTHONUNBUFFERED: 1
+    # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#secret-variables
     DOCKER_PASSWORD: $(DOCKER_PASSWORD)
+    DOCKER_ACCESS_TOKEN: $(DOCKER_ACCESS_TOKEN)
     ORACLE_DOCKER_PASSWORD: $(ORACLE_DOCKER_PASSWORD)

--- a/sap_hana/tests/common.py
+++ b/sap_hana/tests/common.py
@@ -6,6 +6,7 @@ import os
 from datadog_checks.dev import get_docker_hostname, get_here
 from datadog_checks.sap_hana import SapHanaCheck
 
+
 HERE = get_here()
 COMPOSE_FILE = os.path.join(HERE, 'docker', 'docker-compose.yaml')
 SERVER = get_docker_hostname()

--- a/sap_hana/tests/common.py
+++ b/sap_hana/tests/common.py
@@ -6,7 +6,6 @@ import os
 from datadog_checks.dev import get_docker_hostname, get_here
 from datadog_checks.sap_hana import SapHanaCheck
 
-
 HERE = get_here()
 COMPOSE_FILE = os.path.join(HERE, 'docker', 'docker-compose.yaml')
 SERVER = get_docker_hostname()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Set the DOCKER_ACCESS_TOKEN as a secret.

### Motivation
<!-- What inspired you to submit this pull request? -->

Seems like I forgot to set it back to a secret in our config and add it in this file. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Worked [here](https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=117799&view=logs&j=910f82a4-622d-5ace-f877-8b75c045486c&t=8eb50bb1-e140-5af2-ec58-7d4b906239a3)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.