### PR TITLE
Validate the manifest file before the dashboards in the CI

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -52,6 +52,10 @@ jobs:
       run: |
         ddev validate config $CHANGED
 
+    - name: Run manifest validation
+      run: |
+        ddev validate manifest $CHANGED
+
     - name: Run dashboard validation
       run: |
         ddev validate dashboards $CHANGED
@@ -83,10 +87,6 @@ jobs:
     - name: Run licenses validation
       run: |
         ddev validate licenses
-
-    - name: Run manifest validation
-      run: |
-        ddev validate manifest $CHANGED
 
     - name: Run metadata validation
       run: |


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Run the manifest validation before the dashboards validation.

### Motivation
<!-- What inspired you to submit this pull request? -->

[Dashboards are retrieved](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/dashboards.py#L95) from the manifest file. If the manifest is broken, the dashboards validation will fail with a cryptic and misleading message. Example [here](https://github.com/DataDog/integrations-extras/actions/runs/3395812713/jobs/5646160209)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.