### PR TITLE
add licences for python-oracledb

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -68,7 +68,7 @@ KNOWN_LICENSES = {
     'psf': 'PSF',
     'psf license': 'PSF',
     'python software foundation license': 'PSF',
-    'upl': 'UPL'
+    'upl': 'UPL',
 }
 KNOWN_CLASSIFIERS = {'Python Software Foundation License': 'PSF'}
 CLASSIFIER_TO_HIGHEST_SPDX = {

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -68,6 +68,7 @@ KNOWN_LICENSES = {
     'psf': 'PSF',
     'psf license': 'PSF',
     'python software foundation license': 'PSF',
+    'upl': 'UPL'
 }
 KNOWN_CLASSIFIERS = {'Python Software Foundation License': 'PSF'}
 CLASSIFIER_TO_HIGHEST_SPDX = {
@@ -104,6 +105,7 @@ CLASSIFIER_TO_HIGHEST_SPDX = {
     'Mozilla Public License 1.1 (MPL 1.1)': 'MPL-1.1',
     'Mozilla Public License 2.0 (MPL 2.0)': 'MPL-2.0',
     'Netscape Public License (NPL)': 'NPL-1.1',
+    "Universal Permissive License (UPL)": 'UPL',
     'W3C License': 'W3C',
     'Zope Public License': 'ZPL-2.1',
 }
@@ -281,7 +283,7 @@ def licenses(ctx, sync):
             package_license = package_license.strip('"')
 
             expanded_licenses = []
-            for separator in ('/', ' OR ', ' or '):
+            for separator in (' and/or ','/', ' OR ', ' or '):
                 if separator in package_license:
                     expanded_licenses.extend(package_license.split(separator))
                     break

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -283,7 +283,7 @@ def licenses(ctx, sync):
             package_license = package_license.strip('"')
 
             expanded_licenses = []
-            for separator in (' and/or ','/', ' OR ', ' or '):
+            for separator in (' and/or ', '/', ' OR ', ' or '):
                 if separator in package_license:
                     expanded_licenses.extend(package_license.split(separator))
                     break


### PR DESCRIPTION
### What does this PR do?
Adds the ability to parse `' and/or '` seperator for license validator

### Motivation
https://github.com/DataDog/integrations-core/pull/13298/files
License Format: (Apache and/or UPL)
https://pypi.org/project/oracledb/

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.