### PR TITLE
Add py2 tests for sonarqube

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/constants.py
@@ -139,7 +139,17 @@ integration_type_links = {
 
 # If a file changes in a PR with any of these file extensions,
 # a test will run against the check containing the file
-TESTABLE_FILE_PATTERNS = ('*.py', '*.ini', '*.in', '*.txt', '*.yml', '*.yaml', '**/tests/*', '**/pyproject.toml')
+TESTABLE_FILE_PATTERNS = (
+    '*.py',
+    '*.ini',
+    '*.in',
+    '*.txt',
+    '*.yml',
+    '*.yaml',
+    '**/tests/*',
+    '**/pyproject.toml',
+    '**/hatch.toml',
+)
 NON_TESTABLE_FILES = ('auto_conf.yaml', 'agent_requirements.in')
 
 ROOT = ''

--- a/sonarqube/hatch.toml
+++ b/sonarqube/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["38"]
+python = ["27", "38"]
 version = ["7.9", "8.5", "9.3"]
 
 # You can use M1 env if you want to run on M1 processor machine


### PR DESCRIPTION
Sonarqube is listed as py2 compatible but does not have py2 tests.
Consider hatch.toml file in testable files for PR tests to run