### PR TITLE
Allow `bench` as an env name for running benchmarks with hatch

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -273,7 +273,7 @@ def select_hatch_envs(
         envs_selected[:] = [
             env_name
             for env_name, config in get_available_hatch_envs(check, e2e_tests_only=e2e_tests_only).items()
-            if config.get('benchmark-env', False)
+            if env_name == 'bench' or config.get('benchmark-env', False)
         ]
     elif latest:
         envs_selected[:] = [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Allow `bench` test env as a benchmark env using hatch.

### Motivation
<!-- What inspired you to submit this pull request? -->

- Bench tests are not running for integrations migrated to hatch 🙈. Example [here](https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=118518&view=logs&jobId=70a237a0-2c52-52f8-23f1-657d682c7ecf&j=70a237a0-2c52-52f8-23f1-657d682c7ecf&t=24c0e73f-1122-5cb1-40ea-3a63edc6dac8) with vault on master 
- `bench` is also the bench env name used with [tox](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/testing.py#L211-L212)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.