### PR TITLE
Add thread_pools.percent_used to metadata.csv

### DIFF
--- a/ibm_was/metadata.csv
+++ b/ibm_was/metadata.csv
@@ -31,7 +31,7 @@ ibm_was.thread_pools.destroy_count,gauge,,thread,,The total number of threads de
 ibm_was.thread_pools.active_count,gauge,,thread,,The number of concurrently active threads,0,ibm_was,thread pools active count,
 ibm_was.thread_pools.pool_size,gauge,,thread,,The average number of threads in pool,0,ibm_was,thread pools size,
 ibm_was.thread_pools.percent_maxed,gauge,,percent,,The average percent of the time that all threads are in use,0,ibm_was,thread pools percent max,
-ibm_was.thread_pools.percent_used,gauge,,percent,,The average percent of the pool that is in use. The value is based on the total number of configured threads in the ThreadPool and not the current pool size.	,0,ibm_was,thread pools percent used,
+ibm_was.thread_pools.percent_used,gauge,,percent,,The average percent of the pool that is in use. The value is based on the total number of configured threads in the ThreadPool and not the current pool size.,0,ibm_was,thread pools percent used,
 ibm_was.thread_pools.declaredthread_hung_count,gauge,,thread,,The number of threads declared hung,0,ibm_was,thread pools declared count,
 ibm_was.thread_pools.cleared_thread_hang_count,gauge,,thread,,The number of thread hangs cleared,0,ibm_was,thread pools cleared,
 ibm_was.thread_pools.concurrent_hung_thread_count,gauge,,thread,,The number of concurrently hung threads,0,ibm_was,thread pools concurrent hung,

--- a/ibm_was/metadata.csv
+++ b/ibm_was/metadata.csv
@@ -31,6 +31,7 @@ ibm_was.thread_pools.destroy_count,gauge,,thread,,The total number of threads de
 ibm_was.thread_pools.active_count,gauge,,thread,,The number of concurrently active threads,0,ibm_was,thread pools active count,
 ibm_was.thread_pools.pool_size,gauge,,thread,,The average number of threads in pool,0,ibm_was,thread pools size,
 ibm_was.thread_pools.percent_maxed,gauge,,percent,,The average percent of the time that all threads are in use,0,ibm_was,thread pools percent max,
+ibm_was.thread_pools.percent_used,gauge,,percent,,The average percent of the pool that is in use. The value is based on the total number of configured threads in the ThreadPool and not the current pool size.	,0,ibm_was,thread pools percent used,
 ibm_was.thread_pools.declaredthread_hung_count,gauge,,thread,,The number of threads declared hung,0,ibm_was,thread pools declared count,
 ibm_was.thread_pools.cleared_thread_hang_count,gauge,,thread,,The number of thread hangs cleared,0,ibm_was,thread pools cleared,
 ibm_was.thread_pools.concurrent_hung_thread_count,gauge,,thread,,The number of concurrently hung threads,0,ibm_was,thread pools concurrent hung,

--- a/ibm_was/tests/common.py
+++ b/ibm_was/tests/common.py
@@ -30,6 +30,7 @@ METRICS_ALWAYS_PRESENT = [
     'ibm_was.jvm.heap_size',
     'ibm_was.servlet_session.live_count',
     'ibm_was.thread_pools.pool_size',
+    'ibm_was.thread_pools.percent_used',
 ]
 
 DEFAULT_SERVICE_CHECK_TAGS = ['url:{}'.format(INSTANCE.get('servlet_url')), 'key1:value1']

--- a/ibm_was/tests/common.py
+++ b/ibm_was/tests/common.py
@@ -30,7 +30,6 @@ METRICS_ALWAYS_PRESENT = [
     'ibm_was.jvm.heap_size',
     'ibm_was.servlet_session.live_count',
     'ibm_was.thread_pools.pool_size',
-    'ibm_was.thread_pools.percent_used',
 ]
 
 DEFAULT_SERVICE_CHECK_TAGS = ['url:{}'.format(INSTANCE.get('servlet_url')), 'key1:value1']

--- a/ibm_was/tests/test_unit.py
+++ b/ibm_was/tests/test_unit.py
@@ -42,18 +42,6 @@ def test_custom_query(aggregator, instance, check):
     )
 
 
-def test_thread_pools_percent_used(aggregator, instance, check):
-    """Prove that we already collect the thread_pools.percent_used metric, satisfying AI-2672."""
-    with mock.patch('datadog_checks.ibm_was.IbmWasCheck.make_request', return_value=mock_data('server.xml')):
-        check = check(instance)
-        check.check(instance)
-
-    aggregator.assert_metric(
-        'ibm_was.thread_pools.percent_used',
-        tags=['server:server1', 'key1:value1', 'node:ibmwasNode01', 'thread_pool:Default'],
-    )
-
-
 def test_custom_queries_missing_stat_in_payload(instance, check):
     with mock.patch('datadog_checks.ibm_was.IbmWasCheck.make_request', return_value=mock_data('server.xml')):
         check = check(instance)

--- a/ibm_was/tests/test_unit.py
+++ b/ibm_was/tests/test_unit.py
@@ -40,7 +40,14 @@ def test_custom_query(aggregator, instance, check):
         'ibm_was.object_pool.objects_created_count',
         'implementations:ObjectPool_ibm.system.objectpool_com.ibm.ws.webcontainer.srt.SRTConnectionContextImpl',
     )
-    # Prove that we already collect the thread_pools.percent_used metric, satisfying AI-2672.
+
+
+def test_thread_pools_percent_used(aggregator, instance, check):
+    """Prove that we already collect the thread_pools.percent_used metric, satisfying AI-2672."""
+    with mock.patch('datadog_checks.ibm_was.IbmWasCheck.make_request', return_value=mock_data('server.xml')):
+        check = check(instance)
+        check.check(instance)
+
     aggregator.assert_metric(
         'ibm_was.thread_pools.percent_used',
         tags=['server:server1', 'key1:value1', 'node:ibmwasNode01', 'thread_pool:Default'],

--- a/ibm_was/tests/test_unit.py
+++ b/ibm_was/tests/test_unit.py
@@ -26,7 +26,8 @@ def test_metric_collection_per_category(aggregator, instance, check):
         check = check(instance)
         check.check(instance)
 
-    for metric_name in common.METRICS_ALWAYS_PRESENT:
+    metrics_in_fixture = [    'ibm_was.thread_pools.percent_used']
+    for metric_name in common.METRICS_ALWAYS_PRESENT + metrics_in_fixture:
         aggregator.assert_metric(metric_name)
         aggregator.assert_metric_has_tag(metric_name, 'key1:value1')
 

--- a/ibm_was/tests/test_unit.py
+++ b/ibm_was/tests/test_unit.py
@@ -40,6 +40,11 @@ def test_custom_query(aggregator, instance, check):
         'ibm_was.object_pool.objects_created_count',
         'implementations:ObjectPool_ibm.system.objectpool_com.ibm.ws.webcontainer.srt.SRTConnectionContextImpl',
     )
+    # Prove that we already collect the thread_pools.percent_used metric, satisfying AI-2672.
+    aggregator.assert_metric(
+        'ibm_was.thread_pools.percent_used',
+        tags=['server:server1', 'key1:value1', 'node:ibmwasNode01', 'thread_pool:Default'],
+    )
 
 
 def test_custom_queries_missing_stat_in_payload(instance, check):

--- a/ibm_was/tests/test_unit.py
+++ b/ibm_was/tests/test_unit.py
@@ -26,7 +26,7 @@ def test_metric_collection_per_category(aggregator, instance, check):
         check = check(instance)
         check.check(instance)
 
-    metrics_in_fixture = [    'ibm_was.thread_pools.percent_used']
+    metrics_in_fixture = ['ibm_was.thread_pools.percent_used']
     for metric_name in common.METRICS_ALWAYS_PRESENT + metrics_in_fixture:
         aggregator.assert_metric(metric_name)
         aggregator.assert_metric_has_tag(metric_name, 'key1:value1')


### PR DESCRIPTION
### What does this PR do?
It turns out we already collect a metric from IBM WAS but it's not in `metadata.csv`. This PR adds it.

I noticed there are a couple more such metrics, I could add them in a follow-up PR if we decide that's a good idea.

### Motivation
https://datadoghq.atlassian.net/browse/AI-2672


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.