### PR TITLE
Log that we collect stats only when we in fact do collect them.

### DIFF
--- a/ibm_was/datadog_checks/ibm_was/ibm_was.py
+++ b/ibm_was/datadog_checks/ibm_was/ibm_was.py
@@ -64,8 +64,8 @@ class IbmWasCheck(AgentCheck):
                 server_tags.extend(node_tags)
 
                 for category, prefix in iteritems(self.metric_categories):
-                    self.log.debug("Collecting %s stats", category)
                     if self.collect_stats.get(category):
+                        self.log.debug("Collecting %s stats", category)
                         stats = self.get_node_from_name(server, category)
                         self.process_stats(stats, prefix, server_tags)
 


### PR DESCRIPTION
### What does this PR do?
Log that we collect stats only when we in fact do collect them.

### Motivation
Small follow-up to #13323 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.