### PR TITLE
Replaces kubernetes_cluster tag by kube_cluster_name

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_clusters.json
+++ b/kubernetes/assets/dashboards/kubernetes_clusters.json
@@ -3210,7 +3210,7 @@
                                             "value": 24
                                         }
                                     ],
-                                    "q": "top(sum:kubernetes_state.pod.ready{*,$cluster,condition:true,$scope} by {kubernetes_cluster,host,nodepool}, 10, 'last', 'desc')"
+                                    "q": "top(sum:kubernetes_state.pod.ready{*,$cluster,condition:true,$scope} by {kube_cluster_name,host,nodepool}, 10, 'last', 'desc')"
                                 }
                             ],
                             "title": "Pods in ready state by node",

--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -350,7 +350,7 @@
                 "type": "toplist",
                 "requests": [
                   {
-                    "q": "top(sum:kubernetes.pods.running{$scope,$namespace,$deployment,$cluster,$statefulset,$daemonset,$job} by {kubernetes_cluster,kube_namespace}, 100, 'max', 'desc')",
+                    "q": "top(sum:kubernetes.pods.running{$scope,$namespace,$deployment,$cluster,$statefulset,$daemonset,$job} by {kube_cluster_name,kube_namespace}, 100, 'max', 'desc')",
                     "conditional_formats": [
                       {
                         "comparator": ">",
@@ -383,7 +383,7 @@
                 "type": "toplist",
                 "requests": [
                   {
-                    "q": "top(sum:kubernetes_state.pod.ready{$scope,$cluster,$namespace,$deployment,condition:true,$statefulset,$daemonset,$job} by {kubernetes_cluster,host,nodepool}, 10, 'last', 'desc')",
+                    "q": "top(sum:kubernetes_state.pod.ready{$scope,$cluster,$namespace,$deployment,condition:true,$statefulset,$daemonset,$job} by {kube_cluster_name,host,nodepool}, 10, 'last', 'desc')",
                     "conditional_formats": [
                       {
                         "comparator": "<=",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Replaces `kubernetes_cluster` tag with `kube_cluster_name` tag as the former does not exist, while the latter is the now official Cluster tag for aggregation

### Motivation
<!-- What inspired you to submit this pull request? -->
* Customer reached out to mention that our OOTB dashboards are using `kubernetes_cluster` which is a deprecated/removed tag

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.