### PR TITLE
remove SIT ownership of workflows and CI files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -189,5 +189,5 @@ datadog_checks_base/datadog_checks/base/checks/windows/              @DataDog/wi
 /datadog_checks_downloader/                                           @DataDog/software-integrity-and-trust @DataDog/agent-integrations @trishankatdatadog
 docs/developer/process/integration-release.md                         @DataDog/software-integrity-and-trust @DataDog/agent-integrations @trishankatdatadog
 # As well as the pipelines.
-/.github/workflows/                                                   @DataDog/software-integrity-and-trust @DataDog/agent-integrations @trishankatdatadog
-/.gitlab-ci.yml                                                       @DataDog/software-integrity-and-trust @DataDog/agent-integrations @trishankatdatadog
+/.github/workflows/                                                   @DataDog/agent-integrations @trishankatdatadog
+/.gitlab-ci.yml                                                       @DataDog/agent-integrations @trishankatdatadog


### PR DESCRIPTION
### What does this PR do?

remove SIT ownership of workflows and CI files.

### Motivation

SIT review does not seem necessary for every PR touching any of these files.

### Notes

See https://datadoghq.atlassian.net/browse/SINT-878

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.