### PR TITLE
Fix disk read/write widgets on kubernetes cluster dashboard

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_clusters.json
+++ b/kubernetes/assets/dashboards/kubernetes_clusters.json
@@ -3790,11 +3790,11 @@
                                     "display_type": "line",
                                     "metadata": [
                                         {
-                                            "alias_name": "network writes per node",
-                                            "expression": "sum:kubernetes.io.write_bytes{$scope,$cluster} by {kube_replica_set,host}-avg:kubernetes_state.replicaset.replicas_ready{$scope,$cluster} by {host}"
+                                            "alias_name": "disk writes per node ",
+                                            "expression": "sum:kubernetes.io.write_bytes{$scope,$cluster} by {kube_replica_set,host}"
                                         }
                                     ],
-                                    "q": "sum:kubernetes.io.write_bytes{$scope,$cluster} by {kube_replica_set,host}-avg:kubernetes_state.replicaset.replicas_ready{$scope,$cluster} by {host}",
+                                    "q": "sum:kubernetes.io.write_bytes{$scope,$cluster} by {kube_replica_set,host}",
                                     "style": {
                                         "line_type": "solid",
                                         "line_width": "normal",
@@ -3940,11 +3940,11 @@
                                     "display_type": "line",
                                     "metadata": [
                                         {
-                                            "alias_name": "disk reads per node ",
-                                            "expression": "sum:kubernetes.io.read_bytes{$scope,$cluster} by {kube_replica_set,host}-avg:kubernetes_state.replicaset.replicas_ready{$scope,$cluster} by {host}"
+                                            "alias_name": "disk reads per node",
+                                            "expression": "sum:kubernetes.io.read_bytes{$scope,$cluster} by {kube_replica_set,host}"
                                         }
                                     ],
-                                    "q": "sum:kubernetes.io.read_bytes{$scope,$cluster} by {kube_replica_set,host}-avg:kubernetes_state.replicaset.replicas_ready{$scope,$cluster} by {host}",
+                                    "q": "sum:kubernetes.io.read_bytes{$scope,$cluster} by {kube_replica_set,host}",
                                     "style": {
                                         "line_type": "solid",
                                         "line_width": "normal",

--- a/kubernetes/assets/dashboards/kubernetes_clusters.json
+++ b/kubernetes/assets/dashboards/kubernetes_clusters.json
@@ -3791,10 +3791,10 @@
                                     "metadata": [
                                         {
                                             "alias_name": "IO writes per node ",
-                                            "expression": "sum:kubernetes.io.write_bytes{$scope,$cluster} by {kube_replica_set,host}"
+                                            "expression": "sum:kubernetes.io.write_bytes{$scope,$cluster} by {host}"
                                         }
                                     ],
-                                    "q": "sum:kubernetes.io.write_bytes{$scope,$cluster} by {kube_replica_set,host}",
+                                    "q": "sum:kubernetes.io.write_bytes{$scope,$cluster} by {host}",
                                     "style": {
                                         "line_type": "solid",
                                         "line_width": "normal",
@@ -3941,10 +3941,10 @@
                                     "metadata": [
                                         {
                                             "alias_name": "disk reads per node",
-                                            "expression": "sum:kubernetes.io.read_bytes{$scope,$cluster} by {kube_replica_set,host}"
+                                            "expression": "sum:kubernetes.io.read_bytes{$scope,$cluster} by {host}"
                                         }
                                     ],
-                                    "q": "sum:kubernetes.io.read_bytes{$scope,$cluster} by {kube_replica_set,host}",
+                                    "q": "sum:kubernetes.io.read_bytes{$scope,$cluster} by {host}",
                                     "style": {
                                         "line_type": "solid",
                                         "line_width": "normal",

--- a/kubernetes/assets/dashboards/kubernetes_clusters.json
+++ b/kubernetes/assets/dashboards/kubernetes_clusters.json
@@ -3790,7 +3790,7 @@
                                     "display_type": "line",
                                     "metadata": [
                                         {
-                                            "alias_name": "disk writes per node ",
+                                            "alias_name": "IO writes per node ",
                                             "expression": "sum:kubernetes.io.write_bytes{$scope,$cluster} by {kube_replica_set,host}"
                                         }
                                     ],


### PR DESCRIPTION
### What does this PR do?
Remove comparaison between disk info and replicaset_ready state to display disk read/write per replicaset
Fix graph metadata to correct title disk and not network.

### Motivation
Doesn't makes sens to substract disk informations and number of ready replicaset.
And title metadata was mentioning network while widget and metric is related to disk. 

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.