### PR TITLE
Remove default_backend parameter from cryptography calls.

### DIFF
--- a/cisco_aci/datadog_checks/cisco_aci/api.py
+++ b/cisco_aci/datadog_checks/cisco_aci/api.py
@@ -5,7 +5,6 @@
 import base64
 import random
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 
@@ -40,9 +39,7 @@ class SessionWrapper:
 
         self.cert_key = cert_key
         if cert_key:
-            self.cert_key = serialization.load_pem_private_key(
-                cert_key, password=cert_key_password, backend=default_backend()
-            )
+            self.cert_key = serialization.load_pem_private_key(cert_key, password=cert_key_password)
 
     def login(self, password):
         data = '<aaaUser name="{}" pwd="{}"/>\n'.format(self.username, password)

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -47,7 +47,6 @@ requests_ntlm = None
 requests_oauthlib = None
 oauth2 = None
 jwt = None
-default_backend = None
 serialization = None
 
 LOGGER = logging.getLogger(__file__)
@@ -884,10 +883,6 @@ class DCOSAuthTokenReader(object):
     def read(self, **request):
         if self._token is None or 'error' in request:
             with open(self._private_key_path, 'rb') as f:
-                global default_backend
-                if default_backend is None:
-                    from cryptography.hazmat.backends import default_backend
-
                 global serialization
                 if serialization is None:
                     from cryptography.hazmat.primitives import serialization
@@ -896,7 +891,7 @@ class DCOSAuthTokenReader(object):
                 if jwt is None:
                     import jwt
 
-                private_key = serialization.load_pem_private_key(f.read(), password=None, backend=default_backend())
+                private_key = serialization.load_pem_private_key(f.read(), password=None)
 
                 serialized_private = private_key.private_bytes(
                     encoding=serialization.Encoding.PEM,

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -4,7 +4,6 @@
 from contextlib import closing
 
 import snowflake.connector as sf
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
 from datadog_checks.base import AgentCheck, ConfigurationError, ensure_bytes, to_native_string
@@ -119,7 +118,7 @@ class SnowflakeCheck(AgentCheck):
             # https://docs.snowflake.com/en/user-guide/python-connector-example.html#using-key-pair-authentication-key-pair-rotation
             with open(self._config.private_key_path, "rb") as key:
                 p_key = serialization.load_pem_private_key(
-                    key.read(), password=ensure_bytes(self._config.private_key_password), backend=default_backend()
+                    key.read(), password=ensure_bytes(self._config.private_key_password)
                 )
 
                 pkb = p_key.private_bytes(

--- a/tls/datadog_checks/tls/tls_local.py
+++ b/tls/datadog_checks/tls/tls_local.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import load_der_x509_certificate, load_pem_x509_certificate
 
 from datadog_checks.base import ConfigurationError
@@ -60,7 +59,6 @@ class TLSLocalCheck(object):
 
     @staticmethod
     def local_cert_loader(cert):
-        backend = default_backend()
         if b'-----BEGIN CERTIFICATE-----' in cert:
-            return load_pem_x509_certificate(cert, backend)
-        return load_der_x509_certificate(cert, backend)
+            return load_pem_x509_certificate(cert)
+        return load_der_x509_certificate(cert)

--- a/tls/datadog_checks/tls/tls_remote.py
+++ b/tls/datadog_checks/tls/tls_remote.py
@@ -5,7 +5,6 @@ import ssl
 from hashlib import sha256
 from struct import pack
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.x509.base import load_der_x509_certificate
 from cryptography.x509.extensions import ExtensionNotFound
 from cryptography.x509.oid import AuthorityInformationAccessOID, ExtensionOID
@@ -93,7 +92,7 @@ class TLSRemoteCheck(object):
         # Load https://cryptography.io/en/latest/x509/reference/#cryptography.x509.Certificate
         try:
             self.log.debug('Deserializing peer certificate')
-            cert = load_der_x509_certificate(der_cert, default_backend())
+            cert = load_der_x509_certificate(der_cert)
             self.log.debug('Deserialized peer certificate: %s', cert)
             return cert, protocol_version
         except Exception as e:
@@ -181,7 +180,7 @@ class TLSRemoteCheck(object):
         # https://tools.ietf.org/html/rfc3280#section-4.2.2.1
         # https://tools.ietf.org/html/rfc5280#section-5.2.7
         try:
-            cert = load_der_x509_certificate(der_cert, default_backend())
+            cert = load_der_x509_certificate(der_cert)
         except Exception as e:
             self.log.error('Error while deserializing peer certificate to discover intermediate certificates: %s', e)
             return

--- a/vault/tests/docker/provider/run/main.py
+++ b/vault/tests/docker/provider/run/main.py
@@ -2,12 +2,13 @@ import time
 from datetime import datetime, timedelta, timezone
 
 import jwt
+from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
 
 def main():
     with open('/home/run/priv.pem', 'rb') as f:
-        private_key = serialization.load_pem_private_key(f.read(), password=None)
+        private_key = serialization.load_pem_private_key(f.read(), password=None, backend=default_backend())
 
     serialized_private = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,

--- a/vault/tests/docker/provider/run/main.py
+++ b/vault/tests/docker/provider/run/main.py
@@ -2,13 +2,12 @@ import time
 from datetime import datetime, timedelta, timezone
 
 import jwt
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
 
 def main():
     with open('/home/run/priv.pem', 'rb') as f:
-        private_key = serialization.load_pem_private_key(f.read(), password=None, backend=default_backend())
+        private_key = serialization.load_pem_private_key(f.read(), password=None)
 
     serialized_private = private_key.private_bytes(
         encoding=serialization.Encoding.PEM,


### PR DESCRIPTION
### What does this PR do?
Remove parameter that will be soon deprecated by cryptography.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.