### PR TITLE
Refactor oracle tests

### DIFF
--- a/oracle/tests/test_custom_queries.py
+++ b/oracle/tests/test_custom_queries.py
@@ -25,7 +25,7 @@ def test_if_only_custom_queries_default_queries_are_not_set(instance, only_custo
     assert len(check._query_manager.queries) == expected_default_queries
 
 
-def test_custom_queries(aggregator, check):
+def test_custom_queries(aggregator, check, dd_run_check, instance):
     con = mock.MagicMock()
     cursor = mock.MagicMock()
     data = [[["tag_value1", "1"]], [[1, 2, "tag_value2"]]]
@@ -50,13 +50,14 @@ def test_custom_queries(aggregator, check):
             "tags": ["query_tags2"],
         },
     ]
-    check.instance['custom_queries'] = custom_queries
-    check._fix_custom_queries()
-    check._cached_connection = con
-    query_manager = QueryManager(check, check.execute_query_raw, tags=['custom_tag'])
-    query_manager.compile_queries()
+    instance['custom_queries'] = custom_queries
+    instance['tags'] = ['custom_tag']
+    instance['only_custom_queries'] = True
 
-    query_manager.execute()
+    check = Oracle(CHECK_NAME, {}, [instance])
+    with mock.patch("datadog_checks.oracle.oracle.Oracle._connection", new_callable=mock.PropertyMock) as connection:
+        connection.return_value = con
+        dd_run_check(check)
 
     aggregator.assert_metric(
         "oracle.test1.metric", value=1, count=1, tags=["tag_name:tag_value1", "query_tags1", "custom_tag"]
@@ -77,7 +78,7 @@ def test_custom_queries(aggregator, check):
     )
 
 
-def test_custom_queries_multiple_results(aggregator, check):
+def test_custom_queries_multiple_results(aggregator, check, dd_run_check, instance):
     con = mock.MagicMock()
     cursor = mock.MagicMock()
     data = [["tag_value1", "1"], ["tag_value2", "2"]]
@@ -93,13 +94,15 @@ def test_custom_queries_multiple_results(aggregator, check):
         }
     ]
 
-    check.instance['custom_queries'] = custom_queries
-    check._fix_custom_queries()
-    check._cached_connection = con
-    query_manager = QueryManager(check, check.execute_query_raw, tags=['custom_tag'])
-    query_manager.compile_queries()
+    instance['custom_queries'] = custom_queries
+    instance['only_custom_queries'] = True
+    instance['tags'] = ['custom_tag']
 
-    query_manager.execute()
+    check = Oracle(CHECK_NAME, {}, [instance])
+
+    with mock.patch("datadog_checks.oracle.oracle.Oracle._connection", new_callable=mock.PropertyMock) as connection:
+        connection.return_value = con
+        dd_run_check(check)
 
     aggregator.assert_metric(
         "oracle.test1.metric", value=1, count=1, tags=["tag_name:tag_value1", "query_tags1", "custom_tag"]

--- a/oracle/tests/test_custom_queries.py
+++ b/oracle/tests/test_custom_queries.py
@@ -5,7 +5,6 @@
 import mock
 import pytest
 
-from datadog_checks.base.utils.db import QueryManager
 from datadog_checks.oracle import Oracle
 
 from .common import CHECK_NAME


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR rewrites some tests for Oracle integration's custom query behavior to be less dependent on private functions.

### Motivation
<!-- What inspired you to submit this pull request? -->
🧹 🧹 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.