### PR TITLE
Remove invalid 'service' field in snmp example config

### DIFF
--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -139,6 +139,8 @@ files:
           type: boolean
           example: true
       - template: init_config/default
+        overrides:
+          service.hidden: true
     - template: instances
       options:
       - name: ip_address
@@ -402,3 +404,5 @@ files:
           type: boolean
           example: true
       - template: instances/default
+        overrides:
+          service.hidden: true

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -106,13 +106,6 @@ init_config:
     #
     # ignore_nonincreasing_oid: false
 
-    ## @param service - string - optional
-    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
-    ##
-    ## Additionally, this sets the default `service` for every log source.
-    #
-    # service: <SERVICE>
-
 ## Every instance is scheduled independently of the others.
 #
 instances:
@@ -340,13 +333,6 @@ instances:
     # tags:
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
-
-    ## @param service - string - optional
-    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
-    ##
-    ## Overrides any `service` defined in the `init_config` section.
-    #
-    # service: <SERVICE>
 
     ## @param min_collection_interval - number - optional - default: 15
     ## This changes the collection interval of the check. For more information, see:


### PR DESCRIPTION
`service` was added in this [PR](https://github.com/DataDog/integrations-core/pull/9766) but it's not a valid field of the snmp integration