### PR TITLE
Adds `system.core.frequency` metric

### DIFF
--- a/system_core/datadog_checks/system_core/system_core.py
+++ b/system_core/datadog_checks/system_core/system_core.py
@@ -18,6 +18,7 @@ class SystemCore(AgentCheck):
 
         # https://psutil.readthedocs.io/en/latest/#psutil.cpu_times
         cpu_times = psutil.cpu_times(percpu=True)
+        self.log.debug('CPU times: %s', str(cpu_times))
         for i, cpu in enumerate(cpu_times):
             tags = instance_tags + ['core:{0}'.format(i)]
             for key, value in iteritems(cpu._asdict()):
@@ -31,6 +32,7 @@ class SystemCore(AgentCheck):
         # scpufreq(current=2236.812, min=800.0, max=3500.0)
         # Ignore min/max as they are often reported as 0.0 if undetermined.
         cpu_freq = psutil.cpu_freq(percpu=True)
+        self.log.debug('CPU frequency: %s', str(cpu_freq))
         for i, cpu in enumerate(cpu_freq):
             if Platform.is_unix():
                 # Per-cpu frequency retrieval (Linux only)

--- a/system_core/datadog_checks/system_core/system_core.py
+++ b/system_core/datadog_checks/system_core/system_core.py
@@ -12,13 +12,11 @@ class SystemCore(AgentCheck):
     def check(self, instance):
         instance_tags = instance.get('tags', [])
 
-        # https://psutil.readthedocs.io/en/latest/#psutil.cpu_count
-        n_cpus = psutil.cpu_count()
-        self.gauge('system.core.count', n_cpus, tags=instance_tags)
-
         # https://psutil.readthedocs.io/en/latest/#psutil.cpu_times
         cpu_times = psutil.cpu_times(percpu=True)
+        self.gauge('system.core.count', len(n_cpus), tags=instance_tags)
         self.log.debug('CPU times: %s', str(cpu_times))
+
         for i, cpu in enumerate(cpu_times):
             tags = instance_tags + ['core:{0}'.format(i)]
             for key, value in iteritems(cpu._asdict()):

--- a/system_core/datadog_checks/system_core/system_core.py
+++ b/system_core/datadog_checks/system_core/system_core.py
@@ -14,7 +14,7 @@ class SystemCore(AgentCheck):
 
         # https://psutil.readthedocs.io/en/latest/#psutil.cpu_times
         cpu_times = psutil.cpu_times(percpu=True)
-        self.gauge('system.core.count', len(n_cpus), tags=instance_tags)
+        self.gauge('system.core.count', len(cpu_times), tags=instance_tags)
         self.log.debug('CPU times: %s', str(cpu_times))
 
         for i, cpu in enumerate(cpu_times):
@@ -24,7 +24,7 @@ class SystemCore(AgentCheck):
 
         total_cpu_times = psutil.cpu_times()
         for key, value in iteritems(total_cpu_times._asdict()):
-            self.rate('system.core.{0}.total'.format(key), 100.0 * value / n_cpus, tags=instance_tags)
+            self.rate('system.core.{0}.total'.format(key), 100.0 * value / len(cpu_times), tags=instance_tags)
 
         # https://psutil.readthedocs.io/en/latest/#psutil.cpu_freq
         # scpufreq(current=2236.812, min=800.0, max=3500.0)

--- a/system_core/datadog_checks/system_core/system_core.py
+++ b/system_core/datadog_checks/system_core/system_core.py
@@ -5,21 +5,34 @@ import psutil
 from six import iteritems
 
 from datadog_checks.base import AgentCheck
+from datadog_checks.base.utils.platform import Platform
 
 
 class SystemCore(AgentCheck):
     def check(self, instance):
         instance_tags = instance.get('tags', [])
 
-        cpu_times = psutil.cpu_times(percpu=True)
-        self.gauge('system.core.count', len(cpu_times), tags=instance_tags)
+        # https://psutil.readthedocs.io/en/latest/#psutil.cpu_count
+        n_cpus = psutil.cpu_count()
+        self.gauge('system.core.count', n_cpus, tags=instance_tags)
 
+        # https://psutil.readthedocs.io/en/latest/#psutil.cpu_times
+        cpu_times = psutil.cpu_times(percpu=True)
         for i, cpu in enumerate(cpu_times):
             tags = instance_tags + ['core:{0}'.format(i)]
             for key, value in iteritems(cpu._asdict()):
                 self.rate('system.core.{0}'.format(key), 100.0 * value, tags=tags)
 
         total_cpu_times = psutil.cpu_times()
-        n_cpus = psutil.cpu_count()
         for key, value in iteritems(total_cpu_times._asdict()):
             self.rate('system.core.{0}.total'.format(key), 100.0 * value / n_cpus, tags=instance_tags)
+
+        # https://psutil.readthedocs.io/en/latest/#psutil.cpu_freq
+        # scpufreq(current=2236.812, min=800.0, max=3500.0)
+        # Ignore min/max as they are often reported as 0.0 if undetermined.
+        cpu_freq = psutil.cpu_freq(percpu=True)
+        for i, cpu in enumerate(cpu_freq):
+            if Platform.is_unix():
+                # Per-cpu frequency retrieval (Linux only)
+                tags = instance_tags + ['core:{0}'.format(i)]
+            self.gauge('system.core.frequency', cpu._asdict().get('current'), tags=tags)

--- a/system_core/metadata.csv
+++ b/system_core/metadata.csv
@@ -24,3 +24,4 @@ system.core.interrupt,gauge,,percent,,[Windows] The percentage of time a given C
 system.core.interrupt.total,gauge,,percent,,[Windows] The percentage of time the whole CPU has spent servicing hardware interrupts,0,system,cpu interrupt total,
 system.core.dpc,gauge,,percent,,[Windows] The percentage of time a given CPU core has spent servicing deferred procedure calls (DPCs),0,system,cpu dpc,
 system.core.dpc.total,gauge,,percent,,[Windows] The percentage of time the whole CPU has spent servicing deferred procedure calls (DPCs),0,system,cpu dpc total,
+system.core.frequency,gauge,,megahertz,,The frequency or clock speed a given CPU,0,system,cpu frequency,

--- a/system_core/tests/common.py
+++ b/system_core/tests/common.py
@@ -11,8 +11,6 @@ CHECK_NAME = "system_core"
 
 INSTANCE = {"tags": ["tag1:value1"]}
 
-MOCK_PSUTIL_CPU_COUNT = 4
-
 if Platform.is_mac():
     CHECK_RATES = ['system.core.idle', 'system.core.nice', 'system.core.system', 'system.core.user']
     MOCK_PSUTIL_CPU_TIMES = [

--- a/system_core/tests/common.py
+++ b/system_core/tests/common.py
@@ -11,6 +11,8 @@ CHECK_NAME = "system_core"
 
 INSTANCE = {"tags": ["tag1:value1"]}
 
+MOCK_PSUTIL_CPU_COUNT = 4
+
 if Platform.is_mac():
     CHECK_RATES = ['system.core.idle', 'system.core.nice', 'system.core.system', 'system.core.user']
     MOCK_PSUTIL_CPU_TIMES = [
@@ -19,6 +21,7 @@ if Platform.is_mac():
         psutil._psosx.scputimes(user=7486.51, nice=0.0, system=5991.36, idle=40031.88),
         psutil._psosx.scputimes(user=3964.85, nice=0.0, system=2862.37, idle=46682.5),
     ]
+    MOCK_PSUTIL_CPU_FREQ = [psutil._common.scpufreq(current=2500, min=0.0, max=0.0)]
 elif Platform.is_unix():
     CHECK_RATES = [
         'system.core.idle',
@@ -82,6 +85,12 @@ elif Platform.is_unix():
             guest_nice=0.0,
         ),
     ]
+    MOCK_PSUTIL_CPU_FREQ = [
+        psutil._common.scpufreq(current=2500, min=0.0, max=0.0),
+        psutil._common.scpufreq(current=2500, min=0.0, max=0.0),
+        psutil._common.scpufreq(current=2500, min=0.0, max=0.0),
+        psutil._common.scpufreq(current=2500, min=0.0, max=0.0),
+    ]
 else:  # windows
     CHECK_RATES = [
         'system.core.user',
@@ -96,6 +105,7 @@ else:  # windows
         psutil._pswindows.scputimes(user=7486.51, system=5991.36, idle=40031.88, interrupt=0.05, dpc=0.0),
         psutil._pswindows.scputimes(user=3964.85, system=2862.37, idle=46682.50, interrupt=0.05, dpc=0.0),
     ]
+    MOCK_PSUTIL_CPU_FREQ = [psutil._common.scpufreq(current=2500, min=0.0, max=0.0)]
 
 
 EXPECTED_METRICS = CHECK_RATES

--- a/system_core/tests/test_system_core.py
+++ b/system_core/tests/test_system_core.py
@@ -17,7 +17,6 @@ class TestSystemCore:
 
         with mock.patch('datadog_checks.system_core.system_core.psutil') as psutil_mock:
             psutil_mock.cpu_times.side_effect = fake_cpu_times
-            psutil_mock.cpu_count.return_value = common.MOCK_PSUTIL_CPU_COUNT
             psutil_mock.cpu_freq.return_value = common.MOCK_PSUTIL_CPU_FREQ
             c.check({})
 

--- a/system_core/tests/test_system_core.py
+++ b/system_core/tests/test_system_core.py
@@ -15,11 +15,14 @@ class TestSystemCore:
     def test_system_core(self, aggregator):
         c = SystemCore('system_core', {}, {}, [{}])
 
-        psutil_mock = mock.MagicMock(side_effect=fake_cpu_times)
-        with mock.patch('datadog_checks.system_core.system_core.psutil.cpu_times', psutil_mock):
+        with mock.patch('datadog_checks.system_core.system_core.psutil') as psutil_mock:
+            psutil_mock.cpu_times.side_effect = fake_cpu_times
+            psutil_mock.cpu_count.return_value = common.MOCK_PSUTIL_CPU_COUNT
+            psutil_mock.cpu_freq.return_value = common.MOCK_PSUTIL_CPU_FREQ
             c.check({})
 
         aggregator.assert_metric('system.core.count', value=4, count=1)
+        aggregator.assert_metric('system.core.frequency', value=2500)
 
         for rate in common.CHECK_RATES:
             for i in range(4):


### PR DESCRIPTION
### What does this PR do?
Adds CPU Core frequency aka ClockSpeed metric.

### Motivation
AGENT-8778

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.