### PR TITLE
Add an option to show the memray report

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -50,6 +50,7 @@ from .console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, echo_succes
 @click.option('--force-base-min', is_flag=True, help='Force using lowest viable release version of datadog-checks-base')
 @click.option('--force-env-rebuild', is_flag=True, help='Force creating a new env')
 @click.option('--memray', is_flag=True, help='Run memray to measure memory usage')
+@click.option('--memray-show-report', is_flag=True, help='Print the memray report at the end of the test suite')
 @click.pass_context
 def test(
     ctx,
@@ -78,6 +79,7 @@ def test(
     force_base_min,
     force_env_rebuild,
     memray,
+    memray_show_report,
 ):
     """Run tests for Agent-based checks.
 
@@ -202,6 +204,7 @@ def test(
             e2e=e2e,
             ddtrace=ddtrace_check,
             memray=memray,
+            memray_show_report=memray_show_report,
         )
         if coverage:
             pytest_options = pytest_options.format(pytest_coverage_sources(check))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -501,6 +501,7 @@ def construct_pytest_options(
     e2e=False,
     ddtrace=False,
     memray=False,
+    memray_show_report=False,
 ):
     # Prevent no verbosity
     pytest_options = f'--verbosity={verbose or 1}'
@@ -559,6 +560,9 @@ def construct_pytest_options(
             abort('\nThe `--memray` option can only be used on Linux or MacOS!')
 
         pytest_options += ' --memray'
+
+        if not memray_show_report:
+            pytest_options += ' --hide-memray-summary'
 
     if marker:
         pytest_options += f' -m "{marker}"'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a new option to the `test` command to show the memray report. By default, hide them.

### Motivation
<!-- What inspired you to submit this pull request? -->

The memray reports can be quite verbose (see [this PR description](https://github.com/DataDog/integrations-core/pull/13160) with an example) and are displayed by default. This is a lot of text if we have lots of tests to run. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This does not prevent memray to run. If a memory test fail, you will still get the info about this specific test.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.