### PR TITLE
Add a dummy --memray option to the pytest plugin

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -333,7 +333,7 @@ def pytest_collection_modifyitems(config, items):
         return
 
     if PY2 and config.getoption("--memray"):
-        warnings.warn("The --memray option can't be used with py2 environments.")
+        warnings.warn("--memray option ignored as it's not supported for py2 environments.")
 
     skip_latest_metrics = pytest.mark.skip(reason="need --run-latest-metrics option to run")
     for item in items:

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -6,10 +6,12 @@ from __future__ import absolute_import
 import json
 import os
 import re
+import warnings
 from base64 import urlsafe_b64encode
 from typing import Dict, List, Optional, Tuple
 
 import pytest
+from six import PY2
 
 from .._env import (
     E2E_FIXTURE_NAME,
@@ -317,6 +319,10 @@ def pytest_configure(config):
 def pytest_addoption(parser):
     parser.addoption("--run-latest-metrics", action="store_true", default=False, help="run check_metrics tests")
 
+    if PY2:
+        # Add a dummy memray option to make it possible to run memray on ci only on py3 environments
+        parser.addoption("--memray", action="store_true", default=False, help="Dummy parameter for memray")
+
 
 def pytest_collection_modifyitems(config, items):
     # at test collection time, this function gets called by pytest, see:
@@ -325,6 +331,10 @@ def pytest_collection_modifyitems(config, items):
     if config.getoption("--run-latest-metrics"):
         # --run-check-metrics given in cli: do not skip slow tests
         return
+
+    if PY2 and config.getoption("--memray"):
+        warnings.warn("The --memray option can't be used with py2 environments.")
+
     skip_latest_metrics = pytest.mark.skip(reason="need --run-latest-metrics option to run")
     for item in items:
         if "latest_metrics" in item.keywords:

--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -320,7 +320,7 @@ def pytest_addoption(parser):
     parser.addoption("--run-latest-metrics", action="store_true", default=False, help="run check_metrics tests")
 
     if PY2:
-        # Add a dummy memray option to make it possible to run memray on ci only on py3 environments
+        # Add a dummy memray option to make it possible to run memray with `ddev test --memray <integration>` only on py3 environments
         parser.addoption("--memray", action="store_true", default=False, help="Dummy parameter for memray")
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a new dummy `--memray` option to the pytest plugin.

### Motivation
<!-- What inspired you to submit this pull request? -->

- Memray does not support python 2
- In [this PR](https://github.com/DataDog/integrations-core/pull/13350), I'm enabling memray on the CI. The problem is that the pytest options we define are used for each environment, including the py2 ones, which makes the CI fail because the option is not know for py2 environments.
- I'm adding a fake option that just throws a warning so the tests do not fail. This way we can run memray on py3 environments.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Thanks to @alopezz for this idea!

Output:

```
╰─❯ ddev test --memray eks_fargate                                                                                                                                                                   ─╯
Running tests for `eks_fargate`
-------------------------------
───────────────────────────────────────────────────────────────────────────────────────────────── py27 ─────────────────────────────────────────────────────────────────────────────────────────────────
Finished checking dependencies
cmd [1] | pytest -v --benchmark-skip tests
========================================================================================= test session starts ==========================================================================================
platform darwin -- Python 2.7.16, pytest-4.6.11, py-1.11.0, pluggy-0.13.1 -- /Users/florent.clarret/Library/Application Support/hatch/env/virtual/datadog-eks-fargate-Bbd2p0gs/py27/bin/python
cachedir: .pytest_cache
benchmark: 3.4.1 (defaults: timer=time.time disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/florent.clarret/go/src/github.com/DataDog/integrations-core/eks_fargate
plugins: cov-2.12.1, benchmark-3.4.1, ddtrace-0.53.2, flaky-3.7.0, mock-2.0.0, datadog-checks-dev-17.3.2
collected 3 items                                                                                                                                                                                      

tests/test_eks_fargate.py::test_eksfargate PASSED                                                                                                                                                [ 33%]
tests/test_eks_fargate.py::test_not_eksfargate PASSED                                                                                                                                            [ 66%]
tests/test_eks_fargate.py::test_extract_resource_values PASSED                                                                                                                                   [100%]

=========================================================================================== warnings summary ===========================================================================================
/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/utils/http.py:16
  /Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/utils/http.py:16: CryptographyDeprecationWarning: Python 2 is no longer supported by the Python core team. Support for it is now deprecated in cryptography, and will be removed in the next release.
    from cryptography.x509 import load_der_x509_certificate

/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py:336
  /Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py:336: UserWarning: The --memray option can't be used with py2 environments.
    warnings.warn("The --memray option can't be used with py2 environments.")

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================= 3 passed, 2 warnings in 0.51 seconds =================================================================================
───────────────────────────────────────────────────────────────────────────────────────────────── py38 ─────────────────────────────────────────────────────────────────────────────────────────────────
Finished checking dependencies
cmd [1] | pytest -v --benchmark-skip tests
========================================================================================= test session starts ==========================================================================================
platform darwin -- Python 3.8.13, pytest-7.1.3, pluggy-1.0.0 -- /Users/florent.clarret/Library/Application Support/hatch/env/virtual/datadog-eks-fargate-Bbd2p0gs/py38/bin/python
cachedir: .pytest_cache
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/florent.clarret/go/src/github.com/DataDog/integrations-core/eks_fargate
plugins: ddtrace-0.53.2, flaky-3.7.0, mock-3.10.0, datadog-checks-dev-17.3.2, memray-1.3.1, cov-4.0.0, benchmark-4.0.0
collected 3 items                                                                                                                                                                                      

tests/test_eks_fargate.py::test_eksfargate PASSED                                                                                                                                                [ 33%]
tests/test_eks_fargate.py::test_not_eksfargate PASSED                                                                                                                                            [ 66%]
tests/test_eks_fargate.py::test_extract_resource_values PASSED                                                                                                                                   [100%]


============================================================================================ MEMRAY REPORT =============================================================================================
Allocations results for tests/test_eks_fargate.py::test_eksfargate

         📦 Total memory allocated: 863.2KiB
         📏 Total allocations: 1984
         📊 Histogram of allocation sizes: |█ ▂      |
         🥇 Biggest allocating functions:
                - raw_decode:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/json/decoder.py:353 -> 261.7KiB
                - __subclasscheck__:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/abc.py:102 -> 256.0KiB
                - MapItems:/Users/florent.clarret/Library/Application Support/hatch/env/virtual/datadog-eks-fargate-Bbd2p0gs/py38/lib/python3.8/site-packages/immutables/_protocols.py:44 -> 256.0KiB
                - log_typos_in_options:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/checks/base.py:448 -> 6.0KiB
                - __setitem__:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/os.py:681 -> 3.7KiB


Allocations results for tests/test_eks_fargate.py::test_not_eksfargate

         📦 Total memory allocated: 162.6KiB
         📏 Total allocations: 460
         📊 Histogram of allocation sizes: |▆ █ ▂   ▂|
         🥇 Biggest allocating functions:
                - decode:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/codecs.py:322 -> 73.0KiB
                - mock_from_file:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/eks_fargate/tests/test_eks_fargate.py:18 -> 73.0KiB
                - mock_from_file:/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/eks_fargate/tests/test_eks_fargate.py:17 -> 4.1KiB
                - __setitem__:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/os.py:681 -> 3.7KiB
                - __setitem__:/Users/florent.clarret/.pyenv/versions/3.8.13/lib/python3.8/os.py:682 -> 2.2KiB


========================================================================================== 3 passed in 0.43s ===========================================================================================
cmd [1] | flake8 --config=../.flake8 .
cmd [2] | black --config ../pyproject.toml --check --diff .
All done! ✨ 🍰 ✨
13 files would be left unchanged.
cmd [3] | isort --settings-path ../pyproject.toml --check-only --diff .
Skipped 1 files

Passed!

```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.