### PR TITLE
Fix requests/capacity widgets on kubernetes nodes dashboard

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_nodes.json
+++ b/kubernetes/assets/dashboards/kubernetes_nodes.json
@@ -1030,7 +1030,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes.cpu.requests{$cluster,$host} by {kube_cluster_name}/sum:kubernetes.cpu.capacity{$cluster,$host} by {kube_cluster_name}*100",
+                        "q": "sum:kubernetes_state.container.cpu_requested{{$cluster,$host} by {kube_cluster_name}/sum:kubernetes_state.node.cpu_capacity{$cluster,$host} by {kube_cluster_name}*100",
                         "display_type": "line",
                         "style": {
                             "palette": "dog_classic",
@@ -1218,7 +1218,7 @@
                 "type": "timeseries",
                 "requests": [
                     {
-                        "q": "sum:kubernetes.cpu.requests{$cluster,$host} by {host}/sum:kubernetes.cpu.capacity{$cluster,$host} by {host}*100",
+                        "q": "sum:kubernetes_state.container.cpu_requested{$cluster,$host} by {host}/sum:kubernetes_state.node.cpu_capacity{$cluster,$host} by {host}*100",
                         "display_type": "line",
                         "style": {
                             "palette": "dog_classic",


### PR DESCRIPTION
### What does this PR do?
Replace deprecated requests and capacity metrics with cluster-agent metrics.

### Motivation
Cluster-agent have moved metrics names and deprecates kubernetes.* so dashboards needs to be updated accordingly. 

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.