### PR TITLE
Add memray to the base check

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -42,6 +42,7 @@ kubernetes,PyPI,Apache-2.0,Kubernetes
 ldap3,PyPI,LGPL-3.0-only,Giovanni Cannata
 lxml,PyPI,BSD-3-Clause,lxml dev team
 lz4,PyPI,BSD-3-Clause,Jonathan Underwood
+memray,PyPI,Apache-2.0,Pablo Galindo Salgado
 mmh3,PyPI,CC0-1.0,Hajime Senuma
 oauthlib,PyPI,BSD-3-Clause,The OAuthlib Community
 openstacksdk,PyPI,Apache-2.0,OpenStack

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1176,7 +1176,7 @@ class AgentCheck(object):
 
                 if self._memray_remaining_iterations <= 0:
                     self.log.info("Stopping memray.")
-                    self._memray.__exit__()
+                    self._memray.__exit__(None, None, None)
                     self._memray = None
 
         return error_report

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -513,20 +513,23 @@ class AgentCheck(object):
             if sys.platform not in ("linux", "darwin"):
                 raise ConfigurationError("`enable_memray` option is only supported on Linux and macOS.")
 
-            output_file = self.instance.get('memray_file', self.init_config.get('memray_file'))
+            output_file = self.instance.get(
+                'memray_file', self.init_config.get('memray_file') + ".{}".format(self.check_id)
+            )
             native_mode = self.instance.get('memray_native_mode', self.init_config.get('memray_native_mode', False))
 
             if output_file is None:
                 raise ConfigurationError('Setting `memray_file` must be provided to use memray.')
 
             import memray
+
             # Default to 1h if min_collection_interval is set to 15s (the default value)
-            self._memray_remaining_iterations = self.instance.get('memray_iteration_count',
-                                                                  self.init_config.get('memray_iteration_count', 240))
+            self._memray_remaining_iterations = self.instance.get(
+                'memray_iteration_count', self.init_config.get('memray_iteration_count', 240)
+            )
             self._memray = memray.Tracker(file_name=output_file, native_traces=native_mode)
             self.log.info("Enabling memray for {} iterations.".format(self._memray_remaining_iterations))
             self._memray.__enter__()
-
 
     @staticmethod
     def load_configuration_model(import_path, model_name, config):

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -1114,7 +1114,8 @@ class AgentCheck(object):
         the check is running. It's up to the python implementation to make sure
         cancel is thread safe and won't block.
         """
-        pass
+        self.log.info("Stopping memray.")
+        self._memray.__exit__(None, None, None)
 
     def run(self):
         # type: () -> str

--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -520,7 +520,7 @@ class AgentCheck(object):
 
             import memray
 
-            self._memray = memray.Tracker(output_file, native_traces=native_mode)
+            self._memray = memray.Tracker(file_name=output_file, native_traces=native_mode)
             self._memray.__enter__()
 
     @staticmethod

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -44,6 +44,7 @@ ldap3==2.9.1
 lxml==4.9.1
 lz4==2.2.1; python_version < '3.0'
 lz4==3.1.3; python_version > '3.0'
+memray==1.4.1; python_version > '3.0' and (platform_system == 'Linux' or platform_system == 'Darwin')
 mmh3==2.5.1; python_version < '3.0'
 mmh3==3.0.0; python_version > '3.0'
 oauthlib==3.1.0; python_version < '3.0'

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -52,6 +52,7 @@ deps = [
     "immutables==0.19; python_version > '3.0'",
     "ipaddress==1.0.23; python_version < '3.0'",
     "jellyfish==0.9.0; python_version > '3.0'",
+    "memray==1.4.1; sys_platform != 'win32' and python_version > '3.0'",
     "prometheus-client==0.12.0; python_version < '3.0'",
     "prometheus-client==0.15.0; python_version > '3.0'",
     "protobuf==3.17.3; python_version < '3.0'",

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -52,7 +52,7 @@ deps = [
     "immutables==0.19; python_version > '3.0'",
     "ipaddress==1.0.23; python_version < '3.0'",
     "jellyfish==0.9.0; python_version > '3.0'",
-    "memray==1.4.1; sys_platform != 'win32' and python_version > '3.0'",
+    "memray==1.4.1;  python_version > '3.0' and (platform_system=='Linux' or platform_system=='Darwin')",
     "prometheus-client==0.12.0; python_version < '3.0'",
     "prometheus-client==0.15.0; python_version > '3.0'",
     "protobuf==3.17.3; python_version < '3.0'",

--- a/datadog_checks_base/tests/base/utils/memray/__init__.py
+++ b/datadog_checks_base/tests/base/utils/memray/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/datadog_checks_base/tests/base/utils/memray/test_check.py
+++ b/datadog_checks_base/tests/base/utils/memray/test_check.py
@@ -6,7 +6,7 @@ from mock import MagicMock, patch
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.constants import ServiceCheck
-from datadog_checks.dev.testing import requires_py2, requires_py3
+from datadog_checks.dev.testing import requires_py2, requires_py3, requires_unix
 
 
 class MemrayCheck(AgentCheck):
@@ -35,6 +35,7 @@ class MemrayCheck(AgentCheck):
     ],
 )
 @requires_py3
+@requires_unix
 def test_memray_windows(caplog, dd_run_check, aggregator, datadog_agent, init_config, instance_config):
     check = MemrayCheck('memory', init_config, [instance_config])
 
@@ -53,6 +54,7 @@ def test_memray_windows(caplog, dd_run_check, aggregator, datadog_agent, init_co
     ],
 )
 @requires_py2
+@requires_unix
 def test_memray_py2(caplog, dd_run_check, aggregator, datadog_agent, init_config, instance_config):
     check = MemrayCheck('memory', init_config, [instance_config])
 
@@ -87,6 +89,7 @@ def test_memray_py2(caplog, dd_run_check, aggregator, datadog_agent, init_config
     ],
 )
 @requires_py3
+@requires_unix
 def test_memray(caplog, dd_run_check, aggregator, datadog_agent, init_config, instance_config, native_traces):
     check = MemrayCheck('memory', init_config, [instance_config])
     tracker_mock = MagicMock()

--- a/datadog_checks_base/tests/base/utils/memray/test_check.py
+++ b/datadog_checks_base/tests/base/utils/memray/test_check.py
@@ -14,7 +14,7 @@ class MemrayCheck(AgentCheck):
     __NAMESPACE__ = 'memray'
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(MemrayCheck, self).__init__(*args, **kwargs)
         self.check_initializations.append(self.initialize)
 
     def initialize(self):

--- a/datadog_checks_base/tests/base/utils/memray/test_check.py
+++ b/datadog_checks_base/tests/base/utils/memray/test_check.py
@@ -49,7 +49,7 @@ def test_memray_windows(caplog, dd_run_check, aggregator, datadog_agent, init_co
         pytest.param({'tags': ['bar:baz'], 'enable_memray': True}, {'tags': ['foo:bar']}, id='Init-level config'),
     ],
 )
-@pytest.mark.skipif(not PY2, reason='Memray is not supported on py2 environments')
+@pytest.mark.skipif(ON_WINDOWS or not PY2, reason='Memray is not supported on py2 environments')
 def test_memray_py2(caplog, dd_run_check, aggregator, datadog_agent, init_config, instance_config):
     check = MemrayCheck('memory', init_config, [instance_config])
     check.check_id = 'test:123'

--- a/datadog_checks_base/tests/base/utils/memray/test_check.py
+++ b/datadog_checks_base/tests/base/utils/memray/test_check.py
@@ -93,6 +93,7 @@ def test_memray(caplog, dd_run_check, aggregator, datadog_agent, init_config, in
 
     with patch("memray.Tracker", return_value=tracker_mock) as mock:
         dd_run_check(check)
+        dd_run_check(check)
 
     mock.assert_called_with(file_name="my-file", native_traces=native_traces)
     tracker_mock.__enter__.assert_called_once()

--- a/datadog_checks_base/tests/base/utils/memray/test_check.py
+++ b/datadog_checks_base/tests/base/utils/memray/test_check.py
@@ -13,7 +13,7 @@ class MemrayCheck(AgentCheck):
     __NAMESPACE__ = 'memray'
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(MemrayCheck, self).__init__(*args, **kwargs)
         self.check_id = "test:123"
         self.tags = ['bar:baz']
         self.check_initializations.append(self.initialize)

--- a/datadog_checks_base/tests/base/utils/memray/test_check.py
+++ b/datadog_checks_base/tests/base/utils/memray/test_check.py
@@ -73,7 +73,10 @@ def test_memray_py2(caplog, dd_run_check, aggregator, datadog_agent, init_config
             id='Instance-level config without native traces',
         ),
         pytest.param(
-            {'enable_memray': True, 'memray_file': 'my-file', 'memray_iteration_count': 3}, {}, False, id='Init-level config without native traces'
+            {'enable_memray': True, 'memray_file': 'my-file', 'memray_iteration_count': 3},
+            {},
+            False,
+            id='Init-level config without native traces',
         ),
         pytest.param(
             {},

--- a/datadog_checks_base/tests/base/utils/memray/test_check.py
+++ b/datadog_checks_base/tests/base/utils/memray/test_check.py
@@ -1,0 +1,58 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+from six import PY2
+
+from datadog_checks.base import AgentCheck, ConfigurationError
+from datadog_checks.base.constants import ServiceCheck
+from datadog_checks.dev.utils import ON_WINDOWS
+
+
+class MemrayCheck(AgentCheck):
+    __NAMESPACE__ = 'memray'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.check_initializations.append(self.initialize)
+
+    def initialize(self):
+        self.gauge('initialize', 0, tags=self.tags)
+        self.log.debug('Initializing - %s - %s', self.name, self.check_id)
+
+    def check(self, _):
+        self.gauge('metric', 0, tags=self.tags)
+        self.service_check('sc', ServiceCheck.OK if self.redirecting else ServiceCheck.CRITICAL, tags=self.tags)
+
+
+@pytest.mark.parametrize(
+    'init_config, instance_config',
+    [
+        pytest.param({'tags': ['bar:baz']}, {'enable_memray': True, 'tags': ['foo:bar']}, id='Instance-level config'),
+        pytest.param({'tags': ['bar:baz'], 'enable_memray': True}, {'tags': ['foo:bar']}, id='Init-level config'),
+    ],
+)
+@pytest.mark.skipif(not ON_WINDOWS, reason='Memray is not supported on Windows')
+def test_memray_windows(caplog, dd_run_check, aggregator, datadog_agent, init_config, instance_config):
+    check = MemrayCheck('memory', init_config, [instance_config])
+    check.check_id = 'test:123'
+
+    with pytest.raises(ConfigurationError, match='^`enable_memray` option is only supported on Linux and macOS.$'):
+        dd_run_check(check)
+
+
+@pytest.mark.parametrize(
+    'init_config, instance_config',
+    [
+        pytest.param({'tags': ['bar:baz']}, {'enable_memray': True, 'tags': ['foo:bar']}, id='Instance-level config'),
+        pytest.param({'tags': ['bar:baz'], 'enable_memray': True}, {'tags': ['foo:bar']}, id='Init-level config'),
+    ],
+)
+@pytest.mark.skipif(not PY2, reason='Memray is not supported on py2 environments')
+def test_memray_py2(caplog, dd_run_check, aggregator, datadog_agent, init_config, instance_config):
+    check = MemrayCheck('memory', init_config, [instance_config])
+    check.check_id = 'test:123'
+
+    with pytest.raises(ConfigurationError, match='^`enable_memray` option is not supported for py2 environments.$'):
+        dd_run_check(check)

--- a/datadog_checks_base/tests/base/utils/memray/test_check.py
+++ b/datadog_checks_base/tests/base/utils/memray/test_check.py
@@ -64,37 +64,41 @@ def test_memray_py2(caplog, dd_run_check, aggregator, datadog_agent, init_config
 
 
 @pytest.mark.parametrize(
-    'init_config, instance_config, native_traces',
+    'init_config, instance_config, native_traces, filename',
     [
         pytest.param(
             {},
             {'enable_memray': True, 'memray_file': 'my-file', 'memray_iteration_count': 3},
             False,
+            'my-file',
             id='Instance-level config without native traces',
         ),
         pytest.param(
             {'enable_memray': True, 'memray_file': 'my-file', 'memray_iteration_count': 3},
             {},
             False,
+            'my-file.test:123',
             id='Init-level config without native traces',
         ),
         pytest.param(
             {},
             {'enable_memray': True, 'memray_file': 'my-file', 'memray_native_mode': True, 'memray_iteration_count': 3},
             True,
+            'my-file',
             id='Instance-level config with native traces',
         ),
         pytest.param(
             {'enable_memray': True, 'memray_file': 'my-file', 'memray_native_mode': True, 'memray_iteration_count': 3},
             {},
             True,
+            'my-file.test:123',
             id='Init-level config with native traces',
         ),
     ],
 )
 @requires_py3
 @requires_unix
-def test_memray(caplog, dd_run_check, aggregator, datadog_agent, init_config, instance_config, native_traces):
+def test_memray(caplog, dd_run_check, aggregator, datadog_agent, init_config, instance_config, native_traces, filename):
     check = MemrayCheck('memory', init_config, [instance_config])
     tracker_mock = MagicMock()
 
@@ -102,7 +106,7 @@ def test_memray(caplog, dd_run_check, aggregator, datadog_agent, init_config, in
         dd_run_check(check)
         dd_run_check(check)
 
-    mock.assert_called_with(file_name="my-file", native_traces=native_traces)
+    mock.assert_called_with(file_name=filename, native_traces=native_traces)
     tracker_mock.__enter__.assert_called_once()
     tracker_mock.__exit__.assert_not_called()
 

--- a/datadog_checks_base/tests/base/utils/memray/test_check.py
+++ b/datadog_checks_base/tests/base/utils/memray/test_check.py
@@ -1,20 +1,23 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from unittest import mock
 
 import pytest
-from six import PY2
+from mock import MagicMock, patch
 
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.constants import ServiceCheck
-from datadog_checks.dev.utils import ON_WINDOWS
+from datadog_checks.dev.testing import requires_py2, requires_py3
 
 
 class MemrayCheck(AgentCheck):
     __NAMESPACE__ = 'memray'
 
     def __init__(self, *args, **kwargs):
-        super(MemrayCheck, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
+        self.check_id = "test:123"
+        self.tags = ['bar:baz']
         self.check_initializations.append(self.initialize)
 
     def initialize(self):
@@ -23,36 +26,75 @@ class MemrayCheck(AgentCheck):
 
     def check(self, _):
         self.gauge('metric', 0, tags=self.tags)
-        self.service_check('sc', ServiceCheck.OK if self.redirecting else ServiceCheck.CRITICAL, tags=self.tags)
+        self.service_check('sc', ServiceCheck.OK, tags=self.tags)
 
 
 @pytest.mark.parametrize(
     'init_config, instance_config',
     [
-        pytest.param({'tags': ['bar:baz']}, {'enable_memray': True, 'tags': ['foo:bar']}, id='Instance-level config'),
-        pytest.param({'tags': ['bar:baz'], 'enable_memray': True}, {'tags': ['foo:bar']}, id='Init-level config'),
+        pytest.param({}, {'enable_memray': True}, id='Instance-level config'),
+        pytest.param({'enable_memray': True}, {}, id='Init-level config'),
     ],
 )
-@pytest.mark.skipif(not ON_WINDOWS, reason='Memray is not supported on Windows')
+@requires_py3
 def test_memray_windows(caplog, dd_run_check, aggregator, datadog_agent, init_config, instance_config):
     check = MemrayCheck('memory', init_config, [instance_config])
-    check.check_id = 'test:123'
 
-    with pytest.raises(ConfigurationError, match='^`enable_memray` option is only supported on Linux and macOS.$'):
-        dd_run_check(check)
+    with mock.patch('sys.platform', 'windows'):
+        with pytest.raises(
+            ConfigurationError, match='^`enable_memray` option is only supported on Linux and macOS\\.$'
+        ):
+            check.load_memray_context_manager()
 
 
 @pytest.mark.parametrize(
     'init_config, instance_config',
     [
-        pytest.param({'tags': ['bar:baz']}, {'enable_memray': True, 'tags': ['foo:bar']}, id='Instance-level config'),
-        pytest.param({'tags': ['bar:baz'], 'enable_memray': True}, {'tags': ['foo:bar']}, id='Init-level config'),
+        pytest.param({}, {'enable_memray': True}, id='Instance-level config'),
+        pytest.param({'enable_memray': True}, {}, id='Init-level config'),
     ],
 )
-@pytest.mark.skipif(ON_WINDOWS or not PY2, reason='Memray is not supported on py2 environments')
+@requires_py2
 def test_memray_py2(caplog, dd_run_check, aggregator, datadog_agent, init_config, instance_config):
     check = MemrayCheck('memory', init_config, [instance_config])
-    check.check_id = 'test:123'
 
-    with pytest.raises(ConfigurationError, match='^`enable_memray` option is not supported for py2 environments.$'):
+    with pytest.raises(ConfigurationError, match='^`enable_memray` option is not supported for py2 environments\\.$'):
+        check.load_memray_context_manager()
+
+
+@pytest.mark.parametrize(
+    'init_config, instance_config, native_traces',
+    [
+        pytest.param(
+            {},
+            {'enable_memray': True, 'memray_file': 'my-file'},
+            False,
+            id='Instance-level config without native traces',
+        ),
+        pytest.param(
+            {'enable_memray': True, 'memray_file': 'my-file'}, {}, False, id='Init-level config without native traces'
+        ),
+        pytest.param(
+            {},
+            {'enable_memray': True, 'memray_file': 'my-file', 'memray_native_mode': True},
+            True,
+            id='Instance-level config with native traces',
+        ),
+        pytest.param(
+            {'enable_memray': True, 'memray_file': 'my-file', 'memray_native_mode': True},
+            {},
+            True,
+            id='Init-level config with native traces',
+        ),
+    ],
+)
+@requires_py3
+def test_memray(caplog, dd_run_check, aggregator, datadog_agent, init_config, instance_config, native_traces):
+    check = MemrayCheck('memory', init_config, [instance_config])
+    tracker_mock = MagicMock()
+
+    with patch("memray.Tracker", return_value=tracker_mock) as mock:
         dd_run_check(check)
+
+    mock.assert_called_with(file_name="my-file", native_traces=native_traces)
+    tracker_mock.__enter__.assert_called_once()

--- a/datadog_checks_base/tests/base/utils/memray/test_check.py
+++ b/datadog_checks_base/tests/base/utils/memray/test_check.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from unittest import mock
-
 import pytest
 from mock import MagicMock, patch
 
@@ -40,7 +38,7 @@ class MemrayCheck(AgentCheck):
 def test_memray_windows(caplog, dd_run_check, aggregator, datadog_agent, init_config, instance_config):
     check = MemrayCheck('memory', init_config, [instance_config])
 
-    with mock.patch('sys.platform', 'windows'):
+    with patch('sys.platform', 'windows'):
         with pytest.raises(
             ConfigurationError, match='^`enable_memray` option is only supported on Linux and macOS\\.$'
         ):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a new set of config options to the base check to enable memray. 

- At first, we planned to stop memray when the agent shuts down, in the `cancel` method. It turns out that this method is not called in this case. I decided to switch to running memray for a fix amount of check invocations, which can also be defined in the config.
- As of now, we are generating one file per check instance. The file is stored locally. Each memray tracker can only write one file, so if the file is defined at the init_config level, we append the id of the check to the filename. 

### Motivation
<!-- What inspired you to submit this pull request? -->

https://datadoghq.atlassian.net/browse/AITOOLS-35

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Those options are not documented yet. I think we can do that in a follow-up PR because we will also need to update all the existing integrations (just like we did with the isolated_process option)
- Feel free to suggest better names for the options, my names suck.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.