### PR TITLE
Fix typo in platfrom-integrations team name

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/trello.py
@@ -59,7 +59,7 @@ class TrelloClient:
             'team/container-app': 'Container App',
             'team/integrations': 'Integrations',
             'team/database-monitoring': 'Database Monitoring',
-            'team/plaftorm-integrations': 'Platform Integrations',
+            'team/platform-integrations': 'Platform Integrations',
             'team/agent-security': 'Runtime-Security',
             'team/network-device-monitoring': 'Network Device Monitoring',
             'team/remote-config': 'Remote-Config',


### PR DESCRIPTION
This PR fixes typo in the platform-integrations label name, which caused QA card generation script to be unable to properly create cards.