### PR TITLE
Fix labeler for releases

### DIFF
--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -2,7 +2,7 @@ base_package:
 - datadog_checks_base/**/*
 changelog/no-changelog:
 - requirements-agent-release.txt
-- datadog_checks_dev/datadog_checks/dev/__about__.py
+- '*/__about__.py'
 - all:
   - '*/!(datadog_checks)/**'
 - all:
@@ -438,4 +438,4 @@ integration/zk:
 - zk/**/*
 release:
 - requirements-agent-release.txt
-- datadog_checks_dev/datadog_checks/dev/__about__.py
+- '*/__about__.py'


### PR DESCRIPTION
### What does this PR do?
Updates labeler filter to label release PRs with `changelog/no-changelog` and `release`.

### Motivation
bugfix

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.