### PR TITLE
Make `git_show_file` raise when git fails

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/git.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/git.py
@@ -100,7 +100,7 @@ def git_show_file(path, ref):
     command = f'git show {ref}:{path}'
 
     with chdir(root):
-        return run_command(command, capture=True).stdout
+        return run_command(command, capture=True, check=True).stdout
 
 
 def git_commit(targets, message, force=False, sign=False, update=False):

--- a/datadog_checks_dev/tests/tooling/test_git.py
+++ b/datadog_checks_dev/tests/tooling/test_git.py
@@ -99,7 +99,7 @@ def test_git_show_file():
             set_root('/foo/')
             git_show_file('path-string', 'git-ref-string')
             chdir.assert_called_once_with('/foo/')
-            run.assert_called_once_with('git show git-ref-string:path-string', capture=True)
+            run.assert_called_once_with('git show git-ref-string:path-string', capture=True, check=True)
 
 
 def test_git_commit():


### PR DESCRIPTION
### What does this PR do?

Makes `git_show_file` (used to get the contents of a file on an arbitrary git ref) raise when the git command fails, which is normally because:
- The file doesn't exist on the given ref.
- The given ref doesn't exist.

### Motivation

This function was returning an empty string on failure, which means we can't tell whether the file contents can't be retrieved (e.g. if it doesn't exist) or whether the file was empty originally.

I wanted to use this function for [AITOOLS-60](https://datadoghq.atlassian.net/browse/AITOOLS-60), and this behavior would help.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.