### PR TITLE
Add the missing `__path__` variable

### DIFF
--- a/kube_proxy/datadog_checks/__init__.py
+++ b/kube_proxy/datadog_checks/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add the `__path__` variable to the kube_proxy integration. 

### Motivation
<!-- What inspired you to submit this pull request? -->

- It should be there, see https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/%7Bcheck_name%7D/datadog_checks/__init__.py
- Revealed by [this PR](https://github.com/DataDog/integrations-core/pull/13366)
- CI is failing, example [here](https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=119742&view=logs&jobId=026f262d-50fd-5ef9-347c-fe645c0b84ea&j=026f262d-50fd-5ef9-347c-fe645c0b84ea&t=2becebdc-a330-5bc4-f5a3-595047c5e91b)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.