### PR TITLE
Mention the stable URLs of OOTB dashboards

### DIFF
--- a/docs/developer/guidelines/dashboards.md
+++ b/docs/developer/guidelines/dashboards.md
@@ -26,6 +26,9 @@ ddev meta dash export <URL_OF_DASHBOARD> <INTEGRATION>
 The command will add the dashboard definition to the `manifest.json` file of the integration.
 The dashboard JSON payload will be available in `/assets/dashboards/<DASHBOARD_TITLE>.json`.
 
+!!! tip
+    The dashboard will be available at the following address `/dash/integration/<DASHBOARD_KEY>` in each region, where `<DASHBOARD_KEY>` is the one you have in the `manifest.json` file of the integration for this dashboard. This can be useful when you want to add a link to another dashboard inside your dashboard.
+
 Commit the changes and create a pull request.
 
 ### Verify the Preset Dashboard

--- a/docs/developer/guidelines/dashboards.md
+++ b/docs/developer/guidelines/dashboards.md
@@ -27,7 +27,7 @@ The command will add the dashboard definition to the `manifest.json` file of the
 The dashboard JSON payload will be available in `/assets/dashboards/<DASHBOARD_TITLE>.json`.
 
 !!! tip
-    The dashboard will be available at the following address `/dash/integration/<DASHBOARD_KEY>` in each region, where `<DASHBOARD_KEY>` is the one you have in the `manifest.json` file of the integration for this dashboard. This can be useful when you want to add a link to another dashboard inside your dashboard.
+    The dashboard is available at the following address `/dash/integration/<DASHBOARD_KEY>` in each region, where `<DASHBOARD_KEY>` is the one you have in the `manifest.json` file of the integration for this dashboard. This can be useful when you want to add a link to another dashboard inside your dashboard.
 
 Commit the changes and create a pull request.
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a tip in the doc to mention OOTB dashboards have a stable URL without their ID.

### Motivation
<!-- What inspired you to submit this pull request? -->

I did not know this was a thing and this is very useful when we have several dashboards in the same integration and we would like to mention and link them in the dashboard. 

For instance, those two links lead to the same OOTB dashboard for us1:

- https://app.datadoghq.com/dash/integration/15/redis---overview
- https://app.datadoghq.com/dash/integration/redis

For eu:

- https://app.datadoghq.eu/dash/integration/2/redis---overview
- https://app.datadoghq.eu/dash/integration/redis

With the manifest: 

```
"dashboards": {
      "redis": "assets/dashboards/overview.json"
},
```

Thanks to that, we can have this kind of link in our dashboard:

```md
More info on [this dashboard](/dash/integration/redis)
```

This is going to work on each DC.

I hope that's clear enough (not really sure to be honest)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I used this tip in this PR: https://github.com/DataDog/integrations-core/pull/13391

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.