### PR TITLE
Change replication metrics to an aggregation

### DIFF
--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -184,6 +184,10 @@ REPLICATION_STATS_METRICS = {
             'postgresql.replication.wal_replay_lag',
             AgentCheck.gauge,
         ),
+        'max(age(backend_xmin))': (
+            'postgresql.replication.backend_xmin_age',
+            AgentCheck.gauge,
+        ),
     },
     'relation': False,
     'query': """

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -172,21 +172,24 @@ SELECT {metrics_columns}
 REPLICATION_STATS_METRICS = {
     'descriptors': [('application_name', 'wal_app_name'), ('state', 'wal_state'), ('sync_state', 'wal_sync_state')],
     'metrics': {
-        'GREATEST (0, EXTRACT(epoch from write_lag)) as write_lag': (
+        'max(GREATEST (0, EXTRACT(epoch from write_lag))) as write_lag': (
             'postgresql.replication.wal_write_lag',
             AgentCheck.gauge,
         ),
-        'GREATEST (0, EXTRACT(epoch from flush_lag)) AS flush_lag': (
+        'max(GREATEST (0, EXTRACT(epoch from flush_lag))) AS flush_lag': (
             'postgresql.replication.wal_flush_lag',
             AgentCheck.gauge,
         ),
-        'GREATEST (0, EXTRACT(epoch from replay_lag)) AS replay_lag': (
+        'max(GREATEST (0, EXTRACT(epoch from replay_lag))) AS replay_lag': (
             'postgresql.replication.wal_replay_lag',
             AgentCheck.gauge,
         ),
     },
     'relation': False,
-    'query': 'SELECT application_name, state, sync_state, {metrics_columns} FROM pg_stat_replication',
+    'query': """
+SELECT application_name, state, sync_state, {metrics_columns}
+FROM pg_stat_replication
+GROUP BY application_name, state, sync_state""",
 }
 
 CONNECTION_METRICS = {

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -81,8 +81,8 @@ def mock_cursor_for_replica_stats():
 
         def cursor_execute(query):
             if "FROM pg_stat_replication" in query:
-                data.appendleft(['app1', 'streaming', 'async', 12, 12, 12])
-                data.appendleft(['app2', 'backup', 'sync', 13, 13, 13])
+                data.appendleft(['app1', 'streaming', 'async', 12, 12, 12, 12])
+                data.appendleft(['app2', 'backup', 'sync', 13, 13, 13, 13])
             elif query == 'SHOW SERVER_VERSION;':
                 data.appendleft(['10.15'])
 

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -247,7 +247,7 @@ def test_replication_stats(aggregator, integration_check, pg_instance):
     app2_tags = base_tags + ['wal_sync_state:sync', 'wal_state:backup', 'wal_app_name:app2']
 
     aggregator.assert_metric('postgresql.db.count', 0, base_tags)
-    for suffix in ('wal_write_lag', 'wal_flush_lag', 'wal_replay_lag'):
+    for suffix in ('wal_write_lag', 'wal_flush_lag', 'wal_replay_lag', 'backend_xmin_age'):
         metric_name = 'postgresql.replication.{}'.format(suffix)
         aggregator.assert_metric(metric_name, 12, app1_tags)
         aggregator.assert_metric(metric_name, 13, app2_tags)


### PR DESCRIPTION
### What does this PR do?
Use an aggregation for `postgresql.replication.*` metrics to get the worst lagging hosts.
Add `postgresql.replication.backend_xmin_age` to report the worst `backend_xmin` as seen from the primary.

### Motivation
As it is, the check is doing the following:
```
base=> SELECT application_name, state, sync_state, GREATEST (0, EXTRACT(epoch from write_lag)) as write_lag, GREATEST (0, EXTRACT(epoch from flush_lag)) AS flush_lag, GREATEST (0, EXTRACT(epoch from replay_lag)) AS replay_lag FROM pg_stat_replication;
 application_name |   state   | sync_state | write_lag | flush_lag | replay_lag
------------------+-----------+------------+-----------+-----------+------------
 walreceiver      | streaming | async      |  0.000458 |  0.001474 |   0.001556
 walreceiver      | streaming | async      |  0.000325 |  0.001016 |   0.001022
 walreceiver      | streaming | async      |  0.000567 |  0.001574 |   0.001694
 walreceiver      | streaming | async      |  0.000761 |  0.001721 |   0.001812
 walreceiver      | streaming | async      |   0.00075 |  0.001562 |    0.00163
```

Then, for each result, we will submit it as a gauge. However, since `application_name`, `state` and `sync_state` are equals, only the latest point will be submitted.
Thus, we won't be able to see if a host is lagging if the last one is up to date. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.