### PR TITLE
Stop using deprecated distutils.version classes

### DIFF
--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -4,7 +4,8 @@
 from __future__ import division
 
 from copy import deepcopy
-from distutils.version import LooseVersion
+
+from packaging.version import Version
 
 from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.mongo.api import MongoApi
@@ -95,10 +96,10 @@ class MongoDb(AgentCheck):
             potential_collectors.append(JumboStatsCollector(self, tags))
         if 'top' in self._config.additional_metrics:
             potential_collectors.append(TopCollector(self, tags))
-        if LooseVersion(self._mongo_version) >= LooseVersion("3.6"):
+        if Version(self._mongo_version) >= Version("3.6"):
             potential_collectors.append(SessionStatsCollector(self, tags))
         if self._config.collections_indexes_stats:
-            if LooseVersion(self._mongo_version) >= LooseVersion("3.2"):
+            if Version(self._mongo_version) >= Version("3.2"):
                 potential_collectors.append(
                     IndexStatsCollector(self, self._config.db_name, tags, self._config.coll_names)
                 )

--- a/varnish/datadog_checks/varnish/varnish.py
+++ b/varnish/datadog_checks/varnish/varnish.py
@@ -5,9 +5,9 @@ import json
 import re
 import xml.parsers.expat  # python 2.4 compatible
 from collections import defaultdict
-from distutils.version import LooseVersion
 from os import geteuid
 
+from packaging.version import Version
 from six import PY3, iteritems
 from six.moves import filter
 
@@ -156,7 +156,7 @@ class Varnish(AgentCheck):
         if geteuid() != 0:
             cmd.append('sudo')
 
-        if version < LooseVersion('4.1.0'):
+        if version < Version('4.1.0'):
             cmd.extend(self.varnishadm_path + ['-S', self.secretfile_path, 'debug.health'])
         else:
             cmd.extend(
@@ -210,12 +210,12 @@ class Varnish(AgentCheck):
         if raw_version is None:
             raw_version = '3.0.0'
 
-        version = LooseVersion(raw_version)
+        version = Version(raw_version)
 
         # Location of varnishstat
-        if version < LooseVersion('3.0.0'):
+        if version < Version('3.0.0'):
             varnishstat_format = "text"
-        elif version < LooseVersion('5.0.0'):  # we default to json starting version 5.0.0
+        elif version < Version('5.0.0'):  # we default to json starting version 5.0.0
             varnishstat_format = "xml"
 
         return version, varnishstat_format

--- a/varnish/tests/test_unit.py
+++ b/varnish/tests/test_unit.py
@@ -2,10 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from distutils.version import LooseVersion
-
 import mock
 import pytest
+from packaging.version import Version
 
 from datadog_checks.varnish import Varnish
 
@@ -20,9 +19,9 @@ pyestmark = [pytest.mark.unit]
 @pytest.mark.parametrize(
     'version, uuid, expected_cmd',
     [
-        ((LooseVersion('4.0.0'), 'xml'), 0, [common.VARNISHADM_PATH, '-S', common.SECRETFILE_PATH, 'debug.health']),
+        ((Version('4.0.0'), 'xml'), 0, [common.VARNISHADM_PATH, '-S', common.SECRETFILE_PATH, 'debug.health']),
         (
-            (LooseVersion('4.1.0'), 'xml'),
+            (Version('4.1.0'), 'xml'),
             1,
             [
                 'sudo',
@@ -64,19 +63,19 @@ def test_command_line_manually_unhealthy(
     'version, uuid, expected_cmd, output_mock',
     [
         (
-            (LooseVersion("3.9.0"), 'xml'),
+            (Version("3.9.0"), 'xml'),
             0,
             [common.VARNISHADM_PATH, '-S', common.SECRETFILE_PATH, 'debug.health'],
             mocks.debug_health_mock,
         ),
         (
-            (LooseVersion('4.0.0'), 'xml'),
+            (Version('4.0.0'), 'xml'),
             0,
             [common.VARNISHADM_PATH, '-S', common.SECRETFILE_PATH, 'debug.health'],
             mocks.backend_list_mock_v4,
         ),
         (
-            (LooseVersion('4.1.0'), 'xml'),
+            (Version('4.1.0'), 'xml'),
             1,
             [
                 'sudo',
@@ -91,7 +90,7 @@ def test_command_line_manually_unhealthy(
             mocks.backend_list_mock_v4,
         ),
         (
-            (LooseVersion('5.0.0'), 'json'),
+            (Version('5.0.0'), 'json'),
             0,
             [
                 common.VARNISHADM_PATH,
@@ -105,7 +104,7 @@ def test_command_line_manually_unhealthy(
             mocks.backend_list_mock_v5,
         ),
         (
-            (LooseVersion('5.0.0'), 'json'),
+            (Version('5.0.0'), 'json'),
             1,
             [
                 'sudo',
@@ -120,7 +119,7 @@ def test_command_line_manually_unhealthy(
             mocks.backend_list_mock_v5,
         ),
         (
-            (LooseVersion('6.5.0'), 'json'),
+            (Version('6.5.0'), 'json'),
             0,
             [
                 common.VARNISHADM_PATH,
@@ -134,7 +133,7 @@ def test_command_line_manually_unhealthy(
             mocks.backend_list_mock_v6_5,
         ),
         (
-            (LooseVersion('6.5.0'), 'json'),
+            (Version('6.5.0'), 'json'),
             1,
             [
                 'sudo',

--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -61,8 +61,8 @@ import socket
 import struct
 from collections import defaultdict
 from contextlib import closing
-from distutils.version import LooseVersion  # pylint: disable=E0611,E0401
 
+from packaging.version import Version
 from six import PY3, StringIO, iteritems
 
 from datadog_checks.base import AgentCheck, ensure_bytes, ensure_unicode, is_affirmative
@@ -187,7 +187,7 @@ class ZookeeperCheck(AgentCheck):
                 self.service_check('zookeeper.mode', status, message=message, tags=self.sc_tags)
 
         # Read metrics from the `mntr` output
-        if zk_version and LooseVersion(zk_version) > LooseVersion("3.4.0"):
+        if zk_version and Version(zk_version) > Version("3.4.0"):
             try:
                 mntr_out = self._send_command('mntr')
             except ZKConnectionFailure:
@@ -278,7 +278,7 @@ class ZookeeperCheck(AgentCheck):
             # grabs the entire version number for inventories.
             metadata_version = total_match.group(1)
             self.set_metadata('version', metadata_version)
-        has_connections_val = LooseVersion(version) > LooseVersion("3.4.4")
+        has_connections_val = Version(version) > Version("3.4.4")
 
         # Clients:
         buf.readline()  # skip the Clients: header

--- a/zk/tests/common.py
+++ b/zk/tests/common.py
@@ -3,7 +3,8 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import os
-from distutils.version import LooseVersion  # pylint: disable=E0611,E0401
+
+from packaging.version import Version
 
 from datadog_checks.zk import ZookeeperCheck
 
@@ -35,7 +36,7 @@ def assert_mntr_metrics_by_version(aggregator, skip=None):
     zk_version = os.environ.get("ZK_VERSION") or "3.4.10"
     metrics_to_check = METRICS_34
     optional_metrics = []
-    if zk_version and LooseVersion(zk_version) >= LooseVersion("3.6"):
+    if zk_version and Version(zk_version) >= Version("3.6"):
         metrics_to_check = METRICS_36
         optional_metrics = METRICS_36_OPTIONAL
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Move from `distuils.version` to `packaging.version`.

### Motivation
<!-- What inspired you to submit this pull request? -->

- `distuils.version` classes are deprectaed
- https://datadoghq.atlassian.net/browse/AITOOLS-95

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.