### PR TITLE
Fix logic when other params are passed into instances

### DIFF
--- a/argocd/datadog_checks/argocd/check.py
+++ b/argocd/datadog_checks/argocd/check.py
@@ -92,7 +92,8 @@ class ArgocdCheck(OpenMetricsBaseCheckV2, ConfigMixin):
         return argocd_cluster_connection_status_transformer
 
     def configure_additional_transformers(self):
-        for endpoint in self.instance.keys():
+        endpoints = [key for key in self.instance.keys() if "_endpoint" in key]
+        for endpoint in endpoints:
             if endpoint == "app_controller_endpoint":
                 self.scrapers[self.instance[endpoint]].metric_transformer.add_custom_transformer(
                     ("argocd_cluster_connection_status"),

--- a/argocd/tests/common.py
+++ b/argocd/tests/common.py
@@ -2,11 +2,18 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-MOCKED_APP_CONTROLLER_INSTANCE = {'app_controller_endpoint': 'app_controller:8082'}
+MOCKED_APP_CONTROLLER_INSTANCE = {'app_controller_endpoint': 'http://app_controller:8082'}
 
-MOCKED_API_SERVER_INSTANCE = {'api_server_endpoint': 'api_server:8083'}
+MOCKED_APP_CONTROLLER_WITH_OTHER_PARAMS = {
+    'app_controller_endpoint': 'http://app_controller:8082',
+    'empty_default_hostname': True,
+    'enable_health_service_check': True,
+    'collect_histogram_buckets': True,
+}
 
-MOCKED_REPO_SERVER_INSTANCE = {'repo_server_endpoint': 'repo_server:8084'}
+MOCKED_API_SERVER_INSTANCE = {'api_server_endpoint': 'http://api_server:8083'}
+
+MOCKED_REPO_SERVER_INSTANCE = {'repo_server_endpoint': 'http://repo_server:8084'}
 
 EMPTY_INSTANCE = {''}
 

--- a/argocd/tests/test_argocd.py
+++ b/argocd/tests/test_argocd.py
@@ -14,6 +14,7 @@ from .common import (
     APP_CONTROLLER_METRICS,
     MOCKED_API_SERVER_INSTANCE,
     MOCKED_APP_CONTROLLER_INSTANCE,
+    MOCKED_APP_CONTROLLER_WITH_OTHER_PARAMS,
     MOCKED_REPO_SERVER_INSTANCE,
     NOT_EXPOSED_METRICS,
     REPO_SERVER_METRICS,
@@ -25,6 +26,7 @@ from .utils import get_fixture_path
     'namespace, instance, metrics',
     [
         ('app_controller', MOCKED_APP_CONTROLLER_INSTANCE, APP_CONTROLLER_METRICS),
+        ('app_controller', MOCKED_APP_CONTROLLER_WITH_OTHER_PARAMS, APP_CONTROLLER_METRICS),
         ('api_server', MOCKED_API_SERVER_INSTANCE, API_SERVER_METRICS),
         ('repo_server', MOCKED_REPO_SERVER_INSTANCE, REPO_SERVER_METRICS),
     ],
@@ -67,22 +69,22 @@ def test_app_controller_service_check(dd_run_check, aggregator, mock_http_respon
     aggregator.assert_service_check(
         'argocd.app_controller.cluster.connection.status',
         ServiceCheck.OK,
-        tags=['endpoint:app_controller:8082', 'name:bar'],
+        tags=['endpoint:http://app_controller:8082', 'name:bar'],
     )
     aggregator.assert_service_check(
         'argocd.app_controller.cluster.connection.status',
         ServiceCheck.CRITICAL,
-        tags=['endpoint:app_controller:8082', 'name:foo'],
+        tags=['endpoint:http://app_controller:8082', 'name:foo'],
     )
     aggregator.assert_service_check(
         'argocd.app_controller.cluster.connection.status',
         ServiceCheck.UNKNOWN,
-        tags=['endpoint:app_controller:8082', 'name:baz'],
+        tags=['endpoint:http://app_controller:8082', 'name:baz'],
     )
     aggregator.assert_service_check(
         'argocd.app_controller.cluster.connection.status',
         ServiceCheck.UNKNOWN,
-        tags=['endpoint:app_controller:8082', 'name:faz'],
+        tags=['endpoint:http://app_controller:8082', 'name:faz'],
     )
 
 


### PR DESCRIPTION
### What does this PR do?
Fix an issue in which when other params are being passed into the instance, the check would throw an error. I originally iterated over the instances expecting there to be endpoints only when setting up custom transformers. Also added a more robust test instance that would reflect what people would use if they would use this check to the tests.

