### PR TITLE
Alopez/ddev/validate license headers

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/__init__.py
@@ -17,6 +17,7 @@ from .http import http
 from .imports import imports
 from .integration_style import integration_style
 from .jmx_metrics import jmx_metrics
+from .license_headers import license_headers
 from .licenses import licenses
 from .manifest import manifest
 from .metadata import metadata
@@ -42,6 +43,7 @@ ALL_COMMANDS = (
     integration_style,
     jmx_metrics,
     legacy_signature,
+    license_headers,
     licenses,
     manifest,
     metadata,

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
@@ -1,0 +1,51 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pathlib
+
+import click
+
+from ...constants import get_root
+from ...license_headers import validate_license_headers
+from ...testing import process_checks_option
+from ...utils import complete_valid_checks
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
+
+IGNORES = {"datadog_checks_dev": ["datadog_checks/dev/tooling/templates"]}
+
+
+@click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate license headers in python files')
+@click.argument('check', shell_complete=complete_valid_checks, required=False)
+@click.pass_context
+def license_headers(ctx, check):
+    """Validate license headers in python code files.
+
+    If `check` is specified, only the check will be validated, if check value is 'changed' will only apply to changed
+    checks, an 'all' or empty `check` value will validate all README files.
+    """
+    root = pathlib.Path(get_root())
+    is_extras = ctx.obj['repo_choice'] == 'extras'
+    is_marketplace = ctx.obj['repo_choice'] == 'marketplace'
+
+    if is_extras or is_marketplace:
+        echo_info('License header is not implemented for `extras` or `marketplace`.')
+
+    checks = process_checks_option(check, source='integrations')
+
+    total_errors = 0
+
+    for check_name in checks:
+        path_to_check = root / check_name
+        ignores = [pathlib.Path(p) for p in IGNORES.get(check_name, [])]
+        errors = validate_license_headers(path_to_check, extra_ignore=ignores)
+
+        for err in errors:
+            echo_failure(f'{check_name}/{err.path}: {err.message}')
+            total_errors += 1
+
+    if total_errors:
+        echo_failure(f'Found {total_errors} files with errors.')
+        abort()
+    else:
+        echo_success('All license headers are valid.')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
@@ -2,8 +2,14 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import pathlib
 import re
+from collections import namedtuple
+from typing import Callable, List, Optional
 
+from ..errors import SubprocessError
+from .git import git_show_file
+from .utils import get_license_header as get_default_license_header
 
 _COPYRIGHT_PATTERN = re.compile(
     r"""
@@ -11,8 +17,76 @@ _COPYRIGHT_PATTERN = re.compile(
     \#\ All\ rights\ reserved\s*\n
     \#\ .*?(?i:license).*?$    # License info (matching string `license` while ignoring case)
     """,
-    re.MULTILINE | re.VERBOSE
+    re.MULTILINE | re.VERBOSE,
 )
+
+LicenseHeaderError = namedtuple("LicenseHeaderError", ["message", "path"])
+
+
+def _get_previous(path):
+    """Returns contents of previous (origin/master) version of file at `path` if it exists, and `None` otherwise."""
+    try:
+        return git_show_file(str(path), "origin/master")
+    except SubprocessError:
+        return None
+
+
+def validate_license_headers(
+    check_path: pathlib.Path, get_previous: Callable[[pathlib.Path], Optional[str]] = _get_previous
+) -> List[LicenseHeaderError]:
+    """
+    Validate license headers under `check_path` and return a list of validation errors.
+
+    Assumptions regarding which files require license header validation:
+    - Only python (*.py) files need a license header
+    - Code under hidden folders (starting with `.`) are ignored
+    - Files under the following folders are not checked, as it's where integration
+      testing environments are typically defined, where licenses may be a bit more heterogeneous:
+      - tests/docker
+      - tests/compose
+    """
+    root = check_path
+
+    def _validate_license_headers_recur(path):
+        for child in path.iterdir():
+            if child.is_dir():
+                # Skip hidden folders
+                if child.relative_to(child.parent).as_posix().startswith('.'):
+                    continue
+
+                # Skip blacklisted folders
+                relpath = child.relative_to(root)
+                if relpath.as_posix() in ("tests/docker", "tests/compose"):
+                    continue
+
+                yield from _validate_license_headers_recur(child)
+                continue
+
+            # Skip non-python files
+            if child.suffix != '.py':
+                continue
+
+            with open(child) as f:
+                contents = f.read()
+
+            license_header = parse_license_header(contents)
+            relpath = child.relative_to(root).as_posix()
+
+            # License is missing altogether
+            if not license_header:
+                yield LicenseHeaderError("missing", relpath)
+                continue
+
+            # When file already existed, check whether the license has changed
+            previous = get_previous(child)
+            if previous:
+                if license_header != parse_license_header(previous):
+                    yield LicenseHeaderError("existing file has changed license", relpath)
+            # When it's a new file, compare it to the current header template
+            elif license_header != get_default_license_header():
+                yield LicenseHeaderError("new file does not match template", relpath)
+
+    return list(_validate_license_headers_recur(check_path))
 
 
 def parse_license_header(contents):

--- a/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 from typing import Callable, List, Optional
 
 from ..errors import SubprocessError
+from .constants import get_root
 from .git import git_show_file
 from .utils import get_license_header as get_default_license_header
 
@@ -25,8 +26,11 @@ LicenseHeaderError = namedtuple("LicenseHeaderError", ["message", "path"])
 
 def _get_previous(path):
     """Returns contents of previous (origin/master) version of file at `path` if it exists, and `None` otherwise."""
+    # git_show_file relies on global context to compute the final path from a relative one,
+    # so we need to pass it the relative path it expects
+    relpath = path.relative_to(get_root())
     try:
-        return git_show_file(str(path), "origin/master")
+        return git_show_file(str(relpath), "origin/master")
     except SubprocessError:
         return None
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
@@ -1,0 +1,25 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import re
+
+
+_COPYRIGHT_PATTERN = re.compile(
+    r"""
+    ^(?:\#\ \(C\)\s*.*?\s*)+\n      # Copyright holders
+    \#\ All\ rights\ reserved\s*\n
+    \#\ .*?(?i:license).*?$    # License info (matching string `license` while ignoring case)
+    """,
+    re.MULTILINE | re.VERBOSE
+)
+
+
+def parse_license_header(contents):
+    """
+    Return the license header at the top of the `contents` string.
+
+    It returns an empty string if no license header is found.
+    """
+    match = _COPYRIGHT_PATTERN.match(contents)
+    return match[0] if match else ""

--- a/datadog_checks_dev/tests/tooling/test_license_headers.py
+++ b/datadog_checks_dev/tests/tooling/test_license_headers.py
@@ -144,6 +144,18 @@ def test_validate_license_headers_skips_blacklisted_folders(tmp_path, relpath):
     assert validate_license_headers(check_path) == []
 
 
+def test_validate_license_headers_skips_explicitly_ignored_folders(tmp_path):
+    check_path = tmp_path / "check"
+    path_to_ignore = pathlib.Path("path/to/ignore")
+    target_path = check_path / path_to_ignore
+    target_path.mkdir(parents=True)
+
+    with open(target_path / "some.py", "w") as f:
+        f.write("import os\n")
+
+    assert validate_license_headers(check_path, extra_ignore=[path_to_ignore]) == []
+
+
 def test_validate_license_headers_returns_error_on_new_file_with_header_not_matching_template(tmp_path):
     check_path = tmp_path / "check"
     check_path.mkdir()

--- a/datadog_checks_dev/tests/tooling/test_license_headers.py
+++ b/datadog_checks_dev/tests/tooling/test_license_headers.py
@@ -2,9 +2,12 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+import pathlib
+
 import pytest
 
-from datadog_checks.dev.tooling.license_headers import parse_license_header
+from datadog_checks.dev.tooling.license_headers import parse_license_header, validate_license_headers
+from datadog_checks.dev.tooling.utils import get_license_header
 
 
 @pytest.mark.parametrize("years", ["2000-present", "2001-2003", "2014"])
@@ -38,10 +41,13 @@ def test_parse_license_header_multiple_holders():
     assert parse_license_header(file_contents) == expected_header
 
 
-@pytest.mark.parametrize("license_line", [
-    "# Licensed under a 3-clause BSD style license (see LICENSE)",
-    "# Licensed under Simplified BSD License (see LICENSE)"
-])
+@pytest.mark.parametrize(
+    "license_line",
+    [
+        "# Licensed under a 3-clause BSD style license (see LICENSE)",
+        "# Licensed under Simplified BSD License (see LICENSE)",
+    ],
+)
 def test_parse_license_header_different_licenses(license_line):
     expected_header = """# (C) Foo, Inc. 2000-present
 # All rights reserved
@@ -49,3 +55,157 @@ def test_parse_license_header_different_licenses(license_line):
 
     file_contents = f"{expected_header}\n\nimport os"
     assert parse_license_header(file_contents) == expected_header
+
+
+def test_validate_license_headers_returns_no_errors_when_directory_is_empty(tmp_path):
+    assert validate_license_headers(tmp_path) == []
+
+
+def test_validate_license_headers_returns_error_for_a_file_without_license(tmp_path):
+    check_path = tmp_path / "check"
+    check_path.mkdir()
+
+    with open(check_path / "setup.py", "w") as f:
+        f.write(
+            """
+import os
+"""
+        )
+
+    errors = validate_license_headers(check_path)
+    assert len(errors) == 1
+    assert errors[0].message == "missing"
+    assert errors[0].path == "setup.py"
+
+
+def test_validate_license_headers_when_all_files_have_valid_headers_returns_empty_list(tmp_path):
+    check_path = tmp_path / "check"
+    check_path.mkdir()
+
+    with open(check_path / "setup.py", "w") as f:
+        f.write(
+            f"""{get_license_header()}
+
+import os
+"""
+        )
+
+    assert validate_license_headers(check_path, get_previous=_make_get_previous()) == []
+
+
+def test_validate_license_headers_works_with_arbitrary_nesting(tmp_path):
+    check_path = tmp_path / "check"
+    check_path.mkdir()
+
+    nested_path = check_path / "datadog_checks/check"
+    nested_path.mkdir(parents=True)
+    with open(nested_path / "check.py", "w") as f:
+        f.write(
+            """
+import os
+"""
+        )
+
+    errors = validate_license_headers(check_path)
+    assert len(errors) == 1
+    assert errors[0].message == "missing"
+    assert errors[0].path == "datadog_checks/check/check.py"
+
+
+def test_validate_license_headers_skips_non_python_files(tmp_path):
+    check_path = tmp_path / "check"
+    check_path.mkdir()
+
+    with open(check_path / "pyproject.toml", "w") as f:
+        f.write("[something]\n")
+
+    assert validate_license_headers(check_path) == []
+
+
+@pytest.mark.parametrize(
+    "relpath",
+    [
+        ".hidden",
+        ".hidden/subfolder",
+        "tests/docker",
+        "tests/docker/subfolder",
+        "tests/compose",
+        "tests/compose/subfolder",
+    ],
+)
+def test_validate_license_headers_skips_blacklisted_folders(tmp_path, relpath):
+    check_path = tmp_path / "check"
+    target_path = check_path / relpath
+    target_path.mkdir(parents=True)
+
+    with open(target_path / "some.py", "w") as f:
+        f.write("import os\n")
+
+    assert validate_license_headers(check_path) == []
+
+
+def test_validate_license_headers_returns_error_on_new_file_with_header_not_matching_template(tmp_path):
+    check_path = tmp_path / "check"
+    check_path.mkdir()
+
+    with open(check_path / "setup.py", "w") as f:
+        f.write(
+            """# (C) Foo, Inc. 1999-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import os
+"""
+        )
+
+    errors = validate_license_headers(check_path, get_previous=_make_get_previous())
+    assert len(errors) == 1
+    assert errors[0].message == "new file does not match template"
+    assert errors[0].path == "setup.py"
+
+
+def test_validate_license_headers_returns_error_on_existing_file_with_changed_header(tmp_path):
+    check_path = tmp_path / "check"
+    check_path.mkdir()
+
+    original_license = """# (C) Foo, Inc. 1999-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+"""
+
+    prev_contents = f"{original_license}\n\nimport os\n"
+
+    with open(check_path / "setup.py", "w") as f:
+        f.write(
+            """# (C) Foo, Inc. 2000-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import os
+"""
+        )
+
+    with open(check_path / "unchanged_file.py", "w") as f:
+        f.write(prev_contents)
+
+    fake_get_previous = _make_get_previous(
+        {
+            pathlib.Path(check_path / "setup.py"): prev_contents,
+            pathlib.Path(check_path / "unchanged_file.py"): prev_contents,
+        }
+    )
+
+    errors = validate_license_headers(check_path, get_previous=fake_get_previous)
+    assert len(errors) == 1
+    assert errors[0].message == "existing file has changed license"
+    assert errors[0].path == "setup.py"
+
+
+def _make_get_previous(d: dict = None):
+    if d is None:
+        d = {}
+
+    def _fake_get_previous(path):
+        return d.get(path)
+
+    return _fake_get_previous

--- a/datadog_checks_dev/tests/tooling/test_license_headers.py
+++ b/datadog_checks_dev/tests/tooling/test_license_headers.py
@@ -1,0 +1,51 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+
+from datadog_checks.dev.tooling.license_headers import parse_license_header
+
+
+@pytest.mark.parametrize("years", ["2000-present", "2001-2003", "2014"])
+@pytest.mark.parametrize("holder", ["Datadog, Inc.", "Foo Bar", "Foo Bar <foo@bar.com>"])
+def test_parse_license_header(years, holder):
+    expected_header = f"""# (C) {holder} {years}
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)"""
+
+    file_contents = f"{expected_header}\n\nimport os"
+    assert parse_license_header(file_contents) == expected_header
+
+
+def test_parse_license_header_empty_input():
+    assert parse_license_header("") == ""
+
+
+def test_parse_license_header_no_license():
+    file_contents = "import os\n"
+
+    assert parse_license_header(file_contents) == ""
+
+
+def test_parse_license_header_multiple_holders():
+    expected_header = """# (C) Foo, Inc. 2000-present
+# (C) Mr. Bar <bar@bar.com> 2013
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)"""
+
+    file_contents = f"{expected_header}\n\nimport os"
+    assert parse_license_header(file_contents) == expected_header
+
+
+@pytest.mark.parametrize("license_line", [
+    "# Licensed under a 3-clause BSD style license (see LICENSE)",
+    "# Licensed under Simplified BSD License (see LICENSE)"
+])
+def test_parse_license_header_different_licenses(license_line):
+    expected_header = """# (C) Foo, Inc. 2000-present
+# All rights reserved
+# {license_line}"""
+
+    file_contents = f"{expected_header}\n\nimport os"
+    assert parse_license_header(file_contents) == expected_header


### PR DESCRIPTION
### What does this PR do?

Adds the `ddev validate license-header` subcommand, which behaves similarly to other validation subcommands.

### Motivation

[AITOOLS-46](https://datadoghq.atlassian.net/browse/AITOOLS-46)

### Additional Notes

- I'd also like feedback on my interpretation of the requirements and on the usefulness of this as implemented.
- There's lots of files with missing headers (265 as per the rule that this subcommand implements).
- The above two points would need resolution before considering adding this validation to CI.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.