### PR TITLE
minimal e2e test kube_apiserver_metrics

### DIFF
--- a/kube_apiserver_metrics/hatch.toml
+++ b/kube_apiserver_metrics/hatch.toml
@@ -7,4 +7,4 @@ python = ["27", "38"]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 
 [envs.default]
-e2e-env = false
+e2e-env = true

--- a/kube_apiserver_metrics/tests/conftest.py
+++ b/kube_apiserver_metrics/tests/conftest.py
@@ -1,14 +1,18 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from copy import deepcopy
+
 import pytest
+
+INSTANCE = {'prometheus_url': 'https://localhost:443/metrics', 'bearer_token_auth': 'false', 'tags': ["custom:tag"]}
 
 
 @pytest.fixture(scope='session')
 def dd_environment():
-    yield
+    yield deepcopy(INSTANCE)
 
 
 @pytest.fixture
 def instance():
-    return {}
+    return deepcopy(INSTANCE)

--- a/kube_apiserver_metrics/tests/test_e2e.py
+++ b/kube_apiserver_metrics/tests/test_e2e.py
@@ -1,0 +1,12 @@
+import pytest
+
+from datadog_checks.base import AgentCheck
+
+
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, aggregator, instance):
+    with pytest.raises(Exception):
+        dd_agent_check(instance, rate=True)
+    endpoint_tag = "endpoint:" + instance.get('prometheus_url')
+    tags = instance.get('tags').append(endpoint_tag)
+    aggregator.assert_service_check("kube_apiserver.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)


### PR DESCRIPTION
What does this PR do?
Add a minimal `kube_apiserver_metrics` E2E test to ensure the check is able to run.

Motivation
Expand testing to ensure integrations errors are caught in our CI pipeline

Review checklist (to be filled by reviewers)
 Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
 PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
 Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
 PR must have changelog/ and integration/ labels attached