### PR TITLE
minimal e2e test kube_dns

### DIFF
--- a/kube_dns/hatch.toml
+++ b/kube_dns/hatch.toml
@@ -4,4 +4,4 @@
 python = ["27", "38"]
 
 [envs.default]
-e2e-env = false
+e2e-env = true

--- a/kube_dns/tests/conftest.py
+++ b/kube_dns/tests/conftest.py
@@ -1,0 +1,22 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from copy import deepcopy
+
+import pytest
+
+INSTANCE = {
+    'prometheus_endpoint': 'http://localhost:10055/metrics',
+    'health_service_check': True,
+    'tags': ['custom:tag'],
+}
+
+
+@pytest.fixture(scope='session')
+def dd_environment():
+    yield deepcopy(INSTANCE)
+
+
+@pytest.fixture
+def instance():
+    return deepcopy(INSTANCE)

--- a/kube_dns/tests/test_e2e.py
+++ b/kube_dns/tests/test_e2e.py
@@ -1,0 +1,13 @@
+import pytest
+
+from datadog_checks.base import AgentCheck
+
+
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, aggregator, instance):
+
+    with pytest.raises(Exception):
+        dd_agent_check(instance, rate=True)
+    endpoint_tag = "endpoint:" + instance.get('prometheus_endpoint')
+    tags = instance.get('tags').append(endpoint_tag)
+    aggregator.assert_service_check("kubedns.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)


### PR DESCRIPTION
What does this PR do?
Add a minimal `kube_dns` E2E test to ensure the check is able to run.

Motivation
Expand testing to ensure integrations errors are caught in our CI pipeline

Review checklist (to be filled by reviewers)
Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
PR must have changelog/ and integration/ labels attached