### PR TITLE
Kyle/add minimal e2e

### DIFF
--- a/kube_apiserver_metrics/hatch.toml
+++ b/kube_apiserver_metrics/hatch.toml
@@ -5,6 +5,3 @@ python = ["27", "38"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
-
-[envs.default]
-e2e-env = true

--- a/kube_apiserver_metrics/tests/conftest.py
+++ b/kube_apiserver_metrics/tests/conftest.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2019-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy

--- a/kube_apiserver_metrics/tests/test_e2e.py
+++ b/kube_apiserver_metrics/tests/test_e2e.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
 from datadog_checks.base import AgentCheck

--- a/kube_apiserver_metrics/tests/test_e2e.py
+++ b/kube_apiserver_metrics/tests/test_e2e.py
@@ -11,5 +11,5 @@ def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
     endpoint_tag = "endpoint:" + instance.get('prometheus_url')
-    tags = instance.get('tags').append(endpoint_tag)
+    tags = instance.get('tags', []) + [endpoint_tag]
     aggregator.assert_service_check("kube_apiserver.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)

--- a/kube_controller_manager/hatch.toml
+++ b/kube_controller_manager/hatch.toml
@@ -4,9 +4,6 @@ base-package-features = [
     "kube",
 ]
 
-[envs.default]
-e2e-env = true
-
 [[envs.default.matrix]]
 python = ["27", "38"]
 

--- a/kube_controller_manager/hatch.toml
+++ b/kube_controller_manager/hatch.toml
@@ -5,7 +5,7 @@ base-package-features = [
 ]
 
 [envs.default]
-e2e-env = false
+e2e-env = true
 
 [[envs.default.matrix]]
 python = ["27", "38"]

--- a/kube_controller_manager/tests/conftest.py
+++ b/kube_controller_manager/tests/conftest.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from copy import deepcopy
+
+import pytest
+
+INSTANCE = {
+    'prometheus_url': 'http://localhost:10055/metrics',
+    'tags': ['custom:tag'],
+}
+
+
+@pytest.fixture(scope='session')
+def dd_environment():
+    yield deepcopy(INSTANCE)
+
+
+@pytest.fixture
+def instance():
+    return deepcopy(INSTANCE)

--- a/kube_controller_manager/tests/conftest.py
+++ b/kube_controller_manager/tests/conftest.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2019-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy

--- a/kube_controller_manager/tests/test_e2e.py
+++ b/kube_controller_manager/tests/test_e2e.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
 from datadog_checks.base import AgentCheck

--- a/kube_controller_manager/tests/test_e2e.py
+++ b/kube_controller_manager/tests/test_e2e.py
@@ -12,7 +12,7 @@ def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
     endpoint_tag = "endpoint:" + instance.get('prometheus_url')
-    tags = instance.get('tags').append(endpoint_tag)
+    tags = instance.get('tags', []) + [endpoint_tag]
     aggregator.assert_service_check(
         "kube_controller_manager.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags
     )

--- a/kube_controller_manager/tests/test_e2e.py
+++ b/kube_controller_manager/tests/test_e2e.py
@@ -1,0 +1,15 @@
+import pytest
+
+from datadog_checks.base import AgentCheck
+
+
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, aggregator, instance):
+
+    with pytest.raises(Exception):
+        dd_agent_check(instance, rate=True)
+    endpoint_tag = "endpoint:" + instance.get('prometheus_url')
+    tags = instance.get('tags').append(endpoint_tag)
+    aggregator.assert_service_check(
+        "kube_controller_manager.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags
+    )

--- a/kube_dns/hatch.toml
+++ b/kube_dns/hatch.toml
@@ -2,6 +2,3 @@
 
 [[envs.default.matrix]]
 python = ["27", "38"]
-
-[envs.default]
-e2e-env = true

--- a/kube_dns/tests/conftest.py
+++ b/kube_dns/tests/conftest.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2019-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy

--- a/kube_dns/tests/test_e2e.py
+++ b/kube_dns/tests/test_e2e.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
 from datadog_checks.base import AgentCheck

--- a/kube_dns/tests/test_e2e.py
+++ b/kube_dns/tests/test_e2e.py
@@ -12,5 +12,5 @@ def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
     endpoint_tag = "endpoint:" + instance.get('prometheus_endpoint')
-    tags = instance.get('tags').append(endpoint_tag)
+    tags = instance.get('tags', []) + [endpoint_tag]
     aggregator.assert_service_check("kubedns.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)

--- a/kube_metrics_server/hatch.toml
+++ b/kube_metrics_server/hatch.toml
@@ -2,6 +2,3 @@
 
 [[envs.default.matrix]]
 python = ["27", "38"]
-
-[envs.default]
-e2e-env = true

--- a/kube_metrics_server/hatch.toml
+++ b/kube_metrics_server/hatch.toml
@@ -4,4 +4,4 @@
 python = ["27", "38"]
 
 [envs.default]
-e2e-env = false
+e2e-env = true

--- a/kube_metrics_server/tests/conftest.py
+++ b/kube_metrics_server/tests/conftest.py
@@ -1,0 +1,23 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from copy import deepcopy
+
+import pytest
+
+INSTANCE = {
+    'prometheus_url': 'https://localhost:443/metrics',
+    'send_histograms_buckets': True,
+    'health_service_check': True,
+    'tags': ['custom:tag'],
+}
+
+
+@pytest.fixture(scope='session')
+def dd_environment():
+    yield deepcopy(INSTANCE)
+
+
+@pytest.fixture
+def instance():
+    return deepcopy(INSTANCE)

--- a/kube_metrics_server/tests/conftest.py
+++ b/kube_metrics_server/tests/conftest.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2019-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy

--- a/kube_metrics_server/tests/test_e2e.py
+++ b/kube_metrics_server/tests/test_e2e.py
@@ -12,5 +12,5 @@ def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
     endpoint_tag = "endpoint:" + instance.get('prometheus_url')
-    tags = instance.get('tags').append(endpoint_tag)
+    tags = instance.get('tags', []) + [endpoint_tag]
     aggregator.assert_service_check("kube_metrics_server.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)

--- a/kube_metrics_server/tests/test_e2e.py
+++ b/kube_metrics_server/tests/test_e2e.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
 from datadog_checks.base import AgentCheck

--- a/kube_metrics_server/tests/test_e2e.py
+++ b/kube_metrics_server/tests/test_e2e.py
@@ -1,0 +1,13 @@
+import pytest
+
+from datadog_checks.base import AgentCheck
+
+
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, aggregator, instance):
+
+    with pytest.raises(Exception):
+        dd_agent_check(instance, rate=True)
+    endpoint_tag = "endpoint:" + instance.get('prometheus_url')
+    tags = instance.get('tags').append(endpoint_tag)
+    aggregator.assert_service_check("kube_metrics_server.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)

--- a/kube_proxy/tests/conftest.py
+++ b/kube_proxy/tests/conftest.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2019-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy
@@ -9,7 +9,6 @@ INSTANCE = {
     'prometheus_url': 'http://localhost:10249/metrics',
     'tags': ['custom:tag'],
 }
-
 
 @pytest.fixture(scope='session')
 def dd_environment():

--- a/kube_proxy/tests/conftest.py
+++ b/kube_proxy/tests/conftest.py
@@ -1,0 +1,21 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from copy import deepcopy
+
+import pytest
+
+INSTANCE = {
+    'prometheus_url': 'http://localhost:10249/metrics',
+    'tags': ['custom:tag'],
+}
+
+
+@pytest.fixture(scope='session')
+def dd_environment():
+    yield deepcopy(INSTANCE)
+
+
+@pytest.fixture
+def instance():
+    return deepcopy(INSTANCE)

--- a/kube_proxy/tests/conftest.py
+++ b/kube_proxy/tests/conftest.py
@@ -10,6 +10,7 @@ INSTANCE = {
     'tags': ['custom:tag'],
 }
 
+
 @pytest.fixture(scope='session')
 def dd_environment():
     yield deepcopy(INSTANCE)

--- a/kube_proxy/tests/test_e2e.py
+++ b/kube_proxy/tests/test_e2e.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
 from datadog_checks.base import AgentCheck

--- a/kube_proxy/tests/test_e2e.py
+++ b/kube_proxy/tests/test_e2e.py
@@ -12,5 +12,5 @@ def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
     endpoint_tag = "endpoint:" + instance.get('prometheus_url')
-    tags = instance.get('tags').append(endpoint_tag)
+    tags = instance.get('tags', []) + [endpoint_tag]
     aggregator.assert_service_check("kubeproxy.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)

--- a/kube_proxy/tests/test_e2e.py
+++ b/kube_proxy/tests/test_e2e.py
@@ -1,0 +1,13 @@
+import pytest
+
+from datadog_checks.base import AgentCheck
+
+
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, aggregator, instance):
+
+    with pytest.raises(Exception):
+        dd_agent_check(instance, rate=True)
+    endpoint_tag = "endpoint:" + instance.get('prometheus_url')
+    tags = instance.get('tags').append(endpoint_tag)
+    aggregator.assert_service_check("kubeproxy.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)

--- a/kube_proxy/tox.ini
+++ b/kube_proxy/tox.ini
@@ -11,6 +11,8 @@ envdir =
     py27: {toxworkdir}/py27
     py38: {toxworkdir}/py38
 dd_check_style = true
+description =
+    py{27,38}: e2e ready
 usedevelop = true
 platform = linux|darwin
 extras = deps

--- a/kube_scheduler/hatch.toml
+++ b/kube_scheduler/hatch.toml
@@ -9,6 +9,3 @@ python = ["27", "38"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
-
-[envs.default]
-e2e-env = true

--- a/kube_scheduler/hatch.toml
+++ b/kube_scheduler/hatch.toml
@@ -11,4 +11,4 @@ python = ["27", "38"]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 
 [envs.default]
-e2e-env = false
+e2e-env = true

--- a/kube_scheduler/tests/conftest.py
+++ b/kube_scheduler/tests/conftest.py
@@ -1,0 +1,22 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from copy import deepcopy
+
+import pytest
+
+INSTANCE = {
+    'prometheus_url': 'http://localhost:10251/metrics',
+    'send_histograms_buckets': True,
+    'tags': ['custom:tag'],
+}
+
+
+@pytest.fixture(scope='session')
+def dd_environment():
+    yield deepcopy(INSTANCE)
+
+
+@pytest.fixture
+def instance():
+    return deepcopy(INSTANCE)

--- a/kube_scheduler/tests/conftest.py
+++ b/kube_scheduler/tests/conftest.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2019-present
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy

--- a/kube_scheduler/tests/test_e2e.py
+++ b/kube_scheduler/tests/test_e2e.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 
 from datadog_checks.base import AgentCheck

--- a/kube_scheduler/tests/test_e2e.py
+++ b/kube_scheduler/tests/test_e2e.py
@@ -12,5 +12,5 @@ def test_e2e(dd_agent_check, aggregator, instance):
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
     endpoint_tag = "endpoint:" + instance.get('prometheus_url')
-    tags = instance.get('tags').append(endpoint_tag)
+    tags = instance.get('tags', []) + [endpoint_tag]
     aggregator.assert_service_check("kube_scheduler.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)

--- a/kube_scheduler/tests/test_e2e.py
+++ b/kube_scheduler/tests/test_e2e.py
@@ -1,0 +1,13 @@
+import pytest
+
+from datadog_checks.base import AgentCheck
+
+
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, aggregator, instance):
+
+    with pytest.raises(Exception):
+        dd_agent_check(instance, rate=True)
+    endpoint_tag = "endpoint:" + instance.get('prometheus_url')
+    tags = instance.get('tags').append(endpoint_tag)
+    aggregator.assert_service_check("kube_scheduler.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)

--- a/kubernetes_state/hatch.toml
+++ b/kubernetes_state/hatch.toml
@@ -1,8 +1,5 @@
 [env.collectors.datadog-checks]
 
-[envs.default]
-e2e-env = false
-
 [[envs.default.matrix]]
 python = ["27", "38"]
 

--- a/kubernetes_state/tests/conftest.py
+++ b/kubernetes_state/tests/conftest.py
@@ -1,0 +1,24 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from copy import deepcopy
+
+import pytest
+
+INSTANCE = {
+    'host': 'foo',
+    'kube_state_url': 'http://example.com:8080/metrics',
+    'health_service_check': True,
+    'tags': ['optional:tag1'],
+    'telemetry': False,
+}
+
+
+@pytest.fixture(scope='session')
+def dd_environment():
+    yield deepcopy(INSTANCE)
+
+
+@pytest.fixture
+def instance():
+    return deepcopy(INSTANCE)

--- a/kubernetes_state/tests/test_e2e.py
+++ b/kubernetes_state/tests/test_e2e.py
@@ -8,8 +8,9 @@ from datadog_checks.base import AgentCheck
 
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, aggregator, instance):
+	
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
     endpoint_tag = "endpoint:" + instance.get('kube_state_url')
-    tags = instance.get('tags').append(endpoint_tag)
+    tags = instance.get('tags', []) + [endpoint_tag]
     aggregator.assert_service_check("kubernetes_state.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)

--- a/kubernetes_state/tests/test_e2e.py
+++ b/kubernetes_state/tests/test_e2e.py
@@ -8,7 +8,7 @@ from datadog_checks.base import AgentCheck
 
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, aggregator, instance):
-	
+
     with pytest.raises(Exception):
         dd_agent_check(instance, rate=True)
     endpoint_tag = "endpoint:" + instance.get('kube_state_url')

--- a/kubernetes_state/tests/test_e2e.py
+++ b/kubernetes_state/tests/test_e2e.py
@@ -1,0 +1,15 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.base import AgentCheck
+
+
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, aggregator, instance):
+    with pytest.raises(Exception):
+        dd_agent_check(instance, rate=True)
+    endpoint_tag = "endpoint:" + instance.get('kube_state_url')
+    tags = instance.get('tags').append(endpoint_tag)
+    aggregator.assert_service_check("kubernetes_state.prometheus.health", AgentCheck.CRITICAL, count=2, tags=tags)


### PR DESCRIPTION
What does this PR do?
Add a minimal E2E test for a number of integrations to ensure the check is able to run.

Motivation
Expand testing to ensure integrations errors are caught in our CI pipeline

Review checklist (to be filled by reviewers)
Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
PR must have changelog/ and integration/ labels attached