### PR TITLE
Fix inflated query metrics when pg_stat_statements.max is set above 10k

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -317,6 +317,12 @@ files:
           value:
             type: number
             example: 10
+        - name: ignore_pg_stat_statements_max_warning
+          description: |
+            Disable emission of warnings for `pg_stat_statements.max` being set higher than 10000.
+          value:
+            type: boolean
+            example: false
     - name: query_samples
       description: Configure collection of query samples
       options:

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -317,12 +317,14 @@ files:
           value:
             type: number
             example: 10
-        - name: ignore_pg_stat_statements_max_warning
+        - name: pg_stat_statements_max_warning_threshold
           description: |
-            Disable emission of warnings for `pg_stat_statements.max` being set higher than 10000.
+            Set the threshold for a safe value of `pg_stat_statements.max`. If the database is configured with a value
+            higher than this threshold, a warning is emitted to recommend lowering the setting value.
           value:
-            type: boolean
-            example: false
+            type: number
+            example: 10000
+            hidden: true
     - name: query_samples
       description: Configure collection of query samples
       options:

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -78,6 +78,7 @@ class QueryMetrics(BaseModel):
 
     collection_interval: Optional[float]
     enabled: Optional[bool]
+    ignore_pg_stat_statements_max_warning: Optional[bool]
 
 
 class QuerySamples(BaseModel):

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -78,7 +78,7 @@ class QueryMetrics(BaseModel):
 
     collection_interval: Optional[float]
     enabled: Optional[bool]
-    ignore_pg_stat_statements_max_warning: Optional[bool]
+    pg_stat_statements_max_warning_threshold: Optional[float]
 
 
 class QuerySamples(BaseModel):

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -265,6 +265,11 @@ instances:
         #
         # collection_interval: 10
 
+        ## @param ignore_pg_stat_statements_max_warning - boolean - optional - default: false
+        ## Disable emission of warnings for `pg_stat_statements.max` being set higher than 10000.
+        #
+        # ignore_pg_stat_statements_max_warning: false
+
     ## Configure collection of query samples
     #
     # query_samples:

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -265,10 +265,11 @@ instances:
         #
         # collection_interval: 10
 
-        ## @param ignore_pg_stat_statements_max_warning - boolean - optional - default: false
-        ## Disable emission of warnings for `pg_stat_statements.max` being set higher than 10000.
+        ## @param pg_stat_statements_max_warning_threshold - number - optional - default: 10000
+        ## Set the threshold for a safe value of `pg_stat_statements.max`. If the database is configured with a value
+        ## higher than this threshold, a warning is emitted to recommend lowering the setting value.
         #
-        # ignore_pg_stat_statements_max_warning: false
+        # pg_stat_statements_max_warning_threshold: 10000
 
     ## Configure collection of query samples
     #

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -27,7 +27,7 @@ except ImportError:
 
 STATEMENTS_QUERY = """
 SELECT {cols}
-  FROM {pg_stat_statements_view} as pg_stat_statements
+  FROM {pg_stat_hstatements_view} as pg_stat_statements
   LEFT JOIN pg_roles
          ON pg_stat_statements.userid = pg_roles.oid
   LEFT JOIN pg_database
@@ -235,7 +235,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 self._check.record_warning(
                     DatabaseConfigurationError.high_pg_stat_statements_max,
                     warning_with_tags(
-                        "pg_stat_statements.max is set to %d which is higher to the supported "
+                        "pg_stat_statements.max is set to %d which is higher than the supported "
                         "value of %d. This can have a negative impact on database and collection of "
                         "query metrics performance. Consider lowering the pg_stat_statements.max value to %d. "
                         "Alternatively, you may acknowledge the potential performance impact by increasing the "

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -27,7 +27,7 @@ except ImportError:
 
 STATEMENTS_QUERY = """
 SELECT {cols}
-  FROM {pg_stat_hstatements_view} as pg_stat_statements
+  FROM {pg_stat_statements_view} as pg_stat_statements
   LEFT JOIN pg_roles
          ON pg_stat_statements.userid = pg_roles.oid
   LEFT JOIN pg_database

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -121,8 +121,9 @@ class PostgresStatementMetrics(DBMAsyncJob):
             shutdown_callback=shutdown_callback,
         )
         self._metrics_collection_interval = collection_interval
-        self._pg_stat_statements_max_warning_threshold = \
-            config.statement_metrics_config.get('pg_stat_statements_max_warning_threshold', 10000)
+        self._pg_stat_statements_max_warning_threshold = config.statement_metrics_config.get(
+            'pg_stat_statements_max_warning_threshold', 10000
+        )
         self._config = config
         self._state = StatementMetrics()
         self._stat_column_cache = []

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -31,6 +31,7 @@ class DatabaseConfigurationError(Enum):
     pg_stat_statements_not_created = 'pg-stat-statements-not-created'
     pg_stat_statements_not_loaded = 'pg-stat-statements-not-loaded'
     undefined_explain_function = 'undefined-explain-function'
+    high_pg_stat_statements_max = 'high-pg-stat-statements-max-configuration'
 
 
 def warning_with_tags(warning_message, *args, **kwargs):

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1556,23 +1556,27 @@ def test_statement_metrics_database_errors(
 
 
 @pytest.mark.parametrize(
-    "pg_stat_statements_max_threshold,expected_warnings", [
-        (9999, [
-            'pg_stat_statements.max is set to 10000 which is higher than the supported value of 9999. '
-            'This can have a negative impact on database and collection of query metrics performance. '
-            'Consider lowering the pg_stat_statements.max value to 9999. Alternatively, you may acknowledge the '
-            'potential performance impact by increasing the query_metrics.pg_stat_statements_max_warning_threshold to '
-            'equal or greater than 9999 to silence this warning. '
-            'See https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#'
-            'high-pg-stat-statements-max-configuration for more details\n'
-            'code=high-pg-stat-statements-max-configuration dbname=datadog_test host=stubbed.hostname '
-            'threshold=9999 value=10000',
-        ]),
+    "pg_stat_statements_max_threshold,expected_warnings",
+    [
+        (
+                9999,
+                [
+                    'pg_stat_statements.max is set to 10000 which is higher than the supported value of 9999. '
+                    'This can have a negative impact on database and collection of query metrics performance. '
+                    'Consider lowering the pg_stat_statements.max value to 9999. Alternatively, you may acknowledge '
+                    'the potential performance impact by increasing the '
+                    'query_metrics.pg_stat_statements_max_warning_threshold to equal or greater than 9999 to silence '
+                    'this warning. See https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#'
+                    'high-pg-stat-statements-max-configuration for more details\n'
+                    'code=high-pg-stat-statements-max-configuration dbname=datadog_test host=stubbed.hostname '
+                    'threshold=9999 value=10000',
+                ]
+        ),
         (10000, []),
     ],
 )
 def test_pg_stat_statements_max_warning(
-        integration_check, dbm_instance, pg_stat_statements_max_threshold, expected_warnings
+    integration_check, dbm_instance, pg_stat_statements_max_threshold, expected_warnings
 ):
     dbm_instance['query_metrics']['pg_stat_statements_max_warning_threshold'] = pg_stat_statements_max_threshold
     check = integration_check(dbm_instance)

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1553,3 +1553,29 @@ def test_statement_metrics_database_errors(
     )
 
     assert check.warnings == expected_warnings
+
+@pytest.mark.parametrize(
+    "pg_stat_statements_max_threshold,expected_warnings", [
+        (9999, [
+            'pg_stat_statements.max is set to 10000 which is higher to the supported value of 9999. '
+            'This can have a negative impact on database and collection of query metrics performance. '
+            'Consider lowering the pg_stat_statements.max value to 9999. Alternatively, you may acknowledge the '
+            'potential performance impact by increasing the query_metrics.pg_stat_statements_max_warning_threshold to '
+            'equal or greater than 9999 to silence this warning. '
+            'See https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#'
+            'high-pg-stat-statements-max-configuration for more details\n'
+            'code=high-pg-stat-statements-max-configuration dbname=datadog_test host=stubbed.hostname '
+            'threshold=9999 value=10000',
+        ]),
+        (10000, []),
+    ],
+)
+def test_pg_stat_statements_max_warning(
+        integration_check, dbm_instance, pg_stat_statements_max_threshold, expected_warnings
+):
+    dbm_instance['query_metrics']['pg_stat_statements_max_warning_threshold'] = pg_stat_statements_max_threshold
+    check = integration_check(dbm_instance)
+    check._connect()
+    check.check(dbm_instance)
+
+    assert check.warnings == expected_warnings

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1554,6 +1554,7 @@ def test_statement_metrics_database_errors(
 
     assert check.warnings == expected_warnings
 
+
 @pytest.mark.parametrize(
     "pg_stat_statements_max_threshold,expected_warnings", [
         (9999, [

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1559,18 +1559,18 @@ def test_statement_metrics_database_errors(
     "pg_stat_statements_max_threshold,expected_warnings",
     [
         (
-                9999,
-                [
-                    'pg_stat_statements.max is set to 10000 which is higher than the supported value of 9999. '
-                    'This can have a negative impact on database and collection of query metrics performance. '
-                    'Consider lowering the pg_stat_statements.max value to 9999. Alternatively, you may acknowledge '
-                    'the potential performance impact by increasing the '
-                    'query_metrics.pg_stat_statements_max_warning_threshold to equal or greater than 9999 to silence '
-                    'this warning. See https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#'
-                    'high-pg-stat-statements-max-configuration for more details\n'
-                    'code=high-pg-stat-statements-max-configuration dbname=datadog_test host=stubbed.hostname '
-                    'threshold=9999 value=10000',
-                ]
+            9999,
+            [
+                'pg_stat_statements.max is set to 10000 which is higher than the supported value of 9999. '
+                'This can have a negative impact on database and collection of query metrics performance. '
+                'Consider lowering the pg_stat_statements.max value to 9999. Alternatively, you may acknowledge '
+                'the potential performance impact by increasing the '
+                'query_metrics.pg_stat_statements_max_warning_threshold to equal or greater than 9999 to silence '
+                'this warning. See https://docs.datadoghq.com/database_monitoring/setup_postgres/troubleshooting#'
+                'high-pg-stat-statements-max-configuration for more details\n'
+                'code=high-pg-stat-statements-max-configuration dbname=datadog_test host=stubbed.hostname '
+                'threshold=9999 value=10000',
+            ],
         ),
         (10000, []),
     ],

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1558,7 +1558,7 @@ def test_statement_metrics_database_errors(
 @pytest.mark.parametrize(
     "pg_stat_statements_max_threshold,expected_warnings", [
         (9999, [
-            'pg_stat_statements.max is set to 10000 which is higher to the supported value of 9999. '
+            'pg_stat_statements.max is set to 10000 which is higher than the supported value of 9999. '
             'This can have a negative impact on database and collection of query metrics performance. '
             'Consider lowering the pg_stat_statements.max value to 9999. Alternatively, you may acknowledge the '
             'potential performance impact by increasing the query_metrics.pg_stat_statements_max_warning_threshold to '


### PR DESCRIPTION
### What does this PR do?

#### Context and issue
Before this change, we had a hardcoded limit of 10000 rows on the query we used to retrieve query stats from `pg_stat_statements`. This is fine in most cases as our [setup docs](https://docs.datadoghq.com/database_monitoring/setup_postgres/selfhosted?tab=postgres10) recommend setting `pg_stat_statements.max` to 10000 in the postgres configuration. However, that setting is optional and it's possible for customers to have a higher value for `pg_stat_statements.max`. In such cases, the integration's assumption that the full set of queries was captured on every check execution was broken as some queries could fall in and out of the "window" of 10000 rows imposed by the `LIMIT 10000`. When this would happen, a query having fallen out of the window and coming back in would be reported as if the current stats had all been happening in the last check execution. Hence the inflated metrics. 

In practice, this looked something like this:
<img width="542" alt="Screen Shot 2022-11-29 at 4 25 26 PM" src="https://user-images.githubusercontent.com/788439/204677825-e406e3a6-0701-4ee1-8b95-625070e82ea9.png">

#### Change
This PR updates the query that fetches stats from `pg_stat_statement` to remove the limit. Since it's always going to be problematic to have a limit in the integration that is less than the configured `pg_stat_statements.max`, we're opting for the better user experience of leaving only one knob to tweak: postgres' `pg_stat_statements.max` setting. To mitigate for the potential performance issues on the database and the postgres integration, this PR also includes detection of a high `pg_stat_statements.max` setting value and a warning is emitted when this happens. A user can then either update the warning threshold if the risk is acknowledged and judged acceptable or they can lower their `pg_stat_statements.max` configuration on the db side. 

### Motivation
A report of unexplainable inflated query metrics with postgres. 

### Additional Notes
Tracked internally in [DBM-1845](https://datadoghq.atlassian.net/browse/DBM-1895)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.