### PR TITLE
Add well formatted agent errors on common connection issues for SQL Server

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -285,7 +285,7 @@ class Connection(object):
         except Exception as e:
             error_message = self.test_network_connectivity()
             tcp_connection_status = error_message if error_message else "OK"
-            exception_msg, conn_warn_msg = format_connection_exception(e, driver, self.log)
+            exception_msg, conn_warn_msg = format_connection_exception(e, driver)
             message = "Unable to connect to SQL Server (host={} database={}). TCP-connection({}). Exception: {}".format(
                 host, database, tcp_connection_status, exception_msg
             )
@@ -295,9 +295,6 @@ class Connection(object):
             password = self.instance.get('password')
             if password is not None:
                 message = message.replace(password, "*" * 6)
-
-            self.log.warning(exception_msg)
-            # self.log.warning(conn_warn_msg.value)
 
             if conn_warn_msg is None:
                 conn_warn_msg = ConnectionErrWarning.unknown

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -316,6 +316,10 @@ class Connection(object):
                 # the message that is raised here (along with the exception stack trace)
                 # is what will be seen in the agent status output.
                 raise_from(SQLConnectionError(check_err_message), None)
+            else:
+                # if not the default db, we should still log this exception
+                # to give the customer an opportunity to fix the issue
+                self.log.debug(check_err_message)
 
     def _setup_new_connection(self, rawconn):
         with rawconn.cursor() as cursor:

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -285,7 +285,7 @@ class Connection(object):
         except Exception as e:
             error_message = self.test_network_connectivity()
             tcp_connection_status = error_message if error_message else "OK"
-            exception_msg, conn_warn_msg = format_connection_exception(e, driver)
+            exception_msg, conn_warn_msg = format_connection_exception(e, driver, self.log)
             message = "Unable to connect to SQL Server (host={} database={}). TCP-connection({}). Exception: {}".format(
                 host, database, tcp_connection_status, exception_msg
             )
@@ -295,6 +295,9 @@ class Connection(object):
             password = self.instance.get('password')
             if password is not None:
                 message = message.replace(password, "*" * 6)
+
+            self.log.warning(exception_msg)
+            # self.log.warning(conn_warn_msg.value)
 
             if conn_warn_msg is None:
                 conn_warn_msg = ConnectionErrWarning.unknown

--- a/sqlserver/datadog_checks/sqlserver/connection_errors.py
+++ b/sqlserver/datadog_checks/sqlserver/connection_errors.py
@@ -1,0 +1,148 @@
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+import re
+from enum import Enum
+
+try:
+    import pyodbc
+except ImportError:
+    pyodbc = None
+
+try:
+    import adodbapi
+    from adodbapi.apibase import OperationalError
+    from pywintypes import com_error
+except ImportError:
+    adodbapi = None
+
+
+class SQLConnectionError(Exception):
+    """Exception raised for SQL instance connection issues"""
+
+    pass
+
+
+class ConnectionErrWarning(Enum):
+    """
+    Denotes the various reasons a connection might fail.
+    """
+
+    unknown = "diagnosing-common-connection-issues"
+    login_failed_for_user = "sql-server-unable-to-connect-login-failed-for-user"
+    tcp_connection_failed = "sql-server-unable-to-connect-due-to-invalid-connection-string-attribute"
+    certificate_verify_failed = "ssl-provider-the-certificate-chain-was-issued-by-an-authority-that-is-not-trusted"
+    driver_not_installed = "picking-a-sql-server-driver"
+    dsn_not_found = "data-source-name-not-found-and-no-default-driver-specified"
+    ssl_security_error = 'sql-server-unable-to-connect-ssl-security-error-18'
+
+
+ODBC_DB_FAILURE_REGEX = "(cannot open database .* requested by the login. the login failed|login timeout expired)"
+
+
+# Connection error messages, which we expect to get from an ODBC driver
+# ODBC drivers have inconsistent error codes across versions, so regex on
+# the known error messages
+known_odbc_error_patterns = {
+    # DSN could be specified incorrectly in config
+    "data source name not found, and no default driver specified": ConnectionErrWarning.dsn_not_found,
+    # driver not installed on host
+    "can't open lib .* file not found": ConnectionErrWarning.driver_not_installed,
+    # SSL verification failed
+    "certificate verify failed": ConnectionErrWarning.certificate_verify_failed,
+    # Connection & login issues
+    ODBC_DB_FAILURE_REGEX: ConnectionErrWarning.tcp_connection_failed,
+    "login failed for user": ConnectionErrWarning.login_failed_for_user,
+    "ssl security error": ConnectionErrWarning.ssl_security_error,
+}
+
+# Connection error messages, which we expect to get from an ADO provider
+known_ado_errors = {
+    # typically results in an -2147467259 error code, which is not very descriptive. Identifying this error
+    # can help provide specific troubleshooting help to the customer
+    "certificate chain was issued by an authority that is not trusted": ConnectionErrWarning.certificate_verify_failed,
+}
+
+# ADO provider connection errors yield a hresult code, which
+# can be mapped to helpful err messages
+known_hresult_codes = {
+    -2147352567: ["unable to connect", ConnectionErrWarning.tcp_connection_failed],
+    -2147217843: ["login failed for user", ConnectionErrWarning.login_failed_for_user],
+    -2146824582: ["provider not found", ConnectionErrWarning.driver_not_installed],
+    # this error can also be e caused by a failed TCP connection, but we are already reporting on the TCP
+    # connection status via test_network_connectivity, so we don't need to explicitly state that
+    # as an error condition in this message
+    -2147467259: ["could not open database requested by login", ConnectionErrWarning.tcp_connection_failed],
+}
+
+
+def warning_with_tags(warning_message, *args, **kwargs):
+    if args:
+        warning_message = warning_message % args
+
+    return "{msg}\n{tags}".format(
+        msg=warning_message, tags=" ".join('{key}={value}'.format(key=k, value=v) for k, v in sorted(kwargs.items()))
+    )
+
+
+def format_connection_exception(e, driver):
+    """
+    Formats the provided database connection exception.
+    If the exception comes from an ADO Provider and contains a misleading 'Invalid connection string attribute' message
+    then the message is replaced with more descriptive messages based on the contained HResult error codes.
+    """
+    if adodbapi is not None:
+        if isinstance(e, OperationalError) and e.args and isinstance(e.args[0], com_error):
+            e_comm = e.args[0]
+            hresult = e_comm.hresult
+            sub_hresult = None
+            internal_message = None
+            if e_comm.args and len(e_comm.args) == 4:
+                internal_args = e_comm.args[2]
+                if len(internal_args) == 6:
+                    internal_message = internal_args[2]
+                    sub_hresult = internal_args[5]
+            base_message, base_conn_err = _lookup_ado_conn_error_and_msg(hresult, internal_message)
+            sub_message, sub_conn_err = _lookup_ado_conn_error_and_msg(sub_hresult, internal_message)
+            if internal_message == 'Invalid connection string attribute':
+                if base_message and sub_message:
+                    conn_err = sub_conn_err if sub_conn_err else base_conn_err
+                    return base_message + ": " + sub_message, conn_err
+            else:
+                # else we can return the original exception message + lookup the proper
+                # ConnectionErrWarning for this issue
+                conn_err = sub_conn_err if sub_conn_err else base_conn_err
+                return repr(e), conn_err
+
+    elif pyodbc is not None:
+        e_msg = repr(e)
+        conn_err = _lookup_odbc_conn_error(e_msg)
+        if conn_err == ConnectionErrWarning.driver_not_installed:
+            installed, drivers = _get_is_odbc_driver_installed(driver)
+            if not installed and drivers:
+                e_msg += " configured odbc driver {} not in list of installed drivers: {}".format(driver, drivers)
+        return e_msg, conn_err
+
+    return repr(e), None
+
+
+def _get_is_odbc_driver_installed(configured_driver):
+    if pyodbc is not None:
+        drivers = pyodbc.drivers()
+        return configured_driver in drivers, drivers
+    return False, None
+
+
+def _lookup_odbc_conn_error(msg):
+    for k in known_odbc_error_patterns.keys():
+        if re.search(k.lower(), msg.lower()):
+            return known_odbc_error_patterns[k]
+
+
+def _lookup_ado_conn_error_and_msg(hresult, msg):
+    for k in known_ado_errors.keys():
+        if k.lower() in msg.lower():
+            return None, known_ado_errors[k]
+    if hresult > 0:
+        res = known_hresult_codes.get(hresult)
+        if len(res) > 0:
+            return res[0], res[1]

--- a/sqlserver/datadog_checks/sqlserver/connection_errors.py
+++ b/sqlserver/datadog_checks/sqlserver/connection_errors.py
@@ -48,7 +48,7 @@ known_error_patterns = {
     # driver not installed on host
     "(can't open lib .* file not found|Provider cannot be found)": ConnectionErrorCode.driver_not_found,
     # Connection & login issues
-    "(cannot open database .* requested by the login. the login failed|"
+    "(cannot open database .* requested by the login|"
     "login timeout expired)": ConnectionErrorCode.tcp_connection_failed,
     "(login failed for user|The login is from an untrusted domain)": ConnectionErrorCode.login_failed_for_user,
     "ssl security error": ConnectionErrorCode.ssl_security_error,

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -486,7 +486,7 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
         if databases is None:
             databases = []
 
-        cursor.execute('select DB_NAME()')  # This can return None in some implementations so it cannot be chained
+        cursor.execute('select DB_NAME()')  # This can return None in some implementations, so it cannot be chained
         data = cursor.fetchall()
         current_db = data[0][0]
         logger.debug("%s: current db is %s", cls.__name__, current_db)

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -681,7 +681,7 @@ class SQLServer(AgentCheck):
         return self._dynamic_queries
 
     def collect_metrics(self):
-        """Fetch the metrics from all of the associated database tables."""
+        """Fetch the metrics from all the associated database tables."""
 
         with self.connection.open_managed_default_connection():
             with self.connection.get_managed_cursor() as cursor:

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -435,10 +435,16 @@ def test_connection_error_reporting(
         with connection.open_managed_default_connection():
             pytest.fail("connection should not have succeeded")
 
-    message = str(excinfo.value)
-    assert re.search(expected_error_pattern, message)
+    message = str(excinfo.value).lower()
+    assert re.search(expected_error_pattern, message, re.IGNORECASE)
     expected_link = "see {}#{} for more details".format(SUPPORT_LINK, expected_error.value)
-    assert re.search(expected_link, message, re.IGNORECASE)
+    if expected_error == ConnectionErrorCode.tcp_connection_failed:
+        user_link = "see {}#{} for more details".format(SUPPORT_LINK, ConnectionErrorCode.login_failed_for_user.value)
+        assert (
+            expected_link.lower() in message or user_link.lower() in message
+        )
+    else:
+        assert expected_link.lower() in message
 
 
 @pytest.mark.unit

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -327,26 +327,27 @@ def test_connection_failure(aggregator, dd_run_check, instance_docker):
             "unknown_adoprovider",
             {'adoprovider': "fake"},
             {".*": "TCP-connection\\(OK\\).*Provider cannot be found. It may not be properly installed."},
-            ConnectionErrWarning.driver_not_installed,
+            ConnectionErrWarning.driver_not_found,
         ),
         (
             "unknown_odbc_driver",
             {'driver': "{SQL Driver For Fake Tests 2022}"},
             {
-                "odbc-linux|odbc-windows": "TCP-connection\\(OK\\).*"
-                # "Can't open lib .* file not found .* configured odbc driver .* not in list of installed drivers",
-                "Can't open lib .* file not found",
+                "odbc-linux": "TCP-connection\\(OK\\).*"
+                "Can't open lib .* file not found .* configured odbc driver .* not in list of installed drivers",
+                "odbc-windows": "TCP-connection\\(OK\\).*"
+                "Data source name not found.* and no default driver specified",
             },
-            ConnectionErrWarning.driver_not_installed,
+            ConnectionErrWarning.driver_not_found,
         ),
         (
             "odbc_driver_incorrect_dsn",
             {'dsn': "Not The Real DSN"},
             {
                 "odbc-linux|odbc-windows": "TCP-connection\\(OK\\).*"
-                "Data source name not found, and no default driver specified",
+                "Data source name not found.* and no default driver specified",
             },
-            ConnectionErrWarning.dsn_not_found,
+            ConnectionErrWarning.driver_not_found,
         ),
         (
             "unknown_hostname",

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -440,9 +440,7 @@ def test_connection_error_reporting(
     expected_link = "see {}#{} for more details".format(SUPPORT_LINK, expected_error.value)
     if expected_error == ConnectionErrorCode.tcp_connection_failed:
         user_link = "see {}#{} for more details".format(SUPPORT_LINK, ConnectionErrorCode.login_failed_for_user.value)
-        assert (
-            expected_link.lower() in message or user_link.lower() in message
-        )
+        assert expected_link.lower() in message or user_link.lower() in message
     else:
         assert expected_link.lower() in message
 

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -157,7 +157,7 @@ def test_autodiscovery_database_metrics(aggregator, dd_run_check, instance_autod
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    'service_check_enabled, default_count, extra_count',
+    'service_check_enabled,default_count,extra_count',
     [(True, 4, 1), (False, 0, 0)],
 )
 @pytest.mark.usefixtures('dd_environment')
@@ -176,7 +176,7 @@ def test_autodiscovery_db_service_checks(
         status=SQLServer.OK,
     )
 
-    # verify all databses in autodiscovery have a service check
+    # verify all databases in autodiscovery have a service check
     aggregator.assert_service_check(
         'sqlserver.database.can_connect',
         count=default_count,
@@ -189,14 +189,21 @@ def test_autodiscovery_db_service_checks(
         tags=['db:msdb', 'optional:tag1', 'sqlserver_host:localhost,1433'],
         status=SQLServer.OK,
     )
-    # unavailable_db is an 'offline' database which prevents connections so we expect this service check to be
+    # unavailable_db is an 'offline' database which prevents connections, so we expect this service check to be
     # critical but not cause a failure of the check
-    aggregator.assert_service_check(
-        'sqlserver.database.can_connect',
-        count=extra_count,
-        tags=['db:unavailable_db', 'optional:tag1', 'sqlserver_host:localhost,1433'],
-        status=SQLServer.CRITICAL,
-    )
+    # TODO: add support to the assert_service_check function to take a message regex pattern
+    # to match against, so this assertion does not require the exact string
+    sc = aggregator.service_checks('sqlserver.database.can_connect')
+    db_critical_exists = False
+    for c in sc:
+        if c.status == SQLServer.CRITICAL:
+            db_critical_exists = True
+            assert (
+                c.tags.sort()
+                == ['db:unavailable_db', 'optional:tag1', 'sqlserver_host:{}'.format(check.resolved_hostname)].sort()
+            )
+    if service_check_enabled:
+        assert db_critical_exists
 
 
 @pytest.mark.integration

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -22,16 +22,16 @@ except ImportError:
 @pytest.mark.usefixtures('dd_environment')
 def test_check_invalid_password(aggregator, dd_run_check, init_config, instance_docker):
     instance_docker['password'] = 'FOO'
-
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
 
-    with pytest.raises(SQLConnectionError):
+    with pytest.raises(SQLConnectionError) as excinfo:
         sqlserver_check.initialize_connection()
         sqlserver_check.check(instance_docker)
     aggregator.assert_service_check(
         'sqlserver.can_connect',
         status=sqlserver_check.CRITICAL,
-        tags=['sqlserver_host:localhost,1433', 'db:master', 'optional:tag1'],
+        tags=['sqlserver_host:{}'.format(sqlserver_check.resolved_hostname), 'db:master', 'optional:tag1'],
+        message=str(excinfo.value),
     )
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds the following:

1. Support for reporting agent errors on common sqlserver connection issues. This should help reduce integration setup friction for customers.
2. Updates the default drivers for each connectors so customers will no longer use old/out dated drivers by default

     `adoprovider` connector -> `'MSOLEDBSQL'`
     `odbc` connector -> `'{ODBC Driver 18 for SQL Server}'`

The updated agent error formatting results in this error messages like this showing up in the agent status when there are connection issues.

```
Error: Unable to connect to SQL Server, see https://docs.datadoghq.com/database_monitoring/setup_sql_server/troubleshooting#login-failed-for-user for more details on how to debug this issue. TCP-connection(OK), Exception: ProgrammingError('42000', "[42000] [FreeTDS][SQL Server]Login failed for user 'datadog'. (18456) (SQLDriverConnect)")
code=login-failed-for-user connector=odbc database=master driver=FreeTDS host=dbm-sqlserver-ee-2019-ao.cfxxae8cilce.us-east-1.rds.amazonaws.com
```

Note the pointer to our troubleshooting documentation on how to debug login issues https://docs.datadoghq.com/database_monitoring/setup_sql_server/troubleshooting#login-failed-for-user. These messages will be forwarded to our backend & used to support a new UI around debugging agent setup & configuration issues.

Relies on this extra docs PR https://github.com/DataDog/documentation/pull/16080

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.