### PR TITLE
Make `ddev validate license-header` honor gitignore files

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
@@ -40,7 +40,7 @@ def license_headers(ctx, check):
         path_to_check = root / check_name
         ignores = [pathlib.Path(p) for p in IGNORES.get(check_name, [])]
         ignores.extend([pathlib.Path(p) for p in IGNORES.get("all")])
-        errors = validate_license_headers(path_to_check, ignore=ignores)
+        errors = validate_license_headers(path_to_check, ignore=ignores, repo_root=root)
 
         for err in errors:
             echo_failure(f'{check_name}/{err.path}: {err.message}')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
@@ -100,7 +100,10 @@ def validate_license_headers(
         elif license_header != get_default_license_header():
             return LicenseHeaderError("file does not match expected license format", relpath)
 
-    gitignore_matcher = _GitIgnoreMatcher.from_path_to_root(check_path, repo_root)
+    if repo_root:
+        gitignore_matcher = _GitIgnoreMatcher.from_path_to_root(check_path, repo_root)
+    else:
+        gitignore_matcher = _GitIgnoreMatcher(check_path)
 
     # Walk through subdirs and validate files
     errors = []
@@ -122,7 +125,16 @@ def parse_license_header(contents):
 
 
 class _GitIgnoreMatcher:
-    """Class to combine multiple `GitIgnoreSpec`s"""
+    """A class to find gitignore matches recursively. Each instance represents
+    a folder in a directory structure with possibly a `.gitignore` file in it.
+
+    Instances get linked to other instances representing their parent folder,
+    so that parents' .gitignore files are taken into account if necessary
+    to determine a match.
+
+    This implementation doesn't support overriding (via the negation `!` operator) of
+    ignored patterns defined in parents.
+    """
 
     def __init__(self, path, parent=None):
         self._parent = parent
@@ -130,28 +142,30 @@ class _GitIgnoreMatcher:
         self._matcher = _gitignore_spec_from_file(path / '.gitignore')
 
     @classmethod
-    def from_path_to_root(cls, path, repo_root=None):
-        if repo_root:
-            parents = [parent for parent in reversed(path.relative_to(repo_root).parents)]
-            instance = cls(repo_root)
-            for parent in parents[1:]:
-                instance = instance.for_path(repo_root / parent)
-            return instance.for_path(path)
-        else:
-            return cls(path)
+    def from_path_to_root(cls, path, repo_root):
+        """Create a matcher with parents linked up to the provided `repo_root`"""
+        # Create all the intermediate instances between the `repo_root` and the `path`
+        # and link them together.
+        parents = [parent for parent in reversed(path.relative_to(repo_root).parents)]
+        instance = cls(repo_root)
+        for parent in parents[1:]:
+            instance = instance.for_path(repo_root / parent)
+
+        return instance.for_path(path)
 
     def for_path(self, path):
         """Returns a new matcher that takes the current matcher as a parent."""
         return self.__class__(path, self)
 
-    def match(self, relpath):
-        """Return whether the given relative path is matched, checking top to bottom."""
-        path_to_match = relpath.relative_to(self._path).as_posix()
+    def match(self, path):
+        """Return whether the given path is matched, checking top to bottom."""
+        # Each .gitignore must match relative patterns based on the folder it's in
+        path_to_match = path.relative_to(self._path).as_posix()
 
         if self._matcher and self._matcher.match_file(path_to_match):
             return True
         elif self._parent:
-            return self._parent.match(relpath)
+            return self._parent.match(path)
         else:
             return False
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
@@ -53,7 +53,6 @@ def validate_license_headers(
     - Only python (*.py) files need a license header
     - Code under hidden folders (starting with `.`) are ignored
     """
-    root = check_path
     ignoreset = set(ignore or [])
 
     def walk_recursively(path, gitignore_matcher):
@@ -69,7 +68,7 @@ def validate_license_headers(
                 if child.relative_to(child.parent).as_posix().startswith('.'):
                     continue
 
-                relpath = child.relative_to(root)
+                relpath = child.relative_to(check_path)
                 # Skip blacklisted folders
                 if relpath in ignoreset:
                     continue
@@ -86,7 +85,7 @@ def validate_license_headers(
             contents = f.read()
 
         license_header = parse_license_header(contents)
-        relpath = path.relative_to(root).as_posix()
+        relpath = path.relative_to(check_path).as_posix()
 
         # License is missing altogether
         if not license_header:
@@ -101,11 +100,11 @@ def validate_license_headers(
         elif license_header != get_default_license_header():
             return LicenseHeaderError("file does not match expected license format", relpath)
 
-    gitignore_matcher = _GitIgnoreMatcher.from_path_to_root(root, repo_root)
+    gitignore_matcher = _GitIgnoreMatcher.from_path_to_root(check_path, repo_root)
 
     # Walk through subdirs and validate files
     errors = []
-    for candidate in walk_recursively(root, gitignore_matcher):
+    for candidate in walk_recursively(check_path, gitignore_matcher):
         if error := validate_license_header(candidate):
             errors.append(error)
 

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -72,7 +72,7 @@ cli = [
     "orjson",
     "packaging",
     "pip-tools",
-    "pathspec",
+    "pathspec>=0.10.0",
     "platformdirs>=2.0.0a3",
     "pyperclip>=1.7.0",
     "pysmi>=0.3.4",

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -72,6 +72,7 @@ cli = [
     "orjson",
     "packaging",
     "pip-tools",
+    "pathspec",
     "platformdirs>=2.0.0a3",
     "pyperclip>=1.7.0",
     "pysmi>=0.3.4",

--- a/datadog_checks_dev/tests/tooling/test_license_headers.py
+++ b/datadog_checks_dev/tests/tooling/test_license_headers.py
@@ -207,3 +207,20 @@ def _make_get_previous(d: dict = None):
         return d.get(path)
 
     return _fake_get_previous
+
+
+def test_validate_license_headers_honors_gitignore_file_on_check_path(tmp_path):
+    check_path = tmp_path / "check"
+    check_path.mkdir()
+
+    # .gitignore at check_path
+    with open(check_path / ".gitignore", "w") as f:
+        f.write("build/\n")
+
+    target_path = check_path / "foo" / "build"
+    target_path.mkdir(parents=True)
+
+    with open(target_path / "some.py", "w") as f:
+        f.write("import os\n")
+
+    assert validate_license_headers(check_path) == []

--- a/datadog_checks_dev/tests/tooling/test_license_headers.py
+++ b/datadog_checks_dev/tests/tooling/test_license_headers.py
@@ -224,3 +224,24 @@ def test_validate_license_headers_honors_gitignore_file_on_check_path(tmp_path):
         f.write("import os\n")
 
     assert validate_license_headers(check_path) == []
+
+
+def test_validate_license_headers_honors_nested_gitignore_files(tmp_path):
+    check_path = tmp_path / "check"
+    check_path.mkdir()
+
+    # .gitignore at check_path allows `build/`
+    with open(check_path / ".gitignore", "w") as f:
+        f.write("!build/\n")
+
+    target_path = check_path / "foo" / "build"
+    target_path.mkdir(parents=True)
+
+    # .gitignore at subfolder disallows `build/`, overriding the parent's gitignore
+    with open(check_path / "foo" / ".gitignore", "w") as f:
+        f.write("build/\n")
+
+    with open(target_path / "some.py", "w") as f:
+        f.write("import os\n")
+
+    assert validate_license_headers(check_path) == []


### PR DESCRIPTION
### What does this PR do?

Makes `ddev validate license-header` honor gitignore files.

### Motivation

https://github.com/DataDog/integrations-core/pull/13417#discussion_r1035095161

### Additional Notes

The implementation doesn't support all possible combinations of gitignore files that may appear at different levels. In particular, a negation (`!`) pattern won't re-include patterns excluded by gitignore files found in parents. Implementing this functionality properly would add significant complexity, which is not worth it since we barely use that pattern at all, and the places where I've found it used, it doesn't concern files that would require license header validation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.