### PR TITLE
Add to debug logging in mysql statement samples job

### DIFF
--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -470,7 +470,9 @@ class MySQLStatementSamples(DBMAsyncJob):
             self._check.histogram(
                 "dd.mysql.get_new_events_statements.rows", len(rows), tags=tags, hostname=self._check.resolved_hostname
             )
-            self._log.debug("Read %s rows from %s", len(rows), events_statements_table)
+            self._log.debug(
+                "Read %s rows from %s after checkpoint %d", len(rows), events_statements_table, self._checkpoint
+            )
             return rows
 
     def _filter_valid_statement_rows(self, rows):
@@ -670,7 +672,9 @@ class MySQLStatementSamples(DBMAsyncJob):
                 continue
             rows = self._get_new_events_statements(table, 1)
             if not rows:
-                self._log.debug("No statements found in %s table. checking next one.", table)
+                self._log.debug(
+                    "No statements found in %s table after checkpoint %d. checking next one.", table, self._checkpoint
+                )
                 continue
             events_statements_table = table
             break

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -454,7 +454,13 @@ class MySQLStatementSamples(DBMAsyncJob):
                 ),
                 params,
             )
+            self._log.debug(
+                "Fetching all rows from events statements query, table %s. Using window function? %s",
+                events_statements_table,
+                self._has_window_functions,
+            )
             rows = cursor.fetchall()
+
             self._cursor_run(cursor, drop_temp_table_query)
             tags = (
                 self._tags


### PR DESCRIPTION
### What does this PR do?
Adds to debug logging in mysql statement samples job:
- adds the checkpoint we are using to filter statements
- adds a log just before we fetch all rows, with datapoint about window function usage

### Motivation
We have a curious [support issue](https://datadoghq.atlassian.net/browse/SDBM-296) for MySQL running on Aurora. After a failover, we report no rows available in the events statements tables, which prevents us from collecting any query samples. Restarting the agent resolves this. It's clear that we are getting into the `_get_new_events_statements` function, and incorrectly reporting that the events statements tables have no rows; but it's not clear what is causing the incorrect row counts to be reported. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.