### PR TITLE
Add an option to ignore failed environments in env start

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -47,7 +47,9 @@ from .stop import stop
 @click.option('--filter', '-k', 'test_filter', help='Only run tests matching given substring expression')
 @click.option('--changed', is_flag=True, help='Only test changed checks')
 @click.option('--debug', '-d', is_flag=True, help='Set the log level to debug')
-@click.option('--skip-failed-environments', '-sfe', is_flag=True, help='Skip environments that failed to start and continue')
+@click.option(
+    '--skip-failed-environments', '-sfe', is_flag=True, help='Skip environments that failed to start and continue'
+)
 @click.pass_context
 def test(
     ctx,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add an option to ignore failed environments in env start

### Motivation
<!-- What inspired you to submit this pull request? -->

Some integrations have environments only for windows platforms and some for linux/windows. This is not ideal but that's what we have right now. It means that if you want to run all the tests that are compatible with your current platform, you'll have to enumerate them one by one because otherwise the test suite will stop after the first failed environment.

https://datadoghq.atlassian.net/browse/AITOOLS-53

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- I did not add unit test because it's not possible to mock the context passed to a click command invoked by the runner in a unit test. We will try to improve it when the commands will be ported to ddev
- You can test it on any windows only integrations on your mac. With the option, it should iterate over all the envs, without it will stop after the first one. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.