### PR TITLE
Pin the keystoneauth1 version for py2

### DIFF
--- a/openstack_controller/pyproject.toml
+++ b/openstack_controller/pyproject.toml
@@ -41,6 +41,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "openstacksdk==0.39.0; python_version < '3.0'",
+    "keystoneauth1==5.0.0; python_version < '3.0'",
     "openstacksdk==0.61.0; python_version > '3.0'",
 ]
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Pin the keystoneauth1 version for py2

### Motivation
<!-- What inspired you to submit this pull request? -->

Version 5.1.0 broke our py2 tests.

Note: py2 is not officially supported. The version 5.0.0 even dropped py 36 and 37

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.