### PR TITLE
Revert "Fix exception thrown when database is null in config"

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -394,7 +394,7 @@ class Connection(object):
                 self.close_cursor(cursor)
 
         exists = False
-        if database and database.lower() in self.existing_databases:
+        if database.lower() in self.existing_databases:
             case_insensitive, cased_name = self.existing_databases[database.lower()]
             if case_insensitive or database == cased_name:
                 exists = True


### PR DESCRIPTION
Reverts DataDog/integrations-core#12882

While the original fix addresses the warning, it actually breaks the integration for customers using autodiscovery. This is because it changes the initialization behavior from a log to an initialization error.

### Explanation

On this line, the DB will never exist: https://github.com/DataDog/integrations-core/blob/d64e5bb0128a024d139f7a1021d8521a36650baf/sqlserver/datadog_checks/sqlserver/sqlserver.py#L287 because `self.connection.check_database()` called with no database configured results in a database of `None`. The exception is caught here and ignored: https://github.com/DataDog/integrations-core/blob/d64e5bb0128a024d139f7a1021d8521a36650baf/sqlserver/datadog_checks/sqlserver/sqlserver.py#L313-L314

With my change in the original PR, the DB `None` does not exist, resulting in this flow and a `ConfigurationError` being raised: https://github.com/DataDog/integrations-core/blob/d64e5bb0128a024d139f7a1021d8521a36650baf/sqlserver/datadog_checks/sqlserver/sqlserver.py#L287-L307