### PR TITLE
Add Cloudera cm-client dependency

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,8 +63,8 @@ trigger-agent-build:
       changes:
         - datadog_checks_base/datadog_checks/base/data/agent_requirements.in
       when: always
-    - if: ($CI_COMMIT_BRANCH !~ /^7.[0-9]{2}.x/)
-      when: always
+    # - if: ($CI_COMMIT_BRANCH !~ /^7.[0-9]{2}.x/)
+    #   when: always
   cache:
     <<: *slack-cache
   script:

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -19,6 +19,7 @@ cachetools,PyPI,MIT,Thomas Kemmer
 check-postgres,"https://github.com/bucardo/",BSD-2-Clause,Greg Sabino Mullane
 clickhouse-cityhash,PyPI,MIT,Alexander [Amper] Marshalov
 clickhouse-driver,PyPI,MIT,Konstantin Lebedev
+cm-client,PyPI,Apache-2.0,
 contextlib2,PyPI,PSF,Nick Coghlan
 cryptography,PyPI,Apache-2.0,The Python Cryptographic Authority and individual contributors | The cryptography developers
 cryptography,PyPI,BSD-3-Clause,The Python Cryptographic Authority and individual contributors | The cryptography developers

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -15,6 +15,7 @@ cachetools==5.2.0; python_version > '3.0'
 clickhouse-cityhash==1.0.2.3
 clickhouse-driver==0.2.0; python_version < '3.0'
 clickhouse-driver==0.2.3; python_version > '3.0'
+cm-client==45.0.4
 contextlib2==0.6.0.post1; python_version < '3.0'
 cryptography==3.3.2; python_version < '3.0'
 cryptography==38.0.3; python_version > '3.0'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -28,6 +28,8 @@ EXPLICIT_LICENSES = {
     'gssapi': ['ISC'],
     # https://github.com/cannatag/ldap3/blob/dev/COPYING.txt
     'ldap3': ['LGPL-3.0-only'],
+    # https://cloudera.github.io/cm_api/
+    'cm-client': ['Apache-2.0'],
     # https://github.com/oauthlib/oauthlib/blob/master/LICENSE
     'oauthlib': ['BSD-3-Clause'],
     # https://github.com/paramiko/paramiko/blob/master/LICENSE


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR is an offshoot of https://github.com/DataDog/integrations-core/pull/13244 which adds the Cloudera integration. Instead of adding the `cm-client` dependency in the main Cloudera PR, we are separating the dependency PR. This would stop running all pipelines and starting an agent build every time a commit was made, which would save time when running CI.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.