### PR TITLE
Output non-critical information to stderr

### DIFF
--- a/ddev/src/ddev/cli/config/__init__.py
+++ b/ddev/src/ddev/cli/config/__init__.py
@@ -36,9 +36,9 @@ def find(app, copy):
 
         pyperclip.copy(config_path)
     elif ' ' in config_path:
-        app.display_info(f'"{config_path}"')
+        app.display(f'"{config_path}"')
     else:
-        app.display_info(config_path)
+        app.display(config_path)
 
 
 @config.command(short_help='Show the contents of the config file')
@@ -47,7 +47,7 @@ def find(app, copy):
 def show(app, all_keys):
     """Show the contents of the config file."""
     if not app.config_file.path.is_file():  # no cov
-        app.display_info('No config file found! Please try `ddev config restore`.')
+        app.display_critical('No config file found! Please try `ddev config restore`.')
     else:
         from rich.syntax import Syntax
 

--- a/ddev/src/ddev/cli/status/__init__.py
+++ b/ddev/src/ddev/cli/status/__init__.py
@@ -15,14 +15,14 @@ if TYPE_CHECKING:
 @click.pass_obj
 def status(app: Application):
     """Show information about the current environment."""
-    app.display_always(f'Repo: {app.repo.name} @ {app.repo.path}')
-    app.display_always(f'Branch: {app.repo.git.current_branch}')
-    app.display_always(f'Org: {app.config.org.name}')
+    app.display(f'Repo: {app.repo.name} @ {app.repo.path}')
+    app.display(f'Branch: {app.repo.git.current_branch}')
+    app.display(f'Org: {app.config.org.name}')
 
     if changed_integrations := [i.name for i in app.repo.integrations.iter_changed()]:
         import shutil
         import textwrap
 
-        app.display_always(
+        app.display(
             textwrap.shorten(f'Changed: {", ".join(changed_integrations)}', width=shutil.get_terminal_size().columns)
         )

--- a/ddev/src/ddev/cli/terminal.py
+++ b/ddev/src/ddev/cli/terminal.py
@@ -58,45 +58,57 @@ class Terminal:
 
         return errors
 
+    def display(self, text='', **kwargs):
+        self.console.print(text, style=self._style_level_info, overflow='ignore', no_wrap=True, crop=False, **kwargs)
+
+    def display_critical(self, text='', **kwargs):
+        self.console.stderr = True
+        try:
+            self.console.print(
+                text, style=self._style_level_error, overflow='ignore', no_wrap=True, crop=False, **kwargs
+            )
+        finally:
+            self.console.stderr = False
+
     def display_error(self, text='', stderr=True, indent=None, link=None, **kwargs):
         if self.verbosity < -2:
             return
 
-        self.display(text, self._style_level_error, stderr=stderr, indent=indent, link=link, **kwargs)
+        self.output(text, self._style_level_error, stderr=stderr, indent=indent, link=link, **kwargs)
 
-    def display_warning(self, text='', stderr=False, indent=None, link=None, **kwargs):
+    def display_warning(self, text='', stderr=True, indent=None, link=None, **kwargs):
         if self.verbosity < -1:
             return
 
-        self.display(text, self._style_level_warning, stderr=stderr, indent=indent, link=link, **kwargs)
+        self.output(text, self._style_level_warning, stderr=stderr, indent=indent, link=link, **kwargs)
 
-    def display_info(self, text='', stderr=False, indent=None, link=None, **kwargs):
+    def display_info(self, text='', stderr=True, indent=None, link=None, **kwargs):
         if self.verbosity < 0:
             return
 
-        self.display(text, self._style_level_info, stderr=stderr, indent=indent, link=link, **kwargs)
+        self.output(text, self._style_level_info, stderr=stderr, indent=indent, link=link, **kwargs)
 
-    def display_success(self, text='', stderr=False, indent=None, link=None, **kwargs):
+    def display_success(self, text='', stderr=True, indent=None, link=None, **kwargs):
         if self.verbosity < 0:
             return
 
-        self.display(text, self._style_level_success, stderr=stderr, indent=indent, link=link, **kwargs)
+        self.output(text, self._style_level_success, stderr=stderr, indent=indent, link=link, **kwargs)
 
-    def display_waiting(self, text='', stderr=False, indent=None, link=None, **kwargs):
+    def display_waiting(self, text='', stderr=True, indent=None, link=None, **kwargs):
         if self.verbosity < 0:
             return
 
-        self.display(text, self._style_level_waiting, stderr=stderr, indent=indent, link=link, **kwargs)
+        self.output(text, self._style_level_waiting, stderr=stderr, indent=indent, link=link, **kwargs)
 
-    def display_debug(self, text='', level=1, stderr=False, indent=None, link=None, **kwargs):
+    def display_debug(self, text='', level=1, stderr=True, indent=None, link=None, **kwargs):
         if not 1 <= level <= 3:
             raise ValueError('Debug output can only have verbosity levels between 1 and 3 (inclusive)')
         elif self.verbosity < level:
             return
 
-        self.display(text, self._style_level_debug, stderr=stderr, indent=indent, link=link, **kwargs)
+        self.output(text, self._style_level_debug, stderr=stderr, indent=indent, link=link, **kwargs)
 
-    def display_header(self, title='', *, stderr=False):
+    def display_header(self, title=''):
         self.console.rule(Text(title, self._style_level_success))
 
     def display_markdown(self, text, stderr=False, **kwargs):
@@ -137,7 +149,7 @@ class Terminal:
                 finally:
                     self.platform.displaying_status = False
 
-    def display(self, text='', style=None, *, stderr=False, indent=None, link=None, **kwargs):
+    def output(self, text='', style=None, *, stderr=False, indent=None, link=None, **kwargs):
         kwargs.setdefault('overflow', 'ignore')
         kwargs.setdefault('no_wrap', True)
         kwargs.setdefault('crop', False)
@@ -158,10 +170,8 @@ class Terminal:
                 self.console.stderr = False
 
     def display_raw(self, text, **kwargs):
+        # No styling
         self.console.print(text, overflow='ignore', no_wrap=True, crop=False, **kwargs)
-
-    def display_always(self, text, **kwargs):
-        self.console.print(text, style=self._style_level_info, overflow='ignore', no_wrap=True, crop=False, **kwargs)
 
     @staticmethod
     def prompt(text, **kwargs):


### PR DESCRIPTION
### Motivation

https://clig.dev/#the-basics

> **Send output to `stdout`.** The primary output for your command should go to `stdout`. Anything that is machine readable should also go to `stdout`—this is where piping sends things by default.
>
> **Send messaging to `stderr`.** Log messages, errors, and so on should all be sent to `stderr`. This means that when commands are piped together, these messages are displayed to the user and not fed into the next command.