### PR TITLE
Do not force pytest version

### DIFF
--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -36,8 +36,10 @@ dependencies = [
     "flaky",
     "mock",
     "psutil",
-    "pytest<7.2.0",  # pytest 7.2.0 has broken our tests
-    "pytest-benchmark[histogram]>=3.2.1",
+    "py>=1.8.2; python_version < '3.0'",  # https://github.com/ionelmc/pytest-benchmark/issues/226
+    "pytest",
+    "pytest-benchmark[histogram]<4.0.0; python_version < '3.0'",
+    "pytest-benchmark[histogram]>=4.0.0; python_version > '3.0'",
     "pytest-cov>=2.6.1",
     "pytest-memray>=1.3.0; python_version > '3.0' and (platform_system=='Linux' or platform_system=='Darwin')",
     "pytest-mock",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Stop forcing pytest version to <7.2.0.

### Motivation
<!-- What inspired you to submit this pull request? -->

- pytest 7.2.0 dropped the `py` dependency
- pytest-benchmark required this dependency but they forgot to add it to their requirements. They added it back in the version 4.0.0, which dropped py2 so we do not use it so the tests fail because of this missing library
- We opened a PR to force the version https://github.com/DataDog/integrations-core/pull/13198

I need pytest>=7.2.0 to update the pytest-memray plugin to 1.4.0 (changelog [here](https://pytest-memray.readthedocs.io/en/latest/news.html#v1-4-0-2022-12-02)) that requires it because they added a way to run memray only on tests that really use it. It will allow us to speed up the test suite and get rid of [this PR](https://github.com/DataDog/integrations-core/pull/13350)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.