### PR TITLE
Bump pytest-memray version

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -49,7 +49,7 @@ from .console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, echo_succes
 @click.option('--force-base-unpinned', is_flag=True, help='Force using datadog-checks-base as specified by check dep')
 @click.option('--force-base-min', is_flag=True, help='Force using lowest viable release version of datadog-checks-base')
 @click.option('--force-env-rebuild', is_flag=True, help='Force creating a new env')
-@click.option('--memray', is_flag=True, help='Run memray to measure memory usage')
+@click.option('--memray', is_flag=True, help='Run memray to measure memory usage on all tests')
 @click.option('--memray-show-report', is_flag=True, help='Print the memray report at the end of the test suite')
 @click.pass_context
 def test(

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "pytest-benchmark[histogram]<4.0.0; python_version < '3.0'",
     "pytest-benchmark[histogram]>=4.0.0; python_version > '3.0'",
     "pytest-cov>=2.6.1",
-    "pytest-memray>=1.3.0; python_version > '3.0' and (platform_system=='Linux' or platform_system=='Darwin')",
+    "pytest-memray>=1.4.0; python_version > '3.0' and (platform_system=='Linux' or platform_system=='Darwin')",
     "pytest-mock",
     "pyyaml>=5.4.1",
     "requests>=2.22.0",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump pytest-memray version to >= 1.4.0

### Motivation
<!-- What inspired you to submit this pull request? -->

- pytest-memray 1.4.0 now starts the memray tracker only on tests that require it (that use the memray fixtures) by default. Changelog [here](https://github.com/bloomberg/pytest-memray/releases/tag/1.4.0)
- To run memray on all the tests, we need to explicitely pass the `--memray` option. This mean that memray will be enabled by default on the CI, only for the tests that require it, without any modification in the pipeline itself.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This PR requires [this one](https://github.com/DataDog/integrations-core/pull/13461) to be merged first

Thanks to this, we can get rid of [this PR](https://github.com/DataDog/integrations-core/pull/13350). Also, we do not have a global overhead anymore. Only tests that require memray are slightly slower than they would be without memray.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.