### PR TITLE
Remove the --memray-show-report option

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py
@@ -340,7 +340,7 @@ def pytest_collection_modifyitems(config, items):
         return
 
     if PY2:
-        for option in ("--memray", "--hide-memray-summary"):
+        for option in ("--memray",):
             if config.getoption(option):
                 warnings.warn("`{}` option ignored as it's not supported for py2 environments.".format(option))
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -50,7 +50,6 @@ from .console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, echo_succes
 @click.option('--force-base-min', is_flag=True, help='Force using lowest viable release version of datadog-checks-base')
 @click.option('--force-env-rebuild', is_flag=True, help='Force creating a new env')
 @click.option('--memray', is_flag=True, help='Run memray to measure memory usage on all tests')
-@click.option('--memray-show-report', is_flag=True, help='Print the memray report at the end of the test suite')
 @click.pass_context
 def test(
     ctx,
@@ -79,7 +78,6 @@ def test(
     force_base_min,
     force_env_rebuild,
     memray,
-    memray_show_report,
 ):
     """Run tests for Agent-based checks.
 
@@ -204,7 +202,6 @@ def test(
             e2e=e2e,
             ddtrace=ddtrace_check,
             memray=memray,
-            memray_show_report=memray_show_report,
         )
         if coverage:
             pytest_options = pytest_options.format(pytest_coverage_sources(check))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/testing.py
@@ -506,7 +506,6 @@ def construct_pytest_options(
     e2e=False,
     ddtrace=False,
     memray=False,
-    memray_show_report=False,
 ):
     # Prevent no verbosity
     pytest_options = f'--verbosity={verbose or 1}'
@@ -565,9 +564,6 @@ def construct_pytest_options(
             abort('\nThe `--memray` option can only be used on Linux or MacOS!')
 
         pytest_options += ' --memray'
-
-        if not memray_show_report:
-            pytest_options += ' --hide-memray-summary'
 
     if marker:
         pytest_options += f' -m "{marker}"'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Drop the --memray-show-report option

### Motivation
<!-- What inspired you to submit this pull request? -->

Following [this PR](https://github.com/DataDog/integrations-core/pull/13462) and the new pytest-memray version, we do not need to explicitly enable memray for the unit tests and the report will be hidden by default. Manually running them and get the reports can still be useful though. To do that we would run `ddev test impala --memray` for instance to get the reports, but in this case there's no need to keep the old `--hide-memray-summary`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.