### PR TITLE
Add supporting configuration template for Multi-instance performance counters

### DIFF
--- a/active_directory/datadog_checks/active_directory/data/conf.yaml.example
+++ b/active_directory/datadog_checks/active_directory/data/conf.yaml.example
@@ -73,7 +73,7 @@ instances:
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
     ##   include_fast: This is the list of wildcards or exact instance names used to select which
-    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 instances to monitor. It is faster than the regular expression `include` filter
     ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.

--- a/active_directory/datadog_checks/active_directory/data/conf.yaml.example
+++ b/active_directory/datadog_checks/active_directory/data/conf.yaml.example
@@ -72,6 +72,9 @@ instances:
     ##            If not set, all instances are monitored.
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
+    ##   include_fast: This is the list of wildcards or exact instance names used to select which
+    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.
     ##                    The `total` count type represents the total number of encountered instances.

--- a/aspdotnet/datadog_checks/aspdotnet/data/conf.yaml.example
+++ b/aspdotnet/datadog_checks/aspdotnet/data/conf.yaml.example
@@ -73,7 +73,7 @@ instances:
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
     ##   include_fast: This is the list of wildcards or exact instance names used to select which
-    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 instances to monitor. It is faster than the regular expression `include` filter
     ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.

--- a/aspdotnet/datadog_checks/aspdotnet/data/conf.yaml.example
+++ b/aspdotnet/datadog_checks/aspdotnet/data/conf.yaml.example
@@ -72,6 +72,9 @@ instances:
     ##            If not set, all instances are monitored.
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
+    ##   include_fast: This is the list of wildcards or exact instance names used to select which
+    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.
     ##                    The `total` count type represents the total number of encountered instances.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/common/perf_counters.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/common/perf_counters.yaml
@@ -26,7 +26,7 @@
       exclude: This is the list of regular expressions used to select which instances to ignore.
                If not set, no instances are ignored. Note: `_Total` instances are always ignored.
       include_fast: This is the list of wildcards or exact instance names used to select which
-                    instances to monitor. It is faster than regular expression "include" filter
+                    instances to monitor. It is faster than the regular expression `include` filter
                     because it relies on the Windows PDH built-in wildcard filtering.
       instance_counts: This is a mapping used to select the count of instances to submit, where each
                        key is a count type and the value is the metric name to use, ignoring `name`.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/common/perf_counters.yaml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/common/perf_counters.yaml
@@ -25,6 +25,9 @@
                If not set, all instances are monitored.
       exclude: This is the list of regular expressions used to select which instances to ignore.
                If not set, no instances are ignored. Note: `_Total` instances are always ignored.
+      include_fast: This is the list of wildcards or exact instance names used to select which
+                    instances to monitor. It is faster than regular expression "include" filter
+                    because it relies on the Windows PDH built-in wildcard filtering.
       instance_counts: This is a mapping used to select the count of instances to submit, where each
                        key is a count type and the value is the metric name to use, ignoring `name`.
                        The `total` count type represents the total number of encountered instances.

--- a/dotnetclr/datadog_checks/dotnetclr/data/conf.yaml.example
+++ b/dotnetclr/datadog_checks/dotnetclr/data/conf.yaml.example
@@ -73,7 +73,7 @@ instances:
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
     ##   include_fast: This is the list of wildcards or exact instance names used to select which
-    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 instances to monitor. It is faster than the regular expression `include` filter
     ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.

--- a/dotnetclr/datadog_checks/dotnetclr/data/conf.yaml.example
+++ b/dotnetclr/datadog_checks/dotnetclr/data/conf.yaml.example
@@ -72,6 +72,9 @@ instances:
     ##            If not set, all instances are monitored.
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
+    ##   include_fast: This is the list of wildcards or exact instance names used to select which
+    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.
     ##                    The `total` count type represents the total number of encountered instances.

--- a/exchange_server/datadog_checks/exchange_server/data/conf.yaml.example
+++ b/exchange_server/datadog_checks/exchange_server/data/conf.yaml.example
@@ -73,7 +73,7 @@ instances:
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
     ##   include_fast: This is the list of wildcards or exact instance names used to select which
-    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 instances to monitor. It is faster than the regular expression `include` filter
     ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.

--- a/exchange_server/datadog_checks/exchange_server/data/conf.yaml.example
+++ b/exchange_server/datadog_checks/exchange_server/data/conf.yaml.example
@@ -72,6 +72,9 @@ instances:
     ##            If not set, all instances are monitored.
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
+    ##   include_fast: This is the list of wildcards or exact instance names used to select which
+    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.
     ##                    The `total` count type represents the total number of encountered instances.

--- a/hyperv/datadog_checks/hyperv/data/conf.yaml.example
+++ b/hyperv/datadog_checks/hyperv/data/conf.yaml.example
@@ -73,7 +73,7 @@ instances:
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
     ##   include_fast: This is the list of wildcards or exact instance names used to select which
-    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 instances to monitor. It is faster than the regular expression `include` filter
     ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.

--- a/hyperv/datadog_checks/hyperv/data/conf.yaml.example
+++ b/hyperv/datadog_checks/hyperv/data/conf.yaml.example
@@ -72,6 +72,9 @@ instances:
     ##            If not set, all instances are monitored.
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
+    ##   include_fast: This is the list of wildcards or exact instance names used to select which
+    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.
     ##                    The `total` count type represents the total number of encountered instances.

--- a/iis/datadog_checks/iis/data/conf.yaml.example
+++ b/iis/datadog_checks/iis/data/conf.yaml.example
@@ -108,6 +108,9 @@ instances:
     ##            If not set, all instances are monitored.
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
+    ##   include_fast: This is the list of wildcards or exact instance names used to select which
+    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.
     ##                    The `total` count type represents the total number of encountered instances.

--- a/iis/datadog_checks/iis/data/conf.yaml.example
+++ b/iis/datadog_checks/iis/data/conf.yaml.example
@@ -109,7 +109,7 @@ instances:
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
     ##   include_fast: This is the list of wildcards or exact instance names used to select which
-    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 instances to monitor. It is faster than the regular expression `include` filter
     ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.

--- a/windows_performance_counters/datadog_checks/windows_performance_counters/data/conf.yaml.example
+++ b/windows_performance_counters/datadog_checks/windows_performance_counters/data/conf.yaml.example
@@ -45,6 +45,9 @@ instances:
     ##            If not set, all instances are monitored.
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
+    ##   include_fast: This is the list of wildcards or exact instance names used to select which
+    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.
     ##                    The `total` count type represents the total number of encountered instances.

--- a/windows_performance_counters/datadog_checks/windows_performance_counters/data/conf.yaml.example
+++ b/windows_performance_counters/datadog_checks/windows_performance_counters/data/conf.yaml.example
@@ -46,7 +46,7 @@ instances:
     ##   exclude: This is the list of regular expressions used to select which instances to ignore.
     ##            If not set, no instances are ignored. Note: `_Total` instances are always ignored.
     ##   include_fast: This is the list of wildcards or exact instance names used to select which
-    ##                 instances to monitor. It is faster than regular expression "include" filter
+    ##                 instances to monitor. It is faster than the regular expression `include` filter
     ##                 because it relies on the Windows PDH built-in wildcard filtering.
     ##   instance_counts: This is a mapping used to select the count of instances to submit, where each
     ##                    key is a count type and the value is the metric name to use, ignoring `name`.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Provides and documents `include_fast` as new multi-instance counter configuration. It is complimentary to https://github.com/DataDog/integrations-core/pull/13243 PR.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.