### PR TITLE
Re-raise the exception when the environment failed to start

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/test.py
@@ -116,6 +116,7 @@ def test(
                     if skip_failed_environments:
                         echo_warning(f"Skipping {env} environment because it failed to start.")
                         continue
+                    raise
             elif env not in config_envs:
                 continue
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Re-raise the exception if we do not skip the failed environments.

### Motivation
<!-- What inspired you to submit this pull request? -->

- [This PR](https://github.com/DataDog/integrations-core/pull/13443) broke the sqlserver tests: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=120923&view=logs&jobId=1844037c-5a79-57cd-fd15-36c50f4dfdba&j=1844037c-5a79-57cd-fd15-36c50f4dfdba&t=67bd1e36-418d-51b1-65b1-619a0984e1b6
- It fails because I forgot to stop the program in case of an error and the `stop` method fails with docker environments. I tested it with the `iis` integration on my laptop, which does not do anything in the `stop` method.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

It also means that the `sqlserver` tests are not running completely because we have some linux tests after the windows one that stops the execution. Example here: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=120819&view=logs&jobId=1844037c-5a79-57cd-fd15-36c50f4dfdba&j=1844037c-5a79-57cd-fd15-36c50f4dfdba&t=67bd1e36-418d-51b1-65b1-619a0984e1b6. The `py38-linux-odbc-2019-high-cardinality` env is not running because of that. I'll open a follow-up PR to fix that

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.