### PR TITLE
Force the semver version to >=2.13.0

### DIFF
--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -76,7 +76,7 @@ cli = [
     "pyperclip>=1.7.0",
     "pysmi>=0.3.4",
     "securesystemslib[crypto]==0.20.1",
-    "semver",
+    "semver>=2.13.0",
     "tabulate>=0.8.9",
     "toml>=0.9.4, <1.0.0",
     "tomli>=1.1.0",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Force the semver version to >=2.13.0

### Motivation
<!-- What inspired you to submit this pull request? -->

Attempt to fix https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=121079&view=logs&j=40b3f23d-1644-5d89-acd8-67daa1a59c69&t=5f83278f-38f4-50d4-bb3f-a8d7354c3b39&l=460, it happens sometimes, not always and this seems to work consistently on my machine.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.