### PR TITLE
Collect the number of cpu cores using `psutil.cpu_count()`

### DIFF
--- a/system_core/datadog_checks/system_core/system_core.py
+++ b/system_core/datadog_checks/system_core/system_core.py
@@ -12,9 +12,12 @@ class SystemCore(AgentCheck):
     def check(self, instance):
         instance_tags = instance.get('tags', [])
 
+        # https://psutil.readthedocs.io/en/latest/#psutil.cpu_count
+        n_cpus = psutil.cpu_count()
+        self.gauge('system.core.count', n_cpus, tags=instance_tags)
+
         # https://psutil.readthedocs.io/en/latest/#psutil.cpu_times
         cpu_times = psutil.cpu_times(percpu=True)
-        self.gauge('system.core.count', len(cpu_times), tags=instance_tags)
         self.log.debug('CPU times: %s', str(cpu_times))
 
         for i, cpu in enumerate(cpu_times):
@@ -24,7 +27,7 @@ class SystemCore(AgentCheck):
 
         total_cpu_times = psutil.cpu_times()
         for key, value in iteritems(total_cpu_times._asdict()):
-            self.rate('system.core.{0}.total'.format(key), 100.0 * value / len(cpu_times), tags=instance_tags)
+            self.rate('system.core.{0}.total'.format(key), 100.0 * value /  n_cpus, tags=instance_tags)
 
         # https://psutil.readthedocs.io/en/latest/#psutil.cpu_freq
         # scpufreq(current=2236.812, min=800.0, max=3500.0)

--- a/system_core/datadog_checks/system_core/system_core.py
+++ b/system_core/datadog_checks/system_core/system_core.py
@@ -27,7 +27,7 @@ class SystemCore(AgentCheck):
 
         total_cpu_times = psutil.cpu_times()
         for key, value in iteritems(total_cpu_times._asdict()):
-            self.rate('system.core.{0}.total'.format(key), 100.0 * value /  n_cpus, tags=instance_tags)
+            self.rate('system.core.{0}.total'.format(key), 100.0 * value / n_cpus, tags=instance_tags)
 
         # https://psutil.readthedocs.io/en/latest/#psutil.cpu_freq
         # scpufreq(current=2236.812, min=800.0, max=3500.0)

--- a/system_core/tests/common.py
+++ b/system_core/tests/common.py
@@ -11,6 +11,8 @@ CHECK_NAME = "system_core"
 
 INSTANCE = {"tags": ["tag1:value1"]}
 
+MOCK_PSUTIL_CPU_COUNT = 4
+
 if Platform.is_mac():
     CHECK_RATES = ['system.core.idle', 'system.core.nice', 'system.core.system', 'system.core.user']
     MOCK_PSUTIL_CPU_TIMES = [

--- a/system_core/tests/test_system_core.py
+++ b/system_core/tests/test_system_core.py
@@ -17,6 +17,7 @@ class TestSystemCore:
 
         with mock.patch('datadog_checks.system_core.system_core.psutil') as psutil_mock:
             psutil_mock.cpu_times.side_effect = fake_cpu_times
+            psutil_mock.cpu_count.return_value = common.MOCK_PSUTIL_CPU_COUNT
             psutil_mock.cpu_freq.return_value = common.MOCK_PSUTIL_CPU_FREQ
             c.check({})
 


### PR DESCRIPTION
### What does this PR do?
Small change in logic in how we collect number of cpu cores. We used to count the length of CPU times, but there's a built in function in psutil that returns the count.

Was initially part of #[13349](https://github.com/DataDog/integrations-core/pull/13349) but it was better to split them up.