### PR TITLE
Add procedure name on query metrics/events

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -212,7 +212,7 @@ class SqlserverActivity(DBMAsyncJob):
             statement = obfuscate_sql_with_metadata(row['statement_text'], self.check.obfuscator_options)
             procedure_statement = None
             # sqlserver doesn't have a boolean data type so convert integer to boolean
-            row['is_proc'] = is_statement_proc(row['text'])
+            row['is_proc'], procedure_name = is_statement_proc(row['text'])
             if row['is_proc'] and 'text' in row:
                 procedure_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             obfuscated_statement = statement['query']
@@ -225,6 +225,8 @@ class SqlserverActivity(DBMAsyncJob):
             # its related plan events
             if procedure_statement:
                 row['procedure_signature'] = compute_sql_signature(procedure_statement['query'])
+            if procedure_name:
+                row['procedure_name'] = procedure_name
         except Exception as e:
             if self.check.log_unobfuscated_queries:
                 raw_query_text = row['text'] if row.get('is_proc', False) else row['statement_text']

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -285,7 +285,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             try:
                 statement = obfuscate_sql_with_metadata(row['statement_text'], self.check.obfuscator_options)
                 procedure_statement = None
-                row['is_proc'] = is_statement_proc(row['text'])
+                row['is_proc'], procedure_name = is_statement_proc(row['text'])
                 if row['is_proc']:
                     procedure_statement = obfuscate_sql_with_metadata(row['text'], self.check.obfuscator_options)
             except Exception as e:
@@ -306,6 +306,8 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             if procedure_statement:
                 row['procedure_text'] = procedure_statement['query']
                 row['procedure_signature'] = compute_sql_signature(procedure_statement['query'])
+            if procedure_name:
+                row['procedure_name'] = procedure_name
             row['query_signature'] = compute_sql_signature(obfuscated_statement)
             row['query_hash'] = _hash_to_hex(row['query_hash'])
             row['query_plan_hash'] = _hash_to_hex(row['query_plan_hash'])
@@ -500,6 +502,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                         },
                         "query_signature": query_signature,
                         "procedure_signature": row.get('procedure_signature', None),
+                        "procedure_name": row.get('procedure_name', None),
                         "statement": row[text_key],
                         "metadata": {
                             "tables": row['dd_tables'],

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -35,13 +35,14 @@ def is_statement_proc(text):
         if idx_proc < 0:
             idx_proc = _get_index_for_keyword(t, 'PROC')
         # ensure either PROC or PROCEDURE are found and CREATE occurs before PROCEDURE
-        return 0 <= idx_create < idx_proc and idx_proc >= 0, _get_procedure_name(t, idx_proc)
+        if 0 <= idx_create < idx_proc and idx_proc >= 0:
+            return True, _get_procedure_name(t, idx_proc)
     return False, None
 
 
 def _get_procedure_name(t, idx):
     if idx >= 0 and idx + 1 < len(t):
-        return t[idx + 1]
+        return t[idx + 1].lower()
     return None
 
 

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -35,8 +35,14 @@ def is_statement_proc(text):
         if idx_proc < 0:
             idx_proc = _get_index_for_keyword(t, 'PROC')
         # ensure either PROC or PROCEDURE are found and CREATE occurs before PROCEDURE
-        return 0 <= idx_create < idx_proc and idx_proc >= 0
-    return False
+        return 0 <= idx_create < idx_proc and idx_proc >= 0, _get_procedure_name(t, idx_proc)
+    return False, None
+
+
+def _get_procedure_name(t, idx):
+    if idx >= 0 and idx + 1 < len(t):
+        return t[idx + 1]
+    return None
 
 
 def _get_index_for_keyword(text, keyword):

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -434,7 +434,7 @@ def test_get_estimated_row_size_bytes(dbm_instance, file):
 
 
 @pytest.mark.parametrize(
-    "query,is_proc",
+    "query,is_proc,expected_name",
     [
         [
             """\
@@ -444,6 +444,7 @@ def test_get_estimated_row_size_bytes(dbm_instance, file):
             END;
             """,
             True,
+            "bobProcedure",
         ],
         [
             """\
@@ -453,6 +454,7 @@ def test_get_estimated_row_size_bytes(dbm_instance, file):
             END;
             """,
             True,
+            "bobProcedure",
         ],
         [
             """\
@@ -462,6 +464,7 @@ def test_get_estimated_row_size_bytes(dbm_instance, file):
             end;
             """,
             True,
+            "bobProcedureLowercase",
         ],
         [
             """\
@@ -472,6 +475,7 @@ def test_get_estimated_row_size_bytes(dbm_instance, file):
             END;
             """,
             True,
+            "bobProcedure",
         ],
         [
             """\
@@ -481,6 +485,7 @@ def test_get_estimated_row_size_bytes(dbm_instance, file):
             END;
             """,
             True,
+            "bobProcedure",
         ],
         [
             """\
@@ -493,27 +498,34 @@ def test_get_estimated_row_size_bytes(dbm_instance, file):
             END;
             """,
             True,
+            "bobProcedure",
         ],
         [
             "CREATE TABLE bob_table",
             False,
+            None,
         ],
         [
             "Exec procedure",
             False,
+            None,
         ],
         [
             "CREATEprocedure",
             False,
+            None,
         ],
         [
             "procedure create",
             False,
+            None,
         ],
     ],
 )
-def test_is_statement_procedure(query, is_proc):
-    assert is_statement_proc(query) == is_proc
+def test_is_statement_procedure(query, is_proc, expected_name):
+    p, name = is_statement_proc(query)
+    assert p == is_proc
+    assert re.match(name, expected_name, re.IGNORECASE) if expected_name else expected_name == name
 
 
 def test_activity_collection_rate_limit(aggregator, dd_run_check, dbm_instance):

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -151,6 +151,7 @@ def test_collect_load_activity(
     assert 'statement_text' not in blocked_row, "statement_text field should not be forwarded"
     if is_proc:
         assert blocked_row['procedure_signature'], "missing procedure signature"
+        assert blocked_row['procedure_name'], "missing procedure name"
     assert re.match(match_pattern, blocked_row['text'], re.IGNORECASE), "incorrect blocked query"
     assert blocked_row['database_name'] == "datadog_test", "incorrect database_name"
     assert blocked_row['id'], "missing session id"

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -355,6 +355,7 @@ def test_statement_metrics_and_plans(
             assert row['is_proc'] == is_proc
         if is_proc and not is_encrypted:
             assert row['procedure_signature'], "missing proc signature"
+            assert row['procedure_name'], "missing proc name"
         if disable_secondary_tags:
             assert 'database_name' not in row
         else:
@@ -367,6 +368,7 @@ def test_statement_metrics_and_plans(
         assert all(row['plan_handle'] == matching_rows[0]['plan_handle'] for row in matching_rows)
     if is_proc and not is_encrypted:
         assert all(row['procedure_signature'] == matching_rows[0]['procedure_signature'] for row in matching_rows)
+        assert all(row['procedure_name'] == matching_rows[0]['procedure_name'] for row in matching_rows)
 
     dbm_samples = aggregator.get_event_platform_events("dbm-samples")
     assert dbm_samples, "should have collected at least one sample"
@@ -402,6 +404,7 @@ def test_statement_metrics_and_plans(
             assert event['sqlserver']['is_statement_encrypted']
         elif is_proc:
             assert event['db']['procedure_signature'], "missing proc signature"
+            assert event['db']['procedure_name'], "missing proc name"
             assert not event['db']['query_signature'], "procedure plans should not have query_signature field set"
         else:
             assert event['db']['plan']['definition'], "event plan definition missing"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds support to collect a `procedure_name` for query metrics (and events) so we can tie query execution statistics for particular queries that execute in the context of a procedure back to said stored proc. 

### Motivation
<!-- What inspired you to submit this pull request? -->

This was requested by a customer who after upgrading to 7.40, which contained this fix https://github.com/DataDog/integrations-core/pull/12613, was unable to easily lookup from which stored procedure a particular query was executing within 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.