### PR TITLE
(DOCS-3364) Add header for monitor example in docs

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -32,7 +32,11 @@ The Datadog Terraform provider is available through the [Terraform Registry][1].
     ```
 
 4. Run `terraform init`. This initializes the directory for use with Terraform and pulls the Datadog provider.
-5. Create any `.tf` file in the `terraform_config/` directory and start creating Datadog resources. For example:
+5. Create any `.tf` file in the `terraform_config/` directory and start creating Datadog resources. 
+
+## Create a monitor
+
+This example demonstrates a `monitor.tf` file that creates a [live process monitor][5].
 
     ```
     # monitor.tf
@@ -51,7 +55,7 @@ The Datadog Terraform provider is available through the [Terraform Registry][1].
     }
     ```
 
-6. Run `terraform apply` to create this monitor in your Datadog account!
+Run `terraform apply` to create this monitor in your Datadog account.
 
 ## Send Events to Datadog
 
@@ -98,3 +102,4 @@ Need help? Contact [Datadog support][3].
 [2]: https://learn.hashicorp.com/tutorials/terraform/install-cli
 [3]: https://docs.datadoghq.com/help/
 [4]: https://github.com/DataDog/datadogpy
+[5]: https://docs.datadoghq.com/monitors/types/process/


### PR DESCRIPTION
### What does this PR do?
Adds a header and section for the example monitor that's provided.

### Motivation
This is to make the section more easily discoverable, and linkable from other pages in the docs. See DOCS-3364 for more details.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.