### PR TITLE
Add recommended monitor

### DIFF
--- a/argocd/assets/recommended_monitors/application_sync_status.json
+++ b/argocd/assets/recommended_monitors/application_sync_status.json
@@ -1,7 +1,7 @@
 {
     "name": "[ArgoCD] Application Sync Status",
     "type": "query alert",
-    "query": "max(last_30m):avg:argocd.app_controller.app.info{!sync_status:synced} by {sync_status,name} < 1",
+    "query": "max(last_30m):avg:argocd.app_controller.app.info{!sync_status:synced} by {sync_status,name} <= 1",
     "message": "{{#is_alert}}\nApplication {{name.name}} has been reporting with a sync_status:{{sync_status.name}} for the last 30 minutes.\n{{/is_alert}}",
     "tags": [
         "integration:argocd"

--- a/argocd/assets/recommended_monitors/application_sync_status.json
+++ b/argocd/assets/recommended_monitors/application_sync_status.json
@@ -20,6 +20,6 @@
     "priority": null,
     "restricted_roles": null,
     "recommended_monitor_metadata": {
-        "description": "Notify your team when your Applications are not in synced in Argo CD"
+        "description": "Notify your team when your applications are not synced in Argo CD"
     }
 }

--- a/argocd/assets/recommended_monitors/application_sync_status.json
+++ b/argocd/assets/recommended_monitors/application_sync_status.json
@@ -1,7 +1,7 @@
 {
     "name": "[ArgoCD] Application Sync Status",
     "type": "query alert",
-    "query": "max(last_30m):avg:argocd.app_controller.app.info{!sync_status:synced} by {sync_status,name} <= 1",
+    "query": "max(last_30m):default_zero(avg:argocd.app_controller.app.info{!sync_status:synced} by {sync_status,name}) >= 1",
     "message": "{{#is_alert}}\nApplication {{name.name}} has been reporting with a sync_status:{{sync_status.name}} for the last 30 minutes.\n{{/is_alert}}",
     "tags": [
         "integration:argocd"

--- a/argocd/assets/recommended_monitors/application_sync_status.json
+++ b/argocd/assets/recommended_monitors/application_sync_status.json
@@ -1,5 +1,5 @@
 {
-    "name": "Application {{name.name}} is not synced",
+    "name": "[ArgoCD] Application Synced Status",
     "type": "query alert",
     "query": "avg(last_30m):avg:argocd.app_controller.app.info{!sync_status:synced} by {sync_status,name} >= 1",
     "message": "{{#is_alert}}\nApplication {{name.name}} has been reporting with a sync_status:{{sync_status.name}} for the last 30 minutes.\n{{/is_alert}}",

--- a/argocd/assets/recommended_monitors/application_sync_status.json
+++ b/argocd/assets/recommended_monitors/application_sync_status.json
@@ -1,5 +1,5 @@
 {
-    "name": "Application {{name.name}} is not Synced",
+    "name": "Application {{name.name}} is not synced",
     "type": "query alert",
     "query": "avg(last_30m):avg:argocd.app_controller.app.info{!sync_status:synced} by {sync_status,name} >= 1",
     "message": "{{#is_alert}}\nApplication {{name.name}} has been reporting with a sync_status:{{sync_status.name}} for the last 30 minutes.\n{{/is_alert}}",

--- a/argocd/assets/recommended_monitors/application_sync_status.json
+++ b/argocd/assets/recommended_monitors/application_sync_status.json
@@ -1,7 +1,7 @@
 {
     "name": "[ArgoCD] Application Sync Status",
     "type": "query alert",
-    "query": "avg(last_30m):avg:argocd.app_controller.app.info{!sync_status:synced} by {sync_status,name} >= 1",
+    "query": "max(last_30m):avg:argocd.app_controller.app.info{!sync_status:synced} by {sync_status,name} < 1",
     "message": "{{#is_alert}}\nApplication {{name.name}} has been reporting with a sync_status:{{sync_status.name}} for the last 30 minutes.\n{{/is_alert}}",
     "tags": [
         "integration:argocd"

--- a/argocd/assets/recommended_monitors/application_sync_status.json
+++ b/argocd/assets/recommended_monitors/application_sync_status.json
@@ -2,7 +2,7 @@
     "name": "Application {{name.name}} is not Synced",
     "type": "query alert",
     "query": "avg(last_30m):avg:argocd.app_controller.app.info{!sync_status:synced} by {sync_status,name} >= 1",
-    "message": "{{#is_alert}}\nApplication {{name.name}} has been reporting with a sync_status:{{sync_status.name}} for the last 30 minutes.\n{{/is_alert}} \n\n{{#is_recovery}}\nApplication {{name.name}} is now synced.\n{{/is_recovery}} ",
+    "message": "{{#is_alert}}\nApplication {{name.name}} has been reporting with a sync_status:{{sync_status.name}} for the last 30 minutes.\n{{/is_alert}}",
     "tags": [
         "integration:argocd"
     ],

--- a/argocd/assets/recommended_monitors/application_sync_status.json
+++ b/argocd/assets/recommended_monitors/application_sync_status.json
@@ -1,5 +1,5 @@
 {
-    "name": "[ArgoCD] Application Synced Status",
+    "name": "[ArgoCD] Application Sync Status",
     "type": "query alert",
     "query": "avg(last_30m):avg:argocd.app_controller.app.info{!sync_status:synced} by {sync_status,name} >= 1",
     "message": "{{#is_alert}}\nApplication {{name.name}} has been reporting with a sync_status:{{sync_status.name}} for the last 30 minutes.\n{{/is_alert}}",

--- a/argocd/assets/recommended_monitors/application_sync_status.json
+++ b/argocd/assets/recommended_monitors/application_sync_status.json
@@ -1,0 +1,25 @@
+{
+    "name": "Application {{name.name}} is not Synced",
+    "type": "query alert",
+    "query": "avg(last_30m):avg:argocd.app_controller.app.info{!sync_status:synced} by {sync_status,name} >= 1",
+    "message": "{{#is_alert}}\nApplication {{name.name}} has been reporting with a sync_status:{{sync_status.name}} for the last 30 minutes.\n{{/is_alert}} \n\n{{#is_recovery}}\nApplication {{name.name}} is now synced.\n{{/is_recovery}} ",
+    "tags": [
+        "integration:argocd"
+    ],
+    "options": {
+        "thresholds": {
+            "critical": 1
+        },
+        "notify_audit": false,
+        "require_full_window": false,
+        "notify_no_data": false,
+        "renotify_interval": 0,
+        "include_tags": true,
+        "new_group_delay": 60
+    },
+    "priority": null,
+    "restricted_roles": null,
+    "recommended_monitor_metadata": {
+        "description": "Notify your team when your Applications are not in synced in Argo CD"
+    }
+}

--- a/argocd/manifest.json
+++ b/argocd/manifest.json
@@ -43,6 +43,9 @@
     "logs": {},
     "dashboards": {
       "Argo CD Overview": "assets/dashboards/argo_cd_overview.json"
+    },
+    "monitors": {
+      "Sync Status": "assets/recommended_monitors/application_sync_status.json"
     }
   },
   "author": {


### PR DESCRIPTION
### What does this PR do?
This PRs add a recommended monitor for Argo CD integration. The monitor is designed to look at the metric for `argocd.app_controller.app.info`. This metric returns a static value of one and has the status as a tag. 

The monitor is intended to monitor `argocd.app_controller.app.info` and looks for groups that are not synced (`!sync_status:synced`) and breaks it down by `sync_status` and `name`. 

Trigger: if any group reports with `!sync_status:synced` for 30 minutes.
Recovery: I don't think that's possible because the group disappears when it becomes synced

Note: I added a default_zero to this because monitor looks for a metric with a group that isn't `synced`. If the group becomes synced, it will disappear. But because gauge are interpolated with their last value for 5 mins after they disappear, this could cause false positives. Default_zero also ensures that for the full duration of the 30 minutes, the app wasn't synced at all. 