### PR TITLE
Add `--fix` flag to `ddev validate license-headers` for automatically fixing errors

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
@@ -10,15 +10,16 @@ from ...constants import get_root
 from ...license_headers import validate_license_headers
 from ...testing import process_checks_option
 from ...utils import complete_valid_checks
-from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success
+from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning
 
 IGNORES = {"datadog_checks_dev": ["datadog_checks/dev/tooling/templates"], "all": ["tests/compose", "tests/docker"]}
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate license headers in python files')
 @click.argument('check', shell_complete=complete_valid_checks, required=False)
+@click.option('--fix', is_flag=True, help='Attempt to fix errors')
 @click.pass_context
-def license_headers(ctx, check):
+def license_headers(ctx, check, fix):
     """Validate license headers in python code files.
 
     If `check` is specified, only the check will be validated, if check value is 'changed' will only apply to changed
@@ -35,6 +36,7 @@ def license_headers(ctx, check):
     checks = process_checks_option(check, source='integrations')
 
     total_errors = 0
+    total_fixes = 0
 
     for check_name in checks:
         path_to_check = root / check_name
@@ -44,10 +46,37 @@ def license_headers(ctx, check):
 
         for err in errors:
             echo_failure(f'{check_name}/{err.path}: {err.message}')
+            if fix and fix_file(path_to_check, err):
+                total_fixes += 1
             total_errors += 1
 
-    if total_errors:
+    if not total_errors:
+        echo_success('All license headers are valid.')
+        return
+
+    if not fix:
         echo_failure(f'Found {total_errors} files with errors.')
         abort()
-    else:
-        echo_success('All license headers are valid.')
+
+    if fix:
+        if total_errors > total_fixes:
+            echo_failure(
+                f'Found {total_errors} files with errors, '
+                f'{total_errors - total_fixes} still have errors that require manual fixing.'
+            )
+            abort()
+        else:
+            echo_success(f'Found {total_errors} files with errors, and all were fixed.')
+
+
+def fix_file(check_path, error):
+    filepath = check_path / error.path
+    if error.fixed is None:
+        echo_warning(f"File cannot be automatically fixed: {filepath}")
+        return False
+
+    with open(filepath, 'w') as f:
+        f.write(error.fixed)
+
+    echo_success(f"Fixed {filepath}!")
+    return True

--- a/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
@@ -94,7 +94,8 @@ def validate_license_headers(
         # When file already existed, check whether the license has changed
         previous = get_previous(path)
         if previous:
-            if license_header != parse_license_header(previous):
+            previous_license_header = parse_license_header(previous)
+            if previous_license_header and license_header != previous_license_header:
                 return LicenseHeaderError("existing file has changed license", relpath)
         # When it's a new file, compare it to the current header template
         elif license_header != get_default_license_header():

--- a/datadog_checks_dev/tests/tooling/test_license_headers.py
+++ b/datadog_checks_dev/tests/tooling/test_license_headers.py
@@ -162,6 +162,7 @@ import os
     assert len(errors) == 1
     assert errors[0].message == "file does not match expected license format"
     assert errors[0].path == "setup.py"
+    assert errors[0].fixed == f"{get_license_header()}\n\nimport os\n"
 
 
 def test_validate_license_headers_returns_error_on_existing_file_with_changed_header(tmp_path):
@@ -170,8 +171,7 @@ def test_validate_license_headers_returns_error_on_existing_file_with_changed_he
 
     original_license = """# (C) Foo, Inc. 1999-present
 # All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-"""
+# Licensed under a 3-clause BSD style license (see LICENSE)"""
 
     prev_contents = f"{original_license}\n\nimport os\n"
 
@@ -181,7 +181,7 @@ def test_validate_license_headers_returns_error_on_existing_file_with_changed_he
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import os
+import sys
 """,
     )
 
@@ -199,6 +199,7 @@ import os
     assert len(errors) == 1
     assert errors[0].message == "existing file has changed license"
     assert errors[0].path == "setup.py"
+    assert errors[0].fixed == f"{original_license}\n\nimport sys\n"
 
 
 def test_validate_license_headers_accepts_any_header_when_previous_version_with_no_license_exists(tmp_path):

--- a/datadog_checks_dev/tests/tooling/test_license_headers.py
+++ b/datadog_checks_dev/tests/tooling/test_license_headers.py
@@ -81,10 +81,11 @@ def test_validate_license_headers_returns_error_for_a_file_without_license(tmp_p
 
     _write_file_without_license(check_path / "setup.py")
 
-    errors = validate_license_headers(check_path)
+    errors = validate_license_headers(check_path, get_previous=_make_get_previous())
     assert len(errors) == 1
     assert errors[0].message == "missing license header"
     assert errors[0].path == "setup.py"
+    assert errors[0].fixed == f"{get_license_header()}\n\nimport os\n"
 
 
 def test_validate_license_headers_when_all_files_have_valid_headers_returns_empty_list(tmp_path):
@@ -110,7 +111,7 @@ def test_validate_license_headers_works_with_arbitrary_nesting(tmp_path):
     nested_path.mkdir(parents=True)
     _write_file_without_license(nested_path / "check.py")
 
-    errors = validate_license_headers(check_path)
+    errors = validate_license_headers(check_path, get_previous=_make_get_previous())
     assert len(errors) == 1
     assert errors[0].message == "missing license header"
     assert errors[0].path == "datadog_checks/check/check.py"
@@ -227,6 +228,22 @@ import os
     assert validate_license_headers(check_path, get_previous=fake_get_previous) == []
 
 
+def test_validate_license_headers_does_not_suggest_fix_for_missing_header_when_file_is_not_new(tmp_path):
+    check_path = tmp_path / "check"
+    check_path.mkdir()
+
+    _write_file_without_license(check_path / "setup.py")
+    fake_get_previous = _make_get_previous(
+        {
+            pathlib.Path(check_path / "setup.py"): "",
+        }
+    )
+
+    errors = validate_license_headers(check_path, get_previous=fake_get_previous)
+    assert len(errors) == 1
+    assert errors[0].fixed is None
+
+
 def _make_get_previous(d: dict = None):
     if d is None:
         d = {}
@@ -249,7 +266,7 @@ def test_validate_license_headers_honors_gitignore_file_on_check_path(tmp_path):
 
     _write_file_without_license(target_path / "some.py")
 
-    assert validate_license_headers(check_path) == []
+    assert validate_license_headers(check_path, get_previous=_make_get_previous()) == []
 
 
 def test_validate_license_headers_honors_nested_gitignore_files_reincluding_file(tmp_path):
@@ -267,7 +284,7 @@ def test_validate_license_headers_honors_nested_gitignore_files_reincluding_file
 
     _write_file_without_license(target_path / "some.py")
 
-    assert validate_license_headers(check_path) == []
+    assert validate_license_headers(check_path, get_previous=_make_get_previous()) == []
 
 
 def test_validate_license_headers_honors_gitignore_relative_patterns(tmp_path):
@@ -284,14 +301,14 @@ def test_validate_license_headers_honors_gitignore_relative_patterns(tmp_path):
 
     _write_file_without_license(target_path / "some.py")
 
-    assert validate_license_headers(check_path) == []
+    assert validate_license_headers(check_path, get_previous=_make_get_previous()) == []
 
     # And the pattern lets a more nested build folder through
     target_path = check_path / "foo" / "deeper" / "build"
     target_path.mkdir(parents=True)
     _write_file_without_license(target_path / "some.py")
 
-    errors = validate_license_headers(check_path)
+    errors = validate_license_headers(check_path, get_previous=_make_get_previous())
     assert len(errors) > 0
     assert errors[0].path == (target_path / "some.py").relative_to(check_path).as_posix()
 
@@ -310,10 +327,10 @@ def test_validate_license_headers_honors_gitignore_from_parents(tmp_path):
 
     _write_file_without_license(target_path / "some.py")
 
-    errors = validate_license_headers(check_path, repo_root=tmp_path)
+    errors = validate_license_headers(check_path, repo_root=tmp_path, get_previous=_make_get_previous())
     assert len(errors) > 0
     assert errors[0].path == (target_path / "some.py").relative_to(check_path).as_posix()
 
     # If we override this in a subdir, we shouldn't get an error
     _write_string_to_file(check_path / ".gitignore", "foo/\n")
-    assert validate_license_headers(check_path, repo_root=tmp_path) == []
+    assert validate_license_headers(check_path, repo_root=tmp_path, get_previous=_make_get_previous()) == []

--- a/datadog_checks_dev/tests/tooling/test_license_headers.py
+++ b/datadog_checks_dev/tests/tooling/test_license_headers.py
@@ -201,6 +201,31 @@ import os
     assert errors[0].path == "setup.py"
 
 
+def test_validate_license_headers_accepts_any_header_when_previous_version_with_no_license_exists(tmp_path):
+    check_path = tmp_path / "check"
+    check_path.mkdir()
+
+    prev_contents = "\n\nimport os\n"
+
+    _write_string_to_file(
+        check_path / "setup.py",
+        """# (C) Foo, Inc. 2000-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import os
+""",
+    )
+
+    fake_get_previous = _make_get_previous(
+        {
+            pathlib.Path(check_path / "setup.py"): prev_contents,
+        }
+    )
+
+    assert validate_license_headers(check_path, get_previous=fake_get_previous) == []
+
+
 def _make_get_previous(d: dict = None):
     if d is None:
         d = {}


### PR DESCRIPTION
### What does this PR do?

Adds autofix functionality to `ddev validate license-headers`.

### Motivation

Part of [AITOOLS-60](https://datadoghq.atlassian.net/browse/AITOOLS-60).

### Additional Notes

This required changing how we deal with the case where the license header is missing in the original file:

- _Any_ header added to an existing file that didn't have a header is fine and passes validation.
- I decided against trying to auto-fix for this case. We can't just stamp the current license header (with the current year) because the year must match the year the file was first created. I didn't think it was worth going down the rabbit hole of figuring out the original year from git and generate a license dynamically from that.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.