### PR TITLE
Add missing license headers and make `ddev validate license-headers` pass

### DIFF
--- a/active_directory/setup.py
+++ b/active_directory/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 # Always prefer setuptools over distutils
 # To use a consistent encoding
 from codecs import open

--- a/active_directory/tests/__init__.py
+++ b/active_directory/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/active_directory/tests/__init__.py
+++ b/active_directory/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/activemq_xml/tests/__init__.py
+++ b/activemq_xml/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/activemq_xml/tests/__init__.py
+++ b/activemq_xml/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/airflow/tests/k8s_sample/dags/task_fail.py
+++ b/airflow/tests/k8s_sample/dags/task_fail.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from datetime import datetime
 
 from airflow import DAG

--- a/airflow/tests/k8s_sample/dags/task_ok.py
+++ b/airflow/tests/k8s_sample/dags/task_ok.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from datetime import datetime
 
 from airflow import DAG

--- a/apache/datadog_checks/apache/__about__.py
+++ b/apache/datadog_checks/apache/__about__.py
@@ -1,1 +1,5 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 __version__ = "4.2.0"

--- a/aspdotnet/tests/__init__.py
+++ b/aspdotnet/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/aspdotnet/tests/__init__.py
+++ b/aspdotnet/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/avi_vantage/datadog_checks/avi_vantage/metrics.py
+++ b/avi_vantage/datadog_checks/avi_vantage/metrics.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 VIRTUAL_SERVICE_METRICS = {
     # The following commented metrics are documented but don't seem to be available.
     # "dns_client.avg_avi_errors": {

--- a/avi_vantage/tests/test_config_validation.py
+++ b/avi_vantage/tests/test_config_validation.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import pytest
 
 from datadog_checks.avi_vantage import AviVantageCheck

--- a/btrfs/datadog_checks/btrfs/__init__.py
+++ b/btrfs/datadog_checks/btrfs/__init__.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from .__about__ import __version__
 from .btrfs import BTRFS
 

--- a/btrfs/setup.py
+++ b/btrfs/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 # To use a consistent encoding
 from codecs import open
 from os import path

--- a/btrfs/tests/__init__.py
+++ b/btrfs/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/btrfs/tests/__init__.py
+++ b/btrfs/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/cacti/tests/__init__.py
+++ b/cacti/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/cacti/tests/__init__.py
+++ b/cacti/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/calico/datadog_checks/__init__.py
+++ b/calico/datadog_checks/__init__.py
@@ -1,1 +1,5 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/calico/setup.py
+++ b/calico/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from codecs import open  # To use a consistent encoding
 from os import path
 

--- a/calico/tests/__init__.py
+++ b/calico/tests/__init__.py
@@ -1,1 +1,3 @@
-
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/cassandra/tests/__init__.py
+++ b/cassandra/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/cassandra/tests/__init__.py
+++ b/cassandra/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/cassandra_nodetool/tests/__init__.py
+++ b/cassandra_nodetool/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/cassandra_nodetool/tests/__init__.py
+++ b/cassandra_nodetool/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/ceph/datadog_checks/ceph/__about__.py
+++ b/ceph/datadog_checks/ceph/__about__.py
@@ -1,1 +1,5 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 __version__ = "2.7.0"

--- a/ceph/datadog_checks/ceph/__init__.py
+++ b/ceph/datadog_checks/ceph/__init__.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from .__about__ import __version__
 from .ceph import Ceph
 

--- a/ceph/setup.py
+++ b/ceph/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 # To use a consistent encoding
 from codecs import open
 from os import path

--- a/ceph/tests/__init__.py
+++ b/ceph/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/ceph/tests/__init__.py
+++ b/ceph/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/cert_manager/setup.py
+++ b/cert_manager/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from codecs import open  # To use a consistent encoding
 from os import path
 

--- a/cilium/tests/legacy/__init__.py
+++ b/cilium/tests/legacy/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/cilium/tests/legacy/__init__.py
+++ b/cilium/tests/legacy/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/cisco_aci/tests/cisco_aci_query.py
+++ b/cisco_aci/tests/cisco_aci_query.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import json
 
 import requests

--- a/cisco_aci/tests/common.py
+++ b/cisco_aci/tests/common.py
@@ -1,4 +1,4 @@
-# C Datadog, Inc. 2018
+# (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under Simplified BSD License see LICENSE
 

--- a/cisco_aci/tests/mock_sender.py
+++ b/cisco_aci/tests/mock_sender.py
@@ -1,4 +1,4 @@
-# C Datadog, Inc. 2018
+# (C) Datadog, Inc. 2018
 # All rights reserved
 # Licensed under Simplified BSD License see LICENSE
 

--- a/consul/datadog_checks/consul/__about__.py
+++ b/consul/datadog_checks/consul/__about__.py
@@ -1,1 +1,5 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 __version__ = "2.2.0"

--- a/consul/datadog_checks/consul/__init__.py
+++ b/consul/datadog_checks/consul/__init__.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from .__about__ import __version__
 from .consul import ConsulCheck
 

--- a/consul/tests/__init__.py
+++ b/consul/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/consul/tests/__init__.py
+++ b/consul/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/couch/datadog_checks/couch/__about__.py
+++ b/couch/datadog_checks/couch/__about__.py
@@ -1,1 +1,5 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 __version__ = "5.2.0"

--- a/couch/tests/__init__.py
+++ b/couch/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/couch/tests/__init__.py
+++ b/couch/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/couchbase/datadog_checks/couchbase/couchbase_consts.py
+++ b/couchbase/datadog_checks/couchbase/couchbase_consts.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import re
 
 from datadog_checks.base import AgentCheck

--- a/couchbase/tests/__init__.py
+++ b/couchbase/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/couchbase/tests/__init__.py
+++ b/couchbase/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/crio/setup.py
+++ b/crio/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from codecs import open  # To use a consistent encoding
 from os import path
 

--- a/crio/tests/conftest.py
+++ b/crio/tests/conftest.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from copy import deepcopy
 
 import pytest

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/license_headers.py
@@ -12,7 +12,13 @@ from ...testing import process_checks_option
 from ...utils import complete_valid_checks
 from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_success, echo_warning
 
-IGNORES = {"datadog_checks_dev": ["datadog_checks/dev/tooling/templates"], "all": ["tests/compose", "tests/docker"]}
+IGNORES = {
+    "all": ["tests/compose", "tests/docker"],
+    "datadog_checks_dev": ["datadog_checks/dev/tooling/templates"],
+    "php_fpm": ["datadog_checks/php_fpm/vendor"],
+    "snmp": ["tests/mibs"],
+    "tokumx": ["datadog_checks/tokumx/vendor"],
+}
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Validate license headers in python files')

--- a/directory/datadog_checks/directory/__init__.py
+++ b/directory/datadog_checks/directory/__init__.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from .__about__ import __version__
 from .directory import DirectoryCheck
 

--- a/directory/tests/__init__.py
+++ b/directory/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/directory/tests/__init__.py
+++ b/directory/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/dns_check/tests/__init__.py
+++ b/dns_check/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/dns_check/tests/__init__.py
+++ b/dns_check/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/dotnetclr/setup.py
+++ b/dotnetclr/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 # To use a consistent encoding
 from codecs import open
 from os import path

--- a/dotnetclr/tests/__init__.py
+++ b/dotnetclr/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/dotnetclr/tests/__init__.py
+++ b/dotnetclr/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/ecs_fargate/tests/__init__.py
+++ b/ecs_fargate/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/ecs_fargate/tests/__init__.py
+++ b/ecs_fargate/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/eks_fargate/conftest.py
+++ b/eks_fargate/conftest.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import sys
 
 

--- a/envoy/datadog_checks/envoy/parser.py
+++ b/envoy/datadog_checks/envoy/parser.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import re
 from math import isnan
 from typing import Any, Dict, List, Tuple

--- a/envoy/datadog_checks/envoy/utils.py
+++ b/envoy/datadog_checks/envoy/utils.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import re
 
 import requests

--- a/envoy/tests/__init__.py
+++ b/envoy/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/envoy/tests/__init__.py
+++ b/envoy/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/envoy/tests/common.py
+++ b/envoy/tests/common.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import os
 
 import pytest

--- a/envoy/tests/conftest.py
+++ b/envoy/tests/conftest.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import os
 
 import pytest

--- a/envoy/tests/legacy/__init__.py
+++ b/envoy/tests/legacy/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/envoy/tests/legacy/__init__.py
+++ b/envoy/tests/legacy/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/envoy/tests/legacy/common.py
+++ b/envoy/tests/legacy/common.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import os
 
 from datadog_checks.dev import get_docker_hostname

--- a/envoy/tests/legacy/test_bench.py
+++ b/envoy/tests/legacy/test_bench.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import pytest
 
 from datadog_checks.envoy import Envoy

--- a/envoy/tests/legacy/test_metrics.py
+++ b/envoy/tests/legacy/test_metrics.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from datadog_checks.envoy.metrics import METRIC_PREFIX, METRIC_TREE, METRICS
 from datadog_checks.envoy.utils import make_metric_tree
 

--- a/envoy/tests/legacy/test_parser.py
+++ b/envoy/tests/legacy/test_parser.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import pytest
 
 from datadog_checks.envoy.errors import UnknownMetric, UnknownTags

--- a/envoy/tests/legacy/test_utils.py
+++ b/envoy/tests/legacy/test_utils.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from datadog_checks.envoy.utils import make_metric_tree
 
 

--- a/envoy/tests/test_check.py
+++ b/envoy/tests/test_check.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import pytest
 
 from datadog_checks.dev.utils import get_metadata_metrics

--- a/envoy/tests/test_e2e.py
+++ b/envoy/tests/test_e2e.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import pytest
 
 from datadog_checks.envoy import Envoy

--- a/etcd/tests/__init__.py
+++ b/etcd/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/etcd/tests/__init__.py
+++ b/etcd/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/exchange_server/tests/__init__.py
+++ b/exchange_server/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/exchange_server/tests/__init__.py
+++ b/exchange_server/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/fluentd/tests/__init__.py
+++ b/fluentd/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/fluentd/tests/__init__.py
+++ b/fluentd/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/fluentd/tests/mock/fluentd_version.py
+++ b/fluentd/tests/mock/fluentd_version.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import sys
 
 if __name__ == "__main__":

--- a/foundationdb/datadog_checks/__init__.py
+++ b/foundationdb/datadog_checks/__init__.py
@@ -1,1 +1,5 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)  # type: ignore

--- a/foundationdb/setup.py
+++ b/foundationdb/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from codecs import open  # To use a consistent encoding
 from os import path
 

--- a/foundationdb/tests/__init__.py
+++ b/foundationdb/tests/__init__.py
@@ -1,1 +1,3 @@
-
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/gearmand/tests/__init__.py
+++ b/gearmand/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/gearmand/tests/__init__.py
+++ b/gearmand/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/gitlab/tests/__init__.py
+++ b/gitlab/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/gitlab/tests/__init__.py
+++ b/gitlab/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/gitlab_runner/tests/__init__.py
+++ b/gitlab_runner/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/gitlab_runner/tests/__init__.py
+++ b/gitlab_runner/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/glusterfs/datadog_checks/glusterfs/metrics.py
+++ b/glusterfs/datadog_checks/glusterfs/metrics.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 CLUSTER_STATS = {
     'node_count': 'nodes.count',
     'nodes_active': 'nodes.active',

--- a/gunicorn/tests/__init__.py
+++ b/gunicorn/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/gunicorn/tests/__init__.py
+++ b/gunicorn/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/haproxy/datadog_checks/haproxy/__about__.py
+++ b/haproxy/datadog_checks/haproxy/__about__.py
@@ -1,1 +1,5 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 __version__ = "4.4.0"

--- a/haproxy/setup.py
+++ b/haproxy/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 # To use a consistent encoding
 from codecs import open
 from os import path

--- a/haproxy/tests/__init__.py
+++ b/haproxy/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/haproxy/tests/__init__.py
+++ b/haproxy/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/haproxy/tests/legacy/__init__.py
+++ b/haproxy/tests/legacy/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/haproxy/tests/legacy/__init__.py
+++ b/haproxy/tests/legacy/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/haproxy/tests/legacy/common.py
+++ b/haproxy/tests/legacy/common.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import os
 
 import pytest

--- a/haproxy/tests/legacy/test_unit.py
+++ b/haproxy/tests/legacy/test_unit.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import copy
 import os
 from collections import defaultdict

--- a/hdfs_datanode/tests/__init__.py
+++ b/hdfs_datanode/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/hdfs_datanode/tests/__init__.py
+++ b/hdfs_datanode/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/hdfs_namenode/tests/__init__.py
+++ b/hdfs_namenode/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/hdfs_namenode/tests/__init__.py
+++ b/hdfs_namenode/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/http_check/tests/__init__.py
+++ b/http_check/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/http_check/tests/__init__.py
+++ b/http_check/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/http_check/tests/common.py
+++ b/http_check/tests/common.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)

--- a/http_check/tests/common.py
+++ b/http_check/tests/common.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2018-present
+﻿# (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)

--- a/http_check/tests/test_integration_e2e.py
+++ b/http_check/tests/test_integration_e2e.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)

--- a/http_check/tests/test_unit.py
+++ b/http_check/tests/test_unit.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)

--- a/ibm_i/datadog_checks/ibm_i/query_script.py
+++ b/ibm_i/datadog_checks/ibm_i/query_script.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import sys
 from contextlib import closing
 

--- a/ibm_i/tests/test_e2e.py
+++ b/ibm_i/tests/test_e2e.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import pytest
 
 from datadog_checks.ibm_i import IbmICheck

--- a/iis/tests/__init__.py
+++ b/iis/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/iis/tests/__init__.py
+++ b/iis/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/kafka_consumer/tests/__init__.py
+++ b/kafka_consumer/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/kafka_consumer/tests/__init__.py
+++ b/kafka_consumer/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/kong/tests/__init__.py
+++ b/kong/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/kong/tests/__init__.py
+++ b/kong/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/kong/tests/common.py
+++ b/kong/tests/common.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import logging
 
 from datadog_checks.dev import get_docker_hostname, get_here

--- a/kong/tests/conftest.py
+++ b/kong/tests/conftest.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import os
 
 import pytest

--- a/kong/tests/test_integration_e2e.py
+++ b/kong/tests/test_integration_e2e.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import os
 import platform
 

--- a/kube_apiserver_metrics/tests/common.py
+++ b/kube_apiserver_metrics/tests/common.py
@@ -1,1 +1,5 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 APISERVER_INSTANCE_BEARER_TOKEN = "XXX"

--- a/kubelet/conftest.py
+++ b/kubelet/conftest.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import sys
 
 

--- a/kubelet/datadog_checks/kubelet/__init__.py
+++ b/kubelet/datadog_checks/kubelet/__init__.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from .__about__ import __version__
 from .common import PodListUtils, get_pod_by_uid, is_static_pending_pod
 from .kubelet import KubeletCheck

--- a/kubelet/tests/__init__.py
+++ b/kubelet/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/kubelet/tests/__init__.py
+++ b/kubelet/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/kubernetes_state/tests/__init__.py
+++ b/kubernetes_state/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/kubernetes_state/tests/__init__.py
+++ b/kubernetes_state/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/kyototycoon/tests/__init__.py
+++ b/kyototycoon/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/kyototycoon/tests/__init__.py
+++ b/kyototycoon/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/lighttpd/datadog_checks/lighttpd/__init__.py
+++ b/lighttpd/datadog_checks/lighttpd/__init__.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from .__about__ import __version__
 from .lighttpd import Lighttpd
 

--- a/lighttpd/tests/__init__.py
+++ b/lighttpd/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/lighttpd/tests/__init__.py
+++ b/lighttpd/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/linkerd/tests/__init__.py
+++ b/linkerd/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/linkerd/tests/__init__.py
+++ b/linkerd/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/linkerd/tests/common.py
+++ b/linkerd/tests/common.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from datadog_checks.base.stubs import aggregator
 from datadog_checks.dev import get_here
 from datadog_checks.linkerd.metrics import construct_metrics_config

--- a/linkerd/tests/conftest.py
+++ b/linkerd/tests/conftest.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import os
 
 import pytest

--- a/linux_proc_extras/tests/__init__.py
+++ b/linux_proc_extras/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/linux_proc_extras/tests/__init__.py
+++ b/linux_proc_extras/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/mapreduce/datadog_checks/mapreduce/metrics.py
+++ b/mapreduce/datadog_checks/mapreduce/metrics.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 """
 MapReduce Job Metrics
 ---------------------

--- a/mapreduce/tests/__init__.py
+++ b/mapreduce/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/mapreduce/tests/__init__.py
+++ b/mapreduce/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/marathon/setup.py
+++ b/marathon/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from codecs import open
 from os import path
 

--- a/marathon/tests/__init__.py
+++ b/marathon/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/marathon/tests/__init__.py
+++ b/marathon/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/marklogic/tests/test_parsers.py
+++ b/marklogic/tests/test_parsers.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2020-present
+﻿# (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest

--- a/marklogic/tests/test_parsers.py
+++ b/marklogic/tests/test_parsers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)

--- a/mcache/tests/__init__.py
+++ b/mcache/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/mcache/tests/__init__.py
+++ b/mcache/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from pymongo import MongoClient, ReadPreference
 from pymongo.errors import ConnectionFailure
 

--- a/mongo/datadog_checks/mongo/collectors/__init__.py
+++ b/mongo/datadog_checks/mongo/collectors/__init__.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from .base import MongoCollector
 from .coll_stats import CollStatsCollector
 from .custom_queries import CustomQueriesCollector

--- a/mongo/datadog_checks/mongo/collectors/base.py
+++ b/mongo/datadog_checks/mongo/collectors/base.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import re
 
 from six import PY3, iteritems

--- a/mongo/datadog_checks/mongo/collectors/coll_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/coll_stats.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from six import iteritems
 
 from datadog_checks.base import AgentCheck

--- a/mongo/datadog_checks/mongo/collectors/conn_pool_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/conn_pool_stats.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from datadog_checks.mongo.collectors.base import MongoCollector
 from datadog_checks.mongo.common import ReplicaSetDeployment
 

--- a/mongo/datadog_checks/mongo/collectors/custom_queries.py
+++ b/mongo/datadog_checks/mongo/collectors/custom_queries.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from copy import deepcopy
 
 import pymongo

--- a/mongo/datadog_checks/mongo/collectors/db_stat.py
+++ b/mongo/datadog_checks/mongo/collectors/db_stat.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from datadog_checks.mongo.collectors.base import MongoCollector
 from datadog_checks.mongo.common import MongosDeployment, ReplicaSetDeployment
 

--- a/mongo/datadog_checks/mongo/collectors/fsynclock.py
+++ b/mongo/datadog_checks/mongo/collectors/fsynclock.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from datadog_checks.mongo.collectors.base import MongoCollector
 from datadog_checks.mongo.common import MongosDeployment, ReplicaSetDeployment
 

--- a/mongo/datadog_checks/mongo/collectors/index_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/index_stats.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from datadog_checks.mongo.collectors.base import MongoCollector
 
 

--- a/mongo/datadog_checks/mongo/collectors/jumbo_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/jumbo_stats.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from datadog_checks.base import AgentCheck
 from datadog_checks.mongo.collectors import MongoCollector
 from datadog_checks.mongo.common import MongosDeployment

--- a/mongo/datadog_checks/mongo/collectors/replica.py
+++ b/mongo/datadog_checks/mongo/collectors/replica.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import time
 
 from six.moves.urllib.parse import urlsplit

--- a/mongo/datadog_checks/mongo/collectors/replication_info.py
+++ b/mongo/datadog_checks/mongo/collectors/replication_info.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import pymongo
 
 from datadog_checks.base.utils.common import round_value

--- a/mongo/datadog_checks/mongo/collectors/server_status.py
+++ b/mongo/datadog_checks/mongo/collectors/server_status.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from datadog_checks.mongo.collectors.base import MongoCollector
 
 

--- a/mongo/datadog_checks/mongo/collectors/session_stats.py
+++ b/mongo/datadog_checks/mongo/collectors/session_stats.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from datadog_checks.base import AgentCheck
 from datadog_checks.mongo.collectors.base import MongoCollector
 from datadog_checks.mongo.common import MongosDeployment

--- a/mongo/datadog_checks/mongo/collectors/top.py
+++ b/mongo/datadog_checks/mongo/collectors/top.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from six import iteritems
 
 from datadog_checks.mongo.collectors.base import MongoCollector

--- a/mongo/datadog_checks/mongo/common.py
+++ b/mongo/datadog_checks/mongo/common.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 # Source
 SOURCE_TYPE_NAME = 'mongodb'
 

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import certifi
 
 from datadog_checks.base import ConfigurationError, is_affirmative

--- a/mongo/tests/__init__.py
+++ b/mongo/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/mongo/tests/__init__.py
+++ b/mongo/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/mongo/tests/mocked_api.py
+++ b/mongo/tests/mocked_api.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import itertools
 import json
 import os

--- a/mongo/tests/test_integration.py
+++ b/mongo/tests/test_integration.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import json
 import os
 

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import datetime
 import decimal
 import time

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import re
 import time
 from collections import namedtuple

--- a/mysql/datadog_checks/mysql/util.py
+++ b/mysql/datadog_checks/mysql/util.py
@@ -1,5 +1,7 @@
+# (C) Datadog, Inc. 2022-present
 # All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from enum import Enum
 
 

--- a/mysql/tests/__init__.py
+++ b/mysql/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/mysql/tests/__init__.py
+++ b/mysql/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import concurrent.futures.thread
 import json
 import os

--- a/nagios/tests/__init__.py
+++ b/nagios/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/nagios/tests/__init__.py
+++ b/nagios/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/network/datadog_checks/network/__init__.py
+++ b/network/datadog_checks/network/__init__.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from .__about__ import __version__
 from .network import Network
 

--- a/network/setup.py
+++ b/network/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 # Always prefer setuptools over distutils
 # To use a consistent encoding
 from codecs import open

--- a/network/tests/__init__.py
+++ b/network/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/network/tests/__init__.py
+++ b/network/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/network/tests/test_e2e.py
+++ b/network/tests/test_e2e.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import pytest
 
 from datadog_checks.base.utils.platform import Platform

--- a/nfsstat/tests/__init__.py
+++ b/nfsstat/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/nfsstat/tests/__init__.py
+++ b/nfsstat/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/nginx/tests/__init__.py
+++ b/nginx/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/nginx/tests/__init__.py
+++ b/nginx/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/openmetrics/tests/__init__.py
+++ b/openmetrics/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/openmetrics/tests/__init__.py
+++ b/openmetrics/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/openmetrics/tests/common.py
+++ b/openmetrics/tests/common.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from datadog_checks.dev import get_docker_hostname, get_here
 
 CHECK_NAME = 'openmetrics'

--- a/openmetrics/tests/test_integration.py
+++ b/openmetrics/tests/test_integration.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import pytest
 
 from datadog_checks.openmetrics import OpenMetricsCheck

--- a/openstack/tests/__init__.py
+++ b/openstack/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/openstack/tests/__init__.py
+++ b/openstack/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/openstack_controller/tests/__init__.py
+++ b/openstack_controller/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/openstack_controller/tests/__init__.py
+++ b/openstack_controller/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/openstack_controller/tests/test_openstack_sdk_api.py
+++ b/openstack_controller/tests/test_openstack_sdk_api.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import mock
 import pytest
 from openstack.exceptions import SDKException

--- a/oracle/tests/__init__.py
+++ b/oracle/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/oracle/tests/__init__.py
+++ b/oracle/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/pdh_check/tests/__init__.py
+++ b/pdh_check/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/pdh_check/tests/__init__.py
+++ b/pdh_check/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/pgbouncer/setup.py
+++ b/pgbouncer/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from codecs import open
 from os import path
 

--- a/pgbouncer/tests/__init__.py
+++ b/pgbouncer/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/pgbouncer/tests/__init__.py
+++ b/pgbouncer/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/php_fpm/tests/__init__.py
+++ b/php_fpm/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/php_fpm/tests/__init__.py
+++ b/php_fpm/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/postfix/tests/__init__.py
+++ b/postfix/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/postfix/tests/__init__.py
+++ b/postfix/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/postgres/datadog_checks/postgres/__init__.py
+++ b/postgres/datadog_checks/postgres/__init__.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from .__about__ import __version__
 from .postgres import PostgreSql
 

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import copy
 import re
 import time

--- a/postgres/tests/__init__.py
+++ b/postgres/tests/__init__.py
@@ -1,0 +1,4 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+

--- a/postgres/tests/__init__.py
+++ b/postgres/tests/__init__.py
@@ -1,4 +1,3 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-

--- a/powerdns_recursor/setup.py
+++ b/powerdns_recursor/setup.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 # Always prefer setuptools over distutils
 # To use a consistent encoding
 from codecs import open

--- a/process/tests/__init__.py
+++ b/process/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/prometheus/tests/__init__.py
+++ b/prometheus/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/prometheus/tests/conftest.py
+++ b/prometheus/tests/conftest.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import os
 
 import mock

--- a/rabbitmq/tests/__init__.py
+++ b/rabbitmq/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/redisdb/tests/__init__.py
+++ b/redisdb/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/rethinkdb/tests/unit/test_utils.py
+++ b/rethinkdb/tests/unit/test_utils.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import datetime as dt
 
 import pytest

--- a/riak/tests/__init__.py
+++ b/riak/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/snmp/tests/test_parsing.py
+++ b/snmp/tests/test_parsing.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import logging
 
 import mock

--- a/snmp/tests/test_utils.py
+++ b/snmp/tests/test_utils.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from typing import Any, Tuple
 
 import pytest

--- a/solr/tests/__init__.py
+++ b/solr/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/spark/tests/__init__.py
+++ b/spark/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import binascii
 import datetime
 import re

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import binascii
 import math
 import time

--- a/sqlserver/tests/__init__.py
+++ b/sqlserver/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+﻿# (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -1,4 +1,7 @@
-# -*- coding: utf-8 -*-
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from __future__ import unicode_literals
 
 import concurrent

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-# -*- coding: utf8 -*-
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2020-present
+﻿# (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+﻿# (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -1,4 +1,7 @@
-# -*- coding: utf-8 -*-
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from __future__ import unicode_literals
 
 import logging

--- a/squid/tests/__init__.py
+++ b/squid/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/squid/tests/test_e2e.py
+++ b/squid/tests/test_e2e.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2019-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import pytest
 
 from datadog_checks.squid import SquidCheck

--- a/ssh_check/tests/__init__.py
+++ b/ssh_check/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/statsd/tests/__init__.py
+++ b/statsd/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/supervisord/tests/__init__.py
+++ b/supervisord/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/system_core/tests/__init__.py
+++ b/system_core/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/system_swap/tests/__init__.py
+++ b/system_swap/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/teamcity/tests/__init__.py
+++ b/teamcity/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/varnish/tests/__init__.py
+++ b/varnish/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/vault/tests/__init__.py
+++ b/vault/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/voltdb/tests/fixtures/generate_data.py
+++ b/voltdb/tests/fixtures/generate_data.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 # Not used by tests, but can be manually run to generate the mock_results.json file.
 import json
 import random

--- a/vsphere/datadog_checks/vsphere/config.py
+++ b/vsphere/datadog_checks/vsphere/config.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import re
 from typing import Any, Dict, List
 

--- a/vsphere/datadog_checks/vsphere/types.py
+++ b/vsphere/datadog_checks/vsphere/types.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 from typing import Any, Dict, List, Optional, Pattern, Type, TypedDict
 
 # CONFIG ALIASES

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2019-present
+﻿# (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import datetime as dt

--- a/vsphere/tests/test_check.py
+++ b/vsphere/tests/test_check.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)

--- a/vsphere/tests/test_e2e.py
+++ b/vsphere/tests/test_e2e.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import pytest
 
 from datadog_checks.base import AgentCheck

--- a/vsphere/tests/test_filters.py
+++ b/vsphere/tests/test_filters.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2019-present
+﻿# (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 import re

--- a/vsphere/tests/test_filters.py
+++ b/vsphere/tests/test_filters.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)

--- a/vsphere/tests/test_utils.py
+++ b/vsphere/tests/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)

--- a/weblogic/tests/test_check.py
+++ b/weblogic/tests/test_check.py
@@ -1,3 +1,7 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
 import pytest
 
 from datadog_checks.dev.jmx import JVM_E2E_METRICS_NEW

--- a/win32_event_log/tests/__init__.py
+++ b/win32_event_log/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/win32_event_log/tests/legacy/__init__.py
+++ b/win32_event_log/tests/legacy/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2020-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/wmi_check/tests/__init__.py
+++ b/wmi_check/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/yarn/tests/__init__.py
+++ b/yarn/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/zk/tests/__init__.py
+++ b/zk/tests/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)


### PR DESCRIPTION
### What does this PR do?

Adds / fixes license headers to make `ddev validate license-headers` pass. It also explicitly ignores some paths that do not require licensing.

### Motivation

Make `ddev validate license-headers` pass on the repo so that we can add it to the CI moving forward.

### Additional Notes

To find the year where the files were created so that I could write the appropriate year to each license header, I used `git log --format=%ad --date=format:%Y -- "$f" | tail -1`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.