### PR TITLE
Enforce one of components or components_discovery config per instance

### DIFF
--- a/sonarqube/assets/configuration/spec.yaml
+++ b/sonarqube/assets/configuration/spec.yaml
@@ -74,8 +74,7 @@ files:
                 exclude:
                   - issues.(false_positive_issues|reopened_issues)
 
-          Note: This is required for all project checks, whether `is_jmx` is set to `true`
-          or `false.
+          Note: Only one of `components`, `components_discovery`, or `is_jmx` may be configured in a single instance.
         options:
           - name: tag
             description: |
@@ -113,6 +112,7 @@ files:
                     - issues.
               exclude:
                 - temp*
+          Note: Only one of `components`, `components_discovery`, or `is_jmx` may be configured in a single instance.
         options:
           - name: limit
             description: |
@@ -163,6 +163,7 @@ files:
             If `is_jmx` is set to true at the init_config level, this flag is ignored.
 
             Note: Setting `is_jmx` to true disables some configuration options.
+            Note: Only one of `components`, `components_discovery`, or `is_jmx` may be configured in a single instance.
           user.description: |
             The user name for connecting to JMX (or HTTP if `is_jmx = false`).
           password.description: |

--- a/sonarqube/datadog_checks/sonarqube/check.py
+++ b/sonarqube/datadog_checks/sonarqube/check.py
@@ -162,6 +162,10 @@ class SonarqubeCheck(AgentCheck):
         self._default_tag = self.instance.get('default_tag', 'component')
         if not isinstance(self._default_tag, str):
             raise ConfigurationError('The `default_tag` setting must be a string')
+        if self.instance.get('components') and self.instance.get('components_discovery'):
+            raise ConfigurationError(
+                'Only one of `components` or `components_discovery` may be configured in each instance.'
+            )
         self._default_include = self.compile_metric_patterns(self.instance, 'default_include')
         self._default_exclude = self.compile_metric_patterns(self.instance, 'default_exclude')
 

--- a/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
+++ b/sonarqube/datadog_checks/sonarqube/data/conf.yaml.example
@@ -139,8 +139,7 @@ instances:
     ##       exclude:
     ##         - issues.(false_positive_issues|reopened_issues)
     ##
-    ## Note: This is required for all project checks, whether `is_jmx` is set to `true`
-    ## or `false.
+    ## Note: Only one of `components`, `components_discovery`, or `is_jmx` may be configured in a single instance.
     #
     # components:
 
@@ -174,6 +173,7 @@ instances:
     ##           - issues.
     ##     exclude:
     ##       - temp*
+    ## Note: Only one of `components`, `components_discovery`, or `is_jmx` may be configured in a single instance.
     #
     # components_discovery:
 
@@ -500,6 +500,7 @@ instances:
     ## If `is_jmx` is set to true at the init_config level, this flag is ignored.
     ##
     ## Note: Setting `is_jmx` to true disables some configuration options.
+    ## Note: Only one of `components`, `components_discovery`, or `is_jmx` may be configured in a single instance.
     #
     # is_jmx: true
 


### PR DESCRIPTION
### What does this PR do?
When `components` and `components_discovery` are both configured in the same instance,  duplicate metrics may get collected if the inclusion filters overlap between the two config options. 

### Motivation
QA

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.