### PR TITLE
Do not add `can_use_jdbc` to `check_initializations`

### DIFF
--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -87,7 +87,6 @@ class Oracle(AgentCheck):
         )
 
         self.check_initializations.append(self._query_manager.compile_queries)
-        self.check_initializations.append(self.can_use_jdbc)
 
         self._query_errors = 0
         self._connection_errors = 0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not add `can_use_jdbc` to `check_initializations`

### Motivation
<!-- What inspired you to submit this pull request? -->

This is not really needed since those function are called during the first run, which is also the case for [this](https://github.com/DataDog/integrations-core/blob/master/oracle/datadog_checks/oracle/oracle.py#L153-L158).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.