### PR TITLE
Update journald readme to include `config_id`

### DIFF
--- a/journald/README.md
+++ b/journald/README.md
@@ -101,7 +101,7 @@ logs:
 
 ##### Tailing the same journal multiple times
 
-In some situations it may be desirable to tail the same journal more than once in order to report different units with different source or service tags. 
+If you want to report units with different source or service tags, these must appear in separate journald configs.
 
 In order to do this you must uniquely identify the journal config with a `config_id` (available in agent `7.41.0`+)
 

--- a/journald/README.md
+++ b/journald/README.md
@@ -103,7 +103,7 @@ logs:
 
 If you want to report units with different source or service tags, these must appear in separate journald configs.
 
-In order to do this you must uniquely identify the journal config with a `config_id` (available in agent `7.41.0`+)
+In order to do this you must uniquely identify the journal config with a `config_id` (available in agent `7.41.0`+).
 
 ```yaml
 logs:

--- a/journald/README.md
+++ b/journald/README.md
@@ -99,6 +99,29 @@ logs:
           - sshd.service
 ```
 
+##### Tailing the same journal multiple times
+
+In some situations it may be desirable to tail the same journal more than once in order to report different units with different source or service tags. 
+
+In order to do this you must uniquely identify the journal config with a `config_id` (available in agent `7.41.0`+)
+
+```yaml
+logs:
+    - type: journald
+      config_id: my-app1
+      source: my-app1
+      service: my-app1
+      include_units:
+          - my-app1.service
+
+    - type: journald
+      config_id: my-app2
+      source: my-app2
+      service: my-app2
+      include_units:
+          - my-app2.service
+```
+
 ##### Collect container tags
 
 Tags are critical for finding information in highly dynamic containerized environments, which is why the Agent can collect container tags in journald logs.


### PR DESCRIPTION
### What does this PR do?
Document new advanced feature now that 7.41 is available: using `config_id` to identify multiple instances of the same tailer.  

### Motivation
Docs update

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.