### PR TITLE
Exclude tracefs by default from disk checks

### DIFF
--- a/disk/assets/configuration/spec.yaml
+++ b/disk/assets/configuration/spec.yaml
@@ -14,6 +14,7 @@ files:
             value:
               example:
                 - iso9660$
+                - tracefs$
               type: array
               items:
                 type: string

--- a/disk/datadog_checks/disk/data/conf.yaml.default
+++ b/disk/datadog_checks/disk/data/conf.yaml.default
@@ -10,6 +10,7 @@ init_config:
     #
     # file_system_global_exclude:
     #   - iso9660$
+    #   - tracefs$
 
     ## @param device_global_exclude - list of strings - optional
     ## Instruct the check to always add these patterns to `device_exclude`.

--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -547,6 +547,8 @@ class Disk(AgentCheck):
         return [
             # CDROM
             'iso9660$',
+            # tracefs
+            'tracefs$',
         ]
 
     @staticmethod

--- a/disk/tests/test_filter.py
+++ b/disk/tests/test_filter.py
@@ -36,7 +36,7 @@ def test_bad_config_string_regex():
     c = Disk('disk', {}, [instance])
 
     assert_regex_equal(c._file_system_include, re.compile('test', re.I))
-    assert_regex_equal(c._file_system_exclude, re.compile('test|iso9660$', re.I))
+    assert_regex_equal(c._file_system_exclude, re.compile('test|iso9660$|tracefs$', re.I))
     assert_regex_equal(c._device_include, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._device_exclude, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._mount_point_include, re.compile('test', IGNORE_CASE))
@@ -55,7 +55,7 @@ def test_ignore_empty_regex():
     c = Disk('disk', {}, [instance])
 
     assert_regex_equal(c._file_system_include, re.compile('test', re.I))
-    assert_regex_equal(c._file_system_exclude, re.compile('test|iso9660$', re.I))
+    assert_regex_equal(c._file_system_exclude, re.compile('test|iso9660$|tracefs$', re.I))
     assert_regex_equal(c._device_include, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._device_exclude, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._mount_point_include, re.compile('test', IGNORE_CASE))

--- a/disk/tests/test_filter_deprecated.py
+++ b/disk/tests/test_filter_deprecated.py
@@ -160,7 +160,7 @@ def test_legacy_config():
     }
     c = Disk('disk', {}, [instance])
 
-    assert_regex_equal(c._file_system_exclude, re.compile('iso9660$|test$', re.I))
+    assert_regex_equal(c._file_system_exclude, re.compile('iso9660$|tracefs$|test$', re.I))
     assert_regex_equal(c._device_exclude, re.compile('test1$|test2', IGNORE_CASE))
     assert_regex_equal(c._mount_point_exclude, re.compile('(/host)?/proc/sys/fs/binfmt_misc$|test', IGNORE_CASE))
 

--- a/disk/tests/test_filter_deprecated.py
+++ b/disk/tests/test_filter_deprecated.py
@@ -21,7 +21,7 @@ def test_bad_config_string_regex_deprecated():
     c = Disk('disk', {}, [instance])
 
     assert_regex_equal(c._file_system_include, re.compile('test', re.I))
-    assert_regex_equal(c._file_system_exclude, re.compile('test|iso9660$', re.I))
+    assert_regex_equal(c._file_system_exclude, re.compile('test|iso9660$|tracefs$', re.I))
     assert_regex_equal(c._device_include, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._device_exclude, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._mount_point_include, re.compile('test', IGNORE_CASE))
@@ -40,7 +40,7 @@ def test_ignore_empty_regex_deprecated():
     c = Disk('disk', {}, [instance])
 
     assert_regex_equal(c._file_system_include, re.compile('test', re.I))
-    assert_regex_equal(c._file_system_exclude, re.compile('test|iso9660$', re.I))
+    assert_regex_equal(c._file_system_exclude, re.compile('test|iso9660$|tracefs$', re.I))
     assert_regex_equal(c._device_include, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._device_exclude, re.compile('test', IGNORE_CASE))
     assert_regex_equal(c._mount_point_include, re.compile('test', IGNORE_CASE))

--- a/disk/tests/test_unit.py
+++ b/disk/tests/test_unit.py
@@ -23,7 +23,7 @@ def test_default_options():
     assert check._use_mount is False
     assert check._all_partitions is False
     assert check._file_system_include is None
-    assert check._file_system_exclude == re.compile('iso9660$', re.I)
+    assert check._file_system_exclude == re.compile('iso9660$|tracefs$', re.I)
     assert check._device_include is None
     assert check._device_exclude is None
     assert check._mount_point_include is None


### PR DESCRIPTION
Attempting to include tracefs volumes causes a spammy WARN-level log message by default.

### What does this PR do?
Adds tracefs to the default `file_system_exclude`

### Motivation
This causes a spammy log message every time disk checks run

### Additional Notes
Issues where this was reported:
https://github.com/DataDog/integrations-core/issues/5675 
https://github.com/DataDog/dd-agent/issues/3875

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.