### PR TITLE
Skip checking database names when replica is recovering

### DIFF
--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -221,6 +221,9 @@ class MongoDb(AgentCheck):
         if isinstance(deployment, ReplicaSetDeployment) and deployment.is_arbiter:
             self.log.debug("Replicaset and arbiter deployment, no databases will be checked")
             dbnames = []
+        elif deployment.replset_state == 3:
+            self.log.debug("Replicaset is in recovering state, will skip reading database names")
+            dbnames = []
         else:
             server_databases = api.list_database_names()
             self.gauge('mongodb.dbs', len(server_databases), tags=tags)

--- a/mongo/datadog_checks/mongo/mongo.py
+++ b/mongo/datadog_checks/mongo/mongo.py
@@ -221,7 +221,7 @@ class MongoDb(AgentCheck):
         if isinstance(deployment, ReplicaSetDeployment) and deployment.is_arbiter:
             self.log.debug("Replicaset and arbiter deployment, no databases will be checked")
             dbnames = []
-        elif deployment.replset_state == 3:
+        elif isinstance(deployment, ReplicaSetDeployment) and deployment.replset_state == 3:
             self.log.debug("Replicaset is in recovering state, will skip reading database names")
             dbnames = []
         else:

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -154,6 +154,7 @@ def test_emits_ok_service_check_when_alibaba_replicaset_role_configsvr_deploymen
     mock_server_info.assert_called_once()
     mock_list_database_names.assert_called_once()
 
+
 @mock.patch(
     'pymongo.database.Database.command',
     side_effect=[


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
When a replica state is in the [recovering state](https://www.mongodb.com/docs/manual/reference/replica-states/#mongodb-replstate-replstate.RECOVERING), it should not be ready to accept any reads. Originally, we would try to get the [list of databases](https://github.com/mongodb/mongo-python-driver/blob/4.2.0/pymongo/mongo_client.py#L1821-L1839), which would result the following error in the Agent:

```
      Error: node is recovering, full error: {'ok': 0.0, 'errmsg': 'node is recovering', 'code': 13436, 'codeName': 'NotPrimaryOrSecondary'}
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py", line 1116, in run
          self.check(instance)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/mongo/mongo.py", line 185, in check
          self._check()
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/mongo/mongo.py", line 224, in _check
          dbnames = self._get_db_names(api, deployment, tags)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/mongo/mongo.py", line 239, in _get_db_names
          server_databases = api.list_database_names()
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/mongo/api.py", line 55, in list_database_names
          return self._cli.list_database_names(session)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1839, in list_database_names
          return [doc["name"] for doc in self.list_databases(session, nameOnly=True, comment=comment)]
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1812, in list_databases
          res = admin._retryable_read_command(cmd, session=session)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/pymongo/database.py", line 843, in _retryable_read_command
          return self.__client._retryable_read(_cmd, read_preference, session)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/pymongo/_csot.py", line 105, in csot_wrapper
          return func(self, *args, **kwargs)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/pymongo/mongo_client.py", line 1420, in _retryable_read
          return func(session, server, sock_info, read_pref)
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/pymongo/database.py", line 831, in _cmd
          return self._command(
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/pymongo/database.py", line 682, in _command
          return sock_info.command(
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/pymongo/pool.py", line 766, in command
          return command(
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/pymongo/network.py", line 166, in command
          helpers._check_command_response(
        File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/pymongo/helpers.py", line 168, in _check_command_response
          raise NotPrimaryError(errmsg, response)
      pymongo.errors.NotPrimaryError: node is recovering, full error: {'ok': 0.0, 'errmsg': 'node is recovering', 'code': 13436, 'codeName': 'NotPrimaryOrSecondary'}
```

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/integrations-core/issues/13284

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.