### PR TITLE
Fix collected event docs

### DIFF
--- a/vsphere/README.md
+++ b/vsphere/README.md
@@ -61,18 +61,12 @@ collect_per_instance_filters:
 
 This check watches vCenter's Event Manager for events and emits them to Datadog. It emits the following event types:
 
-- AlarmStatusChangedEvent:Gray
+- AlarmStatusChangedEvent
 - VmBeingHotMigratedEvent
 - VmReconfiguredEvent
 - VmPoweredOnEvent
 - VmMigratedEvent
-- TaskEvent:Initialize powering On
-- TaskEvent:Power Off virtual machine
-- TaskEvent:Power On virtual machine
-- TaskEvent:Reconfigure virtual machine
-- TaskEvent:Relocate virtual machine
-- TaskEvent:Suspend virtual machine
-- TaskEvent:Migrate virtual machine
+- TaskEvent
 - VmMessageEvent
 - VmSuspendedEvent
 - VmPoweredOffEvent


### PR DESCRIPTION
### What does this PR do?
Fixes the list of events the integration collects in the readme.
 
### Motivation
The docs were incorrect regarding the events the integration collects. We do have an event [filter](https://github.com/DataDog/integrations-core/blob/master/vsphere/datadog_checks/vsphere/event.py#L16-L34) but the specific event messages listed are actually [excluded](https://github.com/DataDog/integrations-core/blob/master/vsphere/datadog_checks/vsphere/event.py#L66-L70) instead of included. For example, we collect all TaskEvents but filter out some such as `"Initialize powering On"` since we already collect `VmPoweredOnEvent`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.