### PR TITLE
Clean up system core cpu freq logic a little

### DIFF
--- a/system_core/datadog_checks/system_core/system_core.py
+++ b/system_core/datadog_checks/system_core/system_core.py
@@ -35,6 +35,6 @@ class SystemCore(AgentCheck):
         cpu_freq = psutil.cpu_freq(percpu=True)
         self.log.debug('CPU frequency: %s', str(cpu_freq))
         for i, cpu in enumerate(cpu_freq):
-            # Per-cpu frequency retrieval (Unix only)
+            # Only on unix systems we tag cpu frequency by CPU core.
             tags = instance_tags + ['core:{0}'.format(i)] if Platform.is_unix() else instance_tags
             self.gauge('system.core.frequency', cpu.current, tags=tags)

--- a/system_core/datadog_checks/system_core/system_core.py
+++ b/system_core/datadog_checks/system_core/system_core.py
@@ -35,7 +35,6 @@ class SystemCore(AgentCheck):
         cpu_freq = psutil.cpu_freq(percpu=True)
         self.log.debug('CPU frequency: %s', str(cpu_freq))
         for i, cpu in enumerate(cpu_freq):
-            if Platform.is_unix():
-                # Per-cpu frequency retrieval (Linux only)
-                tags = instance_tags + ['core:{0}'.format(i)]
-            self.gauge('system.core.frequency', cpu._asdict().get('current'), tags=tags)
+            # Per-cpu frequency retrieval (Unix only)
+            tags = instance_tags + ['core:{0}'.format(i)] if Platform.is_unix() else instance_tags
+            self.gauge('system.core.frequency', cpu.current, tags=tags)

--- a/system_core/tests/test_system_core.py
+++ b/system_core/tests/test_system_core.py
@@ -6,8 +6,8 @@ from collections import defaultdict
 import mock
 from six import iteritems
 
-from datadog_checks.system_core import SystemCore
 from datadog_checks.base.utils.platform import Platform
+from datadog_checks.system_core import SystemCore
 
 from . import common
 
@@ -38,7 +38,8 @@ class TestSystemCore:
         """
         c = SystemCore('system_core', {}, {}, [{}])
         with mock.patch('datadog_checks.system_core.system_core.psutil') as psutil_mock, mock.patch.object(
-                Platform, 'is_unix') as is_unix_mock:
+            Platform, 'is_unix'
+        ) as is_unix_mock:
             psutil_mock.cpu_times.side_effect = fake_cpu_times
             psutil_mock.cpu_count.return_value = common.MOCK_PSUTIL_CPU_COUNT
             psutil_mock.cpu_freq.return_value = common.MOCK_PSUTIL_CPU_FREQ

--- a/system_core/tests/test_system_core.py
+++ b/system_core/tests/test_system_core.py
@@ -7,6 +7,7 @@ import mock
 from six import iteritems
 
 from datadog_checks.system_core import SystemCore
+from datadog_checks.base.utils.platform import Platform
 
 from . import common
 
@@ -22,13 +23,29 @@ class TestSystemCore:
             c.check({})
 
         aggregator.assert_metric('system.core.count', value=4, count=1)
-        aggregator.assert_metric('system.core.frequency', value=2500)
+        for i, _freq in enumerate(common.MOCK_PSUTIL_CPU_FREQ):
+            aggregator.assert_metric('system.core.frequency', value=2500, tags=['core:{}'.format(i)])
 
         for rate in common.CHECK_RATES:
             for i in range(4):
                 aggregator.assert_metric(rate, count=1, tags=['core:{0}'.format(i)])
 
             aggregator.assert_metric('{}.total'.format(rate), count=1)
+
+    def test_system_core_not_unix(self, aggregator, dd_run_check):
+        """
+        We force the 'is_unix' check to be false to make sure no per-CPU tags are attached to the frequency metric.
+        """
+        c = SystemCore('system_core', {}, {}, [{}])
+        with mock.patch('datadog_checks.system_core.system_core.psutil') as psutil_mock, mock.patch.object(
+                Platform, 'is_unix') as is_unix_mock:
+            psutil_mock.cpu_times.side_effect = fake_cpu_times
+            psutil_mock.cpu_count.return_value = common.MOCK_PSUTIL_CPU_COUNT
+            psutil_mock.cpu_freq.return_value = common.MOCK_PSUTIL_CPU_FREQ
+            is_unix_mock.return_value = False
+            dd_run_check(c)
+
+        aggregator.assert_metric('system.core.frequency', value=2500, tags=[])
 
 
 def fake_cpu_times(percpu=False):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- remove unnecessary conversion to dict
- make sure variable with tags for cpu frequency is always defined.

### Motivation
<!-- What inspired you to submit this pull request? -->
[qa card](https://trello.com/c/YfJQEvXv/12526-adds-systemcorefrequency-metric)
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.