### PR TITLE
Update regex to match legacy provider

### DIFF
--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -286,10 +286,22 @@ Configure one or more filters for the event log. A filter allows you to choose w
       log_processing_rules:
         - type: include_at_match
           name: include_legacy_x01
-          pattern: '"EventID":{"value":"(101|201|301)"'
+          pattern: '"EventID":(?:{"value":)?"(101|201|301)"'
   ```
 
-  Agent versions 7.41 and later normalize the EventID field and this legacy pattern is no longer applicable.
+  Agent versions 7.41 and later normalize the EventID field. This removes the need for the substring, `(?:{"value":)?`, from legacy pattern as it is no longer applicable. A shorter regex pattern can be used from 7.41 onwards as seen below:
+
+  ```yaml
+  logs:
+    - type: windows_event
+      channel_path: Security
+      source: windows.event
+      service: Windows
+      log_processing_rules:
+        - type: include_at_match
+          name: include_x01
+          pattern: '"EventID":"(101|201|301)"'
+  ```
 
 <!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -220,7 +220,7 @@ Configure one or more filters for the event log. A filter allows you to choose w
       log_processing_rules:
       - type: include_at_match
         name: relevant_security_events
-        pattern: '"EventID":"(1102|4624|4625|4634|4648|4728|4732|4735|4737|4740|4755|4756)"'
+        pattern: '"EventID":(?:{"value":)?"(1102|4624|4625|4634|4648|4728|4732|4735|4737|4740|4755|4756)"'
 
     - type: windows_event
       channel_path: Security
@@ -229,7 +229,7 @@ Configure one or more filters for the event log. A filter allows you to choose w
       log_processing_rules:
       - type: exclude_at_match
         name: relevant_security_events
-        pattern: '"EventID":"(1102|4624)"'
+        pattern: '"EventID":(?:{"value":)?"(1102|4624)"'
 
     - type: windows_event
       channel_path: System
@@ -261,7 +261,7 @@ Configure one or more filters for the event log. A filter allows you to choose w
       log_processing_rules:
         - type: include_at_match
           name: include_x01
-          pattern: '"EventID":"(101|201|301)"'
+          pattern: '"EventID":(?:{"value":)?"(101|201|301)"'
   ```
 
   **Note**: The pattern may vary based on the format of the logs. The [Agent `stream-logs` subcommand][15] can be used to view this format.


### PR DESCRIPTION
### What does this PR do?
Updates the regex to match EventIDs of either legacy or non-legacy providers.

### Motivation
It is not always obvious which Windows Events use the Legacy provider.

### Additional Notes
<img width="1096" alt="image" src="https://user-images.githubusercontent.com/20986892/208556614-401eb28a-3fa6-4341-82d3-26986863941d.png">


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.