### PR TITLE
Clarifies that Prometheus and Openmetrics checks are mutually exclusive

### DIFF
--- a/vault/assets/service_checks.json
+++ b/vault/assets/service_checks.json
@@ -54,7 +54,7 @@
             "endpoint"
         ],
         "name": "Vault prometheus health",
-        "description": "Returns `CRITICAL` if the check cannot access the metrics endpoint. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if the check cannot access the metrics endpoint. Returns `OK` otherwise. This service check is only available by using the legacy OpenMetrics implementation (`use_openmetrics: false`)"
     },
     {
         "agent_version": "7.35.0",
@@ -69,6 +69,6 @@
             "endpoint"
         ],
         "name": "OpenMetrics endpoint health",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to the OpenMetrics endpoint, otherwise returns `OK`."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to the OpenMetrics endpoint, otherwise returns `OK`. This service check is only available by using the newer OpenMetrics implementation (`use_openmetrics: true`)"
     }
 ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Clarifies that `vault.prometheus.health` and `vault.openmetrics.health` checks depend on the Openmetrics version used.
### Motivation
<!-- What inspired you to submit this pull request? -->
* Customer reached out as they did not understand why `vault.openmetrics.health` was not available for their Vault integration.
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.