### PR TITLE
Pin and bump the datadog_checks_dev version

### DIFF
--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
 ]
 dependencies = [
-    "datadog-checks-dev[cli]>=17.5.0",
+    "datadog-checks-dev[cli]==17.6.0",
     "hatch>=1.6.3",
     "jsonpointer",
     "pyperclip",

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
 ]
 dependencies = [
-    "datadog-checks-dev[cli]==17.7.0",
+    "datadog-checks-dev[cli]==17.8.1",
     "hatch>=1.6.3",
     "jsonpointer",
     "pyperclip",

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
 ]
 dependencies = [
-    "datadog-checks-dev[cli]==17.6.0",
+    "datadog-checks-dev[cli]==17.7.0",
     "hatch>=1.6.3",
     "jsonpointer",
     "pyperclip",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Pin the datadog_checks_dev version

### Motivation
<!-- What inspired you to submit this pull request? -->

We faced various issues related to the fact that `datadog_checks_dev` was not pinned and some people were using an outdated `datadog_checks_dev` (but that still satisfied the requirements). This lead us to have different errors using the new `ddev` cli, even if we were using the exact same `ddev` version, because we were in fact not using the same `datadog_checks_dev` version. 

I know that fixing this issue is easy (once you know where it comes from) for us, and we just need to `pip install datadog_checks_dev[cli]` to bring the latest version and `ddev` will start working again as expected.  However, I do think some of our users may also get these kind of errors and that will not be that easy for them to fix. 

My opinion is that it will be easier for everyone to pin the `datadog_checks_dev` to be 100% sure that for a specific version `ddev`, everyone uses the same `datadog_checks_dev` version. However, it also means that each time we release a new `datadog_checks_dev` version, we will also have to release `ddev` to use this new version. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This PR is also meant to discuss about that, feel free to let me know what you think. If we choose to pin, then I'll also update our docs in a follow-up PR to make that clear.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.