### PR TITLE
Prevent unnecessary non-SSL connection attempts

### DIFF
--- a/ibm_mq/datadog_checks/ibm_mq/config.py
+++ b/ibm_mq/datadog_checks/ibm_mq/config.py
@@ -166,6 +166,9 @@ class IBMMQConfig:
 
             pattern = pattern.replace('<queue_manager>', re.escape(self.queue_manager_name))
             self.queue_manager_process_pattern = re.compile(pattern)
+
+            # Implied immunity to IBM MQ's memory leak
+            self.try_basic_auth = False
         else:
             self.queue_manager_process_pattern = None
 

--- a/ibm_mq/tests/test_ibm_mq_unit.py
+++ b/ibm_mq/tests/test_ibm_mq_unit.py
@@ -6,6 +6,7 @@ import pytest
 from six import iteritems
 
 from datadog_checks.base import AgentCheck, ConfigurationError
+from datadog_checks.dev.testing import requires_py3
 
 from .common import skip_windows_ci
 
@@ -263,3 +264,12 @@ def test_ssl_check_normal_connection_before_ssl_connection(instance_ssl_dummy):
 
         get_normal_connection.assert_called_with(config, logger)
         get_ssl_connection.assert_called_with(config, logger)
+
+
+@requires_py3
+def test_queue_manager_process_direct_ssl(instance):
+    from datadog_checks.ibm_mq.config import IBMMQConfig
+
+    instance['queue_manager_process'] = 'amqpcsea {}'.format(instance['queue_manager'])
+    config = IBMMQConfig(instance, {})
+    assert config.try_basic_auth is False


### PR DESCRIPTION
### Motivation

Customer noticed some connection errors over time, but they enabled the `queue_manager_process` option and thus are relatively immune to IBM MQ's memory leak