### PR TITLE
[DBM-1862] Add items to agent metadata

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -126,6 +126,7 @@ class MySql(AgentCheck):
     def _send_metadata(self):
         self.set_metadata('version', self.version.version + '+' + self.version.build)
         self.set_metadata('flavor', self.version.flavor)
+        self.set_metadata('resolved_hostname', self.resolved_hostname)
 
     @property
     def resolved_hostname(self):

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -275,6 +275,7 @@ def version_metadata():
         'version.raw': mock.ANY,
         'version.build': mock.ANY,
         'flavor': flavor,
+        'resolved_hostname': 'forced_hostname',
     }
 
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -224,6 +224,7 @@ class PostgreSql(AgentCheck):
                 self._resolved_hostname = self.resolve_db_host()
             else:
                 self._resolved_hostname = self.agent_hostname
+        self.set_metadata('resolved_hostname', self._resolved_hostname)
         return self._resolved_hostname
 
     @property

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -301,12 +301,13 @@ def test_version_metadata(integration_check, pg_instance, datadog_agent):
     version_metadata = {
         'version.scheme': 'semver',
         'version.major': version[0],
+        'resolved_hostname': 'stubbed.hostname',
     }
     if len(version) == 2:
         version_metadata['version.minor'] = version[1]
 
     datadog_agent.assert_metadata('test:123', version_metadata)
-    datadog_agent.assert_metadata_count(5)  # for raw and patch
+    datadog_agent.assert_metadata_count(6)  # for raw and patch
 
 
 def test_state_clears_on_connection_error(integration_check, pg_instance):

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -131,6 +131,8 @@ class SQLServer(AgentCheck):
             self.cloud_metadata.update({'gcp': gcp})
         if azure:
             self.cloud_metadata.update({'azure': azure})
+
+        self.set_metadata('driver', self.instance.get('driver', None))
         obfuscator_options_config = self.instance.get('obfuscator_options', {}) or {}
         self.obfuscator_options = to_native_string(
             json.dumps(

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -206,7 +206,7 @@ class SQLServer(AgentCheck):
             if self.reported_hostname:
                 self._resolved_hostname = self.reported_hostname
             elif self.dbm_enabled:
-                host, port = split_sqlserver_host_port(self.instance.get('host'))
+                host, _ = split_sqlserver_host_port(self.instance.get('host'))
                 self._resolved_hostname = resolve_db_host(host)
                 engine_edition = self.static_info_cache.get(STATIC_INFO_ENGINE_EDITION)
                 if engine_edition == ENGINE_EDITION_SQL_DATABASE:
@@ -231,6 +231,7 @@ class SQLServer(AgentCheck):
                     self._resolved_hostname = "{}/{}".format(host, configured_database)
             else:
                 self._resolved_hostname = self.agent_hostname
+        self.set_metadata('resolved_hostname', self._resolved_hostname)
         return self._resolved_hostname
 
     def load_static_information(self):


### PR DESCRIPTION
### What does this PR do?
Described in [[DBM-1862](https://datadoghq.atlassian.net/browse/DBM-1862)]: Add `resolved_hostname` to metadata for sqlserver, postgres and mysql checks. For sqlserver, also add `driver`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.

[DBM-1862]: https://datadoghq.atlassian.net/browse/DBM-1862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ