### PR TITLE
Add option to enable distribution metrics for query text length from pg_stat_statements

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -318,14 +318,15 @@ files:
             type: number
             example: 10
         - name: pg_stat_statements_max_warning_threshold
+          hidden: true
           description: |
             Set the threshold for a safe value of `pg_stat_statements.max`. If the database is configured with a value
             higher than this threshold, a warning is emitted to recommend lowering the setting value.
           value:
             type: number
             example: 10000
-            hidden: true
         - name: enable_pg_stat_statements_query_text_length_telemetry
+          hidden: true
           description: |
             Enables distribution metrics for monitoring query text length from pg_stat_statements. 
             This is useful for debugging purposes, but it shouldn't be left enabled because this could 
@@ -333,7 +334,6 @@ files:
           value:
             type: boolean
             example: false
-            hidden: true
     - name: query_samples
       description: Configure collection of query samples
       options:

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -325,6 +325,15 @@ files:
             type: number
             example: 10000
             hidden: true
+        - name: enable_pg_stat_statements_query_text_length_telemetry
+          description: |
+            Enables distribution metrics for monitoring query text length from pg_stat_statements. 
+            This is useful for debugging purposes, but it shouldn't be left enabled because this could 
+            degrade the integration's performance.
+          value:
+            type: boolean
+            example: false
+            hidden: true
     - name: query_samples
       description: Configure collection of query samples
       options:

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -77,6 +77,7 @@ class QueryMetrics(BaseModel):
         allow_mutation = False
 
     collection_interval: Optional[float]
+    enable_pg_stat_statements_query_text_length_telemetry: Optional[bool]
     enabled: Optional[bool]
     pg_stat_statements_max_warning_threshold: Optional[float]
 

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -265,19 +265,6 @@ instances:
         #
         # collection_interval: 10
 
-        ## @param pg_stat_statements_max_warning_threshold - number - optional - default: 10000
-        ## Set the threshold for a safe value of `pg_stat_statements.max`. If the database is configured with a value
-        ## higher than this threshold, a warning is emitted to recommend lowering the setting value.
-        #
-        # pg_stat_statements_max_warning_threshold: 10000
-
-        ## @param enable_pg_stat_statements_query_text_length_telemetry - boolean - optional - default: false
-        ## Enables distribution metrics for monitoring query text length from pg_stat_statements. 
-        ## This is useful for debugging purposes, but it shouldn't be left enabled because this could 
-        ## degrade the integration's performance.
-        #
-        # enable_pg_stat_statements_query_text_length_telemetry: false
-
     ## Configure collection of query samples
     #
     # query_samples:

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -271,6 +271,13 @@ instances:
         #
         # pg_stat_statements_max_warning_threshold: 10000
 
+        ## @param enable_pg_stat_statements_query_text_length_telemetry - boolean - optional - default: false
+        ## Enables distribution metrics for monitoring query text length from pg_stat_statements. 
+        ## This is useful for debugging purposes, but it shouldn't be left enabled because this could 
+        ## degrade the integration's performance.
+        #
+        # enable_pg_stat_statements_query_text_length_telemetry: false
+
     ## Configure collection of query samples
     #
     # query_samples:

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -394,12 +394,17 @@ class PostgresStatementMetrics(DBMAsyncJob):
     def _normalize_queries(self, rows):
         normalized_rows = []
         for row in rows:
-            self._check.histogram(
-                "postgresql.pg_stat_statements.query_text_length",
-                len(row['query']),
-                tags=self._tags,
-                hostname=self._check.resolved_hostname,
-            )
+            if is_affirmative(
+                self._config.statement_metrics_config.get(
+                    'enable_pg_stat_statements_query_text_length_telemetry', False
+                )
+            ):
+                self._check.histogram(
+                    "postgresql.pg_stat_statements.query_text_length",
+                    len(row['query']),
+                    tags=self._tags,
+                    hostname=self._check.resolved_hostname,
+                )
             normalized_row = dict(copy.copy(row))
             try:
                 statement = obfuscate_sql_with_metadata(row['query'], self._obfuscate_options)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds an option (hidden) to enable distribution metrics for query text length from pg_stat_statements. 

### Motivation
<!-- What inspired you to submit this pull request? -->
The purpose of this metric was to bring greater visibility into our integration to help with support cases. However, we found that there was a significant jump in agent CPU usage in the latest release candidate (7.42) from ~11% to ~40%.

![Screen Shot 2022-12-21 at 1 15 33 PM](https://user-images.githubusercontent.com/30381624/208985854-2165d552-a4be-435a-87dc-556c05f10a7c.png)

We utilized APM's profiler to narrow down CPU time and found that the histogram was the clear outlier, roughly spending ~30-40% of it's time just emitting these metrics for **each** row, which can be in the 1000s.

<img width="1118" alt="image" src="https://user-images.githubusercontent.com/30381624/208986345-0f69c47a-ff74-4701-945c-eabfb01ff775.png">

Afterwards, we created an agent build without these metrics and the CPU utilization decreased.

![slack-imgs](https://user-images.githubusercontent.com/30381624/208989280-889c7e09-21b0-41ca-8fbb-10af726ebf61.png)



### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.