### PR TITLE
Add option to enable distribution metrics for query text length from pg_stat_statements

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -318,13 +318,22 @@ files:
             type: number
             example: 10
         - name: pg_stat_statements_max_warning_threshold
+          hidden: true
           description: |
             Set the threshold for a safe value of `pg_stat_statements.max`. If the database is configured with a value
             higher than this threshold, a warning is emitted to recommend lowering the setting value.
           value:
             type: number
             example: 10000
-            hidden: true
+        - name: enable_pg_stat_statements_query_text_length_telemetry
+          hidden: true
+          description: |
+            Enables distribution metrics for monitoring query text length from pg_stat_statements. 
+            This is useful for debugging purposes, but it shouldn't be left enabled because this could 
+            degrade the integration's performance.
+          value:
+            type: boolean
+            example: false
     - name: query_samples
       description: Configure collection of query samples
       options:

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -77,6 +77,7 @@ class QueryMetrics(BaseModel):
         allow_mutation = False
 
     collection_interval: Optional[float]
+    enable_pg_stat_statements_query_text_length_telemetry: Optional[bool]
     enabled: Optional[bool]
     pg_stat_statements_max_warning_threshold: Optional[float]
 

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -265,12 +265,6 @@ instances:
         #
         # collection_interval: 10
 
-        ## @param pg_stat_statements_max_warning_threshold - number - optional - default: 10000
-        ## Set the threshold for a safe value of `pg_stat_statements.max`. If the database is configured with a value
-        ## higher than this threshold, a warning is emitted to recommend lowering the setting value.
-        #
-        # pg_stat_statements_max_warning_threshold: 10000
-
     ## Configure collection of query samples
     #
     # query_samples:

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -394,12 +394,17 @@ class PostgresStatementMetrics(DBMAsyncJob):
     def _normalize_queries(self, rows):
         normalized_rows = []
         for row in rows:
-            self._check.histogram(
-                "postgresql.pg_stat_statements.query_text_length",
-                len(row['query']),
-                tags=self._tags,
-                hostname=self._check.resolved_hostname,
-            )
+            if is_affirmative(
+                self._config.statement_metrics_config.get(
+                    'enable_pg_stat_statements_query_text_length_telemetry', False
+                )
+            ):
+                self._check.histogram(
+                    "postgresql.pg_stat_statements.query_text_length",
+                    len(row['query']),
+                    tags=self._tags,
+                    hostname=self._check.resolved_hostname,
+                )
             normalized_row = dict(copy.copy(row))
             try:
                 statement = obfuscate_sql_with_metadata(row['query'], self._obfuscate_options)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Cherry picked https://github.com/DataDog/integrations-core/pull/13564 for RC 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.