### PR TITLE
Disable `exclude_labels` parameter by default

### DIFF
--- a/istio/assets/configuration/spec.yaml
+++ b/istio/assets/configuration/spec.yaml
@@ -42,6 +42,24 @@ files:
           overrides:
             openmetrics_endpoint.required: false
             openmetrics_endpoint.hidden: true
+            exclude_labels.enabled: false
+            exclude_labels.value.example:
+              - source_version
+              - destination_version
+              - source_canonical_revision
+              - destination_canonical_revision
+              - source_principal
+              - destination_principal
+              - source_cluster
+              - destination_cluster
+              - source_canonical_service
+              - destination_canonical_service
+              - source_workload_namespace
+              - destination_workload_namespace
+              - request_protocol
+              - connection_security_policy
+              - destination_service
+              - source_workload
             tag_by_endpoint.hidden: false
             tag_by_endpoint.enabled: true
             tag_by_endpoint.value.example: true

--- a/istio/assets/configuration/spec.yaml
+++ b/istio/assets/configuration/spec.yaml
@@ -42,24 +42,6 @@ files:
           overrides:
             openmetrics_endpoint.required: false
             openmetrics_endpoint.hidden: true
-            exclude_labels.enabled: true
-            exclude_labels.value.example:
-              - source_version
-              - destination_version
-              - source_canonical_revision
-              - destination_canonical_revision
-              - source_principal
-              - destination_principal
-              - source_cluster
-              - destination_cluster
-              - source_canonical_service
-              - destination_canonical_service
-              - source_workload_namespace
-              - destination_workload_namespace
-              - request_protocol
-              - connection_security_policy
-              - destination_service
-              - source_workload
             tag_by_endpoint.hidden: false
             tag_by_endpoint.enabled: true
             tag_by_endpoint.value.example: true

--- a/istio/assets/configuration/spec.yaml
+++ b/istio/assets/configuration/spec.yaml
@@ -42,6 +42,16 @@ files:
           overrides:
             openmetrics_endpoint.required: false
             openmetrics_endpoint.hidden: true
+            exclude_labels.description: |
+              A list of labels to exclude, useful for high cardinality values like timestamps or UUIDs.
+              May be used in conjunction with `include_labels`.
+              Labels defined in `exclude_labels` will take precedence in case of overlap.
+              
+              Special care need to be taken when using this option. It can cause data to be inaccurately
+              aggregated. For reference, see: https://github.com/DataDog/integrations-core/pull/13567
+              for reason why this is disabled by default.
+
+              Note: Label filtering happens before `rename_labels`.
             exclude_labels.enabled: false
             exclude_labels.value.example:
               - source_version
@@ -108,27 +118,3 @@ files:
           type: boolean
           example: False
           display_default: True
-      - name: exclude_labels
-        description: A list of labels to be excluded
-        enabled: true
-        value:
-          type: array
-          items:
-            type: string
-          example:
-            - source_version
-            - destination_version
-            - source_canonical_revision
-            - destination_canonical_revision
-            - source_principal
-            - destination_principal
-            - source_cluster
-            - destination_cluster
-            - source_canonical_service
-            - destination_canonical_service
-            - source_workload_namespace
-            - destination_workload_namespace
-            - request_protocol
-            - connection_security_policy
-            - destination_service
-            - source_workload

--- a/istio/assets/configuration/spec.yaml
+++ b/istio/assets/configuration/spec.yaml
@@ -47,9 +47,9 @@ files:
               May be used in conjunction with `include_labels`.
               Labels defined in `exclude_labels` will take precedence in case of overlap.
               
-              Special care need to be taken when using this option. It can cause data to be inaccurately
-              aggregated. For reference, see: https://github.com/DataDog/integrations-core/pull/13567
-              for reason why this is disabled by default.
+              Special care needs to be taken when using this option, as it can cause data to be inaccurately
+              aggregated. For reference, see https://github.com/DataDog/integrations-core/pull/13567
+              for the reason why this is disabled by default.
 
               Note: Label filtering happens before `rename_labels`.
             exclude_labels.enabled: false

--- a/istio/datadog_checks/istio/data/auto_conf.yaml
+++ b/istio/datadog_checks/istio/data/auto_conf.yaml
@@ -37,24 +37,3 @@ instances:
     ## Wether to include an endpoint tag or not. This only applies if `use openmentrics` is enabled.
     #
     tag_by_endpoint: false
-
-    ## @param exclude_labels - list of strings - optional
-    ## A list of labels to be excluded
-    #
-    exclude_labels:
-      - source_version
-      - destination_version
-      - source_canonical_revision
-      - destination_canonical_revision
-      - source_principal
-      - destination_principal
-      - source_cluster
-      - destination_cluster
-      - source_canonical_service
-      - destination_canonical_service
-      - source_workload_namespace
-      - destination_workload_namespace
-      - request_protocol
-      - connection_security_policy
-      - destination_service
-      - source_workload

--- a/istio/datadog_checks/istio/data/auto_conf.yaml
+++ b/istio/datadog_checks/istio/data/auto_conf.yaml
@@ -37,3 +37,24 @@ instances:
     ## Wether to include an endpoint tag or not. This only applies if `use openmentrics` is enabled.
     #
     tag_by_endpoint: false
+
+    ## @param exclude_labels - list of strings - optional
+    ## A list of labels to be excluded
+    #
+    exclude_labels:
+      - source_version
+      - destination_version
+      - source_canonical_revision
+      - destination_canonical_revision
+      - source_principal
+      - destination_principal
+      - source_cluster
+      - destination_cluster
+      - source_canonical_service
+      - destination_canonical_service
+      - source_workload_namespace
+      - destination_workload_namespace
+      - request_protocol
+      - connection_security_policy
+      - destination_service
+      - source_workload

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -161,7 +161,23 @@ instances:
     ##
     ## Note: Label filtering happens before `rename_labels`.
     #
-    # exclude_labels: []
+    # exclude_labels:
+    #   - source_version
+    #   - destination_version
+    #   - source_canonical_revision
+    #   - destination_canonical_revision
+    #   - source_principal
+    #   - destination_principal
+    #   - source_cluster
+    #   - destination_cluster
+    #   - source_canonical_service
+    #   - destination_canonical_service
+    #   - source_workload_namespace
+    #   - destination_workload_namespace
+    #   - request_protocol
+    #   - connection_security_policy
+    #   - destination_service
+    #   - source_workload
 
     ## @param include_labels - list of strings - optional
     ## A list of labels to include. May be used in conjunction with `exclude_labels`.

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -159,6 +159,10 @@ instances:
     ## May be used in conjunction with `include_labels`.
     ## Labels defined in `exclude_labels` will take precedence in case of overlap.
     ##
+    ## Special care need to be taken when using this option. It can cause data to be inaccurately
+    ## aggregated. For reference, see: https://github.com/DataDog/integrations-core/pull/13567
+    ## for reason why this is disabled by default.
+    ##
     ## Note: Label filtering happens before `rename_labels`.
     #
     # exclude_labels:

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -159,9 +159,9 @@ instances:
     ## May be used in conjunction with `include_labels`.
     ## Labels defined in `exclude_labels` will take precedence in case of overlap.
     ##
-    ## Special care need to be taken when using this option. It can cause data to be inaccurately
-    ## aggregated. For reference, see: https://github.com/DataDog/integrations-core/pull/13567
-    ## for reason why this is disabled by default.
+    ## Special care needs to be taken when using this option, as it can cause data to be inaccurately
+    ## aggregated. For reference, see https://github.com/DataDog/integrations-core/pull/13567
+    ## for the reason why this is disabled by default.
     ##
     ## Note: Label filtering happens before `rename_labels`.
     #

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -161,23 +161,7 @@ instances:
     ##
     ## Note: Label filtering happens before `rename_labels`.
     #
-    exclude_labels:
-      - source_version
-      - destination_version
-      - source_canonical_revision
-      - destination_canonical_revision
-      - source_principal
-      - destination_principal
-      - source_cluster
-      - destination_cluster
-      - source_canonical_service
-      - destination_canonical_service
-      - source_workload_namespace
-      - destination_workload_namespace
-      - request_protocol
-      - connection_security_policy
-      - destination_service
-      - source_workload
+    # exclude_labels: []
 
     ## @param include_labels - list of strings - optional
     ## A list of labels to include. May be used in conjunction with `exclude_labels`.

--- a/istio/datadog_checks/istio/data/conf.yaml.example
+++ b/istio/datadog_checks/istio/data/conf.yaml.example
@@ -161,7 +161,7 @@ instances:
     ##
     ## Special care needs to be taken when using this option, as it can cause data to be inaccurately
     ## aggregated. For reference, see https://github.com/DataDog/integrations-core/pull/13567
-    ## for the reason why this is disabled by default.
+    ## for the reason this is disabled by default.
     ##
     ## Note: Label filtering happens before `rename_labels`.
     #


### PR DESCRIPTION
### What does this PR do?
`exclude_labels` was enabled initially to prevent labels with high cardinality to be collected. This causes issues because when metrics are collected from prometheus, the aggregator would sometimes add different metric values together due to unique labels being ignored.  This essentially reverts: #11953 and #10020

For example:
```
metric_a{tag_a:foo, tag_b:bar} 10
metric_a{tag_a:foo, tag_b:baz} 20
```

In this scenario 2 metrics are collected:
name = `metric_a`
tag = `[tag_a:foo, tag_b:bar]`
value = `10`

and

name = `metric_a`
tag = `[tag_a:foo, tag_b:baz]`
value = `20`

If we exclude the `tag_b` label. Then we group the above together and submit a single metric:
name = `metric_a`
tag = `[tag_a:foo]`
value = `20` (since this was processed last)

As for counters, we aggregate them together:
`20 - 10 = 10` on first submission. Then on the second iteration it will notice that `10` > `20` and will reset the counter to `0`. So it'll will submit `20 - 0 = 20`. 