### PR TITLE
Standardize integration selection

### DIFF
--- a/ddev/src/ddev/repo/core.py
+++ b/ddev/src/ddev/repo/core.py
@@ -70,83 +70,59 @@ class IntegrationRegistry:
         return integration
 
     def iter(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
-        selected = self.__finalize_selection(selection)
-        for path in sorted(self.repo.path.iterdir()):
-            integration = self.__get_from_path(path)
-            if selected and integration.name not in selected:
-                continue
-            elif integration.is_integration:
+        for integration in self.__iter_filtered(selection):
+            if integration.is_integration:
                 yield integration
 
     def iter_all(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
-        selected = self.__finalize_selection(selection)
-        for path in sorted(self.repo.path.iterdir()):
-            integration = self.__get_from_path(path)
-            if selected and integration.name not in selected:
-                continue
-            elif integration.is_valid:
+        for integration in self.__iter_filtered(selection):
+            if integration.is_valid:
                 yield integration
 
     def iter_packages(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
-        selected = self.__finalize_selection(selection)
-        for path in sorted(self.repo.path.iterdir()):
-            integration = self.__get_from_path(path)
-            if selected and integration.name not in selected:
-                continue
-            elif integration.is_package:
+        for integration in self.__iter_filtered(selection):
+            if integration.is_package:
                 yield integration
 
     def iter_tiles(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
-        selected = self.__finalize_selection(selection)
-        for path in sorted(self.repo.path.iterdir()):
-            integration = self.__get_from_path(path)
-            if selected and integration.name not in selected:
-                continue
-            elif integration.is_tile:
+        for integration in self.__iter_filtered(selection):
+            if integration.is_tile:
                 yield integration
 
     def iter_testable(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
-        selected = self.__finalize_selection(selection)
-        for path in sorted(self.repo.path.iterdir()):
-            integration = self.__get_from_path(path)
-            if selected and integration.name not in selected:
-                continue
-            elif integration.is_testable:
+        for integration in self.__iter_filtered(selection):
+            if integration.is_testable:
                 yield integration
 
     def iter_shippable(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
-        selected = self.__finalize_selection(selection)
-        for path in sorted(self.repo.path.iterdir()):
-            integration = self.__get_from_path(path)
-            if selected and integration.name not in selected:
-                continue
-            elif integration.is_shippable:
+        for integration in self.__iter_filtered(selection):
+            if integration.is_shippable:
                 yield integration
 
     def iter_agent_checks(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
-        selected = self.__finalize_selection(selection)
-        for path in sorted(self.repo.path.iterdir()):
-            integration = self.__get_from_path(path)
-            if selected and integration.name not in selected:
-                continue
-            elif integration.is_agent_check:
+        for integration in self.__iter_filtered(selection):
+            if integration.is_agent_check:
                 yield integration
 
     def iter_jmx_checks(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
+        for integration in self.__iter_filtered(selection):
+            if integration.is_jmx_check:
+                yield integration
+
+    def iter_changed(self) -> Iterable[Integration]:
+        yield from self.iter_all()
+
+    def __iter_filtered(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
         selected = self.__finalize_selection(selection)
+        if selected is None:
+            return
+
         for path in sorted(self.repo.path.iterdir()):
             integration = self.__get_from_path(path)
             if selected and integration.name not in selected:
                 continue
-            elif integration.is_jmx_check:
-                yield integration
 
-    def iter_changed(self) -> Iterable[Integration]:
-        changed_root_entries = self.__get_changed_root_entries()
-        for path in sorted(self.repo.path.iterdir()):
-            integration = self.__get_from_path(path)
-            if integration.is_valid and integration.name in changed_root_entries:
-                yield integration
+            yield integration
 
     def __get_from_path(self, path: Path) -> Integration:
         if path.name in self.__cache:
@@ -157,9 +133,9 @@ class IntegrationRegistry:
 
         return integration
 
-    def __finalize_selection(self, selection: Iterable[str]) -> set[str]:
+    def __finalize_selection(self, selection: Iterable[str]) -> set[str] | None:
         if not selection:
-            return self.__get_changed_root_entries()
+            return self.__get_changed_root_entries() or None
         elif 'all' in selection:
             return set()
         else:

--- a/ddev/src/ddev/repo/core.py
+++ b/ddev/src/ddev/repo/core.py
@@ -69,56 +69,80 @@ class IntegrationRegistry:
         self.__cache[name] = integration
         return integration
 
-    def iter(self) -> Iterable[Integration]:
+    def iter(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
+        selected = self.__finalize_selection(selection)
         for path in sorted(self.repo.path.iterdir()):
             integration = self.__get_from_path(path)
-            if integration.is_integration:
+            if selected and integration.name not in selected:
+                continue
+            elif integration.is_integration:
                 yield integration
 
-    def iter_all(self) -> Iterable[Integration]:
+    def iter_all(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
+        selected = self.__finalize_selection(selection)
         for path in sorted(self.repo.path.iterdir()):
             integration = self.__get_from_path(path)
-            if integration.is_valid:
+            if selected and integration.name not in selected:
+                continue
+            elif integration.is_valid:
                 yield integration
 
-    def iter_packages(self) -> Iterable[Integration]:
+    def iter_packages(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
+        selected = self.__finalize_selection(selection)
         for path in sorted(self.repo.path.iterdir()):
             integration = self.__get_from_path(path)
-            if integration.is_package:
+            if selected and integration.name not in selected:
+                continue
+            elif integration.is_package:
                 yield integration
 
-    def iter_tiles(self) -> Iterable[Integration]:
+    def iter_tiles(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
+        selected = self.__finalize_selection(selection)
         for path in sorted(self.repo.path.iterdir()):
             integration = self.__get_from_path(path)
-            if integration.is_tile:
+            if selected and integration.name not in selected:
+                continue
+            elif integration.is_tile:
                 yield integration
 
-    def iter_testable(self) -> Iterable[Integration]:
+    def iter_testable(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
+        selected = self.__finalize_selection(selection)
         for path in sorted(self.repo.path.iterdir()):
             integration = self.__get_from_path(path)
-            if integration.is_testable:
+            if selected and integration.name not in selected:
+                continue
+            elif integration.is_testable:
                 yield integration
 
-    def iter_shippable(self) -> Iterable[Integration]:
+    def iter_shippable(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
+        selected = self.__finalize_selection(selection)
         for path in sorted(self.repo.path.iterdir()):
             integration = self.__get_from_path(path)
-            if integration.is_shippable:
+            if selected and integration.name not in selected:
+                continue
+            elif integration.is_shippable:
                 yield integration
 
-    def iter_agent_checks(self) -> Iterable[Integration]:
+    def iter_agent_checks(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
+        selected = self.__finalize_selection(selection)
         for path in sorted(self.repo.path.iterdir()):
             integration = self.__get_from_path(path)
-            if integration.is_agent_check:
+            if selected and integration.name not in selected:
+                continue
+            elif integration.is_agent_check:
                 yield integration
 
-    def iter_jmx_checks(self) -> Iterable[Integration]:
+    def iter_jmx_checks(self, selection: Iterable[str] = ()) -> Iterable[Integration]:
+        selected = self.__finalize_selection(selection)
         for path in sorted(self.repo.path.iterdir()):
             integration = self.__get_from_path(path)
-            if integration.is_jmx_check:
+            if selected and integration.name not in selected:
+                continue
+            elif integration.is_jmx_check:
                 yield integration
 
     def iter_changed(self) -> Iterable[Integration]:
-        changed_root_entries = {relative_path.split('/', 1)[0] for relative_path in self.repo.git.changed_files}
+        changed_root_entries = self.__get_changed_root_entries()
         for path in sorted(self.repo.path.iterdir()):
             integration = self.__get_from_path(path)
             if integration.is_valid and integration.name in changed_root_entries:
@@ -132,3 +156,14 @@ class IntegrationRegistry:
             self.__cache[path.name] = integration
 
         return integration
+
+    def __finalize_selection(self, selection: Iterable[str]) -> set[str]:
+        if not selection:
+            return self.__get_changed_root_entries()
+        elif 'all' in selection:
+            return set()
+        else:
+            return set(selection)
+
+    def __get_changed_root_entries(self) -> set[str]:
+        return {relative_path.split('/', 1)[0] for relative_path in self.repo.git.changed_files}

--- a/ddev/tests/repo/test_core.py
+++ b/ddev/tests/repo/test_core.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 
+import pytest
+
 from ddev.integration.core import Integration
 from ddev.repo.config import RepositoryConfig
 from ddev.repo.constants import NOT_SHIPPABLE
@@ -42,413 +44,95 @@ class TestGetIntegration:
         assert isinstance(integration, Integration)
 
 
-class TestIterationOnlyIntegrations:
-    def test_default_changed(self, repository):
-        repo = Repository(repository.path.name, str(repository.path))
-
-        integration_names = []
-        for path in repository.path.iterdir():
-            if (path / 'manifest.json').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        integration = integration_names[0]
-        (repository.path / integration / 'foo.txt').touch()
-
-        changed = [integration]
-        integrations = list(repo.integrations.iter())
-
-        assert [integration.name for integration in integrations] == changed
-        assert list(repo.integrations.iter()) == integrations
-
-    def test_selection(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (path / 'manifest.json').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = [integration_names[0]]
-        integrations = list(repo.integrations.iter(selection))
-
-        assert [integration.name for integration in integrations] == selection
-        assert list(repo.integrations.iter(selection)) == integrations
-
-    def test_all(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (path / 'manifest.json').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = ['all']
-        integrations = list(repo.integrations.iter(selection))
-
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter(selection)) == integrations
-
-
-class TestIterationAllValid:
-    def test_default_changed(self, repository):
-        repo = Repository(repository.path.name, str(repository.path))
-
-        integration_names = []
-        for path in repository.path.iterdir():
-            if (path / 'manifest.json').is_file() or (path / 'pyproject.toml').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        integration = integration_names[0]
-        (repository.path / integration / 'foo.txt').touch()
-
-        changed = [integration]
-        integrations = list(repo.integrations.iter_all())
-
-        assert [integration.name for integration in integrations] == changed
-        assert list(repo.integrations.iter_all()) == integrations
-
-    def test_selection(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (path / 'manifest.json').is_file() or (path / 'pyproject.toml').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = [integration_names[0]]
-        integrations = list(repo.integrations.iter_all(selection))
-
-        assert [integration.name for integration in integrations] == selection
-        assert list(repo.integrations.iter_all(selection)) == integrations
-
-    def test_all(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (path / 'manifest.json').is_file() or (path / 'pyproject.toml').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = ['all']
-        integrations = list(repo.integrations.iter_all(selection))
-
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_all(selection)) == integrations
-
-
-class TestIterationPackages:
-    def test_default_changed(self, repository):
-        repo = Repository(repository.path.name, str(repository.path))
-
-        integration_names = []
-        for path in repository.path.iterdir():
-            if (path / 'pyproject.toml').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        integration = integration_names[0]
-        (repository.path / integration / 'foo.txt').touch()
-
-        changed = [integration]
-        integrations = list(repo.integrations.iter_packages())
-
-        assert [integration.name for integration in integrations] == changed
-        assert list(repo.integrations.iter_packages()) == integrations
-
-    def test_selection(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (path / 'pyproject.toml').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = [integration_names[0]]
-        integrations = list(repo.integrations.iter_packages(selection))
-
-        assert [integration.name for integration in integrations] == selection
-        assert list(repo.integrations.iter_packages(selection)) == integrations
-
-    def test_all(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (path / 'pyproject.toml').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = ['all']
-        integrations = list(repo.integrations.iter_packages(selection))
-
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_packages(selection)) == integrations
-
-
-class TestIterationTiles:
-    def test_default_changed(self, repository):
-        repo = Repository(repository.path.name, str(repository.path))
-
-        integration_names = []
-        for path in repository.path.iterdir():
-            if (path / 'manifest.json').is_file() and not (path / 'pyproject.toml').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        integration = integration_names[0]
-        (repository.path / integration / 'foo.txt').touch()
-
-        changed = [integration]
-        integrations = list(repo.integrations.iter_tiles())
-
-        assert [integration.name for integration in integrations] == changed
-        assert list(repo.integrations.iter_tiles()) == integrations
-
-    def test_selection(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (path / 'manifest.json').is_file() and not (path / 'pyproject.toml').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = [integration_names[0]]
-        integrations = list(repo.integrations.iter_tiles(selection))
-
-        assert [integration.name for integration in integrations] == selection
-        assert list(repo.integrations.iter_tiles(selection)) == integrations
-
-    def test_all(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (path / 'manifest.json').is_file() and not (path / 'pyproject.toml').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = ['all']
-        integrations = list(repo.integrations.iter_tiles(selection))
-
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_tiles(selection)) == integrations
-
-
-class TestIterationTestable:
-    def test_default_changed(self, repository):
-        repo = Repository(repository.path.name, str(repository.path))
-
-        integration_names = []
-        for path in repository.path.iterdir():
-            # TODO: remove tox when the Hatch migration is complete
-            if (path / 'hatch.toml').is_file() or (path / 'tox.ini').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        integration = integration_names[0]
-        (repository.path / integration / 'foo.txt').touch()
-
-        changed = [integration]
-        integrations = list(repo.integrations.iter_testable())
-
-        assert [integration.name for integration in integrations] == changed
-        assert list(repo.integrations.iter_testable()) == integrations
-
-    def test_selection(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            # TODO: remove tox when the Hatch migration is complete
-            if (path / 'hatch.toml').is_file() or (path / 'tox.ini').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = [integration_names[0]]
-        integrations = list(repo.integrations.iter_testable(selection))
-
-        assert [integration.name for integration in integrations] == selection
-        assert list(repo.integrations.iter_testable(selection)) == integrations
-
-    def test_all(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            # TODO: remove tox when the Hatch migration is complete
-            if (path / 'hatch.toml').is_file() or (path / 'tox.ini').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = ['all']
-        integrations = list(repo.integrations.iter_testable(selection))
-
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_testable(selection)) == integrations
-
-
-class TestIterationShippable:
-    def test_default_changed(self, repository):
-        repo = Repository(repository.path.name, str(repository.path))
-
-        integration_names = []
-        for path in repository.path.iterdir():
-            if (path / 'pyproject.toml').is_file() and path.name not in NOT_SHIPPABLE:
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        integration = integration_names[0]
-        (repository.path / integration / 'foo.txt').touch()
-
-        changed = [integration]
-        integrations = list(repo.integrations.iter_shippable())
-
-        assert [integration.name for integration in integrations] == changed
-        assert list(repo.integrations.iter_shippable()) == integrations
-
-    def test_selection(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (path / 'pyproject.toml').is_file() and path.name not in NOT_SHIPPABLE:
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = [integration_names[0]]
-        integrations = list(repo.integrations.iter_shippable(selection))
-
-        assert [integration.name for integration in integrations] == selection
-        assert list(repo.integrations.iter_shippable(selection)) == integrations
-
-    def test_all(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (path / 'pyproject.toml').is_file() and path.name not in NOT_SHIPPABLE:
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = ['all']
-        integrations = list(repo.integrations.iter_shippable(selection))
-
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_shippable(selection)) == integrations
-
-
-class TestIterationAgentChecks:
-    def test_default_changed(self, repository):
-        repo = Repository(repository.path.name, str(repository.path))
-
-        integration_names = []
-        for path in repository.path.iterdir():
-            if (
+class TestIntegrationsIteration:
+
+    iter_test_params = [
+        pytest.param("iter", lambda path: (path / 'manifest.json').is_file(), id="only integrations"),
+        pytest.param(
+            "iter_all",
+            lambda path: (path / 'manifest.json').is_file() or (path / 'pyproject.toml').is_file(),
+            id="all valid",
+        ),
+        pytest.param("iter_packages", lambda path: (path / 'pyproject.toml').is_file(), id="packages"),
+        pytest.param(
+            "iter_tiles",
+            lambda path: (path / 'manifest.json').is_file() and not (path / 'pyproject.toml').is_file(),
+            id="tiles",
+        ),
+        # TODO: remove tox when the Hatch migration is complete
+        pytest.param(
+            "iter_testable", lambda path: (path / 'hatch.toml').is_file() or (path / 'tox.ini').is_file(), id="testable"
+        ),
+        pytest.param(
+            "iter_shippable",
+            lambda path: (path / 'pyproject.toml').is_file() and path.name not in NOT_SHIPPABLE,
+            id="shippable",
+        ),
+        pytest.param(
+            "iter_agent_checks",
+            lambda path: (
                 package_root := path / 'datadog_checks' / path.name.replace('-', '_') / '__init__.py'
-            ).is_file() and package_root.read_text().count('import ') > 1:
-                integration_names.append(path.name)
-        integration_names.sort()
+            ).is_file()
+            and package_root.read_text().count('import ') > 1,
+            id="agent checks",
+        ),
+        pytest.param(
+            "iter_jmx_checks",
+            lambda path: (path / 'datadog_checks' / path.name.replace('-', '_') / 'data' / 'metrics.yaml').is_file(),
+            id="jmx checks",
+        ),
+    ]
 
-        integration = integration_names[0]
-        (repository.path / integration / 'foo.txt').touch()
-
-        changed = [integration]
-        integrations = list(repo.integrations.iter_agent_checks())
-
-        assert [integration.name for integration in integrations] == changed
-        assert list(repo.integrations.iter_agent_checks()) == integrations
-
-    def test_selection(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (
-                package_root := path / 'datadog_checks' / path.name.replace('-', '_') / '__init__.py'
-            ).is_file() and package_root.read_text().count('import ') > 1:
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = [integration_names[0]]
-        integrations = list(repo.integrations.iter_agent_checks(selection))
-
-        assert [integration.name for integration in integrations] == selection
-        assert list(repo.integrations.iter_agent_checks(selection)) == integrations
-
-    def test_all(self, local_repo):
-        repo = Repository(local_repo.name, str(local_repo))
-
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (
-                package_root := path / 'datadog_checks' / path.name.replace('-', '_') / '__init__.py'
-            ).is_file() and package_root.read_text().count('import ') > 1:
-                integration_names.append(path.name)
-        integration_names.sort()
-
-        selection = ['all']
-        integrations = list(repo.integrations.iter_agent_checks(selection))
-
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_agent_checks(selection)) == integrations
-
-
-class TestIterationJMXChecks:
-    def test_default_changed(self, repository):
+    @pytest.mark.parametrize(
+        "method_name, integration_filter",
+        iter_test_params,
+    )
+    def test_integrations_iteration_default_changed(self, method_name, integration_filter, repository):
         repo = Repository(repository.path.name, str(repository.path))
 
-        integration_names = []
-        for path in repository.path.iterdir():
-            if (path / 'datadog_checks' / path.name.replace('-', '_') / 'data' / 'metrics.yaml').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
+        integration_names = sorted(path.name for path in repository.path.iterdir() if integration_filter(path))
 
         integration = integration_names[0]
-        (repository.path / integration / 'foo.txt').touch()
+        (repo.path / integration / 'foo.txt').touch()
 
         changed = [integration]
-        integrations = list(repo.integrations.iter_jmx_checks())
+        iter_method = getattr(repo.integrations, method_name)
+        integrations = list(iter_method())
 
         assert [integration.name for integration in integrations] == changed
-        assert list(repo.integrations.iter_jmx_checks()) == integrations
+        assert list(iter_method()) == integrations
 
-    def test_selection(self, local_repo):
+    @pytest.mark.parametrize(
+        "method_name, integration_filter",
+        iter_test_params,
+    )
+    def test_integrations_iteration_selection(self, method_name, integration_filter, local_repo):
         repo = Repository(local_repo.name, str(local_repo))
 
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (path / 'datadog_checks' / path.name.replace('-', '_') / 'data' / 'metrics.yaml').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
+        integration_names = sorted(path.name for path in local_repo.iterdir() if integration_filter(path))
 
         selection = [integration_names[0]]
-        integrations = list(repo.integrations.iter_jmx_checks(selection))
+        iter_method = getattr(repo.integrations, method_name)
+        integrations = list(iter_method(selection))
 
         assert [integration.name for integration in integrations] == selection
-        assert list(repo.integrations.iter_jmx_checks(selection)) == integrations
+        assert list(iter_method(selection)) == integrations
 
-    def test_all(self, local_repo):
+    @pytest.mark.parametrize(
+        "method_name, integration_filter",
+        iter_test_params,
+    )
+    def test_integrations_iteration_select_all(self, method_name, integration_filter, local_repo):
         repo = Repository(local_repo.name, str(local_repo))
 
-        integration_names = []
-        for path in local_repo.iterdir():
-            if (path / 'datadog_checks' / path.name.replace('-', '_') / 'data' / 'metrics.yaml').is_file():
-                integration_names.append(path.name)
-        integration_names.sort()
+        integration_names = sorted(path.name for path in local_repo.iterdir() if integration_filter(path))
 
         selection = ['all']
-        integrations = list(repo.integrations.iter_jmx_checks(selection))
+        iter_method = getattr(repo.integrations, method_name)
+        integrations = list(iter_method(selection))
 
         assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_jmx_checks(selection)) == integrations
+        assert list(iter_method(selection)) == integrations
 
 
 class TestIterationChanged:

--- a/ddev/tests/repo/test_core.py
+++ b/ddev/tests/repo/test_core.py
@@ -42,8 +42,26 @@ class TestGetIntegration:
         assert isinstance(integration, Integration)
 
 
-class TestIteration:
-    def test_only_integrations(self, local_repo):
+class TestIterationOnlyIntegrations:
+    def test_default_changed(self, repository):
+        repo = Repository(repository.path.name, str(repository.path))
+
+        integration_names = []
+        for path in repository.path.iterdir():
+            if (path / 'manifest.json').is_file():
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        integration = integration_names[0]
+        (repository.path / integration / 'foo.txt').touch()
+
+        changed = [integration]
+        integrations = list(repo.integrations.iter())
+
+        assert [integration.name for integration in integrations] == changed
+        assert list(repo.integrations.iter()) == integrations
+
+    def test_selection(self, local_repo):
         repo = Repository(local_repo.name, str(local_repo))
 
         integration_names = []
@@ -52,9 +70,61 @@ class TestIteration:
                 integration_names.append(path.name)
         integration_names.sort()
 
-        integrations = list(repo.integrations.iter())
+        selection = [integration_names[0]]
+        integrations = list(repo.integrations.iter(selection))
+
+        assert [integration.name for integration in integrations] == selection
+        assert list(repo.integrations.iter(selection)) == integrations
+
+    def test_all(self, local_repo):
+        repo = Repository(local_repo.name, str(local_repo))
+
+        integration_names = []
+        for path in local_repo.iterdir():
+            if (path / 'manifest.json').is_file():
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        selection = ['all']
+        integrations = list(repo.integrations.iter(selection))
+
         assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter()) == integrations
+        assert list(repo.integrations.iter(selection)) == integrations
+
+
+class TestIterationAllValid:
+    def test_default_changed(self, repository):
+        repo = Repository(repository.path.name, str(repository.path))
+
+        integration_names = []
+        for path in repository.path.iterdir():
+            if (path / 'manifest.json').is_file() or (path / 'pyproject.toml').is_file():
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        integration = integration_names[0]
+        (repository.path / integration / 'foo.txt').touch()
+
+        changed = [integration]
+        integrations = list(repo.integrations.iter_all())
+
+        assert [integration.name for integration in integrations] == changed
+        assert list(repo.integrations.iter_all()) == integrations
+
+    def test_selection(self, local_repo):
+        repo = Repository(local_repo.name, str(local_repo))
+
+        integration_names = []
+        for path in local_repo.iterdir():
+            if (path / 'manifest.json').is_file() or (path / 'pyproject.toml').is_file():
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        selection = [integration_names[0]]
+        integrations = list(repo.integrations.iter_all(selection))
+
+        assert [integration.name for integration in integrations] == selection
+        assert list(repo.integrations.iter_all(selection)) == integrations
 
     def test_all(self, local_repo):
         repo = Repository(local_repo.name, str(local_repo))
@@ -65,11 +135,33 @@ class TestIteration:
                 integration_names.append(path.name)
         integration_names.sort()
 
-        integrations = list(repo.integrations.iter_all())
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_all()) == integrations
+        selection = ['all']
+        integrations = list(repo.integrations.iter_all(selection))
 
-    def test_packages(self, local_repo):
+        assert [integration.name for integration in integrations] == integration_names
+        assert list(repo.integrations.iter_all(selection)) == integrations
+
+
+class TestIterationPackages:
+    def test_default_changed(self, repository):
+        repo = Repository(repository.path.name, str(repository.path))
+
+        integration_names = []
+        for path in repository.path.iterdir():
+            if (path / 'pyproject.toml').is_file():
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        integration = integration_names[0]
+        (repository.path / integration / 'foo.txt').touch()
+
+        changed = [integration]
+        integrations = list(repo.integrations.iter_packages())
+
+        assert [integration.name for integration in integrations] == changed
+        assert list(repo.integrations.iter_packages()) == integrations
+
+    def test_selection(self, local_repo):
         repo = Repository(local_repo.name, str(local_repo))
 
         integration_names = []
@@ -78,11 +170,48 @@ class TestIteration:
                 integration_names.append(path.name)
         integration_names.sort()
 
-        integrations = list(repo.integrations.iter_packages())
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_packages()) == integrations
+        selection = [integration_names[0]]
+        integrations = list(repo.integrations.iter_packages(selection))
 
-    def test_tiles(self, local_repo):
+        assert [integration.name for integration in integrations] == selection
+        assert list(repo.integrations.iter_packages(selection)) == integrations
+
+    def test_all(self, local_repo):
+        repo = Repository(local_repo.name, str(local_repo))
+
+        integration_names = []
+        for path in local_repo.iterdir():
+            if (path / 'pyproject.toml').is_file():
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        selection = ['all']
+        integrations = list(repo.integrations.iter_packages(selection))
+
+        assert [integration.name for integration in integrations] == integration_names
+        assert list(repo.integrations.iter_packages(selection)) == integrations
+
+
+class TestIterationTiles:
+    def test_default_changed(self, repository):
+        repo = Repository(repository.path.name, str(repository.path))
+
+        integration_names = []
+        for path in repository.path.iterdir():
+            if (path / 'manifest.json').is_file() and not (path / 'pyproject.toml').is_file():
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        integration = integration_names[0]
+        (repository.path / integration / 'foo.txt').touch()
+
+        changed = [integration]
+        integrations = list(repo.integrations.iter_tiles())
+
+        assert [integration.name for integration in integrations] == changed
+        assert list(repo.integrations.iter_tiles()) == integrations
+
+    def test_selection(self, local_repo):
         repo = Repository(local_repo.name, str(local_repo))
 
         integration_names = []
@@ -91,11 +220,49 @@ class TestIteration:
                 integration_names.append(path.name)
         integration_names.sort()
 
-        integrations = list(repo.integrations.iter_tiles())
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_tiles()) == integrations
+        selection = [integration_names[0]]
+        integrations = list(repo.integrations.iter_tiles(selection))
 
-    def test_testable(self, local_repo):
+        assert [integration.name for integration in integrations] == selection
+        assert list(repo.integrations.iter_tiles(selection)) == integrations
+
+    def test_all(self, local_repo):
+        repo = Repository(local_repo.name, str(local_repo))
+
+        integration_names = []
+        for path in local_repo.iterdir():
+            if (path / 'manifest.json').is_file() and not (path / 'pyproject.toml').is_file():
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        selection = ['all']
+        integrations = list(repo.integrations.iter_tiles(selection))
+
+        assert [integration.name for integration in integrations] == integration_names
+        assert list(repo.integrations.iter_tiles(selection)) == integrations
+
+
+class TestIterationTestable:
+    def test_default_changed(self, repository):
+        repo = Repository(repository.path.name, str(repository.path))
+
+        integration_names = []
+        for path in repository.path.iterdir():
+            # TODO: remove tox when the Hatch migration is complete
+            if (path / 'hatch.toml').is_file() or (path / 'tox.ini').is_file():
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        integration = integration_names[0]
+        (repository.path / integration / 'foo.txt').touch()
+
+        changed = [integration]
+        integrations = list(repo.integrations.iter_testable())
+
+        assert [integration.name for integration in integrations] == changed
+        assert list(repo.integrations.iter_testable()) == integrations
+
+    def test_selection(self, local_repo):
         repo = Repository(local_repo.name, str(local_repo))
 
         integration_names = []
@@ -105,11 +272,49 @@ class TestIteration:
                 integration_names.append(path.name)
         integration_names.sort()
 
-        integrations = list(repo.integrations.iter_testable())
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_testable()) == integrations
+        selection = [integration_names[0]]
+        integrations = list(repo.integrations.iter_testable(selection))
 
-    def test_shippable(self, local_repo):
+        assert [integration.name for integration in integrations] == selection
+        assert list(repo.integrations.iter_testable(selection)) == integrations
+
+    def test_all(self, local_repo):
+        repo = Repository(local_repo.name, str(local_repo))
+
+        integration_names = []
+        for path in local_repo.iterdir():
+            # TODO: remove tox when the Hatch migration is complete
+            if (path / 'hatch.toml').is_file() or (path / 'tox.ini').is_file():
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        selection = ['all']
+        integrations = list(repo.integrations.iter_testable(selection))
+
+        assert [integration.name for integration in integrations] == integration_names
+        assert list(repo.integrations.iter_testable(selection)) == integrations
+
+
+class TestIterationShippable:
+    def test_default_changed(self, repository):
+        repo = Repository(repository.path.name, str(repository.path))
+
+        integration_names = []
+        for path in repository.path.iterdir():
+            if (path / 'pyproject.toml').is_file() and path.name not in NOT_SHIPPABLE:
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        integration = integration_names[0]
+        (repository.path / integration / 'foo.txt').touch()
+
+        changed = [integration]
+        integrations = list(repo.integrations.iter_shippable())
+
+        assert [integration.name for integration in integrations] == changed
+        assert list(repo.integrations.iter_shippable()) == integrations
+
+    def test_selection(self, local_repo):
         repo = Repository(local_repo.name, str(local_repo))
 
         integration_names = []
@@ -118,11 +323,50 @@ class TestIteration:
                 integration_names.append(path.name)
         integration_names.sort()
 
-        integrations = list(repo.integrations.iter_shippable())
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_shippable()) == integrations
+        selection = [integration_names[0]]
+        integrations = list(repo.integrations.iter_shippable(selection))
 
-    def test_agent_checks(self, local_repo):
+        assert [integration.name for integration in integrations] == selection
+        assert list(repo.integrations.iter_shippable(selection)) == integrations
+
+    def test_all(self, local_repo):
+        repo = Repository(local_repo.name, str(local_repo))
+
+        integration_names = []
+        for path in local_repo.iterdir():
+            if (path / 'pyproject.toml').is_file() and path.name not in NOT_SHIPPABLE:
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        selection = ['all']
+        integrations = list(repo.integrations.iter_shippable(selection))
+
+        assert [integration.name for integration in integrations] == integration_names
+        assert list(repo.integrations.iter_shippable(selection)) == integrations
+
+
+class TestIterationAgentChecks:
+    def test_default_changed(self, repository):
+        repo = Repository(repository.path.name, str(repository.path))
+
+        integration_names = []
+        for path in repository.path.iterdir():
+            if (
+                package_root := path / 'datadog_checks' / path.name.replace('-', '_') / '__init__.py'
+            ).is_file() and package_root.read_text().count('import ') > 1:
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        integration = integration_names[0]
+        (repository.path / integration / 'foo.txt').touch()
+
+        changed = [integration]
+        integrations = list(repo.integrations.iter_agent_checks())
+
+        assert [integration.name for integration in integrations] == changed
+        assert list(repo.integrations.iter_agent_checks()) == integrations
+
+    def test_selection(self, local_repo):
         repo = Repository(local_repo.name, str(local_repo))
 
         integration_names = []
@@ -133,11 +377,50 @@ class TestIteration:
                 integration_names.append(path.name)
         integration_names.sort()
 
-        integrations = list(repo.integrations.iter_agent_checks())
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_agent_checks()) == integrations
+        selection = [integration_names[0]]
+        integrations = list(repo.integrations.iter_agent_checks(selection))
 
-    def test_jmx_checks(self, local_repo):
+        assert [integration.name for integration in integrations] == selection
+        assert list(repo.integrations.iter_agent_checks(selection)) == integrations
+
+    def test_all(self, local_repo):
+        repo = Repository(local_repo.name, str(local_repo))
+
+        integration_names = []
+        for path in local_repo.iterdir():
+            if (
+                package_root := path / 'datadog_checks' / path.name.replace('-', '_') / '__init__.py'
+            ).is_file() and package_root.read_text().count('import ') > 1:
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        selection = ['all']
+        integrations = list(repo.integrations.iter_agent_checks(selection))
+
+        assert [integration.name for integration in integrations] == integration_names
+        assert list(repo.integrations.iter_agent_checks(selection)) == integrations
+
+
+class TestIterationJMXChecks:
+    def test_default_changed(self, repository):
+        repo = Repository(repository.path.name, str(repository.path))
+
+        integration_names = []
+        for path in repository.path.iterdir():
+            if (path / 'datadog_checks' / path.name.replace('-', '_') / 'data' / 'metrics.yaml').is_file():
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        integration = integration_names[0]
+        (repository.path / integration / 'foo.txt').touch()
+
+        changed = [integration]
+        integrations = list(repo.integrations.iter_jmx_checks())
+
+        assert [integration.name for integration in integrations] == changed
+        assert list(repo.integrations.iter_jmx_checks()) == integrations
+
+    def test_selection(self, local_repo):
         repo = Repository(local_repo.name, str(local_repo))
 
         integration_names = []
@@ -146,11 +429,30 @@ class TestIteration:
                 integration_names.append(path.name)
         integration_names.sort()
 
-        integrations = list(repo.integrations.iter_jmx_checks())
-        assert [integration.name for integration in integrations] == integration_names
-        assert list(repo.integrations.iter_jmx_checks()) == integrations
+        selection = [integration_names[0]]
+        integrations = list(repo.integrations.iter_jmx_checks(selection))
 
-    def test_changed(self, repository):
+        assert [integration.name for integration in integrations] == selection
+        assert list(repo.integrations.iter_jmx_checks(selection)) == integrations
+
+    def test_all(self, local_repo):
+        repo = Repository(local_repo.name, str(local_repo))
+
+        integration_names = []
+        for path in local_repo.iterdir():
+            if (path / 'datadog_checks' / path.name.replace('-', '_') / 'data' / 'metrics.yaml').is_file():
+                integration_names.append(path.name)
+        integration_names.sort()
+
+        selection = ['all']
+        integrations = list(repo.integrations.iter_jmx_checks(selection))
+
+        assert [integration.name for integration in integrations] == integration_names
+        assert list(repo.integrations.iter_jmx_checks(selection)) == integrations
+
+
+class TestIterationChanged:
+    def test(self, repository):
         repo = Repository(repository.path.name, str(repository.path))
 
         new_integration = repo.path / 'new'


### PR DESCRIPTION
### What does this PR do?

For commands that take an optional `INTEGRATIONS` argument:

- not specifying any will target every integration that has changed in Git
- selecting `all` will target every integration