### PR TITLE
Fix setting of default health URL for kube_dns, kube_proxy, kube_metrics_server health checks

### DIFF
--- a/kube_dns/datadog_checks/kube_dns/kube_dns.py
+++ b/kube_dns/datadog_checks/kube_dns/kube_dns.py
@@ -37,11 +37,6 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
         # Create instances we can use in OpenMetricsBaseCheck
         generic_instances = None
         if instances is not None:
-            generic_instances = self.create_generic_instances(instances)
-
-        super(KubeDNSCheck, self).__init__(name, init_config, instances=generic_instances)
-
-        if instances is not None:
             for instance in instances:
                 url = instance.get('health_url')
                 prometheus_endpoint = instance.get('prometheus_endpoint')
@@ -50,6 +45,9 @@ class KubeDNSCheck(OpenMetricsBaseCheck):
                     url = re.sub(r':[0-9]+/metrics$', ':8081/readiness', prometheus_endpoint)
 
                 instance['health_url'] = url
+            generic_instances = self.create_generic_instances(instances)
+
+        super(KubeDNSCheck, self).__init__(name, init_config, instances=generic_instances)
 
     def check(self, instance):
         endpoint = instance.get('prometheus_endpoint')

--- a/kube_metrics_server/datadog_checks/kube_metrics_server/kube_metrics_server.py
+++ b/kube_metrics_server/datadog_checks/kube_metrics_server/kube_metrics_server.py
@@ -93,6 +93,16 @@ class KubeMetricsServerCheck(OpenMetricsBaseCheck):
     DEFAULT_METRIC_LIMIT = 0
 
     def __init__(self, name, init_config, instances):
+        if instances is not None:
+            for instance in instances:
+                url = instance.get('health_url')
+                prometheus_url = instance.get('prometheus_url')
+
+                if url is None and re.search(r'/metrics$', prometheus_url):
+                    url = re.sub(r'/metrics$', '/livez', prometheus_url)
+
+                instance['health_url'] = url
+
         super(KubeMetricsServerCheck, self).__init__(
             name,
             init_config,
@@ -106,16 +116,6 @@ class KubeMetricsServerCheck(OpenMetricsBaseCheck):
             },
             default_namespace=KUBE_METRICS_SERVER_NAMESPACE,
         )
-
-        if instances is not None:
-            for instance in instances:
-                url = instance.get('health_url')
-                prometheus_url = instance.get('prometheus_url')
-
-                if url is None and re.search(r'/metrics$', prometheus_url):
-                    url = re.sub(r'/metrics$', '/livez', prometheus_url)
-
-                instance['health_url'] = url
 
     def check(self, instance):
         # Get the configuration for this specific instance


### PR DESCRIPTION
### What does this PR do?
Attempts to fix a bug from https://github.com/DataDog/integrations-core/pull/10668; the default health check urls for `kube_dns`, `kube_proxy`, and `kube_metrics_server` weren't being set so the `<integration>.up` service checks were missing unless the health url was manually specified.

Example yaml config
```yaml
ad_identifiers:
  - kube-proxy

init_config:

instances:
  - prometheus_url: http://%%host%%:10249/metrics
```

Example check run
```
=== Service Checks ===
[
...
  {
    "check": "kubeproxy.up",
    "host_name": "xxx",
    "timestamp": 1671742559,
    "status": 0,
    "message": "",
    "tags": [
      "image_id:<image-id>,
      "image_name:k8s.gcr.io/kube-proxy",
      "image_tag:v1.24.0",
      "kube_container_name:kube-proxy",
      "kube_daemon_set:kube-proxy",
      "kube_namespace:kube-system",
      "kube_ownerref_kind:daemonset",
      "kube_priority_class:system-node-critical",
      "kube_qos:BestEffort",
      "pod_phase:running",
      "short_image:kube-proxy"
    ]
  }
]
```

### Motivation
Missing service checks

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.