### PR TITLE
Add option to enable profiling of Python integrations

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/utils/__init__.py
@@ -1,6 +1,9 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+
+from ..config import is_affirmative
 
 try:
     import datadog_agent
@@ -15,6 +18,12 @@ try:
         else:
             patch(requests=True)
 
+    if is_affirmative(datadog_agent.get_config('integration_profiling')):
+        from ddtrace.profiling import Profiler
+
+        prof = Profiler(service='datadog-agent-integrations')
+        prof.start()
+
 except ImportError:
-    # Tracing Integrations is only available with Agent 6
+    # Tracing & profiling Integrations is only available with Agent 6
     pass


### PR DESCRIPTION
### What does this PR do?

Add new config option `integration_profiling` which enables [profiling](https://docs.datadoghq.com/profiler/enabling/python/#usage) of python integrations.

### Motivation

This has proven valuable several times already while troubleshooting performance issues so we're adding it as an option to have it available by default without requiring a custom build.

![image](https://user-images.githubusercontent.com/3707657/209403548-c2ffee67-972c-4533-98cf-a1178d03f1fc.png)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.