### PR TITLE
Update integration tracing naming scheme

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -19,6 +19,7 @@ from datadog_checks.base import is_affirmative
 from datadog_checks.base.log import get_check_logger
 from datadog_checks.base.utils.db.types import Transformer
 from datadog_checks.base.utils.serialization import json
+from datadog_checks.base.utils.tracing import INTEGRATION_TRACING_SERVICE_NAME
 
 from ..common import to_native_string
 
@@ -46,16 +47,20 @@ SUBMISSION_METHODS = {
 
 def _traced_dbm_async_job_method(f):
     # traces DBMAsyncJob.run_job only if tracing is enabled
-    if os.getenv('DDEV_TRACE_ENABLED', 'false') == 'true':
+    if os.getenv('DDEV_TRACE_ENABLED', 'false') == 'true' or is_affirmative(
+        datadog_agent.get_config('integration_tracing')
+    ):
         try:
             from ddtrace import tracer
 
             @functools.wraps(f)
             def wrapper(self, *args, **kwargs):
                 with tracer.trace(
+                    # match the same primary operation name as the regular integration tracing so that these async job
+                    # resources appear in the resource list alongside the main check resource
                     "run",
-                    service="{}-integration".format(self._check.name),
-                    resource="{}.run_job".format(type(self).__name__),
+                    service=INTEGRATION_TRACING_SERVICE_NAME,
+                    resource="{}.{}".format(self._check.name, type(self).__name__),
                 ):
                     self.run_job()
 

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -60,7 +60,7 @@ def _traced_dbm_async_job_method(f):
                     # resources appear in the resource list alongside the main check resource
                     "run",
                     service=INTEGRATION_TRACING_SERVICE_NAME,
-                    resource="{}.{}".format(self._check.name, type(self).__name__),
+                    resource="{}.{}".format(self._check.name, self._job_name),
                 ):
                     self.run_job()
 

--- a/datadog_checks_base/tests/base/utils/test_tracing.py
+++ b/datadog_checks_base/tests/base/utils/test_tracing.py
@@ -8,7 +8,7 @@ import mock
 import pytest
 
 from datadog_checks.base.stubs import aggregator
-from datadog_checks.base.utils.tracing import traced_class
+from datadog_checks.base.utils.tracing import INTEGRATION_TRACING_SERVICE_NAME, traced_class
 
 
 class MockAgentCheck(object):
@@ -44,8 +44,8 @@ def test_traced_class(traces_enabled):
         if os.environ['DDEV_TRACE_ENABLED'] == 'true':
             tracer.trace.assert_has_calls(
                 [
-                    mock.call('__init__', resource='__init__', service='dummy-integration'),
-                    mock.call('check', resource='check', service='dummy-integration'),
+                    mock.call('__init__', resource='dummy', service=INTEGRATION_TRACING_SERVICE_NAME),
+                    mock.call('check', resource='dummy', service=INTEGRATION_TRACING_SERVICE_NAME),
                 ],
                 any_order=True,
             )


### PR DESCRIPTION
### What does this PR do?

Follow-up to https://github.com/DataDog/integrations-core/pull/13576, update the integrations tracing naming scheme to ensure all integrations appear under a single service, matching the name of the service used for profiling. This enables better linking between APM & profiling data, specifically the "Code Hotspots" feature. 

<img width="843" alt="image" src="https://user-images.githubusercontent.com/3707657/209735024-d2087728-534b-439c-ad90-699b9a49f5ad.png">

Since all integrations are now reporting under a single service, the resource name is updated to refer only to the integration name in order to enable us to differentiate reporting from the different integrations. They are all visible in the resource list:

<img width="440" alt="image" src="https://user-images.githubusercontent.com/3707657/209734679-51a9e229-db00-4f39-8412-03a529558d6e.png">

### Motivation

Improve the tracing & profiling experience for python integrations. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.