### PR TITLE
openstack remove redundant tracing

### DIFF
--- a/datadog_checks_base/tests/base/utils/test_tracing.py
+++ b/datadog_checks_base/tests/base/utils/test_tracing.py
@@ -8,7 +8,7 @@ import mock
 import pytest
 
 from datadog_checks.base.stubs import aggregator
-from datadog_checks.base.utils.tracing import traced, traced_class
+from datadog_checks.base.utils.tracing import traced_class
 
 
 class MockAgentCheck(object):
@@ -27,54 +27,8 @@ class DummyCheck(MockAgentCheck):
         super(DummyCheck, self).__init__(*args, **kwargs)
         self.checked = False
 
-    @traced
     def check(self, instance):
         self.gauge('dummy.metric', 10)
-
-
-@pytest.mark.parametrize(
-    'agent_config, init_config, called',
-    [
-        pytest.param({}, {}, False, id='agent_notset_init_notset_notcalled'),
-        pytest.param({'integration_tracing': True}, {}, False, id='agent_true_init_notset_notcalled'),
-        pytest.param(
-            {'integration_tracing': True}, {'trace_check': False}, False, id='agent_true_init_false_notcalled'
-        ),
-        pytest.param(
-            {'integration_tracing': False}, {'trace_check': False}, False, id='agent_false_init_false_notcalled'
-        ),
-        pytest.param({}, {'trace_check': True}, False, id='agent_notset_init_true_notcalled'),
-        pytest.param(
-            {'integration_tracing': False}, {'trace_check': True}, False, id='agent_false_init_true_notcalled'
-        ),
-        pytest.param(
-            {'integration_tracing': True, 'integration_tracing_futures': False},
-            {'trace_check': True},
-            True,
-            id='agent_true_init_true_called',
-        ),
-        pytest.param(
-            {'integration_tracing': True, 'integration_tracing_futures': True},
-            {'trace_check': True},
-            True,
-            id='agent_true_futures_true_init_true_called',
-        ),
-    ],
-)
-def test_traced(aggregator, agent_config, init_config, called):
-    check = DummyCheck('dummy', init_config, [{}])
-
-    with mock.patch('datadog_checks.base.utils.tracing.datadog_agent') as datadog_agent, mock.patch(
-        'ddtrace.tracer'
-    ) as tracer:
-        datadog_agent.get_config = lambda k: agent_config.get(k)
-        check.check({})
-
-        if called:
-            tracer.trace.assert_called_once_with('check', service='dummy-integration', resource='check')
-        else:
-            tracer.trace.assert_not_called()
-        aggregator.assert_metric('dummy.metric', 10, count=1)
 
 
 @pytest.mark.parametrize('traces_enabled', [pytest.param('false'), (pytest.param('true'))])

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -12,7 +12,6 @@ from six import iteritems, itervalues
 
 from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.common import pattern_filter
-from datadog_checks.base.utils.tracing import traced
 
 from .api import ApiFactory
 from .exceptions import (
@@ -661,7 +660,6 @@ class OpenStackControllerCheck(AgentCheck):
             # Fast fail in the absence of an api
             raise IncompleteConfig("Could not initialise Openstack API")
 
-    @traced
     def check(self, instance):
         # Initialize global variable that are per instances
         self.external_host_tags = {}


### PR DESCRIPTION
### What does this PR do?

Remove the `@traced` decorator as it was redundant and used only by the openstack integration. All integrations already have optional tracing by default via the `@traced_class` decorator on the common base class `AgentCheck`.

### Motivation

Simplify integration tracing. This is part of an effort to improve integration tracing instrumentation. See https://github.com/DataDog/integrations-core/pull/13579. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.