### PR TITLE
reduce overhead of integration tracing

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -19,7 +19,7 @@ from datadog_checks.base import is_affirmative
 from datadog_checks.base.log import get_check_logger
 from datadog_checks.base.utils.db.types import Transformer
 from datadog_checks.base.utils.serialization import json
-from datadog_checks.base.utils.tracing import INTEGRATION_TRACING_SERVICE_NAME
+from datadog_checks.base.utils.tracing import INTEGRATION_TRACING_SERVICE_NAME, tracing_enabled
 
 from ..common import to_native_string
 
@@ -46,10 +46,8 @@ SUBMISSION_METHODS = {
 
 
 def _traced_dbm_async_job_method(f):
-    # traces DBMAsyncJob.run_job only if tracing is enabled
-    if os.getenv('DDEV_TRACE_ENABLED', 'false') == 'true' or is_affirmative(
-        datadog_agent.get_config('integration_tracing')
-    ):
+    integration_tracing, _ = tracing_enabled()
+    if integration_tracing:
         try:
             from ddtrace import tracer
 

--- a/datadog_checks_base/tests/base/utils/test_tracing.py
+++ b/datadog_checks_base/tests/base/utils/test_tracing.py
@@ -45,7 +45,7 @@ class DummyCheck(MockAgentCheck):
 def traced_mock_classes():
     # temporarily unset the DDEV_TRACE_ENABLED flag to enable testing
     # the exhaustive tracing option
-    ddev_tracce_enabled = os.environ.pop('DDEV_TRACE_ENABLED', None)
+    ddev_trace_enabled = os.environ.pop('DDEV_TRACE_ENABLED', None)
     # the mock classes must be traced within a single test execution in order for
     # us to be able to control the parameters used by the traced_class wrapper
     # The regular AgentCheck common base class applies traced_class but here
@@ -56,7 +56,7 @@ def traced_mock_classes():
     yield
     MockAgentCheck, DummyCheck = orig_mock_agent, orig_dummy
     if ddev_tracce_enabled:
-        os.environ['DDEV_TRACE_ENABLED'] = ddev_tracce_enabled
+        os.environ['DDEV_TRACE_ENABLED'] = ddev_trace_enabled
 
 
 @pytest.mark.parametrize(

--- a/datadog_checks_base/tests/base/utils/test_tracing.py
+++ b/datadog_checks_base/tests/base/utils/test_tracing.py
@@ -55,7 +55,7 @@ def traced_mock_classes():
     MockAgentCheck, DummyCheck = traced_class(MockAgentCheck), traced_class(DummyCheck)
     yield
     MockAgentCheck, DummyCheck = orig_mock_agent, orig_dummy
-    if ddev_tracce_enabled:
+    if ddev_trace_enabled:
         os.environ['DDEV_TRACE_ENABLED'] = ddev_trace_enabled
 
 

--- a/datadog_checks_base/tests/base/utils/test_tracing.py
+++ b/datadog_checks_base/tests/base/utils/test_tracing.py
@@ -55,7 +55,8 @@ def traced_mock_classes():
     MockAgentCheck, DummyCheck = traced_class(MockAgentCheck), traced_class(DummyCheck)
     yield
     MockAgentCheck, DummyCheck = orig_mock_agent, orig_dummy
-    os.environ['DDEV_TRACE_ENABLED'] = ddev_tracce_enabled
+    if ddev_tracce_enabled:
+        os.environ['DDEV_TRACE_ENABLED'] = ddev_tracce_enabled
 
 
 @pytest.mark.parametrize(

--- a/datadog_checks_base/tests/base/utils/test_tracing.py
+++ b/datadog_checks_base/tests/base/utils/test_tracing.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import os
+from contextlib import contextmanager
 
 import mock
 import pytest
@@ -18,6 +19,12 @@ class MockAgentCheck(object):
         self.instances = args[2]
         self.check_id = ''
 
+    def run(self):
+        self.check(self.instances[0])
+
+    def check(self, instance):
+        raise NotImplementedError
+
     def gauge(self, name, value):
         aggregator.submit_metric(self, self.check_id, aggregator.GAUGE, name, value, [], 'hostname', False)
 
@@ -25,29 +32,65 @@ class MockAgentCheck(object):
 class DummyCheck(MockAgentCheck):
     def __init__(self, *args, **kwargs):
         super(DummyCheck, self).__init__(*args, **kwargs)
-        self.checked = False
 
-    def check(self, instance):
+    def check(self, _):
         self.gauge('dummy.metric', 10)
+        self.dummy_method()
+
+    def dummy_method(self):
+        self.gauge('foo', 10)
 
 
-@pytest.mark.parametrize('traces_enabled', [pytest.param('false'), (pytest.param('true'))])
-def test_traced_class(traces_enabled):
-    with mock.patch.dict(os.environ, {'DDEV_TRACE_ENABLED': traces_enabled}, clear=True), mock.patch(
-        'ddtrace.tracer'
-    ) as tracer:
-        TracedDummyClass = traced_class(DummyCheck)
+@contextmanager
+def traced_mock_classes():
+    # temporarily unset the DDEV_TRACE_ENABLED flag to enable testing
+    # the exhaustive tracing option
+    ddev_tracce_enabled = os.environ.pop('DDEV_TRACE_ENABLED', None)
+    # the mock classes must be traced within a single test execution in order for
+    # us to be able to control the parameters used by the traced_class wrapper
+    # The regular AgentCheck common base class applies traced_class but here
+    # in the test to keep things simple we trace both base and child classes directly
+    global MockAgentCheck, DummyCheck
+    orig_mock_agent, orig_dummy = MockAgentCheck, DummyCheck
+    MockAgentCheck, DummyCheck = traced_class(MockAgentCheck), traced_class(DummyCheck)
+    yield
+    MockAgentCheck, DummyCheck = orig_mock_agent, orig_dummy
+    os.environ['DDEV_TRACE_ENABLED'] = ddev_tracce_enabled
 
-        check = TracedDummyClass('dummy', {}, [{}])
-        check.check({})
 
-        if os.environ['DDEV_TRACE_ENABLED'] == 'true':
-            tracer.trace.assert_has_calls(
-                [
-                    mock.call('__init__', resource='dummy', service=INTEGRATION_TRACING_SERVICE_NAME),
-                    mock.call('check', resource='dummy', service=INTEGRATION_TRACING_SERVICE_NAME),
-                ],
-                any_order=True,
-            )
+@pytest.mark.parametrize(
+    'integration_tracing', [pytest.param(False, id="tracing_false"), pytest.param(True, id="tracing_true")]
+)
+@pytest.mark.parametrize(
+    'integration_tracing_exhaustive',
+    [pytest.param(False, id="exhaustive_false"), pytest.param(True, id="exhaustive_true")],
+)
+def test_traced_class(integration_tracing, integration_tracing_exhaustive, datadog_agent):
+    def _get_config(key):
+        return {
+            'integration_tracing': str(integration_tracing).lower(),
+            'integration_tracing_exhaustive': str(integration_tracing_exhaustive).lower(),
+        }.get(key, None)
+
+    with mock.patch.object(datadog_agent, 'get_config', _get_config), mock.patch('ddtrace.tracer') as tracer:
+
+        with traced_mock_classes():
+            check = DummyCheck('dummy', {}, [{}])
+            check.run()
+
+        if integration_tracing:
+            called_services = set([c.kwargs['service'] for c in tracer.trace.mock_calls if 'service' in c.kwargs])
+            called_methods = set([c.args[0] for c in tracer.trace.mock_calls if c.args])
+
+            assert called_services == {INTEGRATION_TRACING_SERVICE_NAME}
+            assert 'run' in called_methods, "'run' must always be traced"
+
+            exhaustive_only_methods = {'__init__', 'check', 'dummy_method'}
+            if integration_tracing_exhaustive:
+                for m in exhaustive_only_methods:
+                    assert m in called_methods
+            else:
+                for m in exhaustive_only_methods:
+                    assert m not in called_methods
         else:
             tracer.trace.assert_not_called()


### PR DESCRIPTION
### What does this PR do?

When `integration_tracing: true` we will now trace only each integration's `run` method instead of tracing all methods. All methods are traced only when the new `integration_tracing_exhaustive: true` option is set.

When the `DDEV_TRACE_ENABLED` env var is set it turns on both `integration_tracing` and `integration_tracing_exhaustive`.

### Motivation

We do this in order to reduce the overhead of tracing when running continuously in production. Some integrations make 1000s of calls to various internal methods, leading to 1000s of spans being recorded. 

<img width="537" alt="image" src="https://user-images.githubusercontent.com/3707657/209980618-bb5812f6-a514-4e18-be76-85aa1a638f79.png">

Many of these methods are so fast that the overhead added by tracing exceeds the execution time of the methods themselves. Here is a recent example where a new `self.histogram` call was added to an integration and a significant fraction of time was spent tracing the 1000s of executions of that method. 

![image](https://user-images.githubusercontent.com/3707657/209883063-b10549de-cb00-45d6-ac01-9b3361f2b3de.png)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.