### PR TITLE
pg excluded deadlock test from e2e tests & increase wait time

### DIFF
--- a/postgres/tests/test_deadlock.py
+++ b/postgres/tests/test_deadlock.py
@@ -2,128 +2,125 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-# FIXME: Flaky E2E tests (12/08/2022)
+import copy
+import select
+import time
 
-# import copy
-# import select
-# import time
+import psycopg2
+import pytest
 
-# import psycopg2
-# import pytest
-
-# from .common import DB_NAME, HOST, PORT, POSTGRES_VERSION
+from .common import DB_NAME, HOST, PORT, POSTGRES_VERSION
 
 
-# def wait_on_result(cursor=None, sql=None, binds=None, expected_value=None):
-#     for _i in range(100):
-#         cursor.execute(sql, binds)
-#         result = cursor.fetchone()[0]
-#         if result == expected_value:
-#             break
+def wait_on_result(cursor=None, sql=None, binds=None, expected_value=None):
+    for _i in range(300):
+        cursor.execute(sql, binds)
+        result = cursor.fetchone()[0]
+        if result == expected_value:
+            break
 
-#         time.sleep(0.1)
-#     else:
-#         return False
+        time.sleep(0.1)
+    else:
+        return False
 
-#     return True
+    return True
 
 
-# @pytest.mark.e2e
-# @pytest.mark.skipif(
-#     POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 9.2,
-#     reason='Deadlock test requires version 9.2 or higher (make sure POSTGRES_VERSION is set)',
-# )
-# def test_deadlock(aggregator, dd_run_check, integration_check, pg_instance):
-#     check = integration_check(pg_instance)
-#     check._connect()
-#     cursor = check.db.cursor()
+@pytest.mark.skipif(
+    POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 9.2,
+    reason='Deadlock test requires version 9.2 or higher (make sure POSTGRES_VERSION is set)',
+)
+def test_deadlock(aggregator, dd_run_check, integration_check, pg_instance):
+    check = integration_check(pg_instance)
+    check._connect()
+    cursor = check.db.cursor()
 
-#     def wait(conn):
-#         while True:
-#             state = conn.poll()
-#             if state == psycopg2.extensions.POLL_OK:
-#                 break
-#             elif state == psycopg2.extensions.POLL_WRITE:
-#                 select.select([], [conn.fileno()], [])
-#             elif state == psycopg2.extensions.POLL_READ:
-#                 select.select([conn.fileno()], [], [])
-#             else:
-#                 raise psycopg2.OperationalError("poll() returned %s" % state)
-#             time.sleep(0.1)
+    def wait(conn):
+        while True:
+            state = conn.poll()
+            if state == psycopg2.extensions.POLL_OK:
+                break
+            elif state == psycopg2.extensions.POLL_WRITE:
+                select.select([], [conn.fileno()], [])
+            elif state == psycopg2.extensions.POLL_READ:
+                select.select([conn.fileno()], [], [])
+            else:
+                raise psycopg2.OperationalError("poll() returned %s" % state)
+            time.sleep(0.1)
 
-#     conn_args = {'host': HOST, 'dbname': DB_NAME, 'user': "bob", 'password': "bob"}
-#     conn_args_async = copy.copy(conn_args)
-#     conn_args_async["async_"] = 1
-#     conn1 = psycopg2.connect(**conn_args)
-#     conn1.autocommit = False
+    conn_args = {'host': HOST, 'dbname': DB_NAME, 'user': "bob", 'password': "bob"}
+    conn_args_async = copy.copy(conn_args)
+    conn_args_async["async_"] = 1
+    conn1 = psycopg2.connect(**conn_args)
+    conn1.autocommit = False
 
-#     conn2 = psycopg2.connect(**conn_args_async)
-#     wait(conn2)
+    conn2 = psycopg2.connect(**conn_args_async)
+    wait(conn2)
 
-#     appname = 'deadlock sess'
-#     appname1 = appname + '1'
-#     appname2 = appname + '2'
-#     appname_sql = "SET application_name=%s"
-#     update_sql = "update personsdup1 set address = 'changed' where personid = %s"
+    appname = 'deadlock sess'
+    appname1 = appname + '1'
+    appname2 = appname + '2'
+    appname_sql = "SET application_name=%s"
+    update_sql = "update personsdup1 set address = 'changed' where personid = %s"
 
-#     deadlock_count_sql = "select deadlocks from pg_stat_database where datname = %s"
-#     cursor.execute(deadlock_count_sql, (DB_NAME,))
-#     deadlocks_before = cursor.fetchone()[0]
+    deadlock_count_sql = "select deadlocks from pg_stat_database where datname = %s"
+    cursor.execute(deadlock_count_sql, (DB_NAME,))
+    deadlocks_before = cursor.fetchone()[0]
 
-#     cur1 = conn1.cursor()
-#     cur1.execute(appname_sql, (appname1,))
-#     cur1.execute(update_sql, (1,))
+    cur1 = conn1.cursor()
+    cur1.execute(appname_sql, (appname1,))
+    cur1.execute(update_sql, (1,))
 
-#     cur2 = conn2.cursor()
-#     cur2.execute(
-#         """SET application_name=%s;
-# begin transaction;
-# {};
-# {};
-# commit;
-# """.format(
-#             update_sql, update_sql
-#         ),
-#         (appname2, 2, 1),
-#     )
+    cur2 = conn2.cursor()
+    cur2.execute(
+        """SET application_name=%s;
+begin transaction;
+{};
+{};
+commit;
+""".format(
+            update_sql, update_sql
+        ),
+        (appname2, 2, 1),
+    )
 
-#     lock_count_sql = """SELECT COUNT(1)
-#    FROM  pg_catalog.pg_locks         blocked_locks
-#     JOIN pg_catalog.pg_stat_activity blocked_activity  ON blocked_activity.pid = blocked_locks.pid
-#     JOIN pg_catalog.pg_locks         blocking_locks
-#         ON blocking_locks.locktype = blocked_locks.locktype
-#         AND blocking_locks.DATABASE IS NOT DISTINCT FROM blocked_locks.DATABASE
-#         AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
-#         AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
-#         AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
-#         AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
-#         AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
-#         AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
-#         AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
-#         AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
-#         AND blocking_locks.pid != blocked_locks.pid
-#     JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
-#    WHERE NOT blocked_locks.GRANTED
-#     AND blocking_activity.application_name = %s
-#     AND blocked_activity.application_name = %s """
+    lock_count_sql = """SELECT COUNT(1)
+   FROM  pg_catalog.pg_locks         blocked_locks
+    JOIN pg_catalog.pg_stat_activity blocked_activity  ON blocked_activity.pid = blocked_locks.pid
+    JOIN pg_catalog.pg_locks         blocking_locks
+        ON blocking_locks.locktype = blocked_locks.locktype
+        AND blocking_locks.DATABASE IS NOT DISTINCT FROM blocked_locks.DATABASE
+        AND blocking_locks.relation IS NOT DISTINCT FROM blocked_locks.relation
+        AND blocking_locks.page IS NOT DISTINCT FROM blocked_locks.page
+        AND blocking_locks.tuple IS NOT DISTINCT FROM blocked_locks.tuple
+        AND blocking_locks.virtualxid IS NOT DISTINCT FROM blocked_locks.virtualxid
+        AND blocking_locks.transactionid IS NOT DISTINCT FROM blocked_locks.transactionid
+        AND blocking_locks.classid IS NOT DISTINCT FROM blocked_locks.classid
+        AND blocking_locks.objid IS NOT DISTINCT FROM blocked_locks.objid
+        AND blocking_locks.objsubid IS NOT DISTINCT FROM blocked_locks.objsubid
+        AND blocking_locks.pid != blocked_locks.pid
+    JOIN pg_catalog.pg_stat_activity blocking_activity ON blocking_activity.pid = blocking_locks.pid
+   WHERE NOT blocked_locks.GRANTED
+    AND blocking_activity.application_name = %s
+    AND blocked_activity.application_name = %s """
 
-#     is_locked = wait_on_result(cursor=cursor, sql=lock_count_sql, binds=(appname1, appname2), expected_value=1)
+    is_locked = wait_on_result(cursor=cursor, sql=lock_count_sql, binds=(appname1, appname2), expected_value=1)
 
-#     if not is_locked:
-#         raise Exception("ERROR: Couldn't reproduce a deadlock. That can happen on an extremely overloaded system.")
+    if not is_locked:
+        raise Exception("ERROR: Couldn't reproduce a deadlock. That can happen on an extremely overloaded system.")
 
-#     try:
-#         cur1.execute(update_sql, (2,))
-#         cur1.execute("commit")
-#     except psycopg2.errors.DeadlockDetected:
-#         pass
+    try:
+        cur1.execute(update_sql, (2,))
+        cur1.execute("commit")
+    except psycopg2.errors.DeadlockDetected:
+        pass
 
-#     dd_run_check(check)
+    dd_run_check(check)
 
-#     wait_on_result(cursor=cursor, sql=deadlock_count_sql, binds=(DB_NAME,), expected_value=deadlocks_before + 1)
+    wait_on_result(cursor=cursor, sql=deadlock_count_sql, binds=(DB_NAME,), expected_value=deadlocks_before + 1)
 
-#     aggregator.assert_metric(
-#         'postgresql.deadlocks.count',
-#         value=deadlocks_before + 1,
-#         tags=pg_instance["tags"] + ["db:{}".format(DB_NAME), "port:{}".format(PORT)],
-#     )
+    aggregator.assert_metric(
+        'postgresql.deadlocks.count',
+        value=deadlocks_before + 1,
+        tags=pg_instance["tags"] + ["db:{}".format(DB_NAME), "port:{}".format(PORT)],
+    )


### PR DESCRIPTION
### What does this PR do?
The deadlock test generates a deadlock and verifies that deadlock count metric increased. Since the deadlock counter doesn't increase synchronously, the test must wait until the deadlock counter increases. The deadlock test checks in a loop every 100 ms if the deadlock counter increased. This normally lasts no longer than a second or two, but it can take longer on a busy system. To reduce the likelihood of a failed tests, I increased the maximum wait time from 10 s to 30 s. Besides that, I excluded the deadlock test from e2e tests.

### Motivation
This change was done after the integrations tests for the new agent release started failing. @alexbarksdale quickly commented out the deadlock test. 

### Additional Notes
There's no guarantee that the deadlock counter is increased within a time limit. So, there's still some risk left that the check might fail on a busy system. The implemented changes, however, significantly reduce the failure probability. In a daily stand we discussed the problem and came to conclusion that the advantage of keeping the test outweighs the risk of a failed test. Should the test fail again, it can be commented out.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.