### PR TITLE
configured hostname in datadog.yaml explicitly to avoid issue https:/…

### DIFF
--- a/databricks/README.md
+++ b/databricks/README.md
@@ -71,6 +71,11 @@ if [[ \${DB_IS_DRIVER} = "TRUE" ]]; then
   # ENABLE LOGS IN datadog.yaml TO COLLECT DRIVER LOGS
   sed -i '/.*logs_enabled:.*/a logs_enabled: true' /etc/datadog-agent/datadog.yaml
 
+  # CONFIGURE HOSTNAME EXPLICITLY IN datadog.yaml TO PREVENT AGENT FROM FAILING ON VERSION 7.40+
+  # SEE https://github.com/DataDog/datadog-agent/issues/14152 FOR CHANGE
+  hostname=\$(hostname | xargs)
+  echo "hostname: \$hostname" >> /etc/datadog-agent/datadog.yaml
+
   # WAITING UNTIL MASTER PARAMS ARE LOADED, THEN GRABBING IP AND PORT
   while [ -z \$gotparams ]; do
     if [ -e "/tmp/master-params" ]; then
@@ -156,6 +161,11 @@ if [[ \${DB_IS_DRIVER} = "TRUE" ]]; then
 
   # ENABLE LOGS IN datadog.yaml TO COLLECT DRIVER LOGS
   sed -i '/.*logs_enabled:.*/a logs_enabled: true' /etc/datadog-agent/datadog.yaml
+
+  # CONFIGURE HOSTNAME EXPLICITLY IN datadog.yaml TO PREVENT AGENT FROM FAILING ON VERSION 7.40+
+  # SEE https://github.com/DataDog/datadog-agent/issues/14152 FOR CHANGE
+  hostname=\$(hostname | xargs)
+  echo "hostname: \$hostname" >> /etc/datadog-agent/datadog.yaml
 
   while [ -z \$gotparams ]; do
     if [ -e "/tmp/driver-env.sh" ]; then
@@ -248,6 +258,11 @@ if [ \$DB_IS_DRIVER ]; then
 
   # ENABLE LOGS IN datadog.yaml TO COLLECT DRIVER LOGS
   sed -i '/.*logs_enabled:.*/a logs_enabled: true' /etc/datadog-agent/datadog.yaml
+
+  # CONFIGURE HOSTNAME EXPLICITLY IN datadog.yaml TO PREVENT AGENT FROM FAILING ON VERSION 7.40+
+  # SEE https://github.com/DataDog/datadog-agent/issues/14152 FOR CHANGE
+  hostname=\$(hostname | xargs)
+  echo "hostname: \$hostname" >> /etc/datadog-agent/datadog.yaml
 
   while [ -z \$gotparams ]; do
     if [ -e "/tmp/driver-env.sh" ]; then


### PR DESCRIPTION
…/github.com/DataDog/datadog-agent/issues/14152

### What does this PR do?
This PR explicitly sets the hostname parameter in the datadog.yaml in the Databricks integration init script. Without this change, the Agent will be unable to collect metrics starting in version 7.40+ because of this change: https://github.com/DataDog/datadog-agent/issues/14152.

### Motivation
Without this change, our Databricks init script will not work according to our current instructions. 

### Additional Notes
N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.