### PR TITLE
Run downloader tests on windows

### DIFF
--- a/.azure-pipelines/changes.yml
+++ b/.azure-pipelines/changes.yml
@@ -44,7 +44,7 @@ jobs:
 - template: './templates/test-single-windows.yml'
   parameters:
     job_name: Changed
-    check: '--changed datadog_checks_base datadog_checks_dev active_directory aspdotnet disk dns_check dotnetclr exchange_server ibm_mq iis network pdh_check sqlserver tcp_check win32_event_log windows_performance_counters windows_service wmi_check'
+    check: '--changed datadog_checks_base datadog_checks_dev datadog_checks_downloader active_directory aspdotnet disk dns_check dotnetclr exchange_server ibm_mq iis network pdh_check sqlserver tcp_check win32_event_log windows_performance_counters windows_service wmi_check'
     ${{ if eq(variables['System.PullRequest.IsFork'], 'False') }}:
       ddtrace_flag: '--ddtrace'
     validate_changed: changed

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -100,6 +100,7 @@ class TUFDownloader:
         self.__updater.refresh()
 
     def __download_with_tuf(self, target_relpath):
+        # FIX: It looks like something might be going wrong here on Windows
         target = self.__updater.get_targetinfo(target_relpath)
         if target is None:
             raise TargetNotFoundError(f'Target at {target_relpath} not found')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation

Kitchen tests started to fail for windows, presumably due to #13331. E.g. https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/210470215):

```
            RuntimeError:
       Failed to install integrations package 'datadog-cilium==2.2.1' - Traceback (most recent call last):
         File "C:\Program Files\Datadog\Datadog Agent\embedded3\lib\runpy.py", line 194, in _run_module_as_main
           return _run_code(code, main_globals, None,
         File "C:\Program Files\Datadog\Datadog Agent\embedded3\lib\runpy.py", line 87, in _run_code
           exec(code, run_globals)
         File "C:\Program Files\Datadog\Datadog Agent\embedded3\lib\site-packages\datadog_checks\downloader\__main__.py", line 9, in <module>
           sys.exit(download())
         File "C:\Program Files\Datadog\Datadog Agent\embedded3\lib\site-packages\datadog_checks\downloader\cli.py", line 124, in download
           wheel_abspath = tuf_downloader.download(wheel_relpath)
         File "C:\Program Files\Datadog\Datadog Agent\embedded3\lib\site-packages\datadog_checks\downloader\download.py", line 266, in download
           return self.__download_with_tuf_in_toto(target_relpath)
         File "C:\Program Files\Datadog\Datadog Agent\embedded3\lib\site-packages\datadog_checks\downloader\download.py", line 253, in __download_with_tuf_in_toto
           self.__download_and_verify_in_toto_metadata(target_relpath, target_abspath, target)
         File "C:\Program Files\Datadog\Datadog Agent\embedded3\lib\site-packages\datadog_checks\downloader\download.py", line 229, in __download_and_verify_in_toto_metadata
           root_layout_abspath, root_layout_target = self.__download_in_toto_root_layout()
         File "C:\Program Files\Datadog\Datadog Agent\embedded3\lib\site-packages\datadog_checks\downloader\download.py", line 129, in __download_in_toto_root_layout
           return self.__download_with_tuf(target_relpath)
         File "C:\Program Files\Datadog\Datadog Agent\embedded3\lib\site-packages\datadog_checks\downloader\download.py", line 105, in __download_with_tuf
           raise TargetNotFoundError(f'Target at {target_relpath} not found')
       datadog_checks.downloader.exceptions.TargetNotFoundError: Target at in-toto-metadata\5.core.root.layout not found
```

It turns out we're not testing on Windows on CI, so this might have been caught before merge, but wasn't.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.