### PR TITLE
Skip yanked artifacts from PyPi

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -149,7 +149,6 @@ def sync():
 def filter_releases(releases):
     filtered_releases = []
     for version, artifacts in releases.items():
-
         parsed_version = parse_version(version)
         if not parsed_version.is_prerelease:
             filtered_releases.append((parsed_version, artifacts))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -149,6 +149,7 @@ def sync():
 def filter_releases(releases):
     filtered_releases = []
     for version, artifacts in releases.items():
+
         parsed_version = parse_version(version)
         if not parsed_version.is_prerelease:
             filtered_releases.append((parsed_version, artifacts))
@@ -189,6 +190,9 @@ async def scrape_version_data(urls):
                 versions.append(version)
 
                 for artifact in artifacts:
+                    if artifact.get("yanked", False):
+                        continue
+
                     if latest_py2 is None and artifact_compatible_with_python(artifact, '2'):
                         latest_py2 = version
                     if latest_py3 is None and artifact_compatible_with_python(artifact, '3'):

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -38,12 +38,12 @@ dependencies = [
     "psutil",
     "py>=1.8.2; python_version < '3.0'",  # https://github.com/ionelmc/pytest-benchmark/issues/226
     "pytest",
+    "pytest-asyncio>=0.20.3; python_version > '3.0'",
     "pytest-benchmark[histogram]<4.0.0; python_version < '3.0'",
     "pytest-benchmark[histogram]>=4.0.0; python_version > '3.0'",
     "pytest-cov>=2.6.1",
     "pytest-memray>=1.4.0; python_version > '3.0' and (platform_system=='Linux' or platform_system=='Darwin')",
     "pytest-mock",
-    "pytest-asyncio==0.20.3; python_version > '3.0'",
     "pyyaml>=5.4.1",
     "requests>=2.22.0",
     "shutilwhich==1.1.0; python_version < '3.0'",

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "pytest-cov>=2.6.1",
     "pytest-memray>=1.4.0; python_version > '3.0' and (platform_system=='Linux' or platform_system=='Darwin')",
     "pytest-mock",
+    "pytest-asyncio==0.20.3; python_version > '3.0'",
     "pyyaml>=5.4.1",
     "requests>=2.22.0",
     "shutilwhich==1.1.0; python_version < '3.0'",

--- a/datadog_checks_dev/tests/tooling/commands/test_dep.py
+++ b/datadog_checks_dev/tests/tooling/commands/test_dep.py
@@ -9,7 +9,7 @@ import pytest
 from mock import MagicMock
 
 from datadog_checks.dev.testing import requires_py3
-from datadog_checks.dev.tooling.commands.dep import scrape_version_data
+
 
 class AsyncIterator:
     def __init__(self, urls):
@@ -120,6 +120,9 @@ def mock_map(_, func, urls):
 @requires_py3
 @pytest.mark.asyncio
 async def test_scrape_version_data(mock_request, pypi_response, expected_result):
+    # It should be at the top of the file, but it breaks the `test_agent.test_get_agent_tags` test.
+    from datadog_checks.dev.tooling.commands.dep import scrape_version_data
+
     mock_request.return_value = MagicMock()
     mock_request.return_value.read.return_value = asyncio.Future()
     mock_request.return_value.read.return_value.set_result(json.dumps(pypi_response))

--- a/datadog_checks_dev/tests/tooling/commands/test_dep.py
+++ b/datadog_checks_dev/tests/tooling/commands/test_dep.py
@@ -3,10 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import asyncio
 import json
-from unittest.mock import patch
 
 import pytest
-from mock import MagicMock
+from mock import MagicMock, patch
 
 from datadog_checks.dev.testing import requires_py3
 

--- a/datadog_checks_dev/tests/tooling/commands/test_dep.py
+++ b/datadog_checks_dev/tests/tooling/commands/test_dep.py
@@ -1,0 +1,128 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+from mock import MagicMock
+
+from datadog_checks.dev.testing import requires_py3
+from datadog_checks.dev.tooling.commands.dep import scrape_version_data
+
+class AsyncIterator:
+    def __init__(self, urls):
+        self.urls = iter(urls)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return await next(self.urls)
+        except StopIteration:
+            raise StopAsyncIteration
+
+    def __aexit__(self, *args):
+        pass
+
+
+# mock aiomultiprocess.Pool.map
+def mock_map(_, func, urls):
+    return AsyncIterator([func(u) for u in urls])
+
+
+@pytest.mark.parametrize(
+    'pypi_response, expected_result',
+    [
+        pytest.param(
+            {
+                "info": {"name": "protobuf"},
+                "releases": {
+                    "1.0.0": [
+                        {"python_version": "py2", "requires_python": None, "yanked": False},
+                        {"python_version": "py3", "requires_python": None, "yanked": False},
+                    ],
+                    "2.0.0": [
+                        {"python_version": "py2", "requires_python": None, "yanked": False},
+                        {"python_version": "py3", "requires_python": None, "yanked": False},
+                    ],
+                },
+            },
+            {'protobuf': {'py2': '2.0.0', 'py3': '2.0.0'}},
+            id='two versions',
+        ),
+        pytest.param(
+            {
+                "info": {"name": "protobuf"},
+                "releases": {
+                    "1.0.0": [
+                        {"python_version": "py2", "requires_python": None, "yanked": False},
+                        {"python_version": "py3", "requires_python": None, "yanked": False},
+                    ]
+                },
+            },
+            {'protobuf': {'py2': '1.0.0', 'py3': '1.0.0'}},
+            id='one versions',
+        ),
+        pytest.param(
+            {
+                "info": {"name": "protobuf"},
+                "releases": {
+                    "1.0.0": [
+                        {"python_version": "py3", "requires_python": ">=3", "yanked": False},
+                    ],
+                    "2.0.0": [
+                        {"python_version": "py3", "requires_python": ">=3", "yanked": False},
+                    ],
+                },
+            },
+            {'protobuf': {'py2': None, 'py3': '2.0.0'}},
+            id='no py2',
+        ),
+        pytest.param(
+            {
+                "info": {"name": "protobuf"},
+                "releases": {
+                    "1.0.0": [
+                        {"python_version": "py2", "requires_python": "<=3", "yanked": False},
+                    ],
+                    "2.0.0": [
+                        {"python_version": "py2", "requires_python": "<=3", "yanked": False},
+                    ],
+                },
+            },
+            {'protobuf': {'py2': '2.0.0', 'py3': None}},
+            id='no py3',
+        ),
+        pytest.param(
+            {
+                "info": {"name": "protobuf"},
+                "releases": {
+                    "1.0.0": [
+                        {"python_version": "py2", "requires_python": None, "yanked": False},
+                        {"python_version": "py3", "requires_python": None, "yanked": False},
+                    ],
+                    "2.0.0": [
+                        {"python_version": "py2", "requires_python": None, "yanked": True},
+                        {"python_version": "py3", "requires_python": None, "yanked": False},
+                    ],
+                },
+            },
+            {'protobuf': {'py2': '1.0.0', 'py3': '2.0.0'}},
+            id='yanked one py2 version',
+        ),
+    ],
+)
+@patch("aiomultiprocess.Pool.map", mock_map)
+@patch("aiohttp.ClientSession._request")
+@requires_py3
+@pytest.mark.asyncio
+async def test_scrape_version_data(mock_request, pypi_response, expected_result):
+    mock_request.return_value = MagicMock()
+    mock_request.return_value.read.return_value = asyncio.Future()
+    mock_request.return_value.read.return_value.set_result(json.dumps(pypi_response))
+
+    package_data = await scrape_version_data(["pypi-url-for-package"])
+    assert package_data == expected_result


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Skip yanked artifacts from PyPi when using `ddev dep updates --sync`.

### Motivation
<!-- What inspired you to submit this pull request? -->

https://datadoghq.atlassian.net/browse/AITOOLS-61

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Full PyPi payload example https://pypi.org/pypi/protobuf/json

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.