### PR TITLE
Fix the valid_integrations fixture

### DIFF
--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -71,7 +71,7 @@ def local_repo() -> Path:
 @pytest.fixture(scope='session')
 def valid_integrations(local_repo) -> list[str]:
     repo = Repository(local_repo.name, str(local_repo))
-    return [path.name for path in repo.integrations.iter_all(('all',))]
+    return [path.name for path in repo.integrations.iter_all(['all'])]
 
 
 @pytest.fixture

--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -71,7 +71,7 @@ def local_repo() -> Path:
 @pytest.fixture(scope='session')
 def valid_integrations(local_repo) -> list[str]:
     repo = Repository(local_repo.name, str(local_repo))
-    return [path.name for path in repo.integrations.iter_all()]
+    return [path.name for path in repo.integrations.iter_all(('all',))]
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the `valid_integrations` to return all the valid integrations we have in the repo. 

### Motivation
<!-- What inspired you to submit this pull request? -->

Since https://github.com/DataDog/integrations-core/pull/13570, `iter_all` only returns the modified integrations by default. When there's no modification between your branch and master, it now returns an empty list, hence [this error](https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=123924&view=logs&j=16e22227-8deb-5530-dfc3-e3f564238956&t=dc8e9a3b-87f0-5140-ccd3-47aec2a819b1&l=895) on master. 

I modified the fixture to return all of them, no matter what, so the list is never empty. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.