### PR TITLE
Inject trace context into logs when integration_tracing is enabled

### DIFF
--- a/datadog_checks_base/datadog_checks/base/log.py
+++ b/datadog_checks_base/datadog_checks/base/log.py
@@ -2,10 +2,10 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
+import sys
 import warnings
 from typing import Callable
 
-import sys
 from six import PY2, text_type
 from urllib3.exceptions import InsecureRequestWarning
 
@@ -61,6 +61,7 @@ class CheckLoggingAdapter(logging.LoggerAdapter):
         self.log(TRACE_LEVEL, msg, *args, **kwargs)
 
     if PY2:
+
         def warn(self, msg, *args, **kwargs):
             self.log(logging.WARNING, msg, *args, **kwargs)
 
@@ -72,7 +73,6 @@ class CheckLoggingAdapter(logging.LoggerAdapter):
 
 
 class CheckLogFormatter(logging.Formatter):
-
     def __init__(self):
         super(CheckLogFormatter, self).__init__()
         integration_tracing, _ = tracing_enabled()
@@ -87,7 +87,7 @@ class CheckLogFormatter(logging.Formatter):
             'check_id': getattr(record, '_check_id', '-'),
             'filename': getattr(record, '_filename', record.filename),
             'lineno': getattr(record, '_lineno', record.lineno),
-            'message': message
+            'message': message,
         }
 
         if not self.integration_tracing_enabled:
@@ -95,7 +95,9 @@ class CheckLogFormatter(logging.Formatter):
 
         attributes['trace_id'] = getattr(record, 'dd.trace_id', 0)
         attributes['span_id'] = getattr(record, 'dd.span_id', 0)
-        return "{check_id} | ({filename}:{lineno}) | dd.trace_id={trace_id} dd.span_id={span_id} | {message}".format(**attributes)
+        return "{check_id} | ({filename}:{lineno}) | dd.trace_id={trace_id} dd.span_id={span_id} | {message}".format(
+            **attributes
+        )
 
 
 class AgentLogHandler(logging.Handler):

--- a/datadog_checks_base/datadog_checks/base/utils/__init__.py
+++ b/datadog_checks_base/datadog_checks/base/utils/__init__.py
@@ -14,9 +14,9 @@ try:
         # handle thread monitoring as an additional option
         # See: http://pypi.datadoghq.com/trace/docs/other_integrations.html#futures
         if datadog_agent.get_config('integration_tracing_futures'):
-            patch(requests=True, futures=True)
+            patch(logging=True, requests=True, futures=True)
         else:
-            patch(requests=True)
+            patch(logging=True, requests=True)
 
     if is_affirmative(datadog_agent.get_config('integration_profiling')):
         from ddtrace.profiling import Profiler

--- a/datadog_checks_base/tests/test_log.py
+++ b/datadog_checks_base/tests/test_log.py
@@ -7,10 +7,11 @@ import logging
 import warnings
 
 import mock
+import pytest
 
 from datadog_checks import log
 from datadog_checks.base import AgentCheck
-from datadog_checks.base.log import DEFAULT_FALLBACK_LOGGER, get_check_logger, init_logging
+from datadog_checks.base.log import DEFAULT_FALLBACK_LOGGER, CheckLogFormatter, get_check_logger, init_logging
 
 
 def test_get_py_loglevel():
@@ -25,7 +26,6 @@ def test_get_py_loglevel():
 
 
 def test_logging_capture_warnings():
-
     with mock.patch('logging.Logger.warning') as log_warning:
         warnings.warn("hello-world")
 
@@ -79,3 +79,37 @@ def test_get_check_logger_argument_fallback(caplog):
 
     assert log is logger
     assert "This is a warning" in caplog.text
+
+
+class MockAgentLogHandler(logging.Handler):
+    def __init__(self):
+        super(MockAgentLogHandler, self).__init__()
+        self.formatter = CheckLogFormatter()
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(self.format(record))
+
+
+@pytest.mark.parametrize('integration_tracing_enabled', [False, True])
+def test_log_trace_context_injection(integration_tracing_enabled):
+    def _tracing_enabled():
+        return integration_tracing_enabled, False
+
+    with mock.patch('datadog_checks.base.log.tracing_enabled', _tracing_enabled):
+        logger = logging.getLogger("test_log_trace_context_injection")
+        logger.handlers = []
+        handler = MockAgentLogHandler()
+        assert handler.formatter.integration_tracing_enabled == integration_tracing_enabled
+
+        logger.addHandler(handler)
+        logger.setLevel(logging.INFO)
+        logger.info("hello", extra={'dd.trace_id': 1, 'dd.span_id': 2})
+
+        assert len(handler.records) == 1
+        record = handler.records[0]
+
+        if integration_tracing_enabled:
+            assert "dd.trace_id=1 dd.span_id=2" in record
+        else:
+            assert "dd.trace_id=1 dd.span_id=2" not in record


### PR DESCRIPTION
### What does this PR do?

When `integration_tracing: true` inject `trace_id` and `span_id` into integration logs, enabling easy correlation from traces to logs and vice versa.

We'll update the agent's default log parsing rules as a follow-up to ensure the trace_id is correctly parsed and remapped. 

### Motivation

Enable easy correlation between traces & logs. 

#### Traces to logs
<img width="841" alt="image" src="https://user-images.githubusercontent.com/3707657/210866368-80a61c4e-350f-42da-b5a6-0140f92bdf69.png">

#### Logs to traces
<img width="899" alt="image" src="https://user-images.githubusercontent.com/3707657/210866634-c5fc2e71-9743-47ad-a5b7-1325b0bb19bc.png">


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.