### PR TITLE
Bump the base check dependency

### DIFF
--- a/snowflake/pyproject.toml
+++ b/snowflake/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=25.1.0",
+    "datadog-checks-base>=27.5.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the base check dependency

### Motivation
<!-- What inspired you to submit this pull request? -->

- The nightly ci that uses the minimal base check version fails because after https://github.com/DataDog/integrations-core/pull/13367 we forgot to bump the minimal version. That's because of the cryptography version
- CI: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=124039&view=logs&jobId=a1b8d459-48c9-569c-0f4f-6d3b7ccf97d9&j=98116001-eedc-5551-9b85-d853f2e6b9c4&t=fd2d295c-84f5-5531-ef2d-aad9544d1719

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Run `ddev test --force-base-min --force-env-rebuild --junit snowflake` to reproduce

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.