### PR TITLE
Stop ignoring the `protobuf` dependency when updating them

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -37,7 +37,6 @@ IGNORED_DEPS = {
     'cryptography',
     'dnspython',
     'pymysql',  # https://github.com/DataDog/integrations-core/pull/12612
-    'protobuf',  # Breaking datadog_checks_base
     'foundationdb',  # Breaking datadog_checks_base tests
     'openstacksdk',  # Breaking openstack_controller tests
     'pyasn1',  # Breaking snmp tests


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Stop ignoring the `protobuf` dependency when updating them with the `ddev dep updates --sync` command.

### Motivation
<!-- What inspired you to submit this pull request? -->

- Follow-up PR of https://github.com/DataDog/integrations-core/pull/13632
- Recommended by @jose-manuel-almaza in https://datadoghq.atlassian.net/browse/AITOOLS-61

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I'll merge this one after https://github.com/DataDog/integrations-core/pull/13632

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.