### PR TITLE
Bump the base check dependency

### DIFF
--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=25.2.2",
+    "datadog-checks-base>=25.4.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the base check dependency

### Motivation
<!-- What inspired you to submit this pull request? -->

- The nightly ci build that uses the minimal base check version defined by the integration fails https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=124039&view=logs&j=5ba36005-b42a-55ea-a600-e8154d8d1b6b&t=fc8845e1-5f01-5ab3-fa2b-f094edac31cf
- The query executor was added in this PR https://github.com/DataDog/integrations-core/pull/11869 and got shipped with the base check `25.4.0`: https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/CHANGELOG.md#2540--2022-05-10
- This PR https://github.com/DataDog/integrations-core/pull/13374 started to use the executor, but forgot to bump the minimal version of the base check 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- To reproduce, run `ddev test --force-base-min --force-env-rebuild --junit postgres`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.