### PR TITLE
Fix MariaDB InnoDB pending flush metric parsing

### DIFF
--- a/mysql/datadog_checks/mysql/innodb_metrics.py
+++ b/mysql/datadog_checks/mysql/innodb_metrics.py
@@ -203,9 +203,13 @@ class InnoDBMetrics(object):
                     results['Innodb_pending_aio_log_ios'] = 0
                     results['Innodb_pending_aio_sync_ios'] = 0
             elif line.find('Pending flushes (fsync)') == 0:
-                # Pending flushes (fsync) log: 0; buffer pool: 0
-                results['Innodb_pending_log_flushes'] = long(row[4])
-                results['Innodb_pending_buffer_pool_flushes'] = long(row[7])
+                if len(row) == 4:
+                    # Pending flushes (fsync): 0
+                    results['Innodb_pending_buffer_pool_flushes'] = long(row[3])
+                else:
+                    # Pending flushes (fsync) log: 0; buffer pool: 0
+                    results['Innodb_pending_log_flushes'] = long(row[4])
+                    results['Innodb_pending_buffer_pool_flushes'] = long(row[7])
 
             # INSERT BUFFER AND ADAPTIVE HASH INDEX
             elif line.find('Ibuf for space 0: size ') == 0:

--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -32,6 +32,7 @@ flavor = ["mariadb"]
 version = [
   "10.2",  # EOL 23 May 2022
   "10.5",  # EOL 24 June 2025
+  "10.10", # EOL 17 November 2023
 ]
 
 [envs.default.overrides]


### PR DESCRIPTION
### What does this PR do?

This PR fixes the parsing of InnoDB pending flush metrics for modern MariaDB hosts (10.8+).

### Motivation

We have been observing the following error when metrics are collected from our MariaDB host:

```
2023-01-09 10:25:16 UTC | CORE | ERROR | (pkg/collector/worker/check_logger.go:69 in Error) | check:mysql | Error running check: [{"message": "list index out of range", "traceback": "Traceback (most recent call last):\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py\", line 1122, in run\n    self.check(instance)\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/mysql/mysql.py\", line 248, in check\n    raise e\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/mysql/mysql.py\", line 229, in check\n    self._collect_metrics(db, tags=tags)\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/mysql/mysql.py\", line 378, in _collect_metrics\n    results.update(self.innodb_stats.get_stats_from_innodb_status(db))\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/mysql/innodb_metrics.py\", line 207, in get_stats_from_innodb_status\n    results['Innodb_pending_log_flushes'] = long(row[4])\nIndexError: list index out of range\n"}]
```
The issue is within the output of `SHOW /*!50000 ENGINE*/ INNODB STATUS`, the section containing the metrics for pending flushes is subtly different for newer versions of MariaDB than it is for MySQL.

* MariaDB message: https://github.com/MariaDB/server/blob/11.0/storage/innobase/os/os0file.cc#L3840
* MySQL message: https://github.com/mysql/mysql-server/blob/8.0/storage/innobase/os/os0file.cc#L7852
* Commit that caused the messages to become out of sync: https://github.com/MariaDB/server/commit/685d958e38b825ad9829be311f26729cccf37c46#diff-9ad78a90c176f897bb2dc367c152ec687ff55cc92dbe7a0c364845af536e23e1R3916

### Additional Notes

N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.