### PR TITLE
Do not sign commits in tests

### DIFF
--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -111,6 +111,7 @@ def local_clone(isolation, local_repo) -> Generator[ClonedRepo, None, None]:
     with cloned_repo_path.as_cwd():
         PLATFORM.check_command_output(['git', 'config', 'user.name', 'Foo Bar'])
         PLATFORM.check_command_output(['git', 'config', 'user.email', 'foo@bar.baz'])
+        PLATFORM.check_command_output(['git', 'config', 'commit.gpgsign', 'false'])
 
     cloned_repo = ClonedRepo(cloned_repo_path, 'origin/master', 'ddev-testing')
     cloned_repo.reset_branch()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not sign commits during tests

### Motivation
<!-- What inspired you to submit this pull request? -->

My setup requires to sign my commits with my yubikey. When I run the tests, it waits for me to touch my Yubikey 😅 I was wondering why the tests took so long, until it timed out. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.