### PR TITLE
Migrate from `called_with` to `assert_called_with`

### DIFF
--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -94,7 +94,7 @@ def test_connection_uses_tls():
 
     with mock.patch('aerospike.client') as client:
         check.get_client()
-        assert client.assert_called_with({'host': [check._host], 'tls': tls_config})
+        client.assert_called_with({'hosts': [check._host], 'tls': tls_config})
 
 
 @pytest.mark.parametrize(

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -94,7 +94,7 @@ def test_connection_uses_tls():
 
     with mock.patch('aerospike.client') as client:
         check.get_client()
-        assert client.assert_called_with({'host': check._host, 'tls': tls_config})
+        assert client.assert_called_with({'host': [check._host], 'tls': tls_config})
 
 
 @pytest.mark.parametrize(

--- a/aerospike/tests/test_unit.py
+++ b/aerospike/tests/test_unit.py
@@ -94,7 +94,7 @@ def test_connection_uses_tls():
 
     with mock.patch('aerospike.client') as client:
         check.get_client()
-        assert client.called_with({'host': check._host, 'tls': tls_config})
+        assert client.assert_called_with({'host': check._host, 'tls': tls_config})
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Migrate from `called_with` to `assert_called_with`

### Motivation
<!-- What inspired you to submit this pull request? -->

- CI is failing on master https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=124396&view=logs&jobId=e6fbf30e-778c-5f2e-ae39-62f4185f213c&j=e6fbf30e-778c-5f2e-ae39-62f4185f213c&t=0e9729ef-3bcb-570e-bbdc-63508c8af0c7
- A new version of the `mock` lib got released [yesterday](https://pypi.org/project/mock/) and now throws an error when using `called_*` instead of `assert_called_*`: https://mock.readthedocs.io/en/latest/changelog.html#id1

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.