### PR TITLE
Remove broker_id tag from service_check.json

### DIFF
--- a/amazon_msk/assets/service_checks.json
+++ b/amazon_msk/assets/service_checks.json
@@ -27,8 +27,7 @@
             "host",
             "endpoint",
             "cluster_arn",
-            "region_name",
-            "broker_id"
+            "region_name"
         ],
         "name": "Amazon Kafka prometheus health",
         "description": "Returns `CRITICAL` if the check cannot access a metrics endpoint. Otherwise, returns `OK`."


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The `broker_id` tag is not supposed to be collected on `aws.msk.prometheus.health`, although this was listed in the `service_checks.json`. This service check didn't have `broker_id` as a tag even in the [original implementation of the check](https://github.com/DataDog/integrations-core/pull/5127/files#diff-141423149133df2d7b8fe69c88c1e72a284c0c808714c440392b2f1d83a645cfR54).
### Motivation
<!-- What inspired you to submit this pull request? -->
Support

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.