### PR TITLE
Update the platform to `windows`

### DIFF
--- a/active_directory/hatch.toml
+++ b/active_directory/hatch.toml
@@ -6,7 +6,7 @@ dependencies = [
 ]
 e2e-env = false
 platforms = [
-  "win32",
+  "windows",
 ]
 
 [[envs.default.matrix]]

--- a/aspdotnet/hatch.toml
+++ b/aspdotnet/hatch.toml
@@ -6,7 +6,7 @@ dependencies = [
 ]
 e2e-env = false
 platforms = [
-  "win32",
+  "windows",
 ]
 
 [[envs.default.matrix]]

--- a/dotnetclr/hatch.toml
+++ b/dotnetclr/hatch.toml
@@ -6,7 +6,7 @@ dependencies = [
 ]
 e2e-env = false
 platforms = [
-  "win32",
+  "windows",
 ]
 
 [[envs.default.matrix]]

--- a/exchange_server/hatch.toml
+++ b/exchange_server/hatch.toml
@@ -8,5 +8,5 @@ dependencies = [
   "datadog_checks_tests_helper @ {root:uri}/../datadog_checks_tests_helper",
 ]
 platforms = [
-  "win32",
+  "windows",
 ]

--- a/hyperv/hatch.toml
+++ b/hyperv/hatch.toml
@@ -5,7 +5,7 @@ python = ["2.7", "3.8"]
 
 [envs.default]
 platforms = [
-  "win32",
+  "windows",
 ]
 
 [envs.bench]

--- a/iis/hatch.toml
+++ b/iis/hatch.toml
@@ -9,7 +9,7 @@ dependencies = [
 ]
 e2e-env = false
 platforms = [
-  "win32",
+  "windows",
 ]
 
 [envs.default.overrides]

--- a/pdh_check/hatch.toml
+++ b/pdh_check/hatch.toml
@@ -8,5 +8,5 @@ dependencies = [
   "datadog_checks_tests_helper @ {root:uri}/../datadog_checks_tests_helper",
 ]
 platforms = [
-  "win32",
+  "windows",
 ]

--- a/win32_event_log/hatch.toml
+++ b/win32_event_log/hatch.toml
@@ -6,7 +6,7 @@ python = ["2.7", "3.8"]
 [envs.default]
 e2e-env = false
 platforms = [
-  "win32",
+  "windows",
 ]
 
 [envs.default.overrides]

--- a/win32_event_log/hatch.toml
+++ b/win32_event_log/hatch.toml
@@ -11,5 +11,5 @@ platforms = [
 
 [envs.default.overrides]
 matrix.python.scripts = [
-  { key = "test", value = "_dd-test tests/legacy", if = ["2.7"] },
+  { key = "test", value = "pytest -v --benchmark-skip tests/legacy", if = ["2.7"] },
 ]

--- a/windows_performance_counters/hatch.toml
+++ b/windows_performance_counters/hatch.toml
@@ -5,5 +5,5 @@ python = ["3.8"]
 
 [envs.default]
 platforms = [
-  "win32",
+  "windows",
 ]

--- a/windows_service/hatch.toml
+++ b/windows_service/hatch.toml
@@ -5,7 +5,7 @@ python = ["2.7", "3.8"]
 
 [envs.default]
 platforms = [
-  "win32",
+  "windows",
 ]
 
 [envs.default.env-vars]

--- a/wmi_check/hatch.toml
+++ b/wmi_check/hatch.toml
@@ -14,5 +14,5 @@ python = ["2.7", "3.8"]
 [envs.default]
 e2e-env = false
 platforms = [
-  "win32",
+  "windows",
 ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Switch from `win32` to `windows` platform in the hatch file. I also fixed the win32_event_log test command to run only the py2 tests with py2

### Motivation
<!-- What inspired you to submit this pull request? -->

`win32` seems to not be correctly taken into account. Tests are not running on master: 
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=124511&view=logs&jobId=07e99708-ce69-5454-a6f3-c9c372405ab5&j=d65fd6b8-c63e-5a4e-97a3-9b85857d5129&t=10847e51-470b-5c5e-9d8a-e8ee2f0656bd
- https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=124511&view=logs&jobId=07e99708-ce69-5454-a6f3-c9c372405ab5&j=07e99708-ce69-5454-a6f3-c9c372405ab5&t=7d431cc5-8a3c-54a5-b88c-fa79e094c778

I'm not an hatch expert, but it seems like hatch is using https://docs.python.org/3/library/platform.html#platform.system: https://github.com/pypa/hatch/blob/master/src/hatch/utils/platform.py#L248-L259. Also https://hatch.pypa.io/latest/config/environment/overview/#supported-platforms

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.