### PR TITLE
Mask the env variables used in the config file during the tests

### DIFF
--- a/ddev/hatch.toml
+++ b/ddev/hatch.toml
@@ -16,4 +16,5 @@ pre-install-commands = [
 ]
 env-exclude = [
   "DD_GITHUB_USER",  # Used in `ddev config show` tests
+  "DD_SITE",  # Used in `ddev config show` tests
 ]

--- a/ddev/hatch.toml
+++ b/ddev/hatch.toml
@@ -14,3 +14,6 @@ dependencies = [
 pre-install-commands = [
   "python -m pip install --disable-pip-version-check {verbosity:flag:-1} -e ../datadog_checks_dev[cli]",
 ]
+env-exclude = [
+  "DD_GITHUB_USER",  # Used in `ddev config show` tests
+]

--- a/ddev/hatch.toml
+++ b/ddev/hatch.toml
@@ -14,6 +14,3 @@ dependencies = [
 pre-install-commands = [
   "python -m pip install --disable-pip-version-check {verbosity:flag:-1} -e ../datadog_checks_dev[cli]",
 ]
-env-exclude = [
-  "DD_*",
-]

--- a/ddev/hatch.toml
+++ b/ddev/hatch.toml
@@ -15,6 +15,5 @@ pre-install-commands = [
   "python -m pip install --disable-pip-version-check {verbosity:flag:-1} -e ../datadog_checks_dev[cli]",
 ]
 env-exclude = [
-  "DD_GITHUB_USER",  # Used in `ddev config show` tests
-  "DD_SITE",  # Used in `ddev config show` tests
+  "DD_*",
 ]

--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -96,7 +96,7 @@ def config_file(tmp_path, monkeypatch) -> ConfigFile:
         monkeypatch.delenv(env_var, raising=False)
 
     path = Path(tmp_path, 'config.toml')
-    os.environ[ConfigEnvVars.CONFIG] = str(path)
+    monkeypatch.setenv(ConfigEnvVars.CONFIG) = str(path)
     config = ConfigFile(path)
     config.restore()
     return config

--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -83,7 +83,18 @@ def valid_integration(valid_integrations) -> str:
 
 
 @pytest.fixture(autouse=True)
-def config_file(tmp_path) -> ConfigFile:
+def config_file(tmp_path, monkeypatch) -> ConfigFile:
+    for env_var in (
+        'DD_GITHUB_USER',
+        'DD_GITHUB_TOKEN',
+        'DD_SITE',
+        'DD_LOGS_CONFIG_DD_URL',
+        'DD_DD_URL',
+        'DD_API_KEY',
+        'DD_APP_KEY',
+    ):
+        monkeypatch.delenv(env_var, raising=False)
+
     path = Path(tmp_path, 'config.toml')
     os.environ[ConfigEnvVars.CONFIG] = str(path)
     config = ConfigFile(path)

--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -96,7 +96,7 @@ def config_file(tmp_path, monkeypatch) -> ConfigFile:
         monkeypatch.delenv(env_var, raising=False)
 
     path = Path(tmp_path, 'config.toml')
-    monkeypatch.setenv(ConfigEnvVars.CONFIG) = str(path)
+    monkeypatch.setenv(ConfigEnvVars.CONFIG, str(path))
     config = ConfigFile(path)
     config.restore()
     return config


### PR DESCRIPTION
### What does this PR do?

Mask the env variables used in the config file during the tests

### Motivation
<!-- What inspired you to submit this pull request? -->

The following tests are failing in my local environment: 
- tests/cli/config/test_show.py::test_default_scrubbed
- tests/cli/config/test_show.py::test_reveal

I have the `DD_GITHUB_USER` env variable configured. It is read during the `ddev config show` tests and modifies the output the tests are asserting, which makes them fail.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.