### PR TITLE
Add `ddev validate license-headers` to validations run on CI

### DIFF
--- a/.azure-pipelines/templates/run-validations.yml
+++ b/.azure-pipelines/templates/run-validations.yml
@@ -109,6 +109,12 @@ steps:
       ddev validate licenses
     displayName: 'Validate third-party license list'
 
+- ${{ if eq(parameters.repo, 'core') }}:
+  - script: |
+      echo "ddev validate license-headers ${{ parameters.validate_changed }}"
+      ddev validate license-headers ${{ parameters.validate_changed }}
+    displayName: 'Validate license headers on source code files'
+
 - ${{ if eq(parameters.repo, 'marketplace') }}:
   - script: |
       echo "ddev validate eula"

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -88,6 +88,10 @@ jobs:
       run: |
         ddev validate licenses
 
+    - name: Run license header validation
+      run: |
+        ddev validate license-headers $CHANGED
+
     - name: Run metadata validation
       run: |
         ddev validate metadata $CHANGED

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2018-present
+# (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division

--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2019-present
+# (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import division


### PR DESCRIPTION
### What does this PR do?

Adds license header validation to CI

### Motivation

[AITOOLS-60](https://datadoghq.atlassian.net/browse/AITOOLS-60)

### Additional Notes

See d5717a076533e3a4308f10f6bbacba549ac7f10b and associated https://github.com/DataDog/integrations-core/pull/13674#issuecomment-1378750339 for an example of detected license change, not allowed by the validation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.

[AITOOLS-60]: https://datadoghq.atlassian.net/browse/AITOOLS-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ