### PR TITLE
Automatically delete the agent container when the container is stopped

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -357,6 +357,8 @@ class DockerInterface(object):
         command = [
             'docker',
             'run',
+            # Remove it when stopped
+            '--rm',
             # Keep it up
             '-d',
             # Ensure consistent naming
@@ -405,7 +407,6 @@ class DockerInterface(object):
     def stop_agent(self):
         # Only error for exit code if config actually exists
         run_command(['docker', 'stop', '-t', '0', self.container_name], capture=True, check=self.exists())
-        run_command(['docker', 'rm', self.container_name], capture=True, check=self.exists())
 
     def restart_agent(self):
         return run_command(['docker', 'restart', self.container_name], capture=True)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Automatically delete the agent container when the container is stopped

### Motivation
<!-- What inspired you to submit this pull request? -->

- First step to resolve https://datadoghq.atlassian.net/browse/AITOOLS-71. It only solves the issue mentioned for tests that do not run docker containers locally to run the tests (except the agent) such as vsphere.
- I'll work on the integration env itself in another PR

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Steps to reproduce/test:
1. Run `ddev env start vsphere py3.8-7.0`
2. Run `docker stop dd_vsphere_py3.8-7.0` or reboot the docker daemon/your computer
3. Run `ddev env start vsphere py3.8-7.0` again -> it should work

Note: the other agent container are already using this option: [here](https://github.com/DataDog/integrations-core/blob/bdebedadb675c7f74a037bd0745a1d478515f9bc/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py#L222) and [there](https://github.com/DataDog/integrations-core/blob/bdebedadb675c7f74a037bd0745a1d478515f9bc/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py#L255)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.