### PR TITLE
Support license header validation for files encoded with utf8 with bom

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/license_headers.py
@@ -81,7 +81,7 @@ def validate_license_headers(
                 yield child
 
     def validate_license_header(path):
-        with open(path) as f:
+        with open(path, encoding='utf-8-sig') as f:
             contents = f.read()
 
         license_header = parse_license_header(contents)

--- a/datadog_checks_dev/tests/tooling/test_license_headers.py
+++ b/datadog_checks_dev/tests/tooling/test_license_headers.py
@@ -103,6 +103,25 @@ import os
     assert validate_license_headers(check_path, get_previous=_make_get_previous()) == []
 
 
+def test_validate_license_headers_handles_files_encoded_in_utf8_with_bom(tmp_path):
+    """This tests that a utf8 bom at the beginning of the file doesn't prevent the
+    validator from finding the header. We need that encoding in some files that contain
+    non-ascii characters to make py2 use the right encoding.
+    """
+    check_path = tmp_path / "check"
+    check_path.mkdir()
+
+    with open(check_path / "setup.py", "w", encoding="utf-8-sig") as f:
+        f.write(
+            f"""{get_license_header()}
+
+import os
+"""
+        )
+
+    assert validate_license_headers(check_path, get_previous=_make_get_previous()) == []
+
+
 def test_validate_license_headers_works_with_arbitrary_nesting(tmp_path):
     check_path = tmp_path / "check"
     check_path.mkdir()


### PR DESCRIPTION
### What does this PR do?

Allows the license header validation to ignore the utf8 bom mark when deciding whether a file starts with the license header.

### Motivation

https://github.com/DataDog/integrations-core/pull/13511#issuecomment-1363886945. I was able to get rid of the magic comment on those few files that needed it by encoding the necessary files using the [utf8 bom](https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8) that Python supports. Alas, I forgot to check if those files which seemed to start with the license header actually passed validation, which I only found out after adding the validation to our CI (#13674).

### Additional Notes

In theory we could come up with alternatives that would make the validator less strict towards having the license header at the _actual_ beginning of the file, but this solution patches the only special case that we really have at the moment and keeps the logic simple.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.