### PR TITLE
Always recreate the containers when using docker-compose in tests

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/docker.py
@@ -220,7 +220,7 @@ class ComposeFileUp(LazyFunction):
         self.compose_file = compose_file
         self.build = build
         self.service_name = service_name
-        self.command = ['docker', 'compose', '-f', self.compose_file, 'up', '-d']
+        self.command = ['docker', 'compose', '-f', self.compose_file, 'up', '-d', '--force-recreate']
 
         if self.build:
             self.command.append('--build')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Always recreate the containers when using docker-compose in tests

### Motivation
<!-- What inspired you to submit this pull request? -->

- Second PR for https://datadoghq.atlassian.net/browse/AITOOLS-71 (first one: https://github.com/DataDog/integrations-core/pull/13675)
- Thanks to that, docker compose won't fail if a container with this name already exists but will recreate it instead. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

To rest it: 
- Run `ddev env start cloudera py3.8`
- Run `docker stop dd_cloudera_py3.8 cloudera` or or reboot the docker daemon/your computer
- Run `ddev env start cloudera py3.8` -> it should work

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.