### PR TITLE
Create `postgresql.activity.wait_event_count` metric for Postgres

### DIFF
--- a/postgres/datadog_checks/postgres/metrics_cache.py
+++ b/postgres/datadog_checks/postgres/metrics_cache.py
@@ -207,7 +207,7 @@ class PostgresMetricsCache:
         return (descriptors, aggregation_columns)
 
     def get_wait_event_metrics(self, version):
-        if version < V9_6:
+        if version < V10:
             return
         metrics_data = self.wait_event_metrics
         if metrics_data is None:

--- a/postgres/datadog_checks/postgres/metrics_cache.py
+++ b/postgres/datadog_checks/postgres/metrics_cache.py
@@ -184,6 +184,9 @@ class PostgresMetricsCache:
         return self.replication_stats_metrics
 
     def get_wait_event_metrics(self, version):
+        if version < V9_6:
+            return
+
         metrics_data = self.wait_event_metrics
         if metrics_data is None:
             excluded_aggregations = self.config.activity_metrics_excluded_aggregations

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -328,7 +328,7 @@ class PostgreSql(AgentCheck):
             column_values = row[len(descriptors) :]
 
             # build a map of descriptors and their values
-            desc_map = {name: value for (_, name), value in zip(descriptors, descriptor_values) if value}
+            desc_map = {name: value for (_, name), value in zip(descriptors, descriptor_values) if value is not None}
 
             # Build tags.
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -403,7 +403,10 @@ class PostgreSql(AgentCheck):
 
         if self._config.collect_activity_metrics:
             activity_metrics = self.metrics_cache.get_activity_metrics(self.version)
+            wait_event_metrics = self.metrics_cache.get_wait_event_metrics(self.version)
+
             self._query_scope(cursor, activity_metrics, instance_tags, False)
+            self._query_scope(cursor, wait_event_metrics, instance_tags, False)
 
         for scope in list(metric_scope) + self._config.custom_metrics:
             self._query_scope(cursor, scope, instance_tags, scope in self._config.custom_metrics)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -328,7 +328,7 @@ class PostgreSql(AgentCheck):
             column_values = row[len(descriptors) :]
 
             # build a map of descriptors and their values
-            desc_map = {name: value for (_, name), value in zip(descriptors, descriptor_values)}
+            desc_map = {name: value for (_, name), value in zip(descriptors, descriptor_values) if value}
 
             # Build tags.
 

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -276,17 +276,16 @@ SELECT s.schemaname,
     'relation': False,
 }
 
-WAIT_EVENT_QUERY = """
-SELECT wait_event_type, wait_event, backend_type, {aggregation_columns_select}
-    {{metrics_columns}}
-FROM pg_stat_activity
-WHERE wait_event is not null
-GROUP BY datid, wait_event_type, wait_event, backend_type {aggregation_columns_group}
-"""
-
-WAIT_EVENT_METRICS = {
-    'count(*)': ('postgresql.activity.wait_event_count', AgentCheck.gauge),
-}
+# Default descriptors and aggregations for wait_event_metrics
+# and activity_metrics
+# Elements in the activity_metrics_excluded_aggregations list
+# will be excluded
+ACTIVITY_DEFAULT_DESCRIPTORS = [
+    ('application_name', 'app'),
+    ('datname', 'db'),
+    ('usename', 'user'),
+]
+ACTIVITY_DEFAULT_AGGREGATIONS = [d[0] for d in ACTIVITY_DEFAULT_DESCRIPTORS]
 
 # The metrics we retrieve from pg_stat_activity when the postgres version >= 9.6
 ACTIVITY_METRICS_9_6 = [
@@ -368,3 +367,15 @@ SELECT {aggregation_columns_select}
 FROM pg_stat_activity
 GROUP BY datid {aggregation_columns_group}
 """
+
+ACTIVITY_WAIT_EVENT_QUERY = """
+SELECT wait_event_type, wait_event, backend_type, {aggregation_columns_select}
+    {{metrics_columns}}
+FROM pg_stat_activity
+WHERE wait_event is not null
+GROUP BY datid, wait_event_type, wait_event, backend_type {aggregation_columns_group}
+"""
+
+ACTIVITY_WAIT_EVENT_METRICS = {
+    'count(*)': ('postgresql.activity.wait_event_count', AgentCheck.gauge),
+}

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -276,6 +276,18 @@ SELECT s.schemaname,
     'relation': False,
 }
 
+WAIT_EVENT_QUERY = """
+SELECT wait_event_type, wait_event, backend_type, {aggregation_columns_select}
+    {{metrics_columns}}
+FROM pg_stat_activity
+WHERE wait_event is not null
+GROUP BY datid, wait_event_type, wait_event, backend_type {aggregation_columns_group}
+"""
+
+WAIT_EVENT_METRICS = {
+    'count(*)': ('postgresql.activity.wait_event_count', AgentCheck.gauge),
+}
+
 # The metrics we retrieve from pg_stat_activity when the postgres version >= 9.6
 ACTIVITY_METRICS_9_6 = [
     "SUM(CASE WHEN xact_start IS NOT NULL THEN 1 ELSE 0 END)",

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -68,6 +68,7 @@ postgresql.before_xid_wraparound,gauge,,transaction,,The number of transactions 
 postgresql.activity.backend_xmin_age,gauge,,transaction,,The age of the oldest backend's xmin horizon relative to latest stable xid.,-1,postgres,activity xmin,
 postgresql.activity.backend_xid_age,gauge,,transaction,,The age of the oldest backend's xid relative to latest stable xid.,-1,postgres,activity xid,
 postgresql.activity.xact_start_age,gauge,,second,,The age of the oldest active transactions.,-1,postgres,activity xact,
+postgresql.activity.wait_event_count,gauge,,,,"The number of backend processes aggregated per wait_event_type and wait_event. The list of event type is available in https://www.postgresql.org/docs/current/monitoring-stats.html",0,postgres,activity wait event,
 postgresql.active_queries,gauge,,,,The number of active queries in this database.,0,postgres,active queries,
 postgresql.active_waiting_queries,gauge,,,,The number of waiting queries in this database in state active.,0,postgres,transactions active_waiting queries,
 postgresql.waiting_queries,gauge,,,,The number of waiting queries in this database.,0,postgres,transactions waiting queries,

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -68,7 +68,7 @@ postgresql.before_xid_wraparound,gauge,,transaction,,The number of transactions 
 postgresql.activity.backend_xmin_age,gauge,,transaction,,The age of the oldest backend's xmin horizon relative to latest stable xid.,-1,postgres,activity xmin,
 postgresql.activity.backend_xid_age,gauge,,transaction,,The age of the oldest backend's xid relative to latest stable xid.,-1,postgres,activity xid,
 postgresql.activity.xact_start_age,gauge,,second,,The age of the oldest active transactions.,-1,postgres,activity xact,
-postgresql.activity.wait_event_count,gauge,,,,"The number of backend processes aggregated per wait_event_type and wait_event. The list of event type is available in https://www.postgresql.org/docs/current/monitoring-stats.html",0,postgres,activity wait event,
+postgresql.activity.wait_event_count,gauge,,,,"The number of backend processes aggregated per wait_event_type and wait_event. Only available starting PG10. The list of event type is available in https://www.postgresql.org/docs/current/monitoring-stats.html",0,postgres,activity wait event,
 postgresql.active_queries,gauge,,,,The number of active queries in this database.,0,postgres,active queries,
 postgresql.active_waiting_queries,gauge,,,,The number of waiting queries in this database in state active.,0,postgres,transactions active_waiting queries,
 postgresql.waiting_queries,gauge,,,,The number of waiting queries in this database.,0,postgres,transactions waiting queries,

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -129,7 +129,7 @@ def set_tag_to_value(tag, tags_to_replace, replace_value):
 
 
 def check_wait_event_metrics(aggregator, tags, hostname=None, count=1):
-    if float(POSTGRES_VERSION) < 9.6:
+    if float(POSTGRES_VERSION) < 10.0:
         return
 
     launch_wait_event_tuple = [
@@ -143,6 +143,7 @@ def check_wait_event_metrics(aggregator, tags, hostname=None, count=1):
         ['backend_type:checkpointer', 'wait_event:CheckpointerMain', 'wait_event_type:Activity'],
         ['backend_type:autovacuum launcher', 'wait_event:AutoVacuumMain', 'wait_event_type:Activity'],
     ]
+    # No db, user nor app for system processes
     system_tags = [set_tag_to_value(t, ['db', 'user', 'app'], None) for t in tags]
     system_tags = [t for t in system_tags if t]
 

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -137,6 +137,12 @@ def check_wait_event_metrics(aggregator, tags, hostname=None, count=1):
         'wait_event:LogicalLauncherMain',
         'wait_event_type:Activity',
     ]
+    if float(POSTGRES_VERSION) < 11.0:
+        launch_wait_event_tuple = [
+            'backend_type:background worker',
+            'wait_event:LogicalLauncherMain',
+            'wait_event_type:Activity',
+        ]
     system_wait_event_tuples = [
         ['backend_type:walwriter', 'wait_event:WalWriterMain', 'wait_event_type:Activity'],
         ['backend_type:background writer', 'wait_event:BgWriterMain', 'wait_event_type:Activity'],

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -129,6 +129,9 @@ def set_tag_to_value(tag, tags_to_replace, replace_value):
 
 
 def check_wait_event_metrics(aggregator, tags, hostname=None, count=1):
+    if float(POSTGRES_VERSION) < 9.6:
+        return
+
     launch_wait_event_tuple = [
         'backend_type:logical replication launcher',
         'wait_event:LogicalLauncherMain',

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -145,7 +145,8 @@ def check_wait_event_metrics(aggregator, tags, hostname=None, count=1):
         ]
     system_wait_event_tuples = [
         ['backend_type:walwriter', 'wait_event:WalWriterMain', 'wait_event_type:Activity'],
-        ['backend_type:background writer', 'wait_event:BgWriterMain', 'wait_event_type:Activity'],
+        # Background writer may be hibernating
+        # ['backend_type:background writer', 'wait_event:BgWriterMain', 'wait_event_type:Activity'],
         ['backend_type:checkpointer', 'wait_event:CheckpointerMain', 'wait_event_type:Activity'],
         ['backend_type:autovacuum launcher', 'wait_event:AutoVacuumMain', 'wait_event_type:Activity'],
     ]

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -28,7 +28,7 @@ from .common import (
     check_wait_event_metrics,
     requires_static_version,
 )
-from .utils import requires_over_10, requires_over_96
+from .utils import requires_over_10
 
 CONNECTION_METRICS = ['postgresql.max_connections', 'postgresql.percent_usage_connections']
 
@@ -159,7 +159,7 @@ def test_activity_metrics(aggregator, integration_check, pg_instance):
     check_wait_event_metrics(aggregator, expected_tags)
 
 
-@requires_over_96
+@requires_over_10
 def test_wait_event_client_read(aggregator, integration_check, pg_instance):
     pg_instance['collect_activity_metrics'] = True
 

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -28,7 +28,7 @@ from .common import (
     check_wait_event_metrics,
     requires_static_version,
 )
-from .utils import requires_over_10
+from .utils import requires_over_10, requires_over_96
 
 CONNECTION_METRICS = ['postgresql.max_connections', 'postgresql.percent_usage_connections']
 
@@ -159,7 +159,8 @@ def test_activity_metrics(aggregator, integration_check, pg_instance):
     check_wait_event_metrics(aggregator, expected_tags)
 
 
-def test_wait_event_metric(aggregator, integration_check, pg_instance):
+@requires_over_96
+def test_wait_event_client_read(aggregator, integration_check, pg_instance):
     pg_instance['collect_activity_metrics'] = True
 
     # Keep a query in Client read

--- a/postgres/tests/utils.py
+++ b/postgres/tests/utils.py
@@ -5,11 +5,6 @@ import pytest
 
 from .common import POSTGRES_VERSION
 
-requires_over_96 = pytest.mark.skipif(
-    POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 9.6,
-    reason='This test is for over 10 only (make sure POSTGRES_VERSION is set)',
-)
-
 requires_over_10 = pytest.mark.skipif(
     POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 10,
     reason='This test is for over 10 only (make sure POSTGRES_VERSION is set)',

--- a/postgres/tests/utils.py
+++ b/postgres/tests/utils.py
@@ -5,6 +5,11 @@ import pytest
 
 from .common import POSTGRES_VERSION
 
+requires_over_96 = pytest.mark.skipif(
+    POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 9.6,
+    reason='This test is for over 10 only (make sure POSTGRES_VERSION is set)',
+)
+
 requires_over_10 = pytest.mark.skipif(
     POSTGRES_VERSION is None or float(POSTGRES_VERSION) < 10,
     reason='This test is for over 10 only (make sure POSTGRES_VERSION is set)',


### PR DESCRIPTION
### What does this PR do?
Create `postgresql.activity.wait_event_count` metric which will provide the count of backend processes aggregated by `wait_event` and `wait_event_type` from `pg_stat_activity`.
The `wait_event_type` and `wait_event` lists are available in https://www.postgresql.org/docs/current/monitoring-stats.html#WAIT-EVENT-TABLE
`wait_event` and `wait_event_type` are available from PG 9.6 https://pgpedia.info/p/pg_stat_activity.html

### Motivation
On client's wait events, this can provide information on wether queries for a specific application are waiting for some kind of locks or buffer reads or if most of them are waiting for the client to fetch the results. 
On system's wait events, this can give insight on vacuum processes (waiting for lock to truncate), wal writer state (WALInsert, WALBufMapping...) or data file operations (Sync, Read, Write, Truncate).

### Additional Notes
One issue I had was to manage empty tag like `application_name` which is empty for system processes. One solution I've found was to not set the tag when tag value was None.
```
desc_map = {name: value for (_, name), value in zip(descriptors, descriptor_values) if value is not None}
```
This avoid the `app:None` or weird `app:` tags. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.