### PR TITLE
Validate the new release version when provided

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
@@ -2,6 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
+import re
 from contextlib import suppress
 
 import click
@@ -16,9 +17,16 @@ from . import changelog
 from .show import changes
 
 
+def validate_version(ctx, param, value):
+    if re.match("^\\d+\\.\\d+\\.\\d+(-(rc|pre|alpha|beta)\\.\\d+)?$", value):
+        return value
+
+    raise click.BadParameter('must match `^\\d+\\.\\d+\\.\\d+(-(rc|pre|alpha|beta)\\.\\d+)?$`')
+
+
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Release one or more checks')
 @click.argument('checks', shell_complete=complete_valid_checks, nargs=-1, required=True)
-@click.option('--version')
+@click.option('--version', callback=validate_version)
 @click.option('--end')
 @click.option('--new', 'initial_release', is_flag=True, help='Ensure versions are at 1.0.0')
 @click.option('--skip-sign', is_flag=True, help='Skip the signing of release metadata')

--- a/datadog_checks_dev/tests/tooling/commands/release/test_make.py
+++ b/datadog_checks_dev/tests/tooling/commands/release/test_make.py
@@ -1,0 +1,51 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import sys
+
+import pytest
+
+from datadog_checks.dev import run_command
+from datadog_checks.dev.tooling.commands.release.make import validate_version
+
+
+@pytest.mark.parametrize(
+    'version',
+    [
+        pytest.param("", id='empty'),
+        pytest.param("1", id='only major'),
+        pytest.param("1.2", id='no patch'),
+        pytest.param("1.2.3-alpha", id='alpha with no number'),
+        pytest.param("1.2-alpha.1", id='alpha with no patch'),
+        pytest.param("1-alpha.1", id='alpha with no minor'),
+        pytest.param("1.2.3-alpha.1a", id='alpha with extra chars'),
+    ],
+)
+def test_release_make_with_invalid_input_version(version):
+    result = run_command(
+        [sys.executable, '-m', 'datadog_checks.dev', '-x', 'release', 'make', 'my_check', '--version', version],
+        capture=True,
+    )
+
+    assert result.code == 2
+    assert result.stdout == ""
+    assert (
+        "Invalid value for '--version': must match `^\\d+\\.\\d+\\.\\d+(-(rc|pre|alpha|beta)\\.\\d+)?$" in result.stderr
+    )
+
+
+@pytest.mark.parametrize(
+    'version',
+    [
+        "1.2.3",
+        "1.2.3-alpha.1",
+        "1.2.3-alpha.12",
+        "1.2.3-beta.1",
+        "1.2.3-rc.1",
+        "1.2.3-pre.1",
+    ],
+)
+# TODO: replace this test with a one that calls `ddev release make` directly
+#  once we move the command to the new ddev cli
+def test_validate_version(version):
+    assert version == validate_version(None, None, version)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Validate the new release version when provided for the `ddev release make` command

### Motivation
<!-- What inspired you to submit this pull request? -->

https://datadoghq.atlassian.net/browse/AITOOLS-55

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- There's currently no tests to validate the whole command works. It will be easier to do that once we will migrate the command to the new ddev cli. 
- The tests that use an incorrect version can call directly the command since click will validate them before calling the function itself. It also validate that our option correctly defines the callback function to validate the value.
- I added a couple of tests to validate the function allows valid values, but calling the function directly. This should be refactored to a test that calls directly the command and make sure it works well as a whole, but let's do that in another PR.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.