### PR TITLE
replication role tag bug fix

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -634,7 +634,11 @@ class PostgreSql(AgentCheck):
             # Check version
             self._connect()
             if self._config.tag_replication_role:
-                tags.extend(["replication_role:{}".format(self._get_replication_role())])
+                replication_role_tag = "replication_role:{}".format(self._get_replication_role())
+                tags.append(replication_role_tag)
+                self.tags_without_db = [t for t in copy.copy(self.tags_without_db) if not t.startswith("replication_role:")]
+                self.tags_without_db.append(replication_role_tag)
+
             self.log.debug("Running check against version %s: is_aurora: %s", str(self.version), str(self.is_aurora))
             self._collect_stats(tags)
             self._collect_custom_queries(tags)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -636,7 +636,9 @@ class PostgreSql(AgentCheck):
             if self._config.tag_replication_role:
                 replication_role_tag = "replication_role:{}".format(self._get_replication_role())
                 tags.append(replication_role_tag)
-                self.tags_without_db = [t for t in copy.copy(self.tags_without_db) if not t.startswith("replication_role:")]
+                self.tags_without_db = [
+                    t for t in copy.copy(self.tags_without_db) if not t.startswith("replication_role:")
+                ]
                 self.tags_without_db.append(replication_role_tag)
 
             self.log.debug("Running check against version %s: is_aurora: %s", str(self.version), str(self.is_aurora))

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -11,6 +11,11 @@ from pytest import fail
 from semver import VersionInfo
 from six import iteritems
 
+from .common import (
+    DB_NAME,
+    PORT,
+)
+
 from datadog_checks.postgres import PostgreSql, util
 from datadog_checks.postgres.version_utils import VersionUtils
 
@@ -260,6 +265,33 @@ def test_replication_stats(aggregator, integration_check, pg_instance):
     aggregator.assert_all_metrics_covered()
 
 
+def test_replication_tag(aggregator, integration_check, pg_instance):
+    REPLICATION_TAG_TEST_METRIC = 'postgresql.db.count'
+   
+    expected_tags = pg_instance['tags'] + ['port:{}'.format(PORT)]
+    check = integration_check(pg_instance)
+    
+    #default configuration (no replication)
+    check.check(pg_instance)
+    aggregator.assert_metric(REPLICATION_TAG_TEST_METRIC, tags=expected_tags) 
+    aggregator.reset()
+    
+    #role = master
+    pg_instance['tag_replication_role'] = True
+    check = integration_check(pg_instance)
+
+    check.check(pg_instance)
+    ROLE_TAG = "replication_role:master"
+    aggregator.assert_metric(REPLICATION_TAG_TEST_METRIC, tags=expected_tags + [ROLE_TAG]) 
+    aggregator.reset()
+   
+    #switchover: master -> standby
+    STANDBY = "standby"
+    check._get_replication_role = MagicMock(return_value=STANDBY)
+    check.check(pg_instance)
+    ROLE_TAG = "replication_role:{}".format(STANDBY)
+    aggregator.assert_metric(REPLICATION_TAG_TEST_METRIC, tags=expected_tags + [ROLE_TAG]) 
+    
 def test_query_timeout_connection_string(aggregator, integration_check, pg_instance):
     pg_instance['password'] = ''
     pg_instance['query_timeout'] = 1000

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -11,13 +11,10 @@ from pytest import fail
 from semver import VersionInfo
 from six import iteritems
 
-from .common import (
-    DB_NAME,
-    PORT,
-)
-
 from datadog_checks.postgres import PostgreSql, util
 from datadog_checks.postgres.version_utils import VersionUtils
+
+from .common import PORT
 
 pytestmark = pytest.mark.unit
 
@@ -267,31 +264,32 @@ def test_replication_stats(aggregator, integration_check, pg_instance):
 
 def test_replication_tag(aggregator, integration_check, pg_instance):
     REPLICATION_TAG_TEST_METRIC = 'postgresql.db.count'
-   
+
     expected_tags = pg_instance['tags'] + ['port:{}'.format(PORT)]
     check = integration_check(pg_instance)
-    
-    #default configuration (no replication)
+
+    # default configuration (no replication)
     check.check(pg_instance)
-    aggregator.assert_metric(REPLICATION_TAG_TEST_METRIC, tags=expected_tags) 
+    aggregator.assert_metric(REPLICATION_TAG_TEST_METRIC, tags=expected_tags)
     aggregator.reset()
-    
-    #role = master
+
+    # role = master
     pg_instance['tag_replication_role'] = True
     check = integration_check(pg_instance)
 
     check.check(pg_instance)
     ROLE_TAG = "replication_role:master"
-    aggregator.assert_metric(REPLICATION_TAG_TEST_METRIC, tags=expected_tags + [ROLE_TAG]) 
+    aggregator.assert_metric(REPLICATION_TAG_TEST_METRIC, tags=expected_tags + [ROLE_TAG])
     aggregator.reset()
-   
-    #switchover: master -> standby
+
+    # switchover: master -> standby
     STANDBY = "standby"
     check._get_replication_role = MagicMock(return_value=STANDBY)
     check.check(pg_instance)
     ROLE_TAG = "replication_role:{}".format(STANDBY)
-    aggregator.assert_metric(REPLICATION_TAG_TEST_METRIC, tags=expected_tags + [ROLE_TAG]) 
-    
+    aggregator.assert_metric(REPLICATION_TAG_TEST_METRIC, tags=expected_tags + [ROLE_TAG])
+
+
 def test_query_timeout_connection_string(aggregator, integration_check, pg_instance):
     pg_instance['password'] = ''
     pg_instance['query_timeout'] = 1000


### PR DESCRIPTION
### What does this PR do?
- Bug fix for the missing `replication_role` tag. 
- Unit test cases added for checking the correctness of the `replication_role` tag before and after a switchover. 

### Motivation
In the course of implementing `deadlock.count` metric in https://github.com/DataDog/integrations-core/pull/13374 I refactored the code that prunes `db` tag from the instance metrics. In doing so, I considered all but `replication_role` tag. Unlike most of the tags that are loaded from the static configuration, `replication_role` is read from the database and  changes after a switchover. Since the unit tests for this tag weren't implemented the bug remained unnoticed.

### Additional Notes


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.