### PR TITLE
Fix some agent tests

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/common.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/agent/common.py
@@ -4,9 +4,8 @@
 import os
 
 from semver import VersionInfo
-
+from ...git import git_show_file
 from ...constants import get_agent_release_requirements
-from ...git import git_show_file, git_tag_list
 from ...release import DATADOG_PACKAGE_PREFIX, get_folder_name, get_package_name
 from ...utils import parse_agent_req_file
 
@@ -16,6 +15,7 @@ def get_agent_tags(since, to):
     Return a list of tags from integrations-core representing an Agent release,
     sorted by more recent first.
     """
+    from ...git import git_tag_list
     agent_tags = sorted(VersionInfo.parse(t) for t in git_tag_list(r'^\d+\.\d+\.\d+$'))
 
     # default value for `to` is the latest tag

--- a/datadog_checks_dev/tests/tooling/commands/test_agent.py
+++ b/datadog_checks_dev/tests/tooling/commands/test_agent.py
@@ -2,16 +2,21 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import mock
+import pytest
+
+from datadog_checks.dev.tooling.commands.agent.common import get_agent_tags
 
 
-def test_get_agent_tags():
-    with mock.patch('datadog_checks.dev.tooling.git.git_tag_list') as tag_lst:
-        from datadog_checks.dev.tooling.commands.agent.common import get_agent_tags
-
-        tag_lst.return_value = ['1.2.3', '4.5.6', '7.8.9']
-
-        assert get_agent_tags(since='1.0.0', to='5.0.0') == ['4.5.6', '1.2.3']
-        assert get_agent_tags(since='4.5.6', to='5.0.0') == ['4.5.6']
-        assert get_agent_tags(since='4.5.6', to='8.0.0') == ['7.8.9', '4.5.6']
-        assert get_agent_tags(since='1.0.0', to=None) == ['7.8.9', '4.5.6', '1.2.3']
-        assert get_agent_tags(since='8.0.0', to=None) == []
+@pytest.mark.parametrize(
+    'since, to, expected_result',
+    [
+        pytest.param('1.0.0', '5.0.0', ['4.5.6', '1.2.3']),
+        pytest.param('4.5.6', '5.0.0', ['4.5.6']),
+        pytest.param('4.5.6', '8.0.0', ['7.8.9', '4.5.6']),
+        pytest.param('1.0.0', None, ['7.8.9', '4.5.6', '1.2.3']),
+        pytest.param('8.0.0', None, []),
+    ],
+)
+@mock.patch('datadog_checks.dev.tooling.git.git_tag_list', return_value=['1.2.3', '4.5.6', '7.8.9'])
+def test_get_agent_tags(mock_git_tag_list, since, to, expected_result):
+    assert get_agent_tags(since=since, to=to) == expected_result


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix and refactor some agent tests. Also speed up startup time for `ddev`, importing stuff only when needed.

### Motivation
<!-- What inspired you to submit this pull request? -->

- This test depends on the order of the tests. 
- It is now failing on master because we added some other tests: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=124992&view=logs&jobId=83bb99ea-9ab1-5c8c-b843-8f48234d7592&j=40b3f23d-1644-5d89-acd8-67daa1a59c69&t=1cb4eb6e-5673-5999-7c1c-994687145201

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.