### PR TITLE
Fix UNKNOWN service check with backend:name

### DIFF
--- a/varnish/datadog_checks/varnish/varnish.py
+++ b/varnish/datadog_checks/varnish/varnish.py
@@ -317,6 +317,12 @@ class Varnish(AgentCheck):
               --------------------------------------------------------------RR Good Recv
               ------------------------------------------------------------HHHH Happy
 
+        Example output (v6):
+
+            Backend name   Admin      Probe    Health     Last change
+            boot.default   healthy    0/0      healthy    Mon, 16 Jan 2023 09:13:41 GMT
+            boot.image     healthy    0/0      healthy    Mon, 16 Jan 2023 09:13:41 GMT
+
         """
         # Process status by backend.
         backends_by_status = defaultdict(list)
@@ -326,7 +332,7 @@ class Varnish(AgentCheck):
             tokens = filter(None, line.strip().split(' '))
             tokens = [t for t in tokens]
             if len(tokens):
-                if tokens == ['Backend', 'name', 'Admin', 'Probe']:
+                if all(t in tokens for t in ['Backend', 'name', 'Admin', 'Probe']):
                     # skip the column headers that exist in new output format
                     continue
                 # parse new output format


### PR DESCRIPTION
### What does this PR do?
Header row not being skipped due to different format for Varnish 6; results in UNKNOWN service check with `backend:name`

<img width="730" alt="image" src="https://user-images.githubusercontent.com/20986892/212650468-833ad26b-d8da-4efb-b420-f9090ad2f732.png">


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.