### PR TITLE
Increase waiting time when setting up environent for integration tests

### DIFF
--- a/clickhouse/tests/conftest.py
+++ b/clickhouse/tests/conftest.py
@@ -15,7 +15,7 @@ from . import common
 def dd_environment():
     conditions = []
     for i in range(6):
-        conditions.append(CheckEndpoints(['http://{}:{}'.format(common.HOST, common.HTTP_START_PORT + i)]))
+        conditions.append(CheckEndpoints(['http://{}:{}'.format(common.HOST, common.HTTP_START_PORT + i)], wait=5))
         conditions.append(
             CheckDockerLogs(
                 'clickhouse-0{}'.format(i + 1), 'Logging errors to /var/log/clickhouse-server/clickhouse-server.err.log'


### PR DESCRIPTION

### What does this PR do?

Increase wait between attempts to check conditions when setting up the test environment. This should increase the total waiting time and greatly increase the chance of the setup succeeding.

### Motivation

These tests have been flaking for a while ([example](https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=125028&view=logs&jobId=8e96ab15-72b0-549c-5ab8-f9fece94b017&j=8e96ab15-72b0-549c-5ab8-f9fece94b017&t=3fa80c11-d62b-5625-9d93-4d60cdfd2103)).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.