### PR TITLE
Split tests by type

### DIFF
--- a/couchbase/tests/common.py
+++ b/couchbase/tests/common.py
@@ -445,3 +445,58 @@ elif COUCHBASE_MAJOR_VERSION == 7:
         'couchbase.by_bucket.vb_replica_queue_fill',
         'couchbase.by_bucket.xdc_ops',
     ]
+
+
+NODE_STATS = [
+    'cmd_get',
+    'curr_items',
+    'curr_items_tot',
+    'couch_docs_data_size',
+    'couch_docs_actual_disk_size',
+    'couch_spatial_data_size',
+    'couch_spatial_disk_size',
+    'couch_views_data_size',
+    'couch_views_actual_disk_size',
+    'ep_bg_fetched',
+    'get_hits',
+    'mem_used',
+    'ops',
+    'vb_active_num_non_resident',
+    'vb_replica_curr_items',
+]
+
+if COUCHBASE_MAJOR_VERSION == 7:
+    NODE_STATS += ['index_data_size', 'index_disk_size']
+
+TOTAL_STATS = [
+    'hdd.free',
+    'hdd.used',
+    'hdd.total',
+    'hdd.quota_total',
+    'hdd.used_by_data',
+    'ram.used',
+    'ram.total',
+    'ram.quota_total',
+    'ram.quota_total_per_node',
+    'ram.quota_used_per_node',
+    'ram.quota_used',
+    'ram.used_by_data',
+]
+
+BUCKET_TAGS = CHECK_TAGS + ['bucket:{}'.format(BUCKET_NAME)]
+
+
+def _assert_bucket_metrics(aggregator, tags, device=None):
+    for metric in BY_BUCKET_METRICS:
+        aggregator.assert_metric(metric, tags=tags, device=device, count=1)
+
+    for metric in OPTIONAL_BY_BUCKET_METRICS:
+        aggregator.assert_metric(metric, tags=tags, device=device, at_least=0)
+
+
+def _assert_stats(aggregator, node_tags, device=None):
+    for mname in NODE_STATS:
+        aggregator.assert_metric('couchbase.by_node.{}'.format(mname), tags=node_tags, count=1, device=device)
+    # Assert 'couchbase.' metrics
+    for mname in TOTAL_STATS:
+        aggregator.assert_metric('couchbase.{}'.format(mname), tags=CHECK_TAGS, count=1)

--- a/couchbase/tests/test_e2e.py
+++ b/couchbase/tests/test_e2e.py
@@ -1,0 +1,28 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+
+from datadog_checks.dev.utils import get_metadata_metrics
+
+from .common import BUCKET_NAME, BUCKET_TAGS, CHECK_TAGS, PORT, _assert_bucket_metrics, _assert_stats
+
+
+@pytest.mark.e2e
+def test_e2e(dd_agent_check, instance, couchbase_container_ip):
+    """
+    Test couchbase metrics not including 'couchbase.query.'
+    """
+    aggregator = dd_agent_check(instance)
+
+    # Assert each type of metric (buckets, nodes, totals) except query
+    _assert_bucket_metrics(aggregator, BUCKET_TAGS, device=BUCKET_NAME)
+
+    # Assert 'couchbase.by_node.' metrics
+    node_tags = CHECK_TAGS + ['node:{}:{}'.format(couchbase_container_ip, PORT)]
+    device = '{}:{}'.format(couchbase_container_ip, PORT)
+    _assert_stats(aggregator, node_tags, device=device)
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Split the couchbase test files by test type. This PR does not change anything else, it just moves code.

### Motivation
<!-- What inspired you to submit this pull request? -->

Part of https://datadoghq.atlassian.net/browse/AI-2561, follow-up PR of https://github.com/DataDog/integrations-core/pull/13708

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.