### PR TITLE
Revert increased waiting time

### DIFF
--- a/clickhouse/tests/conftest.py
+++ b/clickhouse/tests/conftest.py
@@ -15,12 +15,12 @@ from . import common
 def dd_environment():
     conditions = []
     for i in range(6):
+        conditions.append(CheckEndpoints(['http://{}:{}'.format(common.HOST, common.HTTP_START_PORT + i)]))
         conditions.append(
             CheckDockerLogs(
                 'clickhouse-0{}'.format(i + 1), 'Logging errors to /var/log/clickhouse-server/clickhouse-server.err.log'
             )
         )
-        conditions.append(CheckEndpoints(['http://{}:{}'.format(common.HOST, common.HTTP_START_PORT + i)]))
     with docker_run(common.COMPOSE_FILE, conditions=conditions, sleep=10, attempts=2):
         yield common.CONFIG
 

--- a/clickhouse/tests/conftest.py
+++ b/clickhouse/tests/conftest.py
@@ -15,12 +15,12 @@ from . import common
 def dd_environment():
     conditions = []
     for i in range(6):
-        conditions.append(CheckEndpoints(['http://{}:{}'.format(common.HOST, common.HTTP_START_PORT + i)], wait=5))
         conditions.append(
             CheckDockerLogs(
                 'clickhouse-0{}'.format(i + 1), 'Logging errors to /var/log/clickhouse-server/clickhouse-server.err.log'
             )
         )
+        conditions.append(CheckEndpoints(['http://{}:{}'.format(common.HOST, common.HTTP_START_PORT + i)]))
     with docker_run(common.COMPOSE_FILE, conditions=conditions, sleep=10, attempts=2):
         yield common.CONFIG
 


### PR DESCRIPTION
### What does this PR do?

Reverts #13709 and ~~reorders conditions when setting up environment. I'm not confident that this would help, but it makes sense to reorder the conditions like this.~~

EDIT: Reordering actually caused tests to consistently fail on CI (I couldn't get them to work even after retrying multiple times). Therefore, I'm simply reverting this to the state before #13709. I think the problem is only with version 21.8 of Clickhouse, but more investigation would be needed to see how to solve this flake; in the meantime, we should keep the statu quo.

### Motivation

#13709 didn't help and it actually failed when merged; it simply took more time.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.