### PR TITLE
Document feature in journald user-level filtering

### DIFF
--- a/journald/README.md
+++ b/journald/README.md
@@ -83,12 +83,11 @@ If your journal is located elsewhere, add a `path` parameter with the correspond
 
 ##### Filter journal units
 
-It's possible to filter in and out specific system-level units by using these parameters:
+You can filter in and out specific _system-level_ units by using these parameters:
 
 - `include_units`: Includes all system-level units specified.
 - `exclude_units`: Excludes all system-level units specified.
 
-Note:
 
 Example:
 
@@ -101,11 +100,22 @@ logs:
           - sshd.service
 ```
 
-As of Datadog Agent version `7.37.0`+, user-level unit filtering can done by using these parameters:
+In Datadog Agent version `7.37.0`+, you can filter _user-level_ units by using these parameters:
 
 - `include_user_units`: Includes all user-level units specified.
 - `exclude_user_units`: Excludes all user-level units specified.
-- **Note**: A wildcard `*` can also be used in in either `exclude_units` or `exclude_user_units` if only a particular Journald log log is desired.
+
+**Note**: Use the `*` wildcard in `exclude_units` or `exclude_user_units` to specify a particular Journald log.
+
+Example:
+
+```yaml
+logs:
+    # Collect all system-level unit logs.
+    - type: journald
+      exclude_user_units:
+          - '*'
+```
 
 ##### Tailing the same journal multiple times
 

--- a/journald/README.md
+++ b/journald/README.md
@@ -83,7 +83,7 @@ If your journal is located elsewhere, add a `path` parameter with the correspond
 
 ##### Filter journal units
 
-You can filter in and out specific _system-level_ units by using these parameters:
+You can filter specific _system-level_ units by using these parameters:
 
 - `include_units`: Includes all system-level units specified.
 - `exclude_units`: Excludes all system-level units specified.

--- a/journald/README.md
+++ b/journald/README.md
@@ -83,10 +83,12 @@ If your journal is located elsewhere, add a `path` parameter with the correspond
 
 ##### Filter journal units
 
-It's possible to filter in and out specific units by using these parameters:
+It's possible to filter in and out specific system-level units by using these parameters:
 
-- `include_units`: Includes all units specified.
-- `exclude_units`: Excludes all units specified.
+- `include_units`: Includes all system-level units specified.
+- `exclude_units`: Excludes all system-level units specified.
+
+Note:
 
 Example:
 
@@ -98,6 +100,12 @@ logs:
           - docker.service
           - sshd.service
 ```
+
+As of Datadog Agent version `7.37.0`+, user-level unit filtering can done by using these parameters:
+
+- `include_user_units`: Includes all user-level units specified.
+- `exclude_user_units`: Excludes all user-level units specified.
+- **Note**: A wildcard `*` can also be used in in either `exclude_units` or `exclude_user_units` if only a particular Journald log log is desired.
 
 ##### Tailing the same journal multiple times
 

--- a/journald/assets/configuration/spec.yaml
+++ b/journald/assets/configuration/spec.yaml
@@ -3,6 +3,68 @@ files:
 - name: journald.yaml
   options:
   - template: logs
-    example:
-    - type: journald
-      container_mode: true
+    multiple: true
+    options:
+      - name: type
+        description: ''
+        required: true
+        enabled: true
+        value:
+          type: string
+          example: journald
+          display_default: journald
+      - name: container_mode
+        description: |
+          Automatically sets the source attribute to the corresponding short image
+            name of the container for logs coming from Docker containers.
+
+          Available from Datadog Agent 7.17.0 and above.
+        value:
+          type: boolean
+          display_default: false
+          example: true
+      - name: include_units
+        description: |
+          List of system-level service units to include from log collection.
+        value:
+          type: array
+          items:
+            type: string
+          example:
+            - docker.service
+            - sshd.service
+      - name: exclude_units
+        description: |
+          List of system-level service units to exclude from log collection.
+          Note: The excluded units will take precedence over include_units.
+
+          From Datadog Agent 7.37.0+, a wildcard can be used to exclude all
+            system-level unit log thereby collecting only user-level unit logs.
+        value:
+          type: array
+          items:
+            type: string
+          example:
+            - '*'
+      - name: include_user_units
+        description: |
+          List of user-level service units to include from log collection.
+        value:
+          type: array
+          items:
+            type: string
+          example:
+            - linger-example.service
+      - name: exclude_user_units
+        description: |
+          List of user-level service units to exclude from log collection.
+          Note: The excluded units will take precedence over include_user_units.
+
+          From Datadog Agent 7.37.0+, a wildcard can be used to exclude all
+            user-level unit log thereby collecting only system-level unit logs.
+        value:
+          type: array
+          items:
+            type: string
+          example:
+            - '*'

--- a/journald/assets/configuration/spec.yaml
+++ b/journald/assets/configuration/spec.yaml
@@ -3,6 +3,7 @@ files:
 - name: journald.yaml
   options:
   - template: logs
+    enabled: true
     multiple: true
     options:
       - name: type
@@ -39,7 +40,7 @@ files:
           Note: The excluded units will take precedence over include_units.
 
           From Datadog Agent 7.37.0+, a wildcard can be used to exclude all
-            system-level unit log thereby collecting only user-level unit logs.
+            system-level unit logs, thereby collecting only user-level unit logs.
         value:
           type: array
           items:
@@ -61,7 +62,7 @@ files:
           Note: The excluded units will take precedence over include_user_units.
 
           From Datadog Agent 7.37.0+, a wildcard can be used to exclude all
-            user-level unit log thereby collecting only system-level unit logs.
+            user-level unit logs, thereby collecting only system-level unit logs.
         value:
           type: array
           items:

--- a/journald/datadog_checks/journald/data/conf.yaml.example
+++ b/journald/datadog_checks/journald/data/conf.yaml.example
@@ -13,7 +13,7 @@
 ##
 ## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
 #
-# logs:
+logs:
 
     ## @param type - string - required
     #
@@ -39,7 +39,7 @@
     ## Note: The excluded units will take precedence over include_units.
     ##
     ## From Datadog Agent 7.37.0+, a wildcard can be used to exclude all
-    ##   system-level unit log thereby collecting only user-level unit logs.
+    ##   system-level unit logs, thereby collecting only user-level unit logs.
     #
     # exclude_units:
     #   - '*'
@@ -55,7 +55,7 @@
     ## Note: The excluded units will take precedence over include_user_units.
     ##
     ## From Datadog Agent 7.37.0+, a wildcard can be used to exclude all
-    ##   user-level unit log thereby collecting only system-level unit logs.
+    ##   user-level unit logs, thereby collecting only system-level unit logs.
     #
     # exclude_user_units:
     #   - '*'

--- a/journald/datadog_checks/journald/data/conf.yaml.example
+++ b/journald/datadog_checks/journald/data/conf.yaml.example
@@ -14,5 +14,48 @@
 ## Discover Datadog log collection: https://docs.datadoghq.com/logs/log_collection/
 #
 # logs:
-#   - type: journald
-#     container_mode: true
+
+    ## @param type - string - required
+    #
+  - type: journald
+
+    ## @param container_mode - boolean - optional - default: false
+    ## Automatically sets the source attribute to the corresponding short image
+    ##   name of the container for logs coming from Docker containers.
+    ##
+    ## Available from Datadog Agent 7.17.0 and above.
+    #
+    # container_mode: true
+
+    ## @param include_units - list of strings - optional
+    ## List of system-level service units to include from log collection.
+    #
+    # include_units:
+    #   - docker.service
+    #   - sshd.service
+
+    ## @param exclude_units - list of strings - optional
+    ## List of system-level service units to exclude from log collection.
+    ## Note: The excluded units will take precedence over include_units.
+    ##
+    ## From Datadog Agent 7.37.0+, a wildcard can be used to exclude all
+    ##   system-level unit log thereby collecting only user-level unit logs.
+    #
+    # exclude_units:
+    #   - '*'
+
+    ## @param include_user_units - list of strings - optional
+    ## List of user-level service units to include from log collection.
+    #
+    # include_user_units:
+    #   - linger-example.service
+
+    ## @param exclude_user_units - list of strings - optional
+    ## List of user-level service units to exclude from log collection.
+    ## Note: The excluded units will take precedence over include_user_units.
+    ##
+    ## From Datadog Agent 7.37.0+, a wildcard can be used to exclude all
+    ##   user-level unit log thereby collecting only system-level unit logs.
+    #
+    # exclude_user_units:
+    #   - '*'


### PR DESCRIPTION
### What does this PR do?
Document feature in introduced in [#11398](https://github.com/DataDog/datadog-agent/pull/11398)

### Motivation
- AGENT-7627
- FRAGENT-1752

### Additional Notes
Same as #13701 13701

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.