### PR TITLE
Remove the latest env

### DIFF
--- a/powerdns_recursor/hatch.toml
+++ b/powerdns_recursor/hatch.toml
@@ -15,6 +15,3 @@ matrix.version.env-vars = [
   { key = "POWERDNS_HOST_PORT_0", value = "28082", if = ["4.0"] },
   { key = "POWERDNS_HOST_PORT_1", value = "25353", if = ["4.0"] },
 ]
-
-[envs.latest.env-vars]
-POSTGRES_VERSION = "latest"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove the latest env

### Motivation
<!-- What inspired you to submit this pull request? -->

- This was a mistake in https://github.com/DataDog/integrations-core/pull/13405, there's no latest env. Moreover we are building these images and we do not provide a latest one
- Spotted here: https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=124988&view=logs&j=1c9fd5d6-a258-5519-419c-101bcd1e02f2&t=eeb4971e-e545-5e41-1be7-4ec8036a8a1b
- No, it was not a copy/paste from the `postgres` integration, I have no idea what you're talking about. I'm not saying a word without my lawyer.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.