### PR TITLE
Fix `ddev make release` when the `version` parameter is not provided

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py
@@ -18,10 +18,13 @@ from .show import changes
 
 
 def validate_version(ctx, param, value):
-    if re.match("^\\d+\\.\\d+\\.\\d+(-(rc|pre|alpha|beta)\\.\\d+)?$", value):
-        return value
+    if value is not None:
+        if re.match("^\\d+\\.\\d+\\.\\d+(-(rc|pre|alpha|beta)\\.\\d+)?$", value):
+            return value
 
-    raise click.BadParameter('must match `^\\d+\\.\\d+\\.\\d+(-(rc|pre|alpha|beta)\\.\\d+)?$`')
+        raise click.BadParameter('must match `^\\d+\\.\\d+\\.\\d+(-(rc|pre|alpha|beta)\\.\\d+)?$`')
+
+    return None
 
 
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Release one or more checks')

--- a/datadog_checks_dev/tests/tooling/commands/release/test_make.py
+++ b/datadog_checks_dev/tests/tooling/commands/release/test_make.py
@@ -43,6 +43,7 @@ def test_release_make_with_invalid_input_version(version):
         "1.2.3-beta.1",
         "1.2.3-rc.1",
         "1.2.3-pre.1",
+        None,
     ],
 )
 # TODO: replace this test with a one that calls `ddev release make` directly


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix `ddev make release` when the `version` parameter is not provided

### Motivation
<!-- What inspired you to submit this pull request? -->

- 🤦 [Here](https://github.com/DataDog/integrations-core/pull/13687), I forgot the most basic use case to test... Even if the option is not provided by the user, the callback function is called with `None`. In that case, the code raises an error: 

```
  File "/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/make.py", line 21, in validate_version
    if re.match("^\\d+\\.\\d+\\.\\d+(-(rc|pre|alpha|beta)\\.\\d+)?$", value):
  File "/Users/florent.clarret/.pyenv/versions/3.9.9/lib/python3.9/re.py", line 191, in match
    return _compile(pattern, flags).match(string)
TypeError: expected string or bytes-like object
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Spotted when the integrations-extras pipeline tried to release the `go_pprof_scraper` integration.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.