### PR TITLE
PG: Add metrics for wal files: count, size and age

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -258,6 +258,7 @@ files:
       description: |
         Collect metrics about WAL file age.
         NOTE: You must be running the check local to your database if you want to enable this option.
+        Starting PG10, wal metrics are collected by default using `pg_ls_waldir` and don't need local access anymore.
       value:
         type: boolean
         example: false

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -204,6 +204,7 @@ instances:
     ## @param collect_wal_metrics - boolean - optional - default: false
     ## Collect metrics about WAL file age.
     ## NOTE: You must be running the check local to your database if you want to enable this option.
+    ## Starting PG10, wal metrics are collected by default using `pg_ls_waldir` and don't need local access anymore.
     #
     # collect_wal_metrics: false
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -35,6 +35,7 @@ from .util import (
     SLRU_METRICS,
     SNAPSHOT_TXID_METRICS,
     SNAPSHOT_TXID_METRICS_LT_13,
+    WAL_FILE_METRICS,
     DatabaseConfigurationError,  # noqa: F401
     fmt,
     get_schema_field,
@@ -173,6 +174,7 @@ class PostgreSql(AgentCheck):
             if self.is_aurora is False:
                 queries.append(QUERY_PG_STAT_WAL_RECEIVER)
             queries.append(QUERY_PG_REPLICATION_SLOTS)
+            queries.append(WAL_FILE_METRICS)
 
         if self.version >= V13:
             queries.append(SNAPSHOT_TXID_METRICS)
@@ -220,7 +222,11 @@ class PostgreSql(AgentCheck):
         return "standby" if role else "master"
 
     def _collect_wal_metrics(self, instance_tags):
-        wal_file_age = self._get_wal_file_age()
+        if self.version >= V10:
+            # _collect_stats will gather wal file metrics
+            # for PG >= V10
+            return
+        wal_file_age = self._get_local_wal_file_age()
         if wal_file_age is not None:
             self.gauge(
                 "postgresql.wal_age",
@@ -229,18 +235,8 @@ class PostgreSql(AgentCheck):
                 hostname=self.resolved_hostname,
             )
 
-    def _get_wal_dir(self):
-        if self.version >= V10:
-            wal_dir = "pg_wal"
-        else:
-            wal_dir = "pg_xlog"
-
-        wal_log_dir = os.path.join(self._config.data_directory, wal_dir)
-
-        return wal_log_dir
-
-    def _get_wal_file_age(self):
-        wal_log_dir = self._get_wal_dir()
+    def _get_local_wal_file_age(self):
+        wal_log_dir = os.path.join(self._config.data_directory, "pg_xlog")
         if not os.path.isdir(wal_log_dir):
             self.log.warning(
                 "Cannot access WAL log directory: %s. Ensure that you are "

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -384,6 +384,22 @@ select txid_snapshot_xmin(txid_current_snapshot), txid_snapshot_xmax(txid_curren
     ],
 }
 
+WAL_FILE_METRICS = {
+    'name': 'wal_metrics',
+    'query': """
+SELECT
+count(*),
+sum(size),
+EXTRACT (EPOCH FROM now() - min(modification))
+  FROM pg_ls_waldir();
+""",
+    'columns': [
+        {'name': 'postgresql.wal_count', 'type': 'gauge'},
+        {'name': 'postgresql.wal_size', 'type': 'gauge'},
+        {'name': 'postgresql.wal_age', 'type': 'gauge'},
+    ],
+}
+
 FUNCTION_METRICS = {
     'descriptors': [('schemaname', 'schema'), ('funcname', 'function')],
     'metrics': {

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -114,6 +114,8 @@ postgresql.slru.truncates,count,,,,"Number of truncates for this SLRU (simple le
 postgresql.transactions.duration.max,gauge,,nanosecond,,"The age of the longest running transaction per user, db and app. (DBM only)",0,postgres,postgres transactions duration max,
 postgresql.transactions.duration.sum,gauge,,nanosecond,,"The sum of the age of all running transactions per user, db and app. (DBM only)",0,postgres,postgres transactions duration sum,
 postgresql.uptime,gauge,,second,,"The uptime of the server in seconds.",0,postgres,postgres uptime,
+postgresql.wal_size,gauge,,byte,,The sum of all WAL files on disk.,-1,postgres,wal size,
+postgresql.wal_count,gauge,,,,The number WAL files on disk.,-1,postgres,wal count,
 postgresql.wal_age,gauge,,second,,The age in seconds of the oldest WAL file.,0,postgres,wal age,
 postgresql.wal_receiver.connected,gauge,,,,"The status of the WAL receiver. This metric will be set to 1 with a 'status:disconnected' tag if the instance doesn't have a running WAL receiver. Otherwise it will use status value from pg_stat_wal_receiver.",0,postgres,wal receiver connected,
 postgresql.wal_receiver.received_timeline,gauge,,,,"Timeline number of last write-ahead log location received and flushed to disk, the initial value of this field being the timeline number of the first log location used when WAL receiver is started.",0,postgres,wal receiver tli,

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -17,6 +17,7 @@ from datadog_checks.postgres.util import (
     REPLICATION_STATS_METRICS,
     SLRU_METRICS,
     SNAPSHOT_TXID_METRICS,
+    WAL_FILE_METRICS,
 )
 from datadog_checks.postgres.version_utils import VersionUtils
 
@@ -275,4 +276,12 @@ def check_slru_metrics(aggregator, expected_tags, count=1):
 
 def check_snapshot_txid_metrics(aggregator, expected_tags, count=1):
     for metric_name in _iterate_metric_name(SNAPSHOT_TXID_METRICS['columns']):
+        aggregator.assert_metric(metric_name, count=count, tags=expected_tags)
+
+
+def check_wal_metrics(aggregator, expected_tags, count=1):
+    if float(POSTGRES_VERSION) < 10:
+        return
+
+    for metric_name in _iterate_metric_name(WAL_FILE_METRICS['columns']):
         aggregator.assert_metric(metric_name, count=count, tags=expected_tags)

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -32,6 +32,7 @@ from .common import (
     check_snapshot_txid_metrics,
     check_stat_replication,
     check_uptime_metrics,
+    check_wal_metrics,
     check_wal_receiver_metrics,
     get_expected_instance_tags,
     requires_static_version,
@@ -67,6 +68,7 @@ def test_common_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check_logical_replication_slots(aggregator, expected_tags)
     check_physical_replication_slots(aggregator, expected_tags)
     check_snapshot_txid_metrics(aggregator, expected_tags=expected_tags)
+    check_wal_metrics(aggregator, expected_tags=expected_tags)
 
     aggregator.assert_all_metrics_covered()
 
@@ -513,6 +515,43 @@ def test_query_timeout(aggregator, integration_check, pg_instance):
     cursor = check.db.cursor()
     with pytest.raises(psycopg2.errors.QueryCanceled):
         cursor.execute("select pg_sleep(2000)")
+
+
+@requires_over_10
+def test_wal_metrics(aggregator, integration_check, pg_instance):
+    check = integration_check(pg_instance)
+    # Default PG's wal size is 16MB
+    wal_size = 16777216
+
+    postgres_conn = _get_superconn(pg_instance)
+    with postgres_conn.cursor() as cur:
+        cur.execute("select count(*) from pg_ls_waldir();")
+        expected_num_wals = cur.fetchall()[0][0]
+
+    check.check(pg_instance)
+
+    expected_wal_size = expected_num_wals * wal_size
+    dd_agent_tags = pg_instance['tags'] + [
+        'port:{}'.format(PORT),
+        'dd.internal.resource:database_instance:{}'.format(check.resolved_hostname),
+    ]
+    aggregator.assert_metric('postgresql.wal_count', count=1, value=expected_num_wals, tags=dd_agent_tags)
+    aggregator.assert_metric('postgresql.wal_size', count=1, value=expected_wal_size, tags=dd_agent_tags)
+
+    with postgres_conn.cursor() as cur:
+        # Force a wal switch
+        cur.execute("select pg_switch_wal();")
+        cur.fetchall()
+        # Checkpoint to accelerate new wal file
+        cur.execute("CHECKPOINT;")
+
+    aggregator.reset()
+    check.check(pg_instance)
+
+    expected_num_wals += 1
+    expected_wal_size = expected_num_wals * wal_size
+    aggregator.assert_metric('postgresql.wal_count', count=1, value=expected_num_wals, tags=dd_agent_tags)
+    aggregator.assert_metric('postgresql.wal_size', count=1, value=expected_wal_size, tags=dd_agent_tags)
 
 
 def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance):

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -16,6 +16,7 @@ from .common import (
     check_slru_metrics,
     check_snapshot_txid_metrics,
     check_uptime_metrics,
+    check_wal_metrics,
     check_wal_receiver_metrics,
 )
 from .utils import _get_superconn, _wait_for_value, requires_over_10
@@ -42,6 +43,7 @@ def test_common_replica_metrics(aggregator, integration_check, metrics_cache_rep
     check_conflict_metrics(aggregator, expected_tags=expected_tags)
     check_uptime_metrics(aggregator, expected_tags=expected_tags)
     check_snapshot_txid_metrics(aggregator, expected_tags=expected_tags)
+    check_wal_metrics(aggregator, expected_tags=expected_tags)
 
     aggregator.assert_all_metrics_covered()
 

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -6,13 +6,12 @@ import copy
 import mock
 import psycopg2
 import pytest
-from mock import MagicMock, PropertyMock
+from mock import MagicMock
 from pytest import fail
 from semver import VersionInfo
 from six import iteritems
 
 from datadog_checks.postgres import PostgreSql, util
-from datadog_checks.postgres.version_utils import VersionUtils
 
 from .common import PORT
 
@@ -233,24 +232,6 @@ def test_resolved_hostname_metadata(check, test_case):
     with mock.patch('datadog_checks.base.stubs.datadog_agent.set_check_metadata') as m:
         check.set_metadata('resolved_hostname', test_case)
         m.assert_any_call('test:123', 'resolved_hostname', test_case)
-
-
-@pytest.mark.parametrize(
-    'pg_version, wal_path',
-    [
-        ('9.6.2', '/var/lib/postgresql/data/pg_xlog'),
-        ('10.0.0', '/var/lib/postgresql/data/pg_wal'),
-    ],
-)
-def test_get_wal_dir(integration_check, pg_instance, pg_version, wal_path):
-    pg_instance['data_directory'] = "/var/lib/postgresql/data/"
-    check = integration_check(pg_instance)
-
-    version_utils = VersionUtils.parse_version(pg_version)
-    with mock.patch('datadog_checks.postgres.PostgreSql.version', new_callable=PropertyMock) as mock_version:
-        mock_version.return_value = version_utils
-        path_name = check._get_wal_dir()
-        assert path_name == wal_path
 
 
 @pytest.mark.usefixtures('mock_cursor_for_replica_stats')


### PR DESCRIPTION
### What does this PR do?
Add `postgres.wal_count`, `postgres.wal_size` and `postgres.wal_age` metrics
without the need to run locally. Only available starting PG10.

### Motivation
PG10 introduces the `pg_ls_waldir` function which allows us to inspect
the WAL dir content without the need to run the agent locally.
Use it to export the count, total size and age of the WAL files.

### Additional Notes
Since there's no constraint on running `pg_ls_waldir` except to have
`pg_monitor` access, it would make sense to make it available by default
instead of being opt-in as it was before.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.