### PR TITLE
Change the performance counter used by the iis.app_pool_up service check so it can tell when the app pool is down.

### DIFF
--- a/iis/datadog_checks/iis/check.py
+++ b/iis/datadog_checks/iis/check.py
@@ -6,7 +6,7 @@ from datadog_checks.base.checks.windows.perf_counters.counter import PerfObject
 from datadog_checks.base.constants import ServiceCheck
 
 from .metrics import METRICS_CONFIG
-from .service_check import site_service_check, app_pool_service_check
+from .service_check import app_pool_service_check, site_service_check
 
 
 class IISCheckV2(PerfCountersBaseCheckWithLegacySupport):
@@ -139,9 +139,7 @@ class CompatibilityPerfObject(PerfObject):
             # Submit the counter's value as a metric
             gauge_method(metric_name, value, tags=tags)
             # Submit a service check
-            service_check_method(
-                self.instance_service_check_name, status, tags=tags
-            )
+            service_check_method(self.instance_service_check_name, status, tags=tags)
 
         del check
         del modifiers

--- a/iis/datadog_checks/iis/check.py
+++ b/iis/datadog_checks/iis/check.py
@@ -6,6 +6,7 @@ from datadog_checks.base.checks.windows.perf_counters.counter import PerfObject
 from datadog_checks.base.constants import ServiceCheck
 
 from .metrics import METRICS_CONFIG
+from .service_check import site_service_check, app_pool_service_check
 
 
 class IISCheckV2(PerfCountersBaseCheckWithLegacySupport):
@@ -61,7 +62,7 @@ class IISCheckV2(PerfCountersBaseCheckWithLegacySupport):
                 object_config,
                 use_localized_counters,
                 tags,
-                'Current Application Pool Uptime',
+                'Current Application Pool State',
                 'app_pool',
                 self.instance.get('app_pools', []),
             )
@@ -90,13 +91,13 @@ class CompatibilityPerfObject(PerfObject):
         object_config,
         use_localized_counters,
         tags,
-        uptime_counter,
+        service_check_counter,
         instance_type,
         instances_included,
     ):
         super().__init__(check, connection, object_name, object_config, use_localized_counters, tags)
 
-        self.uptime_counter = uptime_counter
+        self.service_check_counter = service_check_counter
         self.instance_type = instance_type
         self.instance_service_check_name = f'{self.instance_type}_up'
         self.instances_included = set(instances_included)
@@ -124,16 +125,22 @@ class CompatibilityPerfObject(PerfObject):
         return super()._instance_excluded(instance)
 
     def get_custom_transformers(self):
-        return {self.uptime_counter: self.__get_uptime_transformer}
+        return {self.service_check_counter: self.__get_service_check_transformer}
 
-    def __get_uptime_transformer(self, check, metric_name, modifiers):
+    def __get_service_check_transformer(self, check, metric_name, modifiers):
         gauge_method = check.gauge
         service_check_method = check.service_check
 
         def submit_uptime(value, tags=None):
+            if self.instance_type == 'site':
+                status = site_service_check(value)
+            elif self.instance_type == 'app_pool':
+                status = app_pool_service_check(value)
+            # Submit the counter's value as a metric
             gauge_method(metric_name, value, tags=tags)
+            # Submit a service check
             service_check_method(
-                self.instance_service_check_name, ServiceCheck.CRITICAL if value == 0 else ServiceCheck.OK, tags=tags
+                self.instance_service_check_name, status, tags=tags
             )
 
         del check

--- a/iis/datadog_checks/iis/check.py
+++ b/iis/datadog_checks/iis/check.py
@@ -132,13 +132,14 @@ class CompatibilityPerfObject(PerfObject):
         service_check_method = check.service_check
 
         def submit_uptime(value, tags=None):
+            # Submit the counter's value as a metric
+            gauge_method(metric_name, value, tags=tags)
+
+            # Submit a service check
             if self.instance_type == 'site':
                 status = site_service_check(value)
             elif self.instance_type == 'app_pool':
                 status = app_pool_service_check(value)
-            # Submit the counter's value as a metric
-            gauge_method(metric_name, value, tags=tags)
-            # Submit a service check
             service_check_method(self.instance_service_check_name, status, tags=tags)
 
         del check

--- a/iis/datadog_checks/iis/iis.py
+++ b/iis/datadog_checks/iis/iis.py
@@ -5,7 +5,7 @@ from six import PY3, iteritems
 
 from datadog_checks.base import PDHBaseCheck, is_affirmative
 
-from .service_check import site_service_check, app_pool_service_check
+from .service_check import app_pool_service_check, site_service_check
 
 DEFAULT_COUNTERS = [
     ["Web Service", None, "Service Uptime", "iis.uptime", "gauge"],
@@ -42,6 +42,7 @@ DEFAULT_COUNTERS = [
 ]
 
 TOTAL_INSTANCE = '_Total'
+
 
 class IIS(PDHBaseCheck):
     SITE = 'site'

--- a/iis/datadog_checks/iis/service_check.py
+++ b/iis/datadog_checks/iis/service_check.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from datadog_checks.base.constants import ServiceCheck

--- a/iis/datadog_checks/iis/service_check.py
+++ b/iis/datadog_checks/iis/service_check.py
@@ -1,0 +1,40 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from datadog_checks.base.constants import ServiceCheck
+
+# Maps "\APP_POOL_WAS(<INSTANCE>)\Current Application Pool State" values
+# Values found in Performance Monitor
+# TODO: Use a python Enum when we drop Python 2 support
+IIS_APPLICATION_POOL_STATE = {
+    'Uninitialized': 1,
+    'Initialized': 2,
+    'Running': 3,
+    'Disabling': 4,
+    'Disabled': 5,
+    'Shutdown Pending': 6,
+    'Delete Pending': 7
+}
+# Add int -> string mapping to the dict
+IIS_APPLICATION_POOL_STATE.update({v: k for k, v in IIS_APPLICATION_POOL_STATE.items()})
+
+
+def site_service_check(uptime):
+    # For sites the "\Web Service(<INSTANCE>)\Service Uptime" counter resets
+    # to 0 when the site is stopped. So we can use it for the service check.
+    uptime = int(uptime)
+    if uptime == 0:
+        return ServiceCheck.CRITICAL
+    return ServiceCheck.OK
+
+
+def app_pool_service_check(status):
+    # For app pools we can't use "\APP_POOL_WAS(<INSTANCE>)\Current Application Pool Uptime" for
+    # the service check because it does NOT reset to 0 when the app pool is stopped. It only
+    # resets to 0 once the app pool is started again.
+    # Instead we use the "\APP_POOL_WAS(<INSTANCE>)\Current Application Pool State" counter which
+    # reports whether the app pool is running, stopping, etc.
+    status = int(status)
+    if status == IIS_APPLICATION_POOL_STATE['Running']:
+        return ServiceCheck.OK
+    return ServiceCheck.CRITICAL

--- a/iis/datadog_checks/iis/service_check.py
+++ b/iis/datadog_checks/iis/service_check.py
@@ -13,7 +13,7 @@ IIS_APPLICATION_POOL_STATE = {
     'Disabling': 4,
     'Disabled': 5,
     'Shutdown Pending': 6,
-    'Delete Pending': 7
+    'Delete Pending': 7,
 }
 # Add int -> string mapping to the dict
 IIS_APPLICATION_POOL_STATE.update({v: k for k, v in IIS_APPLICATION_POOL_STATE.items()})

--- a/iis/hatch.toml
+++ b/iis/hatch.toml
@@ -7,10 +7,8 @@ python = ["2.7", "3.8"]
 dependencies = [
   "datadog_checks_tests_helper @ {root:uri}/../datadog_checks_tests_helper",
 ]
-e2e-env = false
+e2e-env = true
 platforms = [
   "windows",
 ]
 
-[envs.default.overrides]
-matrix.python.e2e-env = { value = true, if = ["3.8"] }

--- a/iis/tests/common.py
+++ b/iis/tests/common.py
@@ -3,6 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from datadog_checks.iis.iis import DEFAULT_COUNTERS
 from datadog_checks.iis.metrics import METRICS_CONFIG
+from datadog_checks.iis.service_check import IIS_APPLICATION_POOL_STATE
 
 CHECK_NAME = 'iis'
 MINIMAL_INSTANCE = {'host': '.'}
@@ -48,8 +49,12 @@ SITE_METRICS = [counter_data[3] for counter_data in DEFAULT_COUNTERS if counter_
 APP_POOL_METRICS = [counter_data[3] for counter_data in DEFAULT_COUNTERS if counter_data[0] == 'APP_POOL_WAS']
 
 PERFORMANCE_OBJECTS = {}
+# Set arbitrary values for the counters
 for object_name, instances in (('APP_POOL_WAS', ['foo-pool', 'bar-pool']), ('Web Service', ['foo.site', 'bar.site'])):
     PERFORMANCE_OBJECTS[object_name] = (
         instances,
         {counter: [9000, 0] for counter in METRICS_CONFIG[object_name]['counters'][0]},
     )
+# Set a specific value for the app pool service check counter
+# \APP_POOL_WAS(<INSTANCE>)\Current Application Pool State
+PERFORMANCE_OBJECTS['APP_POOL_WAS'][1]['Current Application Pool State'] = [IIS_APPLICATION_POOL_STATE['Running'], 0]

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -17,7 +17,8 @@ def dd_environment():
         'start_commands': [
             # Install IIS
             'powershell.exe -Command Add-WindowsFeature Web-Server'
-        ]}
+        ],
+    }
 
 
 @pytest.fixture

--- a/iis/tests/conftest.py
+++ b/iis/tests/conftest.py
@@ -12,7 +12,12 @@ from .common import INSTANCE
 
 @pytest.fixture(scope="session")
 def dd_environment():
-    yield INSTANCE, {'docker_platform': 'windows'}
+    yield INSTANCE, {
+        'docker_platform': 'windows',
+        'start_commands': [
+            # Install IIS
+            'powershell.exe -Command Add-WindowsFeature Web-Server'
+        ]}
 
 
 @pytest.fixture

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -3,14 +3,141 @@
 # Licensed under Simplified BSD License (see LICENSE)
 
 import pytest
+import subprocess
+import six
+import socket
 
-from datadog_checks.dev.testing import requires_py3
+from datadog_checks.base import AgentCheck
+from datadog_checks.dev.utils import get_active_env
 from datadog_checks.iis import IIS
+from datadog_checks.iis.service_check import IIS_APPLICATION_POOL_STATE
+
+from .common import CHECK_NAME
 
 
 @pytest.mark.e2e
-@requires_py3
-def test_e2e_py3(dd_agent_check, aggregator, instance):
+def test_e2e(dd_agent_check, aggregator, instance):
+    """
+    Check should run without error if IIS is installed
+    """
     aggregator = dd_agent_check(instance)
-    aggregator.assert_service_check('iis.windows.perf.health', IIS.CRITICAL)
-    assert aggregator.metric_names == []
+    if six.PY3:
+        aggregator.assert_service_check('iis.windows.perf.health', IIS.OK)
+
+
+@pytest.fixture
+def iis_host(aggregator, dd_default_hostname):
+    if six.PY2:
+        # the python2 version of the check uses the configured hostname,
+        # which is the hostnane of the docker host.
+        return 'iis_host:{}'.format(socket.gethostname())
+    else:
+        # the python3 version of the check uses the perf counter server field,
+        # which is the hostname of the container.
+        hostname = run_command(['hostname'])
+        return 'iis_host:{}'.format(hostname)
+
+
+def normalize_tags(tags):
+    if six.PY2:
+        # The python2 version of the check calls self.normalize_tag
+        a = AgentCheck()
+        return [a.normalize_tag(tag) for tag in tags]
+    else:
+        return tags
+
+
+def run_command(command):
+    """
+    Run a command in the docker container being used for E2E tests
+    """
+    container_name = 'dd_{}_{}'.format(CHECK_NAME, get_active_env())
+    result = subprocess.check_output(
+        ['docker', 'exec', container_name] + command,
+    ).decode().strip()
+    return result
+
+
+def start_iis():
+    app_pools = ['DefaultAppPool']
+    sites = ['Default Web Site']
+
+    for app_pool in app_pools:
+        run_command(['powershell.exe', '-Command', 'Start-WebAppPool -Name "{}"'.format(app_pool)])
+    for site in sites:
+        run_command(['powershell.exe', '-Command', 'Start-IISSite -Name "{}"'.format(site)])
+
+
+def stop_iis():
+    app_pools = ['DefaultAppPool']
+    sites = ['Default Web Site']
+
+    for app_pool in app_pools:
+        run_command(['powershell.exe', '-Command', 'if((Get-WebAppPoolState -Name "{app_pool}").Value -ne "Stopped") {{ Stop-WebAppPool -Name "{app_pool}" }}'.format(app_pool=app_pool)])
+    for site in sites:
+        run_command(['powershell.exe', '-Command', 'Stop-IISSite -Name "{}" -Confirm:$false'.format(site)])
+
+
+@pytest.mark.e2e
+def test_service_checks(dd_agent_check, aggregator, instance, iis_host):
+    """
+    Test that the site and app_pool service checks are correct for running and non-existent instances
+    """
+    start_iis()
+
+    aggregator = dd_agent_check(instance)
+
+    namespace_data = (
+        (IIS.SITE, IIS.OK, ['Default Web Site']),
+        (IIS.APP_POOL, IIS.OK, ['DefaultAppPool']),
+        (IIS.SITE, IIS.CRITICAL, ['Non Existing Website']),
+        (IIS.APP_POOL, IIS.CRITICAL, ['Non Existing App Pool']),
+    )
+    for namespace, status, values in namespace_data:
+        for value in values:
+            aggregator.assert_service_check(
+                'iis.{}_up'.format(namespace), status, tags=normalize_tags(['{}:{}'.format(namespace, value), iis_host]), count=1
+            )
+
+
+@pytest.mark.e2e
+def test_site_uptime(dd_agent_check, aggregator, instance, iis_host):
+    """
+    Assert that the site uptime goes to 0 when the site is stopped.
+    The uptime is used to calculate the serive check for sites.
+    """
+    stop_iis()
+
+    aggregator = dd_agent_check(instance)
+
+    aggregator.assert_metric('iis.uptime', value=0, tags=normalize_tags(['site:Default Web Site', iis_host]))
+
+
+@pytest.mark.e2e
+def test_app_pool_status_running(dd_agent_check, aggregator, instance, iis_host):
+    """
+    Assert the app pool state when it is running.
+    The status is used to calculate the serive check for app pools.
+    """
+    start_iis()
+
+    aggregator = dd_agent_check(instance)
+
+    value = IIS_APPLICATION_POOL_STATE['Running']
+    assert value == 3
+    aggregator.assert_metric('iis.app_pool.state', value=value, tags=normalize_tags(['app_pool:DefaultAppPool', iis_host]))
+
+
+@pytest.mark.e2e
+def test_app_pool_status_stopped(dd_agent_check, aggregator, instance, iis_host):
+    """
+    Assert the app pool state when it is stopped.
+    The status is used to calculate the serive check for app pools.
+    """
+    stop_iis()
+
+    aggregator = dd_agent_check(instance)
+
+    value = IIS_APPLICATION_POOL_STATE['Disabled']
+    assert value == 5
+    aggregator.assert_metric('iis.app_pool.state', value=value, tags=normalize_tags(['app_pool:DefaultAppPool', iis_host]))

--- a/iis/tests/test_e2e.py
+++ b/iis/tests/test_e2e.py
@@ -54,13 +54,7 @@ def run_container_command(command):
     Run a command in the docker container being used for E2E tests
     """
     container_name = 'dd_{}_{}'.format(CHECK_NAME, get_active_env())
-    result = (
-        run_command(
-            ['docker', 'exec', container_name] + command,
-            capture=True,
-            check=True
-        )
-    )
+    result = run_command(['docker', 'exec', container_name] + command, capture=True, check=True)
     return result
 
 

--- a/iis/tests/test_iis.py
+++ b/iis/tests/test_iis.py
@@ -69,8 +69,12 @@ def test_basic_check(aggregator, dd_run_check):
 
     for _, namespace, values in namespace_data:
         for value in values:
+            status = IIS.OK
+            if namespace == 'app_pool':
+                # Expect failure b/c pdh mock doesn't support setting values for counters
+                status = IIS.CRITICAL
             aggregator.assert_service_check(
-                'iis.{}_up'.format(namespace), IIS.OK, tags=['{}:{}'.format(namespace, value), iis_host], count=1
+                'iis.{}_up'.format(namespace), status, tags=['{}:{}'.format(namespace, value), iis_host], count=1
             )
 
     aggregator.assert_all_metrics_covered()
@@ -93,8 +97,12 @@ def test_check_on_specific_websites_and_app_pools(aggregator, dd_run_check):
 
     for _, namespace, values in namespace_data:
         for value in values:
+            status = IIS.OK
+            if namespace == 'app_pool':
+                # Expect failure b/c pdh mock doesn't support setting values for counters
+                status = IIS.CRITICAL
             aggregator.assert_service_check(
-                'iis.{}_up'.format(namespace), IIS.OK, tags=['{}:{}'.format(namespace, value), iis_host], count=1
+                'iis.{}_up'.format(namespace), status, tags=['{}:{}'.format(namespace, value), iis_host], count=1
             )
 
     aggregator.assert_service_check('iis.site_up', IIS.CRITICAL, tags=['site:Non_Existing_Website', iis_host], count=1)
@@ -144,9 +152,13 @@ def test_check(aggregator, dd_run_check):
     for _, namespace, values in namespace_data_ok:
         # Exclude `Total`
         for value in values[1:]:
+            status = IIS.OK
+            if namespace == 'app_pool':
+                # Expect failure b/c pdh mock doesn't support setting values for counters
+                status = IIS.CRITICAL
             aggregator.assert_service_check(
                 'iis.{}_up'.format(namespace),
-                IIS.OK,
+                status,
                 tags=['mytag1', 'mytag2', '{}:{}'.format(namespace, value), iis_host],
                 count=1,
             )
@@ -185,9 +197,13 @@ def test_check_without_sites_specified(aggregator, dd_run_check):
 
     for _, namespace, values in namespace_data:
         for value in values:
+            status = IIS.OK
+            if namespace == 'app_pool':
+                # Expect failure b/c pdh mock doesn't support setting values for counters
+                status = IIS.CRITICAL
             aggregator.assert_service_check(
                 'iis.{}_up'.format(namespace),
-                IIS.OK,
+                status,
                 tags=['mytag1', 'mytag2', '{}:{}'.format(namespace, value), iis_host],
                 count=1,
             )
@@ -210,9 +226,13 @@ def test_legacy_check_version(aggregator, dd_run_check):
 
     for _, namespace, values in namespace_data:
         for value in values:
+            status = IIS.OK
+            if namespace == 'app_pool':
+                # Expect failure b/c pdh mock doesn't support setting values for counters
+                status = IIS.CRITICAL
             aggregator.assert_service_check(
                 'iis.{}_up'.format(namespace),
-                IIS.OK,
+                status,
                 tags=['{}:{}'.format(namespace, value), iis_host],
                 count=1,
             )

--- a/iis/tests/test_unit.py
+++ b/iis/tests/test_unit.py
@@ -5,6 +5,7 @@ from datadog_checks.base.constants import ServiceCheck
 from datadog_checks.dev.testing import requires_py3
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.iis import IIS
+from datadog_checks.iis.service_check import IIS_APPLICATION_POOL_STATE
 
 from .common import DEFAULT_COUNTERS, PERFORMANCE_OBJECTS
 
@@ -44,9 +45,13 @@ def test_check_all(aggregator, dd_default_hostname, dd_run_check, mock_performan
         )
 
         for metric_name, metric_type in app_pool_metrics_data:
+            old_value = value
+            if metric_name == "iis.app_pool.state" and value:
+                value = IIS_APPLICATION_POOL_STATE['Running']
             aggregator.assert_metric(
                 metric_name, value, metric_type=getattr(aggregator, metric_type.upper()), count=1, tags=tags
             )
+            value = old_value
 
     for site, value in (('foo.site', 9000), ('bar.site', 0)):
         tags = ['site:{}'.format(site)]
@@ -93,11 +98,15 @@ def test_check_specific(aggregator, dd_default_hostname, dd_run_check, mock_perf
         )
 
         for metric_name, metric_type in app_pool_metrics_data:
+            old_value = value
+            if metric_name == "iis.app_pool.state" and value:
+                value = IIS_APPLICATION_POOL_STATE['Running']
             aggregator.assert_metric_has_tag(metric_name, 'app_pool:bar-pool', count=0)
             if not app_pool.startswith('missing'):
                 aggregator.assert_metric(
                     metric_name, value, metric_type=getattr(aggregator, metric_type.upper()), count=1, tags=tags
                 )
+            value = old_value
 
     for site, value in (('foo.site', 9000), ('missing.site', 0)):
         tags = ['site:{}'.format(site)]
@@ -139,10 +148,14 @@ def test_check_include_patterns(aggregator, dd_default_hostname, dd_run_check, m
         )
 
         for metric_name, metric_type in app_pool_metrics_data:
+            old_value = value
+            if metric_name == "iis.app_pool.state" and value:
+                value = IIS_APPLICATION_POOL_STATE['Running']
             aggregator.assert_metric_has_tag(metric_name, 'app_pool:bar-pool', count=0)
             aggregator.assert_metric(
                 metric_name, value, metric_type=getattr(aggregator, metric_type.upper()), count=1, tags=tags
             )
+            value = old_value
 
     for site, value in (('foo.site', 9000),):
         tags = ['site:{}'.format(site)]
@@ -183,10 +196,14 @@ def test_check_exclude_patterns(aggregator, dd_default_hostname, dd_run_check, m
         )
 
         for metric_name, metric_type in app_pool_metrics_data:
+            old_value = value
+            if metric_name == "iis.app_pool.state" and value:
+                value = IIS_APPLICATION_POOL_STATE['Running']
             aggregator.assert_metric_has_tag(metric_name, 'app_pool:bar-pool', count=0)
             aggregator.assert_metric(
                 metric_name, value, metric_type=getattr(aggregator, metric_type.upper()), count=1, tags=tags
             )
+            value = old_value
 
     for site, value in (('foo.site', 9000),):
         tags = ['site:{}'.format(site)]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Change the performance counter the `iis.app_pool_up` service check is based on to the `\APP_POOL_WAS(<INSTANCE>)\Current Application Pool State` counter.

### Motivation
<!-- What inspired you to submit this pull request? -->
The `iis.app_pool_up` service check was based on the `\APP_POOL_WAS(<INSTANCE>)\Current Application Pool Uptime` performance counter, but this counter does not reset to zero when the app pool is stopped. It only resets to zero once the app pool is started again. This meant our `iis.app_pool_up` would incorrectly report the app pool as OK. This behavior is different from sites, whose uptime counter does reset to zero when the site is stopped.

https://datadoghq.atlassian.net/browse/WA-181

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.