### PR TITLE
sqlserver.database.state not sent for all databases

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -583,14 +583,11 @@ class SqlDatabaseStats(BaseSqlServerMetric):
         value_column_index = columns.index(self.column)
 
         for row in rows:
-            if row[database_name] != self.instance:
-                continue
-
             column_val = row[value_column_index]
             db_state_desc = row[db_state_desc_index]
             db_recovery_model_desc = row[db_recovery_model_desc_index]
             metric_tags = [
-                'database:{}'.format(str(self.instance)),
+                'database:{}'.format(str(row[database_name])),
                 'database_state_desc:{}'.format(str(db_state_desc)),
                 'database_recovery_model_desc:{}'.format(str(db_recovery_model_desc)),
             ]

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -583,11 +583,14 @@ class SqlDatabaseStats(BaseSqlServerMetric):
         value_column_index = columns.index(self.column)
 
         for row in rows:
+            if row[database_name].lower() != self.instance.lower():
+                continue
+
             column_val = row[value_column_index]
             db_state_desc = row[db_state_desc_index]
             db_recovery_model_desc = row[db_recovery_model_desc_index]
             metric_tags = [
-                'database:{}'.format(str(row[database_name])),
+                'database:{}'.format(str(self.instance)),
                 'database_state_desc:{}'.format(str(db_state_desc)),
                 'database_recovery_model_desc:{}'.format(str(db_recovery_model_desc)),
             ]

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -359,8 +359,8 @@ def test_connection_failure(aggregator, dd_run_check, instance_docker):
                 "TCP Provider: No such host is known",
                 "SQLOLEDB|SQLNCLI11": "TCP-connection\\(ERROR: getaddrinfo failed\\).*"
                 "could not open database requested by login",
-                "odbc-linux": "(TCP-connection\\(ERROR: Temporary failure in name resolution\\).*"
-                "Unable to connect to data source|"
+                "odbc-linux": "((TCP-connection\\(ERROR: Temporary failure in name resolution\\).*)*"
+                "Unable to connect to |"
                 "TCP-connection\\(ERROR: Name or service not known\\).*Login timeout expired)",
             },
             ConnectionErrorCode.tcp_connection_failed,

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -317,3 +317,14 @@ def test_resolved_hostname(dbm_enabled, instance_host, database, reported_hostna
     sqlserver_check.static_info_cache[STATIC_INFO_ENGINE_EDITION] = engine_edition
     sqlserver_check._resolved_hostname = None
     assert sqlserver_check.resolved_hostname == expected_hostname
+
+
+def test_database_state(aggregator, dd_run_check, init_config, instance_docker):
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
+    dd_run_check(sqlserver_check)
+    expected_tags = instance_docker.get('tags', []) + [
+        'database_recovery_model_desc:SIMPLE',
+        'database_state_desc:ONLINE',
+        'database:msdb',
+    ]
+    aggregator.assert_metric('sqlserver.database.state', tags=expected_tags, hostname=sqlserver_check.resolved_hostname)

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -320,11 +320,12 @@ def test_resolved_hostname(dbm_enabled, instance_host, database, reported_hostna
 
 
 def test_database_state(aggregator, dd_run_check, init_config, instance_docker):
+    instance_docker['database'] = 'mAsTeR'
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
     expected_tags = instance_docker.get('tags', []) + [
         'database_recovery_model_desc:SIMPLE',
         'database_state_desc:ONLINE',
-        'database:msdb',
+        'database:{}'.format(instance_docker['database']),
     ]
     aggregator.assert_metric('sqlserver.database.state', tags=expected_tags, hostname=sqlserver_check.resolved_hostname)


### PR DESCRIPTION
### What does this PR do?
The metric `sqlserver.database.state` wasn't being sent in certain agent configurations, see Additional Notes for details. This PR fixes the problem.

In addition, I created a unit test which reproduces the conditions leading to the problem and verifies that the metric is correctly emitted.

Last but not least, some of the tests were failing on EC2. This problem isn't related to the aforementioned bug. The reason for the failed tests is that newer versions of the ODBC/TDS drivers were generating slightly different error messages which weren't matched with the existing regular expressions in tests. I adapted the regular expressions so that they are working correctly also with the new versions of the drivers.  
 
### Motivation
The problem was noticed while resolving the following escalation: https://datadoghq.atlassian.net/browse/SDBM-302.

### Additional Notes
The method `SqlDatabaseStats.fetch_metric` fetches all rows from `sys.databases` and discards everything but the row related to the database for which the metrics are currently being collected. In that filtering, `master.sys.databases.name` is compared to the `database` agent configuration entry. Case sensitive comparison caused the problem. The conversion to insensitive comparison resolved the issue.

The current implementation is suboptimal because `master.sys.databases` is queried once for each database, although, it's possible to extract information for all databases in a single call. In addition, a separate session is opened for each database. This might be problematic in instances containing many databases.

Improving the algorithm isn't in scope for this PR, but it's documented [here](https://datadoghq.atlassian.net/browse/DBM-1970)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.