### PR TITLE
Handle nested options in multi-instances-defined

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
@@ -228,7 +228,7 @@ def write_sub_option(option, writer, indent, multiple, include_top_description=F
                 if include_top_description and option.get('description'):
                     write_description(option, writer, next_indent, 'option')
                 if start_list and 'options' in opt:
-                    writer.write(indent, '-\n')
+                    writer.write(indent, '  -\n')
                 if option_enabled(opt):
                     write_option(opt, writer, next_indent, start_list=True)
                 else:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
@@ -192,7 +192,9 @@ def write_option(option, writer, indent='', start_list=False):
                 for idx, instance in enumerate(option['options']):
                     if idx == 0:
                         start_list = True
-                    write_sub_option(instance, writer, indent, multiple, include_top_description=True, start_list=start_list)
+                    write_sub_option(
+                        instance, writer, indent, multiple, include_top_description=True, start_list=start_list
+                    )
             else:
                 write_sub_option(option, writer, indent, multiple)
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/example.py
@@ -189,8 +189,10 @@ def write_option(option, writer, indent='', start_list=False):
                 writer.write(indent, option_name, ':', '\n')
 
             if multiple and multiple_instances_defined:
-                for instance in option['options']:
-                    write_sub_option(instance, writer, indent, multiple, include_top_description=True)
+                for idx, instance in enumerate(option['options']):
+                    if idx == 0:
+                        start_list = True
+                    write_sub_option(instance, writer, indent, multiple, include_top_description=True, start_list=start_list)
             else:
                 write_sub_option(option, writer, indent, multiple)
 
@@ -210,7 +212,7 @@ def write_option(option, writer, indent='', start_list=False):
                 writer.write(line, '\n')
 
 
-def write_sub_option(option, writer, indent, multiple, include_top_description=False):
+def write_sub_option(option, writer, indent, multiple, include_top_description=False, start_list=False):
     options = sorted(option['options'], key=lambda opt: -opt['display_priority'])
     next_indent = indent + '    '
 
@@ -223,6 +225,8 @@ def write_sub_option(option, writer, indent, multiple, include_top_description=F
             if i == 0 and multiple:
                 if include_top_description and option.get('description'):
                     write_description(option, writer, next_indent, 'option')
+                if start_list and 'options' in opt:
+                    writer.write(indent, '-\n')
                 if option_enabled(opt):
                     write_option(opt, writer, next_indent, start_list=True)
                 else:

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -1712,3 +1712,79 @@ def test_parent_option_enabled():
                 # disabled_sub_option: foo.bar_none
         """
     )
+
+
+def test_multi_instances_w_nested_options():
+    consumer = get_example_consumer(
+        """
+        name: foo
+        version: 0.0.0
+        files:
+        - name: test.yaml
+          example_name: test.yaml.example
+          options:
+          - template: instances
+            multiple_instances_defined: true
+            options:
+            - name: Instance A
+              description: Instance A Example
+              options:
+              - name: option_w_options
+                enabled: true
+                description: Option with options description
+                options:
+                - name: sub_option_1
+                  required: true
+                  description: Sub_option_1 description
+                  value:
+                    type: boolean
+                    example: true
+                - name: sub_option_2
+                  description: Sub_option_2 description
+                  value:
+                    type: string
+                    example: foobar
+            - name: Instance B
+              description: Instance B Example
+              options:
+              - name: option_3
+                description: Option_3 description
+                value:
+                  type: boolean
+                  example: true
+        """
+    )
+
+    files = consumer.render()
+    contents, errors = files['test.yaml.example']
+    assert not errors
+    assert contents == normalize_yaml(
+        """
+        ## Every instance is scheduled independently of the others.
+        #
+        instances:
+
+            ## Instance A Example
+        -
+            ## Option with options description
+            #
+            option_w_options:
+
+                ## @param sub_option_1 - boolean - required
+                ## Sub_option_1 description
+                #
+                sub_option_1: true
+
+                ## @param sub_option_2 - string - optional - default: foobar
+                ## Sub_option_2 description
+                #
+                # sub_option_2: foobar
+
+            ## Instance B Example
+          -
+            ## @param option_3 - boolean - optional - default: true
+            ## Option_3 description
+            #
+            # option_3: true
+        """
+    )

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/test_example.py
@@ -1765,7 +1765,7 @@ def test_multi_instances_w_nested_options():
         instances:
 
             ## Instance A Example
-        -
+          -
             ## Option with options description
             #
             option_w_options:


### PR DESCRIPTION
### What does this PR do?
Handle instances that have `options` when using `multiple_instances_defined` in the spec.yaml. 

### Motivation
When the first instance option also has `options` configured, this instance does not get defined with a `-` in the conf.yaml.example, thus breaking the configuration. I found that this was due to the nested `options` in the spec.yaml:

```
    multiple_instances_defined: true
    options:  ## <== 
    - name: OpenMetrics
      description: RabbitMQ Prometheus Plugin Example
      options:  ## <==
      - name: prometheus_plugin
        description: |
          Settings for talking to the Prometheus plugin of RabbitMQ.
          Specify this section to trigger metric collection from the Prometheus plugin endpoints.
        enabled: true
        options: ## <==
          - name: url
          ...
```

Which produces a misconfigured instance in the conf.yaml.example:

```
instances:

    ## RabbitMQ Prometheus Plugin Example
    ## Settings for talking to the Prometheus plugin of RabbitMQ.
    ## Specify this section to trigger metric collection from the Prometheus plugin endpoints.
    #
    prometheus_plugin:    ## << Missing `-` defining the instance

        ## @param url - string - required
        ## Base URL for OpenMetrics endpoints.
```

See: https://github.com/DataDog/integrations-core/pull/13742/files#diff-7288a04193d6aebd3535045354baecd0f4aadfa3915bb94c1c343a7bf4312978R52

### Additional Notes
When testing locally, this change does not impact other check configurations and indeed fixes the configuration generation for the rabbitmq PR. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.