### PR TITLE
fix `iis.*_up` service check when configured using a mapping

### DIFF
--- a/iis/datadog_checks/iis/check.py
+++ b/iis/datadog_checks/iis/check.py
@@ -99,7 +99,10 @@ class CompatibilityPerfObject(PerfObject):
         self.uptime_counter = uptime_counter
         self.instance_type = instance_type
         self.instance_service_check_name = f'{self.instance_type}_up'
-        self.instances_included = set(instances_included)
+        if isinstance(instances_included, dict):
+            self.instances_included = set(instances_included.get('include', []))
+        else:
+            self.instances_included = set(instances_included)
 
         # Resets during refreshes
         self.instances_unseen = set()


### PR DESCRIPTION
### What does this PR do?
Prevents `iis.*_up` ServiceChecks with `site:`/`app_pool:` = `include`/`exclude` - when used in below example configuration.

```
 -  sites:
      include:
      - Default Web Site
      - foo
      - bar
    app_pools:
      include_fast:
      - baz
```

### Motivation
- AGENT-9272

### Additional Notes
This only addresses the `include`/`exclude` tags when a mapping is provided but does not take into consideration if regex patterns are provided.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.