### PR TITLE
Make service check tests unitary. Add metadata entrypoint

### DIFF
--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -61,6 +61,7 @@ class ClickhouseCheck(AgentCheck):
         self._query_manager.execute()
         self.collect_version()
 
+    @AgentCheck.metadata_entrypoint
     def collect_version(self):
         version = list(self.execute_query_raw('SELECT version()'))[0][0]
 

--- a/clickhouse/tests/test_unit.py
+++ b/clickhouse/tests/test_unit.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import mock
 import pytest
+from clickhouse_driver.errors import Error, NetworkError
 from six import PY3
 
 from datadog_checks.clickhouse import ClickhouseCheck, queries
@@ -84,3 +85,50 @@ def test_latest_metrics_supported(metrics, ignored_columns, metric_source_url):
                 ),
             )
         )
+
+
+@mock.patch('datadog_checks.base.AgentCheck.is_metadata_collection_enabled', return_value=False)
+def test_can_connect_submits_on_every_check_run(is_metadata_collection_enabled, aggregator, instance):
+    """
+    Regression test: a copy of the `can_connect` service check must be submitted for each check run.
+    (It used to be submitted only once on check init, which led to customer seeing "no data" in the UI.)
+    """
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_driver"):
+        # Test for consecutive healthy clickhouse.can_connect statuses
+        num_runs = 3
+        for _ in range(num_runs):
+            check.check({})
+    aggregator.assert_service_check("clickhouse.can_connect", count=num_runs, status=check.OK)
+
+
+@mock.patch('datadog_checks.base.AgentCheck.is_metadata_collection_enabled', return_value=False)
+def test_can_connect_recovers_after_failed_connection(is_metadata_collection_enabled, aggregator, instance):
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+
+    # Test 1 healthy connection --> 2 Unhealthy service checks --> 1 healthy connection. Recovered
+    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_driver"):
+        check.check({})
+    with mock.patch('clickhouse_driver.Client', side_effect=NetworkError('Connection refused')):
+        with mock.patch('datadog_checks.clickhouse.ClickhouseCheck.ping_clickhouse', return_value=False):
+            with pytest.raises(Exception):
+                check.check({})
+            with pytest.raises(Exception):
+                check.check({})
+    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_driver"):
+        check.check({})
+    aggregator.assert_service_check("clickhouse.can_connect", count=2, status=check.CRITICAL)
+    aggregator.assert_service_check("clickhouse.can_connect", count=2, status=check.OK)
+
+
+@mock.patch('datadog_checks.base.AgentCheck.is_metadata_collection_enabled', return_value=False)
+def test_can_connect_recovers_after_failed_ping(is_metadata_collection_enabled, aggregator, instance):
+    check = ClickhouseCheck('clickhouse', {}, [instance])
+    # Test Exception in ping_clickhouse(), but reestablishes connection.
+    with mock.patch("datadog_checks.clickhouse.clickhouse.clickhouse_driver"):
+        check.check({})
+        with mock.patch('datadog_checks.clickhouse.ClickhouseCheck.ping_clickhouse', side_effect=Error()):
+            # connect() should be able to handle an exception in ping_clickhouse() and attempt reconnection
+            check.check({})
+        check.check({})
+    aggregator.assert_service_check("clickhouse.can_connect", count=3, status=check.OK)


### PR DESCRIPTION
This test is very flaky and it can be an unit test, this PR does that and also splits it into three different tests.
Also I noticed the metadata entrypoint annotation was missing, so I added it (also so I could disable metadata collection on the unit tests)