### PR TITLE
Bump setuptools on SQL Server

### DIFF
--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools<61",
+    "setuptools>=66; python_version > '3.0'",
+    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION
Split of https://github.com/DataDog/integrations-core/pull/13748 because it takes too long to run