### PR TITLE
DOCS-4550 - remove container instructions on varnish and cassandra

### DIFF
--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -19,15 +19,6 @@ The Cassandra check is included in the [Datadog Agent][2] package, so you don't 
 
 ### Configuration
 
-Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section.
-
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Host" xxx -->
-
-#### Host
-
-To configure this check for an Agent running on a host:
-
 ##### Metric collection
 
 1. The default configuration of your `cassandra.d/conf.yaml` file activate the collection of your [Cassandra metrics](#metrics). See the [sample cassandra.d/conf.yaml][5] for all available configuration options.
@@ -64,30 +55,6 @@ _Available for Agent versions >6.0_
     To make sure that stacktraces are properly aggregated as one single log, a [multiline processing rule][7] can be added.
 
 3. [Restart the Agent][6].
-
-<!-- xxz tab xxx -->
-<!-- xxx tab "Containerized" xxx -->
-
-#### Containerized
-
-For containerized environments, see the [Autodiscovery Integration Templates][8] for guidance on applying the parameters below. 
-
-##### Metric collection
-
-For containerized environments, see the [Autodiscovery with JMX][9] guide, which includes [updating your Agent Image][17] on your clusters through Autodiscovery.
-
-##### Log collection
-
-_Available for Agent versions >6.0_
-
-Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes Log Collection][10].
-
-| Parameter      | Value                                                  |
-| -------------- | ------------------------------------------------------ |
-| `<LOG_CONFIG>` | `{"source": "cassandra", "service": "<SERVICE_NAME>"}` |
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 ### Validation
 

--- a/varnish/README.md
+++ b/varnish/README.md
@@ -21,13 +21,6 @@ The Varnish check is included in the [Datadog Agent][2] package. No additional i
 
 ### Configuration
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Host" xxx -->
-
-#### Host
-
-To configure this check for an Agent running on a host:
-
 ##### Prepare Varnish
 
 If you're running Varnish 4.1+, add the `dd-agent` system user to the Varnish group using:
@@ -98,18 +91,6 @@ _Available for Agent versions >6.0_
 
 6. [Restart the Agent][5].
 
-<!-- xxz tab xxx -->
-<!-- xxx tab "Containerized" xxx -->
-
-#### Containerized
-
-Configuration of the Varnish check using Autodiscovery in containerized environments is not supported. Collecting metrics in this type of environment may be possible by pushing metrics to DogStatsD using a StatsD plugin. The following 3rd party plugins are available:
-
-- [libvmod-statsd][6]
-- [prometheus_varnish_exporter][7]
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
 
 ### Validation
 


### PR DESCRIPTION
### What does this PR do?
removes containers tab from Varnish and Cassandra docs as it isn't applicable

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.