### PR TITLE
Collect pg_stat_activity rows for non-"client backend" backend types

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -89,7 +89,7 @@ PG_STAT_ACTIVITY_QUERY = re.sub(
     """
     SELECT {current_time_func} {pg_stat_activity_cols} {pg_blocking_func} FROM {pg_stat_activity_view}
     WHERE
-        {backend_type_predicate} OR
+        {backend_type_predicate}
         (coalesce(TRIM(query), '') != '' AND query_start IS NOT NULL {extra_filters})
 """,
 ).strip()
@@ -269,9 +269,9 @@ class PostgresStatementSamples(DBMAsyncJob):
         report_activity = self._report_activity_event()
         cur_time_func = ""
         blocking_func = ""
-        backend_type_predicate = "false"
+        backend_type_predicate = ""
         if self._check.version.compare(V10) >= 0:
-            backend_type_predicate = "backend_type != 'client backend'"
+            backend_type_predicate = "backend_type != 'client backend' OR"
         # minimum version for pg_blocking_pids function is v9.6
         # only call pg_blocking_pids as often as we collect activity snapshots
         if self._check.version >= V9_6 and report_activity:

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -32,7 +32,7 @@ from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.postgres.explain_parameterized_queries import ExplainParameterizedQueries
 
 from .util import DatabaseConfigurationError, warning_with_tags
-from .version_utils import V9_6
+from .version_utils import V9_6, V10
 
 # according to https://unicodebook.readthedocs.io/unicode_encodings.html, the max supported size of a UTF-8 encoded
 # character is 6 bytes
@@ -88,9 +88,9 @@ PG_STAT_ACTIVITY_QUERY = re.sub(
     ' ',
     """
     SELECT {current_time_func} {pg_stat_activity_cols} {pg_blocking_func} FROM {pg_stat_activity_view}
-    WHERE coalesce(TRIM(query), '') != ''
-    AND query_start IS NOT NULL
-    {extra_filters}
+    WHERE
+        {backend_type_predicate} OR
+        (coalesce(TRIM(query), '') != '' AND query_start IS NOT NULL {extra_filters})
 """,
 ).strip()
 
@@ -269,6 +269,9 @@ class PostgresStatementSamples(DBMAsyncJob):
         report_activity = self._report_activity_event()
         cur_time_func = ""
         blocking_func = ""
+        backend_type_predicate = "false"
+        if self._check.version.compare(V10) >= 0:
+            backend_type_predicate = "backend_type != 'client backend'"
         # minimum version for pg_blocking_pids function is v9.6
         # only call pg_blocking_pids as often as we collect activity snapshots
         if self._check.version >= V9_6 and report_activity:
@@ -276,6 +279,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         if report_activity:
             cur_time_func = CURRENT_TIME_FUNC
         query = PG_STAT_ACTIVITY_QUERY.format(
+            backend_type_predicate=backend_type_predicate,
             current_time_func=cur_time_func,
             pg_stat_activity_cols=', '.join(available_activity_columns),
             pg_blocking_func=blocking_func,
@@ -319,15 +323,17 @@ class PostgresStatementSamples(DBMAsyncJob):
         normalized_rows = []
         for row in rows:
             total_count += 1
-            if not row['datname']:
+            if (not row['datname'] or not row['query']) and row.get(
+                'backend_type', 'client backend'
+            ) == 'client backend':
                 continue
             query = row['query']
-            if not query:
-                continue
             if query == '<insufficient privilege>':
                 insufficient_privilege_count += 1
                 continue
-            if self._activity_last_query_start is None or row['query_start'] > self._activity_last_query_start:
+            if self._activity_last_query_start is None or (
+                row['query_start'] and row['query_start'] > self._activity_last_query_start
+            ):
                 self._activity_last_query_start = row['query_start']
             normalized_rows.append(self._normalize_row(row))
         if insufficient_privilege_count > 0:
@@ -348,14 +354,19 @@ class PostgresStatementSamples(DBMAsyncJob):
     def _normalize_row(self, row):
         normalized_row = dict(copy.copy(row))
         obfuscated_query = None
+        backend_type = normalized_row.get('backend_type', 'client backend')
         try:
-            statement = obfuscate_sql_with_metadata(row['query'], self._obfuscate_options)
-            obfuscated_query = statement['query']
-            metadata = statement['metadata']
-            normalized_row['query_signature'] = compute_sql_signature(obfuscated_query)
-            normalized_row['dd_tables'] = metadata.get('tables', None)
-            normalized_row['dd_commands'] = metadata.get('commands', None)
-            normalized_row['dd_comments'] = metadata.get('comments', None)
+            if backend_type != 'client backend':
+                obfuscated_query = backend_type
+                normalized_row['query_signature'] = compute_sql_signature(backend_type)
+            else:
+                statement = obfuscate_sql_with_metadata(row['query'], self._obfuscate_options)
+                obfuscated_query = statement['query']
+                metadata = statement['metadata']
+                normalized_row['query_signature'] = compute_sql_signature(obfuscated_query)
+                normalized_row['dd_tables'] = metadata.get('tables', None)
+                normalized_row['dd_commands'] = metadata.get('commands', None)
+                normalized_row['dd_comments'] = metadata.get('comments', None)
         except Exception as e:
             if self._config.log_unobfuscated_queries:
                 self._log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['query'], e)
@@ -458,11 +469,13 @@ class PostgresStatementSamples(DBMAsyncJob):
 
     @staticmethod
     def _to_active_session(row, track_activity_query_size):
-        if row['state'] is not None and row['state'] != 'idle':
+        if (row.get('backend_type', 'client backend') != 'client backend') or (
+            row['state'] is not None and row['state'] != 'idle'
+        ):
+            active_row = {key: val for key, val in row.items() if val is not None and key != 'query'}
             # Create an active_row, for each session by
             # 1. Removing all null key/value pairs and the original query
             # 2. if row['statement'] is none, replace with ERROR: failed to obfuscate so we can still collect activity
-            active_row = {key: val for key, val in row.items() if val is not None and key != 'query'}
             active_row['query_truncated'] = PostgresStatementSamples._get_truncation_state(
                 track_activity_query_size, row['query']
             ).value
@@ -741,7 +754,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         events = []
         for row in rows:
             try:
-                if row['statement'] is None:
+                if row['statement'] is None or row.get('backend_type', 'client backend') != 'client backend':
                     continue
                 event = self._collect_plan_for_statement(row)
                 if event:

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -917,6 +917,15 @@ def test_activity_snapshot_collection(
         assert bobs_query is not None
         assert blocking_bobs_query is not None
 
+        non_client_backend = [q for q in event['postgres_activity'] if q.get('backend_type', 'client backend') != 'client backend']
+
+        if POSTGRES_VERSION.split('.')[0] == "9":
+            assert len(non_client_backend) == 0
+        else:
+            assert len(non_client_backend) > 0
+            assert all(i['backend_type'] == i['statement'] and i['query_signature'] for i in non_client_backend)
+
+
         for key in expected_out:
             assert expected_out[key] == bobs_query[key]
         if POSTGRES_VERSION.split('.')[0] == "9":

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -917,14 +917,15 @@ def test_activity_snapshot_collection(
         assert bobs_query is not None
         assert blocking_bobs_query is not None
 
-        non_client_backend = [q for q in event['postgres_activity'] if q.get('backend_type', 'client backend') != 'client backend']
+        non_client_backend = [
+            q for q in event['postgres_activity'] if q.get('backend_type', 'client backend') != 'client backend'
+        ]
 
         if POSTGRES_VERSION.split('.')[0] == "9":
             assert len(non_client_backend) == 0
         else:
             assert len(non_client_backend) > 0
             assert all(i['backend_type'] == i['statement'] and i['query_signature'] for i in non_client_backend)
-
 
         for key in expected_out:
             assert expected_out[key] == bobs_query[key]


### PR DESCRIPTION
### What does this PR do?

- Adds the collection of non `client backend` backend type rows from pg_stat_activity

### Motivation

- Some active connections sometimes come back with blocking PIDs that are nowhere to be found in the sampling batch. The assumption is that a background process is the matching blocking PID.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.