### PR TITLE
Assert all metrics are covered in the e2e tests

### DIFF
--- a/envoy/tests/legacy/test_envoy.py
+++ b/envoy/tests/legacy/test_envoy.py
@@ -133,15 +133,17 @@ def test_unknown(fixture_path, mock_http_response, dd_run_check, check):
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    'test_case, extra_config, expected_http_kwargs',
+    'extra_config, expected_http_kwargs',
     [
-        ("new auth config", {'username': 'new_foo', 'password': 'new_bar'}, {'auth': ('new_foo', 'new_bar')}),
-        ("legacy ssl config True", {'verify_ssl': True}, {'verify': True}),
-        ("legacy ssl config False", {'verify_ssl': False}, {'verify': False}),
-        ("legacy ssl config unset", {}, {'verify': True}),
+        pytest.param(
+            {'username': 'new_foo', 'password': 'new_bar'}, {'auth': ('new_foo', 'new_bar')}, id="new auth config"
+        ),
+        pytest.param({'verify_ssl': True}, {'verify': True}, id="legacy ssl config True"),
+        pytest.param({'verify_ssl': False}, {'verify': False}, id="legacy ssl config False"),
+        pytest.param({}, {'verify': True}, id="legacy ssl config unset"),
     ],
 )
-def test_config(test_case, extra_config, expected_http_kwargs, check, dd_run_check):
+def test_config(extra_config, expected_http_kwargs, check, dd_run_check):
     instance = deepcopy(INSTANCES['main'])
     instance.update(extra_config)
     check = check(instance)
@@ -252,7 +254,7 @@ def test_metadata_not_collected(datadog_agent, check):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_metadata_integration(aggregator, datadog_agent, check):
+def test_metadata_integration(datadog_agent, check):
     instance = INSTANCES['main']
     c = check(instance)
     c.check_id = 'test:123'

--- a/envoy/tests/test_check.py
+++ b/envoy/tests/test_check.py
@@ -47,7 +47,7 @@ def test_check(aggregator, dd_run_check, check):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_metadata_integration(aggregator, dd_run_check, datadog_agent, check):
+def test_metadata_integration(dd_run_check, datadog_agent, check):
     c = check(DEFAULT_INSTANCE)
     c.check_id = 'test:123'
     dd_run_check(c)

--- a/envoy/tests/test_e2e.py
+++ b/envoy/tests/test_e2e.py
@@ -4,9 +4,9 @@
 
 import pytest
 
+from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.envoy import Envoy
 
-from datadog_checks.dev.utils import get_metadata_metrics
 from .common import DEFAULT_INSTANCE, FLAKY_METRICS, PROMETHEUS_METRICS, requires_new_environment
 
 pytestmark = [requires_new_environment]

--- a/envoy/tests/test_e2e.py
+++ b/envoy/tests/test_e2e.py
@@ -6,6 +6,7 @@ import pytest
 
 from datadog_checks.envoy import Envoy
 
+from datadog_checks.dev.utils import get_metadata_metrics
 from .common import DEFAULT_INSTANCE, FLAKY_METRICS, PROMETHEUS_METRICS, requires_new_environment
 
 pytestmark = [requires_new_environment]
@@ -21,4 +22,7 @@ def test_e2e(dd_agent_check):
             aggregator.assert_metric(formatted_metric, at_least=0)
             continue
         aggregator.assert_metric(formatted_metric)
+
+    aggregator.assert_all_metrics_covered()
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
     aggregator.assert_service_check('envoy.openmetrics.health', Envoy.OK)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Assert all metrics are covered in the e2e tests
- Assert metrics using the metadata
- Use pytest.param where relevant

### Motivation
<!-- What inspired you to submit this pull request? -->

Noticed they were missing QAing https://github.com/DataDog/integrations-core/pull/13573

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.