### PR TITLE
Report `postgresql.pg_stat_statements.count` as a gauge

### DIFF
--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -362,7 +362,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 tags=self._tags,
                 hostname=self._check.resolved_hostname,
             )
-            self._check.count(
+            self._check.gauge(
                 "postgresql.pg_stat_statements.count",
                 count,
                 tags=self._tags,


### PR DESCRIPTION
### What does this PR do?
Report `postgresql.pg_stat_statements.count` as a gauge

### Motivation
Reporting `postgresql.pg_stat_statements.count` as a count yields is incorrect as reported values will be summed when there are multiple points, making it hard to see which db reached the maximum number of statements in `pg_stat_statements`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.