### PR TITLE
Add validation for `include_aggregated_endpoint`

### DIFF
--- a/rabbitmq/assets/configuration/spec.yaml
+++ b/rabbitmq/assets/configuration/spec.yaml
@@ -29,6 +29,8 @@ files:
           - name: include_aggregated_endpoint
             description: |
               Whether or not to include metrics from the aggregated endpoint (/metrics).
+
+              Note: This option should be set to true when 'unaggregated_endpoint' is unspecified.
             value:
               type: boolean
               example: true

--- a/rabbitmq/assets/configuration/spec.yaml
+++ b/rabbitmq/assets/configuration/spec.yaml
@@ -30,7 +30,7 @@ files:
             description: |
               Whether or not to include metrics from the aggregated endpoint (/metrics).
 
-              Note: This option should be set to true when 'unaggregated_endpoint' is unspecified.
+              Note: This option must be set to true when 'unaggregated_endpoint' is unspecified.
             value:
               type: boolean
               example: true

--- a/rabbitmq/datadog_checks/rabbitmq/config_models/validators.py
+++ b/rabbitmq/datadog_checks/rabbitmq/config_models/validators.py
@@ -23,5 +23,10 @@ def initialize_instance(values, **kwargs):
             agg_ep = plugin_settings['include_aggregated_endpoint']
             if not isinstance(agg_ep, bool):
                 raise TypeError("'prometheus_plugin.include_aggregated_endpoint' must be a boolean.")
+            if not agg_ep and 'unaggregated_endpoint' not in plugin_settings:
+                raise ValueError(
+                    "'prometheus_plugin.include_aggregated_endpoint' field should "
+                    + "be set to 'true' when 'prometheus_plugin.unaggregated_endpoint' is not collected."
+                )
 
     return values

--- a/rabbitmq/datadog_checks/rabbitmq/config_models/validators.py
+++ b/rabbitmq/datadog_checks/rabbitmq/config_models/validators.py
@@ -25,7 +25,7 @@ def initialize_instance(values, **kwargs):
                 raise TypeError("'prometheus_plugin.include_aggregated_endpoint' must be a boolean.")
             if not agg_ep and 'unaggregated_endpoint' not in plugin_settings:
                 raise ValueError(
-                    "'prometheus_plugin.include_aggregated_endpoint' field should "
+                    "'prometheus_plugin.include_aggregated_endpoint' field must "
                     + "be set to 'true' when 'prometheus_plugin.unaggregated_endpoint' is not collected."
                 )
 

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -60,7 +60,7 @@ instances:
         ## @param include_aggregated_endpoint - boolean - optional - default: true
         ## Whether or not to include metrics from the aggregated endpoint (/metrics).
         ##
-        ## Note: This option should be set to true when 'unaggregated_endpoint' is unspecified.
+        ## Note: This option must be set to true when 'unaggregated_endpoint' is unspecified.
         #
         # include_aggregated_endpoint: true
 

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -59,6 +59,8 @@ instances:
 
         ## @param include_aggregated_endpoint - boolean - optional - default: true
         ## Whether or not to include metrics from the aggregated endpoint (/metrics).
+        ##
+        ## Note: This option should be set to true when 'unaggregated_endpoint' is unspecified.
         #
         # include_aggregated_endpoint: true
 

--- a/rabbitmq/tests/test_openmetrics.py
+++ b/rabbitmq/tests/test_openmetrics.py
@@ -240,6 +240,12 @@ def test_aggregated_and_unaggregated_endpoints(endpoint, metrics, aggregator, dd
             r"'prometheus_plugin\.include_aggregated_endpoint' must be a boolean\.",
             id="Aggregated_endpoint must be a boolean.",
         ),
+        pytest.param(
+            {'url': "http://localhost", "include_aggregated_endpoint": False},
+            r"'prometheus_plugin\.include_aggregated_endpoint' field should be set to 'true' "
+            + r"when 'prometheus_plugin\.unaggregated_endpoint' is not collected\.",
+            id="include_aggregated_endpoint must be true when unaggregated_endpoint is missing.",
+        ),
     ],
 )
 def test_config(prom_plugin_settings, err):

--- a/rabbitmq/tests/test_openmetrics.py
+++ b/rabbitmq/tests/test_openmetrics.py
@@ -242,7 +242,7 @@ def test_aggregated_and_unaggregated_endpoints(endpoint, metrics, aggregator, dd
         ),
         pytest.param(
             {'url': "http://localhost", "include_aggregated_endpoint": False},
-            r"'prometheus_plugin\.include_aggregated_endpoint' field should be set to 'true' "
+            r"'prometheus_plugin\.include_aggregated_endpoint' field must be set to 'true' "
             + r"when 'prometheus_plugin\.unaggregated_endpoint' is not collected\.",
             id="include_aggregated_endpoint must be true when unaggregated_endpoint is missing.",
         ),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds validation for `include_aggregated_endpoint` requiring it to be true when `unaggregated_endpoint` is unspecified. Otherwise, the check will run and collect nothing:
```
andrew.zhang@COMP-C02F513WML87 integrations-core % ddev env check rabbitmq          
=========
Collector
=========

  Running Checks
  ==============
    
    rabbitmq (3.3.0)
    ----------------
      Instance ID: rabbitmq:1f8a86b67a8bf2a9 [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/rabbitmq.d/rabbitmq.yaml
      Total Runs: 1
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 31ms
      Last Execution Date : 2023-01-24 21:12:23 UTC (1674594743000)
      Last Successful Execution Date : 2023-01-24 21:12:23 UTC (1674594743000)
      

Check has run only once, if some metrics are missing you can try again with --check-rate to see any other metric if available.
```

### Motivation
<!-- What inspired you to submit this pull request? -->
QA for https://github.com/DataDog/integrations-core/pull/13662
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.