### PR TITLE
Avoid brief postgresql.replication_delay spikes after Postgres restart/reload

### DIFF
--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -144,7 +144,8 @@ LIMIT {table_count_limit}
 }
 
 q1 = (
-    'CASE WHEN pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0 ELSE GREATEST '
+    'CASE WHEN pg_last_wal_receive_lsn() IS NULL OR '
+    'pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn() THEN 0 ELSE GREATEST '
     '(0, EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())) END'
 )
 q2 = 'abs(pg_wal_lsn_diff(pg_last_wal_receive_lsn(), pg_last_wal_replay_lsn()))'
@@ -154,7 +155,8 @@ REPLICATION_METRICS_10 = {
 }
 
 q = (
-    'CASE WHEN pg_last_xlog_receive_location() = pg_last_xlog_replay_location() THEN 0 ELSE GREATEST '
+    'CASE WHEN pg_last_xlog_receive_location() IS NULL OR '
+    'pg_last_xlog_receive_location() = pg_last_xlog_replay_location() THEN 0 ELSE GREATEST '
     '(0, EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp())) END'
 )
 REPLICATION_METRICS_9_1 = {q: ('postgresql.replication_delay', AgentCheck.gauge)}


### PR DESCRIPTION
### What does this PR do?
The `postgresql.replication_delay` metric sometimes spikes after a reload or restart to a large (sometimes multi-day) value and then immediately returns to zero.

`pg_last_xact_replay_timestamp()` doesn't update often on databases that don’t get many writes. Therefore, `now() -
pg_last_xact_replay_timestamp()` can get large on such databases.  This value is normally suppressed when `pg_last_wal_receive_lsn() = pg_last_wal_replay_lsn()`, but upon restart/reload one or both of those functions return `NULL` until replication has resumed. Per Postgres documentation:

> `pg_last_wal_receive_lsn() -> pg_lsn`: ... If streaming replication is disabled, or if it has not yet started, the function returns `NULL`.
>
> `pg_last_wal_replay_lsn() -> pg_lsn`: ... When the server has been started normally without recovery, the function returns `NULL`.

This change suppresses these timestamp differences when `pg_last_wal_receive_lsn()` is `NULL`, i.e. when streaming replication hasn't started yet.

### Motivation
Seeing periodic spikes in `postgresql.replication_delay` even though replication has not fallen behind. These spikes would sometimes trigger monitors.

### Additional Notes
Implements POSTGRES-712.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.