### PR TITLE
Add more granular timing for explain plan

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -415,6 +415,13 @@ class PostgresStatementSamples(DBMAsyncJob):
             self._check.database_monitoring_query_sample(json.dumps(e, default=default_json_event_encoding))
             submitted_count += 1
 
+        elapsed_ms = (time.time() - start_time) * 1000
+        self._check.histogram(
+            "dd.postgres.collect_statement_samples_explain_plans.time",
+            elapsed_ms,
+            tags=self._tags + self._check._get_debug_tags(),
+            hostname=self._check.resolved_hostname,
+        )
         if self._report_activity_event():
             active_connections = self._get_active_connections()
             activity_event = self._create_activity_event(rows, active_connections)
@@ -737,6 +744,7 @@ class PostgresStatementSamples(DBMAsyncJob):
             return event
         return None
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_plans(self, rows):
         events = []
         for row in rows:


### PR DESCRIPTION
### What does this PR do?
Create more focused timing metrics for generating explain plans for samples.

### Motivation
We are considering increasing the frequency of sampling and fetching explain plans. Our current metrics time whole functions, which often include fetching samples, generating explain plans, and fetching active sessions. It would be helpful to have more granular timings for generating explain plans specifically. 


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.