### PR TITLE
Update E2E environment

### DIFF
--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -77,7 +77,7 @@ For containerized environments, see the [Autodiscovery Integration Templates][6]
 | -------------------- | -------------------------------------------------------- |
 | `<INTEGRATION_NAME>` | `cockroachdb`                                            |
 | `<INIT_CONFIG>`      | blank or `{}`                                            |
-| `<INSTANCE_CONFIG>`  | `{"prometheus_url":"http://%%host%%:8080/_status/vars"}` |
+| `<INSTANCE_CONFIG>`  | `{"openmetrics_endpoint":"http://%%host%%:8080/_status/vars"}` |
 
 ##### Log collection
 

--- a/cockroachdb/assets/configuration/spec.yaml
+++ b/cockroachdb/assets/configuration/spec.yaml
@@ -13,6 +13,7 @@ files:
         openmetrics_endpoint.value.example: http://localhost:8080/_status/vars
         tags.value.example:
           - 'node:<NAME>'
+          - 'cluster:<NAME>'
           - <KEY_1>:<VALUE_1>
           - <KEY_2>:<VALUE_2>
     - template: instances/openmetrics_legacy_base

--- a/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
+++ b/cockroachdb/datadog_checks/cockroachdb/data/conf.yaml.example
@@ -587,6 +587,7 @@ instances:
     #
     # tags:
     #   - node:<NAME>
+    #   - cluster:<NAME>
     #   - <KEY_1>:<VALUE_1>
     #   - <KEY_2>:<VALUE_2>
 

--- a/cockroachdb/hatch.toml
+++ b/cockroachdb/hatch.toml
@@ -18,3 +18,4 @@ COCKROACHDB_VERSION = "latest"
 
 [envs.bench.env-vars]
 COCKROACHDB_VERSION = "v22.1.11"
+DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/cockroachdb/hatch.toml
+++ b/cockroachdb/hatch.toml
@@ -10,6 +10,9 @@ matrix.version.env-vars = [
   { key = "COCKROACHDB_VERSION", value = "v22.1.11", if = ["22.1"] },
 ]
 
+[envs.default.env-vars]
+DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
+
 [envs.latest.env-vars]
 COCKROACHDB_VERSION = "latest"
 

--- a/cockroachdb/tests/conftest.py
+++ b/cockroachdb/tests/conftest.py
@@ -32,7 +32,11 @@ def instance_legacy():
 
 @pytest.fixture(scope='session')
 def instance():
-    return {'openmetrics_endpoint': 'http://{}:{}/_status/vars'.format(HOST, PORT)}
+    return {
+        'openmetrics_endpoint': 'http://{}:{}/_status/vars'.format(HOST, PORT),
+        'histogram_buckets_as_distributions': True,
+        'tags': ['cluster:cockroachdb-cluster', 'node:1'],
+    }
 
 
 def _get_start_command():


### PR DESCRIPTION
### What does this PR do?
Updates the E2E environment to enable `histogram_buckets_as_distributions` and add `node` and `cluster` tags to the E2E instance config. 

Also corrects the readme to use `openmetrics` instead of `prometheus_url`

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.