### PR TITLE
Update mcache doc

### DIFF
--- a/mcache/README.md
+++ b/mcache/README.md
@@ -14,7 +14,7 @@ The Memcache check is included in the [Datadog Agent][1] package, so you don't n
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section
 
-When launching the Memcache server, set the binding protocal `-B` to `binary` or `auto`. Automatic (auto) is the default.
+When launching the Memcache server, set the binding protocol `-B` to `binary` or `auto`. Automatic (auto) is the default.
 
 #### Metric collection
 

--- a/mcache/README.md
+++ b/mcache/README.md
@@ -14,7 +14,7 @@ The Memcache check is included in the [Datadog Agent][1] package, so you don't n
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section
 
-When launching memcache server, please set the binding protocal `-B` to `binary` or `auto`. Automatic (auto) is the default.
+When launching the Memcache server, set the binding protocal `-B` to `binary` or `auto`. Automatic (auto) is the default.
 
 #### Metric collection
 

--- a/mcache/README.md
+++ b/mcache/README.md
@@ -14,6 +14,8 @@ The Memcache check is included in the [Datadog Agent][1] package, so you don't n
 
 Follow the instructions below to configure this check for an Agent running on a host. For containerized environments, see the [Containerized](#containerized) section
 
+When launching memcache server, please set the binding protocal `-B` to `binary` or `auto`. Automatic (auto) is the default.
+
 #### Metric collection
 
 <!-- xxx tabs xxx -->


### PR DESCRIPTION
Added a line in the doc to use binary or auto as memcache binding protocol

### What does this PR do?

Added a line in the mcacge doc to use binary or auto as memcache binding protocol instead of ascii

### Motivation
Internal support case 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.