### PR TITLE
Prevent Alphas, Betas and RC versions of checks from being installed unless specified

### DIFF
--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -317,13 +317,9 @@ class TUFDownloader:
             raise MissingVersions(standard_distribution_name)
 
         if not version:
-            # Go through all wheels and remove alphas, betas and rcs
-            non_official_suffixes = ["a", "b", "rc"]
-            for key in list(wheels.keys()):
-                if any(suffix in key for suffix in non_official_suffixes):
-                    del wheels[key]
+            # Go through all wheels and remove alphas, betas and rcs and pick the latest version
             # https://packaging.pypa.io/en/latest/version.html
-            version = str(max(parse_version(v) for v in wheels.keys()))
+            version = str(max(parse_version(v) for v in wheels.keys() if not parse_version(v).is_prerelease))
 
         python_tags = wheels[version]
         if not python_tags:

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -317,6 +317,11 @@ class TUFDownloader:
             raise MissingVersions(standard_distribution_name)
 
         if not version:
+            # Go through all wheels and remove alphas, betas and rcs
+            non_official_suffixes = ["a", "b", "rc"]
+            for key in list(wheels.keys()):
+                if any(suffix in key for suffix in non_official_suffixes):
+                    del wheels[key]
             # https://setuptools.readthedocs.io/en/latest/pkg_resources.html#parsing-utilities
             version = str(max(parse_version(v) for v in wheels.keys()))
 

--- a/datadog_checks_downloader/tests/test_unit.py
+++ b/datadog_checks_downloader/tests/test_unit.py
@@ -1,0 +1,13 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+from unittest.mock import patch
+from datadog_checks.downloader.download import get_wheel_relpath
+
+mocked_wheels = {'3.6.1': {'py2.py3': 'datadog_vsphere-3.6.1-py2.py3-none-any.whl'}, '5.4.0rc2': {'py2.py3': 'datadog_vsphere-5.4.0rc2-py2.py3-none-any.whl'}, '6.2.2a1': {'py2.py3': 'datadog_vsphere-6.2.2b1-py2.py3-none-any.whl'}, '6.3.0b1': {'py2.py3': 'datadog_vsphere-6.3.0b1-py2.py3-none-any.whl'}}
+@patch('datadog_checks.downloader.download.wheels', mocked_wheels)
+def test_non_official_wheel_filter():
+    integration = "datadog-vsphere"
+    result = get_wheel_relpath(integration)
+    assert result == 'simple/datadog-vsphere/datadog_vsphere-3.6.1-py2.py3-none-any.whl'

--- a/datadog_checks_downloader/tests/test_unit.py
+++ b/datadog_checks_downloader/tests/test_unit.py
@@ -7,6 +7,7 @@ from datadog_checks.downloader.download import TUFDownloader
 def test_non_official_wheel_filter(mocker):
     mocked_wheels = {
         '3.6.1': {'py2.py3': 'datadog_vsphere-3.6.1-py2.py3-none-any.whl'},
+        '3.6.2': {'py2.py3': 'datadog_vsphere-3.6.2-py2.py3-none-any.whl'},
         '5.4.0rc2': {'py2.py3': 'datadog_vsphere-5.4.0rc2-py2.py3-none-any.whl'},
         '6.2.2a1': {'py2.py3': 'datadog_vsphere-6.2.2b1-py2.py3-none-any.whl'},
         '6.3.0b1': {'py2.py3': 'datadog_vsphere-6.3.0b1-py2.py3-none-any.whl'},
@@ -19,4 +20,4 @@ def test_non_official_wheel_filter(mocker):
     result = downloader.get_wheel_relpath(integration)
 
     mock_wheels_call.assert_called_once()
-    assert result == 'simple/datadog-vsphere/datadog_vsphere-3.6.1-py2.py3-none-any.whl'
+    assert result == 'simple/datadog-vsphere/datadog_vsphere-3.6.2-py2.py3-none-any.whl'

--- a/datadog_checks_downloader/tests/test_unit.py
+++ b/datadog_checks_downloader/tests/test_unit.py
@@ -1,18 +1,17 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
-from unittest.mock import patch
 from datadog_checks.downloader.download import TUFDownloader
+
 
 def test_non_official_wheel_filter(mocker):
     mocked_wheels = {
         '3.6.1': {'py2.py3': 'datadog_vsphere-3.6.1-py2.py3-none-any.whl'},
         '5.4.0rc2': {'py2.py3': 'datadog_vsphere-5.4.0rc2-py2.py3-none-any.whl'},
         '6.2.2a1': {'py2.py3': 'datadog_vsphere-6.2.2b1-py2.py3-none-any.whl'},
-        '6.3.0b1': {'py2.py3': 'datadog_vsphere-6.3.0b1-py2.py3-none-any.whl'}
+        '6.3.0b1': {'py2.py3': 'datadog_vsphere-6.3.0b1-py2.py3-none-any.whl'},
     }
-    
+
     downloader = TUFDownloader()
     mock_wheels_call = mocker.patch.object(TUFDownloader, '_TUFDownloader__get_versions', return_value=mocked_wheels)
 

--- a/datadog_checks_downloader/tests/test_unit.py
+++ b/datadog_checks_downloader/tests/test_unit.py
@@ -11,6 +11,7 @@ def test_non_official_wheel_filter(mocker):
         '5.4.0rc2': {'py2.py3': 'datadog_vsphere-5.4.0rc2-py2.py3-none-any.whl'},
         '6.2.2a1': {'py2.py3': 'datadog_vsphere-6.2.2b1-py2.py3-none-any.whl'},
         '6.3.0b1': {'py2.py3': 'datadog_vsphere-6.3.0b1-py2.py3-none-any.whl'},
+        '6.3.0pre3': {'py2.py3': 'datadog_vsphere-6.3.0pre1-py2.py3-none-any.whl'},
     }
 
     downloader = TUFDownloader()

--- a/datadog_checks_downloader/tests/test_unit.py
+++ b/datadog_checks_downloader/tests/test_unit.py
@@ -3,11 +3,21 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
 from unittest.mock import patch
-from datadog_checks.downloader.download import get_wheel_relpath
+from datadog_checks.downloader.download import TUFDownloader
 
-mocked_wheels = {'3.6.1': {'py2.py3': 'datadog_vsphere-3.6.1-py2.py3-none-any.whl'}, '5.4.0rc2': {'py2.py3': 'datadog_vsphere-5.4.0rc2-py2.py3-none-any.whl'}, '6.2.2a1': {'py2.py3': 'datadog_vsphere-6.2.2b1-py2.py3-none-any.whl'}, '6.3.0b1': {'py2.py3': 'datadog_vsphere-6.3.0b1-py2.py3-none-any.whl'}}
-@patch('datadog_checks.downloader.download.wheels', mocked_wheels)
-def test_non_official_wheel_filter():
+def test_non_official_wheel_filter(mocker):
+    mocked_wheels = {
+        '3.6.1': {'py2.py3': 'datadog_vsphere-3.6.1-py2.py3-none-any.whl'},
+        '5.4.0rc2': {'py2.py3': 'datadog_vsphere-5.4.0rc2-py2.py3-none-any.whl'},
+        '6.2.2a1': {'py2.py3': 'datadog_vsphere-6.2.2b1-py2.py3-none-any.whl'},
+        '6.3.0b1': {'py2.py3': 'datadog_vsphere-6.3.0b1-py2.py3-none-any.whl'}
+    }
+    
+    downloader = TUFDownloader()
+    mock_wheels_call = mocker.patch.object(TUFDownloader, '_TUFDownloader__get_versions', return_value=mocked_wheels)
+
     integration = "datadog-vsphere"
-    result = get_wheel_relpath(integration)
+    result = downloader.get_wheel_relpath(integration)
+
+    mock_wheels_call.assert_called_once()
     assert result == 'simple/datadog-vsphere/datadog_vsphere-3.6.1-py2.py3-none-any.whl'


### PR DESCRIPTION
### What does this PR do?
The current logic of the checks downloader will look at the newest version of the check. This sometimes can be an alpha, beta or an rc version of the check. This PR aims to only install the officially released version of the check unless it's specified to install an alpha, beta or rc version.

https://datadoghq.atlassian.net/browse/AITOOLS-31