### PR TITLE
Remove the use of the deprecated `pkg_resources` package

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -33,6 +33,7 @@ futures,PyPI,PSF,Copyright (c) 2015 Brian Quinlan
 gearman,PyPI,Apache-2.0,Copyright 2010 Yelp <python-gearman@yelp.com>
 gssapi,PyPI,ISC,"Copyright (c) 2014, The Python GSSAPI Team"
 immutables,PyPI,Apache-2.0,Copyright 2018-present Contributors to the immutables project.
+importlib-metadata,PyPI,Apache-2.0,Copyright Jason R. Coombs
 in-toto,PyPI,Apache-2.0,Copyright 2018 New York University
 ipaddress,PyPI,PSF,Copyright (c) 2013 Philipp Hagemeister
 jellyfish,PyPI,BSD-3-Clause,"Copyright (c) 2015, James Turk"

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -30,7 +30,7 @@ gearman==2.0.2; sys_platform != 'win32' and python_version < '3.0'
 gssapi==1.6.1; python_version < '3.0'
 gssapi==1.8.2; python_version > '3.0'
 immutables==0.19; python_version > '3.0'
-importlib-metadata; python_version < '3.8'
+importlib-metadata==2.1.3; python_version < '3.8'
 in-toto==1.0.1; python_version > '3.0'
 ipaddress==1.0.23; python_version < '3.0'
 jaydebeapi==1.2.3

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -30,6 +30,7 @@ gearman==2.0.2; sys_platform != 'win32' and python_version < '3.0'
 gssapi==1.6.1; python_version < '3.0'
 gssapi==1.8.2; python_version > '3.0'
 immutables==0.19; python_version > '3.0'
+importlib-metadata; python_version < '3.8'
 in-toto==1.0.1; python_version > '3.0'
 ipaddress==1.0.23; python_version < '3.0'
 jaydebeapi==1.2.3

--- a/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
@@ -1,18 +1,22 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import sys
 
-import pkg_resources
+if sys.version_info >= (3, 8):
+    from importlib.metadata import distributions
+else:
+    from importlib_metadata import distributions
 
-DATADOG_CHECK_PREFIX = "datadog-"
+DATADOG_CHECK_PREFIX = 'datadog-'
 
 
 def get_datadog_wheels():
     packages = []
-    dist = list(pkg_resources.working_set)
-    for package in dist:
-        if package.project_name.startswith(DATADOG_CHECK_PREFIX):
-            name = package.project_name[len(DATADOG_CHECK_PREFIX) :].replace('-', '_')
+    for package in distributions():
+        project_name = package.metadata['Name']
+        if project_name.startswith(DATADOG_CHECK_PREFIX):
+            name = project_name[len(DATADOG_CHECK_PREFIX) :].replace('-', '_')
             packages.append(name)
 
     return sorted(packages)[::-1]

--- a/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
+++ b/datadog_checks_base/datadog_checks/base/utils/agent/packages.py
@@ -12,11 +12,11 @@ DATADOG_CHECK_PREFIX = 'datadog-'
 
 
 def get_datadog_wheels():
-    packages = []
+    packages = set()
     for package in distributions():
         project_name = package.metadata['Name']
         if project_name.startswith(DATADOG_CHECK_PREFIX):
             name = project_name[len(DATADOG_CHECK_PREFIX) :].replace('-', '_')
-            packages.append(name)
+            packages.add(name)
 
     return sorted(packages)[::-1]

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -48,6 +48,7 @@ deps = [
     "ddtrace==0.32.2; sys_platform == 'win32' and python_version < '3.0'",
     "ddtrace==0.53.2; sys_platform != 'win32' or python_version > '3.0'",
     "enum34==1.1.10; python_version < '3.0'",
+    "importlib-metadata; python_version < '3.8'",
     "immutables==0.19; python_version > '3.0'",
     "ipaddress==1.0.23; python_version < '3.0'",
     "jellyfish==0.9.0; python_version > '3.0'",

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -48,7 +48,7 @@ deps = [
     "ddtrace==0.32.2; sys_platform == 'win32' and python_version < '3.0'",
     "ddtrace==0.53.2; sys_platform != 'win32' or python_version > '3.0'",
     "enum34==1.1.10; python_version < '3.0'",
-    "importlib-metadata; python_version < '3.8'",
+    "importlib-metadata==2.1.3; python_version < '3.8'",
     "immutables==0.19; python_version > '3.0'",
     "ipaddress==1.0.23; python_version < '3.0'",
     "jellyfish==0.9.0; python_version > '3.0'",

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -317,7 +317,7 @@ class TUFDownloader:
             raise MissingVersions(standard_distribution_name)
 
         if not version:
-            # https://setuptools.readthedocs.io/en/latest/pkg_resources.html#parsing-utilities
+            # https://packaging.pypa.io/en/latest/version.html
             version = str(max(parse_version(v) for v in wheels.keys()))
 
         python_tags = wheels[version]

--- a/datadog_checks_downloader/datadog_checks/downloader/parameters.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/parameters.py
@@ -13,7 +13,7 @@ The module is expected to live here.
 """
 import os.path
 
-from pkg_resources import safe_name
+from packaging.utils import canonicalize_name
 
 from .exceptions import NonDatadogPackage
 
@@ -28,7 +28,7 @@ def substitute(target_relpath):
     if not wheel_distribution_name.startswith('datadog_'):
         raise NonDatadogPackage(wheel_distribution_name)
 
-    standard_distribution_name = safe_name(wheel_distribution_name)
+    standard_distribution_name = canonicalize_name(wheel_distribution_name)
 
     # These names are the exceptions. In this case, the wheel distribution name
     # matches exactly the directory name of the check on GitHub.

--- a/mcache/datadog_checks/mcache/mcache.py
+++ b/mcache/datadog_checks/mcache/mcache.py
@@ -4,7 +4,6 @@
 from __future__ import division
 
 import bmemcached
-import pkg_resources
 from six import iteritems, itervalues
 
 from datadog_checks.base import AgentCheck, ConfigurationError
@@ -104,10 +103,6 @@ class Memcache(AgentCheck):
     OPTIONAL_STATS = {"items": [ITEMS_RATES, ITEMS_GAUGES, None], "slabs": [SLABS_RATES, SLABS_GAUGES, None]}
 
     SERVICE_CHECK = 'memcache.can_connect'
-
-    @classmethod
-    def get_library_versions(cls):
-        return {"memcache": pkg_resources.get_distribution("python-binary-memcached").version}
 
     def _process_response(self, response):
         """


### PR DESCRIPTION
### Additional Notes

This package is also used in a few test suites but that will be a separate PR so changelogs don't get affected