### PR TITLE
Remove dependency on adodbapi (already included in pywin32)

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -6,7 +6,6 @@ PyMySQL,PyPI,MIT,"Copyright (c) 2010, 2013 PyMySQL contributors"
 PySocks,PyPI,BSD-3-Clause,Copyright 2006 Dan-Haim. All rights reserved.
 PyYAML,PyPI,MIT,Copyright (c) 2017-2021 Ingy döt Net
 Pyro4,PyPI,MIT,Copyright (c) 2016 Irmen de Jong
-adodbapi,PyPI,LGPL-2.1-only,"Copyright (C) Henrik Ekelund, Vernon Cole, et.al."
 aerospike,PyPI,Apache-2.0,"Copyright Aerospike, Inc."
 aws-requests-auth,PyPI,BSD-3-Clause,Copyright (c) David Muller.
 beautifulsoup4,PyPI,MIT,Copyright (c) Leonard Richardson

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -1,4 +1,3 @@
-adodbapi==2.6.2.0; sys_platform == 'win32'
 aerospike==4.0.0; sys_platform != 'win32' and sys_platform != 'darwin' and python_version < '3.0'
 aerospike==7.1.1; sys_platform != 'win32' and sys_platform != 'darwin' and python_version > '3.0'
 aws-requests-auth==0.4.3

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -40,7 +40,6 @@ text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "adodbapi==2.6.2.0; sys_platform == 'win32'",
     "lxml==4.9.2",
     "pyodbc==4.0.32; sys_platform != 'darwin' or platform_machine != 'arm64'",
     "pyro4==4.82; sys_platform == 'win32'",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Removes the dependency on `adodbapi` from the `sqlserver` integration.

### Motivation
<!-- What inspired you to submit this pull request? -->

The `adodbapi` module is already provided by `pywin32`, since version `211` (see [documentation page](https://adodbapi.sourceforge.net/)).
The `adodbapi` package isn't maintained separately anymore (since it is part of `pywin32`), hasn't been updated since 2019, and isn't compatible with `setuptools` >= 58.0.0. Its presence prevents us from updating the `setuptools` version used in the Agent.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

n/a

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.