### PR TITLE
Remove test usage of the deprecated `pkg_resources` package

### DIFF
--- a/cockroachdb/tests/conftest.py
+++ b/cockroachdb/tests/conftest.py
@@ -4,7 +4,7 @@
 import os
 
 import pytest
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from datadog_checks.dev import docker_run
 

--- a/ignite/tests/common.py
+++ b/ignite/tests/common.py
@@ -3,7 +3,7 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import os
 
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from datadog_checks.dev import get_here
 from datadog_checks.dev.jmx import JVM_E2E_METRICS_NEW

--- a/mysql/tests/common.py
+++ b/mysql/tests/common.py
@@ -5,7 +5,7 @@ import os
 from sys import maxsize
 
 import pytest
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from datadog_checks.dev import get_docker_hostname
 

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -7,7 +7,7 @@ from os import environ
 
 import mock
 import pytest
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from datadog_checks.base.utils.platform import Platform
 from datadog_checks.dev.utils import get_metadata_metrics

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -14,7 +14,7 @@ from os import environ
 import mock
 import pymysql
 import pytest
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
 from datadog_checks.mysql import MySql

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -11,7 +11,7 @@ from os import environ
 
 import mock
 import pytest
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.utils import DBMAsyncJob


### PR DESCRIPTION
### Motivation

This is part two of https://github.com/DataDog/integrations-core/pull/13842

### Additional Notes

https://github.com/DataDog/integrations-core/pull/12560/files