### PR TITLE
Fix e2e test for topology links to use dd_id

### DIFF
--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -938,8 +938,8 @@ def test_e2e_core_metadata_aos_lldp(dd_agent_check):
         'id': device_id + ':1.216',
         'source_type': 'lldp',
         "local": {
-            "device": {"id": device_id, "id_type": "ndm"},
-            'interface': {'id': device_id + ':1', 'id_type': 'ndm'},
+            "device": {'dd_id': device_id},
+            'interface': {'dd_id': device_id + ':1', 'id': 'e1'},
         },
         "remote": {
             "device": {"id": "00:80:9f:85:78:8e", "id_type": "mac_address"},
@@ -950,8 +950,8 @@ def test_e2e_core_metadata_aos_lldp(dd_agent_check):
         'id': device_id + ':11.217',
         'source_type': 'lldp',
         "local": {
-            "device": {"id": device_id, "id_type": "ndm"},
-            'interface': {'id': device_id + ':11', 'id_type': 'ndm'},
+            "device": {'dd_id': device_id},
+            'interface': {'dd_id': device_id + ':11', 'id': 'e11'},
         },
         "remote": {
             "device": {"id": "00:80:9f:86:0d:d8", "id_type": "mac_address"},

--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -933,6 +933,7 @@ def test_e2e_core_metadata_aos_lldp(dd_agent_check):
     device_ip = instance['ip_address']
     device_id = u'default:' + device_ip
 
+    # CHANGE
     topology_link1 = {
         'id': device_id + ':1.216',
         'source_type': 'lldp',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix e2e test for topology links to use dd_id

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/datadog-agent/pull/15265

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.