### PR TITLE
Add Process signature for ArgoCD

### DIFF
--- a/argocd/manifest.json
+++ b/argocd/manifest.json
@@ -38,7 +38,12 @@
       },
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
-      }
+      },
+      "process_signatures": [
+        "argocd-application-controller",
+        "argocd-repo-server",
+        "argocd-server"
+      ]
     },
     "logs": {},
     "dashboards": {


### PR DESCRIPTION
### What does this PR do?
Add the process signature for the 3 main components of ArgoCD

```
argocd@argocd-application-controller-0:~$ ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
argocd         1  0.0  0.7 807096 32096 ?        Ssl  Jan11  30:51 argocd-application-controller --redis argocd-redis-ha-haproxy:6379
```

```
argocd@argocd-repo-server-6f58577bf4-2drsc:~$ ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
argocd         1  0.0  0.0   2788    96 ?        Ss   Jan11   1:16 tini -- argocd-repo-server --redis argocd-redis-ha-haproxy:6379
argocd         7  0.0  0.6 807352 28000 ?        Sl   Jan11  16:29 argocd-repo-server --redis argocd-redis-ha-haproxy:6379
```

```
argocd@argocd-server-7c6b84847c-s75vn:~$ ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
argocd         1  0.0  1.7 806888 69244 ?        Ssl  09:47   0:37 argocd-server --redis argocd-redis-ha-haproxy:6379
```