### PR TITLE
Remove support for /metrics/per-object endpoint.

### DIFF
--- a/rabbitmq/assets/configuration/spec.yaml
+++ b/rabbitmq/assets/configuration/spec.yaml
@@ -39,10 +39,11 @@ files:
               Which  unaggregated endpoint to use.
               The choices are:
                 - If the field is left unspecified, no endpoint is used.
-                - "per-object" means the /metrics/per-object endpoint is used.
                 - "detailed" means the /metrics/detailed endpoint is used.
                   You can also provide a query for this option, exactly as if you were making an HTTP request
                   to this endpoint. For example, `detailed?family=queue_consumer_count`.
+                  You can specify this and the aggregated endpoint. In that case any duplicate metrics will
+                  be taken from this endpoint and the corresponding aggregated ones dropped.
             value:
               type: string
               example: "detailed"

--- a/rabbitmq/datadog_checks/rabbitmq/config_models/validators.py
+++ b/rabbitmq/datadog_checks/rabbitmq/config_models/validators.py
@@ -15,9 +15,7 @@ def initialize_instance(values, **kwargs):
         if 'unaggregated_endpoint' in plugin_settings:
             unagg_ep = plugin_settings['unaggregated_endpoint']
             if not re.match(r"detailed(\?.+)?$", unagg_ep):
-                raise ValueError(
-                    "'prometheus_plugin.unaggregated_endpoint' must be 'detailed', or 'detailed?<QUERY>'."
-                )
+                raise ValueError("'prometheus_plugin.unaggregated_endpoint' must be 'detailed', or 'detailed?<QUERY>'.")
         if 'include_aggregated_endpoint' in plugin_settings:
             agg_ep = plugin_settings['include_aggregated_endpoint']
             if not isinstance(agg_ep, bool):

--- a/rabbitmq/datadog_checks/rabbitmq/config_models/validators.py
+++ b/rabbitmq/datadog_checks/rabbitmq/config_models/validators.py
@@ -14,10 +14,9 @@ def initialize_instance(values, **kwargs):
             raise ValueError("'prometheus_plugin.url' field must be an HTTP or HTTPS URL.")
         if 'unaggregated_endpoint' in plugin_settings:
             unagg_ep = plugin_settings['unaggregated_endpoint']
-            if not re.match(r'(per-object|detailed(\?.+)?)$', unagg_ep):
+            if not re.match(r"detailed(\?.+)?$", unagg_ep):
                 raise ValueError(
-                    "'prometheus_plugin.unaggregated_endpoint' must be 'per-object', 'detailed', "
-                    "or 'detailed?<QUERY>'."
+                    "'prometheus_plugin.unaggregated_endpoint' must be 'detailed', or 'detailed?<QUERY>'."
                 )
         if 'include_aggregated_endpoint' in plugin_settings:
             agg_ep = plugin_settings['include_aggregated_endpoint']

--- a/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
+++ b/rabbitmq/datadog_checks/rabbitmq/data/conf.yaml.example
@@ -68,10 +68,11 @@ instances:
         ## Which  unaggregated endpoint to use.
         ## The choices are:
         ##   - If the field is left unspecified, no endpoint is used.
-        ##   - "per-object" means the /metrics/per-object endpoint is used.
         ##   - "detailed" means the /metrics/detailed endpoint is used.
         ##     You can also provide a query for this option, exactly as if you were making an HTTP request
         ##     to this endpoint. For example, `detailed?family=queue_consumer_count`.
+        ##     You can specify this and the aggregated endpoint. In that case any duplicate metrics will
+        ##     be taken from this endpoint and the corresponding aggregated ones dropped.
         #
         # unaggregated_endpoint: detailed
 

--- a/rabbitmq/datadog_checks/rabbitmq/openmetrics/metrics.py
+++ b/rabbitmq/datadog_checks/rabbitmq/openmetrics/metrics.py
@@ -409,18 +409,13 @@ def unaggregated_renames_and_exclusions(endpoint):
     """
     exclude_from_agg = set()
     metric_renames = {}
-    if 'detailed' in endpoint:
-        exclude_from_agg = set()
-        for metric_fam in re.findall(r"family=([^&\s]+)", endpoint):
-            exclude_from_agg |= _DETAILED_FAMILIES.get(metric_fam, set())
-        metric_renames = {
-            (re.sub("^rabbitmq_", "rabbitmq_detailed_", k) if k not in _INFO else k): v
-            for k, v in _RENAME_RABBITMQ_TO_DATADOG.items()
-        }
-
-    if 'per-object' in endpoint:
-        metric_renames = _RENAME_RABBITMQ_TO_DATADOG
-
+    exclude_from_agg = set()
+    for metric_fam in re.findall(r"family=([^&\s]+)", endpoint):
+        exclude_from_agg |= _DETAILED_FAMILIES.get(metric_fam, set())
+    metric_renames = {
+        (re.sub("^rabbitmq_", "rabbitmq_detailed_", k) if k not in _INFO else k): v
+        for k, v in _RENAME_RABBITMQ_TO_DATADOG.items()
+    }
     return metric_renames, exclude_from_agg
 
 

--- a/rabbitmq/tests/test_openmetrics.py
+++ b/rabbitmq/tests/test_openmetrics.py
@@ -66,6 +66,30 @@ def test_aggregated_endpoint(aggregated_setting, aggregator, dd_run_check, mock_
     aggregator.assert_all_metrics_covered()
 
 
+def test_aggregated_endpoint_as_per_object(aggregator, dd_run_check, mock_http_response):
+    """Rabbitmq is configured to emit per-object metrics from the `/metrics` endpoint.
+
+    We expect all metrics except the ones unique to the `/metrics` endpoint to be collected.
+    """
+    mock_http_response(file_path=OM_RESPONSE_FIXTURES / "per-object.txt")
+    prometheus_settings = {'url': TEST_URL}
+    check = _rmq_om_check(prometheus_settings)
+    dd_run_check(check)
+
+    for m in DEFAULT_OPENMETRICS - AGGREGATED_ONLY_METRICS:
+        aggregator.assert_metric(m)
+        for tag in IDENTITY_INFO_TAGS:
+            aggregator.assert_metric_has_tag(m, tag)
+
+    for m in MISSING_OPENMETRICS:
+        aggregator.assert_metric(m, at_least=0)
+
+    aggregator.assert_metric('rabbitmq.build_info', tags=[OM_ENDPOINT_TAG] + BUILD_INFO_TAGS + IDENTITY_INFO_TAGS)
+    aggregator.assert_metric('rabbitmq.identity_info', tags=[OM_ENDPOINT_TAG] + IDENTITY_INFO_TAGS)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+    aggregator.assert_all_metrics_covered()
+
+
 @pytest.mark.parametrize(
     'endpoint, fixture_file, expected_metrics',
     [
@@ -81,7 +105,7 @@ def test_aggregated_endpoint(aggregated_setting, aggregator, dd_run_check, mock_
             },
             id="detailed, query queue_coarse_metrics family",
         ),
-        pytest.param("per-object", "per-object.txt", DEFAULT_OPENMETRICS - AGGREGATED_ONLY_METRICS, id="per-object"),
+        # pytest.param("per-object", "per-object.txt", DEFAULT_OPENMETRICS - AGGREGATED_ONLY_METRICS, id="per-object"),
     ],
 )
 def test_unaggregated_endpoint(endpoint, fixture_file, expected_metrics, aggregator, dd_run_check, mock_http_response):
@@ -154,7 +178,7 @@ def mock_http_responses(url, **_params):
             ],
             id="two metric families",
         ),
-        pytest.param('per-object', DEFAULT_OPENMETRICS.difference(AGGREGATED_ONLY_METRICS), id='per-object'),
+        # pytest.param('per-object', DEFAULT_OPENMETRICS.difference(AGGREGATED_ONLY_METRICS), id='per-object'),
     ],
 )
 def test_aggregated_and_unaggregated_endpoints(endpoint, metrics, aggregator, dd_run_check, mocker):
@@ -205,15 +229,18 @@ def test_aggregated_and_unaggregated_endpoints(endpoint, metrics, aggregator, dd
         ),
         pytest.param(
             {'url': "http://localhost", "unaggregated_endpoint": "detailed?"},
-            r"'prometheus_plugin\.unaggregated_endpoint' must be 'per-object', "
-            + r"'detailed', or 'detailed\?<QUERY>'\.",
+            r"'prometheus_plugin\.unaggregated_endpoint' must be 'detailed', or 'detailed\?<QUERY>'\.",
             id="Invalid nonempty unaggregated_endpoint value.",
         ),
         pytest.param(
             {'url': "http://localhost", "unaggregated_endpoint": ""},
-            r"'prometheus_plugin\.unaggregated_endpoint' must be 'per-object', "
-            + r"'detailed', or 'detailed\?<QUERY>'\.",
+            r"'prometheus_plugin\.unaggregated_endpoint' must be 'detailed', or 'detailed\?<QUERY>'\.",
             id="Empty unaggregated_endpoint value is invalid.",
+        ),
+        pytest.param(
+            {'url': "http://localhost", "unaggregated_endpoint": "per-object"},
+            r"'prometheus_plugin\.unaggregated_endpoint' must be 'detailed', or 'detailed\?<QUERY>'\.",
+            id="We do not support per-object endpoint in the config.",
         ),
         pytest.param(
             {'url': "http://localhost", "unaggregated_endpoint": []},

--- a/rabbitmq/tests/test_openmetrics.py
+++ b/rabbitmq/tests/test_openmetrics.py
@@ -105,7 +105,6 @@ def test_aggregated_endpoint_as_per_object(aggregator, dd_run_check, mock_http_r
             },
             id="detailed, query queue_coarse_metrics family",
         ),
-        # pytest.param("per-object", "per-object.txt", DEFAULT_OPENMETRICS - AGGREGATED_ONLY_METRICS, id="per-object"),
     ],
 )
 def test_unaggregated_endpoint(endpoint, fixture_file, expected_metrics, aggregator, dd_run_check, mock_http_response):
@@ -178,7 +177,6 @@ def mock_http_responses(url, **_params):
             ],
             id="two metric families",
         ),
-        # pytest.param('per-object', DEFAULT_OPENMETRICS.difference(AGGREGATED_ONLY_METRICS), id='per-object'),
     ],
 )
 def test_aggregated_and_unaggregated_endpoints(endpoint, metrics, aggregator, dd_run_check, mocker):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove support for scraping the `/metrics/per-object` endpoint. 
### Motivation
<!-- What inspired you to submit this pull request? -->

We decided the danger of cardinality explosion was too high with this endpoint. Customers should be able to get what they need from the `/metrics/detailed` endpoint.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

**Question for reviewers: should we document this in the integration readme or in the config?**

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.