### PR TITLE
Remove references to `C_INCLUDE_PATH` variable on setup

### DIFF
--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -14,12 +14,11 @@ To use the IBM MQ check, you need to make sure the [IBM MQ Client][3] 9.1+ is in
 
 #### On Linux
 
-Update your `LD_LIBRARY_PATH` and `C_INCLUDE_PATH` to include the location of the libraries. (Create these two environment variables if they don't exist yet.)
-For example, if you installed it in `/opt`:
+Update your `LD_LIBRARY_PATH` to include the location of the libraries (or create this environment variable if it doesn't exist yet).
+For example, if you installed the cliend under `/opt`:
 
 ```text
 export LD_LIBRARY_PATH=/opt/mqm/lib64:/opt/mqm/lib:$LD_LIBRARY_PATH
-export C_INCLUDE_PATH=/opt/mqm/inc:$C_INCLUDE_PATH
 ```
 
 **Note**: Agent v6+ uses `upstart`, `systemd` or `launchd` to orchestrate the datadog-agent service. Environment variables may need to be added to the service configuration files at the default locations of:

--- a/ibm_mq/README.md
+++ b/ibm_mq/README.md
@@ -14,8 +14,8 @@ To use the IBM MQ check, you need to make sure the [IBM MQ Client][3] 9.1+ is in
 
 #### On Linux
 
-Update your `LD_LIBRARY_PATH` to include the location of the libraries (or create this environment variable if it doesn't exist yet).
-For example, if you installed the cliend under `/opt`:
+Update your `LD_LIBRARY_PATH` to include the location of the libraries. Create this environment variable if it doesn't exist yet.
+For example, if you installed the client under `/opt`:
 
 ```text
 export LD_LIBRARY_PATH=/opt/mqm/lib64:/opt/mqm/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
### What does this PR do?

Removes references to the `C_INCLUDE_PATH` variable on the readme's setup section.

### Motivation

From what I can tell, that variable points at header files that would only be necessary when building the C extension, and it's not really needed at runtime. The hatch.toml file and some manual tests confirm this.

Removing it from the setup instructions is one thing less to care about.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.