### PR TITLE
Support case-insensitive header fields

### DIFF
--- a/http_check/datadog_checks/http_check/config.py
+++ b/http_check/datadog_checks/http_check/config.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from collections import namedtuple
 
+from requests.structures import CaseInsensitiveDict
+
 from datadog_checks.base import ConfigurationError, ensure_unicode, is_affirmative
 from datadog_checks.base.utils.headers import headers as agent_headers
 
@@ -45,9 +47,9 @@ def from_instance(instance, default_ca_certs=None):
     config_headers = instance.get('headers', {})
     default_headers = is_affirmative(instance.get("include_default_headers", True))
     if default_headers:
-        headers = agent_headers({})
+        headers = CaseInsensitiveDict(agent_headers({}))
     else:
-        headers = {}
+        headers = CaseInsensitiveDict({})
     headers.update(config_headers)
     url = instance.get('url')
     if url is not None:

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -12,6 +12,7 @@ from datetime import datetime
 import requests
 from cryptography import x509
 from requests import Response
+from requests.structures import CaseInsensitiveDict
 from six import PY2, string_types
 from six.moves.urllib.parse import urlparse
 
@@ -115,7 +116,7 @@ class HTTPCheck(AgentCheck):
             self.http.session.trust_env = False
 
             # Add 'Content-Type' for non GET requests when they have not been specified in custom headers
-            if method.upper() in DATA_METHODS and not headers.get("Content-Type"):
+            if method.upper() in DATA_METHODS and not CaseInsensitiveDict(headers).get("Content-Type"):
                 self.http.options["headers"]["Content-Type"] = "application/x-www-form-urlencoded"
 
             http_method = method.lower()

--- a/http_check/datadog_checks/http_check/http_check.py
+++ b/http_check/datadog_checks/http_check/http_check.py
@@ -12,7 +12,6 @@ from datetime import datetime
 import requests
 from cryptography import x509
 from requests import Response
-from requests.structures import CaseInsensitiveDict
 from six import PY2, string_types
 from six.moves.urllib.parse import urlparse
 
@@ -116,7 +115,7 @@ class HTTPCheck(AgentCheck):
             self.http.session.trust_env = False
 
             # Add 'Content-Type' for non GET requests when they have not been specified in custom headers
-            if method.upper() in DATA_METHODS and not CaseInsensitiveDict(headers).get("Content-Type"):
+            if method.upper() in DATA_METHODS and not headers.get("Content-Type"):
                 self.http.options["headers"]["Content-Type"] = "application/x-www-form-urlencoded"
 
             http_method = method.lower()

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -551,6 +551,11 @@ def test_tls_config_ok(dd_run_check, instance, check_hostname):
     ],
 )
 def test_case_insensitive_header_content_type(dd_run_check, headers):
+    """
+    Test that `Content-Type` is accessible from the headers dict regardless of letter case.
+    We're only testing `Content-Type` for a non-GET method because that's the only header field
+    that applies a default header value if omitted.
+    """
     instance = {
         'name': 'foobar',
         'url': 'http://something.com',


### PR DESCRIPTION
### What does this PR do?
Support case-insensitive custom header fields.

This change was initially brought about when a customer configured a custom header for a `POST` method.
Instances that have a non-GET method specified automatically get the `"Content-Type": "application/x-www-form-urlencoded"` header applied if a custom `Content-Type` header is not supplied. Previously, if the custom `Content-Type` header is specified with different cases (lowercase, uppercase, etc.), this header is ignored and the default header is applied.

Per RFC 9110, [RFC 9110: HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110.html#section-5.1-3) header fields are case-insensitive.

### Motivation
Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.