### PR TITLE
Remove the istio archive during the test setup

### DIFF
--- a/istio/tests/conftest.py
+++ b/istio/tests/conftest.py
@@ -59,7 +59,7 @@ def setup_istio():
 
     run_command(["kubectl", "apply", "-f", opj(istio, "samples", "bookinfo", "networking", "bookinfo-gateway.yaml")])
     run_command(["kubectl", "wait", "pods", "--all", "--for=condition=Ready", "--timeout=300s"])
-
+    run_command(["rm", "istio.tar.gz"])
 
 @pytest.fixture(scope='session')
 def dd_environment(dd_save_state):

--- a/istio/tests/conftest.py
+++ b/istio/tests/conftest.py
@@ -61,6 +61,7 @@ def setup_istio():
     run_command(["kubectl", "wait", "pods", "--all", "--for=condition=Ready", "--timeout=300s"])
     run_command(["rm", "istio.tar.gz"])
 
+
 @pytest.fixture(scope='session')
 def dd_environment(dd_save_state):
     with kind_run(conditions=[setup_istio]) as kubeconfig:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove the istio archive during the test setup

### Motivation
<!-- What inspired you to submit this pull request? -->

During the e2e env setup, a tar file is created in the repository and not deleted afterwards.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.