### PR TITLE
Explicitly disallow setting `replicaSet` in the options

### DIFF
--- a/mongo/assets/configuration/spec.yaml
+++ b/mongo/assets/configuration/spec.yaml
@@ -69,7 +69,7 @@ files:
         For a complete list of available connection options, see:
         https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options
 
-        NOTE: For monitoring replica set, do not use the replSet parameter as the Agent expects to always
+        NOTE: For monitoring replica set, do not use the replicaSet parameter as the Agent expects to always
         connect to the same host. Instead configure one check instance for each node.
       value:
         type: object

--- a/mongo/datadog_checks/mongo/config.py
+++ b/mongo/datadog_checks/mongo/config.py
@@ -57,6 +57,12 @@ class MongoConfig(object):
             self.scheme = instance.get('connection_scheme', 'mongodb')
             self.db_name = instance.get('database')
             self.additional_options = instance.get('options', {})
+            if 'replicaSet' in self.additional_options:
+                raise ConfigurationError(
+                    'Setting the `replicaSet` option is not supported. '
+                    'Configure one check instance for each node instead'
+                )
+
             self.auth_source = self.additional_options.get('authSource') or self.db_name or 'admin'
 
         if not self.hosts:

--- a/mongo/datadog_checks/mongo/data/conf.yaml.example
+++ b/mongo/datadog_checks/mongo/data/conf.yaml.example
@@ -67,7 +67,7 @@ instances:
     ## For a complete list of available connection options, see:
     ## https://docs.mongodb.com/manual/reference/connection-string/#connections-connection-options
     ##
-    ## NOTE: For monitoring replica set, do not use the replSet parameter as the Agent expects to always
+    ## NOTE: For monitoring replica set, do not use the replicaSet parameter as the Agent expects to always
     ## connect to the same host. Instead configure one check instance for each node.
     #
     # options: {}

--- a/mongo/tests/test_config.py
+++ b/mongo/tests/test_config.py
@@ -89,3 +89,9 @@ def test_dbnames_non_empty(instance):
     instance['dbnames'] = ['test']
     config = MongoConfig(instance, mock.Mock())
     assert config.db_names == ['test']
+
+
+def test_custom_replicaSet_is_not_allowed(instance):
+    instance['options'] = {'replicaSet': 'foo'}
+    with pytest.raises(ConfigurationError, match='replicaSet'):
+        MongoConfig(instance, mock.Mock())

--- a/mongo/tests/test_unit.py
+++ b/mongo/tests/test_unit.py
@@ -327,15 +327,15 @@ def test_parse_server_config(check):
         'username': 'john doe',  # Space
         'password': 'p@ss\\word',  # Special characters
         'database': 'test',
-        'options': {'replicaSet': 'bar!baz'},  # Special character
+        'options': {'authSource': 'bar!baz'},  # Special character
     }
     config = check(instance)._config
     assert config.username == 'john doe'
     assert config.password == 'p@ss\\word'
     assert config.db_name == 'test'
     assert config.hosts == ['localhost', 'localhost:27018']
-    assert config.clean_server_name == 'mongodb://john doe:*****@localhost,localhost:27018/test?replicaSet=bar!baz'
-    assert config.auth_source == 'test'
+    assert config.clean_server_name == 'mongodb://john doe:*****@localhost,localhost:27018/test?authSource=bar!baz'
+    assert config.auth_source == 'bar!baz'
     assert config.do_auth is True
 
 
@@ -346,14 +346,14 @@ def test_username_no_password(check):
         'hosts': ['localhost', 'localhost:27018'],
         'username': 'john doe',  # Space
         'database': 'test',
-        'options': {'replicaSet': 'bar!baz'},  # Special character
+        'options': {'authSource': 'bar!baz'},  # Special character
     }
     config = check(instance)._config
     assert config.username == 'john doe'
     assert config.db_name == 'test'
     assert config.hosts == ['localhost', 'localhost:27018']
-    assert config.clean_server_name == 'mongodb://john doe@localhost,localhost:27018/test?replicaSet=bar!baz'
-    assert config.auth_source == 'test'
+    assert config.clean_server_name == 'mongodb://john doe@localhost,localhost:27018/test?authSource=bar!baz'
+    assert config.auth_source == 'bar!baz'
     assert config.do_auth is True
 
 
@@ -363,14 +363,14 @@ def test_no_auth(check):
     instance = {
         'hosts': ['localhost', 'localhost:27018'],
         'database': 'test',
-        'options': {'replicaSet': 'bar!baz'},  # Special character
+        'options': {'authSource': 'bar!baz'},  # Special character
     }
     config = check(instance)._config
     assert config.username is None
     assert config.db_name == 'test'
     assert config.hosts == ['localhost', 'localhost:27018']
-    assert config.clean_server_name == "mongodb://localhost,localhost:27018/test?replicaSet=bar!baz"
-    assert config.auth_source == 'test'
+    assert config.clean_server_name == "mongodb://localhost,localhost:27018/test?authSource=bar!baz"
+    assert config.auth_source == 'bar!baz'
     assert config.do_auth is False
 
 


### PR DESCRIPTION
### What does this PR do?

Validates that the config doesn't include the `replicaSet` option as we already say that it is not supported. It also fixes the documentation itself where it was incorrectly named `replSet`.

### Motivation

At least one support case where something like this has come up. Also to keep documentation up to date and to enforce in code what's already documented.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.