### PR TITLE
Exception is thrown when items of a list in a custom query are not iterable

### DIFF
--- a/mongo/datadog_checks/mongo/collectors/custom_queries.py
+++ b/mongo/datadog_checks/mongo/collectors/custom_queries.py
@@ -49,7 +49,6 @@ def replace_datetime(obj, log):
         return [replace_datetime(item, log) for item in obj]
     else:
         return replace_value(obj, log)
-    return obj
 
 
 class CustomQueriesCollector(MongoCollector):

--- a/mongo/datadog_checks/mongo/collectors/custom_queries.py
+++ b/mongo/datadog_checks/mongo/collectors/custom_queries.py
@@ -47,8 +47,7 @@ def replace_datetime(obj, log):
         return {k: replace_datetime(v, log) for k, v in obj.items()}
     elif isinstance(obj, list):
         return [replace_datetime(item, log) for item in obj]
-    else:
-        return replace_value(obj, log)
+    return replace_value(obj, log)
 
 
 class CustomQueriesCollector(MongoCollector):

--- a/mongo/datadog_checks/mongo/collectors/custom_queries.py
+++ b/mongo/datadog_checks/mongo/collectors/custom_queries.py
@@ -42,19 +42,13 @@ def replace_value(obj, log):
 
 def replace_datetime(obj, log):
     log.debug("replace_datetime in %s", obj)
-    if isinstance(obj, dict) or isinstance(obj, list):
-        for k, v in obj.items():
-            if isinstance(v, dict):
-                obj[k] = replace_datetime(v, log)
-            elif isinstance(v, list):
-                new_v = []
-                for item in v:
-                    new_v.append(replace_datetime(item, log))
-                obj[k] = new_v
-            else:
-                obj[k] = replace_value(v, log)
+    # Recur as necessary into dicts and lists
+    if isinstance(obj, dict):
+        return {k: replace_datetime(v, log) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [replace_datetime(item, log) for item in obj]
     else:
-        obj = replace_value(obj, log)
+        return replace_value(obj, log)
     return obj
 
 

--- a/mongo/tests/common.py
+++ b/mongo/tests/common.py
@@ -161,7 +161,6 @@ INSTANCE_CUSTOM_QUERIES_WITH_DATE = {
     ],
 }
 
-
 INSTANCE_CUSTOM_QUERIES_WITH_DATE_AND_OPERATION = {
     'hosts': ['{}:{}'.format(HOST, PORT1)],
     'database': 'test',
@@ -197,7 +196,6 @@ INSTANCE_CUSTOM_QUERIES_WITH_DATE_AND_OPERATION = {
     ],
 }
 
-
 INSTANCE_CUSTOM_QUERIES_WITH_ISODATE = {
     'hosts': ['{}:{}'.format(HOST, PORT1)],
     'database': 'test',
@@ -230,6 +228,27 @@ INSTANCE_CUSTOM_QUERIES_WITH_ISODATE = {
             'metric_prefix': 'dd.custom.mongo.aggregate',
             'tags': ['tag1:val1', 'tag2:val2'],
         }
+    ],
+}
+
+INSTANCE_CUSTOM_QUERIES_WITH_STRING_LIST = {
+    'hosts': ['{}:{}'.format(HOST, PORT1)],
+    'database': 'test',
+    'username': 'testUser2',
+    'password': 'testPass2',
+    'custom_queries': [
+        {
+            'metric_prefix': 'dd.custom.mongo.string',
+            'query': {
+                'find': 'orders',
+                'filter': {'amount': {'$gt': 25}},
+                'sort': {'amount': -1},
+                'projection': {'result': {'$subtract': ['$amount', 1]}},
+            },
+            'fields': [
+                {'field_name': 'result', 'name': 'result', 'type': 'gauge'},
+            ],
+        },
     ],
 }
 

--- a/mongo/tests/test_mongo.py
+++ b/mongo/tests/test_mongo.py
@@ -244,6 +244,23 @@ def test_mongo_custom_query_with_date(aggregator, check, instance, dd_run_check)
     aggregator.assert_metric_has_tag("dd.custom.mongo.aggregate.total", 'tag2:val2', count=2)
 
 
+@common.standalone
+@pytest.mark.parametrize(
+    'instance',
+    [
+        pytest.param(common.INSTANCE_CUSTOM_QUERIES_WITH_STRING_LIST, id='String list'),
+    ],
+)
+def test_mongo_custom_query_with_string_list(aggregator, check, instance, dd_run_check):
+    check = check(instance)
+    dd_run_check(check)
+
+    aggregator.assert_metric("dd.custom.mongo.string.result", value=299, count=1, metric_type=aggregator.GAUGE)
+    aggregator.assert_metric("dd.custom.mongo.string.result", value=99, count=1, metric_type=aggregator.GAUGE)
+    aggregator.assert_metric("dd.custom.mongo.string.result", value=49, count=2, metric_type=aggregator.GAUGE)
+    aggregator.assert_metric_has_tag("dd.custom.mongo.string.result", 'collection:orders', count=4)
+
+
 @common.shard
 def test_mongo_replset(instance_shard, aggregator, check, dd_run_check):
     mongo_check = check(instance_shard)


### PR DESCRIPTION
### What does this PR do?
Fixed the exception that is thrown when a custom query contains non-iterable elements (eg strings) inside a list.
Example:
```
query: {
   'find': 'orders',
   'filter': {'amount': {'$gt': 25}},
   'sort': {'amount': -1},
   'projection': {'result': {'$subtract': ['$amount', 1]}},
},
```
You can check that the `$subtract` function receives a list with a string and a number.
### Motivation
The following exception is thrown before the fix:

`"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/mongo/collectors/custom_queries.py", line 30, in replace_datetime for k, v in obj.items(): AttributeError: 'str' object has no attribute 'items'`
### Additional Notes
In addition to the code that fixes the problem, a test will be added (`test_mongo_custom_query_with_string_list`) that will check that the previously described query is processed correctly

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.