### PR TITLE
[KSM Core] Updates job widgets to use kube_cronjob instead of owner

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_jobs.json
+++ b/kubernetes/assets/dashboards/kubernetes_jobs.json
@@ -542,12 +542,12 @@
                                     "alias": "Last number of Jobs",
                                     "limit": 10,
                                     "order": "desc",
-                                    "q": "top(sum:kubernetes_state.job.count{$kube_cluster_name,owner_kind:cronjob} by {owner_name}, 50, 'mean', 'desc')"
+                                    "q": "top(sum:kubernetes_state.job.count{$kube_cluster_name} by {kube_cronjob}, 50, 'mean', 'desc')"
                                 },
                                 {
                                     "aggregator": "avg",
                                     "alias": "Average number of Jobs",
-                                    "q": "top(sum:kubernetes_state.job.count{$kube_cluster_name,owner_kind:cronjob} by {owner_name}, 50, 'mean', 'desc')"
+                                    "q": "top(sum:kubernetes_state.job.count{$kube_cluster_name} by {kube_cronjob}, 50, 'mean', 'desc')"
                                 }
                             ],
                             "title": "Top Cronjobs by Job count",
@@ -587,7 +587,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kubernetes_state.job.count{$kube_cluster_name,owner_kind:cronjob} by {owner_name}"
+                                            "query": "sum:kubernetes_state.job.count{$kube_cluster_name} by {kube_cronjob}"
                                         }
                                     ],
                                     "response_format": "timeseries",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Updates widgets `Top Cronjobs by Job count` and `Cronjobs by Job count` to use the tags provided by the KSM Core integration, which is the default enabled

### Motivation
* Customer reached out as after moving to our chart 3.x, some widgets do not show data anymore.
* After investigating, these widgets rely on `owner_kind/name`, tags that are no longer being collected by the KSM core check for the metric `kubernetes_state.job.count` which uses `kube_cronjob` instead : 
<img width="420" alt="Image 2023-02-07 at 12 10 02 PM" src="https://user-images.githubusercontent.com/97530782/217229134-91b8b6db-b219-4437-9e5f-18c80ea1dbb3.png">

* Quick demo/sample showing this behaviour : 
<img width="981" alt="Image 2023-02-07 at 12 13 09 PM" src="https://user-images.githubusercontent.com/97530782/217229734-82e2a9d7-4b27-43ec-9c08-950a048ac778.png">


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.