### PR TITLE
Fix IIS Check memory leaked due to a bug in win32pdh.GetFormattedCouterArray()

### DIFF
--- a/iis/datadog_checks/iis/check.py
+++ b/iis/datadog_checks/iis/check.py
@@ -46,8 +46,15 @@ class IISCheckV2(PerfCountersBaseCheckWithLegacySupport):
             if include_fast:
                 new_config['include_fast'] = include_fast
 
-            # No duplicate Sites or Pools can be created
-            new_config['duplicate_instances_exist'] = False
+            # As we have discovered in 7.43 win32pdh function (win32pdh.GetFormattedCounterArray)
+            # has a memory leak. Until it is fixed we are suppressing this single use of the
+            # optimization controlled by "duplicate_instances_exist" flag because
+            # win32pdh.GetFormattedCounterArray is 5-10 times faster than its python re-implementation
+            # (GetFormattedCounterArray). For more details see get_counter_values() comments
+            #
+            # UNCOMMENT BELOW WHEN win32pdh.GetFormattedCounterArray IS FIXED
+            # # No duplicate Sites or Pools can be created
+            # new_config['duplicate_instances_exist'] = False
 
             metrics_config[object_name] = new_config
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Removed optimization which trigger using "leaky" library function used in IIS Check

### Motivation
<!-- What inspired you to submit this pull request? -->
To fix memory leaked introduced in 7.42.


### Additional Notes
<!-- Anything else we should know when reviewing? -->
Test is relatively simple. Assuming you have setup actual IIS and DD default IIS Check. Set min_collection_interval on iis config to 1 (to speed up memory grows). Without the fix in Perfmon ort Task Manager agent.exe memory will steadily climbing up (~20 Mb per hour) and with the fix it will not happen.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.