### PR TITLE
Bump IIS to 2.18.1

### DIFF
--- a/iis/CHANGELOG.md
+++ b/iis/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - iis
 
+## 2.18.1 / 2023-02-08
+
+* [Fixed] Fix IIS Check memory leaked due to a bug in win32pdh.GetFormattedCounterArray(). See [#13897](https://github.com/DataDog/integrations-core/pull/13897).
+
 ## 2.18.0 / 2022-12-09 / Agent 7.42.0
 
 * [Added] Implement multi-instance counters without Windows PdhEnumObjects API. See [#13243](https://github.com/DataDog/integrations-core/pull/13243).

--- a/iis/datadog_checks/iis/__about__.py
+++ b/iis/datadog_checks/iis/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '2.18.0'
+__version__ = '2.18.1'

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -73,7 +73,7 @@ datadog-ibm-i==1.5.0; sys_platform != 'win32'
 datadog-ibm-mq==4.0.3
 datadog-ibm-was==2.3.2
 datadog-ignite==2.2.1
-datadog-iis==2.18.0; sys_platform == 'win32'
+datadog-iis==2.18.1; sys_platform == 'win32'
 datadog-impala==1.0.1
 datadog-istio==4.3.0
 datadog-jboss-wildfly==2.0.1


### PR DESCRIPTION
### What does this PR do?
Updating the version to match 7.43.x release:
https://github.com/DataDog/integrations-core/pull/13902