### PR TITLE
haproxy: bump versions and update metrics

### DIFF
--- a/haproxy/datadog_checks/haproxy/metrics.py
+++ b/haproxy/datadog_checks/haproxy/metrics.py
@@ -4,6 +4,8 @@
 METRIC_MAP = {
     'haproxy_backend_active_servers': 'backend.active.servers',
     'haproxy_backend_agg_server_check_status': 'backend.agg.server.check.status',
+    'haproxy_backend_agg_check_status': 'backend.agg.check.status',
+    'haproxy_backend_agg_server_status': 'backend.agg.server.status',
     'haproxy_backend_backup_servers': 'backend.backup.servers',
     'haproxy_backend_bytes_in_total': 'backend.bytes.in.total',
     'haproxy_backend_bytes_out_total': 'backend.bytes.out.total',

--- a/haproxy/hatch.toml
+++ b/haproxy/hatch.toml
@@ -2,27 +2,27 @@
 
 [[envs.default.matrix]]
 python = ["2.7", "3.8"]
-version = ["2.0", "2.2", "2.3", "2.4", "2.5"]
+version = ["2.0", "2.2", "2.4", "2.5", "2.6", "2.7"]
 
 [[envs.default.matrix]]
 python = ["2.7", "3.8"]
-version = ["1.8", "2.0"]
+version = ["2.0"]
 impl = ["legacy"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
-  # EOL 01 Oct 2022
-  { key = "HAPROXY_VERSION", value = "1.8.30", if = ["1.8"] },
   # EOL 01 Apr 2024
-  { key = "HAPROXY_VERSION", value = "2.0.25", if = ["2.0"] },
+  { key = "HAPROXY_VERSION", value = "2.0.30", if = ["2.0"] },
   # EOL 01 Apr 2025
-  { key = "HAPROXY_VERSION", value = "2.2.19", if = ["2.2"] },
-  # EOL 01 Jan 2022
-  { key = "HAPROXY_VERSION", value = "2.3.16", if = ["2.3"] },
+  { key = "HAPROXY_VERSION", value = "2.2.28", if = ["2.2"] },
   # EOL 01 Apr 2026
-  { key = "HAPROXY_VERSION", value = "2.4.8", if = ["2.4"] },
+  { key = "HAPROXY_VERSION", value = "2.4.21", if = ["2.4"] },
   # EOL 01 Jan 2023
-  { key = "HAPROXY_VERSION", value = "2.5.0", if = ["2.5"] },
+  { key = "HAPROXY_VERSION", value = "2.5.11", if = ["2.5"] },
+  # EOL 01 April 2027
+  { key = "HAPROXY_VERSION", value = "2.6.8", if = ["2.6"] },
+  # EOL 01 Jan 2024
+  { key = "HAPROXY_VERSION", value = "2.7.2", if = ["2.7"] },
 ]
 matrix.impl.env-vars = [
   { key = "HAPROXY_LEGACY", value = "true", if = ["legacy"] },

--- a/haproxy/metadata.csv
+++ b/haproxy/metadata.csv
@@ -1,6 +1,8 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 haproxy.backend.active.servers,gauge,,,,[OpenMetrics V1 and V2] Current number of active servers.,0,haproxy,,
-haproxy.backend.agg.server.check.status,gauge,,,,[OpenMetrics V1 and V2] Backend's aggregated gauge of servers' state check status (since >= 2.4).,0,haproxy,,
+haproxy.backend.agg.server.check.status,gauge,,,,[OpenMetrics V1 and V2] Backend's aggregated gauge of servers' state check status (deprecated).,0,haproxy,,
+haproxy.backend.agg.check.status,gauge,,,,[OpenMetrics V1 and V2] Backend's aggregated gauge of servers' state check status (since >= 2.4).,0,haproxy,,
+haproxy.backend.agg.server.status,gauge,,,,[OpenMetrics V1 and V2] Backend's aggregated gauge of servers' status (since >= 2.4).,0,haproxy,,
 haproxy.backend.backup.servers,gauge,,,,[OpenMetrics V1 and V2] Current number of backup servers.,0,haproxy,,
 haproxy.backend.bytes.in.total,count,,byte,,[OpenMetrics V1] Current total of incoming bytes. By default submitted as count if using prometheus,0,haproxy,,
 haproxy.backend.bytes.in.count,count,,byte,,[OpenMetrics V2] Current total of incoming bytes. By default submitted as count if using prometheus,0,haproxy,,

--- a/haproxy/tests/conftest.py
+++ b/haproxy/tests/conftest.py
@@ -102,6 +102,9 @@ def prometheus_metrics():
                 metrics.pop(metric)
     if HAPROXY_VERSION < version.parse('2.4.9'):
         metrics.pop('haproxy_backend_agg_server_check_status')
+    if HAPROXY_VERSION < version.parse('2.4.21'):
+        metrics.pop('haproxy_backend_agg_check_status')
+        metrics.pop('haproxy_backend_agg_server_status')
 
     metrics = list(metrics.values())
     return metrics


### PR DESCRIPTION
### What does this PR do?

    - remove legacy versions no longer supported (v1.8.x, 2.3.x) from test matrix
    - add support for v2.6.x and v2.7.x
    - update list of metrics:
     * `haproxy_backend_agg_server_check_status` is being deprecated
     in favour of:
     * `haproxy_backend_agg_check_status`
     * `haproxy_backend_agg_server_status`
    (backported in all versions from >= v2.4.21)

### Motivation

keep haproxy integration up to date

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.