### PR TITLE
Update snowflake-connector-python to 3.0.0

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -104,7 +104,7 @@ serpent==1.41; sys_platform == 'win32' and python_version > '3.0'
 service-identity[idna]==21.1.0
 simplejson==3.17.6
 six==1.16.0
-snowflake-connector-python==2.8.3; python_version > '3.0'
+snowflake-connector-python==3.0.0; python_version > '3.0'
 supervisor==4.2.4
 tuf==2.0.0; python_version > '3.0'
 typing==3.10.0.0; python_version < '3.0'

--- a/snowflake/pyproject.toml
+++ b/snowflake/pyproject.toml
@@ -39,7 +39,7 @@ text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "snowflake-connector-python==2.8.3; python_version > '3.0'",
+    "snowflake-connector-python==3.0.0; python_version > '3.0'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?

Updates `snowflake-connector-python` dependency to 3.0.0.

### Motivation

It's needed to make dependency constraints for a cryptography update work: https://github.com/DataDog/integrations-core/pull/13913

### Additional Notes

Should be merged at the same time as the matching update on omnibus: https://github.com/DataDog/datadog-agent/pull/15535

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.