### PR TITLE
Upgrade `cryptography` to `39.0.1`

### DIFF
--- a/cisco_aci/pyproject.toml
+++ b/cisco_aci/pyproject.toml
@@ -42,7 +42,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==38.0.3; python_version > '3.0'",
+    "cryptography==39.0.1; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -18,7 +18,7 @@ clickhouse-driver==0.2.3; python_version > '3.0'
 cm-client==45.0.4
 contextlib2==0.6.0.post1; python_version < '3.0'
 cryptography==3.3.2; python_version < '3.0'
-cryptography==38.0.3; python_version > '3.0'
+cryptography==39.0.1; python_version > '3.0'
 ddtrace==0.32.2; sys_platform == 'win32' and python_version < '3.0'
 ddtrace==0.53.2; (sys_platform != 'win32' and (sys_platform != 'darwin' or platform_machine != 'arm64' and python_version > '3.0')) or python_version > '3.0'
 dnspython==1.16.0

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -45,7 +45,7 @@ deps = [
     "cachetools==5.2.1; python_version > '3.0'",
     "contextlib2==0.6.0.post1; python_version < '3.0'",
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==38.0.3; python_version > '3.0'",
+    "cryptography==39.0.1; python_version > '3.0'",
     "ddtrace==0.32.2; sys_platform == 'win32' and python_version < '3.0'",
     "ddtrace==0.53.2; (sys_platform != 'win32' and (sys_platform != 'darwin' or platform_machine != 'arm64' and python_version > '3.0')) or python_version > '3.0'",
     "enum34==1.1.10; python_version < '3.0'",

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -42,7 +42,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==38.0.3; python_version > '3.0'",
+    "cryptography==39.0.1; python_version > '3.0'",
     "requests-ntlm==1.1.0",
 ]
 

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -44,7 +44,7 @@ deps = [
     "cachetools==3.1.1; python_version < '3.0'",
     "cachetools==5.2.1; python_version > '3.0'",
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==38.0.3; python_version > '3.0'",
+    "cryptography==39.0.1; python_version > '3.0'",
     "futures==3.4.0; python_version < '3.0'",
     "pymysql==0.10.1",
 ]

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -42,7 +42,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==38.0.3; python_version > '3.0'",
+    "cryptography==39.0.1; python_version > '3.0'",
     "ipaddress==1.0.23; python_version < '3.0'",
     "service-identity[idna]==21.1.0",
 ]


### PR DESCRIPTION
### What does this PR do?

Upgrade the version of the `cryptography` python package to `39.0.1`.

### Motivation

* Fix DataDog/image-vuln-scans#814

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.