### PR TITLE
Parse and add the tag `stat_prefix` to `ext_authz` metrics if possible

### DIFF
--- a/envoy/datadog_checks/envoy/metrics.py
+++ b/envoy/datadog_checks/envoy/metrics.py
@@ -818,7 +818,7 @@ METRICS = {
     'cluster.ext_authz.failure_mode_allowed': {
         'tags': (
             ('envoy_cluster', ),
-            ('stat_prefix', ),
+            (),
             (),
         ),
         'method': 'monotonic_count',

--- a/envoy/datadog_checks/envoy/metrics.py
+++ b/envoy/datadog_checks/envoy/metrics.py
@@ -786,7 +786,7 @@ METRICS = {
     'cluster.ext_authz.ok': {
         'tags': (
             ('envoy_cluster', ),
-            (),
+            ('stat_prefix', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -794,7 +794,7 @@ METRICS = {
     'cluster.ext_authz.error': {
         'tags': (
             ('envoy_cluster', ),
-            (),
+            ('stat_prefix', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -802,7 +802,7 @@ METRICS = {
     'cluster.ext_authz.denied': {
         'tags': (
             ('envoy_cluster', ),
-            (),
+            ('stat_prefix', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -810,7 +810,7 @@ METRICS = {
     'cluster.ext_authz.disabled': {
         'tags': (
             ('envoy_cluster', ),
-            (),
+            ('stat_prefix', ),
             (),
         ),
         'method': 'monotonic_count',
@@ -818,7 +818,7 @@ METRICS = {
     'cluster.ext_authz.failure_mode_allowed': {
         'tags': (
             ('envoy_cluster', ),
-            (),
+            ('stat_prefix', ),
             (),
         ),
         'method': 'monotonic_count',

--- a/envoy/tests/fixtures/stat_prefix
+++ b/envoy/tests/fixtures/stat_prefix
@@ -1,0 +1,6 @@
+cluster.foo.ext_authz.denied: 1
+cluster.foo.ext_authz.error: 1
+cluster.foo.ext_authz.ok: 1
+cluster.foo.ext_authz.bar.ok: 2
+cluster.foo.ext_authz.bar.denied: 2
+cluster.foo.ext_authz.bar.error: 2

--- a/envoy/tests/fixtures/stat_prefix
+++ b/envoy/tests/fixtures/stat_prefix
@@ -1,6 +1,10 @@
-cluster.foo.ext_authz.denied: 1
-cluster.foo.ext_authz.error: 1
-cluster.foo.ext_authz.ok: 1
-cluster.foo.ext_authz.bar.ok: 2
-cluster.foo.ext_authz.bar.denied: 2
-cluster.foo.ext_authz.bar.error: 2
+cluster.foo.ext_authz.denied: 0
+cluster.foo.ext_authz.disabled: 1
+cluster.foo.ext_authz.error: 2
+cluster.foo.ext_authz.failure_mode_allowed: 3
+cluster.foo.ext_authz.ok: 4
+cluster.foo.ext_authz.bar.denied: 5
+cluster.foo.ext_authz.bar.disabled: 6
+cluster.foo.ext_authz.bar.error: 7
+cluster.foo.ext_authz.bar.failure_mode_allowed: 8
+cluster.foo.ext_authz.bar.ok: 9

--- a/envoy/tests/legacy/common.py
+++ b/envoy/tests/legacy/common.py
@@ -31,3 +31,11 @@ INSTANCES = {
     },
 }
 ENVOY_VERSION = os.getenv('ENVOY_VERSION')
+
+EXT_METRICS = [
+        "envoy.cluster.ext_authz.denied",
+        "envoy.cluster.ext_authz.disabled",
+        "envoy.cluster.ext_authz.error",
+        "envoy.cluster.ext_authz.failure_mode_allowed",
+        "envoy.cluster.ext_authz.ok",
+]

--- a/envoy/tests/legacy/common.py
+++ b/envoy/tests/legacy/common.py
@@ -33,9 +33,9 @@ INSTANCES = {
 ENVOY_VERSION = os.getenv('ENVOY_VERSION')
 
 EXT_METRICS = [
-        "envoy.cluster.ext_authz.denied",
-        "envoy.cluster.ext_authz.disabled",
-        "envoy.cluster.ext_authz.error",
-        "envoy.cluster.ext_authz.failure_mode_allowed",
-        "envoy.cluster.ext_authz.ok",
+    "envoy.cluster.ext_authz.denied",
+    "envoy.cluster.ext_authz.disabled",
+    "envoy.cluster.ext_authz.error",
+    "envoy.cluster.ext_authz.failure_mode_allowed",
+    "envoy.cluster.ext_authz.ok",
 ]

--- a/envoy/tests/legacy/test_envoy.py
+++ b/envoy/tests/legacy/test_envoy.py
@@ -22,12 +22,13 @@ def test_success(aggregator, check, dd_run_check):
     instance = INSTANCES['main']
     c = check(instance)
     dd_run_check(c)
+    metrics = METRICS - EXT_METRICS
 
     metrics_collected = 0
-    for metric in METRICS:
+    for metric in metrics:
         collected_metrics = aggregator.metrics(METRIC_PREFIX + metric)
         if collected_metrics:
-            expected_tags = [t for t in METRICS[metric]['tags'] if t]
+            expected_tags = [t for t in metrics[metric]['tags'] if t]
             for tag_set in expected_tags:
                 assert all(
                     all(any(tag in mt for mt in m.tags) for tag in tag_set) for m in collected_metrics if m.tags

--- a/envoy/tests/legacy/test_envoy.py
+++ b/envoy/tests/legacy/test_envoy.py
@@ -271,3 +271,21 @@ def test_metadata_integration(datadog_agent, check):
 
     datadog_agent.assert_metadata('test:123', version_metadata)
     datadog_agent.assert_metadata_count(len(version_metadata))
+
+
+@pytest.mark.unit
+def test_stats_prefix_ext_auth(aggregator, fixture_path, mock_http_response, check, dd_run_check):
+    metrics = [
+        "envoy.cluster.ext_authz.denied",
+        "envoy.cluster.ext_authz.error",
+        "envoy.cluster.ext_authz.ok",
+    ]
+    instance = INSTANCES['main']
+    c = check(instance)
+
+    mock_http_response(file_path=fixture_path('stat_prefix')).return_value
+    dd_run_check(c)
+
+    for metric in metrics:
+        aggregator.assert_metric_has_tag_prefix(metric, "stat_prefix", at_least=1)
+        aggregator.assert_metric(metric, count=2)

--- a/envoy/tests/legacy/test_envoy.py
+++ b/envoy/tests/legacy/test_envoy.py
@@ -26,7 +26,8 @@ def test_success(aggregator, check, dd_run_check):
     metrics_collected = 0
     for metric in METRICS:
         collected_metrics = aggregator.metrics(METRIC_PREFIX + metric)
-        # The ext_auth metrics are excluded because the stats_prefix is not always present. They're tested in a different test.
+        # The ext_auth metrics are excluded because the stats_prefix is not always present.
+        # They're tested in a different test.
         if collected_metrics and collected_metrics[0].name not in EXT_METRICS:
             expected_tags = [t for t in METRICS[metric]['tags'] if t]
             for tag_set in expected_tags:

--- a/envoy/tests/legacy/test_envoy.py
+++ b/envoy/tests/legacy/test_envoy.py
@@ -22,13 +22,12 @@ def test_success(aggregator, check, dd_run_check):
     instance = INSTANCES['main']
     c = check(instance)
     dd_run_check(c)
-    metrics = METRICS - EXT_METRICS
 
     metrics_collected = 0
-    for metric in metrics:
+    for metric in METRICS:
         collected_metrics = aggregator.metrics(METRIC_PREFIX + metric)
-        if collected_metrics:
-            expected_tags = [t for t in metrics[metric]['tags'] if t]
+        if collected_metrics and collected_metrics[0].name not in EXT_METRICS:
+            expected_tags = [t for t in METRICS[metric]['tags'] if t]
             for tag_set in expected_tags:
                 assert all(
                     all(any(tag in mt for mt in m.tags) for tag in tag_set) for m in collected_metrics if m.tags
@@ -280,7 +279,6 @@ def test_stats_prefix_ext_auth(aggregator, fixture_path, mock_http_response, che
     tags = ['cluster_name:foo', 'envoy_cluster:foo']
     tags_prefix = tags + ['stat_prefix:bar']
     c = check(instance)
-
     mock_http_response(file_path=fixture_path('stat_prefix')).return_value
     dd_run_check(c)
 

--- a/envoy/tests/legacy/test_envoy.py
+++ b/envoy/tests/legacy/test_envoy.py
@@ -26,6 +26,7 @@ def test_success(aggregator, check, dd_run_check):
     metrics_collected = 0
     for metric in METRICS:
         collected_metrics = aggregator.metrics(METRIC_PREFIX + metric)
+        # The ext_auth metrics are excluded because the stats_prefix is not always present. They're tested in a different test.
         if collected_metrics and collected_metrics[0].name not in EXT_METRICS:
             expected_tags = [t for t in METRICS[metric]['tags'] if t]
             for tag_set in expected_tags:

--- a/envoy/tests/legacy/test_envoy.py
+++ b/envoy/tests/legacy/test_envoy.py
@@ -11,7 +11,7 @@ from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.envoy import Envoy
 from datadog_checks.envoy.metrics import METRIC_PREFIX, METRICS
 
-from .common import ENVOY_VERSION, FLAVOR, HOST, INSTANCES, EXT_METRICS
+from .common import ENVOY_VERSION, EXT_METRICS, FLAVOR, HOST, INSTANCES
 
 CHECK_NAME = 'envoy'
 
@@ -281,5 +281,11 @@ def test_stats_prefix_ext_auth(aggregator, fixture_path, mock_http_response, che
     mock_http_response(file_path=fixture_path('stat_prefix')).return_value
     dd_run_check(c)
     for metric in EXT_METRICS:
-        aggregator.assert_metric(metric, value=EXT_METRICS.index(metric)+5, tags=['cluster_name:foo', 'envoy_cluster:foo', 'stat_prefix:bar'])
-        aggregator.assert_metric(metric, value=EXT_METRICS.index(metric), tags=['cluster_name:foo', 'envoy_cluster:foo'])
+        aggregator.assert_metric(
+            metric,
+            value=EXT_METRICS.index(metric) + 5,
+            tags=['cluster_name:foo', 'envoy_cluster:foo', 'stat_prefix:bar'],
+        )
+        aggregator.assert_metric(
+            metric, value=EXT_METRICS.index(metric), tags=['cluster_name:foo', 'envoy_cluster:foo']
+        )

--- a/envoy/tests/legacy/test_envoy.py
+++ b/envoy/tests/legacy/test_envoy.py
@@ -287,10 +287,10 @@ def test_stats_prefix_ext_auth(aggregator, fixture_path, mock_http_response, che
     # To ensure that this change didn't break the old behavior, both the value and the tags are asserted.
     # The fixture is created with a specific value and the EXT_METRICS list is done in alphabetical order
     # allowing for value to also be asserted
-    for metric in EXT_METRICS:
+    for index, metric in enumerate(EXT_METRICS):
         aggregator.assert_metric(
             metric,
-            value=EXT_METRICS.index(metric) + 5,
+            value=index + 5,
             tags=tags_prefix,
         )
-        aggregator.assert_metric(metric, value=EXT_METRICS.index(metric), tags=tags)
+        aggregator.assert_metric(metric, value=index, tags=tags)


### PR DESCRIPTION
### What does this PR do?
This adds the logic that allows for ext_auth metrics to have the stat_prefix parsed out of the stats payload. To keep backwards compatibility, the original logic was preserved as well.

### Other notes
Albeit a bit hacky, given this is for the legacy implementation, I've tried to touch as a little of the legacy code as possible. 