### PR TITLE
Ensure Zookeeper command execution in proxy environments

### DIFF
--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -229,7 +229,8 @@ class ZookeeperCheck(AgentCheck):
         chunk_size = 1024
         max_reads = 10000
         buf = StringIO()
-        sock.sendall(ensure_bytes(command + "\n")) # Zookeeper expects a newline character at the end of commands; this ensures proxies don't remove it
+        # Zookeeper expects a newline character at the end of commands, add it to prevent removal by proxies
+        sock.sendall(ensure_bytes(command + "\n"))
         # Read the response into a StringIO buffer
         chunk = ensure_unicode(sock.recv(chunk_size))
         buf.write(chunk)

--- a/zk/datadog_checks/zk/zk.py
+++ b/zk/datadog_checks/zk/zk.py
@@ -229,7 +229,7 @@ class ZookeeperCheck(AgentCheck):
         chunk_size = 1024
         max_reads = 10000
         buf = StringIO()
-        sock.sendall(ensure_bytes(command))
+        sock.sendall(ensure_bytes(command + "\n")) # Zookeeper expects a newline character at the end of commands; this ensures proxies don't remove it
         # Read the response into a StringIO buffer
         chunk = ensure_unicode(sock.recv(chunk_size))
         buf.write(chunk)


### PR DESCRIPTION
### What does this PR do?
This PR adds a newline character (`\n`) to the end of the 4wl commands needed for Zookeeper. It appears as though using an Istio proxy causes them to be dropped, resulting in timeout errors for the check when using an Istio proxy. This change resolves the issue. 

### Motivation
This came out of my investigation of [this issue](https://datadoghq.atlassian.net/browse/CONS-5326), and was previously noted in [this card](https://datadoghq.atlassian.net/browse/AGENT-8853) and [this Github issue](https://github.com/istio/istio/issues/11394). 

### Additional Notes
This bug can be reproduced with the following steps: 
1. Start up `minikube` or `kind cluster`
2. Install Istio on the cluster with the steps [here](https://istio.io/latest/docs/setup/install/helm/).
3. Tag the `default` namespace with `kubectl label namespace default istio-injection=enabled --overwrite`
4. Set up Zookeeper deployment: `kubectl create deployment zookeeper --image=zookeeper`
5. Annotate the Zookeeper deployment with the following command: `kubectl annotate pods zookeeper ad.datadoghq.com/zookeeper.checks="{'zk': {'instances': [{'host':'%%host%%', 'port': '2181'}]}}"`
6. Check the agent and confirm that the error is happening with `kubectl exec -it <AGENT_POD> -- agent status`



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.