### PR TITLE
Prevent postgres activity check from collecting samples of its own connection

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -90,7 +90,7 @@ PG_STAT_ACTIVITY_QUERY = re.sub(
     SELECT {current_time_func} {pg_stat_activity_cols} {pg_blocking_func} FROM {pg_stat_activity_view}
     WHERE
         {backend_type_predicate}
-        (coalesce(TRIM(query), '') != '' AND query_start IS NOT NULL {extra_filters})
+        (coalesce(TRIM(query), '') != '' AND pid != pg_backend_pid() AND query_start IS NOT NULL {extra_filters})
 """,
 ).strip()
 
@@ -100,7 +100,7 @@ PG_ACTIVE_CONNECTIONS_QUERY = re.sub(
     """
     SELECT application_name, state, usename, datname, count(*) as connections
     FROM {pg_stat_activity_view}
-    WHERE client_port IS NOT NULL
+    WHERE pid != pg_backend_pid() AND client_port IS NOT NULL
     {extra_filters}
     GROUP BY application_name, state, usename, datname
 """,


### PR DESCRIPTION
### What does this PR do?

- Stop the postgres activity check from collecting a row matching the connection of the query collecting the samples.

All query executions:
![image](https://user-images.githubusercontent.com/91903666/218888011-d7e36bfe-1a89-4107-af53-91c835e73891.png)

Only query executions matching the word "pg_stat_activity":
![image](https://user-images.githubusercontent.com/91903666/218888025-5cd818b8-5fd3-45a1-8022-584ac3bd0ba5.png)


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.