### PR TITLE
Do not skip last bucket when using 'non_cumulative_histogram_buckets'

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transformers/histogram.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transformers/histogram.py
@@ -122,9 +122,7 @@ def get_histogram(check, metric_name, modifiers, global_options):
                                 hostname=hostname,
                                 flush_first_value=flush_first_value,
                             )
-                        # Skip infinity upper bound as that is otherwise the
-                        # same context as the sample suffixed by `_count`
-                        elif sample_name.endswith('_bucket') and not sample.labels['upper_bound'].endswith('inf'):
+                        elif sample_name.endswith('_bucket'):
                             monotonic_count_method(
                                 bucket_metric,
                                 sample.value,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove condition to skip last bucket when using `non_cumulative_histogram_buckets`. 

The condition on the `histogram` method under this option skipped the last bucke on the assumption
that the value is the same as the `_count` metric. However, this is not the case if the buckets have
been decumulated.


### Motivation
<!-- What inspired you to submit this pull request? -->

Conformance with OpenTelemetry output format for OTLP Histograms.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.
