### PR TITLE
Export name tag as db in pgbouncer.databases.pool_size metric

### DIFF
--- a/pgbouncer/datadog_checks/pgbouncer/metrics.py
+++ b/pgbouncer/datadog_checks/pgbouncer/metrics.py
@@ -55,7 +55,7 @@ POOLS_METRICS = {
 }
 
 DATABASES_METRICS = {
-    'descriptors': [('name', 'name')],
+    'descriptors': [('name', 'name'), ('name', 'db')],
     'metrics': [
         ('pool_size', ('pgbouncer.databases.pool_size', GAUGE)),
         ('max_connections', ('pgbouncer.databases.max_connections', GAUGE)),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We'd like to be able to group by "db" to this metric group so we can further apply formula to the metric output.
pgbouncer.databases.pool_size
Dashboard: https://app.datadoghq.com/dashboard/td4-ncx-knz/dre-pgbouncer?fullscreen_end_ts=1676401054991&fullscreen_paused=false&fullscreen_section=edit&fullscreen_start_ts=1676397454991&fullscreen_widget=8843791473888092&tpl_var_k8s_cluster%5B0%5D=general2&tpl_var_k8s_deployment%5B0%5D=pgbouncer-terminator&from_ts=1676396896798&to_ts=1676400496798&live=true

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.