### PR TITLE
Finish splitting tests for different metrics sources

### DIFF
--- a/rabbitmq/hatch.toml
+++ b/rabbitmq/hatch.toml
@@ -5,18 +5,22 @@ dependencies = [
   "pika==0.13.0",
 ]
 
+# Rabbitmq versions <3.8 must be tested on both PY2 and PY3. All these versions use RabbitMQ's management plugin as the source for data.
 [[envs.default.matrix]]
 python = ["2.7", "3.8"]
-version = ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+version = ["3.5", "3.6", "3.7"]
 
+# Rabbitmq versions 3.8+ introduce the Prometheus plugin. This is the preferred way to collect metrics. We drop PY2 support.
 [[envs.default.matrix]]
 python = ["3.8"]
+version = ["3.8", "3.9", "3.10", "3.11"]
+
+# We still support metrics from management plugin as a legacy option and continue to support PY2 for them as well.
+[[envs.default.matrix]]
+python = ["2.7", "3.8"]
 version = ["3.8", "3.9", "3.10", "3.11"]
 plugin = ["mgmt"]
 
-[[envs.default.matrix]]
-python = ["3.8"]
-version = ["3.8", "3.9", "3.10", "3.11"]
 
 [envs.default.overrides]
 matrix.version.env-vars = "RABBITMQ_VERSION"

--- a/rabbitmq/hatch.toml
+++ b/rabbitmq/hatch.toml
@@ -7,7 +7,12 @@ dependencies = [
 
 [[envs.default.matrix]]
 python = ["2.7", "3.8"]
-version = ["3.5", "3.6", "3.7"]
+version = ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+
+[[envs.default.matrix]]
+python = ["3.8"]
+version = ["3.8", "3.9", "3.10", "3.11"]
+plugin = ["mgmt"]
 
 [[envs.default.matrix]]
 python = ["3.8"]
@@ -15,3 +20,4 @@ version = ["3.8", "3.9", "3.10", "3.11"]
 
 [envs.default.overrides]
 matrix.version.env-vars = "RABBITMQ_VERSION"
+name."-mgmt".env-vars = "METRICS_FROM_MANAGEMENT_PLUGIN=true"

--- a/rabbitmq/tests/common.py
+++ b/rabbitmq/tests/common.py
@@ -13,6 +13,10 @@ ROOT = os.path.dirname(os.path.dirname(HERE))
 
 RABBITMQ_VERSION_RAW = os.environ['RABBITMQ_VERSION']
 RABBITMQ_VERSION = version.parse(RABBITMQ_VERSION_RAW)
+METRICS_FROM_MANAGEMENT_PLUGIN = os.environ.get("METRICS_FROM_MANAGEMENT_PLUGIN", False)
+METRICS_PLUGIN = (
+    "management" if RABBITMQ_VERSION < version.parse("3.8") or METRICS_FROM_MANAGEMENT_PLUGIN else "prometheus"
+)
 
 CHECK_NAME = 'rabbitmq'
 

--- a/rabbitmq/tests/common.py
+++ b/rabbitmq/tests/common.py
@@ -4,6 +4,7 @@
 
 import os
 
+import pytest
 from packaging import version
 
 from datadog_checks.base.utils.common import get_docker_hostname
@@ -13,9 +14,17 @@ ROOT = os.path.dirname(os.path.dirname(HERE))
 
 RABBITMQ_VERSION_RAW = os.environ['RABBITMQ_VERSION']
 RABBITMQ_VERSION = version.parse(RABBITMQ_VERSION_RAW)
-METRICS_FROM_MANAGEMENT_PLUGIN = os.environ.get("METRICS_FROM_MANAGEMENT_PLUGIN", False)
-METRICS_PLUGIN = (
-    "management" if RABBITMQ_VERSION < version.parse("3.8") or METRICS_FROM_MANAGEMENT_PLUGIN else "prometheus"
+RABBITMQ_METRICS_PLUGIN = (
+    "management"
+    if RABBITMQ_VERSION < version.parse("3.8") or os.environ.get("METRICS_FROM_MANAGEMENT_PLUGIN", False)
+    else "prometheus"
+)
+
+requires_management = pytest.mark.skipif(
+    RABBITMQ_METRICS_PLUGIN == "prometheus", reason="Not testing management plugin metrics."
+)
+requires_prometheus = pytest.mark.skipif(
+    RABBITMQ_METRICS_PLUGIN == "management", reason="Not testing prometheus plugin (OpenMetrics) metrics."
 )
 
 CHECK_NAME = 'rabbitmq'

--- a/rabbitmq/tests/conftest.py
+++ b/rabbitmq/tests/conftest.py
@@ -11,7 +11,7 @@ import requests
 from datadog_checks.dev import docker_run, temp_dir
 from datadog_checks.rabbitmq import RabbitMQ
 
-from .common import CHECK_NAME, CONFIG, HERE, HOST, METRICS_PLUGIN, OPENMETRICS_CONFIG, PORT
+from .common import CHECK_NAME, CONFIG, HERE, HOST, OPENMETRICS_CONFIG, PORT, RABBITMQ_METRICS_PLUGIN
 
 
 @pytest.fixture(scope="session")
@@ -33,7 +33,7 @@ def dd_environment():
     with docker_run(
         compose_file, log_patterns='Server startup complete', env_vars=env, conditions=[setup_rabbitmq], sleep=5
     ):
-        if METRICS_PLUGIN == "prometheus":
+        if RABBITMQ_METRICS_PLUGIN == "prometheus":
             yield OPENMETRICS_CONFIG
         else:
             yield CONFIG
@@ -175,5 +175,5 @@ def instance():
 # which still supports Py2, we don't load the test files at all. Docs for how we do it:
 # https://docs.pytest.org/en/7.1.x/example/pythoncollection.html#customizing-test-collection
 collect_ignore_glob = []
-if METRICS_PLUGIN == "management":
+if RABBITMQ_METRICS_PLUGIN == "management":
     collect_ignore_glob.append("*openmetrics*")

--- a/rabbitmq/tests/conftest.py
+++ b/rabbitmq/tests/conftest.py
@@ -7,12 +7,11 @@ import subprocess
 
 import pytest
 import requests
-from packaging import version
 
 from datadog_checks.dev import docker_run, temp_dir
 from datadog_checks.rabbitmq import RabbitMQ
 
-from .common import CHECK_NAME, CONFIG, HERE, HOST, OPENMETRICS_CONFIG, PORT, RABBITMQ_VERSION
+from .common import CHECK_NAME, CONFIG, HERE, HOST, METRICS_PLUGIN, OPENMETRICS_CONFIG, PORT
 
 
 @pytest.fixture(scope="session")
@@ -34,7 +33,7 @@ def dd_environment():
     with docker_run(
         compose_file, log_patterns='Server startup complete', env_vars=env, conditions=[setup_rabbitmq], sleep=5
     ):
-        if RABBITMQ_VERSION >= version.parse("3.8"):
+        if METRICS_PLUGIN == "prometheus":
             yield OPENMETRICS_CONFIG
         else:
             yield CONFIG
@@ -172,9 +171,9 @@ def instance():
     return CONFIG
 
 
-# We don't want to maintain compatibility with Python2 in our OpenMetrics tests.
-# If the rabbitmq version is too old for OpenMetrics support we don't load the test files at all.
-# Docs for how we do it: https://docs.pytest.org/en/7.1.x/example/pythoncollection.html#customizing-test-collection
+# We don't want to maintain compatibility with Py2 in our OpenMetrics tests. If we are testing the management plugin
+# which still supports Py2, we don't load the test files at all. Docs for how we do it:
+# https://docs.pytest.org/en/7.1.x/example/pythoncollection.html#customizing-test-collection
 collect_ignore_glob = []
-if RABBITMQ_VERSION < version.parse("3.8"):
+if METRICS_PLUGIN == "management":
     collect_ignore_glob.append("*openmetrics*")

--- a/rabbitmq/tests/test_e2e.py
+++ b/rabbitmq/tests/test_e2e.py
@@ -8,22 +8,22 @@ import pytest
 
 from datadog_checks.dev.utils import get_metadata_metrics
 
-from .common import CONFIG, METRICS_PLUGIN, OPENMETRICS_CONFIG
+from .common import CONFIG, OPENMETRICS_CONFIG, requires_management, requires_prometheus
 from .metrics import DEFAULT_OPENMETRICS, FLAKY_E2E_METRICS, assert_metric_covered
 
 log = logging.getLogger(__file__)
 
-pytestmark = [pytest.mark.e2e]
+pytestmark = pytest.mark.e2e
 
 
-@pytest.mark.skipif(METRICS_PLUGIN == "prometheus", reason="Not testing management plugin metrics.")
+@requires_management
 def test_rabbitmq_e2e_management(dd_agent_check):
     aggregator = dd_agent_check(CONFIG)
     assert_metric_covered(aggregator)
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
-@pytest.mark.skipif(METRICS_PLUGIN == "management", reason="Not testing prometheus plugin (OpenMetrics) metrics.")
+@requires_prometheus
 def test_rabbitmq_e2e_openmetrics(dd_agent_check):
     aggregator = dd_agent_check(OPENMETRICS_CONFIG, rate=True)
     metadata_metrics = get_metadata_metrics()

--- a/rabbitmq/tests/test_e2e.py
+++ b/rabbitmq/tests/test_e2e.py
@@ -5,11 +5,10 @@
 import logging
 
 import pytest
-from packaging import version
 
 from datadog_checks.dev.utils import get_metadata_metrics
 
-from .common import CONFIG, OPENMETRICS_CONFIG, RABBITMQ_VERSION
+from .common import CONFIG, METRICS_PLUGIN, OPENMETRICS_CONFIG
 from .metrics import DEFAULT_OPENMETRICS, FLAKY_E2E_METRICS, assert_metric_covered
 
 log = logging.getLogger(__file__)
@@ -17,16 +16,14 @@ log = logging.getLogger(__file__)
 pytestmark = [pytest.mark.e2e]
 
 
-@pytest.mark.skipif(RABBITMQ_VERSION >= version.parse("3.8"), reason="Test legacy check on rabbitmq versions < 3.8")
-def test_rabbitmq_e2e(dd_agent_check):
+@pytest.mark.skipif(METRICS_PLUGIN == "prometheus", reason="Not testing management plugin metrics.")
+def test_rabbitmq_e2e_management(dd_agent_check):
     aggregator = dd_agent_check(CONFIG)
     assert_metric_covered(aggregator)
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
-@pytest.mark.skipif(
-    RABBITMQ_VERSION < version.parse("3.8"), reason="Test openmetrics check only on rabbitmq versions >= 3.8"
-)
+@pytest.mark.skipif(METRICS_PLUGIN == "management", reason="Not testing prometheus plugin (OpenMetrics) metrics.")
 def test_rabbitmq_e2e_openmetrics(dd_agent_check):
     aggregator = dd_agent_check(OPENMETRICS_CONFIG, rate=True)
     metadata_metrics = get_metadata_metrics()

--- a/rabbitmq/tests/test_integration.py
+++ b/rabbitmq/tests/test_integration.py
@@ -19,6 +19,7 @@ from .common import (
     CONFIG_WITH_FAMILY,
     CONFIG_WITH_FAMILY_NAMED_GROUP,
     HOST,
+    METRICS_PLUGIN,
 )
 from .metrics import (
     COMMON_METRICS,
@@ -31,7 +32,11 @@ from .metrics import (
 
 log = logging.getLogger(__file__)
 
-pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures('dd_environment'),
+    pytest.mark.skipif(METRICS_PLUGIN == "prometheus", reason="Not testing management plugin metrics."),
+]
 
 
 def test_rabbitmq(aggregator, check):

--- a/rabbitmq/tests/test_integration.py
+++ b/rabbitmq/tests/test_integration.py
@@ -19,7 +19,7 @@ from .common import (
     CONFIG_WITH_FAMILY,
     CONFIG_WITH_FAMILY_NAMED_GROUP,
     HOST,
-    METRICS_PLUGIN,
+    requires_management,
 )
 from .metrics import (
     COMMON_METRICS,
@@ -32,11 +32,7 @@ from .metrics import (
 
 log = logging.getLogger(__file__)
 
-pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.usefixtures('dd_environment'),
-    pytest.mark.skipif(METRICS_PLUGIN == "prometheus", reason="Not testing management plugin metrics."),
-]
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment'), requires_management]
 
 
 def test_rabbitmq(aggregator, check):

--- a/rabbitmq/tests/test_unit.py
+++ b/rabbitmq/tests/test_unit.py
@@ -13,13 +13,9 @@ from datadog_checks.rabbitmq.rabbitmq import EXCHANGE_TYPE, NODE_TYPE, OVERVIEW_
 
 from . import common, metrics
 
-pytestmark = [
-    pytest.mark.unit,
-    pytest.mark.skipif(common.METRICS_PLUGIN == "prometheus", reason="Not testing management plugin metrics."),
-]
+pytestmark = [pytest.mark.unit, common.requires_management]
 
 
-@pytest.mark.unit
 def test__get_data(check):
     with mock.patch('datadog_checks.base.utils.http.requests') as r:
         r.get.side_effect = [requests.exceptions.HTTPError, ValueError]
@@ -31,7 +27,6 @@ def test__get_data(check):
             assert isinstance(e, RabbitMQException)
 
 
-@pytest.mark.unit
 def test_status_check(check, aggregator):
     check.check({"rabbitmq_api_url": "http://example.com"})
     assert len(aggregator._service_checks) == 1
@@ -69,7 +64,6 @@ def test_status_check(check, aggregator):
     assert sc.status == RabbitMQ.OK
 
 
-@pytest.mark.unit
 def test__check_aliveness(check, aggregator):
     instance = {"rabbitmq_api_url": "http://example.com"}
     check._get_data = mock.MagicMock()
@@ -89,7 +83,6 @@ def test__check_aliveness(check, aggregator):
         assert isinstance(e, RabbitMQException)
 
 
-@pytest.mark.unit
 def test__get_metrics(check, aggregator):
     data = {'fd_used': 3.14, 'disk_free': 4242, 'mem_used': 9000}
 
@@ -97,7 +90,6 @@ def test__get_metrics(check, aggregator):
     assert check._get_metrics({}, NODE_TYPE, []) == 0
 
 
-@pytest.mark.unit
 def test__get_metrics_3_1(check, aggregator):
     data = {'queue_totals': []}
 
@@ -105,7 +97,6 @@ def test__get_metrics_3_1(check, aggregator):
     assert metrics == 0
 
 
-@pytest.mark.unit
 @mock.patch.object(datadog_checks.rabbitmq.rabbitmq.RabbitMQManagement, '_get_object_data')
 def test_get_stats_empty_exchanges(mock__get_object_data, instance, check, aggregator):
     data = [
@@ -158,7 +149,6 @@ def test_config(check, test_case, extra_config, expected_http_kwargs):
         r.get.assert_called_with('http://localhost:15672/api/connections', **http_wargs)
 
 
-@pytest.mark.unit
 def test_nodes(aggregator, check):
 
     # default, node metrics are collected
@@ -171,7 +161,6 @@ def test_nodes(aggregator, check):
     aggregator.reset()
 
 
-@pytest.mark.unit
 def test_disable_nodes(aggregator, check):
 
     # node metrics collection disabled in config, node metrics should not appear

--- a/rabbitmq/tests/test_unit.py
+++ b/rabbitmq/tests/test_unit.py
@@ -13,7 +13,10 @@ from datadog_checks.rabbitmq.rabbitmq import EXCHANGE_TYPE, NODE_TYPE, OVERVIEW_
 
 from . import common, metrics
 
-pytestmark = pytest.mark.unit
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.skipif(common.METRICS_PLUGIN == "prometheus", reason="Not testing management plugin metrics."),
+]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Management and prometheus (openmetrics) plugin tests are completely separate now.

### Motivation
<!-- What inspired you to submit this pull request? -->

Paying down tech debt :)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.