### PR TITLE
Use `count` instead of `monotonic_count` for counters

### DIFF
--- a/ibm_ace/datadog_checks/ibm_ace/flows.py
+++ b/ibm_ace/datadog_checks/ibm_ace/flows.py
@@ -8,7 +8,7 @@ from datadog_checks.base.utils.constants import MICROSECOND
 class Statistics:
     NAME: str
     GAUGES = set()
-    MONOTONIC_COUNTS = set()
+    COUNTS = set()
     TEMPORAL_PERCENTS = {}
 
     def full_metric_name(self, metric):
@@ -18,8 +18,8 @@ class Statistics:
         for metric, value in data.items():
             if metric in self.GAUGES:
                 check.gauge(self.full_metric_name(metric), value, tags=tags)
-            elif metric in self.MONOTONIC_COUNTS:
-                check.monotonic_count(self.full_metric_name(metric), value, tags=tags)
+            elif metric in self.COUNTS:
+                check.count(self.full_metric_name(metric), value, tags=tags)
             elif metric in self.TEMPORAL_PERCENTS:
                 metric_data = self.TEMPORAL_PERCENTS[metric]
                 check.rate(
@@ -40,7 +40,7 @@ class MessageFlowStatistics(Statistics):
         'MinimumSizeOfInputMessages',
         'NumberOfThreadsInPool',
     ]
-    MONOTONIC_COUNTS = [
+    COUNTS = [
         'TimesMaximumNumberOfThreadsReached',
         'TotalInputMessages',
         'TotalNumberOfBackouts',

--- a/ibm_ace/datadog_checks/ibm_ace/resources.py
+++ b/ibm_ace/datadog_checks/ibm_ace/resources.py
@@ -26,7 +26,7 @@ class Resource:
     def submit(self, check, metric, value, tags):
         # Most metrics seem to be counters:
         # https://www.ibm.com/docs/en/app-connect/12.0?topic=performance-resource-statistics-data
-        check.monotonic_count(self.full_metric_name(metric), value, tags=tags)
+        check.count(self.full_metric_name(metric), value, tags=tags)
 
 
 class ConnectDirectResource(Resource):


### PR DESCRIPTION
### What does this PR do?

It replaces all calls to `monotonic_count` with calls to `count`.

### Motivation

A support case reporting discrepancies between what the IBM ACE UI says and what Datadog reports.

The official docs are not explicit about what the reported counts are, but the fact that they come with interval timestamps seems to imply that they're counts applying only to specific intervals. I confirmed this for `ibm_ace.MessageFlow.TotalInputMessages`, which was the relevant metric on the support case.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.