### PR TITLE
Added required Agent version

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -11,6 +11,8 @@ This check monitors [Argo CD][1] through the Datadog Agent.
 The Argo CD check is included in the [Datadog Agent][2] package.
 No additional installation is needed on your server.
 
+**Note**: This check requires requires Agent version 7.42.0 or above.
+
 ### Configuration
 
 Argo CD exposes Prometheus-formatted metrics on three of their components:

--- a/argocd/README.md
+++ b/argocd/README.md
@@ -11,7 +11,7 @@ This check monitors [Argo CD][1] through the Datadog Agent.
 The Argo CD check is included in the [Datadog Agent][2] package.
 No additional installation is needed on your server.
 
-**Note**: This check requires requires Agent version 7.42.0 or above.
+**Note**: This check requires Agent v7.42.0+.
 
 ### Configuration
 


### PR DESCRIPTION
The Argo CD integration requires Agent version 7.42.0 and above in order to run. We could avoid support tickets created to troubleshoot this if it is made explicit in the docs.

### What does this PR do?
Explicitly indicates the required Agent version for the Argo CD check.

### Motivation
Zendesk ticket [1098161](https://datadog.zendesk.com/agent/tickets/1098161).
Customer's Argo CD check was throwing an error and it was resolved by updating to 7.42.0. They suggested adding this to the doc to avoid the need to create a support ticket.

### Additional Notes
Here is the [integrations-core changelog](https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-7420) showing that Argo CD was first introduced as an integration with version 7.42.0
Note that this is currently the only mention of Argo CD in all versions

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.