### PR TITLE
Remove KafkaClient and refactor tests

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -1,26 +1,11 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-import ssl
 
-from kafka import KafkaAdminClient, KafkaClient
-from kafka.oauth.abstract import AbstractTokenProvider
-from six import string_types
-
-from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
-from datadog_checks.base.utils.http import AuthTokenOAuthReader
+from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.kafka_consumer.client.kafka_client_factory import make_client
 
-from .constants import BROKER_REQUESTS_BATCH_SIZE, CONTEXT_UPPER_BOUND, DEFAULT_KAFKA_TIMEOUT
-
-
-class OAuthTokenProvider(AbstractTokenProvider):
-    def __init__(self, **config):
-        self.reader = AuthTokenOAuthReader(config)
-
-    def token(self):
-        # Read only if necessary or use cached token
-        return self.reader.read() or self.reader._token
+from .constants import BROKER_REQUESTS_BATCH_SIZE, CONTEXT_UPPER_BOUND
 
 
 class KafkaCheck(AgentCheck):
@@ -48,70 +33,12 @@ class KafkaCheck(AgentCheck):
         )
         self._consumer_groups = self.instance.get('consumer_groups', {})
         self._broker_requests_batch_size = self.instance.get('broker_requests_batch_size', BROKER_REQUESTS_BATCH_SIZE)
-        self.client = None
-
-    def create_kafka_client(self):
-        return self._create_kafka_client(clazz=KafkaClient)
-
-    def create_kafka_admin_client(self):
-        return self._create_kafka_client(clazz=KafkaAdminClient)
-
-    def _create_kafka_client(self, clazz):
-        kafka_connect_str = self.instance.get('kafka_connect_str')
-        if not isinstance(kafka_connect_str, (string_types, list)):
-            raise ConfigurationError('kafka_connect_str should be string or list of strings')
-        kafka_version = self.instance.get('kafka_client_api_version')
-        if isinstance(kafka_version, str):
-            kafka_version = tuple(map(int, kafka_version.split(".")))
-
-        tls_context = self.get_tls_context()
-        crlfile = self.instance.get('ssl_crlfile', self.instance.get('tls_crlfile'))
-        if crlfile:
-            tls_context.load_verify_locations(crlfile)
-            tls_context.verify_flags |= ssl.VERIFY_CRL_CHECK_LEAF
-
-        return clazz(
-            bootstrap_servers=kafka_connect_str,
-            client_id='dd-agent',
-            request_timeout_ms=self.init_config.get('kafka_timeout', DEFAULT_KAFKA_TIMEOUT) * 1000,
-            # if `kafka_client_api_version` is not set, then kafka-python automatically probes the cluster for
-            # broker version during the bootstrapping process. Note that this returns the first version found, so in
-            # a mixed-version cluster this will be a non-deterministic result.
-            api_version=kafka_version,
-            # While we check for SASL/SSL params, if not present they will default to the kafka-python values for
-            # plaintext connections
-            security_protocol=self.instance.get('security_protocol', 'PLAINTEXT'),
-            sasl_mechanism=self.instance.get('sasl_mechanism'),
-            sasl_plain_username=self.instance.get('sasl_plain_username'),
-            sasl_plain_password=self.instance.get('sasl_plain_password'),
-            sasl_kerberos_service_name=self.instance.get('sasl_kerberos_service_name', 'kafka'),
-            sasl_kerberos_domain_name=self.instance.get('sasl_kerberos_domain_name'),
-            sasl_oauth_token_provider=(
-                OAuthTokenProvider(**self.instance['sasl_oauth_token_provider'])
-                if 'sasl_oauth_token_provider' in self.instance
-                else None
-            ),
-            ssl_context=tls_context,
-        )
-
-    @property
-    def kafka_client(self):
-        if self._kafka_client is None:
-            # if `kafka_client_api_version` is not set, then kafka-python automatically probes the cluster for
-            # broker version during the bootstrapping process. Note that this returns the first version found, so in
-            # a mixed-version cluster this will be a non-deterministic result.
-            kafka_version = self.instance.get('kafka_client_api_version')
-            if isinstance(kafka_version, str):
-                kafka_version = tuple(map(int, kafka_version.split(".")))
-
-            self._kafka_client = self._create_kafka_admin_client(api_version=kafka_version)
-        return self._kafka_client
+        self.client = make_client(self)
 
     def check(self, _):
         """The main entrypoint of the check."""
         self._consumer_offsets = {}  # Expected format: {(consumer_group, topic, partition): offset}
         self._highwater_offsets = {}  # Expected format: {(topic, partition): offset}
-        self.client = make_client(self)
 
         # Fetch Kafka consumer offsets
         try:
@@ -151,19 +78,6 @@ class KafkaCheck(AgentCheck):
     def collect_broker_metadata(self):
         self.client.collect_broker_metadata()
 
-    def _create_kafka_admin_client(self, api_version):
-        """Return a KafkaAdminClient."""
-        # TODO accept None (which inherits kafka-python default of localhost:9092)
-        kafka_admin_client = self.create_kafka_admin_client()
-        self.log.debug("KafkaAdminClient api_version: %s", kafka_admin_client.config['api_version'])
-        # Force initial population of the local cluster metadata cache
-        kafka_admin_client._client.poll(future=kafka_admin_client._client.cluster.request_update())
-        if kafka_admin_client._client.cluster.topics(exclude_internal_topics=False) is None:
-            raise RuntimeError("Local cluster metadata cache did not populate.")
-        return kafka_admin_client
-
     # TODO: Remove me once the tests are refactored
     def send_event(self, title, text, tags, event_type, aggregation_key, severity='info'):
-        if self.client is None:
-            self.client = make_client(self)
         self.client._send_event(title, text, tags, event_type, aggregation_key, severity='info')

--- a/kafka_consumer/tests/test_kafka_consumer.py
+++ b/kafka_consumer/tests/test_kafka_consumer.py
@@ -9,7 +9,7 @@ import pytest
 
 from datadog_checks.base import ConfigurationError
 from datadog_checks.kafka_consumer import KafkaCheck
-from datadog_checks.kafka_consumer.kafka_consumer import OAuthTokenProvider
+from datadog_checks.kafka_consumer.client.kafka_python_client import OAuthTokenProvider
 
 from .common import BROKER_METRICS, CONSUMER_METRICS, KAFKA_CONNECT_STR
 
@@ -34,22 +34,22 @@ def test_gssapi(kafka_instance, dd_run_check):
 @pytest.mark.unit
 def test_tls_config_ok(kafka_instance_tls):
     with mock.patch('datadog_checks.base.utils.tls.ssl') as ssl:
-        with mock.patch('kafka.KafkaClient') as kafka_client:
+        with mock.patch('kafka.KafkaAdminClient') as kafka_admin_client:
 
             # mock Kafka Client
-            kafka_client.return_value = mock.MagicMock()
+            kafka_admin_client.return_value = mock.MagicMock()
 
             # mock TLS context
             tls_context = mock.MagicMock()
             ssl.SSLContext.return_value = tls_context
 
             kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance_tls])
-            kafka_consumer_check._create_kafka_client(clazz=kafka_client)
+            kafka_consumer_check.client._create_kafka_client(clazz=kafka_admin_client)
 
             assert tls_context.check_hostname is True
             assert tls_context.tls_cert is not None
             assert tls_context.check_hostname is True
-            assert kafka_consumer_check.create_kafka_client is not None
+            assert kafka_consumer_check.client.create_kafka_admin_client is not None
 
 
 @pytest.mark.parametrize(
@@ -108,15 +108,17 @@ def test_oauth_token_client_config(kafka_instance):
         "client_secret": "secret",
     }
 
-    kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [instance])
-    client = kafka_consumer_check.create_kafka_client()
+    with mock.patch('kafka.KafkaAdminClient') as kafka_admin_client:
+        kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [instance])
+        _ = kafka_consumer_check.client._create_kafka_client(clazz=kafka_admin_client)
+        params = kafka_admin_client.call_args_list[0].kwargs
 
-    assert client.config['security_protocol'] == 'SASL_PLAINTEXT'
-    assert client.config['sasl_mechanism'] == 'OAUTHBEARER'
-    assert isinstance(client.config['sasl_oauth_token_provider'], OAuthTokenProvider)
-    assert client.config['sasl_oauth_token_provider'].reader._client_id == "id"
-    assert client.config['sasl_oauth_token_provider'].reader._client_secret == "secret"
-    assert client.config['sasl_oauth_token_provider'].reader._url == "http://fake.url"
+        assert params['security_protocol'] == 'SASL_PLAINTEXT'
+        assert params['sasl_mechanism'] == 'OAUTHBEARER'
+        assert params['sasl_oauth_token_provider'].reader._client_id == "id"
+        assert params['sasl_oauth_token_provider'].reader._client_secret == "secret"
+        assert params['sasl_oauth_token_provider'].reader._url == "http://fake.url"
+        assert isinstance(params['sasl_oauth_token_provider'], OAuthTokenProvider)
 
 
 @pytest.mark.parametrize(
@@ -222,8 +224,8 @@ def test_version_metadata(datadog_agent, kafka_instance, dd_run_check):
     kafka_consumer_check = KafkaCheck('kafka_consumer', {}, [kafka_instance])
     kafka_consumer_check.check_id = 'test:123'
 
-    kafka_client = kafka_consumer_check.create_kafka_client()
-    version_data = [str(part) for part in kafka_client.check_version()]
+    kafka_client = kafka_consumer_check.client.create_kafka_admin_client()
+    version_data = [str(part) for part in kafka_client._client.check_version()]
     kafka_client.close()
     version_parts = {'version.{}'.format(name): part for name, part in zip(('major', 'minor', 'patch'), version_data)}
     version_parts['version.scheme'] = 'semver'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR removes `kafka_python.KafkaClient` from being used in the check and also fixes the tests to use `kafka_python.KafkaAdminClient` instead.

### Motivation
<!-- What inspired you to submit this pull request? -->
Removing legacy code as part of revamp

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.