### PR TITLE
Pass in config to client

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client_factory.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client_factory.py
@@ -2,5 +2,5 @@ from datadog_checks.kafka_consumer.client.kafka_client import KafkaClient
 from datadog_checks.kafka_consumer.client.kafka_python_client import KafkaPythonClient
 
 
-def make_client(check) -> KafkaClient:
-    return KafkaPythonClient(check)
+def make_client(check, config) -> KafkaClient:
+    return KafkaPythonClient(check, config)

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
@@ -30,8 +30,9 @@ class OAuthTokenProvider(AbstractTokenProvider):
 
 
 class KafkaPythonClient(KafkaClient):
-    def __init__(self, check) -> None:
+    def __init__(self, check, config) -> None:
         self.check = check
+        self.config = config
         self.log = check.log
         self._kafka_client = None
         self._highwater_offsets = {}

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -5,10 +5,11 @@
 from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.kafka_consumer.client.kafka_client_factory import make_client
 
+from .config_models import ConfigMixin
 from .constants import BROKER_REQUESTS_BATCH_SIZE, CONTEXT_UPPER_BOUND
 
 
-class KafkaCheck(AgentCheck):
+class KafkaCheck(AgentCheck, ConfigMixin):
 
     __NAMESPACE__ = 'kafka'
 
@@ -33,7 +34,7 @@ class KafkaCheck(AgentCheck):
         )
         self._consumer_groups = self.instance.get('consumer_groups', {})
         self._broker_requests_batch_size = self.instance.get('broker_requests_batch_size', BROKER_REQUESTS_BATCH_SIZE)
-        self.client = make_client(self)
+        self.client = make_client(self, self.config)
 
     def check(self, _):
         """The main entrypoint of the check."""


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR passes in the `config` object into the client class so that `self.check` can eventually be removed from it.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.