### PR TITLE
Switch count method to monotonic count, that's correct for OM counts

### DIFF
--- a/amazon_msk/datadog_checks/amazon_msk/check.py
+++ b/amazon_msk/datadog_checks/amazon_msk/check.py
@@ -136,7 +136,7 @@ class AmazonMskCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
 
     def _submit_both_gauge_and_count(self, name, value, tags, hostname):
         self.gauge(name, value, tags=tags, hostname=hostname)
-        self.count(name + ".count", value, tags=tags, hostname=hostname)
+        self.monotonic_count(name + ".count", value, tags=tags, hostname=hostname)
 
     def configure_additional_transformers(self, transformer_data):
         for metric, data in METRICS_WITH_NAME_AS_LABEL.items():


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This is a fix for a [previous fix](https://github.com/DataDog/integrations-core/pull/13886) given that I learned the difference between `count` and `monotonic_count` methods 🙈 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.