### PR TITLE
Move metric reporting back into main check

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/client/confluent_kafka_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/confluent_kafka_client.py
@@ -10,6 +10,3 @@ class ConfluentKafkaClient:
 
     def get_broker_offset(self):
         pass
-
-    def collect_broker_metadata(self):
-        pass

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/confluent_kafka_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/confluent_kafka_client.py
@@ -11,11 +11,5 @@ class ConfluentKafkaClient:
     def get_broker_offset(self):
         pass
 
-    def report_consumer_offset_and_lag(self):
-        pass
-
-    def report_broker_offset(self):
-        pass
-
     def collect_broker_metadata(self):
         pass

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client.py
@@ -25,13 +25,5 @@ class KafkaClient(ABC):
         pass
 
     @abstractmethod
-    def report_consumer_offsets_and_lag(self):
-        pass
-
-    @abstractmethod
-    def report_highwater_offsets(self):
-        pass
-
-    @abstractmethod
     def collect_broker_metadata(self):
         pass

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client.py
@@ -23,7 +23,3 @@ class KafkaClient(ABC):
     @abstractmethod
     def get_highwater_offsets(self):
         pass
-
-    @abstractmethod
-    def collect_broker_metadata(self):
-        pass

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
@@ -216,13 +216,8 @@ class KafkaPythonClient(KafkaClient):
             self._kafka_client = self._create_kafka_admin_client(api_version=kafka_version)
         return self._kafka_client
 
-    def collect_broker_metadata(self):
-        version_data = [str(part) for part in self.kafka_client._client.check_version()]
-        version_parts = {name: part for name, part in zip(('major', 'minor', 'patch'), version_data)}
-
-        self.check.set_metadata(
-            'version', '.'.join(version_data), scheme='parts', final_scheme='semver', part_map=version_parts
-        )
+    def collect_broker_version(self):
+        return self.kafka_client._client.check_version()
 
     def _highwater_offsets_callback(self, response):
         """Callback that parses an OffsetFetchResponse and saves it to the highwater_offsets dict."""

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
@@ -3,7 +3,6 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import ssl
 from collections import defaultdict
-from time import time
 
 from kafka import KafkaAdminClient
 from kafka import errors as kafka_errors
@@ -87,69 +86,6 @@ class KafkaPythonClient(KafkaClient):
         self.kafka_client._wait_for_futures(self._consumer_futures)
         del self._consumer_futures  # since it's reset on every check run, no sense holding the reference between runs
 
-    def report_consumer_offsets_and_lag(self, contexts_limit):
-        """Report the consumer offsets and consumer lag."""
-        reported_contexts = 0
-        self.log.debug("Reporting consumer offsets and lag metrics")
-        for (consumer_group, topic, partition), consumer_offset in self._consumer_offsets.items():
-            if reported_contexts >= contexts_limit:
-                self.log.debug(
-                    "Reported contexts number %s greater than or equal to contexts limit of %s, returning",
-                    str(reported_contexts),
-                    str(contexts_limit),
-                )
-                return
-            consumer_group_tags = ['topic:%s' % topic, 'partition:%s' % partition, 'consumer_group:%s' % consumer_group]
-            consumer_group_tags.extend(self.check._custom_tags)
-
-            partitions = self.kafka_client._client.cluster.partitions_for_topic(topic)
-            self.log.debug("Received partitions %s for topic %s", partitions, topic)
-            if partitions is not None and partition in partitions:
-                # report consumer offset if the partition is valid because even if leaderless the consumer offset will
-                # be valid once the leader failover completes
-                self.check.gauge('consumer_offset', consumer_offset, tags=consumer_group_tags)
-                reported_contexts += 1
-
-                if (topic, partition) not in self._highwater_offsets:
-                    self.log.warning(
-                        "Consumer group: %s has offsets for topic: %s partition: %s, but no stored highwater offset "
-                        "(likely the partition is in the middle of leader failover) so cannot calculate consumer lag.",
-                        consumer_group,
-                        topic,
-                        partition,
-                    )
-                    continue
-                producer_offset = self._highwater_offsets[(topic, partition)]
-                consumer_lag = producer_offset - consumer_offset
-                if reported_contexts < contexts_limit:
-                    self.check.gauge('consumer_lag', consumer_lag, tags=consumer_group_tags)
-                    reported_contexts += 1
-
-                if consumer_lag < 0:
-                    # this will effectively result in data loss, so emit an event for max visibility
-                    title = "Negative consumer lag for group: {}.".format(consumer_group)
-                    message = (
-                        "Consumer group: {}, topic: {}, partition: {} has negative consumer lag. This should never "
-                        "happen and will result in the consumer skipping new messages until the lag turns "
-                        "positive.".format(consumer_group, topic, partition)
-                    )
-                    key = "{}:{}:{}".format(consumer_group, topic, partition)
-                    self._send_event(title, message, consumer_group_tags, 'consumer_lag', key, severity="error")
-                    self.log.debug(message)
-            else:
-                if partitions is None:
-                    msg = (
-                        "Consumer group: %s has offsets for topic: %s, partition: %s, but that topic has no partitions "
-                        "in the cluster, so skipping reporting these offsets."
-                    )
-                else:
-                    msg = (
-                        "Consumer group: %s has offsets for topic: %s, partition: %s, but that topic partition isn't "
-                        "included in the cluster partitions, so skipping reporting these offsets."
-                    )
-                self.log.warning(msg, consumer_group, topic, partition)
-                self.kafka_client._client.cluster.request_update()  # force metadata update on next poll()
-
     def get_highwater_offsets(self):
         """Fetch highwater offsets for topic_partitions in the Kafka cluster.
 
@@ -214,18 +150,6 @@ class KafkaPythonClient(KafkaClient):
 
             # Loop until all futures resolved.
             self.kafka_client._wait_for_futures(highwater_futures)
-
-    def report_highwater_offsets(self, contexts_limit):
-        """Report the broker highwater offsets."""
-        reported_contexts = 0
-        self.log.debug("Reporting broker offset metric")
-        for (topic, partition), highwater_offset in self._highwater_offsets.items():
-            broker_tags = ['topic:%s' % topic, 'partition:%s' % partition]
-            broker_tags.extend(self.check._custom_tags)
-            self.check.gauge('broker_offset', highwater_offset, tags=broker_tags)
-            reported_contexts += 1
-            if reported_contexts == contexts_limit:
-                return
 
     def create_kafka_admin_client(self):
         return self._create_kafka_client(clazz=KafkaAdminClient)
@@ -485,15 +409,14 @@ class KafkaPythonClient(KafkaClient):
             )
         return self._send_request_to_node(group_coordinator_id, request, wakeup=False)
 
-    def _send_event(self, title, text, tags, event_type, aggregation_key, severity='info'):
-        """Emit an event to the Datadog Event Stream."""
-        event_dict = {
-            'timestamp': int(time()),
-            'msg_title': title,
-            'event_type': event_type,
-            'alert_type': severity,
-            'msg_text': text,
-            'tags': tags,
-            'aggregation_key': aggregation_key,
-        }
-        self.check.event(event_dict)
+    def get_highwater_offsets_dict(self):
+        return self._highwater_offsets
+
+    def get_consumer_offsets_dict(self):
+        return self._consumer_offsets
+
+    def get_partitions_for_topic(self, topic):
+        return self.kafka_client._client.cluster.partitions_for_topic(topic)
+
+    def request_metadata_update(self):
+        self.kafka_client._client.cluster.request_update()

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
@@ -415,3 +415,7 @@ class KafkaPythonClient(KafkaClient):
 
     def request_metadata_update(self):
         self.kafka_client._client.cluster.request_update()
+
+    def reset_offsets(self):
+        self._consumer_offsets = {}
+        self._highwater_offsets = {}

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -157,8 +157,8 @@ class KafkaCheck(AgentCheck, ConfigMixin):
     def collect_broker_metadata(self):
         self.client.collect_broker_metadata()
 
-    # TODO: Remove me once the tests are refactored
 
+    # TODO: Remove me once the tests are refactored
     def send_event(self, title, text, tags, event_type, aggregation_key, severity='info'):
         """Emit an event to the Datadog Event Stream."""
         event_dict = {

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -157,7 +157,6 @@ class KafkaCheck(AgentCheck, ConfigMixin):
     def collect_broker_metadata(self):
         self.client.collect_broker_metadata()
 
-
     def send_event(self, title, text, tags, event_type, aggregation_key, severity='info'):
         """Emit an event to the Datadog Event Stream."""
         event_dict = {

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -40,6 +40,8 @@ class KafkaCheck(AgentCheck, ConfigMixin):
     def check(self, _):
         """The main entrypoint of the check."""
         # Fetch Kafka consumer offsets
+        self.client.reset_offsets()
+
         try:
             self.client.get_consumer_offsets()
         except Exception:
@@ -158,7 +160,7 @@ class KafkaCheck(AgentCheck, ConfigMixin):
         version_data = [str(part) for part in self.client.collect_broker_version()]
         version_parts = {name: part for name, part in zip(('major', 'minor', 'patch'), version_data)}
 
-        self.check.set_metadata(
+        self.set_metadata(
             'version', '.'.join(version_data), scheme='parts', final_scheme='semver', part_map=version_parts
         )
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+from time import time
 
 from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.kafka_consumer.client.kafka_client_factory import make_client
@@ -38,9 +39,6 @@ class KafkaCheck(AgentCheck, ConfigMixin):
 
     def check(self, _):
         """The main entrypoint of the check."""
-        self._consumer_offsets = {}  # Expected format: {(consumer_group, topic, partition): offset}
-        self._highwater_offsets = {}  # Expected format: {(topic, partition): offset}
-
         # Fetch Kafka consumer offsets
         try:
             self.client.get_consumer_offsets()
@@ -70,15 +68,106 @@ class KafkaCheck(AgentCheck, ConfigMixin):
             )
 
         # Report the metrics
-        self.client.report_highwater_offsets(self._context_limit)
-        self.client.report_consumer_offsets_and_lag(self._context_limit - len(self.client._highwater_offsets))
+        # Expected format: {(consumer_group, topic, partition): offset}
+        self._consumer_offsets = self.client.get_consumer_offsets_dict()
+        # Expected format: {(topic, partition): offset}
+        self._highwater_offsets = self.client.get_highwater_offsets_dict()
+
+        self.report_highwater_offsets(self._context_limit)
+        self.report_consumer_offsets_and_lag(self._context_limit - len(self._highwater_offsets))
 
         self.collect_broker_metadata()
+
+    def report_highwater_offsets(self, contexts_limit):
+        """Report the broker highwater offsets."""
+        reported_contexts = 0
+        self.log.debug("Reporting broker offset metric")
+        for (topic, partition), highwater_offset in self._highwater_offsets.items():
+            broker_tags = ['topic:%s' % topic, 'partition:%s' % partition]
+            broker_tags.extend(self._custom_tags)
+            self.gauge('broker_offset', highwater_offset, tags=broker_tags)
+            reported_contexts += 1
+            if reported_contexts == contexts_limit:
+                return
+
+    def report_consumer_offsets_and_lag(self, contexts_limit):
+        """Report the consumer offsets and consumer lag."""
+        reported_contexts = 0
+        self.log.debug("Reporting consumer offsets and lag metrics")
+        for (consumer_group, topic, partition), consumer_offset in self._consumer_offsets.items():
+            if reported_contexts >= contexts_limit:
+                self.log.debug(
+                    "Reported contexts number %s greater than or equal to contexts limit of %s, returning",
+                    str(reported_contexts),
+                    str(contexts_limit),
+                )
+                return
+            consumer_group_tags = ['topic:%s' % topic, 'partition:%s' % partition, 'consumer_group:%s' % consumer_group]
+            consumer_group_tags.extend(self._custom_tags)
+
+            partitions = self.client.get_partitions_for_topic(topic)
+            self.log.debug("Received partitions %s for topic %s", partitions, topic)
+            if partitions is not None and partition in partitions:
+                # report consumer offset if the partition is valid because even if leaderless the consumer offset will
+                # be valid once the leader failover completes
+                self.gauge('consumer_offset', consumer_offset, tags=consumer_group_tags)
+                reported_contexts += 1
+
+                if (topic, partition) not in self._highwater_offsets:
+                    self.log.warning(
+                        "Consumer group: %s has offsets for topic: %s partition: %s, but no stored highwater offset "
+                        "(likely the partition is in the middle of leader failover) so cannot calculate consumer lag.",
+                        consumer_group,
+                        topic,
+                        partition,
+                    )
+                    continue
+                producer_offset = self._highwater_offsets[(topic, partition)]
+                consumer_lag = producer_offset - consumer_offset
+                if reported_contexts < contexts_limit:
+                    self.gauge('consumer_lag', consumer_lag, tags=consumer_group_tags)
+                    reported_contexts += 1
+
+                if consumer_lag < 0:
+                    # this will effectively result in data loss, so emit an event for max visibility
+                    title = "Negative consumer lag for group: {}.".format(consumer_group)
+                    message = (
+                        "Consumer group: {}, topic: {}, partition: {} has negative consumer lag. This should never "
+                        "happen and will result in the consumer skipping new messages until the lag turns "
+                        "positive.".format(consumer_group, topic, partition)
+                    )
+                    key = "{}:{}:{}".format(consumer_group, topic, partition)
+                    self.send_event(title, message, consumer_group_tags, 'consumer_lag', key, severity="error")
+                    self.log.debug(message)
+            else:
+                if partitions is None:
+                    msg = (
+                        "Consumer group: %s has offsets for topic: %s, partition: %s, but that topic has no partitions "
+                        "in the cluster, so skipping reporting these offsets."
+                    )
+                else:
+                    msg = (
+                        "Consumer group: %s has offsets for topic: %s, partition: %s, but that topic partition isn't "
+                        "included in the cluster partitions, so skipping reporting these offsets."
+                    )
+                self.log.warning(msg, consumer_group, topic, partition)
+                self.client.request_metadata_update()  # force metadata update on next poll()
 
     @AgentCheck.metadata_entrypoint
     def collect_broker_metadata(self):
         self.client.collect_broker_metadata()
 
     # TODO: Remove me once the tests are refactored
+
     def send_event(self, title, text, tags, event_type, aggregation_key, severity='info'):
-        self.client._send_event(title, text, tags, event_type, aggregation_key, severity='info')
+        """Emit an event to the Datadog Event Stream."""
+        event_dict = {
+            'timestamp': int(time()),
+            'msg_title': title,
+            'event_type': event_type,
+            'alert_type': severity,
+            'msg_text': text,
+            'tags': tags,
+            'aggregation_key': aggregation_key,
+        }
+        self.event(event_dict)

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -155,7 +155,12 @@ class KafkaCheck(AgentCheck, ConfigMixin):
 
     @AgentCheck.metadata_entrypoint
     def collect_broker_metadata(self):
-        self.client.collect_broker_metadata()
+        version_data = [str(part) for part in self.client.collect_broker_version()]
+        version_parts = {name: part for name, part in zip(('major', 'minor', 'patch'), version_data)}
+
+        self.check.set_metadata(
+            'version', '.'.join(version_data), scheme='parts', final_scheme='semver', part_map=version_parts
+        )
 
     def send_event(self, title, text, tags, event_type, aggregation_key, severity='info'):
         """Emit an event to the Datadog Event Stream."""

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -158,7 +158,6 @@ class KafkaCheck(AgentCheck, ConfigMixin):
         self.client.collect_broker_metadata()
 
 
-    # TODO: Remove me once the tests are refactored
     def send_event(self, title, text, tags, event_type, aggregation_key, severity='info'):
         """Emit an event to the Datadog Event Stream."""
         event_dict = {


### PR DESCRIPTION
### What does this PR do?
Take metric and event reporting out of the kafka client file and put it back in the main check. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.