### PR TITLE
Emit a postgres locks metric which does not require the customer to configure relations

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -198,6 +198,12 @@ files:
       value:
         type: integer
         example: 300
+    - name: collect_relations_metrics
+      description: |
+        If set to true, collects lock metrics.
+      value:
+        type: boolean
+        example: false
     - name: collect_function_metrics
       description: |
         If set to true, collects metrics regarding PL/pgSQL functions from pg_stat_user_functions.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -161,6 +161,11 @@ instances:
     #
     # max_relations: 300
 
+    ## @param collect_relations_metrics - boolean - optional - default: false
+    ## If set to true, collects lock metrics.
+    #
+    # collect_relations_metrics: false
+
     ## @param collect_function_metrics - boolean - optional - default: false
     ## If set to true, collects metrics regarding PL/pgSQL functions from pg_stat_user_functions.
     #

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -161,11 +161,6 @@ instances:
     #
     # max_relations: 300
 
-    ## @param collect_relations_metrics - boolean - optional - default: false
-    ## If set to true, collects lock metrics.
-    #
-    # collect_relations_metrics: false
-
     ## @param collect_function_metrics - boolean - optional - default: false
     ## If set to true, collects metrics regarding PL/pgSQL functions from pg_stat_user_functions.
     #

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -110,7 +110,7 @@ class PostgreSql(AgentCheck):
             lock_metrics = copy.deepcopy(LOCK_METRICS)
             lock_metrics["query"] += " WHERE " + " AND ".join(
                 "datname not ilike '{}'".format(db) for db in self._config.ignore_databases
-            )
+            ) + " LIMIT " + str(self._config.max_relations)
 
             if self._config.dbstrict:
                 q_pg_stat_database["query"] += " AND datname in('{}')".format(self._config.dbname)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -107,10 +107,12 @@ class PostgreSql(AgentCheck):
                 "datname not ilike '{}'".format(db) for db in self._config.ignore_databases
             )
 
-            lock_metrics = copy.deepcopy(LOCK_METRICS)
-            lock_metrics["query"] += " WHERE " + " AND ".join(
-                "datname not ilike '{}'".format(db) for db in self._config.ignore_databases
-            ) + " LIMIT " + str(self._config.max_relations)
+            if self._config.collect_lock_metrics:
+                lock_metrics = copy.deepcopy(LOCK_METRICS)
+                if self._config.ignore_databases:
+                    lock_metrics["query"] += " WHERE " + " AND ".join(
+                        "datname not ilike '{}'".format(db) for db in self._config.ignore_databases
+                    ) + " LIMIT " + str(self._config.max_relations)
 
             if self._config.dbstrict:
                 q_pg_stat_database["query"] += " AND datname in('{}')".format(self._config.dbname)

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -108,17 +108,20 @@ LOCK_METRICS = {
             pn.nspname,
             pd.datname,
             pc.relname,
-            count(*) AS {metrics_columns}
+            count(*)
         FROM pg_locks l
         JOIN pg_database pd ON (l.database = pd.oid)
         JOIN pg_class pc ON (l.relation = pc.oid)
         LEFT JOIN pg_namespace pn ON (pn.oid = pc.relnamespace)
-        WHERE {relations}
-        AND l.mode IS NOT NULL
+        WHERE l.mode IS NOT NULL
         AND pc.relname NOT LIKE 'pg^_%%' ESCAPE '^'
         GROUP BY pd.datname, pc.relname, pn.nspname, locktype, mode""",
     'columns': [
+        {'name': 'mode', 'type': 'tag'},
+        {'name': 'locktype', 'type': 'tag'},
+        {'name': 'namespace', 'type': 'tag'},
         {'name': 'db', 'type': 'tag'},
+        {'name': 'table', 'type': 'tag'},
         {'name': 'postgresql.locks', 'type': 'gauge'},
     ],
 }

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -103,21 +103,20 @@ QUERY_PG_STAT_DATABASE = {
 LOCK_METRICS = {
     'name': 'lock_count',
     'query': """
-SELECT mode,
-       locktype,
-       pn.nspname,
-       pd.datname,
-       pc.relname,
-       count(*) AS {metrics_columns}
-  FROM pg_locks l
-  JOIN pg_database pd ON (l.database = pd.oid)
-  JOIN pg_class pc ON (l.relation = pc.oid)
-  LEFT JOIN pg_namespace pn ON (pn.oid = pc.relnamespace)
- WHERE {relations}
-   AND l.mode IS NOT NULL
-   AND pc.relname NOT LIKE 'pg^_%%' ESCAPE '^'
- GROUP BY pd.datname, pc.relname, pn.nspname, locktype, mode""",
-    'relation': True,
+        SELECT mode,
+            locktype,
+            pn.nspname,
+            pd.datname,
+            pc.relname,
+            count(*) AS {metrics_columns}
+        FROM pg_locks l
+        JOIN pg_database pd ON (l.database = pd.oid)
+        JOIN pg_class pc ON (l.relation = pc.oid)
+        LEFT JOIN pg_namespace pn ON (pn.oid = pc.relnamespace)
+        WHERE {relations}
+        AND l.mode IS NOT NULL
+        AND pc.relname NOT LIKE 'pg^_%%' ESCAPE '^'
+        GROUP BY pd.datname, pc.relname, pn.nspname, locktype, mode""",
     'columns': [
         {'name': 'db', 'type': 'tag'},
         {'name': 'postgresql.locks', 'type': 'gauge'},


### PR DESCRIPTION
### What does this PR do?
creates a new config option called collect_relations_metrics to collect lock metrics

### Motivation
issue: https://datadoghq.atlassian.net/browse/DBM-1933

### Additional Notes
i didn't write the tests, and here are the notes i had as i was working through it:

- What is db here exactly lol: https://github.com/DataDog/integrations-core/blob/6907ffdee6c50cf7ba9922a007f6309c4b0342b1/postgres/datadog_checks/postgres/postgres.py#L103-L106 
```
            lock_metrics = copy.deepcopy(LOCK_METRICS)
            lock_metrics["query"] += " WHERE " + " AND ".join(
                "datname not ilike '{}'".format(db) for db in self._config.ignore_databases
            )
```

- Would it be best to add the LIMIT to the lock metrics query or specify the lock metric as a relations metric? Or both?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.