### PR TITLE
Add pgbouncer_db tag into pgbouncer metrics

### DIFF
--- a/pgbouncer/datadog_checks/pgbouncer/metrics.py
+++ b/pgbouncer/datadog_checks/pgbouncer/metrics.py
@@ -15,7 +15,7 @@ CONFIG_METRICS = {
 }
 
 STATS_METRICS = {
-    'descriptors': [('database', 'db'), ('database', 'pgbouncer_db')],
+    'descriptors': [('database', 'db')],
     'metrics': [
         ('total_requests', ('pgbouncer.stats.requests_per_second', RATE)),  # < 1.8
         ('total_xact_count', ('pgbouncer.stats.transactions_per_second', RATE)),  # >= 1.8
@@ -39,7 +39,7 @@ STATS_METRICS = {
 }
 
 POOLS_METRICS = {
-    'descriptors': [('database', 'db'), ('database', 'pgbouncer_db'), ('user', 'user')],
+    'descriptors': [('database', 'db'), ('user', 'user')],
     'metrics': [
         ('cl_active', ('pgbouncer.pools.cl_active', GAUGE)),
         ('cl_waiting', ('pgbouncer.pools.cl_waiting', GAUGE)),
@@ -55,7 +55,7 @@ POOLS_METRICS = {
 }
 
 DATABASES_METRICS = {
-    'descriptors': [('name', 'name'), ('name', 'pgbouncer_db')],
+    'descriptors': [('name', 'name'), ('name', 'db'), ('database', 'postgres_db')],
     'metrics': [
         ('pool_size', ('pgbouncer.databases.pool_size', GAUGE)),
         ('max_connections', ('pgbouncer.databases.max_connections', GAUGE)),
@@ -65,7 +65,7 @@ DATABASES_METRICS = {
 }
 
 CLIENTS_METRICS = {
-    'descriptors': [('database', 'db'), ('database', 'pgbouncer_db'), ('user', 'user'), ('state', 'state')],
+    'descriptors': [('database', 'db'), ('user', 'user'), ('state', 'state')],
     'metrics': [
         ('connect_time', ('pgbouncer.clients.connect_time', GAUGE)),
         ('request_time', ('pgbouncer.clients.request_time', GAUGE)),
@@ -76,7 +76,7 @@ CLIENTS_METRICS = {
 }
 
 SERVERS_METRICS = {
-    'descriptors': [('database', 'db'), ('database', 'pgbouncer_db'), ('user', 'user'), ('state', 'state')],
+    'descriptors': [('database', 'db'), ('user', 'user'), ('state', 'state')],
     'metrics': [
         ('connect_time', ('pgbouncer.servers.connect_time', GAUGE)),
         ('request_time', ('pgbouncer.servers.request_time', GAUGE)),

--- a/pgbouncer/datadog_checks/pgbouncer/metrics.py
+++ b/pgbouncer/datadog_checks/pgbouncer/metrics.py
@@ -15,7 +15,7 @@ CONFIG_METRICS = {
 }
 
 STATS_METRICS = {
-    'descriptors': [('database', 'db')],
+    'descriptors': [('database', 'db'), ('database', 'pgbouncer_db')],
     'metrics': [
         ('total_requests', ('pgbouncer.stats.requests_per_second', RATE)),  # < 1.8
         ('total_xact_count', ('pgbouncer.stats.transactions_per_second', RATE)),  # >= 1.8
@@ -39,7 +39,7 @@ STATS_METRICS = {
 }
 
 POOLS_METRICS = {
-    'descriptors': [('database', 'db'), ('database', 'name'), ('user', 'user')],
+    'descriptors': [('database', 'db'), ('database', 'pgbouncer_db'), ('user', 'user')],
     'metrics': [
         ('cl_active', ('pgbouncer.pools.cl_active', GAUGE)),
         ('cl_waiting', ('pgbouncer.pools.cl_waiting', GAUGE)),
@@ -55,7 +55,7 @@ POOLS_METRICS = {
 }
 
 DATABASES_METRICS = {
-    'descriptors': [('name', 'name')],
+    'descriptors': [('name', 'name'), ('name', 'pgbouncer_db')],
     'metrics': [
         ('pool_size', ('pgbouncer.databases.pool_size', GAUGE)),
         ('max_connections', ('pgbouncer.databases.max_connections', GAUGE)),
@@ -65,7 +65,7 @@ DATABASES_METRICS = {
 }
 
 CLIENTS_METRICS = {
-    'descriptors': [('database', 'db'), ('user', 'user'), ('state', 'state')],
+    'descriptors': [('database', 'db'), ('database', 'pgbouncer_db'), ('user', 'user'), ('state', 'state')],
     'metrics': [
         ('connect_time', ('pgbouncer.clients.connect_time', GAUGE)),
         ('request_time', ('pgbouncer.clients.request_time', GAUGE)),
@@ -76,7 +76,7 @@ CLIENTS_METRICS = {
 }
 
 SERVERS_METRICS = {
-    'descriptors': [('database', 'db'), ('user', 'user'), ('state', 'state')],
+    'descriptors': [('database', 'db'), ('database', 'pgbouncer_db'), ('user', 'user'), ('state', 'state')],
     'metrics': [
         ('connect_time', ('pgbouncer.servers.connect_time', GAUGE)),
         ('request_time', ('pgbouncer.servers.request_time', GAUGE)),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We are reverting this [PR](https://github.com/DataDog/integrations-core/pull/13952) because "name" tag is conflicting with name from kube_system. Instead of using "name", we will use postgres_db to represent the postgres database name (from `SHOW DATABASES` output).

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.