### PR TITLE
Change "availability_zone" tag to "availability-zone" for ECS Fargate

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -714,7 +714,7 @@ The Agent can autodiscover and attach tags to all data emitted by the entire tas
   | `task_family`                 | Low          | ECS API              |
   | `task_name`                   | Low          | ECS API              |
   | `task_version`                | Low          | ECS API              |
-  | `availability_zone`           | Low          | ECS API              |
+  | `availability-zone`           | Low          | ECS API              |
   | `region`                      | Low          | ECS API              |
 
 ## Data Collected


### PR DESCRIPTION
### What does this PR do?
Updates the "availability_zone" tag to "availability-zone" in the documentation for the ECS Fargate integration.

### Motivation
This change updates the documentation to reflect the change made to tagging for this integration. The former tag name has been deprecated in favor of the latter, with the intention being to make the tagging consistent between Fargate and other AWS infrastructure offerings, such as EC2 and ECS.

### Additional Notes
See corresponding agent code change here: https://github.com/DataDog/datadog-agent/pull/15629

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [X] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [X] PR must have `changelog/` and `integration/` labels attached
- [X] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.