### PR TITLE
Move tls_context creation back into main check

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client.py
@@ -5,13 +5,14 @@ from abc import ABC, abstractmethod
 
 
 class KafkaClient(ABC):
-    def __init__(self, check) -> None:
+    def __init__(self, check, tls_context) -> None:
         self.check = check
         self.log = check.log
         self._kafka_client = None
         self._highwater_offsets = {}
         self._consumer_offsets = {}
         self._context_limit = check._context_limit
+        self._tls_context = tls_context
 
     def should_get_highwater_offsets(self):
         return len(self._consumer_offsets) < self._context_limit

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client_factory.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client_factory.py
@@ -6,5 +6,5 @@ from datadog_checks.kafka_consumer.client.kafka_client import KafkaClient
 from datadog_checks.kafka_consumer.client.kafka_python_client import KafkaPythonClient
 
 
-def make_client(check, config) -> KafkaClient:
-    return KafkaPythonClient(check, config)
+def make_client(check, config, tls_context) -> KafkaClient:
+    return KafkaPythonClient(check, config, tls_context)

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -25,7 +25,8 @@ class KafkaCheck(AgentCheck):
         super(KafkaCheck, self).__init__(name, init_config, instances)
         self.config = KafkaConfig(self.init_config, self.instance)
         self._context_limit = self.config._context_limit
-        self.client = make_client(self, self.config)
+        tls_context = self.get_tls_context()
+        self.client = make_client(self, self.config, tls_context)
 
     def check(self, _):
         """The main entrypoint of the check."""


### PR DESCRIPTION
### What does this PR do?
Move tls_context creation out of the client logic and back into the main check.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.