### PR TITLE
Add test for SNMP Listener with auth proto SHA256

### DIFF
--- a/snmp/tests/compose/data/args_list.txt
+++ b/snmp/tests/compose/data/args_list.txt
@@ -4,6 +4,7 @@
 --v3-user=datadogMD5AES --v3-auth-key=doggiepass --v3-priv-key=doggiePRIVkey --v3-auth-proto=MD5 --v3-priv-proto=AES
 --v3-user=datadogSHADES --v3-auth-key=doggiepass --v3-priv-key=doggiePRIVkey --v3-auth-proto=SHA --v3-priv-proto=DES
 --v3-user=datadogSHAAES --v3-auth-key=doggiepass --v3-priv-key=doggiePRIVkey --v3-auth-proto=SHA --v3-priv-proto=AES
+--v3-user=datadogSHA256AES --v3-auth-key=doggiepass --v3-priv-key=doggiePRIVkey --v3-auth-proto=SHA256 --v3-priv-proto=AES
 --v3-user=datadogSHAAES192 --v3-auth-key=doggiepass --v3-priv-key=doggiePRIVkey --v3-auth-proto=SHA --v3-priv-proto=AES192
 --v3-user=datadogSHAAES192BLMT --v3-auth-key=doggiepass --v3-priv-key=doggiePRIVkey --v3-auth-proto=SHA --v3-priv-proto=AES192BLMT
 --v3-user=datadogSHAAES256 --v3-auth-key=doggiepass --v3-priv-key=doggiePRIVkey --v3-auth-proto=SHA --v3-priv-proto=AES256

--- a/snmp/tests/conftest.py
+++ b/snmp/tests/conftest.py
@@ -34,6 +34,8 @@ E2E_METADATA = {
     ],
 }
 
+EXPECTED_AUTODISCOVERY_CHECKS = 6
+
 
 @pytest.fixture(scope='session')
 def dd_environment():
@@ -83,8 +85,7 @@ def _autodiscovery_ready():
             autodiscovery_checks.append(result_line)
 
     # assert subnets discovered by `snmp_listener` config from datadog.yaml
-    expected_autodiscovery_checks = 5
-    assert len(autodiscovery_checks) == expected_autodiscovery_checks
+    assert len(autodiscovery_checks) == EXPECTED_AUTODISCOVERY_CHECKS
 
 
 def create_datadog_conf_file(tmp_dir):
@@ -123,6 +124,7 @@ def create_datadog_conf_file(tmp_dir):
                 },
                 {
                     'network': '{}.0/27'.format(prefix),
+                    'namespace': 'test-auth-proto-sha',
                     'port': PORT,
                     'version': 3,
                     'timeout': 1,
@@ -132,6 +134,22 @@ def create_datadog_conf_file(tmp_dir):
                     'authentication_protocol': 'sha',
                     'privacy_key': 'doggiePRIVkey',
                     'privacy_protocol': 'des',
+                    'context_name': 'public',
+                    'ignored_ip_addresses': {'{}.2'.format(prefix): True},
+                    'loader': 'core',
+                },
+                {
+                    'network': '{}.0/27'.format(prefix),
+                    'namespace': 'test-auth-proto-sha256',
+                    'port': PORT,
+                    'version': 3,
+                    'timeout': 1,
+                    'retries': 2,
+                    'user': 'datadogSHA256AES',
+                    'authentication_key': 'doggiepass',
+                    'authentication_protocol': 'SHA256',
+                    'privacy_key': 'doggiePRIVkey',
+                    'privacy_protocol': 'AES',
                     'context_name': 'public',
                     'ignored_ip_addresses': {'{}.2'.format(prefix): True},
                     'loader': 'core',

--- a/snmp/tests/test_e2e_snmp_listener.py
+++ b/snmp/tests/test_e2e_snmp_listener.py
@@ -18,6 +18,7 @@ from tests.metrics import (
 )
 
 from . import common, metrics
+from .conftest import EXPECTED_AUTODISCOVERY_CHECKS
 
 pytestmark = [pytest.mark.e2e, common.py3_plus_only]
 
@@ -45,7 +46,7 @@ def test_e2e_snmp_listener(dd_agent_check, container_ip, autodiscovery_ready):
         dd_agent_check,
         {'init_config': {}, 'instances': []},
         rate=True,
-        discovery_min_instances=5,
+        discovery_min_instances=EXPECTED_AUTODISCOVERY_CHECKS,
         discovery_timeout=10,
     )
 
@@ -115,20 +116,21 @@ def test_e2e_snmp_listener(dd_agent_check, container_ip, autodiscovery_ready):
         aggregator.assert_metric(metric, value=value, metric_type=aggregator.GAUGE, count=2, tags=common_tags)
 
     # ==== test snmp v3 ===
-    common_tags = [
-        'snmp_device:{}'.format(snmp_device),
-        'autodiscovery_subnet:{}.0/27'.format(subnet_prefix),
-        'snmp_host:41ba948911b9',
-        'snmp_profile:generic-router',
-        'device_namespace:default',
-    ]
+    for auth_proto in ['sha', 'sha256']:
+        common_tags = [
+            'snmp_device:{}'.format(snmp_device),
+            'autodiscovery_subnet:{}.0/27'.format(subnet_prefix),
+            'snmp_host:41ba948911b9',
+            'snmp_profile:generic-router',
+            'device_namespace:test-auth-proto-%s'.format(auth_proto),
+        ]
 
-    common.assert_common_metrics(aggregator, common_tags, is_e2e=True, loader='core')
-    aggregator.assert_metric('snmp.sysUpTimeInstance', tags=common_tags)
-    for metric in IF_SCALAR_GAUGE:
-        aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=common_tags, count=2)
+        common.assert_common_metrics(aggregator, common_tags, is_e2e=True, loader='core')
+        aggregator.assert_metric('snmp.sysUpTimeInstance', tags=common_tags)
+        for metric in IF_SCALAR_GAUGE:
+            aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=common_tags, count=2)
 
-    # test ignored IPs
+    # ==== test ignored IPs ====
     tags = [
         'snmp_device:{}'.format(_build_device_ip(container_ip, '2')),
         'autodiscovery_subnet:{}.0/27'.format(subnet_prefix),

--- a/snmp/tests/test_e2e_snmp_listener.py
+++ b/snmp/tests/test_e2e_snmp_listener.py
@@ -122,7 +122,7 @@ def test_e2e_snmp_listener(dd_agent_check, container_ip, autodiscovery_ready):
             'autodiscovery_subnet:{}.0/27'.format(subnet_prefix),
             'snmp_host:41ba948911b9',
             'snmp_profile:generic-router',
-            'device_namespace:test-auth-proto-%s'.format(auth_proto),
+            'device_namespace:test-auth-proto-{}'.format(auth_proto),
         ]
 
         common.assert_common_metrics(aggregator, common_tags, is_e2e=True, loader='core')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add test for SNMP Listener with auth proto SHA256

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/datadog-agent/pull/15646

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.