### PR TITLE
Remove self.check and cleanup

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client.py
@@ -5,17 +5,8 @@ from abc import ABC, abstractmethod
 
 
 class KafkaClient(ABC):
-    def __init__(self, check, tls_context) -> None:
-        self.check = check
-        self.log = check.log
-        self._kafka_client = None
-        self._highwater_offsets = {}
-        self._consumer_offsets = {}
-        self._context_limit = check._context_limit
-        self._tls_context = tls_context
-
-    def should_get_highwater_offsets(self):
-        return len(self._consumer_offsets) < self._context_limit
+    def __init__(self) -> None:
+        pass
 
     @abstractmethod
     def get_consumer_offsets(self):

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
@@ -29,14 +29,12 @@ class OAuthTokenProvider(AbstractTokenProvider):
 
 
 class KafkaPythonClient(KafkaClient):
-    def __init__(self, check, config, tls_context) -> None:
-        self.check = check
+    def __init__(self, config, tls_context, log) -> None:
         self.config = config
-        self.log = check.log
+        self.log = log
         self._kafka_client = None
         self._highwater_offsets = {}
         self._consumer_offsets = {}
-        self._context_limit = check._context_limit
         self._tls_context = tls_context
 
     def get_consumer_offsets(self):

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -33,14 +33,15 @@ class KafkaCheck(AgentCheck):
         # Fetch Kafka consumer offsets
         self.client.reset_offsets()
 
-        consumer_offsets = {}
-        highwater_offsets = {}
-
         try:
             self.client.get_consumer_offsets()
         except Exception:
             self.log.exception("There was a problem collecting consumer offsets from Kafka.")
             # don't raise because we might get valid broker offsets
+
+        # Fetch consumer offsets
+        # Expected format: {(consumer_group, topic, partition): offset}
+        consumer_offsets = self.client.get_consumer_offsets_dict()
 
         # Fetch the broker highwater offsets
         try:
@@ -53,9 +54,7 @@ class KafkaCheck(AgentCheck):
             # Unlike consumer offsets, fail immediately because we can't calculate consumer lag w/o highwater_offsets
             raise
 
-        # Report the metrics
-        # Expected format: {(consumer_group, topic, partition): offset}
-        consumer_offsets = self.client.get_consumer_offsets_dict()
+        # Fetch highwater offsets
         # Expected format: {(topic, partition): offset}
         highwater_offsets = self.client.get_highwater_offsets_dict()
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -52,13 +52,12 @@ class KafkaCheck(AgentCheck):
             self.log.exception("There was a problem collecting the highwater mark offsets.")
             # Unlike consumer offsets, fail immediately because we can't calculate consumer lag w/o highwater_offsets
             raise
-        
+
         # Report the metrics
         # Expected format: {(consumer_group, topic, partition): offset}
         consumer_offsets = self.client.get_consumer_offsets_dict()
         # Expected format: {(topic, partition): offset}
         highwater_offsets = self.client.get_highwater_offsets_dict()
-
 
         total_contexts = len(consumer_offsets) + len(highwater_offsets)
         if total_contexts >= self._context_limit:
@@ -70,9 +69,10 @@ class KafkaCheck(AgentCheck):
                 self._context_limit,
             )
 
-
         self.report_highwater_offsets(highwater_offsets, self._context_limit)
-        self.report_consumer_offsets_and_lag(consumer_offsets, highwater_offsets, self._context_limit - len(highwater_offsets))
+        self.report_consumer_offsets_and_lag(
+            consumer_offsets, highwater_offsets, self._context_limit - len(highwater_offsets)
+        )
 
         self.collect_broker_metadata()
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR formally removes `self.check` from the client code to fully separate the logic between check and Kafka client. This PR also does some other cleaning up.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.