### PR TITLE
Add `--instance-filter` option to agent check command

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/check.py
@@ -54,6 +54,7 @@ from ..console import CONTEXT_SETTINGS, abort, echo_failure, echo_info, echo_suc
     type=click.INT,
     help='Number of checks to wait, retry until the specified number of checks is reached',
 )
+@click.option('--instance-filter', help="filter instances using jq style syntax, example: --instance-filter '.ip_address == \"127.0.0.51\"'")
 def check_run(
     check,
     env,
@@ -70,6 +71,7 @@ def check_run(
     discovery_timeout,
     discovery_retry_interval,
     discovery_min_instances,
+    instance_filter,
 ):
     """Run an Agent check."""
     envs = get_configured_envs(check)
@@ -105,6 +107,7 @@ def check_run(
         discovery_timeout=discovery_timeout,
         discovery_retry_interval=discovery_retry_interval,
         discovery_min_instances=discovery_min_instances,
+        instance_filter=instance_filter,
     )
 
     if config_file:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -139,6 +139,7 @@ class DockerInterface(object):
         discovery_timeout=None,
         discovery_retry_interval=None,
         discovery_min_instances=None,
+        instance_filter=None,
     ):
         # JMX check
         if jmx_list:
@@ -177,6 +178,9 @@ class DockerInterface(object):
 
             if discovery_min_instances is not None:
                 command.extend(['--discovery-min-instances', str(discovery_min_instances)])
+
+            if instance_filter is not None:
+                command.extend(['--instance-filter', str(instance_filter)])
 
         if log_level is not None:
             command.extend(['--log-level', log_level])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add `--instance-filter` option to agent check command

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/datadog-agent/pull/15163

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.