### PR TITLE
Revert "Bump setuptools build requirements in all integrations (#13848)"

### DIFF
--- a/active_directory/pyproject.toml
+++ b/active_directory/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/activemq/pyproject.toml
+++ b/activemq/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/activemq_xml/pyproject.toml
+++ b/activemq_xml/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/aerospike/pyproject.toml
+++ b/aerospike/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/amazon_msk/pyproject.toml
+++ b/amazon_msk/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ambari/pyproject.toml
+++ b/ambari/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/apache/pyproject.toml
+++ b/apache/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/aspdotnet/pyproject.toml
+++ b/aspdotnet/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/avi_vantage/pyproject.toml
+++ b/avi_vantage/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/azure_iot_edge/pyproject.toml
+++ b/azure_iot_edge/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/btrfs/pyproject.toml
+++ b/btrfs/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cacti/pyproject.toml
+++ b/cacti/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/calico/pyproject.toml
+++ b/calico/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cassandra/pyproject.toml
+++ b/cassandra/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cassandra_nodetool/pyproject.toml
+++ b/cassandra_nodetool/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ceph/pyproject.toml
+++ b/ceph/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cert_manager/pyproject.toml
+++ b/cert_manager/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.12.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cilium/pyproject.toml
+++ b/cilium/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cisco_aci/pyproject.toml
+++ b/cisco_aci/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/citrix_hypervisor/pyproject.toml
+++ b/citrix_hypervisor/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/clickhouse/pyproject.toml
+++ b/clickhouse/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cloud_foundry_api/pyproject.toml
+++ b/cloud_foundry_api/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cloudera/pyproject.toml
+++ b/cloudera/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/cockroachdb/pyproject.toml
+++ b/cockroachdb/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/confluent_platform/pyproject.toml
+++ b/confluent_platform/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/consul/pyproject.toml
+++ b/consul/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/coredns/pyproject.toml
+++ b/coredns/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/couch/pyproject.toml
+++ b/couch/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/couchbase/pyproject.toml
+++ b/couchbase/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/crio/pyproject.toml
+++ b/crio/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 
@@ -88,8 +87,7 @@ cli = [
     "twine>=1.11.0",
     "virtualenv",
     # TODO: Remove once every check has a pyproject.toml
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
     "wheel>=0.31.0",
 ]
 

--- a/datadog_checks_downloader/pyproject.toml
+++ b/datadog_checks_downloader/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_cluster_agent/pyproject.toml
+++ b/datadog_cluster_agent/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/directory/pyproject.toml
+++ b/directory/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/disk/pyproject.toml
+++ b/disk/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/dns_check/pyproject.toml
+++ b/dns_check/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/dotnetclr/pyproject.toml
+++ b/dotnetclr/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/druid/pyproject.toml
+++ b/druid/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ecs_fargate/pyproject.toml
+++ b/ecs_fargate/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/eks_fargate/pyproject.toml
+++ b/eks_fargate/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/elastic/pyproject.toml
+++ b/elastic/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/envoy/pyproject.toml
+++ b/envoy/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/etcd/pyproject.toml
+++ b/etcd/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/exchange_server/pyproject.toml
+++ b/exchange_server/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/external_dns/pyproject.toml
+++ b/external_dns/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/flink/pyproject.toml
+++ b/flink/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/fluentd/pyproject.toml
+++ b/fluentd/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/foundationdb/pyproject.toml
+++ b/foundationdb/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/gearmand/pyproject.toml
+++ b/gearmand/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/gitlab/pyproject.toml
+++ b/gitlab/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/gitlab_runner/pyproject.toml
+++ b/gitlab_runner/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/glusterfs/pyproject.toml
+++ b/glusterfs/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/go_expvar/pyproject.toml
+++ b/go_expvar/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/gunicorn/pyproject.toml
+++ b/gunicorn/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/haproxy/pyproject.toml
+++ b/haproxy/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/harbor/pyproject.toml
+++ b/harbor/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hazelcast/pyproject.toml
+++ b/hazelcast/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hdfs_datanode/pyproject.toml
+++ b/hdfs_datanode/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hdfs_namenode/pyproject.toml
+++ b/hdfs_namenode/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hive/pyproject.toml
+++ b/hive/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hivemq/pyproject.toml
+++ b/hivemq/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hudi/pyproject.toml
+++ b/hudi/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/hyperv/pyproject.toml
+++ b/hyperv/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ibm_db2/pyproject.toml
+++ b/ibm_db2/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ibm_i/pyproject.toml
+++ b/ibm_i/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ibm_mq/pyproject.toml
+++ b/ibm_mq/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ibm_was/pyproject.toml
+++ b/ibm_was/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ignite/pyproject.toml
+++ b/ignite/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/iis/pyproject.toml
+++ b/iis/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/impala/pyproject.toml
+++ b/impala/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/istio/pyproject.toml
+++ b/istio/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/jboss_wildfly/pyproject.toml
+++ b/jboss_wildfly/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/journald/pyproject.toml
+++ b/journald/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kafka/pyproject.toml
+++ b/kafka/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kafka_consumer/pyproject.toml
+++ b/kafka_consumer/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kong/pyproject.toml
+++ b/kong/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_apiserver_metrics/pyproject.toml
+++ b/kube_apiserver_metrics/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_controller_manager/pyproject.toml
+++ b/kube_controller_manager/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_dns/pyproject.toml
+++ b/kube_dns/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_metrics_server/pyproject.toml
+++ b/kube_metrics_server/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_proxy/pyproject.toml
+++ b/kube_proxy/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_scheduler/pyproject.toml
+++ b/kube_scheduler/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kubelet/pyproject.toml
+++ b/kubelet/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kubernetes_state/pyproject.toml
+++ b/kubernetes_state/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/kyototycoon/pyproject.toml
+++ b/kyototycoon/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/lighttpd/pyproject.toml
+++ b/lighttpd/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/linkerd/pyproject.toml
+++ b/linkerd/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/linux_proc_extras/pyproject.toml
+++ b/linux_proc_extras/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mapr/pyproject.toml
+++ b/mapr/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mapreduce/pyproject.toml
+++ b/mapreduce/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/marathon/pyproject.toml
+++ b/marathon/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/marklogic/pyproject.toml
+++ b/marklogic/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mcache/pyproject.toml
+++ b/mcache/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mesos_master/pyproject.toml
+++ b/mesos_master/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mesos_slave/pyproject.toml
+++ b/mesos_slave/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/nagios/pyproject.toml
+++ b/nagios/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/network/pyproject.toml
+++ b/network/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/nfsstat/pyproject.toml
+++ b/nfsstat/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/nginx/pyproject.toml
+++ b/nginx/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/nginx_ingress_controller/pyproject.toml
+++ b/nginx_ingress_controller/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/openldap/pyproject.toml
+++ b/openldap/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/openmetrics/pyproject.toml
+++ b/openmetrics/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/openstack/pyproject.toml
+++ b/openstack/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/openstack_controller/pyproject.toml
+++ b/openstack_controller/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/oracle/pyproject.toml
+++ b/oracle/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/pan_firewall/pyproject.toml
+++ b/pan_firewall/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/pdh_check/pyproject.toml
+++ b/pdh_check/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/pgbouncer/pyproject.toml
+++ b/pgbouncer/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/php_fpm/pyproject.toml
+++ b/php_fpm/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/postfix/pyproject.toml
+++ b/postfix/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/powerdns_recursor/pyproject.toml
+++ b/powerdns_recursor/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/presto/pyproject.toml
+++ b/presto/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/process/pyproject.toml
+++ b/process/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/prometheus/pyproject.toml
+++ b/prometheus/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/proxysql/pyproject.toml
+++ b/proxysql/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/rabbitmq/pyproject.toml
+++ b/rabbitmq/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/redisdb/pyproject.toml
+++ b/redisdb/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/rethinkdb/pyproject.toml
+++ b/rethinkdb/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/riak/pyproject.toml
+++ b/riak/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/riakcs/pyproject.toml
+++ b/riakcs/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/sap_hana/pyproject.toml
+++ b/sap_hana/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/scylla/pyproject.toml
+++ b/scylla/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/sidekiq/pyproject.toml
+++ b/sidekiq/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/silk/pyproject.toml
+++ b/silk/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/singlestore/pyproject.toml
+++ b/singlestore/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/snmp/pyproject.toml
+++ b/snmp/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/solr/pyproject.toml
+++ b/solr/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/sonarqube/pyproject.toml
+++ b/sonarqube/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/spark/pyproject.toml
+++ b/spark/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/squid/pyproject.toml
+++ b/squid/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/ssh_check/pyproject.toml
+++ b/ssh_check/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/statsd/pyproject.toml
+++ b/statsd/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/supervisord/pyproject.toml
+++ b/supervisord/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/system_core/pyproject.toml
+++ b/system_core/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/system_swap/pyproject.toml
+++ b/system_swap/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/tcp_check/pyproject.toml
+++ b/tcp_check/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/teamcity/pyproject.toml
+++ b/teamcity/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/tenable/pyproject.toml
+++ b/tenable/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/tokumx/pyproject.toml
+++ b/tokumx/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/tomcat/pyproject.toml
+++ b/tomcat/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/twemproxy/pyproject.toml
+++ b/twemproxy/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/twistlock/pyproject.toml
+++ b/twistlock/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/varnish/pyproject.toml
+++ b/varnish/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/vault/pyproject.toml
+++ b/vault/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/vertica/pyproject.toml
+++ b/vertica/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/voltdb/pyproject.toml
+++ b/voltdb/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/vsphere/pyproject.toml
+++ b/vsphere/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/weblogic/pyproject.toml
+++ b/weblogic/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/win32_event_log/pyproject.toml
+++ b/win32_event_log/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/windows_performance_counters/pyproject.toml
+++ b/windows_performance_counters/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/windows_service/pyproject.toml
+++ b/windows_service/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/wmi_check/pyproject.toml
+++ b/wmi_check/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/yarn/pyproject.toml
+++ b/yarn/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 

--- a/zk/pyproject.toml
+++ b/zk/pyproject.toml
@@ -1,8 +1,7 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
+    "setuptools<61",
 ]
 build-backend = "hatchling.build"
 


### PR DESCRIPTION

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Reverts the setuptools bump introduced in #13848.

### Motivation
<!-- What inspired you to submit this pull request? -->

Updating setuptools causes a 10MB increase in memory usage of the Agent.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

n/a

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.