### PR TITLE
Increase number of endpoint check retries to combat flaky tests

### DIFF
--- a/clickhouse/tests/conftest.py
+++ b/clickhouse/tests/conftest.py
@@ -21,7 +21,7 @@ def dd_environment():
                 'clickhouse-0{}'.format(i + 1), 'Logging errors to /var/log/clickhouse-server/clickhouse-server.err.log'
             )
         )
-    with docker_run(common.COMPOSE_FILE, conditions=conditions, sleep=10, attempts=2):
+    with docker_run(common.COMPOSE_FILE, conditions=conditions, sleep=10, attempts=10):
         yield common.CONFIG
 
 

--- a/clickhouse/tests/docker/docker-compose.yaml
+++ b/clickhouse/tests/docker/docker-compose.yaml
@@ -129,7 +129,6 @@ services:
     #   Connection request from old client /172.30.0.7:51646; will be dropped if server is in r-o mode
     # For now, we use zookeeper `3.5.7` instead
     # Similar case: https://stackoverflow.com/a/22884698
-    platform: linux/x86_64
     image: zookeeper:3.5.7
     hostname: clickhouse-zookeeper
     container_name: clickhouse-zookeeper

--- a/clickhouse/tests/docker/docker-compose.yaml
+++ b/clickhouse/tests/docker/docker-compose.yaml
@@ -41,6 +41,16 @@ services:
     ports:
       - "8129:8123"
       - "9002:9000"
+    volumes:
+      - ./override_configs/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
+      - ./override_configs/remote_servers.xml:/etc/clickhouse-server/config.d/remote_servers.xml
+      - ./override_configs/compression.xml:/etc/clickhouse-server/config.d/compression.xml
+      - ./metrika.xml:/etc/metrika.xml
+      - ./macros/macros-02.xml:/etc/clickhouse-server/config.d/macros.xml
+      - ./users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./test_dictionary.xml:/etc/clickhouse-server/test_dictionary.xml
+      - ./test.csv:/opt/dictionaries/test.csv
 
   clickhouse-03:
     << : *ch-node
@@ -49,6 +59,16 @@ services:
     ports:
       - "8130:8123"
       - "9003:9000"
+    volumes:
+      - ./override_configs/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
+      - ./override_configs/remote_servers.xml:/etc/clickhouse-server/config.d/remote_servers.xml
+      - ./override_configs/compression.xml:/etc/clickhouse-server/config.d/compression.xml
+      - ./metrika.xml:/etc/metrika.xml
+      - ./macros/macros-03.xml:/etc/clickhouse-server/config.d/macros.xml
+      - ./users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./test_dictionary.xml:/etc/clickhouse-server/test_dictionary.xml
+      - ./test.csv:/opt/dictionaries/test.csv
 
   clickhouse-04:
     << : *ch-node
@@ -57,6 +77,16 @@ services:
     ports:
       - "8131:8123"
       - "9004:9000"
+    volumes:
+      - ./override_configs/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
+      - ./override_configs/remote_servers.xml:/etc/clickhouse-server/config.d/remote_servers.xml
+      - ./override_configs/compression.xml:/etc/clickhouse-server/config.d/compression.xml
+      - ./metrika.xml:/etc/metrika.xml
+      - ./macros/macros-04.xml:/etc/clickhouse-server/config.d/macros.xml
+      - ./users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./test_dictionary.xml:/etc/clickhouse-server/test_dictionary.xml
+      - ./test.csv:/opt/dictionaries/test.csv
 
   clickhouse-05:
     << : *ch-node
@@ -65,6 +95,16 @@ services:
     ports:
       - "8132:8123"
       - "9005:9000"
+    volumes:
+      - ./override_configs/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
+      - ./override_configs/remote_servers.xml:/etc/clickhouse-server/config.d/remote_servers.xml
+      - ./override_configs/compression.xml:/etc/clickhouse-server/config.d/compression.xml
+      - ./metrika.xml:/etc/metrika.xml
+      - ./macros/macros-05.xml:/etc/clickhouse-server/config.d/macros.xml
+      - ./users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./test_dictionary.xml:/etc/clickhouse-server/test_dictionary.xml
+      - ./test.csv:/opt/dictionaries/test.csv
 
   clickhouse-06:
     << : *ch-node
@@ -73,6 +113,16 @@ services:
     ports:
       - "8133:8123"
       - "9006:9000"
+    volumes:
+      - ./override_configs/zookeeper.xml:/etc/clickhouse-server/config.d/zookeeper.xml
+      - ./override_configs/remote_servers.xml:/etc/clickhouse-server/config.d/remote_servers.xml
+      - ./override_configs/compression.xml:/etc/clickhouse-server/config.d/compression.xml
+      - ./metrika.xml:/etc/metrika.xml
+      - ./macros/macros-06.xml:/etc/clickhouse-server/config.d/macros.xml
+      - ./users.xml:/etc/clickhouse-server/users.d/users.xml
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./test_dictionary.xml:/etc/clickhouse-server/test_dictionary.xml
+      - ./test.csv:/opt/dictionaries/test.csv
 
   clickhouse-zookeeper:
     # Using zookeeper `3.6.0` is raising this error:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Increases the number of times we retry clickhouse endpoints to when testing.

### Motivation
<!-- What inspired you to submit this pull request? -->

We may actually not need this, I'm keeping the PR open in draft mode until we decide either way.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.