### PR TITLE
Bump pyodbc version, it has wheels for M1 and CI

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -69,7 +69,7 @@ pyjwt==2.6.0; python_version > '3.0'
 pymongo[srv]==4.3.3; python_version >= '3.8'
 pymqi==1.12.8; sys_platform != 'darwin' or platform_machine != 'arm64'
 pymysql==0.10.1
-pyodbc==4.0.32; sys_platform != 'darwin' or platform_machine != 'arm64'
+pyodbc==4.0.35
 pyro4==4.82; sys_platform == 'win32'
 pysmi==0.3.4
 pysnmp-mibs==0.1.6

--- a/ibm_i/pyproject.toml
+++ b/ibm_i/pyproject.toml
@@ -41,7 +41,7 @@ text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "pyodbc==4.0.32; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "pyodbc==4.0.35",
 ]
 
 [project.urls]

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -42,7 +42,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "lxml==4.9.2",
-    "pyodbc==4.0.32; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "pyodbc==4.0.35",
     "pyro4==4.82; sys_platform == 'win32'",
     "pywin32==228; sys_platform == 'win32' and python_version < '3.0'",
     "pywin32==304; sys_platform == 'win32' and python_version > '3.0'",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Should kill 2 birds with one stone:

1. Let us run the tests on M1 macs.
2. Fix the broken CI build for ibm_i since this version adds wheels for linux. The CI broke trying to build a wheel out of the tarball.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.