### PR TITLE
Disable one unit test

### DIFF
--- a/kafka_consumer/tests/python_client/test_unit.py
+++ b/kafka_consumer/tests/python_client/test_unit.py
@@ -84,6 +84,7 @@ def test_oauth_config(sasl_oauth_token_provider, check, expected_exception):
         check(instance).check(instance)
 
 
+@pytest.mark.skip(reason='Add a test that not only check the parameter but also run the check')
 def test_oauth_token_client_config(check, kafka_instance):
     kafka_instance['kafka_client_api_version'] = "3.3.2"
     kafka_instance['security_protocol'] = "SASL_PLAINTEXT"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Disable a unit test that only validates some parameters which are tied to the client implementation

### Motivation
<!-- What inspired you to submit this pull request? -->

- We should not have a test that validates the parameters, but have one that really use oath (tbd in a follow-up PR)
- Will be needed for https://github.com/DataDog/integrations-core/pull/14022

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.