### PR TITLE
Add service check assertions to e2e test

### DIFF
--- a/openstack_controller/tests/test_e2e.py
+++ b/openstack_controller/tests/test_e2e.py
@@ -4,6 +4,8 @@
 
 import pytest
 
+from datadog_checks.base import AgentCheck
+
 from . import common
 
 
@@ -13,3 +15,6 @@ def test_check(dd_agent_check):
     for metric in common.DEFAULT_METRICS:
         aggregator.assert_metric(metric)
     aggregator.assert_all_metrics_covered()
+    aggregator.assert_service_check('openstack.neutron.api.up', AgentCheck.OK, count=1)
+    aggregator.assert_service_check('openstack.nova.api.up', AgentCheck.OK, count=1)
+    aggregator.assert_service_check('openstack.keystone.api.up', AgentCheck.OK, count=1)

--- a/openstack_controller/tests/test_e2e.py
+++ b/openstack_controller/tests/test_e2e.py
@@ -12,9 +12,16 @@ from . import common
 @pytest.mark.e2e
 def test_check(dd_agent_check):
     aggregator = dd_agent_check()
+
+    # assert default metrics
     for metric in common.DEFAULT_METRICS:
         aggregator.assert_metric(metric)
     aggregator.assert_all_metrics_covered()
+
+    # assert service checks
     aggregator.assert_service_check('openstack.neutron.api.up', AgentCheck.OK, count=1)
     aggregator.assert_service_check('openstack.nova.api.up', AgentCheck.OK, count=1)
+    aggregator.assert_service_check('openstack.keystone.api.up', AgentCheck.OK, count=1)
+    aggregator.assert_service_check('openstack.nova.hypervisor.up', AgentCheck.OK, count=10)
+    aggregator.assert_service_check('openstack.neutron.network.up', AgentCheck.OK, count=2)
     aggregator.assert_service_check('openstack.keystone.api.up', AgentCheck.OK, count=1)

--- a/openstack_controller/tests/test_e2e.py
+++ b/openstack_controller/tests/test_e2e.py
@@ -24,4 +24,3 @@ def test_check(dd_agent_check):
     aggregator.assert_service_check('openstack.keystone.api.up', AgentCheck.OK, count=1)
     aggregator.assert_service_check('openstack.nova.hypervisor.up', AgentCheck.OK, count=10)
     aggregator.assert_service_check('openstack.neutron.network.up', AgentCheck.OK, count=2)
-    aggregator.assert_service_check('openstack.keystone.api.up', AgentCheck.OK, count=1)


### PR DESCRIPTION
### What does this PR do?
Adds service check asserts to openstack_controller end to end test 

### Motivation
better coverage of the service checks
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.