### PR TITLE
Update postgresql.seq_scans metadata to add missing units

### DIFF
--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -26,7 +26,7 @@ postgresql.bgwriter.buffers_backend_fsync,count,,,,The of times a backend had to
 postgresql.bgwriter.write_time,count,,millisecond,,The total amount of checkpoint processing time spent writing files to disk.,0,postgres,bgw wrt time,
 postgresql.bgwriter.sync_time,count,,millisecond,,The total amount of checkpoint processing time spent synchronizing files to disk.,0,postgres,bgw sync time,
 postgresql.locks,gauge,,lock,,The number of locks active for this database.,0,postgres,locks,
-postgresql.seq_scans,gauge,,,,The number of sequential scans initiated on this table.,0,postgres,seq scans,
+postgresql.seq_scans,gauge,,scan,second,The number of sequential scans initiated on this table.,0,postgres,seq scans,
 postgresql.seq_rows_read,gauge,,row,second,The number of live rows fetched by sequential scans.,0,postgres,seq rows rd,
 postgresql.index_scans,gauge,,,,"The number of index scans initiated on this table, tagged by index.",0,postgres,idx scans,
 postgresql.index_rel_scans,gauge,,,,The overall number of index scans initiated on this table.,0,postgres,idx scans,


### PR DESCRIPTION
### What does this PR do?
Fixes the missing metadata units for the `postgresql.seq_scans` which can lead to a confusing experience. Showing the gauge value in `scans/sec` will make it easier for users to understand this metric. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.