### PR TITLE
Remove setuptools as build depedency

### DIFF
--- a/.azure-pipelines/templates/set-up-windows.yml
+++ b/.azure-pipelines/templates/set-up-windows.yml
@@ -3,3 +3,6 @@ steps:
 # See: https://github.com/giampaolo/psutil/issues/351
 - script: diskperf -y
   displayName: 'Enable disk performance counters'
+# https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=powershell
+- script: powershell New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+  displayName: 'Increase max file path length'

--- a/.azure-pipelines/templates/set-up-windows.yml
+++ b/.azure-pipelines/templates/set-up-windows.yml
@@ -3,6 +3,8 @@ steps:
 # See: https://github.com/giampaolo/psutil/issues/351
 - script: diskperf -y
   displayName: 'Enable disk performance counters'
+# In Python 2 we have to install all packages into hatch envs. This results in long paths that default windows cannot handle.
+# TODO: remove this when we remove Python 2
 # https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=powershell
 - script: powershell New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
   displayName: 'Increase max file path length'

--- a/active_directory/pyproject.toml
+++ b/active_directory/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/active_directory/pyproject.toml
+++ b/active_directory/pyproject.toml
@@ -50,7 +50,6 @@ path = "datadog_checks/active_directory/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/activemq/pyproject.toml
+++ b/activemq/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/activemq/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/activemq/pyproject.toml
+++ b/activemq/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/activemq_xml/pyproject.toml
+++ b/activemq_xml/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/activemq_xml/pyproject.toml
+++ b/activemq_xml/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/activemq_xml/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/aerospike/pyproject.toml
+++ b/aerospike/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/aerospike/pyproject.toml
+++ b/aerospike/pyproject.toml
@@ -52,7 +52,6 @@ path = "datadog_checks/aerospike/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/airflow/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/airflow/pyproject.toml
+++ b/airflow/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/amazon_msk/pyproject.toml
+++ b/amazon_msk/pyproject.toml
@@ -52,7 +52,6 @@ path = "datadog_checks/amazon_msk/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/amazon_msk/pyproject.toml
+++ b/amazon_msk/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/ambari/pyproject.toml
+++ b/ambari/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/ambari/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/ambari/pyproject.toml
+++ b/ambari/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/apache/pyproject.toml
+++ b/apache/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/apache/pyproject.toml
+++ b/apache/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/apache/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/arangodb/pyproject.toml
+++ b/arangodb/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/arangodb/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/argocd/pyproject.toml
+++ b/argocd/pyproject.toml
@@ -46,7 +46,6 @@ path = "datadog_checks/argocd/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/aspdotnet/pyproject.toml
+++ b/aspdotnet/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/aspdotnet/pyproject.toml
+++ b/aspdotnet/pyproject.toml
@@ -50,7 +50,6 @@ path = "datadog_checks/aspdotnet/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/avi_vantage/pyproject.toml
+++ b/avi_vantage/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/avi_vantage/pyproject.toml
+++ b/avi_vantage/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/avi_vantage/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/azure_iot_edge/pyproject.toml
+++ b/azure_iot_edge/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/azure_iot_edge/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/azure_iot_edge/pyproject.toml
+++ b/azure_iot_edge/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/boundary/pyproject.toml
+++ b/boundary/pyproject.toml
@@ -45,7 +45,6 @@ path = "datadog_checks/boundary/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/btrfs/pyproject.toml
+++ b/btrfs/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/btrfs/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/btrfs/pyproject.toml
+++ b/btrfs/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/cacti/pyproject.toml
+++ b/cacti/pyproject.toml
@@ -49,7 +49,6 @@ path = "datadog_checks/cacti/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/cacti/pyproject.toml
+++ b/cacti/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/calico/pyproject.toml
+++ b/calico/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/calico/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/calico/pyproject.toml
+++ b/calico/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/cassandra/pyproject.toml
+++ b/cassandra/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/cassandra/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/cassandra/pyproject.toml
+++ b/cassandra/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/cassandra_nodetool/pyproject.toml
+++ b/cassandra_nodetool/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/cassandra_nodetool/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/cassandra_nodetool/pyproject.toml
+++ b/cassandra_nodetool/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/ceph/pyproject.toml
+++ b/ceph/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/ceph/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/ceph/pyproject.toml
+++ b/ceph/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/cert_manager/pyproject.toml
+++ b/cert_manager/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.12.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/cert_manager/pyproject.toml
+++ b/cert_manager/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/cert_manager/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/cilium/pyproject.toml
+++ b/cilium/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/cilium/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/cilium/pyproject.toml
+++ b/cilium/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/cisco_aci/pyproject.toml
+++ b/cisco_aci/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/cisco_aci/pyproject.toml
+++ b/cisco_aci/pyproject.toml
@@ -52,7 +52,6 @@ path = "datadog_checks/cisco_aci/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/citrix_hypervisor/pyproject.toml
+++ b/citrix_hypervisor/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/citrix_hypervisor/pyproject.toml
+++ b/citrix_hypervisor/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/citrix_hypervisor/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/clickhouse/pyproject.toml
+++ b/clickhouse/pyproject.toml
@@ -56,7 +56,6 @@ path = "datadog_checks/clickhouse/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/clickhouse/pyproject.toml
+++ b/clickhouse/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/cloud_foundry_api/pyproject.toml
+++ b/cloud_foundry_api/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/cloud_foundry_api/pyproject.toml
+++ b/cloud_foundry_api/pyproject.toml
@@ -49,7 +49,6 @@ path = "datadog_checks/cloud_foundry_api/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/cloudera/pyproject.toml
+++ b/cloudera/pyproject.toml
@@ -49,7 +49,6 @@ path = "datadog_checks/cloudera/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/cloudera/pyproject.toml
+++ b/cloudera/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/cockroachdb/pyproject.toml
+++ b/cockroachdb/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/cockroachdb/pyproject.toml
+++ b/cockroachdb/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/cockroachdb/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/confluent_platform/pyproject.toml
+++ b/confluent_platform/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/confluent_platform/pyproject.toml
+++ b/confluent_platform/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/confluent_platform/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/consul/pyproject.toml
+++ b/consul/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/consul/pyproject.toml
+++ b/consul/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/consul/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/coredns/pyproject.toml
+++ b/coredns/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/coredns/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/coredns/pyproject.toml
+++ b/coredns/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/couch/pyproject.toml
+++ b/couch/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/couch/pyproject.toml
+++ b/couch/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/couch/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/couchbase/pyproject.toml
+++ b/couchbase/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/couchbase/pyproject.toml
+++ b/couchbase/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/couchbase/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/crio/pyproject.toml
+++ b/crio/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/crio/pyproject.toml
+++ b/crio/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/crio/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -103,7 +103,6 @@ path = "datadog_checks/base/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/datadog_checks_dev/datadog_checks/dev/plugin/hatch/environment_collector.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/hatch/environment_collector.py
@@ -86,7 +86,7 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
 
             install_commands = []
             if install_command := self.base_package_install_command(
-                    config.get('base-package-features', self.config.get('base-package-features')), env_config
+                config.get('base-package-features', self.config.get('base-package-features')), env_config
             ):
                 install_commands.append(install_command)
             if dev_install_command := self.dev_package_install_command(env_config):

--- a/datadog_checks_dev/datadog_checks/dev/plugin/hatch/environment_collector.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/hatch/environment_collector.py
@@ -36,20 +36,26 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
         return self.config.get('mypy-deps', [])
 
     def dev_package_install_command(self, in_py2_env):
-        if not self.in_core_repo or in_py2_env:
+        if not self.in_core_repo:
             return self.pip_install_command('datadog-checks-dev')
         elif not (self.is_test_package or self.is_dev_package):
-            return self.pip_install_command('-e', '../datadog_checks_dev')
-        return ""
+            if in_py2_env:
+                return self.pip_install_command('../datadog_checks_dev')
+            else:
+                return self.pip_install_command('-e', '../datadog_checks_dev')
+        return ''
 
     def base_package_install_command(self, features, in_py2_env):
-        if not self.in_core_repo or os.environ.get('BASE_PACKAGE_FORCE_UNPINNED') or in_py2_env:
+        if not self.in_core_repo or os.environ.get('BASE_PACKAGE_FORCE_UNPINNED'):
             return self.pip_install_command(self.format_base_package(features))
         elif base_package_version := os.environ.get('BASE_PACKAGE_FORCE_VERSION'):
             return self.pip_install_command(self.format_base_package(features, version=base_package_version))
         elif not (self.is_base_package or self.is_dev_package):
-            return self.pip_install_command('-e', f'../{self.format_base_package(features, local=True)}')
-        return ""
+            if in_py2_env:
+                return self.pip_install_command(f'../{self.format_base_package(features, local=True)}')
+            else:
+                return self.pip_install_command('-e', f'../{self.format_base_package(features, local=True)}')
+        return ''
 
     @staticmethod
     def format_base_package(features, version='', local=False):

--- a/datadog_checks_dev/datadog_checks/dev/plugin/hatch/environment_collector.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/hatch/environment_collector.py
@@ -66,6 +66,12 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
     def pip_install_command(*args):
         return f'python -m pip install --disable-pip-version-check {{verbosity:flag:-1}} {" ".join(args)}'
 
+    def finalize_environments(self, config):
+        for env_config in config.values():
+            if env_config.get('python') == '2.7':
+                env_config['dev-mode'] = False
+        return config
+
     def finalize_config(self, config):
         for env_name, env_config in config.items():
             is_template_env = env_name == 'default'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -270,14 +270,21 @@ class DockerInterface(object):
     def update_check(self):
         command = ['docker', 'exec', self.container_name]
         command.extend(get_pip_exe(self.python_version, platform=self.container_platform))
-        command.extend(('install', '-e', f'{self.check_mount_dir}[deps]'))
+        command.extend(self.install_command(f'{self.check_mount_dir}[deps]'))
         run_command(command, capture=True, check=True)
 
     def update_base_package(self):
         command = ['docker', 'exec', self.container_name]
         command.extend(get_pip_exe(self.python_version, platform=self.container_platform))
-        command.extend(('install', '-e', f'{self.base_mount_dir}[db,deps,http,json,kube]'))
+        command.extend(self.install_command(f'{self.base_mount_dir}[db,deps,http,json,kube]'))
         run_command(command, capture=True, check=True)
+
+    def install_command(self, package_spec):
+        cmd = ['install']
+        if self.python_version == 3:
+            cmd.append('-e')
+        cmd.append(package_spec)
+        return cmd
 
     def update_agent(self):
         if self.agent_build and '/' in self.agent_build:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/local.py
@@ -199,13 +199,20 @@ class LocalAgentInterface(object):
     def update_check(self):
         command = get_pip_exe(self.python_version, self.platform)
         path = path_join(get_root(), self.check)
-        command.extend(('install', '-e', f'{path}[deps]'))
+        command.extend(self.install_command(f'{path}[deps]'))
         return run_command(command, capture=True, check=True)
 
     def update_base_package(self):
         command = get_pip_exe(self.python_version, self.platform)
-        command.extend(('install', '-e', f'{self.base_package}[db,deps,http,json,kube]'))
+        command.extend(self.install_command(f'{self.base_package}[db,deps,http,json,kube]'))
         return run_command(command, capture=True, check=True)
+
+    def install_command(self, package_spec):
+        cmd = ['install']
+        if self.python_version == 3:
+            cmd.append('-e')
+        cmd.append(package_spec)
+        return cmd
 
     def update_agent(self):
         # The Local E2E assumes an Agent is already installed on the machine

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/{check_name}/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/{check_name}/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/{check_name}/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -110,7 +110,6 @@ path = "datadog_checks/dev/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 
@@ -84,12 +82,10 @@ cli = [
     "toml>=0.9.4, <1.0.0",
     "tomli>=1.1.0",
     "tomli-w>=1.0.0",
-    "tox>=3.12.1, <4.0.0", 
+    "tox>=3.12.1, <4.0.0",
     "twine>=1.11.0",
     "virtualenv",
     # TODO: Remove once every check has a pyproject.toml
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
     "wheel>=0.31.0",
 ]
 

--- a/datadog_checks_downloader/pyproject.toml
+++ b/datadog_checks_downloader/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_checks_downloader/pyproject.toml
+++ b/datadog_checks_downloader/pyproject.toml
@@ -50,7 +50,6 @@ path = "datadog_checks/downloader/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/datadog_cluster_agent/pyproject.toml
+++ b/datadog_cluster_agent/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/datadog_cluster_agent/pyproject.toml
+++ b/datadog_cluster_agent/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/datadog_cluster_agent/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/directory/pyproject.toml
+++ b/directory/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/directory/pyproject.toml
+++ b/directory/pyproject.toml
@@ -49,7 +49,6 @@ path = "datadog_checks/directory/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/disk/pyproject.toml
+++ b/disk/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/disk/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/disk/pyproject.toml
+++ b/disk/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/dns_check/pyproject.toml
+++ b/dns_check/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/dns_check/pyproject.toml
+++ b/dns_check/pyproject.toml
@@ -49,7 +49,6 @@ path = "datadog_checks/dns_check/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/dotnetclr/pyproject.toml
+++ b/dotnetclr/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/dotnetclr/pyproject.toml
+++ b/dotnetclr/pyproject.toml
@@ -50,7 +50,6 @@ path = "datadog_checks/dotnetclr/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/druid/pyproject.toml
+++ b/druid/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/druid/pyproject.toml
+++ b/druid/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/druid/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/ecs_fargate/pyproject.toml
+++ b/ecs_fargate/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/ecs_fargate/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/ecs_fargate/pyproject.toml
+++ b/ecs_fargate/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/eks_fargate/pyproject.toml
+++ b/eks_fargate/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/eks_fargate/pyproject.toml
+++ b/eks_fargate/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/eks_fargate/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/elastic/pyproject.toml
+++ b/elastic/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/elastic/pyproject.toml
+++ b/elastic/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/elastic/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/envoy/pyproject.toml
+++ b/envoy/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/envoy/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/envoy/pyproject.toml
+++ b/envoy/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/etcd/pyproject.toml
+++ b/etcd/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/etcd/pyproject.toml
+++ b/etcd/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/etcd/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/exchange_server/pyproject.toml
+++ b/exchange_server/pyproject.toml
@@ -50,7 +50,6 @@ path = "datadog_checks/exchange_server/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/exchange_server/pyproject.toml
+++ b/exchange_server/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/external_dns/pyproject.toml
+++ b/external_dns/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/external_dns/pyproject.toml
+++ b/external_dns/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/external_dns/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/flink/pyproject.toml
+++ b/flink/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/flink/pyproject.toml
+++ b/flink/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/flink/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
     "/requirements-dev.txt",
     "/tox.ini",

--- a/fluentd/pyproject.toml
+++ b/fluentd/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/fluentd/pyproject.toml
+++ b/fluentd/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/fluentd/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/foundationdb/pyproject.toml
+++ b/foundationdb/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/foundationdb/pyproject.toml
+++ b/foundationdb/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/foundationdb/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/gearmand/pyproject.toml
+++ b/gearmand/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/gearmand/pyproject.toml
+++ b/gearmand/pyproject.toml
@@ -50,7 +50,6 @@ path = "datadog_checks/gearmand/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/gitlab/pyproject.toml
+++ b/gitlab/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/gitlab/pyproject.toml
+++ b/gitlab/pyproject.toml
@@ -52,7 +52,6 @@ path = "datadog_checks/gitlab/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/gitlab_runner/pyproject.toml
+++ b/gitlab_runner/pyproject.toml
@@ -52,7 +52,6 @@ path = "datadog_checks/gitlab_runner/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/gitlab_runner/pyproject.toml
+++ b/gitlab_runner/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/glusterfs/pyproject.toml
+++ b/glusterfs/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/glusterfs/pyproject.toml
+++ b/glusterfs/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/glusterfs/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/go_expvar/pyproject.toml
+++ b/go_expvar/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/go_expvar/pyproject.toml
+++ b/go_expvar/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/go_expvar/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/gunicorn/pyproject.toml
+++ b/gunicorn/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/gunicorn/pyproject.toml
+++ b/gunicorn/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/gunicorn/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/haproxy/pyproject.toml
+++ b/haproxy/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/haproxy/pyproject.toml
+++ b/haproxy/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/haproxy/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/harbor/pyproject.toml
+++ b/harbor/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/harbor/pyproject.toml
+++ b/harbor/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/harbor/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/hazelcast/pyproject.toml
+++ b/hazelcast/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/hazelcast/pyproject.toml
+++ b/hazelcast/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/hazelcast/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/hdfs_datanode/pyproject.toml
+++ b/hdfs_datanode/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/hdfs_datanode/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/hdfs_datanode/pyproject.toml
+++ b/hdfs_datanode/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/hdfs_namenode/pyproject.toml
+++ b/hdfs_namenode/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/hdfs_namenode/pyproject.toml
+++ b/hdfs_namenode/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/hdfs_namenode/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/hive/pyproject.toml
+++ b/hive/pyproject.toml
@@ -46,7 +46,6 @@ path = "datadog_checks/hive/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/hive/pyproject.toml
+++ b/hive/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/hivemq/pyproject.toml
+++ b/hivemq/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/hivemq/pyproject.toml
+++ b/hivemq/pyproject.toml
@@ -46,7 +46,6 @@ path = "datadog_checks/hivemq/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 
 ]

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -53,7 +53,6 @@ path = "datadog_checks/http_check/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/hudi/pyproject.toml
+++ b/hudi/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/hudi/pyproject.toml
+++ b/hudi/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/hudi/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/hyperv/pyproject.toml
+++ b/hyperv/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/hyperv/pyproject.toml
+++ b/hyperv/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/hyperv/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/ibm_ace/pyproject.toml
+++ b/ibm_ace/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/ibm_ace/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/ibm_db2/pyproject.toml
+++ b/ibm_db2/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/ibm_db2/pyproject.toml
+++ b/ibm_db2/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/ibm_db2/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/ibm_i/pyproject.toml
+++ b/ibm_i/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/ibm_i/pyproject.toml
+++ b/ibm_i/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/ibm_i/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/ibm_mq/pyproject.toml
+++ b/ibm_mq/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/ibm_mq/pyproject.toml
+++ b/ibm_mq/pyproject.toml
@@ -52,7 +52,6 @@ path = "datadog_checks/ibm_mq/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/ibm_was/pyproject.toml
+++ b/ibm_was/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/ibm_was/pyproject.toml
+++ b/ibm_was/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/ibm_was/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/ignite/pyproject.toml
+++ b/ignite/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/ignite/pyproject.toml
+++ b/ignite/pyproject.toml
@@ -46,7 +46,6 @@ path = "datadog_checks/ignite/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/iis/pyproject.toml
+++ b/iis/pyproject.toml
@@ -50,7 +50,6 @@ path = "datadog_checks/iis/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/iis/pyproject.toml
+++ b/iis/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/impala/pyproject.toml
+++ b/impala/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/impala/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/impala/pyproject.toml
+++ b/impala/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.13.0",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/istio/pyproject.toml
+++ b/istio/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/istio/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/istio/pyproject.toml
+++ b/istio/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/jboss_wildfly/pyproject.toml
+++ b/jboss_wildfly/pyproject.toml
@@ -46,7 +46,6 @@ path = "datadog_checks/jboss_wildfly/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/jboss_wildfly/pyproject.toml
+++ b/jboss_wildfly/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/journald/pyproject.toml
+++ b/journald/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/journald/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
     "/requirements-dev.txt",
     "/tox.ini",

--- a/journald/pyproject.toml
+++ b/journald/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/kafka/pyproject.toml
+++ b/kafka/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/kafka/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/kafka/pyproject.toml
+++ b/kafka/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/kafka_consumer/pyproject.toml
+++ b/kafka_consumer/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/kafka_consumer/pyproject.toml
+++ b/kafka_consumer/pyproject.toml
@@ -54,7 +54,6 @@ path = "datadog_checks/kafka_consumer/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/kong/pyproject.toml
+++ b/kong/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/kong/pyproject.toml
+++ b/kong/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/kong/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/kube_apiserver_metrics/pyproject.toml
+++ b/kube_apiserver_metrics/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/kube_apiserver_metrics/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/kube_apiserver_metrics/pyproject.toml
+++ b/kube_apiserver_metrics/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_controller_manager/pyproject.toml
+++ b/kube_controller_manager/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/kube_controller_manager/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/kube_controller_manager/pyproject.toml
+++ b/kube_controller_manager/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_dns/pyproject.toml
+++ b/kube_dns/pyproject.toml
@@ -52,7 +52,6 @@ path = "datadog_checks/kube_dns/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/kube_dns/pyproject.toml
+++ b/kube_dns/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_metrics_server/pyproject.toml
+++ b/kube_metrics_server/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/kube_metrics_server/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/kube_metrics_server/pyproject.toml
+++ b/kube_metrics_server/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_proxy/pyproject.toml
+++ b/kube_proxy/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/kube_proxy/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/kube_proxy/pyproject.toml
+++ b/kube_proxy/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_scheduler/pyproject.toml
+++ b/kube_scheduler/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/kube_scheduler/pyproject.toml
+++ b/kube_scheduler/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/kube_scheduler/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/kubelet/pyproject.toml
+++ b/kubelet/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/kubelet/pyproject.toml
+++ b/kubelet/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/kubelet/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/kubernetes_state/pyproject.toml
+++ b/kubernetes_state/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/kubernetes_state/pyproject.toml
+++ b/kubernetes_state/pyproject.toml
@@ -52,7 +52,6 @@ path = "datadog_checks/kubernetes_state/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/kyototycoon/pyproject.toml
+++ b/kyototycoon/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/kyototycoon/pyproject.toml
+++ b/kyototycoon/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/kyototycoon/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/lighttpd/pyproject.toml
+++ b/lighttpd/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/lighttpd/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/lighttpd/pyproject.toml
+++ b/lighttpd/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/linkerd/pyproject.toml
+++ b/linkerd/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/linkerd/pyproject.toml
+++ b/linkerd/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/linkerd/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/linux_proc_extras/pyproject.toml
+++ b/linux_proc_extras/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/linux_proc_extras/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/linux_proc_extras/pyproject.toml
+++ b/linux_proc_extras/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/mapr/pyproject.toml
+++ b/mapr/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/mapr/pyproject.toml
+++ b/mapr/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/mapr/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/mapreduce/pyproject.toml
+++ b/mapreduce/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/mapreduce/pyproject.toml
+++ b/mapreduce/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/mapreduce/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/marathon/pyproject.toml
+++ b/marathon/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/marathon/pyproject.toml
+++ b/marathon/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/marathon/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/marklogic/pyproject.toml
+++ b/marklogic/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/marklogic/pyproject.toml
+++ b/marklogic/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/marklogic/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/mcache/pyproject.toml
+++ b/mcache/pyproject.toml
@@ -50,7 +50,6 @@ path = "datadog_checks/mcache/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/mcache/pyproject.toml
+++ b/mcache/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/mesos_master/pyproject.toml
+++ b/mesos_master/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/mesos_master/pyproject.toml
+++ b/mesos_master/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/mesos_master/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/mesos_slave/pyproject.toml
+++ b/mesos_slave/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/mesos_slave/pyproject.toml
+++ b/mesos_slave/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/mesos_slave/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/mongo/pyproject.toml
+++ b/mongo/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/mongo/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -56,7 +56,6 @@ path = "datadog_checks/mysql/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/nagios/pyproject.toml
+++ b/nagios/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/nagios/pyproject.toml
+++ b/nagios/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/nagios/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/network/pyproject.toml
+++ b/network/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/network/pyproject.toml
+++ b/network/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/network/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/nfsstat/pyproject.toml
+++ b/nfsstat/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/nfsstat/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/nfsstat/pyproject.toml
+++ b/nfsstat/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/nginx/pyproject.toml
+++ b/nginx/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/nginx/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/nginx/pyproject.toml
+++ b/nginx/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/nginx_ingress_controller/pyproject.toml
+++ b/nginx_ingress_controller/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/nginx_ingress_controller/pyproject.toml
+++ b/nginx_ingress_controller/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/nginx_ingress_controller/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/openldap/pyproject.toml
+++ b/openldap/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/openldap/pyproject.toml
+++ b/openldap/pyproject.toml
@@ -49,7 +49,6 @@ path = "datadog_checks/openldap/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/openmetrics/pyproject.toml
+++ b/openmetrics/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/openmetrics/pyproject.toml
+++ b/openmetrics/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/openmetrics/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/openstack/pyproject.toml
+++ b/openstack/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/openstack/pyproject.toml
+++ b/openstack/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/openstack/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/openstack_controller/pyproject.toml
+++ b/openstack_controller/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/openstack_controller/pyproject.toml
+++ b/openstack_controller/pyproject.toml
@@ -53,7 +53,6 @@ path = "datadog_checks/openstack_controller/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/oracle/pyproject.toml
+++ b/oracle/pyproject.toml
@@ -57,7 +57,6 @@ path = "datadog_checks/oracle/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/pan_firewall/pyproject.toml
+++ b/pan_firewall/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/pan_firewall/pyproject.toml
+++ b/pan_firewall/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/pan_firewall/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
     "/requirements-dev.txt",
     "/tox.ini",

--- a/pdh_check/pyproject.toml
+++ b/pdh_check/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/pdh_check/pyproject.toml
+++ b/pdh_check/pyproject.toml
@@ -50,7 +50,6 @@ path = "datadog_checks/pdh_check/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/pgbouncer/pyproject.toml
+++ b/pgbouncer/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/pgbouncer/pyproject.toml
+++ b/pgbouncer/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/pgbouncer/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/php_fpm/pyproject.toml
+++ b/php_fpm/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/php_fpm/pyproject.toml
+++ b/php_fpm/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/php_fpm/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/postfix/pyproject.toml
+++ b/postfix/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/postfix/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/postfix/pyproject.toml
+++ b/postfix/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -55,7 +55,6 @@ path = "datadog_checks/postgres/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/powerdns_recursor/pyproject.toml
+++ b/powerdns_recursor/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/powerdns_recursor/pyproject.toml
+++ b/powerdns_recursor/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/powerdns_recursor/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/presto/pyproject.toml
+++ b/presto/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/presto/pyproject.toml
+++ b/presto/pyproject.toml
@@ -46,7 +46,6 @@ path = "datadog_checks/presto/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/process/pyproject.toml
+++ b/process/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/process/pyproject.toml
+++ b/process/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/process/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/prometheus/pyproject.toml
+++ b/prometheus/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/prometheus/pyproject.toml
+++ b/prometheus/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/prometheus/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/proxysql/pyproject.toml
+++ b/proxysql/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/proxysql/pyproject.toml
+++ b/proxysql/pyproject.toml
@@ -49,7 +49,6 @@ path = "datadog_checks/proxysql/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/pulsar/pyproject.toml
+++ b/pulsar/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/pulsar/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/rabbitmq/pyproject.toml
+++ b/rabbitmq/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/rabbitmq/pyproject.toml
+++ b/rabbitmq/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/rabbitmq/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/redisdb/pyproject.toml
+++ b/redisdb/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/redisdb/pyproject.toml
+++ b/redisdb/pyproject.toml
@@ -52,7 +52,6 @@ path = "datadog_checks/redisdb/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/rethinkdb/pyproject.toml
+++ b/rethinkdb/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/rethinkdb/pyproject.toml
+++ b/rethinkdb/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/rethinkdb/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/riak/pyproject.toml
+++ b/riak/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/riak/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/riak/pyproject.toml
+++ b/riak/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/riakcs/pyproject.toml
+++ b/riakcs/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/riakcs/pyproject.toml
+++ b/riakcs/pyproject.toml
@@ -49,7 +49,6 @@ path = "datadog_checks/riakcs/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/sap_hana/pyproject.toml
+++ b/sap_hana/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/sap_hana/pyproject.toml
+++ b/sap_hana/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/sap_hana/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/scylla/pyproject.toml
+++ b/scylla/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/scylla/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/scylla/pyproject.toml
+++ b/scylla/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/sidekiq/pyproject.toml
+++ b/sidekiq/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/sidekiq/pyproject.toml
+++ b/sidekiq/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/sidekiq/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
     "/requirements-dev.txt",
     "/tox.ini",

--- a/silk/pyproject.toml
+++ b/silk/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/silk/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/silk/pyproject.toml
+++ b/silk/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/singlestore/pyproject.toml
+++ b/singlestore/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/singlestore/pyproject.toml
+++ b/singlestore/pyproject.toml
@@ -49,7 +49,6 @@ path = "datadog_checks/singlestore/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/snmp/pyproject.toml
+++ b/snmp/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/snmp/pyproject.toml
+++ b/snmp/pyproject.toml
@@ -58,7 +58,6 @@ path = "datadog_checks/snmp/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/snowflake/pyproject.toml
+++ b/snowflake/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/snowflake/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/solr/pyproject.toml
+++ b/solr/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/solr/pyproject.toml
+++ b/solr/pyproject.toml
@@ -46,7 +46,6 @@ path = "datadog_checks/solr/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/sonarqube/pyproject.toml
+++ b/sonarqube/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/sonarqube/pyproject.toml
+++ b/sonarqube/pyproject.toml
@@ -46,7 +46,6 @@ path = "datadog_checks/sonarqube/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/spark/pyproject.toml
+++ b/spark/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/spark/pyproject.toml
+++ b/spark/pyproject.toml
@@ -50,7 +50,6 @@ path = "datadog_checks/spark/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
+    "setuptools>=66; python_version > '3.0'",
+    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 
@@ -58,7 +60,6 @@ path = "datadog_checks/sqlserver/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/squid/pyproject.toml
+++ b/squid/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/squid/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/squid/pyproject.toml
+++ b/squid/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/ssh_check/MANIFEST.in
+++ b/ssh_check/MANIFEST.in
@@ -1,0 +1,2 @@
+graft datadog_checks
+recursive-exclude tests *

--- a/ssh_check/pyproject.toml
+++ b/ssh_check/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/ssh_check/pyproject.toml
+++ b/ssh_check/pyproject.toml
@@ -1,6 +1,8 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
+    "setuptools>=66; python_version > '3.0'",
+    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 
@@ -51,7 +53,6 @@ path = "datadog_checks/ssh_check/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/statsd/pyproject.toml
+++ b/statsd/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/statsd/pyproject.toml
+++ b/statsd/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/statsd/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/supervisord/pyproject.toml
+++ b/supervisord/pyproject.toml
@@ -49,7 +49,6 @@ path = "datadog_checks/supervisord/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/supervisord/pyproject.toml
+++ b/supervisord/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/system_core/pyproject.toml
+++ b/system_core/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/system_core/pyproject.toml
+++ b/system_core/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/system_core/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/system_swap/pyproject.toml
+++ b/system_swap/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/system_swap/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/system_swap/pyproject.toml
+++ b/system_swap/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/tcp_check/pyproject.toml
+++ b/tcp_check/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/tcp_check/pyproject.toml
+++ b/tcp_check/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/tcp_check/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/teamcity/pyproject.toml
+++ b/teamcity/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/teamcity/pyproject.toml
+++ b/teamcity/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/teamcity/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/tenable/pyproject.toml
+++ b/tenable/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/tenable/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
     "/requirements-dev.txt",
     "/tox.ini",

--- a/tenable/pyproject.toml
+++ b/tenable/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/teradata/pyproject.toml
+++ b/teradata/pyproject.toml
@@ -49,7 +49,6 @@ path = "datadog_checks/teradata/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -54,7 +54,6 @@ path = "datadog_checks/tls/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/tokumx/pyproject.toml
+++ b/tokumx/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/tokumx/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/tokumx/pyproject.toml
+++ b/tokumx/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/tomcat/pyproject.toml
+++ b/tomcat/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/tomcat/pyproject.toml
+++ b/tomcat/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/tomcat/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/traffic_server/pyproject.toml
+++ b/traffic_server/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/traffic_server/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/twemproxy/pyproject.toml
+++ b/twemproxy/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/twemproxy/pyproject.toml
+++ b/twemproxy/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/twemproxy/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/twistlock/pyproject.toml
+++ b/twistlock/pyproject.toml
@@ -49,7 +49,6 @@ path = "datadog_checks/twistlock/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/twistlock/pyproject.toml
+++ b/twistlock/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/varnish/pyproject.toml
+++ b/varnish/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/varnish/pyproject.toml
+++ b/varnish/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/varnish/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/vault/pyproject.toml
+++ b/vault/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/vault/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/vault/pyproject.toml
+++ b/vault/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/vertica/pyproject.toml
+++ b/vertica/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/vertica/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/vertica/pyproject.toml
+++ b/vertica/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/voltdb/pyproject.toml
+++ b/voltdb/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/voltdb/pyproject.toml
+++ b/voltdb/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/voltdb/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/vsphere/pyproject.toml
+++ b/vsphere/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/vsphere/pyproject.toml
+++ b/vsphere/pyproject.toml
@@ -52,7 +52,6 @@ path = "datadog_checks/vsphere/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/weblogic/pyproject.toml
+++ b/weblogic/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/weblogic/pyproject.toml
+++ b/weblogic/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/weblogic/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/win32_event_log/pyproject.toml
+++ b/win32_event_log/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/win32_event_log/pyproject.toml
+++ b/win32_event_log/pyproject.toml
@@ -51,7 +51,6 @@ path = "datadog_checks/win32_event_log/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/windows_performance_counters/pyproject.toml
+++ b/windows_performance_counters/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/windows_performance_counters/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/windows_performance_counters/pyproject.toml
+++ b/windows_performance_counters/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/windows_service/pyproject.toml
+++ b/windows_service/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/windows_service/pyproject.toml
+++ b/windows_service/pyproject.toml
@@ -50,7 +50,6 @@ path = "datadog_checks/windows_service/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/wmi_check/pyproject.toml
+++ b/wmi_check/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/wmi_check/pyproject.toml
+++ b/wmi_check/pyproject.toml
@@ -50,7 +50,6 @@ path = "datadog_checks/wmi_check/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/yarn/pyproject.toml
+++ b/yarn/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/yarn/pyproject.toml
+++ b/yarn/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/yarn/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 

--- a/zk/pyproject.toml
+++ b/zk/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 

--- a/zk/pyproject.toml
+++ b/zk/pyproject.toml
@@ -47,7 +47,6 @@ path = "datadog_checks/zk/__about__.py"
 [tool.hatch.build.targets.sdist]
 include = [
     "/datadog_checks",
-    "/tests",
     "/manifest.json",
 ]
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

This is an easy way to address a CVE with setuptools.

In python 3 we don't use setuptools at build time at all.
Python 2 is not under active development anymore, so we don't need to install the integrations in editable mode, which means we also don't need setuptools there.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.