### PR TITLE
Add an optional metric for tracking the query plan cache size

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -188,6 +188,16 @@ files:
         type: array
         items:
           type: string
+    - name: include_query_plan_cache_metrics
+      hidden: true
+      description: |
+        Set to `true` to emit metrics for tracking the query plan cache. This metric is useful when
+        debugging performance problems related to reading out data from the plan cache. This metric and
+        configuration should be considered unstable and is subject to change without notice.
+      value:
+        type: boolean
+        example: false
+        display_default: false
     - name: adoprovider
       description: |
         Choose the ADO provider.  Note that the (default) provider
@@ -302,7 +312,6 @@ files:
           value:
             type: number
             example: 10
-
     - name: aws
       description: |
         This block defines the configuration for AWS RDS and Aurora instances. 

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -134,6 +134,10 @@ def instance_include_master_files_metrics(field, value):
     return False
 
 
+def instance_include_query_plan_cache_metrics(field, value):
+    return False
+
+
 def instance_include_task_scheduler_metrics(field, value):
     return False
 

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -124,6 +124,7 @@ class InstanceConfig(BaseModel):
     include_fci_metrics: Optional[bool]
     include_instance_metrics: Optional[bool]
     include_master_files_metrics: Optional[bool]
+    include_query_plan_cache_metrics: Optional[bool]
     include_task_scheduler_metrics: Optional[bool]
     log_unobfuscated_plans: Optional[bool]
     log_unobfuscated_queries: Optional[bool]

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -22,6 +22,14 @@ QUERY_SERVER_STATIC_INFO = {
     ],
 }
 
+QUERY_DM_EXEC_REQUESTS_COUNT = {
+    'name': 'sys.dm_exec_query_stats count',
+    'query': """SELECT COUNT(*) FROM sys.dm_exec_query_stats""".strip(),
+    'columns': [
+        {'name': 'query_plan_cache.rows', 'type': 'gauge'},
+    ],
+}
+
 QUERY_AO_FAILOVER_CLUSTER = {
     'name': 'sys.dm_hadr_cluster',
     'query': """

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -22,6 +22,19 @@ QUERY_SERVER_STATIC_INFO = {
     ],
 }
 
+# This query will use the narrowest index available on the "table." While MSFT does not
+# document the sys.dm_exec_query_stats view (a table-valued function), there appears to
+# be an index on the column `plan_handle` based on empirical testing of latency by
+# querying different columns.
+#
+# The following queries had mean latency 400-500ms on a 50K-row plan cache:
+# - select * from sys.dm_exec_query_stats where query_hash = ?
+# - select * from sys.dm_exec_query_stats where sql_handle = ?
+# - select * from sys.dm_exec_query_stats where plan_generation_num = ?
+# - select * from sys.dm_exec_query_stats where statement_end_offset = ?
+#
+# This query had mean latency 406μs:
+# - select * from sys.dm_exec_query_stats where plan_handle = ?
 QUERY_DM_EXEC_QUERY_STATS_COUNT = {
     'name': 'sys.dm_exec_query_stats count',
     'query': """SELECT COUNT(*) FROM sys.dm_exec_query_stats""".strip(),

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -43,6 +43,23 @@ QUERY_DM_EXEC_QUERY_STATS_COUNT = {
     ],
 }
 
+# Retrieves the plan cache size from the memory clerk. From the documentation:
+# "This cache store is used for caching ad hoc queries, prepared statements,
+# and server-side cursors in plan cache"
+QUERY_PLAN_CACHE_SIZE_BYTES = {
+    'name': 'plan cache memory size',
+    'query': """
+        SELECT [type] AS [ClerkType],
+        SUM(pages_kb) * 1024 AS [SizeInBytes]
+        FROM sys.dm_os_memory_clerks WITH (NOLOCK)
+        WHERE [ClerkType] = "CACHESTORE_SQLCP"
+        """,
+    'columns': [
+        {'name': 'clerk_type', 'type': 'tag'},
+        {'name': 'query_plan_cache.bytes', 'type': 'gauge'},
+    ]
+}
+
 QUERY_AO_FAILOVER_CLUSTER = {
     'name': 'sys.dm_hadr_cluster',
     'query': """

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
@@ -34,7 +33,7 @@ QUERY_SERVER_STATIC_INFO = {
 # - select * from sys.dm_exec_query_stats where plan_generation_num = ?
 # - select * from sys.dm_exec_query_stats where statement_end_offset = ?
 #
-# This query had mean latency 406μs:
+# This query had mean latency 406us:
 # - select * from sys.dm_exec_query_stats where plan_handle = ?
 QUERY_DM_EXEC_QUERY_STATS_COUNT = {
     'name': 'sys.dm_exec_query_stats count',

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -22,7 +22,7 @@ QUERY_SERVER_STATIC_INFO = {
     ],
 }
 
-QUERY_DM_EXEC_REQUESTS_COUNT = {
+QUERY_DM_EXEC_QUERY_STATS_COUNT = {
     'name': 'sys.dm_exec_query_stats count',
     'query': """SELECT COUNT(*) FROM sys.dm_exec_query_stats""".strip(),
     'columns': [

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -57,7 +57,7 @@ QUERY_PLAN_CACHE_SIZE_BYTES = {
     'columns': [
         {'name': 'clerk_type', 'type': 'tag'},
         {'name': 'query_plan_cache.bytes', 'type': 'gauge'},
-    ]
+    ],
 }
 
 QUERY_AO_FAILOVER_CLUSTER = {

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -52,7 +52,8 @@ QUERY_PLAN_CACHE_SIZE_BYTES = {
         SELECT [type] AS [ClerkType],
         SUM(pages_kb) * 1024 AS [SizeInBytes]
         FROM sys.dm_os_memory_clerks WITH (NOLOCK)
-        WHERE [ClerkType] = "CACHESTORE_SQLCP"
+        WHERE [type] = 'CACHESTORE_SQLCP'
+        GROUP BY [type]
         """,
     'columns': [
         {'name': 'clerk_type', 'type': 'tag'},

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -63,6 +63,7 @@ from datadog_checks.sqlserver.queries import (
     QUERY_AO_FAILOVER_CLUSTER_MEMBER,
     QUERY_DM_EXEC_QUERY_STATS_COUNT,
     QUERY_FAILOVER_CLUSTER_INSTANCE,
+    QUERY_PLAN_CACHE_SIZE_BYTES,
     QUERY_SERVER_STATIC_INFO,
     get_query_ao_availability_groups,
     get_query_file_stats,
@@ -712,6 +713,7 @@ class SQLServer(AgentCheck):
 
         if is_affirmative(self.instance.get('include_query_plan_cache_metrics', False)):
             queries.extend([QUERY_DM_EXEC_QUERY_STATS_COUNT])
+            queries.extend([QUERY_PLAN_CACHE_SIZE_BYTES])
 
         self._dynamic_queries = self._new_query_executor(queries)
         self._dynamic_queries.compile_queries()

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -61,6 +61,7 @@ from datadog_checks.sqlserver.metrics import DEFAULT_PERFORMANCE_TABLE, VALID_TA
 from datadog_checks.sqlserver.queries import (
     QUERY_AO_FAILOVER_CLUSTER,
     QUERY_AO_FAILOVER_CLUSTER_MEMBER,
+    QUERY_DM_EXEC_QUERY_STATS_COUNT,
     QUERY_FAILOVER_CLUSTER_INSTANCE,
     QUERY_SERVER_STATIC_INFO,
     get_query_ao_availability_groups,
@@ -708,6 +709,9 @@ class SQLServer(AgentCheck):
                 queries.extend([QUERY_FAILOVER_CLUSTER_INSTANCE])
             else:
                 self.log.warning('Failover Cluster Instance metrics are not supported on version 2012')
+
+        if is_affirmative(self.instance.get('include_query_plan_cache_metrics', False)):
+            queries.extend([QUERY_DM_EXEC_QUERY_STATS_COUNT])
 
         self._dynamic_queries = self._new_query_executor(queries)
         self._dynamic_queries.compile_queries()

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -44,7 +44,7 @@ HERE = get_here()
 CHECK_NAME = "sqlserver"
 
 CUSTOM_METRICS = ['sqlserver.clr.execution', 'sqlserver.db.commit_table_entries', 'sqlserver.exec.in_progress']
-UNDOCUMENTED_METRICS = ['sqlserver.query_plan_cache.rows']
+UNDOCUMENTED_METRICS = ['sqlserver.query_plan_cache.rows', 'sqlserver.query_plan_cache.bytes']
 SERVER_METRICS = [
     'sqlserver.server.committed_memory',
     'sqlserver.server.cpu_count',
@@ -64,7 +64,7 @@ def get_expected_file_stats_metrics():
 
 EXPECTED_FILE_STATS_METRICS = get_expected_file_stats_metrics()
 
-EXPECTED_QUERY_PLAN_CACHE_METRICS = ["sqlserver.query_plan_cache.rows"]
+EXPECTED_QUERY_PLAN_CACHE_METRICS = ["sqlserver.query_plan_cache.rows", "sqlserver.query_plan_cache.bytes"]
 
 EXPECTED_DEFAULT_METRICS = (
     [

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -142,6 +142,7 @@ INSTANCE_SQL.update(
         'include_fci_metrics': True,
         'include_ao_metrics': False,
         'include_master_files_metrics': True,
+        'include_query_plan_cache_metrics': True,
         'disable_generic_tags': True,
     }
 )

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -44,6 +44,7 @@ HERE = get_here()
 CHECK_NAME = "sqlserver"
 
 CUSTOM_METRICS = ['sqlserver.clr.execution', 'sqlserver.db.commit_table_entries', 'sqlserver.exec.in_progress']
+UNDOCUMENTED_METRICS = ['sqlserver.query_plan_cache.rows']
 SERVER_METRICS = [
     'sqlserver.server.committed_memory',
     'sqlserver.server.cpu_count',

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -63,6 +63,8 @@ def get_expected_file_stats_metrics():
 
 EXPECTED_FILE_STATS_METRICS = get_expected_file_stats_metrics()
 
+EXPECTED_QUERY_PLAN_CACHE_METRICS = ["sqlserver.query_plan_cache.rows"]
+
 EXPECTED_DEFAULT_METRICS = (
     [
         m[0]
@@ -75,6 +77,7 @@ EXPECTED_DEFAULT_METRICS = (
     ]
     + SERVER_METRICS
     + EXPECTED_FILE_STATS_METRICS
+    + EXPECTED_QUERY_PLAN_CACHE_METRICS
 )
 EXPECTED_METRICS = (
     EXPECTED_DEFAULT_METRICS
@@ -125,27 +128,6 @@ UNEXPECTED_FCI_METRICS = [
 EXPECTED_AO_METRICS_PRIMARY = [m[0] for m in AO_METRICS_PRIMARY]
 EXPECTED_AO_METRICS_SECONDARY = [m[0] for m in AO_METRICS_SECONDARY]
 EXPECTED_AO_METRICS_COMMON = [m[0] for m in AO_METRICS]
-
-INSTANCE_SQL_DEFAULTS = {
-    'host': DOCKER_SERVER,
-    'username': 'sa',
-    'password': 'Password12!',
-    'disable_generic_tags': True,
-}
-INSTANCE_SQL = INSTANCE_SQL_DEFAULTS.copy()
-INSTANCE_SQL.update(
-    {
-        'connector': 'odbc',
-        'driver': '{ODBC Driver 17 for SQL Server}',
-        'include_task_scheduler_metrics': True,
-        'include_db_fragmentation_metrics': True,
-        'include_fci_metrics': True,
-        'include_ao_metrics': False,
-        'include_master_files_metrics': True,
-        'include_query_plan_cache_metrics': True,
-        'disable_generic_tags': True,
-    }
-)
 
 INIT_CONFIG = {
     'custom_metrics': [

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -91,6 +91,7 @@ def instance_docker(instance_docker_defaults):
             'include_fci_metrics': True,
             'include_ao_metrics': False,
             'include_master_files_metrics': True,
+            'include_query_plan_cache_metrics': True,
             'disable_generic_tags': True,
         }
     )

--- a/sqlserver/tests/test_e2e.py
+++ b/sqlserver/tests/test_e2e.py
@@ -50,7 +50,7 @@ def test_ao_primary_replica(dd_agent_check, init_config, instance_ao_docker_prim
     for mname in EXPECTED_AO_METRICS_SECONDARY:
         aggregator.assert_metric(mname, count=0)
 
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=CUSTOM_METRICS)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=CUSTOM_METRICS + UNDOCUMENTED_METRICS)
 
 
 @not_windows_ci
@@ -90,7 +90,7 @@ def test_ao_secondary_replica(dd_agent_check, init_config, instance_ao_docker_se
     for mname in EXPECTED_AO_METRICS_PRIMARY + EXPECTED_QUERY_EXECUTOR_AO_METRICS_PRIMARY:
         aggregator.assert_metric(mname, count=0)
 
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=CUSTOM_METRICS)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=CUSTOM_METRICS + UNDOCUMENTED_METRICS)
 
 
 @not_windows_ado

--- a/sqlserver/tests/test_e2e.py
+++ b/sqlserver/tests/test_e2e.py
@@ -15,6 +15,7 @@ from .common import (
     EXPECTED_QUERY_EXECUTOR_AO_METRICS_COMMON,
     EXPECTED_QUERY_EXECUTOR_AO_METRICS_PRIMARY,
     EXPECTED_QUERY_EXECUTOR_AO_METRICS_SECONDARY,
+    UNDOCUMENTED_METRICS,
     UNEXPECTED_FCI_METRICS,
     UNEXPECTED_QUERY_EXECUTOR_AO_METRICS,
 )
@@ -116,4 +117,4 @@ def test_check_docker(dd_agent_check, init_config, instance_e2e):
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK)
     aggregator.assert_all_metrics_covered()
 
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=CUSTOM_METRICS)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=CUSTOM_METRICS + UNDOCUMENTED_METRICS)

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -9,7 +9,13 @@ import pytest
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import SQLConnectionError
 
-from .common import CHECK_NAME, CUSTOM_METRICS, EXPECTED_DEFAULT_METRICS, assert_metrics
+from .common import (
+    CHECK_NAME,
+    CUSTOM_METRICS,
+    EXPECTED_DEFAULT_METRICS,
+    EXPECTED_QUERY_PLAN_CACHE_METRICS,
+    assert_metrics,
+)
 from .utils import not_windows_ci, windows_ci
 
 try:

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -368,7 +368,11 @@ def test_check_windows_defaults(aggregator, dd_run_check, init_config, instance_
 
     aggregator.assert_metric_has_tag('sqlserver.db.commit_table_entries', 'db:master')
 
+    unexpected_metrics = set(EXPECTED_QUERY_PLAN_CACHE_METRICS)
+
     for mname in EXPECTED_DEFAULT_METRICS + CUSTOM_METRICS:
+        if mname in unexpected_metrics:
+            continue
         aggregator.assert_metric(mname)
 
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK)


### PR DESCRIPTION
### What does this PR do?

This PR adds a metric `sqlserver.query_plan_cache.rows` which is disabled by default. It tracks the size of the table sys.dm_exec_query_stats.

### Motivation

The primary purpose of the metric is to debug performance problems related to excessive plan cache sizes. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.