### PR TITLE
Lower the frequency of query metrics collection

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -260,7 +260,7 @@ files:
             for *every* check instance. Running different instances with different collection intervals is not supported.
           value:
             type: number
-            example: 10
+            example: 60
         - name: dm_exec_query_stats_row_limit
           description: |
             Set the maximum number of query stats rows that can be retrieved in a single check run.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -231,12 +231,12 @@ instances:
         #
         # enabled: true
 
-        ## @param collection_interval - number - optional - default: 10
+        ## @param collection_interval - number - optional - default: 60
         ## Set the query metric collection interval (in seconds). Each collection involves one or more queries to
         ## the SQL Server Query Plan Cache. If a non-default value is chosen then that exact same value must be used
         ## for *every* check instance. Running different instances with different collection intervals is not supported.
         #
-        # collection_interval: 10
+        # collection_interval: 60
 
         ## @param dm_exec_query_stats_row_limit - integer - optional - default: 10000
         ## Set the maximum number of query stats rows that can be retrieved in a single check run.

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -30,7 +30,7 @@ except ImportError:
 
 from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_INFO_VERSION
 
-DEFAULT_COLLECTION_INTERVAL = 10
+DEFAULT_COLLECTION_INTERVAL = 60
 
 SQL_SERVER_QUERY_METRICS_COLUMNS = [
     "execution_count",

--- a/sqlserver/tests/test_high_cardinality.py
+++ b/sqlserver/tests/test_high_cardinality.py
@@ -81,7 +81,7 @@ def test_complete_metrics_run(dd_run_check, dbm_instance, high_cardinality_insta
     second_run_elapsed = _run_queries_and_time_check()
 
     total_elapsed_time = first_run_elapsed + second_run_elapsed
-    assert total_elapsed_time <= 15
+    assert total_elapsed_time <= 60
 
 
 @high_cardinality_only


### PR DESCRIPTION
### What does this PR do?
This lowers the frequency of query metrics collection to only run once every 60s by default. This proposal is being made to balance the staleness of data against having the lowest possible performance impact. We've found that customers generally do not need the high resolution of query metrics with the introduction of Activity events which are sampled at every 10s with much richer information. Query metrics are more often used for historical analysis.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.