### PR TITLE
Add the necessary permissions to make the Agent work with EKS Fargate

### DIFF
--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -63,6 +63,7 @@ rules:
     resources:
     - nodes
     - namespaces
+    - endpoints
     verbs:
     - get
     - list


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This is not a major issue as it will not stop the container or process.

When running Datadog Agent as a sidecar in EKS Fargate, the documented ClusterRole permissions are not enough for endpoints, resulting in an error.

### Motivation
<!-- What inspired you to submit this pull request? -->

From [Install the Datadog Agent on Kubernetes](https://docs.datadoghq.com/ja/containers/kubernetes/installation/?tab=daemonset), you can see the ClusterRole of the Agent installed on k8s. I believe this is necessary because the endpoints are defined in the ClusterRole of the Agent that will be installed on k8s from [Install the Datadog Agent on Kubernetes]().

There may be other permissions required in addition to this modification.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

error log

```
2023-02-01 00:00:00 UTC | CORE | ERROR | (pkg/util/kubernetes/apiserver/apiserver_kubelet.go:28 in NodeMetadataMapping) | Could not collect endpoints from the API Server: "endpoints is forbidden: User \"system:serviceaccount:x:y\" cannot list resource \"endpoints\" in API group \"\" at the cluster scope"
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.