### PR TITLE
Clarify `exact_match` setting document

### DIFF
--- a/process/assets/configuration/spec.yaml
+++ b/process/assets/configuration/spec.yaml
@@ -75,8 +75,8 @@ files:
           type: string
       - name: exact_match
         description: |
-          Matches your search_string on proc.name().
-          If you want to match on a substring within proc.cmdline(), set this to false
+          If you want to match on a substring within `ps -e`, a non full-format CMD, set this to true.
+          If you want to match on a substring within `ps -ef`, a full-format CMD, set this to false.
           Regex is also supported when this flag is set to `false`.
 
           Note: agent v6.11+ on windows runs as an unprivileged `ddagentuser` that does not have access to the full

--- a/process/datadog_checks/process/data/conf.yaml.example
+++ b/process/datadog_checks/process/data/conf.yaml.example
@@ -72,8 +72,8 @@ instances:
     # pid_file: <PID_FILE>
 
     ## @param exact_match - boolean - optional - default: true
-    ## Matches your search_string on proc.name().
-    ## If you want to match on a substring within proc.cmdline(), set this to false
+    ## If you want to match on a substring within `ps -e`, a non full-format CMD, set this to true.
+    ## If you want to match on a substring within `ps -ef`, a full-format CMD, set this to false.
     ## Regex is also supported when this flag is set to `false`.
     ##
     ## Note: agent v6.11+ on windows runs as an unprivileged `ddagentuser` that does not have access to the full


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Clarify `exact_match` setting.

### Motivation
<!-- What inspired you to submit this pull request? -->

The explanation of `exact_match` should be easier.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

[proc.name()](https://github.com/DataDog/integrations-core/blob/58304dfcf51a7ba6b0680c2d3eafa395a0a976fd/process/datadog_checks/process/process.py#L164) is same as the result of `ps -e`.

```bash
$ sudo -u dd-agent /opt/datadog-agent/embedded/bin/python3 -c "import psutil; print([proc.name() for proc in psutil.process_iter(attrs=['name','pid'])])"
['systemd', 'kthreadd', 'rcu_gp', 'rcu_par_gp', 'slub_flushwq', 'netns', 'kworker/0:0H-events_highpri', 'mm_percpu_wq', 'rcu_tasks_rude_', 'rcu_tasks_trace', 'ksoftirqd/0', 'rcu_sched', 'migration/0', 'idle_inject/0', 'cpuhp/0', 'cpuhp/1', 'idle_inject/1', 'migration/1', 'ksoftirqd/1', 'kworker/1:0H-events_highpri', 'kdevtmpfs', 'inet_frag_wq', 'kauditd', 'khungtaskd', 'oom_reaper', 'writeback', 'kcompactd0', 'ksmd', 'khugepaged', 'kintegrityd', 'kblockd', 'blkcg_punt_bio', 'tpm_dev_wq', 'ata_sff', 'md', 'edac-poller', 'devfreq_wq', 'watchdogd', 'kworker/0:1H-kblockd', 'kswapd0', 'ecryptfs-kthrea', 'kthrotld', 'acpi_thermal_pm', 'scsi_eh_0', 'scsi_tmf_0', 'scsi_eh_1', 'scsi_tmf_1', 'vfio-irqfd-clea', 'mld', 'ipv6_addrconf', 'kstrp', 'zswap-shrink', 'kworker/u5:0', 'charger_manager', 'kworker/1:1H-kblockd', 'scsi_eh_2', 'scsi_tmf_2', 'cryptd', 'kdmflush', 'raid5wq', 'jbd2/dm-0-8', 'ext4-rsv-conver', 'systemd-journald', 'kaluad', 'kmpath_rdacd', 'kmpathd', 'kmpath_handlerd', 'multipathd', 'systemd-udevd', 'jbd2/sda2-8', 'ext4-rsv-conver', 'systemd-networkd', 'systemd-resolved', 'dbus-daemon', 'irqbalance', 'networkd-dispat', 'polkitd', 'rsyslogd', 'snapd', 'systemd-logind', 'udisksd', 'cron', 'ModemManager', 'agetty', 'sshd', 'chronyd', 'chronyd', 'systemd', '(sd-pam)', 'dockerd', 'VBoxService', 'sshd', 'sshd', 'bash', 'dbus-daemon', 'sshd', 'sshd', 'bash', 'upowerd', 'packagekitd', 'agent', 'process-agent', 'containerd', 'kworker/u4:2-flush-253:0', 'kworker/u4:3-ext4-rsv-conversion', 'kworker/0:1', 'kworker/0:2-events', 'kworker/1:0-kdmflush', 'kworker/u4:4-ext4-rsv-conversion', 'kworker/1:3-events', 'sudo', 'sudo', 'python3', 'kworker/u4:0-ext4-rsv-conversion']
$ ps -e | head
    PID TTY          TIME CMD
      1 ?        00:00:09 systemd
      2 ?        00:00:00 kthreadd
      3 ?        00:00:00 rcu_gp
      4 ?        00:00:00 rcu_par_gp
      5 ?        00:00:00 slub_flushwq
      6 ?        00:00:00 netns
      8 ?        00:00:00 kworker/0:0H-events_highpri
     10 ?        00:00:00 mm_percpu_wq
     11 ?        00:00:00 rcu_tasks_rude_
```

[proc.cmdline()](https://github.com/DataDog/integrations-core/blob/58304dfcf51a7ba6b0680c2d3eafa395a0a976fd/process/datadog_checks/process/process.py#LL171C39-L171C53) is same as the result of `ps -ef`.

```bash
$ sudo -u dd-agent /opt/datadog-agent/embedded/bin/python3 -c "import psutil; print([proc.cmdline() for proc in psutil.process_iter(attrs=['name','pid'])])"
[['/sbin/init'], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], [], ['/lib/systemd/systemd-journald'], [], [], [], [], ['/sbin/multipathd', '-d', '-s'], ['/lib/systemd/systemd-udevd'], [], [], ['/lib/systemd/systemd-networkd'], ['/lib/systemd/systemd-resolved'], ['@dbus-daemon', '--system', '--address=systemd:', '--nofork', '--nopidfile', '--systemd-activation', '--syslog-only'], ['/usr/sbin/irqbalance', '--foreground'], ['/usr/bin/python3', '/usr/bin/networkd-dispatcher', '--run-startup-triggers'], ['/usr/libexec/polkitd', '--no-debug'], ['/usr/sbin/rsyslogd', '-n', '-iNONE'], ['/usr/lib/snapd/snapd'], ['/lib/systemd/systemd-logind'], ['/usr/libexec/udisks2/udisksd'], ['/usr/sbin/cron', '-f', '-P'], ['/usr/sbin/ModemManager'], ['/sbin/agetty', '-o', '-p -- \\u', '--noclear', 'tty1', 'linux'], ['sshd:', '/usr/sbin/sshd', '-D', '[listener]', '0', 'of', '10-100', 'startups'], ['/usr/sbin/chronyd', '-F', '1'], ['/usr/sbin/chronyd', '-F', '1'], ['/lib/systemd/systemd', '--user'], ['(sd-pam)'], ['/usr/bin/dockerd', '-H', 'fd://', '--containerd=/run/containerd/containerd.sock'], ['/usr/sbin/VBoxService', '--pidfile', '/var/run/vboxadd-service.sh'], ['sshd:', 'vagrant', '[priv]'], ['sshd: vagrant@pts/0', ''], ['-bash'], ['/usr/bin/dbus-daemon', '--session', '--address=systemd:', '--nofork', '--nopidfile', '--systemd-activation', '--syslog-only'], ['sshd:', 'vagrant', '[priv]'], ['sshd: vagrant@pts/2', ''], ['-bash'], ['/usr/libexec/upowerd'], ['/usr/libexec/packagekitd'], ['/opt/datadog-agent/bin/agent/agent', 'run', '-p', '/opt/datadog-agent/run/agent.pid'], ['/opt/datadog-agent/embedded/bin/process-agent', '--config=/etc/datadog-agent/datadog.yaml', '--sysprobe-config=/etc/datadog-agent/system-probe.yaml', '--pid=/opt/datadog-agent/run/process-agent.pid'], ['/usr/local/bin/containerd'], [], [], [], [], [], [], [], [], ['sudo', '-u', 'dd-agent', '/opt/datadog-agent/embedded/bin/python3', '-c', "import psutil; print([proc.cmdline() for proc in psutil.process_iter(attrs=['name','pid'])])"], ['sudo', '-u', 'dd-agent', '/opt/datadog-agent/embedded/bin/python3', '-c', "import psutil; print([proc.cmdline() for proc in psutil.process_iter(attrs=['name','pid'])])"], ['/opt/datadog-agent/embedded/bin/python3', '-c', "import psutil; print([proc.cmdline() for proc in psutil.process_iter(attrs=['name','pid'])])"]]
$ sudo ps -ef | grep agent
dd-agent   47649       1  2 Feb26 ?        00:10:04 /opt/datadog-agent/bin/agent/agent run -p /opt/datadog-agent/run/agent.pid
dd-agent   47650       1  0 Feb26 ?        00:03:44 /opt/datadog-agent/embedded/bin/process-agent --config=/etc/datadog-agent/datadog.yaml --sysprobe-config=/etc/datadog-agent/system-probe.yaml --pid=/opt/datadog-agent/run/process-agent.pid
vagrant   168185    1797  0 06:52 pts/0    00:00:00 grep --color=auto agent
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.