### PR TITLE
Add `{include,exclude}_metrics` to legacy Envoy check

### DIFF
--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -56,9 +56,12 @@ class Envoy(AgentCheck):
         included_metrics = set(
             re.sub(r'^envoy\\?\.', '', s, 1)
             for s in self.instance.get(
-                'included_metrics', self.instance.get(
-                    'metric_whitelist', self.instance.get(
-                        'include_metrics', [],
+                'included_metrics',
+                self.instance.get(
+                    'metric_whitelist',
+                    self.instance.get(
+                        'include_metrics',
+                        [],
                     ),
                 ),
             )
@@ -68,9 +71,12 @@ class Envoy(AgentCheck):
         excluded_metrics = set(
             re.sub(r'^envoy\\?\.', '', s, 1)
             for s in self.instance.get(
-                'excluded_metrics', self.instance.get(
-                    'metric_blacklist', self.instance.get(
-                        'exclude_metrics', [],
+                'excluded_metrics',
+                self.instance.get(
+                    'metric_blacklist',
+                    self.instance.get(
+                        'exclude_metrics',
+                        [],
                     ),
                 ),
             )

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -55,13 +55,13 @@ class Envoy(AgentCheck):
 
         included_metrics = set(
             re.sub(r'^envoy\\?\.', '', s, 1)
-            for s in self.instance.get('included_metrics', self.instance.get('metric_whitelist', []))
+            for s in self.instance.get('included_metrics', self.instance.get('metric_whitelist', self.instance.get('include_metrics', [])))
         )
         self.config_included_metrics = [re.compile(pattern) for pattern in included_metrics]
 
         excluded_metrics = set(
             re.sub(r'^envoy\\?\.', '', s, 1)
-            for s in self.instance.get('excluded_metrics', self.instance.get('metric_blacklist', []))
+            for s in self.instance.get('excluded_metrics', self.instance.get('metric_blacklist', self.instance.get('exclude_metrics', [])))
         )
         self.config_excluded_metrics = [re.compile(pattern) for pattern in excluded_metrics]
 

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -55,13 +55,25 @@ class Envoy(AgentCheck):
 
         included_metrics = set(
             re.sub(r'^envoy\\?\.', '', s, 1)
-            for s in self.instance.get('included_metrics', self.instance.get('metric_whitelist', self.instance.get('include_metrics', [])))
+            for s in self.instance.get(
+                'included_metrics', self.instance.get(
+                    'metric_whitelist', self.instance.get(
+                        'include_metrics', [],
+                    ),
+                ),
+            )
         )
         self.config_included_metrics = [re.compile(pattern) for pattern in included_metrics]
 
         excluded_metrics = set(
             re.sub(r'^envoy\\?\.', '', s, 1)
-            for s in self.instance.get('excluded_metrics', self.instance.get('metric_blacklist', self.instance.get('exclude_metrics', [])))
+            for s in self.instance.get(
+                'excluded_metrics', self.instance.get(
+                    'metric_blacklist', self.instance.get(
+                        'exclude_metrics', [],
+                    ),
+                ),
+            )
         )
         self.config_excluded_metrics = [re.compile(pattern) for pattern in excluded_metrics]
 

--- a/envoy/tests/legacy/common.py
+++ b/envoy/tests/legacy/common.py
@@ -25,6 +25,11 @@ INSTANCES = {
         'included_metrics': [r'envoy\.cluster\.'],
         'excluded_metrics': [r'envoy\.cluster\.out\.'],
     },
+    'include_exclude_metrics': {
+        'stats_url': 'http://{}:{}/stats'.format(HOST, PORT),
+        'include_metrics': [r'envoy\.cluster\.'],
+        'exclude_metrics': [r'envoy\.cluster\.out\.'],
+    },
     'collect_server_info': {
         'stats_url': 'http://{}:{}/stats'.format(HOST, PORT),
         'collect_server_info': 'false',

--- a/envoy/tests/legacy/test_envoy.py
+++ b/envoy/tests/legacy/test_envoy.py
@@ -74,6 +74,18 @@ def test_retrocompatible_config(check):
 
 
 @pytest.mark.unit
+def test_retrocompatible_config2(check):
+    instance = deepcopy(INSTANCES['main'])
+    instance['metric_whitelist'] = deepcopy(INSTANCES['include_exclude_metrics']['include_metrics'])
+    instance['metric_blacklist'] = deepcopy(INSTANCES['include_exclude_metrics']['exclude_metrics'])
+
+    c1 = check(instance)
+    c2 = check(INSTANCES['included_excluded_metrics'])
+    assert c1.config_included_metrics == c2.config_included_metrics
+    assert c1.config_excluded_metrics == c2.config_excluded_metrics
+
+
+@pytest.mark.unit
 def test_success_fixture_included_metrics(aggregator, fixture_path, mock_http_response, check, dd_run_check):
     instance = INSTANCES['included_metrics']
     c = check(instance)

--- a/envoy/tests/legacy/test_envoy.py
+++ b/envoy/tests/legacy/test_envoy.py
@@ -80,7 +80,7 @@ def test_retrocompatible_config2(check):
     instance['metric_blacklist'] = deepcopy(INSTANCES['include_exclude_metrics']['exclude_metrics'])
 
     c1 = check(instance)
-    c2 = check(INSTANCES['included_excluded_metrics'])
+    c2 = check(INSTANCES['include_exclude_metrics'])
     assert c1.config_included_metrics == c2.config_included_metrics
     assert c1.config_excluded_metrics == c2.config_excluded_metrics
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->


When using [stats_url](https://github.com/DataDog/integrations-core/blob/bb108d103e68db601665a61f5e558346f334186d/envoy/datadog_checks/envoy/data/conf.yaml.example#LL63C7-L63C16) instead of [openmetrics_endpoint](https://github.com/DataDog/integrations-core/blob/bb108d103e68db601665a61f5e558346f334186d/envoy/datadog_checks/envoy/data/conf.yaml.example#LL51C5-L51C25), Agent uses legacy [Envoy check](https://github.com/DataDog/integrations-core/blob/bb108d103e68db601665a61f5e558346f334186d/envoy/datadog_checks/envoy/envoy.py#L18). Now legacy Envoy check can take config values from `{include,exclude}_metrics`.

https://github.com/DataDog/integrations-core/blob/bb108d103e68db601665a61f5e558346f334186d/envoy/datadog_checks/envoy/envoy.py#L29-L41

### Motivation
<!-- What inspired you to submit this pull request? -->

Only [{include,exclude}_metrics](https://github.com/DataDog/integrations-core/blob/bb108d103e68db601665a61f5e558346f334186d/envoy/datadog_checks/envoy/data/conf.yaml.example#L145-L160) are defined in the current `conf.yaml.example` for envoy because `{included,excluded}_metrics` are [hidden](https://github.com/DataDog/integrations-core/blob/bb108d103e68db601665a61f5e558346f334186d/envoy/assets/configuration/spec.yaml#L31-L66).
However, legacy Envoy check can take `{included,excluded}_metrics` or `metric_{whitelist,blacklist}` only, cannot take `{include,exclude}_metrics`. This made users confused.

https://github.com/DataDog/integrations-core/blob/bb108d103e68db601665a61f5e558346f334186d/envoy/datadog_checks/envoy/envoy.py#L56-L66

legacy Envoy check should take `{include,exclude}_metrics` to match the current `conf.yaml.example`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.