### PR TITLE
fix: Add missing hpa metric to `kubernetes_state` and `kubernetes_state_core` checks 

### DIFF
--- a/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
+++ b/kubernetes_state/datadog_checks/kubernetes_state/kubernetes_state.py
@@ -246,6 +246,7 @@ class KubernetesState(OpenMetricsBaseCheck):
                         'kube_hpa_status_desired_replicas': 'hpa.desired_replicas',
                         'kube_hpa_status_current_replicas': 'hpa.current_replicas',
                         'kube_hpa_status_condition': 'hpa.condition',
+                        'kube_hpa_status_target_metric' : 'hpa.status_target_metric',
                         'kube_node_info': 'node.count',
                         'kube_pod_info': 'pod.count',
                         'kube_node_status_allocatable_cpu_cores': 'node.cpu_allocatable',

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -61,7 +61,7 @@ kubernetes_state.hpa.min_replicas,gauge,,,,Lower limit for the number of pods th
 kubernetes_state.hpa.max_replicas,gauge,,,,Upper limit for the number of pods that can be set by the autoscaler,0,kubernetes,k8s_state.hpa.max_replicas,
 kubernetes_state.hpa.desired_replicas,gauge,,,,Desired number of replicas of pods managed by this autoscaler,0,kubernetes,k8s_state.hpa.desired_replicas,
 kubernetes_state.hpa.condition,gauge,,,,Observed condition of autoscalers to sum by condition and status,0,kubernetes,k8s_state.hpa.status,
-kubernetes_state.hpa.status_target_metric,gauge,,,,The current metric status used by this autoscaler when calculating the desired replica count,
+kubernetes_state.hpa.status_target_metric,gauge,,,,The current metric status used by this autoscaler when calculating the desired replica count,0,kubernetes,k8s_state.hpa.status_target_metric,
 kubernetes_state.pdb.pods_desired,gauge,,,,Minimum desired number of healthy pods,0,kubernetes,k8s_state.pdb.pods_desired,
 kubernetes_state.pdb.disruptions_allowed,gauge,,,,Number of pod disruptions that are currently allowed,0,kubernetes,k8s_state.pdb.disruptions_allowed,
 kubernetes_state.pdb.pods_healthy,gauge,,,,Current number of healthy pods,1,kubernetes,k8s_state.pdb.pods_healthy,

--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -61,6 +61,7 @@ kubernetes_state.hpa.min_replicas,gauge,,,,Lower limit for the number of pods th
 kubernetes_state.hpa.max_replicas,gauge,,,,Upper limit for the number of pods that can be set by the autoscaler,0,kubernetes,k8s_state.hpa.max_replicas,
 kubernetes_state.hpa.desired_replicas,gauge,,,,Desired number of replicas of pods managed by this autoscaler,0,kubernetes,k8s_state.hpa.desired_replicas,
 kubernetes_state.hpa.condition,gauge,,,,Observed condition of autoscalers to sum by condition and status,0,kubernetes,k8s_state.hpa.status,
+kubernetes_state.hpa.status_target_metric,gauge,,,,The current metric status used by this autoscaler when calculating the desired replica count,
 kubernetes_state.pdb.pods_desired,gauge,,,,Minimum desired number of healthy pods,0,kubernetes,k8s_state.pdb.pods_desired,
 kubernetes_state.pdb.disruptions_allowed,gauge,,,,Number of pod disruptions that are currently allowed,0,kubernetes,k8s_state.pdb.disruptions_allowed,
 kubernetes_state.pdb.pods_healthy,gauge,,,,Current number of healthy pods,1,kubernetes,k8s_state.pdb.pods_healthy,

--- a/kubernetes_state/tests/fixtures/prometheus.txt
+++ b/kubernetes_state/tests/fixtures/prometheus.txt
@@ -13,6 +13,9 @@ kube_hpa_status_current_replicas{hpa="hpa1",namespace="ns1"} 2
 # HELP kube_hpa_status_desired_replicas Desired number of replicas of pods managed by this autoscaler.
 # TYPE kube_hpa_status_desired_replicas gauge
 kube_hpa_status_desired_replicas{hpa="hpa1",namespace="ns1"} 2
+# HELP kube_hpa_status_target_metric The current metric status used by this autoscaler when calculating the desired replica count.
+# TYPE kube_hpa_status_target_metric gauge
+kube_hpa_status_target_metric{hpa="hpa1", namespace="ns1", metric_name="cpu", metric_target_type="utilization"} 50
 # HELP kube_cronjob_created Unix creation timestamp
 # TYPE kube_cronjob_created gauge
 kube_cronjob_created{cronjob="hello",namespace="default"} 1.509978394e+09

--- a/kubernetes_state/tests/test_kubernetes_state.py
+++ b/kubernetes_state/tests/test_kubernetes_state.py
@@ -50,6 +50,7 @@ METRICS = [
     NAMESPACE + '.hpa.desired_replicas',
     NAMESPACE + '.hpa.current_replicas',
     NAMESPACE + '.hpa.condition',
+    NAMESPACE + '.hpa.status_target_metric',
     # pdb
     NAMESPACE + '.pdb.disruptions_allowed',
     NAMESPACE + '.pdb.pods_desired',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add missing metric`kube_hpa_status_target_metric` to the `kubernetes_state` and `kubernetes_state_core` checks.

### Motivation
<!-- What inspired you to submit this pull request? -->
A user will be able to monitor the state of the target metrics.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.