### PR TITLE
Fix dependency update logic for latest versions of `packaging`

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -12,7 +12,7 @@ from aiomultiprocess import Pool
 from packaging.markers import Marker
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
-from packaging.version import parse as parse_version
+from packaging.version import InvalidVersion, Version
 
 from ..constants import get_agent_requirements
 from ..dependencies import (
@@ -148,7 +148,11 @@ def sync():
 def filter_releases(releases):
     filtered_releases = []
     for version, artifacts in releases.items():
-        parsed_version = parse_version(version)
+        try:
+            parsed_version = Version(version)
+        except InvalidVersion:
+            continue
+
         if not parsed_version.is_prerelease:
             filtered_releases.append((parsed_version, artifacts))
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -11,7 +11,7 @@ from aiohttp import request
 from aiomultiprocess import Pool
 from packaging.markers import Marker
 from packaging.requirements import Requirement
-from packaging.specifiers import SpecifierSet
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
 from ..constants import get_agent_requirements
@@ -162,7 +162,12 @@ def filter_releases(releases):
 def artifact_compatible_with_python(artifact, major_version):
     requires_python = artifact['requires_python']
     if requires_python is not None:
-        return SpecifierSet(requires_python).contains(SUPPORTED_PYTHON_MINOR_VERSIONS[major_version])
+        try:
+            specifiers = SpecifierSet(requires_python)
+        except InvalidSpecifier:
+            return False
+
+        return specifiers.contains(SUPPORTED_PYTHON_MINOR_VERSIONS[major_version])
 
     python_version = artifact['python_version']
     return f'py{major_version}' in python_version or f'cp{major_version}' in python_version


### PR DESCRIPTION
### Motivation

Legacy parsing is no longer supported https://github.com/pypa/packaging/blob/5b34465682d40ddd42dd6cba88e158e1674de7b9/CHANGELOG.rst#220---2022-12-07 which then makes versions like https://pypi.org/project/boto/0.8d/ fail

Also accounts for https://github.com/pypa/packaging/issues/566