### PR TITLE
add partitioned table size metrics

### DIFF
--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -105,8 +105,19 @@ def check_common_metrics(aggregator, expected_tags, count=1):
 
 
 def check_db_count(aggregator, expected_tags, count=1):
+    # Partitioned table is not loaded for testing PG version < 10
+    if float(POSTGRES_VERSION) < 10:
+        expected_tables = 5
+    # Partitioned table (parent) do not count until PG 14
+    elif float(POSTGRES_VERSION) < 14:
+        expected_tables = 7
+    else:
+        expected_tables = 8
     aggregator.assert_metric(
-        'postgresql.table.count', value=5, count=count, tags=expected_tags + ['db:{}'.format(DB_NAME), 'schema:public']
+        'postgresql.table.count',
+        value=expected_tables,
+        count=count,
+        tags=expected_tags + ['db:{}'.format(DB_NAME), 'schema:public'],
     )
     aggregator.assert_metric('postgresql.db.count', value=5, count=1)
 

--- a/postgres/tests/compose/resources/03_load_data.sh
+++ b/postgres/tests/compose/resources/03_load_data.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 set -e
 
+if [[ !("$PG_MAJOR" == 9.* ) ]]; then
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" datadog_test <<-EOSQL
+    CREATE TABLE personspart (personid SERIAL, lastname VARCHAR(255), firstname VARCHAR(255), address VARCHAR(255), city VARCHAR(255)) PARTITION BY RANGE (personid);
+    CREATE TABLE personspart_1 PARTITION OF personspart FOR VALUES FROM (MINVALUE) TO (100);
+    CREATE TABLE personspart_2 PARTITION OF personspart FOR VALUES FROM (100) TO (MAXVALUE);
+    INSERT INTO personspart (lastname, firstname, address, city) VALUES ('Cavaille', 'Leo', 'Midtown', 'New York'), ('Someveryveryveryveryveryveryveryveryveryverylongname', 'something', 'Avenue des Champs Elysees', 'Beautiful city of lights');
+    SELECT * FROM personspart;
+    SELECT * FROM personspart;
+    SELECT * FROM personspart;
+EOSQL
+fi
+
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" datadog_test <<-EOSQL
     CREATE TABLE persons (personid SERIAL, lastname VARCHAR(255), firstname VARCHAR(255), address VARCHAR(255), city VARCHAR(255));
     INSERT INTO persons (lastname, firstname, address, city) VALUES ('Cavaille', 'Leo', 'Midtown', 'New York'), ('Someveryveryveryveryveryveryveryveryveryverylongname', 'something', 'Avenue des Champs Elysees', 'Beautiful city of lights');


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds the size metrics for partitioned tables. That is the parent partitioned table size as a sum of partitions sizes. I realize this double counts the partition child tables if those are also included in the relations since they are part of the original size metrics query.

Note. The total tables count behavior is unchanged, only that I now added partitioned tables in the setup for testing.

### Motivation
<!-- What inspired you to submit this pull request? -->
We would like to have this metric. Implements https://github.com/DataDog/integrations-core/issues/13369

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.