### PR TITLE
Add tests for invalid configurations

### DIFF
--- a/openstack_controller/tests/common.py
+++ b/openstack_controller/tests/common.py
@@ -7,6 +7,8 @@ import os
 CHECK_NAME = 'openstack'
 
 FIXTURES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'fixtures')
+TEST_OPENSTACK_CONFIG_PATH = os.path.join(FIXTURES_DIR, 'openstack_config.yaml')
+TEST_OPENSTACK_NO_AUTH_CONFIG_PATH = os.path.join(FIXTURES_DIR, 'openstack_bad_config.yaml')
 
 USE_OPENSTACK_SANDBOX = os.environ.get('USE_OPENSTACK_SANDBOX')
 
@@ -22,7 +24,7 @@ CONFIG_FILE_INSTANCE = {
     'user': {'name': 'test_name', 'password': 'test_pass', 'domain': {'id': 'test_id'}},
     'ssl_verify': False,
     'exclude_network_ids': EXCLUDED_NETWORK_IDS,
-    'openstack_config_file_path': os.path.abspath('./tests/fixtures/openstack_config.yaml'),
+    'openstack_config_file_path': TEST_OPENSTACK_CONFIG_PATH,
     'openstack_cloud_name': 'test_cloud',
 }
 

--- a/openstack_controller/tests/fixtures/openstack_bad_config.yaml
+++ b/openstack_controller/tests/fixtures/openstack_bad_config.yaml
@@ -1,0 +1,12 @@
+clouds:
+  test_cloud:
+    auth:
+      auth_url: http://xxx.xxx.xxx.xxx:5000/v2.0/
+      username: demo
+      password: secrete
+      project_name: demo
+      auth_type: test
+    example:
+      image_name: fedora-20.x86_64
+      flavor_name: m1.small
+      network_name: private

--- a/openstack_controller/tests/test_config.py
+++ b/openstack_controller/tests/test_config.py
@@ -24,6 +24,19 @@ from .common import CHECK_NAME, TEST_OPENSTACK_NO_AUTH_CONFIG_PATH
             'Missing name',
             id='no name, keystone_server_url, cfg path',
         ),
+    ],
+)
+def test_config_invalid(instance, exception_msg):
+
+    check = OpenStackControllerCheck(CHECK_NAME, {}, [instance])
+
+    with pytest.raises(Exception, match=exception_msg):
+        check.check(instance)
+
+
+@pytest.mark.parametrize(
+    'instance, exception_msg',
+    [
         pytest.param(
             {
                 'user': {'name': 'test_name', 'password': 'test_pass', 'domain': {'id': 'test_id'}},
@@ -41,7 +54,7 @@ from .common import CHECK_NAME, TEST_OPENSTACK_NO_AUTH_CONFIG_PATH
                 'name': 'test',
             },
             'Auth plugin requires parameters which were not given: auth_url',
-            id='bad openstack_cloud_name',
+            id='openstack_config_file_path doesn\' exist',
         ),
         pytest.param(
             {
@@ -51,11 +64,11 @@ from .common import CHECK_NAME, TEST_OPENSTACK_NO_AUTH_CONFIG_PATH
                 'openstack_config_file_path': TEST_OPENSTACK_NO_AUTH_CONFIG_PATH,
             },
             re.escape('__init__() got an unexpected keyword argument \'auth_type\''),
-            id='bad config file',
+            id='invalid openstack_config_file',
         ),
     ],
 )
-def test_config_invalid(instance, exception_msg):
+def test_config_invalid_openstack_auth(instance, exception_msg):
 
     check = OpenStackControllerCheck(CHECK_NAME, {}, [instance])
 

--- a/openstack_controller/tests/test_config.py
+++ b/openstack_controller/tests/test_config.py
@@ -14,7 +14,6 @@ from .common import CHECK_NAME, TEST_OPENSTACK_NO_AUTH_CONFIG_PATH
 @pytest.mark.parametrize(
     'instance, exception_msg',
     [
-        pytest.param({'user': {'domain': {'id': 'test_id'}}}, 'Missing name', id='empty'),
         pytest.param({'user': {'domain': {'id': 'test_id'}}}, 'Missing name', id='empty name'),
         pytest.param(
             {

--- a/openstack_controller/tests/test_config.py
+++ b/openstack_controller/tests/test_config.py
@@ -1,0 +1,125 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import copy
+import logging
+import re
+
+import pytest
+
+from datadog_checks.openstack_controller import OpenStackControllerCheck
+
+from .common import CHECK_NAME, CONFIG_FILE_INSTANCE, TEST_OPENSTACK_NO_AUTH_CONFIG_PATH
+
+
+@pytest.mark.parametrize(
+    'options, exception_msg',
+    [
+        pytest.param({'user': {'domain': {'id': 'test_id'}}}, 'Missing name', id='empty'),
+        pytest.param({'user': {'domain': {'id': 'test_id'}}}, 'Missing name', id='empty name'),
+        pytest.param(
+            {
+                'user': {'name': 'test_name', 'password': 'test_pass', 'domain': {'id': 'test_id'}},
+                'openstack_config_file_path': 'test',
+            },
+            'Missing name',
+            id='no name, keystone_server_url, cfg path',
+        ),
+        pytest.param(
+            {
+                'user': {'name': 'test_name', 'password': 'test_pass', 'domain': {'id': 'test_id'}},
+                'openstack_cloud_name': 'test',
+                'openstack_config_file_path': 'test',
+                'name': 'test',
+            },
+            'Cloud test was not found.',
+            id='bad openstack_cloud_name',
+        ),
+        pytest.param(
+            {
+                'user': {'name': 'test_name', 'password': 'test_pass', 'domain': {'id': 'test_id'}},
+                'openstack_config_file_path': 'test',
+                'name': 'test',
+            },
+            'Auth plugin requires parameters which were not given: auth_url',
+            id='bad openstack_cloud_name',
+        ),
+        pytest.param(
+            {
+                'user': {'name': 'test_name', 'password': 'test_pass', 'domain': {'id': 'test_id'}},
+                'name': 'test',
+                'openstack_cloud_name': 'test_cloud',
+                'openstack_config_file_path': TEST_OPENSTACK_NO_AUTH_CONFIG_PATH,
+            },
+            re.escape('__init__() got an unexpected keyword argument \'auth_type\''),
+            id='bad config file',
+        ),
+    ],
+)
+def test_config_invalid(options, exception_msg):
+    instance = copy.deepcopy(CONFIG_FILE_INSTANCE)
+    del instance['openstack_config_file_path']
+    del instance['name']
+    del instance['openstack_cloud_name']
+    del instance['user']
+
+    instance.update(options)
+
+    check = OpenStackControllerCheck(CHECK_NAME, {}, [instance])
+
+    with pytest.raises(Exception, match=exception_msg):
+        check.check(instance)
+
+
+@pytest.mark.parametrize(
+    'options, warning_msg',
+    [
+        pytest.param(
+            {'name': 'test'},
+            'Either keystone_server_url or openstack_config_file_path need to be provided',
+            id='no keystone_server_url, no cfg path',
+        ),
+        pytest.param(
+            {'name': 'test', 'keystone_server_url': 'http://localhost'},
+            'The agent could not contact the specified identity server',
+            id='no user',
+        ),
+        pytest.param(
+            {'name': 'test', 'keystone_server_url': 'http://localhost', 'user': {}},
+            'Please specify the user via the `user` variable in your init_config.',
+            id='bad user',
+        ),
+        pytest.param(
+            {
+                'name': 'test',
+                'keystone_server_url': 'http://localhost',
+                'user': {'password': 'test_pass', 'domain': {'id': 'test_id'}},
+            },
+            'Please specify the user via the `user` variable in your init_config.',
+            id='no user name',
+        ),
+        pytest.param(
+            {
+                'name': 'test',
+                'keystone_server_url': 'http://localhost',
+                'user': {'name': 'test_name', 'domain': {'id': 'test_id'}},
+            },
+            'Please specify the user via the `user` variable in your init_config.',
+            id='no user pw',
+        ),
+    ],
+)
+def test_config_warning(options, warning_msg, caplog):
+    instance = copy.deepcopy(CONFIG_FILE_INSTANCE)
+    del instance['openstack_config_file_path']
+    del instance['name']
+    del instance['openstack_cloud_name']
+
+    instance.update(options)
+    caplog.set_level(logging.WARN)
+
+    check = OpenStackControllerCheck(CHECK_NAME, {}, [instance])
+
+    # try:
+    check.check(instance)
+    assert warning_msg in caplog.text


### PR DESCRIPTION
### What does this PR do?
Adds unit tests for invalid configurations in the openstack_controller checks
 
### Motivation
We don't have any coverage for this and want to refactor the code, so we need to ensure we don't break behavior
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.