### PR TITLE
Add process and runtime to allowed prefixes

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -227,7 +227,7 @@ VALID_UNIT_NAMES = {
     'hop',
 }
 
-ALLOWED_PREFIXES = ['system', 'jvm', 'http', 'datadog', 'sftp']
+ALLOWED_PREFIXES = ['system', 'jvm', 'http', 'datadog', 'sftp', 'process', 'runtime']
 PROVIDER_INTEGRATIONS = {'openmetrics', 'prometheus'}
 
 MAX_DESCRIPTION_LENGTH = 400


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds `process` and `runtime` to `ALLOWED_PREFIXES`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Fix validation for https://github.com/DataDog/integrations-core/pull/13933
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.