### PR TITLE
Update e2e to handle new interface speed metrics

### DIFF
--- a/snmp/tests/metrics.py
+++ b/snmp/tests/metrics.py
@@ -47,6 +47,7 @@ IF_RATES = [
 ]
 IF_SCALAR_GAUGE = ['ifNumber']
 IF_GAUGES = ['ifAdminStatus', 'ifOperStatus', 'ifSpeed', 'ifHighSpeed']
+IF_CUSTOM_SPEED_GAUGES = ['ifInSpeed', 'ifOutSpeed'] # corecheck only
 IF_BANDWIDTH_USAGE = ['ifBandwidthInUsage.rate', 'ifBandwidthOutUsage.rate']
 
 # Generic IP metrics for routers

--- a/snmp/tests/metrics.py
+++ b/snmp/tests/metrics.py
@@ -47,7 +47,7 @@ IF_RATES = [
 ]
 IF_SCALAR_GAUGE = ['ifNumber']
 IF_GAUGES = ['ifAdminStatus', 'ifOperStatus', 'ifSpeed', 'ifHighSpeed']
-IF_CUSTOM_SPEED_GAUGES = ['ifInSpeed', 'ifOutSpeed'] # corecheck only
+IF_CUSTOM_SPEED_GAUGES = ['ifInSpeed', 'ifOutSpeed']  # corecheck only
 IF_BANDWIDTH_USAGE = ['ifBandwidthInUsage.rate', 'ifBandwidthOutUsage.rate']
 
 # Generic IP metrics for routers

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -83,6 +83,9 @@ def assert_apc_ups_metrics(dd_agent_check, config):
     tags = profile_tags + ["snmp_device:{}".format(instance['ip_address'])]
 
     common.assert_common_metrics(aggregator, tags, is_e2e=True, loader='core')
+    aggregator.assert_metric(
+        'datadog.snmp.submitted_metrics', metric_type=aggregator.GAUGE, tags=tags + ['loader:core'], value=31
+    )
 
     for metric in metrics.APC_UPS_METRICS:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=2)

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-# CHANGEME
 import pytest
 from tests.common import SNMP_CONTAINER_NAME
 
@@ -302,7 +301,9 @@ def test_e2e_meraki_cloud_controller(dd_agent_check):
 
     custom_speed_tags = if_tags + ['speed_source:snmp']
     for metric in metrics.IF_CUSTOM_SPEED_GAUGES:
-        aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=custom_speed_tags, count=2)
+        aggregator.assert_metric(
+            'snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=custom_speed_tags, count=2
+        )
 
     aggregator.assert_metric('snmp.sysUpTimeInstance', count=2, tags=common_tags)
     aggregator.assert_metric(

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+# CHANGEME
 import pytest
 from tests.common import SNMP_CONTAINER_NAME
 

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -300,6 +300,10 @@ def test_e2e_meraki_cloud_controller(dd_agent_check):
     for metric in metrics.IF_BANDWIDTH_USAGE:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=if_tags, count=1)
 
+    custom_speed_tags = if_tags + ['speed_source:snmp']
+    for metric in metrics.IF_CUSTOM_SPEED_GAUGES:
+        aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=custom_speed_tags, count=2)
+
     aggregator.assert_metric('snmp.sysUpTimeInstance', count=2, tags=common_tags)
     aggregator.assert_metric(
         'snmp.interface.status',

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -26,13 +26,13 @@ ASSERT_VALUE_METRICS = [
 # Profiles may contain symbols declared twice with different names and the same OID
 # Python check does handles one single metric name per OID symbol
 SKIPPED_CORE_ONLY_METRICS = [
-    'snmp.device.reachable',
-    'snmp.device.unreachable',
-    'snmp.interface.status',
     'snmp.memory.total',
     'snmp.memory.used',
     'snmp.memory.free',
     'snmp.memory.usage',
+    'snmp.device.reachable',
+    'snmp.device.unreachable',
+    'snmp.interface.status',
     'snmp.cpu.usage',
     'snmp.ifInSpeed',
     'snmp.ifOutSpeed',

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -30,10 +30,10 @@ SKIPPED_CORE_ONLY_METRICS = [
     'snmp.memory.used',
     'snmp.memory.free',
     'snmp.memory.usage',
+    'snmp.cpu.usage',
     'snmp.device.reachable',
     'snmp.device.unreachable',
     'snmp.interface.status',
-    'snmp.cpu.usage',
     'snmp.ifInSpeed',
     'snmp.ifOutSpeed',
 ]

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -35,6 +35,8 @@ SKIPPED_CORE_ONLY_METRICS = [
     'snmp.device.reachable',
     'snmp.device.unreachable',
     'snmp.interface.status',
+    'snmp.ifInSpeed',
+    'snmp.ifOutSpeed',
 ]
 
 DEFAULT_TAGS_TO_SKIP = ['loader']

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -12,8 +12,6 @@ from . import common
 
 pytestmark = [pytest.mark.e2e, common.py3_plus_only, common.snmp_integration_only]
 
-SUBMITTED_METRICS_NAME = 'datadog.snmp.submitted_metrics'
-
 SUPPORTED_METRIC_TYPES = [
     {'MIB': 'ABC', 'symbol': {'OID': "1.3.6.1.2.1.7.1.0", 'name': "IAmACounter32"}},  # Counter32
     {'MIB': 'ABC', 'symbol': {'OID': "1.3.6.1.2.1.4.31.1.1.6.1", 'name': "IAmACounter64"}},  # Counter64
@@ -23,12 +21,14 @@ SUPPORTED_METRIC_TYPES = [
 
 ASSERT_VALUE_METRICS = [
     'snmp.devices_monitored',
-    'datadog.snmp.submitted_metrics',
 ]
 
 # Profiles may contain symbols declared twice with different names and the same OID
 # Python check does handles one single metric name per OID symbol
-SKIPPED_CORE_ONLY_COUNTED_AS_SUBMITTED_METRICS = [
+SKIPPED_CORE_ONLY_METRICS = [
+    'snmp.device.reachable',
+    'snmp.device.unreachable',
+    'snmp.interface.status',
     'snmp.memory.total',
     'snmp.memory.used',
     'snmp.memory.free',
@@ -37,11 +37,6 @@ SKIPPED_CORE_ONLY_COUNTED_AS_SUBMITTED_METRICS = [
     'snmp.ifInSpeed',
     'snmp.ifOutSpeed',
 ]
-SKIPPED_CORE_ONLY_METRICS = [
-    'snmp.device.reachable',
-    'snmp.device.unreachable',
-    'snmp.interface.status',
-] + SKIPPED_CORE_ONLY_COUNTED_AS_SUBMITTED_METRICS
 
 DEFAULT_TAGS_TO_SKIP = ['loader']
 
@@ -585,18 +580,6 @@ def assert_python_vs_core(
     for metric_name in aggregator_metrics:
         for stub in aggregator_metrics[metric_name]:
             if stub.name in metrics_to_skip:
-                if stub.name in SKIPPED_CORE_ONLY_COUNTED_AS_SUBMITTED_METRICS:
-                    aggregator._metrics[SUBMITTED_METRICS_NAME] = [
-                        MetricStub(
-                            submittedMetricStub.name,
-                            submittedMetricStub.type,
-                            submittedMetricStub.value - 1,
-                            submittedMetricStub.tags,
-                            submittedMetricStub.hostname,
-                            submittedMetricStub.device,
-                        )
-                        for submittedMetricStub in aggregator._metrics[SUBMITTED_METRICS_NAME]
-                    ]
                 continue
             aggregator._metrics[metric_name].append(normalize_stub_metric(stub, tags_to_skip))
 

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -12,6 +12,8 @@ from . import common
 
 pytestmark = [pytest.mark.e2e, common.py3_plus_only, common.snmp_integration_only]
 
+SUBMITTED_METRICS_NAME = 'datadog.snmp.submitted_metrics'
+
 SUPPORTED_METRIC_TYPES = [
     {'MIB': 'ABC', 'symbol': {'OID': "1.3.6.1.2.1.7.1.0", 'name': "IAmACounter32"}},  # Counter32
     {'MIB': 'ABC', 'symbol': {'OID': "1.3.6.1.2.1.4.31.1.1.6.1", 'name': "IAmACounter64"}},  # Counter64
@@ -26,18 +28,20 @@ ASSERT_VALUE_METRICS = [
 
 # Profiles may contain symbols declared twice with different names and the same OID
 # Python check does handles one single metric name per OID symbol
-SKIPPED_CORE_ONLY_METRICS = [
+SKIPPED_CORE_ONLY_COUNTED_AS_SUBMITTED_METRICS = [
     'snmp.memory.total',
     'snmp.memory.used',
     'snmp.memory.free',
     'snmp.memory.usage',
     'snmp.cpu.usage',
-    'snmp.device.reachable',
-    'snmp.device.unreachable',
-    'snmp.interface.status',
     'snmp.ifInSpeed',
     'snmp.ifOutSpeed',
 ]
+SKIPPED_CORE_ONLY_METRICS = [
+    'snmp.device.reachable',
+    'snmp.device.unreachable',
+    'snmp.interface.status',
+] + SKIPPED_CORE_ONLY_COUNTED_AS_SUBMITTED_METRICS
 
 DEFAULT_TAGS_TO_SKIP = ['loader']
 
@@ -581,6 +585,18 @@ def assert_python_vs_core(
     for metric_name in aggregator_metrics:
         for stub in aggregator_metrics[metric_name]:
             if stub.name in metrics_to_skip:
+                if stub.name in SKIPPED_CORE_ONLY_COUNTED_AS_SUBMITTED_METRICS:
+                    aggregator._metrics[SUBMITTED_METRICS_NAME] = [
+                        MetricStub(
+                            submittedMetricStub.name,
+                            submittedMetricStub.type,
+                            submittedMetricStub.value - 1,
+                            submittedMetricStub.tags,
+                            submittedMetricStub.hostname,
+                            submittedMetricStub.device,
+                        )
+                        for submittedMetricStub in aggregator._metrics[SUBMITTED_METRICS_NAME]
+                    ]
                 continue
             aggregator._metrics[metric_name].append(normalize_stub_metric(stub, tags_to_skip))
 

--- a/snmp/tests/test_e2e_snmp_listener.py
+++ b/snmp/tests/test_e2e_snmp_listener.py
@@ -75,6 +75,12 @@ def test_e2e_snmp_listener(dd_agent_check, container_ip, autodiscovery_ready):
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=1)
         for metric in IF_GAUGES:
             aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=2)
+        custom_speed_tags = tags + ['speed_source:snmp']
+        for metric in metrics.IF_CUSTOM_SPEED_GAUGES:
+            aggregator.assert_metric(
+                'snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=custom_speed_tags, count=2
+            )
+
     for metric in TCP_COUNTS:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.COUNT, tags=common_tags, count=1)
     for metric in TCP_GAUGES:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update e2e to handle new interface speed metrics

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/datadog-agent/pull/15721

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.