### PR TITLE
increase linux pipeline test time limit to match windows

### DIFF
--- a/.azure-pipelines/templates/test-single-linux.yml
+++ b/.azure-pipelines/templates/test-single-linux.yml
@@ -19,7 +19,7 @@ parameters:
 jobs:
 - job: '${{ coalesce(parameters.job_name, parameters.check) }}_Linux'
   displayName: '${{ parameters.display }}'
-  timeoutInMinutes: 90
+  timeoutInMinutes: 180
 
   services:
     ${{ if eq(parameters.ddtrace_flag, '--ddtrace') }}:


### PR DESCRIPTION
### What does this PR do?
Increase linux test timeout from 90 -> 180 minutes. This now matches the windows timeout. 

### Motivation
Ideally, tests should be much faster than this. However we are seeing timeouts on a specific change we are trying to get into the agent before a freeze, so this is a temporary adjustment to get us past this hurdle. See discussion [here](https://dd.slack.com/archives/C9WBCH0AF/p1677626253008479).
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.