### PR TITLE
Pass consumer offsets into highwater offsets

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/client/generic_kafka_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/generic_kafka_client.py
@@ -24,12 +24,12 @@ class GenericKafkaClient(KafkaClient):
 
         return self.python_kafka_client.get_consumer_offsets()
 
-    def get_highwater_offsets(self):
+    def get_highwater_offsets(self, consumer_offsets):
         # TODO when this method is implemented in ConfluentKafkaClient, replace this with:
         # if self.use_legacy_client:
-        #     return self.python_kafka_client.get_highwater_offsets()
-        # return self.confluent_kafka_client.get_highwater_offsets()
-        return self.python_kafka_client.get_highwater_offsets()
+        #     return self.python_kafka_client.get_highwater_offsets(consumer_offsets)
+        # return self.confluent_kafka_client.get_highwater_offsets(consumer_offsets)
+        return self.python_kafka_client.get_highwater_offsets(consumer_offsets)
 
     def get_highwater_offsets_dict(self):
         # TODO when this method is implemented in ConfluentKafkaClient, replace this with:

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
@@ -77,7 +77,7 @@ class KafkaPythonClient(KafkaClient):
         self.kafka_client._wait_for_futures(self._consumer_futures)
         del self._consumer_futures  # since it's reset on every check run, no sense holding the reference between runs
 
-    def get_highwater_offsets(self):
+    def get_highwater_offsets(self, consumer_offsets):
         """Fetch highwater offsets for topic_partitions in the Kafka cluster.
 
         Do this for all partitions in the cluster because even if it has no consumers, we may want to measure whether
@@ -104,7 +104,7 @@ class KafkaPythonClient(KafkaClient):
         # which this run of the check has at least once saved consumer offset. This is later used as a filter for
         # excluding partitions.
         if not self.config._monitor_all_broker_highwatermarks:
-            tps_with_consumer_offset = {(topic, partition) for (_, topic, partition) in self._consumer_offsets}
+            tps_with_consumer_offset = {(topic, partition) for (_, topic, partition) in consumer_offsets}
 
         for batch in self.batchify(
             self.kafka_client._client.cluster.brokers(), self.config._broker_requests_batch_size

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -46,7 +46,7 @@ class KafkaCheck(AgentCheck):
         # Fetch the broker highwater offsets
         try:
             if len(consumer_offsets) < self._context_limit:
-                self.client.get_highwater_offsets()
+                self.client.get_highwater_offsets(consumer_offsets)
             else:
                 self.warning("Context limit reached. Skipping highwater offset collection.")
         except Exception:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This is required since the highwater offset metric depends on the consumer offset metrics. By doing this we can implement the highwater offsets separately to consumer offsets.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.