### PR TITLE
Synchronizes panels to the global time of the `Kubernetes [Pods/Nodes] Overview` dashboards

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_dashboard.json
+++ b/kubernetes/assets/dashboards/kubernetes_dashboard.json
@@ -17,10 +17,7 @@
                 "custom_links": [],
                 "title": "Most memory-intensive pods",
                 "title_size": "16",
-                "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                }
+                "title_align": "left"
             },
             "layout": {
                 "x": 151,
@@ -44,10 +41,7 @@
                 "custom_links": [],
                 "title": "Most CPU-intensive pods",
                 "title_size": "16",
-                "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                }
+                "title_align": "left"
             },
             "layout": {
                 "x": 107,
@@ -145,9 +139,6 @@
                 "title": "Pods available",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -212,9 +203,6 @@
                 "title": "Pods desired",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -283,9 +271,6 @@
                 "title": "Pods unavailable",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -453,9 +438,6 @@
                 "title": "Network errors per node",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -483,9 +465,6 @@
                 "title": "Sum Kubernetes CPU requests per node",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -513,9 +492,6 @@
                 "title": "Sum Kubernetes memory requests per node",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -562,9 +538,6 @@
                 "title": "Network in per node",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -592,9 +565,6 @@
                 "title": "Network out per node",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -631,10 +601,7 @@
                 "query": "source:kubernetes $node",
                 "title": "Number of Kubernetes events per node",
                 "title_size": "16",
-                "title_align": "left",
-                "time": {
-                    "live_span": "1d"
-                }
+                "title_align": "left"
             },
             "layout": {
                 "x": 0,
@@ -750,9 +717,6 @@
                 "title": "Pods desired",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -877,9 +841,6 @@
                 "title": "Container states",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -909,9 +870,6 @@
                 "title": "Ready",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "1h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -941,9 +899,6 @@
                 "title": "Not ready",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "1h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -973,9 +928,6 @@
                 "title": "Disk reads per node",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -1005,9 +957,6 @@
                 "title": "Disk writes per node",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -1183,9 +1132,6 @@
                 "title": "Pods ready",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -1613,9 +1559,6 @@
                 "title": "Network errors per pod",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },

--- a/kubernetes/assets/dashboards/kubernetes_nodes.json
+++ b/kubernetes/assets/dashboards/kubernetes_nodes.json
@@ -57,7 +57,10 @@
                 "tags": [
                     "$cluster",
                     "$host"
-                ]
+                ],
+                "time": {
+                    "live_span": "10m"
+                }
             },
             "layout": {
                 "x": 0,
@@ -79,7 +82,10 @@
                 "tags": [
                     "$cluster",
                     "$host"
-                ]
+                ],
+                "time": {
+                    "live_span": "10m"
+                }
             },
             "layout": {
                 "x": 20,

--- a/kubernetes/assets/dashboards/kubernetes_nodes.json
+++ b/kubernetes/assets/dashboards/kubernetes_nodes.json
@@ -57,10 +57,7 @@
                 "tags": [
                     "$cluster",
                     "$host"
-                ],
-                "time": {
-                    "live_span": "10m"
-                }
+                ]
             },
             "layout": {
                 "x": 0,
@@ -82,10 +79,7 @@
                 "tags": [
                     "$cluster",
                     "$host"
-                ],
-                "time": {
-                    "live_span": "10m"
-                }
+                ]
             },
             "layout": {
                 "x": 20,
@@ -174,9 +168,6 @@
                 "title": "Total Kubernetes CPU requests per node",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -213,9 +204,6 @@
                 "title": "Total Kubernetes memory requests per node",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -341,9 +329,6 @@
                 "title": "Network in per node",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -380,9 +365,6 @@
                 "title": "Network out per node",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -419,9 +401,6 @@
                 "title": "Disk reads per node",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -458,9 +437,6 @@
                 "title": "Disk writes per node",
                 "title_size": "16",
                 "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                },
                 "show_legend": false,
                 "legend_size": "0"
             },
@@ -499,10 +475,7 @@
                 "query": "source:kubernetes $host $cluster",
                 "title": "",
                 "title_size": "16",
-                "title_align": "left",
-                "time": {
-                    "live_span": "4h"
-                }
+                "title_align": "left"
             },
             "layout": {
                 "x": 0,

--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -203,7 +203,6 @@
                 "title": "CPU-intensive pods",
                 "title_size": "16",
                 "title_align": "left",
-                "time": { "live_span": "4h" },
                 "type": "toplist",
                 "requests": [
                   {
@@ -274,7 +273,6 @@
                 "title": "Memory-intensive pods",
                 "title_size": "16",
                 "title_align": "left",
-                "time": { "live_span": "4h" },
                 "type": "toplist",
                 "requests": [
                   {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Synchronizes panels to the global time of the dashboards.

### Motivation
<!-- What inspired you to submit this pull request? -->
Various panels on default Kubernetes dashboards have locked times. This makes those dashboard pretty inconsistent.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Closes [issue](https://github.com/DataDog/integrations-core/issues/13491)
In some cases, a time scope makes sense but not in every case. I was not sure of which panels should be sync with the global time so I removed the time scope for every panel with a lock of 1-4h.
It is possible to test the dashboard by importing them.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.