### PR TITLE
[DBM-1862] add resolved_hostname to metadata to mysql, postgres

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -126,6 +126,7 @@ class MySql(AgentCheck):
     def _send_metadata(self):
         self.set_metadata('version', self.version.version + '+' + self.version.build)
         self.set_metadata('flavor', self.version.flavor)
+        self.set_metadata('resolved_hostname', self.resolved_hostname)
 
     @property
     def resolved_hostname(self):

--- a/mysql/tests/conftest.py
+++ b/mysql/tests/conftest.py
@@ -275,6 +275,7 @@ def version_metadata():
         'version.raw': mock.ANY,
         'version.build': mock.ANY,
         'flavor': flavor,
+        'resolved_hostname': 'forced_hostname',
     }
 
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -224,6 +224,7 @@ class PostgreSql(AgentCheck):
                 self._resolved_hostname = self.resolve_db_host()
             else:
                 self._resolved_hostname = self.agent_hostname
+        self.set_metadata('resolved_hostname', self._resolved_hostname)
         return self._resolved_hostname
 
     @property

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -301,12 +301,13 @@ def test_version_metadata(integration_check, pg_instance, datadog_agent):
     version_metadata = {
         'version.scheme': 'semver',
         'version.major': version[0],
+        'resolved_hostname': 'stubbed.hostname',
     }
     if len(version) == 2:
         version_metadata['version.minor'] = version[1]
 
     datadog_agent.assert_metadata('test:123', version_metadata)
-    datadog_agent.assert_metadata_count(5)  # for raw and patch
+    datadog_agent.assert_metadata_count(6)  # for raw and patch
 
 
 def test_state_clears_on_connection_error(integration_check, pg_instance):


### PR DESCRIPTION
### What does this PR do?
Add resolved_hostname to metadata for MySQL and Postgres.
More context here: [DBM-1862](https://datadoghq.atlassian.net/browse/DBM-1862)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.

[DBM-1862]: https://datadoghq.atlassian.net/browse/DBM-1862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ