### PR TITLE
Remove collect_broker_version

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/client/confluent_kafka_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/confluent_kafka_client.py
@@ -40,9 +40,6 @@ class ConfluentKafkaClient(KafkaClient):
     def request_metadata_update(self):
         raise NotImplementedError
 
-    # def collect_broker_version(self):
-    #     raise NotImplementedError
-
     def get_consumer_offsets(self):
         raise NotImplementedError
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/confluent_kafka_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/confluent_kafka_client.py
@@ -40,8 +40,8 @@ class ConfluentKafkaClient(KafkaClient):
     def request_metadata_update(self):
         raise NotImplementedError
 
-    def collect_broker_version(self):
-        raise NotImplementedError
+    # def collect_broker_version(self):
+    #     raise NotImplementedError
 
     def get_consumer_offsets(self):
         raise NotImplementedError

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/generic_kafka_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/generic_kafka_client.py
@@ -59,13 +59,6 @@ class GenericKafkaClient(KafkaClient):
         # return self.confluent_kafka_client.request_metadata_update()
         return self.python_kafka_client.request_metadata_update()
 
-    def collect_broker_version(self):
-        # TODO when this method is implemented in ConfluentKafkaClient, replace this with:
-        # if self.use_legacy_client:
-        #     return self.python_kafka_client.collect_broker_version()
-        # return self.confluent_kafka_client.collect_broker_version()
-        return self.python_kafka_client.collect_broker_version()
-
     def get_consumer_offsets_dict(self):
         # TODO when this method is implemented in ConfluentKafkaClient, replace this with:
         # if self.use_legacy_client:

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client.py
@@ -45,6 +45,6 @@ class KafkaClient(ABC):
     def request_metadata_update(self):
         pass
 
-    @abstractmethod
-    def collect_broker_version(self):
-        pass
+    # @abstractmethod
+    # def collect_broker_version(self):
+    #     pass

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_client.py
@@ -44,7 +44,3 @@ class KafkaClient(ABC):
     @abstractmethod
     def request_metadata_update(self):
         pass
-
-    # @abstractmethod
-    # def collect_broker_version(self):
-    #     pass

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
@@ -198,8 +198,8 @@ class KafkaPythonClient(KafkaClient):
             self._kafka_client = self._create_kafka_admin_client(api_version=kafka_version)
         return self._kafka_client
 
-    def collect_broker_version(self):
-        return self.kafka_client._client.check_version()
+    # def collect_broker_version(self):
+    #     return self.kafka_client._client.check_version()
 
     def _highwater_offsets_callback(self, response):
         """Callback that parses an OffsetFetchResponse and saves it to the highwater_offsets dict."""

--- a/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client/kafka_python_client.py
@@ -198,9 +198,6 @@ class KafkaPythonClient(KafkaClient):
             self._kafka_client = self._create_kafka_admin_client(api_version=kafka_version)
         return self._kafka_client
 
-    # def collect_broker_version(self):
-    #     return self.kafka_client._client.check_version()
-
     def _highwater_offsets_callback(self, response):
         """Callback that parses an OffsetFetchResponse and saves it to the highwater_offsets dict."""
         if type(response) not in OffsetResponse:

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -73,8 +73,6 @@ class KafkaCheck(AgentCheck):
             consumer_offsets, highwater_offsets, self._context_limit - len(highwater_offsets)
         )
 
-        # self.collect_broker_metadata()
-
     def report_highwater_offsets(self, highwater_offsets, contexts_limit):
         """Report the broker highwater offsets."""
         reported_contexts = 0

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -73,7 +73,7 @@ class KafkaCheck(AgentCheck):
             consumer_offsets, highwater_offsets, self._context_limit - len(highwater_offsets)
         )
 
-        self.collect_broker_metadata()
+        # self.collect_broker_metadata()
 
     def report_highwater_offsets(self, highwater_offsets, contexts_limit):
         """Report the broker highwater offsets."""
@@ -149,15 +149,6 @@ class KafkaCheck(AgentCheck):
                     )
                 self.log.warning(msg, consumer_group, topic, partition)
                 self.client.request_metadata_update()  # force metadata update on next poll()
-
-    @AgentCheck.metadata_entrypoint
-    def collect_broker_metadata(self):
-        version_data = [str(part) for part in self.client.collect_broker_version()]
-        version_parts = {name: part for name, part in zip(('major', 'minor', 'patch'), version_data)}
-
-        self.set_metadata(
-            'version', '.'.join(version_data), scheme='parts', final_scheme='semver', part_map=version_parts
-        )
 
     def send_event(self, title, text, tags, event_type, aggregation_key, severity='info'):
         """Emit an event to the Datadog Event Stream."""

--- a/kafka_consumer/tests/python_client/test_integration.py
+++ b/kafka_consumer/tests/python_client/test_integration.py
@@ -58,21 +58,6 @@ def test_no_partitions(aggregator, check, kafka_instance, dd_run_check):
     assert_check_kafka(aggregator, {'my_consumer': {'marvel': [0]}})
 
 
-def test_version_metadata(datadog_agent, check, kafka_instance, dd_run_check):
-    kafka_consumer_check = check(kafka_instance)
-    kafka_consumer_check.check_id = 'test:123'
-
-    kafka_client = kafka_consumer_check.client.create_kafka_admin_client()
-    version_data = [str(part) for part in kafka_client._client.check_version()]
-    kafka_client.close()
-    version_parts = {f'version.{name}': part for name, part in zip(('major', 'minor', 'patch'), version_data)}
-    version_parts['version.scheme'] = 'semver'
-    version_parts['version.raw'] = '.'.join(version_data)
-
-    dd_run_check(kafka_consumer_check)
-    datadog_agent.assert_metadata('test:123', version_parts)
-
-
 @pytest.mark.parametrize(
     'is_enabled, metric_count, topic_tags',
     [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR removes collect_broker_version from the kafka_consumer check since the Confluent library does not have the ability to query the broker version.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.