### PR TITLE
Deduplicate symlink/target files that contribute to directory size

### DIFF
--- a/directory/tests/test_directory.py
+++ b/directory/tests/test_directory.py
@@ -399,7 +399,9 @@ def test_no_recursive_symlink_loop(aggregator):
 @pytest.mark.parametrize(
     'stat_follow_symlinks, expected_dir_size, expected_file_sizes',
     [
-        pytest.param(True, 250, [('file50', 50), ('file100', 100), ('file100sym', 100)], id='follow_sym'),
+        # du --apparent-size /path/ -L
+        # aka follow symlinks - dedups total directory size
+        pytest.param(True, 150, [('file50', 50), ('file100', 100), ('file100sym', 100)], id='follow_sym'),
         # file100sym = 8 + len(dir): that's the length of the symlink file
         pytest.param(
             False,

--- a/directory/tests/test_directory.py
+++ b/directory/tests/test_directory.py
@@ -413,16 +413,17 @@ def test_no_recursive_symlink_loop(aggregator):
             id='follow_sym',
         ),
         # du --apparent-size /path/ -abc -P
-        # len(tdir + '/main') = 21 = target_dir
-        # file1000sym = 7 + len(target_dir): length of the symlink file
+        # https://docs.python.org/3/library/os.html#os.stat_result.st_size
+        # len(tdir + '/path') = 21 = target_dir
+        # len('/file1000') = 9 = target file
         pytest.param(
             False,
-            1500 + 28 + 28,
+            lambda tdir: 1500 + len(tdir + '/file1000') * 2,
             [
                 ('file500', 500),
                 ('file1000', 1000),
-                ('file1000sym', lambda tdir: 7 + len(tdir + '/main')),
-                ('otherfile1000sym', lambda tdir: 7 + len(tdir + '/othr')),
+                ('file1000sym', lambda tdir: len(tdir + '/file1000')),
+                ('otherfile1000sym', lambda tdir: len(tdir + '/file1000')),
             ],
             id='not_follow_sym',
         ),
@@ -431,7 +432,7 @@ def test_no_recursive_symlink_loop(aggregator):
 def test_stat_follow_symlinks(aggregator, stat_follow_symlinks, expected_dir_size, expected_file_sizes):
     def flatten_value(value):
         if callable(value):
-            return value(tdir)
+            return value(target_dir)
         return value
 
     with temp_directory() as tdir:


### PR DESCRIPTION
### What does this PR do?
Deduplicate symlink/target files that contribute to directory size

### Motivation
AGENT-8861 - bloated `system.disk.directory.bytes`

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.