### PR TITLE
Do not double emit instance metrics when autodiscovery is enabled

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -78,17 +78,17 @@ INSTANCE_METRICS = [
     ('sqlserver.stats.batch_requests', 'Batch Requests/sec', ''),  # BULK_COUNT
     ('sqlserver.stats.sql_compilations', 'SQL Compilations/sec', ''),  # BULK_COUNT
     ('sqlserver.stats.sql_recompilations', 'SQL Re-Compilations/sec', ''),  # BULK_COUNT
-]
-
-# Performance table metrics, initially configured to track at instance-level only
-# With auto-discovery enabled, these metrics will be extended accordingly
-# datadog metric name, counter name, instance name
-INSTANCE_METRICS_TOTAL = [
     # SQLServer:Locks
     ('sqlserver.stats.lock_waits', 'Lock Waits/sec', '_Total'),  # BULK_COUNT
     # SQLServer:Plan Cache
     ('sqlserver.cache.object_counts', 'Cache Object Counts', '_Total'),
     ('sqlserver.cache.pages', 'Cache Pages', '_Total'),
+]
+
+# Performance table metrics, initially configured to track at instance-level only
+# With auto-discovery enabled, these metrics will be extended accordingly
+# datadog metric name, counter name, instance name
+INSTANCE_METRICS_DATABASE = [
     # SQLServer:Databases
     ('sqlserver.database.backup_restore_throughput', 'Backup/Restore Throughput/sec', '_Total'),
     ('sqlserver.database.log_bytes_flushed', 'Log Bytes Flushed/sec', '_Total'),

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -421,27 +421,27 @@ class SQLServer(AgentCheck):
         # If several check instances are querying the same server host, it can be wise to turn these off
         # to avoid sending duplicate metrics
         if is_affirmative(self.instance.get('include_instance_metrics', True)):
-            common_metrics = INSTANCE_METRICS
+            common_metrics = list(INSTANCE_METRICS)
             if not self.dbm_enabled:
-                common_metrics = common_metrics + DBM_MIGRATED_METRICS
+                common_metrics.extend(DBM_MIGRATED_METRICS)
             if not self.databases:
                 # if autodiscovery is enabled, we report metrics from the
                 # INSTANCE_METRICS_DATABASE struct below, so do not double report here
-                common_metrics = common_metrics + INSTANCE_METRICS_DATABASE
+                common_metrics.extend(INSTANCE_METRICS_DATABASE)
             self._add_performance_counters(
                 common_metrics, metrics_to_collect, tags, db=None
             )
 
-        # populated through autodiscovery
-        if self.databases:
-            for db in self.databases:
-                self._add_performance_counters(
-                    INSTANCE_METRICS_DATABASE,
-                    metrics_to_collect,
-                    tags,
-                    db=db.name,
-                    physical_database_name=db.physical_db_name,
-                )
+            # populated through autodiscovery
+            if self.databases:
+                for db in self.databases:
+                    self._add_performance_counters(
+                        INSTANCE_METRICS_DATABASE,
+                        metrics_to_collect,
+                        tags,
+                        db=db.name,
+                        physical_database_name=db.physical_db_name,
+                    )
 
         # Load database statistics
         for name, table, column in DATABASE_METRICS:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -43,7 +43,7 @@ from datadog_checks.sqlserver.const import (
     DEFAULT_AUTODISCOVERY_INTERVAL,
     ENGINE_EDITION_SQL_DATABASE,
     INSTANCE_METRICS,
-    INSTANCE_METRICS_TOTAL,
+    INSTANCE_METRICS_DATABASE,
     PERF_AVERAGE_BULK,
     PERF_COUNTER_BULK_COUNT,
     PERF_COUNTER_LARGE_RAWCOUNT,
@@ -425,16 +425,19 @@ class SQLServer(AgentCheck):
             common_metrics = INSTANCE_METRICS
             if not self.dbm_enabled:
                 common_metrics = common_metrics + DBM_MIGRATED_METRICS
-
+            if not self.databases:
+                # if autodiscovery is enabled, we report metrics from the
+                # INSTANCE_METRICS_DATABASE struct below, so do not double report here
+                common_metrics = common_metrics + INSTANCE_METRICS_DATABASE
             self._add_performance_counters(
-                chain(common_metrics, INSTANCE_METRICS_TOTAL), metrics_to_collect, tags, db=None
+                common_metrics, metrics_to_collect, tags, db=None
             )
 
         # populated through autodiscovery
         if self.databases:
             for db in self.databases:
                 self._add_performance_counters(
-                    INSTANCE_METRICS_TOTAL,
+                    INSTANCE_METRICS_DATABASE,
                     metrics_to_collect,
                     tags,
                     db=db.name,

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -428,9 +428,7 @@ class SQLServer(AgentCheck):
                 # if autodiscovery is enabled, we report metrics from the
                 # INSTANCE_METRICS_DATABASE struct below, so do not double report here
                 common_metrics.extend(INSTANCE_METRICS_DATABASE)
-            self._add_performance_counters(
-                common_metrics, metrics_to_collect, tags, db=None
-            )
+            self._add_performance_counters(common_metrics, metrics_to_collect, tags, db=None)
 
             # populated through autodiscovery
             if self.databases:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -6,7 +6,6 @@ from __future__ import division
 import re
 import time
 from collections import defaultdict
-from itertools import chain
 
 import six
 from cachetools import TTLCache

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -209,13 +209,7 @@ INIT_CONFIG_ALT_TABLES = {
 
 
 def assert_metrics(
-        aggregator,
-        check_tags,
-        service_tags,
-        dbm_enabled=False,
-        hostname=None,
-        database_autodiscovery=False,
-        dbs=None
+    aggregator, check_tags, service_tags, dbm_enabled=False, hostname=None, database_autodiscovery=False, dbs=None
 ):
     """
     Boilerplate asserting all the expected metrics and service checks.

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -17,7 +17,7 @@ from datadog_checks.sqlserver.const import (
     DATABASE_METRICS,
     DBM_MIGRATED_METRICS,
     INSTANCE_METRICS,
-    INSTANCE_METRICS_TOTAL,
+    INSTANCE_METRICS_DATABASE,
     TASK_SCHEDULER_METRICS,
 )
 from datadog_checks.sqlserver.queries import get_query_file_stats
@@ -69,7 +69,7 @@ EXPECTED_DEFAULT_METRICS = (
         for m in chain(
             INSTANCE_METRICS,
             DBM_MIGRATED_METRICS,
-            INSTANCE_METRICS_TOTAL,
+            INSTANCE_METRICS_DATABASE,
             DATABASE_METRICS,
         )
     ]
@@ -90,8 +90,8 @@ EXPECTED_METRICS = (
 )
 
 DBM_MIGRATED_METRICS_NAMES = set(m[0] for m in DBM_MIGRATED_METRICS)
-
 EXPECTED_METRICS_DBM_ENABLED = [m for m in EXPECTED_METRICS if m not in DBM_MIGRATED_METRICS_NAMES]
+DB_PERF_COUNT_METRICS_NAMES = set(m[0] for m in INSTANCE_METRICS_DATABASE)
 
 # These AO metrics are collected using the new QueryExecutor API instead of BaseSqlServerMetric.
 EXPECTED_QUERY_EXECUTOR_AO_METRICS_PRIMARY = [
@@ -208,21 +208,36 @@ INIT_CONFIG_ALT_TABLES = {
 }
 
 
-def assert_metrics(aggregator, expected_tags, dbm_enabled=False, hostname=None, database_autodiscovery=False):
+def assert_metrics(
+        aggregator,
+        check_tags,
+        service_tags,
+        dbm_enabled=False,
+        hostname=None,
+        database_autodiscovery=False,
+        dbs=None
+):
     """
     Boilerplate asserting all the expected metrics and service checks.
     Make sure ALL custom metric is tagged by database.
     """
     aggregator.assert_metric_has_tag('sqlserver.db.commit_table_entries', 'db:master')
     expected_metrics = EXPECTED_METRICS
+    # if dbm is enabled, the integration does not emit certain metrics
+    # as they are emitted from the DBM backend
     if dbm_enabled:
-        dbm_excluded_metrics = [m[0] for m in DBM_MIGRATED_METRICS]
-        expected_metrics = [m for m in EXPECTED_METRICS if m not in dbm_excluded_metrics]
+        expected_metrics = [m for m in expected_metrics if m not in DBM_MIGRATED_METRICS_NAMES]
+    if database_autodiscovery:
+        # when autodiscovery is enabled, we should not double emit metrics,
+        # so we should assert for these separately with the proper tags
+        expected_metrics = [m for m in expected_metrics if m not in DB_PERF_COUNT_METRICS_NAMES]
+        for dbname in dbs:
+            tags = check_tags + ['database:{}'.format(dbname)]
+            for mname in DB_PERF_COUNT_METRICS_NAMES:
+                aggregator.assert_metric(mname, hostname=hostname, tags=tags)
     for mname in expected_metrics:
         assert hostname is not None, "hostname must be explicitly specified for all metrics"
         aggregator.assert_metric(mname, hostname=hostname)
-    aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK, tags=expected_tags)
+    aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK, tags=service_tags)
     aggregator.assert_all_metrics_covered()
-    if not database_autodiscovery:
-        # if we're autodiscovering other databases then there will be duplicate metrics, one per database
-        aggregator.assert_no_duplicate_metrics()
+    aggregator.assert_no_duplicate_metrics()

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -8,12 +8,10 @@ import pytest
 
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import SQLConnectionError
+from datadog_checks.sqlserver.const import INSTANCE_METRICS_DATABASE
 
 from .common import CHECK_NAME, CUSTOM_METRICS, EXPECTED_DEFAULT_METRICS, assert_metrics
 from .utils import not_windows_ci, windows_ci
-from datadog_checks.sqlserver.const import (
-    INSTANCE_METRICS_DATABASE,
-)
 
 try:
     import pyodbc

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -41,8 +41,7 @@ def test_check_invalid_password(aggregator, dd_run_check, init_config, instance_
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
-    'database_autodiscovery,dbm_enabled',
-    [(True, True), (True, False), (False, True), (False, False)]
+    'database_autodiscovery,dbm_enabled', [(True, True), (True, False), (False, True), (False, False)]
 )
 def test_check_docker(aggregator, dd_run_check, init_config, instance_docker, database_autodiscovery, dbm_enabled):
     instance_docker['database_autodiscovery'] = database_autodiscovery

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -11,6 +11,9 @@ from datadog_checks.sqlserver.connection import SQLConnectionError
 
 from .common import CHECK_NAME, CUSTOM_METRICS, EXPECTED_DEFAULT_METRICS, assert_metrics
 from .utils import not_windows_ci, windows_ci
+from datadog_checks.sqlserver.const import (
+    INSTANCE_METRICS_DATABASE,
+)
 
 try:
     import pyodbc
@@ -37,9 +40,22 @@ def test_check_invalid_password(aggregator, dd_run_check, init_config, instance_
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-@pytest.mark.parametrize('database_autodiscovery', [True, False])
-def test_check_docker(aggregator, dd_run_check, init_config, instance_docker, database_autodiscovery):
+@pytest.mark.parametrize(
+    'database_autodiscovery,dbm_enabled',
+    [(True, True), (True, False), (False, True), (False, False)]
+)
+def test_check_docker(aggregator, dd_run_check, init_config, instance_docker, database_autodiscovery, dbm_enabled):
     instance_docker['database_autodiscovery'] = database_autodiscovery
+    # test that all default integration metrics are sent regardless of
+    # if dbm is enabled or not.
+    instance_docker['dbm'] = dbm_enabled
+    # no need to assert metrics that are emitted from the dbm portion of the
+    # integration in this check as they are all internal
+    instance_docker['query_metrics'] = {'enabled': False}
+    instance_docker['query_activity'] = {'enabled': False}
+    autodiscovery_dbs = ['master', 'msdb', 'datadog_test']
+    if database_autodiscovery:
+        instance_docker['autodiscovery_include'] = autodiscovery_dbs
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
     expected_tags = instance_docker.get('tags', []) + [
@@ -48,9 +64,12 @@ def test_check_docker(aggregator, dd_run_check, init_config, instance_docker, da
     ]
     assert_metrics(
         aggregator,
-        expected_tags,
+        check_tags=instance_docker.get('tags', []),
+        service_tags=expected_tags,
+        dbm_enabled=dbm_enabled,
         hostname=sqlserver_check.resolved_hostname,
         database_autodiscovery=database_autodiscovery,
+        dbs=autodiscovery_dbs,
     )
 
 
@@ -246,15 +265,7 @@ def test_autodiscovery_perf_counters(aggregator, dd_run_check, instance_autodisc
     check = SQLServer(CHECK_NAME, {}, [instance_autodiscovery])
     dd_run_check(check)
 
-    expected_metrics = [
-        'sqlserver.database.backup_restore_throughput',
-        'sqlserver.database.log_bytes_flushed',
-        'sqlserver.database.log_flushes',
-        'sqlserver.database.log_flush_wait',
-        'sqlserver.database.transactions',
-        'sqlserver.database.write_transactions',
-        'sqlserver.database.active_transactions',
-    ]
+    expected_metrics = [m[0] for m in INSTANCE_METRICS_DATABASE]
     master_tags = [
         'database:master',
         'optional:tag1',
@@ -263,11 +274,9 @@ def test_autodiscovery_perf_counters(aggregator, dd_run_check, instance_autodisc
         'database:msdb',
         'optional:tag1',
     ]
-    base_tags = ['optional:tag1']
     for metric in expected_metrics:
         aggregator.assert_metric(metric, tags=master_tags)
         aggregator.assert_metric(metric, tags=msdb_tags)
-        aggregator.assert_metric(metric, tags=base_tags)
 
 
 @pytest.mark.integration

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -306,8 +306,9 @@ def test_set_default_driver_conf():
 def test_check_local(aggregator, dd_run_check, init_config, instance_docker):
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
-    expected_tags = instance_docker.get('tags', []) + ['sqlserver_host:{}'.format(DOCKER_SERVER), 'db:master']
-    assert_metrics(aggregator, expected_tags, hostname=sqlserver_check.resolved_hostname)
+    check_tags = instance_docker.get('tags', [])
+    expected_tags = check_tags + ['sqlserver_host:{}'.format(DOCKER_SERVER), 'db:master']
+    assert_metrics(aggregator, check_tags, expected_tags, hostname=sqlserver_check.resolved_hostname)
 
 
 SQL_SERVER_2012_VERSION_EXAMPLE = """\


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR is a follow on to https://github.com/DataDog/integrations-core/pull/13757 and addresses a bug, which has been brought to our attention as an urgent customer issue. Currently in the sqlserver default integration, instance metrics (os performance counter metrics) are collected in the following way:

1. The `include_instance_metrics` config is checked (defaults to True)
2. If `True` all of the metrics in the [INSTANCE_METRICS](https://github.com/DataDog/integrations-core/blob/master/sqlserver/datadog_checks/sqlserver/const.py#L60) AND the [INSTANCE_METRICS_TOTAL](https://github.com/DataDog/integrations-core/blob/master/sqlserver/datadog_checks/sqlserver/const.py#L86) lists are added to the dict of metrics to collect (this means they will be emitted by the integration). 
3. Both sets of metrics are added via the [_add_performance_counters](https://github.com/DataDog/integrations-core/blob/master/sqlserver/datadog_checks/sqlserver/sqlserver.py#L569-L593) method, which match the metrics their associated metric type, and then fetch / tag the metrics properly 

The implementation above is an issue when customers have `autodiscovery` enabled though. With `autodiscovery` enabled, the integration will call [_add_performance_metrics](https://github.com/DataDog/integrations-core/blob/master/sqlserver/datadog_checks/sqlserver/sqlserver.py#L433-L442) as second time in order to tag each relevant metric with `database`.  This results in [these metrics](https://github.com/DataDog/integrations-core/blob/master/sqlserver/datadog_checks/sqlserver/const.py#L92-L99) getting emitted twice.

This results in theses metrics sum's being incorrect eg.:

![Screen Shot 2023-03-07 at 5 47 50 PM](https://user-images.githubusercontent.com/14317240/223571625-0432f04d-ca28-4b67-b8b7-756c67c5f792.png)

### Motivation
<!-- What inspired you to submit this pull request? -->

This has been flagged as an urgent customer issue as its resulting in their metrics being reported incorrectly for sqlserver `database` related performance counter metrics.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

In addition to fixing the issue described above, I also moved the logic for emitting instance metrics with `database` tags under the `include_instance_metrics` check. This would prevent us from emitting performance count metrics if a customer elects to turn the feature off. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.