### PR TITLE
Fix `generate-traps-db` command on windows

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_traps_db.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/snmp/generate_traps_db.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+import pathlib
 from collections import namedtuple
 from enum import Enum
 from functools import lru_cache
@@ -128,7 +129,10 @@ def generate_traps_db(mib_sources, output_dir, output_file, output_format, no_de
             os.mkdir(mibs_sources_dir)
 
         mib_sources = (
-            sorted(set([os.path.abspath(os.path.dirname(x)) for x in mib_files if os.path.sep in x])) + mib_sources
+            sorted(
+                set([pathlib.Path(os.path.abspath(os.path.dirname(x))).as_uri() for x in mib_files if os.path.sep in x])
+            )
+            + mib_sources
         )
 
         mib_files = [os.path.basename(x) for x in mib_files]


### PR DESCRIPTION
### What does this PR do?
When run on windows, `ddev meta snmp generate-traps-db` would fail with a PySmi `Unsupported URL scheme` error

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
Tests to prevent this from happening again will be added via #14002 when this is merged 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.