### PR TITLE
Use confluent-kafka during the test setup

### DIFF
--- a/kafka_consumer/tests/conftest.py
+++ b/kafka_consumer/tests/conftest.py
@@ -6,8 +6,8 @@ import os
 import time
 
 import pytest
+from confluent_kafka.admin import AdminClient
 from datadog_test_libs.utils.mock_dns import mock_local
-from kafka import KafkaConsumer
 from packaging.version import parse as parse_version
 
 from datadog_checks.dev import WaitFor, docker_run
@@ -101,8 +101,13 @@ def _get_bootstrap_server_flag():
 
 
 def find_topics():
-    consumer = KafkaConsumer(bootstrap_servers=KAFKA_CONNECT_STR, request_timeout_ms=1000)
-    return consumer.topics() == set(TOPICS)
+    client = AdminClient(
+        {
+            "bootstrap.servers": KAFKA_CONNECT_STR,
+            "socket.timeout.ms": 1000,
+        }
+    )
+    return set(client.list_topics().topics.keys()) == set(TOPICS)
 
 
 def initialize_topics():

--- a/kafka_consumer/tests/runners.py
+++ b/kafka_consumer/tests/runners.py
@@ -4,7 +4,8 @@
 import threading
 import time
 
-from kafka import KafkaConsumer, KafkaProducer
+from confluent_kafka import Consumer as KafkaConsumer
+from confluent_kafka import Producer as KafkaProducer
 
 from .common import KAFKA_CONNECT_STR, PARTITIONS
 
@@ -31,22 +32,22 @@ class StoppableThread(threading.Thread):
 
 class Producer(StoppableThread):
     def run(self):
-        producer = KafkaProducer(bootstrap_servers=KAFKA_CONNECT_STR)
+        producer = KafkaProducer({'bootstrap.servers': KAFKA_CONNECT_STR})
 
         iteration = 0
         while not self._shutdown_event.is_set():
             for partition in PARTITIONS:
                 try:
-                    producer.send('marvel', b"Peter Parker", partition=partition)
-                    producer.send('marvel', b"Bruce Banner", partition=partition)
-                    producer.send('marvel', b"Tony Stark", partition=partition)
-                    producer.send('marvel', b"Johhny Blaze", partition=partition)
-                    producer.send('marvel', b"\xc2BoomShakalaka", partition=partition)
-                    producer.send('dc', b"Diana Prince", partition=partition)
-                    producer.send('dc', b"Bruce Wayne", partition=partition)
-                    producer.send('dc', b"Clark Kent", partition=partition)
-                    producer.send('dc', b"Arthur Curry", partition=partition)
-                    producer.send('dc', b"\xc2ShakalakaBoom", partition=partition)
+                    producer.produce('marvel', b"Peter Parker", partition=partition)
+                    producer.produce('marvel', b"Bruce Banner", partition=partition)
+                    producer.produce('marvel', b"Tony Stark", partition=partition)
+                    producer.produce('marvel', b"Johhny Blaze", partition=partition)
+                    producer.produce('marvel', b"\xc2BoomShakalaka", partition=partition)
+                    producer.produce('dc', b"Diana Prince", partition=partition)
+                    producer.produce('dc', b"Bruce Wayne", partition=partition)
+                    producer.produce('dc', b"Clark Kent", partition=partition)
+                    producer.produce('dc', b"Arthur Curry", partition=partition)
+                    producer.produce('dc', b"\xc2ShakalakaBoom", partition=partition)
                 except Exception:
                     pass
 
@@ -62,11 +63,11 @@ class KConsumer(StoppableThread):
 
     def run(self):
         consumer = KafkaConsumer(
-            bootstrap_servers=self.kafka_connect_str, group_id="my_consumer", auto_offset_reset='earliest'
+            {'bootstrap.servers': self.kafka_connect_str, 'group.id': 'my_consumer', 'auto.offset.reset': 'earliest'}
         )
         consumer.subscribe(self.topics)
 
         iteration = 0
         while not self._shutdown_event.is_set():
-            consumer.poll(timeout_ms=500, max_records=10)
+            consumer.poll(timeout=500)
             iteration += 1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Replace the python kafka client in the test setup functions.

### Motivation
<!-- What inspired you to submit this pull request? -->

Will be needed to add new e2e envs with authentication

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.