### PR TITLE
Set default idle timeouts on the session and transaction to prevent idle connection accumulation

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -136,6 +136,22 @@ files:
       value:
         type: integer
         example: 5000
+    - name: idle_session_timeout
+      hidden: true
+      description: |
+        Sets the idle_session_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-IDLE-SESSION-TIMEOUT
+        on the connection used by the Agent. This prevents long-running idle connections being pooled forever per-database.
+      value:
+        type: integer
+        example: 180000
+    - name: idle_in_transaction_session_timeout
+      hidden: true
+      description: |
+        Sets the idle_in_transaction_session_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT
+        on the connection used by the Agent. This is a safety measure to prevent long running transactions.
+      value:
+        type: integer
+        example: 180000
     - name: relations
       description: |
         The list of relations/tables must be specified here to track per-relation (table, index , view, etc.) metrics.

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -44,6 +44,8 @@ class PostgresConfig:
             raise ConfigurationError("Application name can include only ASCII characters: %s", self.application_name)
 
         self.query_timeout = int(instance.get('query_timeout', 5000))
+        self.idle_session_timeout = int(instance.get('idle_session_timeout', 180000))
+        self.idle_in_transaction_session_timeout = int(instance.get('idle_in_transaction_session_timeout', 180000))
         self.relations = instance.get('relations', [])
         if self.relations and not self.dbname:
             raise ConfigurationError('"dbname" parameter must be set when using the "relations" parameter.')

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -90,6 +90,14 @@ def instance_gcp(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_idle_in_transaction_session_timeout(field, value):
+    return 180000
+
+
+def instance_idle_session_timeout(field, value):
+    return 180000
+
+
 def instance_ignore_databases(field, value):
     return ['template%', 'rdsadmin', 'azure_maintenance']
 

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -130,6 +130,8 @@ class InstanceConfig(BaseModel):
     empty_default_hostname: Optional[bool]
     gcp: Optional[Gcp]
     host: str
+    idle_in_transaction_session_timeout: Optional[int]
+    idle_session_timeout: Optional[int]
     ignore_databases: Optional[Sequence[str]]
     log_unobfuscated_plans: Optional[bool]
     log_unobfuscated_queries: Optional[bool]

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -429,7 +429,14 @@ class PostgreSql(AgentCheck):
                 self._config.application_name,
             )
             if self._config.query_timeout:
-                connection_string += " options='-c statement_timeout=%s'" % self._config.query_timeout
+                conn_options = (
+                    "-c statement_timeout={}".format(self._config.query_timeout)
+                    + " -c idle_session_timeout={}".format(self._config.idle_session_timeout)
+                    + " -c idle_in_transaction_session_timeout={}".format(
+                        self._config.idle_in_transaction_session_timeout
+                    )
+                )
+                connection_string += " options='{}'".format(conn_options)
             conn = psycopg2.connect(connection_string)
         else:
             args = {

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -1,0 +1,27 @@
+# (C) Datadog, Inc. 2010-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+
+
+def test_connection_settings_defaults(integration_check, pg_instance):
+    """
+    Tests the default session settings are properly configured for all new connections made by the datadog user
+    to the database.
+    """
+    check = integration_check(pg_instance)
+
+    with check._new_connection("postgres") as conn:
+        with conn.cursor() as cursor:
+            cursor.execute("SELECT name, setting FROM pg_settings")
+            settings = cursor.fetchall()
+            settings = {name: value for name, value in settings}
+
+            assert 'statement_timeout' in settings
+            assert settings['statement_timeout'] == str(check._config.query_timeout) != 0
+
+            assert 'idle_in_transaction_session_timeout' in settings
+            assert (
+                settings['idle_in_transaction_session_timeout']
+                == str(check._config.idle_in_transaction_session_timeout)
+                != 0
+            )


### PR DESCRIPTION
### What does this PR do?

Sets reasonable idle connection and transaction timeouts for connections coming from the Agent. The Agent uses connection pooling and long-lived connections to ensure that it has visibility when incidents happen and it's unable to establish new connections to the database. The problem comes in when customers have many databases because Postgres requires a one-to-one connection to a database. These conservative timeouts should prevent super long lived idle connections on seldom used databases while still maintaining connections that are actually used with some frequency.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.