### PR TITLE
Use shutil instead of distutils.spawn

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -6,7 +6,7 @@
 Collects network metrics.
 """
 
-import distutils.spawn
+import shutil
 import re
 import socket
 
@@ -294,7 +294,7 @@ class Network(AgentCheck):
 
         if proc_location != "/proc":
             # If we have `ss`, we're fine with a non-standard `/proc` location
-            if distutils.spawn.find_executable("ss") is None:
+            if shutil.which("ss") is None:
                 self.warning(
                     "Cannot collect connection state: `ss` cannot be found and "
                     "currently with a custom /proc path: %s",

--- a/network/tests/test_linux.py
+++ b/network/tests/test_linux.py
@@ -306,7 +306,7 @@ def test_proc_permissions_error(aggregator, caplog):
         assert 'Unable to read /proc/net/snmp.' in caplog.text
 
 
-@mock.patch('distutils.spawn.find_executable', return_value='/bin/ss')
+@mock.patch('shutil.which', return_value='/bin/ss')
 def test_ss_with_custom_procfs(aggregator):
     instance = copy.deepcopy(common.INSTANCE)
     instance['collect_connection_state'] = True

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -48,5 +48,5 @@ def test_is_collect_cx_state_runnable(aggregator, check, proc_location, ss_found
     instance = copy.deepcopy(common.INSTANCE)
     instance['collect_connection_state'] = True
     check_instance = check(instance)
-    with mock.patch('distutils.spawn.find_executable', lambda x: "/bin/ss" if ss_found else None):
+    with mock.patch('shutil.which', lambda x: "/bin/ss" if ss_found else None):
         assert check_instance.is_collect_cx_state_runnable(proc_location) == expected


### PR DESCRIPTION


### What does this PR do?

Use shutil instead of distutils.spawn

### Motivation

distutils is deprecated and uses more memory to load a native module that is entirely unsed by find_executable anyway.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.