### PR TITLE
Change ddev test env names

### DIFF
--- a/zk/hatch.toml
+++ b/zk/hatch.toml
@@ -3,11 +3,18 @@
 [[envs.default.matrix]]
 python = ["2.7", "3.8"]
 version = ["3.5.8", "3.6.2"]
-ssl = ["True", "False"]
+ssl = ["ssl"]
+
+[[envs.default.matrix]]
+python = ["2.7", "3.8"]
+version = ["3.5.8", "3.6.2"]
 
 [envs.default.overrides]
 matrix.version.env-vars = "ZK_VERSION"
-matrix.ssl.env-vars = "SSL"
+matrix.ssl.env-vars = [
+    { key = "SSL", value = "true", if = ["ssl"] },
+]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
+SSL = "false"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Changes test env names of `zk` from:

```
    py2.7-3.5.8-True
    py2.7-3.5.8-False
    py2.7-3.6.2-True
    py2.7-3.6.2-False
    py3.8-3.5.8-True
    py3.8-3.5.8-False
    py3.8-3.6.2-True
    py3.8-3.6.2-False
```

to 

```
    py2.7-3.5.8-ssl
    py2.7-3.6.2-ssl
    py3.8-3.5.8-ssl
    py3.8-3.6.2-ssl
    py2.7-3.5.8
    py2.7-3.6.2
    py3.8-3.5.8
    py3.8-3.6.2
```

### Motivation
<!-- What inspired you to submit this pull request? -->
This makes it more clear that the `True`/`False` correlated to enabling-SSL
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.