### PR TITLE
Update GV$PROCESS query

### DIFF
--- a/oracle/datadog_checks/oracle/queries.py
+++ b/oracle/datadog_checks/oracle/queries.py
@@ -5,9 +5,9 @@
 
 ProcessMetrics = {
     'name': 'process',
-    'query': 'SELECT PROGRAM, SUM(PGA_USED_MEM), SUM(PGA_ALLOC_MEM), SUM(PGA_FREEABLE_MEM), SUM(PGA_MAX_MEM)\
-         FROM GV$PROCESS GROUP BY PROGRAM',
+    'query': 'SELECT PID, PROGRAM, PGA_USED_MEM, PGA_ALLOC_MEM, PGA_FREEABLE_MEM, PGA_MAX_MEM FROM GV$PROCESS',
     'columns': [
+        {'name': 'pid', 'type': 'tag'},
         {'name': 'program', 'type': 'tag'},
         {'name': 'process.pga_used_memory', 'type': 'gauge'},
         {'name': 'process.pga_allocated_memory', 'type': 'gauge'},

--- a/oracle/datadog_checks/oracle/queries.py
+++ b/oracle/datadog_checks/oracle/queries.py
@@ -5,7 +5,7 @@
 
 ProcessMetrics = {
     'name': 'process',
-    'query': 'SELECT PROGRAM, PGA_USED_MEM, PGA_ALLOC_MEM, PGA_FREEABLE_MEM, PGA_MAX_MEM FROM GV$PROCESS',
+    'query': 'SELECT PROGRAM, SUM(PGA_USED_MEM), SUM(PGA_ALLOC_MEM), SUM(PGA_FREEABLE_MEM), SUM(PGA_MAX_MEM) FROM GV$PROCESS GROUP BY PROGRAM',
     'columns': [
         {'name': 'program', 'type': 'tag'},
         {'name': 'process.pga_used_memory', 'type': 'gauge'},

--- a/oracle/datadog_checks/oracle/queries.py
+++ b/oracle/datadog_checks/oracle/queries.py
@@ -5,7 +5,8 @@
 
 ProcessMetrics = {
     'name': 'process',
-    'query': 'SELECT PROGRAM, SUM(PGA_USED_MEM), SUM(PGA_ALLOC_MEM), SUM(PGA_FREEABLE_MEM), SUM(PGA_MAX_MEM) FROM GV$PROCESS GROUP BY PROGRAM',
+    'query': 'SELECT PROGRAM, SUM(PGA_USED_MEM), SUM(PGA_ALLOC_MEM), SUM(PGA_FREEABLE_MEM), SUM(PGA_MAX_MEM)\
+         FROM GV$PROCESS GROUP BY PROGRAM',
     'columns': [
         {'name': 'program', 'type': 'tag'},
         {'name': 'process.pga_used_memory', 'type': 'gauge'},

--- a/oracle/tests/test_unit.py
+++ b/oracle/tests/test_unit.py
@@ -51,14 +51,14 @@ def test_process_metrics(aggregator, check):
     con = mock.MagicMock()
     cur = mock.MagicMock()
     con.cursor.return_value = cur
-    metrics = copy.deepcopy(queries.ProcessMetrics['columns'][1:])
+    metrics = copy.deepcopy(queries.ProcessMetrics['columns'][2:])
     programs = [
         "PSEUDO",
         "oracle@localhost.localdomain (PMON)",
         "oracle@localhost.localdomain (PSP0)",
         "oracle@localhost.localdomain (VKTM)",
     ]
-    cur.fetchall.return_value = [[program] + ([0] * len(metrics)) for program in programs]
+    cur.fetchall.return_value = [[i, program] + ([0] * len(metrics)) for (i, program) in enumerate(programs)]
 
     check._cached_connection = con
     check._query_manager.queries = [Query(queries.ProcessMetrics)]
@@ -72,7 +72,7 @@ def test_process_metrics(aggregator, check):
             'oracle.{}'.format(metric['name']),
             count=1,
             value=0,
-            tags=['custom_tag', 'program:{}'.format(expected_program)],
+            tags=['custom_tag', 'pid:{}'.format(i), 'program:{}'.format(expected_program)],
         )
 
 


### PR DESCRIPTION
Update GV$PROCESS query to better handle multiple records with the same program value

### What does this PR do?
This PR fixes the GV$PROCESS query so that the program value in each record returned is unique.

### Motivation
The current query returns multiple records with the same program value. And since program is the only tag, only one of the values is reported, and all the other values are omitted within DataDog. Based on my testing, only the values associated with the last record of a given program name is reported. This leads to incorrect calculations of PGA information in the database.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [changelog/Fixed ] PR must have `changelog/` and `integration/` labels attached
- [x] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.