### PR TITLE
Update all the tests to use the `kafka_instance` instead of a custom one

### DIFF
--- a/kafka_consumer/tests/python_client/__init__.py
+++ b/kafka_consumer/tests/python_client/__init__.py
@@ -1,3 +1,0 @@
-# (C) Datadog, Inc. 2023-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/kafka_consumer/tests/python_client/test_integration.py
+++ b/kafka_consumer/tests/python_client/test_integration.py
@@ -1,11 +1,14 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import logging
+
 import pytest
+from contextlib import nullcontext as does_not_raise
 
 from datadog_checks.dev.utils import get_metadata_metrics
 
-from ..common import KAFKA_CONNECT_STR, assert_check_kafka
+from ..common import KAFKA_CONNECT_STR, assert_check_kafka, metrics
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
 
@@ -36,9 +39,9 @@ def test_check_kafka_metrics_limit(aggregator, check, kafka_instance, dd_run_che
     assert len(aggregator._metrics) == 1
 
 
-def test_consumer_config_error(caplog, check, dd_run_check):
-    instance = {'kafka_connect_str': KAFKA_CONNECT_STR, 'tags': ['optional:tag1']}
-    kafka_consumer_check = check(instance)
+def test_consumer_config_error(caplog, check, dd_run_check, kafka_instance):
+    del kafka_instance['consumer_groups']
+    kafka_consumer_check = check(kafka_instance)
 
     dd_run_check(kafka_consumer_check, extract_message=True)
     assert 'monitor_unlisted_consumer_groups is False' in caplog.text
@@ -65,13 +68,10 @@ def test_no_partitions(aggregator, check, kafka_instance, dd_run_check):
         pytest.param(False, 2, ['topic:marvel'], id="Disabled"),
     ],
 )
-def test_monitor_broker_highwatermarks(dd_run_check, check, aggregator, is_enabled, metric_count, topic_tags):
-    instance = {
-        'kafka_connect_str': KAFKA_CONNECT_STR,
-        'consumer_groups': {'my_consumer': {'marvel': None}},
-        'monitor_all_broker_highwatermarks': is_enabled,
-    }
-    dd_run_check(check(instance))
+def test_monitor_broker_highwatermarks(dd_run_check, check, aggregator, kafka_instance, is_enabled, metric_count, topic_tags):
+    kafka_instance['consumer_groups'] = {'my_consumer': {'marvel': None}}
+    kafka_instance['monitor_all_broker_highwatermarks'] = is_enabled
+    dd_run_check(check(kafka_instance))
 
     # After refactor and library migration, write unit tests to assert expected metric values
     aggregator.assert_metric('kafka.broker_offset', count=metric_count)
@@ -80,4 +80,88 @@ def test_monitor_broker_highwatermarks(dd_run_check, check, aggregator, is_enabl
         aggregator.assert_metric_has_tag('kafka.broker_offset', tag, count=2)
 
     aggregator.assert_metric_has_tag_prefix('kafka.broker_offset', 'partition', count=metric_count)
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
+
+
+@pytest.mark.parametrize(
+    'override, expected_exception, exception_msg, metric_count',
+    [
+        pytest.param(
+            {'kafka_connect_str': 12},
+            pytest.raises(
+                Exception, match='ConfigurationError: `kafka_connect_str` should be string or list of strings'
+            ),
+            '',
+            0,
+            id="Invalid Non-string kafka_connect_str",
+        ),
+        pytest.param(
+            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {}},
+            does_not_raise(),
+            'ConfigurationError: Cannot fetch consumer offsets because no consumer_groups are specified and '
+            'monitor_unlisted_consumer_groups is False',
+            0,
+            id="Empty consumer_groups",
+        ),
+        pytest.param(
+            {'kafka_connect_str': None},
+            pytest.raises(Exception, match='kafka_connect_str\n  none is not an allowed value'),
+            '',
+            0,
+            id="Invalid Nonetype kafka_connect_str",
+        ),
+        pytest.param(
+            {'kafka_connect_str': [KAFKA_CONNECT_STR, '127.0.0.1:9093'], 'monitor_unlisted_consumer_groups': True},
+            does_not_raise(),
+            '',
+            4,
+            id="Valid list kafka_connect_str",
+        ),
+        pytest.param(
+            {'kafka_connect_str': KAFKA_CONNECT_STR, 'monitor_unlisted_consumer_groups': True},
+            does_not_raise(),
+            '',
+            4,
+            id="Valid str kafka_connect_str",
+        ),
+        pytest.param(
+            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {}, 'monitor_unlisted_consumer_groups': True},
+            does_not_raise(),
+            '',
+            4,
+            id="Empty consumer_groups and monitor_unlisted_consumer_groups true",
+        ),
+        pytest.param(
+            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {'my_consumer': None}},
+            does_not_raise(),
+            '',
+            4,
+            id="One consumer group, all topics and partitions",
+        ),
+        pytest.param(
+            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {'my_consumer': {'marvel': None}}},
+            does_not_raise(),
+            '',
+            2,
+            id="One consumer group, one topic, all partitions",
+        ),
+        pytest.param(
+            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {'my_consumer': {'marvel': [1]}}},
+            does_not_raise(),
+            '',
+            1,
+            id="One consumer group, one topic, one partition",
+        ),
+    ],
+)
+def test_config(dd_run_check, check, kafka_instance, override, aggregator, expected_exception, exception_msg, metric_count, caplog):
+    caplog.set_level(logging.DEBUG)
+    kafka_instance.update(override)
+    with expected_exception:
+        dd_run_check(check(kafka_instance))
+
+    for m in metrics:
+        aggregator.assert_metric(m, count=metric_count)
+
+    assert exception_msg in caplog.text
     aggregator.assert_metrics_using_metadata(get_metadata_metrics())

--- a/kafka_consumer/tests/python_client/test_unit.py
+++ b/kafka_consumer/tests/python_client/test_unit.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import copy
 import logging
-from contextlib import nullcontext as does_not_raise
 
 import mock
 import pytest
@@ -20,14 +19,13 @@ pytestmark = [pytest.mark.unit]
 
 @pytest.mark.skipif(not LEGACY_CLIENT, reason='not implemented yet with confluent-kafka')
 def test_gssapi(kafka_instance, dd_run_check, check):
-    instance = copy.deepcopy(kafka_instance)
-    instance['sasl_mechanism'] = 'GSSAPI'
-    instance['security_protocol'] = 'SASL_PLAINTEXT'
-    instance['sasl_kerberos_service_name'] = 'kafka'
+    kafka_instance['sasl_mechanism'] = 'GSSAPI'
+    kafka_instance['security_protocol'] = 'SASL_PLAINTEXT'
+    kafka_instance['sasl_kerberos_service_name'] = 'kafka'
     # assert the check doesn't fail with:
     # Exception: Could not find main GSSAPI shared library.
     with pytest.raises(Exception, match='check_version'):
-        dd_run_check(check(instance))
+        dd_run_check(check(kafka_instance))
 
 
 def test_tls_config_ok(check, kafka_instance_tls):
@@ -74,18 +72,18 @@ def test_tls_config_ok(check, kafka_instance_tls):
     ],
 )
 @pytest.mark.skipif(not LEGACY_CLIENT, reason='not implemented yet with confluent-kafka')
-def test_oauth_config(sasl_oauth_token_provider, check, expected_exception):
-    instance = {
+def test_oauth_config(sasl_oauth_token_provider, check, expected_exception, kafka_instance):
+    kafka_instance.update({
         'kafka_connect_str': KAFKA_CONNECT_STR,
         'monitor_unlisted_consumer_groups': True,
         'security_protocol': 'SASL_PLAINTEXT',
         'sasl_mechanism': 'OAUTHBEARER',
         'use_legacy_client': LEGACY_CLIENT,
-    }
-    instance.update(sasl_oauth_token_provider)
+    })
+    kafka_instance.update(sasl_oauth_token_provider)
 
     with expected_exception:
-        check(instance).check(instance)
+        check(kafka_instance).check(kafka_instance)
 
 
 @pytest.mark.skip(reason='Add a test that not only check the parameter but also run the check')
@@ -121,10 +119,8 @@ def test_oauth_token_client_config(check, kafka_instance):
     ],
 )
 def test_tls_config_legacy(extra_config, expected_http_kwargs, check, kafka_instance):
-    instance = kafka_instance
-    instance.update(extra_config)
-
-    kafka_consumer_check = check(instance)
+    kafka_instance.update(extra_config)
+    kafka_consumer_check = check(kafka_instance)
     kafka_consumer_check.get_tls_context()
     actual_options = {
         k: v for k, v in kafka_consumer_check._tls_context_wrapper.config.items() if k in expected_http_kwargs
@@ -132,103 +128,13 @@ def test_tls_config_legacy(extra_config, expected_http_kwargs, check, kafka_inst
     assert expected_http_kwargs == actual_options
 
 
-@pytest.mark.parametrize(
-    'instance, expected_exception, exception_msg, metric_count',
-    [
-        pytest.param(
-            {'kafka_connect_str': 12},
-            pytest.raises(
-                Exception, match='ConfigurationError: `kafka_connect_str` should be string or list of strings'
-            ),
-            '',
-            0,
-            id="Invalid Non-string kafka_connect_str",
-        ),
-        pytest.param(
-            {'kafka_connect_str': [KAFKA_CONNECT_STR, '127.0.0.1:9093']},
-            does_not_raise(),
-            'ConfigurationError: Cannot fetch consumer offsets because no consumer_groups are specified and '
-            'monitor_unlisted_consumer_groups is False',
-            0,
-            id="monitor_unlisted_consumer_groups is False",
-        ),
-        pytest.param(
-            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {}},
-            does_not_raise(),
-            'ConfigurationError: Cannot fetch consumer offsets because no consumer_groups are specified and '
-            'monitor_unlisted_consumer_groups is False',
-            0,
-            id="Empty consumer_groups",
-        ),
-        pytest.param(
-            {'kafka_connect_str': None},
-            pytest.raises(Exception, match='kafka_connect_str\n  none is not an allowed value'),
-            '',
-            0,
-            id="Invalid Nonetype kafka_connect_str",
-        ),
-        pytest.param(
-            {'kafka_connect_str': [KAFKA_CONNECT_STR, '127.0.0.1:9093'], 'monitor_unlisted_consumer_groups': True},
-            does_not_raise(),
-            '',
-            4,
-            id="Valid list kafka_connect_str",
-        ),
-        pytest.param(
-            {'kafka_connect_str': KAFKA_CONNECT_STR, 'monitor_unlisted_consumer_groups': True},
-            does_not_raise(),
-            '',
-            4,
-            id="Valid str kafka_connect_str",
-        ),
-        pytest.param(
-            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {}, 'monitor_unlisted_consumer_groups': True},
-            does_not_raise(),
-            '',
-            4,
-            id="Empty consumer_groups and monitor_unlisted_consumer_groups true",
-        ),
-        pytest.param(
-            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {'my_consumer': None}},
-            does_not_raise(),
-            '',
-            4,
-            id="One consumer group, all topics and partitions",
-        ),
-        pytest.param(
-            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {'my_consumer': {'marvel': None}}},
-            does_not_raise(),
-            '',
-            2,
-            id="One consumer group, one topic, all partitions",
-        ),
-        pytest.param(
-            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {'my_consumer': {'marvel': [1]}}},
-            does_not_raise(),
-            '',
-            1,
-            id="One consumer group, one topic, one partition",
-        ),
-    ],
-)
-def test_config(dd_run_check, check, instance, aggregator, expected_exception, exception_msg, metric_count, caplog):
-    caplog.set_level(logging.DEBUG)
-    with expected_exception:
-        dd_run_check(check(instance))
-
-    for m in metrics:
-        aggregator.assert_metric(m, count=metric_count)
-
-    assert exception_msg in caplog.text
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
-
-
 @pytest.mark.skipif(not LEGACY_CLIENT, reason='The kafka-python implementation raises an exception')
-def test_legacy_invalid_connect_str(dd_run_check, check, aggregator, caplog):
+def test_legacy_invalid_connect_str(dd_run_check, check, aggregator, caplog, kafka_instance):
     caplog.set_level(logging.DEBUG)
-    instance = {'kafka_connect_str': 'invalid', 'use_legacy_client': True}
+    kafka_instance['kafka_connect_str'] = 'invalid'
+    del kafka_instance['consumer_groups']
     with pytest.raises(Exception):
-        dd_run_check(check(instance))
+        dd_run_check(check(kafka_instance))
 
     for m in metrics:
         aggregator.assert_metric(m, count=0)
@@ -243,10 +149,11 @@ def test_legacy_invalid_connect_str(dd_run_check, check, aggregator, caplog):
 
 
 @pytest.mark.skipif(LEGACY_CLIENT, reason='The following condition only occurs in confluent-kafka implementation')
-def test_invalid_connect_str(dd_run_check, check, aggregator, caplog):
+def test_invalid_connect_str(dd_run_check, check, aggregator, caplog, kafka_instance):
     caplog.set_level(logging.DEBUG)
-    instance = {'kafka_connect_str': 'invalid', 'use_legacy_client': False}
-    dd_run_check(check(instance))
+    kafka_instance['kafka_connect_str'] = 'invalid'
+    del kafka_instance['consumer_groups']
+    dd_run_check(check(kafka_instance))
 
     for m in metrics:
         aggregator.assert_metric(m, count=0)

--- a/kafka_consumer/tests/test_e2e.py
+++ b/kafka_consumer/tests/test_e2e.py
@@ -2,8 +2,7 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import pytest
-
-from ..common import assert_check_kafka
+from tests.common import assert_check_kafka
 
 pytestmark = [pytest.mark.e2e]
 

--- a/kafka_consumer/tests/test_integration.py
+++ b/kafka_consumer/tests/test_integration.py
@@ -2,13 +2,12 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
-
-import pytest
 from contextlib import nullcontext as does_not_raise
 
-from datadog_checks.dev.utils import get_metadata_metrics
+import pytest
+from tests.common import KAFKA_CONNECT_STR, assert_check_kafka, metrics
 
-from ..common import KAFKA_CONNECT_STR, assert_check_kafka, metrics
+from datadog_checks.dev.utils import get_metadata_metrics
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
 
@@ -68,7 +67,9 @@ def test_no_partitions(aggregator, check, kafka_instance, dd_run_check):
         pytest.param(False, 2, ['topic:marvel'], id="Disabled"),
     ],
 )
-def test_monitor_broker_highwatermarks(dd_run_check, check, aggregator, kafka_instance, is_enabled, metric_count, topic_tags):
+def test_monitor_broker_highwatermarks(
+    dd_run_check, check, aggregator, kafka_instance, is_enabled, metric_count, topic_tags
+):
     kafka_instance['consumer_groups'] = {'my_consumer': {'marvel': None}}
     kafka_instance['monitor_all_broker_highwatermarks'] = is_enabled
     dd_run_check(check(kafka_instance))
@@ -96,7 +97,7 @@ def test_monitor_broker_highwatermarks(dd_run_check, check, aggregator, kafka_in
             id="Invalid Non-string kafka_connect_str",
         ),
         pytest.param(
-            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {}},
+            {'consumer_groups': {}},
             does_not_raise(),
             'ConfigurationError: Cannot fetch consumer offsets because no consumer_groups are specified and '
             'monitor_unlisted_consumer_groups is False',
@@ -111,42 +112,42 @@ def test_monitor_broker_highwatermarks(dd_run_check, check, aggregator, kafka_in
             id="Invalid Nonetype kafka_connect_str",
         ),
         pytest.param(
-            {'kafka_connect_str': [KAFKA_CONNECT_STR, '127.0.0.1:9093'], 'monitor_unlisted_consumer_groups': True},
+            {'kafka_connect_str': ['localhost:9092', 'localhost:9093'], 'monitor_unlisted_consumer_groups': True},
             does_not_raise(),
             '',
             4,
             id="Valid list kafka_connect_str",
         ),
         pytest.param(
-            {'kafka_connect_str': KAFKA_CONNECT_STR, 'monitor_unlisted_consumer_groups': True},
+            {'monitor_unlisted_consumer_groups': True},
             does_not_raise(),
             '',
             4,
             id="Valid str kafka_connect_str",
         ),
         pytest.param(
-            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {}, 'monitor_unlisted_consumer_groups': True},
+            {'consumer_groups': {}, 'monitor_unlisted_consumer_groups': True},
             does_not_raise(),
             '',
             4,
             id="Empty consumer_groups and monitor_unlisted_consumer_groups true",
         ),
         pytest.param(
-            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {'my_consumer': None}},
+            {'consumer_groups': {'my_consumer': None}},
             does_not_raise(),
             '',
             4,
             id="One consumer group, all topics and partitions",
         ),
         pytest.param(
-            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {'my_consumer': {'marvel': None}}},
+            {'consumer_groups': {'my_consumer': {'marvel': None}}},
             does_not_raise(),
             '',
             2,
             id="One consumer group, one topic, all partitions",
         ),
         pytest.param(
-            {'kafka_connect_str': KAFKA_CONNECT_STR, 'consumer_groups': {'my_consumer': {'marvel': [1]}}},
+            {'consumer_groups': {'my_consumer': {'marvel': [1]}}},
             does_not_raise(),
             '',
             1,
@@ -154,7 +155,9 @@ def test_monitor_broker_highwatermarks(dd_run_check, check, aggregator, kafka_in
         ),
     ],
 )
-def test_config(dd_run_check, check, kafka_instance, override, aggregator, expected_exception, exception_msg, metric_count, caplog):
+def test_config(
+    dd_run_check, check, kafka_instance, override, aggregator, expected_exception, exception_msg, metric_count, caplog
+):
     caplog.set_level(logging.DEBUG)
     kafka_instance.update(override)
     with expected_exception:

--- a/kafka_consumer/tests/test_integration.py
+++ b/kafka_consumer/tests/test_integration.py
@@ -5,7 +5,7 @@ import logging
 from contextlib import nullcontext as does_not_raise
 
 import pytest
-from tests.common import KAFKA_CONNECT_STR, assert_check_kafka, metrics
+from tests.common import assert_check_kafka, metrics
 
 from datadog_checks.dev.utils import get_metadata_metrics
 

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -1,18 +1,16 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import copy
 import logging
 
 import mock
 import pytest
+from tests.common import KAFKA_CONNECT_STR, LEGACY_CLIENT, metrics
 
 from datadog_checks.base import ConfigurationError
 from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.kafka_consumer import KafkaCheck
 from datadog_checks.kafka_consumer.client.kafka_python_client import OAuthTokenProvider
-
-from ..common import KAFKA_CONNECT_STR, LEGACY_CLIENT, metrics
 
 pytestmark = [pytest.mark.unit]
 
@@ -73,13 +71,15 @@ def test_tls_config_ok(check, kafka_instance_tls):
 )
 @pytest.mark.skipif(not LEGACY_CLIENT, reason='not implemented yet with confluent-kafka')
 def test_oauth_config(sasl_oauth_token_provider, check, expected_exception, kafka_instance):
-    kafka_instance.update({
-        'kafka_connect_str': KAFKA_CONNECT_STR,
-        'monitor_unlisted_consumer_groups': True,
-        'security_protocol': 'SASL_PLAINTEXT',
-        'sasl_mechanism': 'OAUTHBEARER',
-        'use_legacy_client': LEGACY_CLIENT,
-    })
+    kafka_instance.update(
+        {
+            'kafka_connect_str': KAFKA_CONNECT_STR,
+            'monitor_unlisted_consumer_groups': True,
+            'security_protocol': 'SASL_PLAINTEXT',
+            'sasl_mechanism': 'OAUTHBEARER',
+            'use_legacy_client': LEGACY_CLIENT,
+        }
+    )
     kafka_instance.update(sasl_oauth_token_provider)
 
     with expected_exception:

--- a/kafka_consumer/tests/test_unit.py
+++ b/kafka_consumer/tests/test_unit.py
@@ -73,11 +73,9 @@ def test_tls_config_ok(check, kafka_instance_tls):
 def test_oauth_config(sasl_oauth_token_provider, check, expected_exception, kafka_instance):
     kafka_instance.update(
         {
-            'kafka_connect_str': KAFKA_CONNECT_STR,
             'monitor_unlisted_consumer_groups': True,
             'security_protocol': 'SASL_PLAINTEXT',
             'sasl_mechanism': 'OAUTHBEARER',
-            'use_legacy_client': LEGACY_CLIENT,
         }
     )
     kafka_instance.update(sasl_oauth_token_provider)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update all the tests to use the kafka_instance instead of a custom one. 

### Motivation
<!-- What inspired you to submit this pull request? -->

If we use a custom one, we do not provide all the necessary parameters such as: 
- Which client to use
- Authentication

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.