### PR TITLE
[DBM-2204] mysql: set self._check instance variables to make tracking work

### DIFF
--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -199,6 +199,7 @@ class MySQLStatementSamples(DBMAsyncJob):
         self._connection_args = connection_args
         self._last_check_run = 0
         self._db = None
+        self._check = check
         self._configured_collection_interval = self._config.statement_samples_config.get('collection_interval', -1)
         self._events_statements_row_limit = self._config.statement_samples_config.get(
             'events_statements_row_limit', 5000

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -79,6 +79,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
             job_name="statement-metrics",
             shutdown_callback=self._close_db_conn,
         )
+        self._check = check
         self._metric_collection_interval = collection_interval
         self._connection_args = connection_args
         self._db = None


### PR DESCRIPTION
### What does this PR do?
The tracked_method decorator is failing to track methods in two classes, MySQLStatementMetrics and MySQLStatementSamples, because the self._check variable is not available. This sets self._check on each
of those classes. 

### Motivation
[Jira bug report](https://datadoghq.atlassian.net/browse/DBM-2204)
[Related support ticket](https://datadoghq.atlassian.net/browse/SDBM-398)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.