### PR TITLE
Adds container memory usage metrics from /stats/summary and kubelet memory usage

### DIFF
--- a/kubelet/datadog_checks/kubelet/summary.py
+++ b/kubelet/datadog_checks/kubelet/summary.py
@@ -150,6 +150,8 @@ class SummaryScraperMixin(object):
                 if cpu_usage:
                     self.gauge(self.NAMESPACE + '.runtime.cpu.usage', cpu_usage, instance_tags)
                 memory_usage = ctr.get('memory', {}).get('usageBytes')
+                if memory_usage:
+                    self.gauge(self.NAMESPACE + '.runtime.memory.usage', memory_usage, instance_tags)
             if ctr.get('name') == 'kubelet':
                 mem_rss = ctr.get('memory', {}).get('rssBytes')
                 if mem_rss:

--- a/kubelet/datadog_checks/kubelet/summary.py
+++ b/kubelet/datadog_checks/kubelet/summary.py
@@ -125,6 +125,10 @@ class SummaryScraperMixin(object):
             if working_set:
                 self.gauge(self.NAMESPACE + '.memory.working_set', working_set, container_tags)
 
+            memory_usage = container.get('memory', {}).get('usageBytes')
+            if memory_usage:
+                self.gauge(self.NAMESPACE + '.memory.usage', memory_usage, container_tags)
+
             # TODO: Review meaning of these metrics as capacity != available + used
             # availableBytes = container.get('rootfs', {}).get('availableBytes')
             capacity_bytes = container.get('rootfs', {}).get('capacityBytes')
@@ -145,6 +149,9 @@ class SummaryScraperMixin(object):
                 cpu_usage = ctr.get('cpu', {}).get('usageNanoCores')
                 if cpu_usage:
                     self.gauge(self.NAMESPACE + '.runtime.cpu.usage', cpu_usage, instance_tags)
+                memory_usage = ctr.get('memory', {}).get('usageBytes')
+                if memory_usage:
+                    self.gauge(self.NAMESPACE + '.runtime.memory.usage', memory_usage, instance_tags)
             if ctr.get('name') == 'kubelet':
                 mem_rss = ctr.get('memory', {}).get('rssBytes')
                 if mem_rss:
@@ -152,3 +159,6 @@ class SummaryScraperMixin(object):
                 cpu_usage = ctr.get('cpu', {}).get('usageNanoCores')
                 if cpu_usage:
                     self.gauge(self.NAMESPACE + '.kubelet.cpu.usage', cpu_usage, instance_tags)
+                memory_usage = ctr.get('memory', {}).get('usageBytes')
+                if memory_usage:
+                    self.gauge(self.NAMESPACE + '.kubelet.memory.usage', memory_usage, instance_tags)

--- a/kubelet/datadog_checks/kubelet/summary.py
+++ b/kubelet/datadog_checks/kubelet/summary.py
@@ -150,8 +150,6 @@ class SummaryScraperMixin(object):
                 if cpu_usage:
                     self.gauge(self.NAMESPACE + '.runtime.cpu.usage', cpu_usage, instance_tags)
                 memory_usage = ctr.get('memory', {}).get('usageBytes')
-                if memory_usage:
-                    self.gauge(self.NAMESPACE + '.runtime.memory.usage', memory_usage, instance_tags)
             if ctr.get('name') == 'kubelet':
                 mem_rss = ctr.get('memory', {}).get('rssBytes')
                 if mem_rss:

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -70,6 +70,7 @@ kubernetes.kubelet.cpu.usage,gauge,,nanocore,,The number of cores used by kubele
 kubernetes.kubelet.memory.usage,gauge,,byte,,Current kubelet memory usage in bytes,-1,kubernetes,k8s.kubelet.mem,
 kubernetes.kubelet.memory.rss,gauge,,byte,,Size of kubelet RSS in bytes,-1,kubernetes,k8s.kubelet.mem.rss,
 kubernetes.runtime.cpu.usage,gauge,,nanocore,,The number of cores used by the runtime,-1,kubernetes,k8s.runtime.cpu,
+kubernetes.runtime.memory.usage,gauge,,byte,,Current runtime memory usage in bytes,-1,kubernetes,k8s.runtime.mem,
 kubernetes.runtime.memory.rss,gauge,,byte,,Size of runtime RSS in bytes,-1,kubernetes,k8s.runtime.mem.rss,
 kubernetes.kubelet.container.log_filesystem.used_bytes,gauge,,byte,,Bytes used by the container's logs on the filesystem (requires kubernetes 1.14+),0,kubernetes,k8s.kubelet.container.log_filesystem,
 kubernetes.kubelet.pod.start.duration,gauge,,microsecond,,Duration in microseconds for a single pod to go from pending to running,0,kubernetes,k8s.kubelet.pod.start.duration,

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -67,6 +67,7 @@ kubernetes.ephemeral_storage.requests,gauge,,byte,,Ephemeral storage request of 
 kubernetes.ephemeral_storage.usage,gauge,,byte,,Ephemeral storage usage of the POD,0,kubernetes,k8s.eph_storage.usage,
 kubernetes.kubelet.evictions,count,,,,The number of pods that have been evicted from the kubelet (ALPHA in kubernetes v1.16),-1,kubernetes,k8s.evict,
 kubernetes.kubelet.cpu.usage,gauge,,nanocore,,The number of cores used by kubelet,-1,kubernetes,k8s.kubelet.cpu,
+kubernetes.kubelet.memory.usage,gauge,,byte,,Current kubelet memory usage in bytes,-1,kubernetes,k8s.kubelet.mem,
 kubernetes.kubelet.memory.rss,gauge,,byte,,Size of kubelet RSS in bytes,-1,kubernetes,k8s.kubelet.mem.rss,
 kubernetes.runtime.cpu.usage,gauge,,nanocore,,The number of cores used by the runtime,-1,kubernetes,k8s.runtime.cpu,
 kubernetes.runtime.memory.rss,gauge,,byte,,Size of runtime RSS in bytes,-1,kubernetes,k8s.runtime.mem.rss,

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -69,6 +69,7 @@ EXPECTED_METRICS_COMMON = [
     'kubernetes.runtime.cpu.usage',
     'kubernetes.runtime.memory.rss',
     'kubernetes.kubelet.cpu.usage',
+    'kubernetes.kubelet.memory.usage',
     'kubernetes.kubelet.memory.rss',
 ]
 
@@ -148,6 +149,7 @@ EXPECTED_METRICS_PROMETHEUS_1_21 = [
     'kubernetes.go_threads',
     'kubernetes.kubelet.container.log_filesystem.used_bytes',
     'kubernetes.kubelet.cpu.usage',
+    'kubernetes.kubelet.memory.usage',
     'kubernetes.kubelet.memory.rss',
     'kubernetes.kubelet.network_plugin.latency.count',
     'kubernetes.kubelet.network_plugin.latency.sum',
@@ -849,6 +851,7 @@ def test_no_tags_no_metrics(monkeypatch, aggregator, tagger):
     aggregator.assert_metric('kubernetes.runtime.cpu.usage')
     aggregator.assert_metric('kubernetes.runtime.memory.rss')
     aggregator.assert_metric('kubernetes.kubelet.cpu.usage')
+    aggregator.assert_metric('kubernetes.kubelet.memory.usage')
     aggregator.assert_metric('kubernetes.kubelet.memory.rss')
     aggregator.assert_metric('kubernetes.apiserver.certificate.expiration.count')
     aggregator.assert_metric('kubernetes.apiserver.certificate.expiration.sum')

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -67,6 +67,7 @@ EXPECTED_METRICS_COMMON = [
     'kubernetes.network.tx_bytes',
     'kubernetes.ephemeral_storage.usage',
     'kubernetes.runtime.cpu.usage',
+    'kubernetes.runtime.memory.usage',
     'kubernetes.runtime.memory.rss',
     'kubernetes.kubelet.cpu.usage',
     'kubernetes.kubelet.memory.usage',
@@ -175,6 +176,7 @@ EXPECTED_METRICS_PROMETHEUS_1_21 = [
     'kubernetes.rest.client.latency.sum',
     'kubernetes.rest.client.requests',
     'kubernetes.runtime.cpu.usage',
+    'kubernetes.runtime.memory.usage',
     'kubernetes.runtime.memory.rss',
 ]
 
@@ -849,6 +851,7 @@ def test_no_tags_no_metrics(monkeypatch, aggregator, tagger):
     aggregator.assert_metric('kubernetes.memory.capacity')
     aggregator.assert_metric('kubernetes.cpu.capacity')
     aggregator.assert_metric('kubernetes.runtime.cpu.usage')
+    aggregator.assert_metric('kubernetes.runtime.memory.usage')
     aggregator.assert_metric('kubernetes.runtime.memory.rss')
     aggregator.assert_metric('kubernetes.kubelet.cpu.usage')
     aggregator.assert_metric('kubernetes.kubelet.memory.usage')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Retrieves memory usage from `/stats/summary` for containers, when `/metrics/cadvisor` content is not available (i.e. Rancher Kubernetes Engine 1.24.x)
* Adds `kubernetes.kubelet.memory.usage`, the memory usage of the `kubelet` when present in syscontainers
* Adds `kubernetes.runtime.memory.usage`, the memory usage of the `runtime` container (when present in syscontainers)

### Motivation
<!-- What inspired you to submit this pull request? -->
* https://datadoghq.atlassian.net/browse/CONT-3666 : in newer versions of RKE, the cAdvisor output is not full, and prevents the Agent from parsing it. A workaround is to use `/stats/summary` as the main source of data to retrieve some metrics, such as `kubernetes.cpu.usage.total`, but some metrics such as `kubernetes.memory.usage` would still not be collected, as the `kubelet` check does not collect `memory.usageBytes` from the JSON yet

### Additional Notes
<!-- Anything else we should know when reviewing? -->
* Force the usage of /stats/summary in the `kubelet` check and ensure `kubernetes.memory.usage` is collected

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.