### PR TITLE
Extract relation metrics for toast tables

### DIFF
--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -108,7 +108,12 @@ SELECT s.relname, c.relname as toast_of, schemaname, {metrics_columns}
 }
 
 TOAST_IDX_METRICS = {
-    'descriptors': [('relname', 'table'), ('toast_of', 'toast_of'), ('schemaname', 'schema'), ('indexrelname', 'index')],
+    'descriptors': [
+        ('relname', 'table'),
+        ('toast_of', 'toast_of'),
+        ('schemaname', 'schema'),
+        ('indexrelname', 'index'),
+    ],
     'metrics': IDX_TABLE_METRICS,
     'query': """
 SELECT s.relname, c.relname as toast_of, schemaname, indexrelname, {metrics_columns}
@@ -274,8 +279,15 @@ INDEX_BLOAT = {
     'relation': True,
 }
 
-RELATION_METRICS = [LOCK_METRICS, REL_METRICS, IDX_METRICS, TOAST_REL_METRICS, TOAST_IDX_METRICS,
-    SIZE_METRICS, STATIO_METRICS]
+RELATION_METRICS = [
+    LOCK_METRICS,
+    REL_METRICS,
+    IDX_METRICS,
+    TOAST_REL_METRICS,
+    TOAST_IDX_METRICS,
+    SIZE_METRICS,
+    STATIO_METRICS,
+]
 
 
 class RelationsManager(object):

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -112,7 +112,7 @@ def check_common_metrics(aggregator, expected_tags, count=1):
 
 def check_db_count(aggregator, expected_tags, count=1):
     aggregator.assert_metric(
-        'postgresql.table.count', value=5, count=count, tags=expected_tags + ['db:{}'.format(DB_NAME), 'schema:public']
+        'postgresql.table.count', value=6, count=count, tags=expected_tags + ['db:{}'.format(DB_NAME), 'schema:public']
     )
     aggregator.assert_metric('postgresql.db.count', value=5, count=1)
 

--- a/postgres/tests/compose/resources/03_load_data.sh
+++ b/postgres/tests/compose/resources/03_load_data.sh
@@ -12,6 +12,11 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" datadog_test <<-EOSQL
     INSERT INTO pgtable (lastname, firstname, address, city) VALUES ('Cavaille', 'Leo', 'Midtown', 'New York'), ('Someveryveryveryveryveryveryveryveryveryverylongname', 'something', 'Avenue des Champs Elysees', 'Beautiful city of lights');
     CREATE TABLE pg_newtable (personid SERIAL, lastname VARCHAR(255), firstname VARCHAR(255), address VARCHAR(255), city VARCHAR(255));
     INSERT INTO pg_newtable (lastname, firstname, address, city) VALUES ('Cavaille', 'Leo', 'Midtown', 'New York'), ('Someveryveryveryveryveryveryveryveryveryverylongname', 'something', 'Avenue des Champs Elysees', 'Beautiful city of lights');
+    CREATE TABLE test_toast (id SERIAL, txt TEXT);
+    insert into test_toast (txt) select string_agg (md5(random()::text),'') as dummy from generate_series(1,5000);
+    update test_toast set txt = txt;
+    SELECT * FROM test_toast;
+    SELECT * FROM test_toast;
     SELECT * FROM persons;
     SELECT * FROM persons;
     SELECT * FROM persons;

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -5,7 +5,6 @@ import psycopg2
 import pytest
 
 from datadog_checks.base import ConfigurationError
-from datadog_checks.dev.utils import get_metadata_metrics
 from datadog_checks.postgres.relationsmanager import (
     IDX_METRICS,
     REL_METRICS,
@@ -87,7 +86,6 @@ def test_relations_metrics(aggregator, integration_check, pg_instance):
     posgres_check = integration_check(pg_instance)
     posgres_check.check(pg_instance)
     _check_relation_metrics(aggregator, pg_instance, 'persons')
-    aggregator.assert_metrics_using_metadata(get_metadata_metrics())
 
 
 @pytest.mark.integration

--- a/postgres/tests/test_relations.py
+++ b/postgres/tests/test_relations.py
@@ -5,7 +5,13 @@ import psycopg2
 import pytest
 
 from datadog_checks.base import ConfigurationError
-from datadog_checks.postgres.relationsmanager import RelationsManager, REL_METRICS, IDX_METRICS, SIZE_METRICS, STATIO_METRICS
+from datadog_checks.postgres.relationsmanager import (
+    IDX_METRICS,
+    REL_METRICS,
+    SIZE_METRICS,
+    STATIO_METRICS,
+    RelationsManager,
+)
 
 from .common import DB_NAME, HOST, PORT
 
@@ -17,9 +23,7 @@ def _get_metric_names(scope):
 
 def _check_relation_metrics(aggregator, pg_instance, relation):
     relation = relation.lower()
-    base_tags = pg_instance['tags'] + [
-        'port:{}'.format(pg_instance['port']),
-        'db:%s' % pg_instance['dbname']]
+    base_tags = pg_instance['tags'] + ['port:{}'.format(pg_instance['port']), 'db:%s' % pg_instance['dbname']]
     expected_tags = base_tags + [
         'table:{}'.format(relation),
         'schema:public',


### PR DESCRIPTION
### What does this PR do?
We currently only pull relation metrics from `pg_stat_user_tables` and `pg_stat_user_indexes`. However, those tables don't  include toast tables so we're missing metrics on toast tables.

### Motivation
Since data bigger than 2KB will be split in chunk of 2KB and moved in the toast table, an update of a table with toast data can generate hundred of tuple updates behind the hood that will not appear on the user table's stats.
We need to fetch them explicitly to get relations metrics like number of live rows/dead rows in the toast table and number of returned rows.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.