### PR TITLE
Add deprecation notice to relmetrics module

### DIFF
--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -1,6 +1,21 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+
+# ===================================== DEPRECATION NOTICE =====================================
+# This module is pending deprecation. For authors and contributors: additional queries should be
+# declared using the QueryExecutor and QueryManager APIs.
+
+# Reason for deprecation:
+# Many of the metrics in this module filter on relations and require customers to explicitly
+# connect to every database on their instance via configuration. This is untenable for customers
+# with many databases and a maintenance pain for most; it is also unnecessary for views which
+# can retrieve all data from all databases when connected to the default database
+# (e.g. pg_locks). So to improve the customer experience and usability of configuration APIs,
+# future implementations of these metrics should support autodiscovery, eliminating the need
+# to connect to a specific database.
+# =============================================================================================
+
 from typing import Any, Dict, List, Union
 
 from datadog_checks.base import AgentCheck, ConfigurationError


### PR DESCRIPTION
### What does this PR do?

Add a deprecation notice to make clear to authors and contributors that our intention is to migrate query execution to a new API. These types of metrics that use per-DB views should be implemented using autodiscovery.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.