### PR TITLE
hack: force buffer cache hit ratio to be instantiated as simple class

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -626,6 +626,17 @@ class SQLServer(AgentCheck):
                     self.log.debug("Got base metric: %s for metric: %s", base_name, counter_name)
                 except Exception as e:
                     self.log.warning("Could not get counter_name of base for metric: %s", e)
+            # HACK: let's see if we get more accurate buffer cache hit ratio data by treating 
+            # it as a count instead of a fraction. Changing the sql type for this metric means 
+            # we will use the SqlSimpleMetric class instead of the fractional class,
+            # and report the raw values intead of dividing by a base metric.
+            # see https://datadoghq.atlassian.net/browse/DBM-2189
+            if sql_type == PERF_RAW_LARGE_FRACTION and counter_name in [
+                'sqlserver.buffer.cache_hit_ratio',
+                'Buffer cache hit ratio',
+            ]:
+                sql_type = PERF_COUNTER_LARGE_RAWCOUNT
+                base_name = None
 
         return sql_type, base_name
 


### PR DESCRIPTION
### What does this PR do?
Currently we appear to always report the sql server buffer cache hit ratio as 100%. In code, we appear to always be dividing the raw metric by the cache hit ratio base metric. However I believe that the base metric is already reporting a ratio, so we're reporting incorrectly when we divide by the base metric. 

This is a hack to test the theory: if we report the raw metric, do we get an accurate cache hit ratio?


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.