### PR TITLE
Add an option to bypass TUF and in-toto verification in the checks downloader

### DIFF
--- a/datadog_checks_downloader/README.md
+++ b/datadog_checks_downloader/README.md
@@ -31,12 +31,6 @@ To install the check in dev mode:
 pip install -e '.[deps]'
 ```
 
-To install also development dependencies needed for executing tests:
-
-```shell
-pip install -r requirements-dev.txt
-```
-
 To download a new or updated integration, you may specify a precise
 [version][7]:
 
@@ -50,11 +44,30 @@ Or you may leave the version unspecified to download the latest version:
 python -m datadog_checks.downloader -vvvv datadog-$INTEGRATION
 ```
 
-You can use `ddev` to run the tests:
+
+### Testing
+
+You can use `ddev` to run the tests.
+
+About how to install `ddev`, see https://docs.datadoghq.com/developers/integrations/python/ and https://datadoghq.dev/integrations-core/.
+
+For running tests locally, you need to download some test data first. You should only have to do it the first time, and later after some updates to the data:
+
+```shell
+hatch run test-data:create
+```
+
+This will run the script under `tests/scripts/download_test_data.py`, which will get a partial copy from
+the actual repository.
+
+Then to run the tests:
 
 ```shell
 ddev test datadog_checks_downloader
 ```
+
+
+### (Legacy) Testing by Invoking Pytest Directly
 
 You can select between online and offline tests when running testsuite using
 pytest:
@@ -77,13 +90,6 @@ To run checks against content served from own local directory where TUF, in-toto
 pytest -vvvv --local-dir=/path/to/dir --distribution-name datadog-active-directory --distribution-version 1.10.0
 ```
 
-Data used for offline tests can be regenerated (for a new repo version) by running:
-```shell
-hatch run test-data:create
-```
-
-This will run the script under `tests/scripts/download_test_data.py`, which will get a partial copy from
-the actual repository.
 
 ## Troubleshooting
 

--- a/datadog_checks_downloader/datadog_checks/downloader/cli.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/cli.py
@@ -85,7 +85,9 @@ def download():
 
     parser.add_argument(
         '--unsafe-disable-verification', action='store_true',
-        help='Disable TUF and in-toto integrity verification. To use only if TUF or in-toto verification fails due to a bug and not an attack.',
+        help=('Disable TUF and in-toto integrity verification. '
+              'To use only if TUF or in-toto verification fails due to a bug and not an attack.'
+        ),
     )
 
     parser.add_argument('--ignore-python-version', action='store_true', help='Ignore Python version requirements.')
@@ -122,7 +124,7 @@ def download():
 
     tuf_downloader = TUFDownloader(
         repository_url_prefix=repository_url_prefix, root_layout_type=root_layout_type, verbose=verbose,
-        disable_verification= args.unsafe_disable_verification,
+        disable_verification=args.unsafe_disable_verification,
     )
     wheel_relpath = tuf_downloader.get_wheel_relpath(
         standard_distribution_name, version=version, ignore_python_version=ignore_python_version

--- a/datadog_checks_downloader/datadog_checks/downloader/cli.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/cli.py
@@ -87,7 +87,7 @@ def download():
         '--unsafe-disable-verification', action='store_true',
         help=('Disable TUF and in-toto integrity verification. '
               'To use only if TUF or in-toto verification fails due to a bug and not an attack.'
-        ),
+              ),
     )
 
     parser.add_argument('--ignore-python-version', action='store_true', help='Ignore Python version requirements.')

--- a/datadog_checks_downloader/datadog_checks/downloader/cli.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/cli.py
@@ -84,10 +84,12 @@ def download():
     )
 
     parser.add_argument(
-        '--unsafe-disable-verification', action='store_true',
-        help=('Disable TUF and in-toto integrity verification. '
-              'To use only if TUF or in-toto verification fails due to a bug and not an attack.'
-              ),
+        '--unsafe-disable-verification',
+        action='store_true',
+        help=(
+            'Disable TUF and in-toto integrity verification. '
+            'To use only if TUF or in-toto verification fails due to a bug and not an attack.'
+        ),
     )
 
     parser.add_argument('--ignore-python-version', action='store_true', help='Ignore Python version requirements.')
@@ -123,7 +125,9 @@ def download():
                 sys.exit(1)
 
     tuf_downloader = TUFDownloader(
-        repository_url_prefix=repository_url_prefix, root_layout_type=root_layout_type, verbose=verbose,
+        repository_url_prefix=repository_url_prefix,
+        root_layout_type=root_layout_type,
+        verbose=verbose,
         disable_verification=args.unsafe_disable_verification,
     )
     wheel_relpath = tuf_downloader.get_wheel_relpath(

--- a/datadog_checks_downloader/datadog_checks/downloader/cli.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/cli.py
@@ -55,10 +55,7 @@ def __find_shipped_integrations():
     return integrations
 
 
-# Public module functions.
-
-
-def download():
+def instantiate_downloader():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
@@ -130,8 +127,21 @@ def download():
         verbose=verbose,
         disable_verification=args.unsafe_disable_verification,
     )
+
+    return tuf_downloader, standard_distribution_name, version, ignore_python_version
+
+
+def run_downloader(tuf_downloader, standard_distribution_name, version, ignore_python_version):
     wheel_relpath = tuf_downloader.get_wheel_relpath(
         standard_distribution_name, version=version, ignore_python_version=ignore_python_version
     )
     wheel_abspath = tuf_downloader.download(wheel_relpath)
     print(wheel_abspath)  # pylint: disable=print-statement
+
+
+# Public module functions.
+
+
+def download():
+    tuf_downloader, standard_distribution_name, version, ignore_python_version = instantiate_downloader()
+    run_downloader(tuf_downloader, standard_distribution_name, version, ignore_python_version)

--- a/datadog_checks_downloader/datadog_checks/downloader/cli.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/cli.py
@@ -83,6 +83,11 @@ def download():
         '--force', action='store_true', help='Force download even if the type of integration may be incorrect.'
     )
 
+    parser.add_argument(
+        '--unsafe-disable-verification', action='store_true',
+        help='Disable TUF and in-toto integrity verification. To use only if TUF or in-toto verification fails due to a bug and not an attack.',
+    )
+
     parser.add_argument('--ignore-python-version', action='store_true', help='Ignore Python version requirements.')
 
     parser.add_argument(
@@ -116,7 +121,8 @@ def download():
                 sys.exit(1)
 
     tuf_downloader = TUFDownloader(
-        repository_url_prefix=repository_url_prefix, root_layout_type=root_layout_type, verbose=verbose
+        repository_url_prefix=repository_url_prefix, root_layout_type=root_layout_type, verbose=verbose,
+        disable_verification= args.unsafe_disable_verification,
     )
     wheel_relpath = tuf_downloader.get_wheel_relpath(
         standard_distribution_name, version=version, ignore_python_version=ignore_python_version

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -12,6 +12,7 @@ import shutil
 import sys
 import tempfile
 import urllib.request
+import urllib.error
 
 from in_toto import verifylib
 from in_toto.exceptions import LinkNotFoundError
@@ -127,10 +128,14 @@ class TUFDownloader:
         target_base_url = self.__updater._target_base_url
         full_url = target_base_url + ('/' if not target_base_url.endswith('/') else '') + tuf_target_path
 
-        with urllib.request.urlopen(full_url) as resp:
-            os.makedirs(os.path.dirname(target_abspath), exist_ok=True)
-            with open(target_abspath, 'wb') as dest:
-                dest.write(resp.read())
+        try:
+            with urllib.request.urlopen(full_url) as resp:
+                os.makedirs(os.path.dirname(target_abspath), exist_ok=True)
+                with open(target_abspath, 'wb') as dest:
+                    dest.write(resp.read())
+        except urllib.error.HTTPError as err:
+            logger.error(f'GET {full_url}: {err}')
+            raise
 
         return target_abspath
 

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -57,7 +57,10 @@ logger = logging.getLogger(__name__)
 
 class TUFDownloader:
     def __init__(
-        self, repository_url_prefix=REPOSITORY_URL_PREFIX, root_layout_type=DEFAULT_ROOT_LAYOUT_TYPE, verbose=0,
+        self,
+        repository_url_prefix=REPOSITORY_URL_PREFIX,
+        root_layout_type=DEFAULT_ROOT_LAYOUT_TYPE,
+        verbose=0,
         disable_verification=False,
     ):
         # 0 => 60 (effectively /dev/null)
@@ -122,11 +125,7 @@ class TUFDownloader:
 
         # reproducing how the "self.__updater.download_target" method computes the URL
         target_base_url = self.__updater._target_base_url
-        full_url = (
-            target_base_url
-            + ('/' if not target_base_url.endswith('/') else '')
-            + tuf_target_path
-        )
+        full_url = target_base_url + ('/' if not target_base_url.endswith('/') else '') + tuf_target_path
 
         with urllib.request.urlopen(full_url) as resp:
             with open(target_abspath, 'wb') as dest:

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -128,8 +128,9 @@ class TUFDownloader:
         full_url = target_base_url + ('/' if not target_base_url.endswith('/') else '') + tuf_target_path
 
         with urllib.request.urlopen(full_url) as resp:
+            os.makedirs(os.path.dirname(target_abspath), exist_ok=True)
             with open(target_abspath, 'wb') as dest:
-                dest.write(resp)
+                dest.write(resp.read())
 
         return target_abspath
 

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import sys
 import tempfile
+import urllib.request
 
 from in_toto import verifylib
 from in_toto.exceptions import LinkNotFoundError
@@ -56,7 +57,8 @@ logger = logging.getLogger(__name__)
 
 class TUFDownloader:
     def __init__(
-        self, repository_url_prefix=REPOSITORY_URL_PREFIX, root_layout_type=DEFAULT_ROOT_LAYOUT_TYPE, verbose=0
+        self, repository_url_prefix=REPOSITORY_URL_PREFIX, root_layout_type=DEFAULT_ROOT_LAYOUT_TYPE, verbose=0,
+        disable_verification=False,
     ):
         # 0 => 60 (effectively /dev/null)
         # 1 => 50 (CRITICAL)
@@ -71,6 +73,8 @@ class TUFDownloader:
 
         self.__root_layout_type = root_layout_type
         self.__root_layout = ROOT_LAYOUTS[self.__root_layout_type]
+
+        self.__disable_verification = disable_verification
 
         # NOTE: The directory where the targets for *this* repository is
         # cached. We hard-code this keep this to a subdirectory dedicated to
@@ -100,18 +104,43 @@ class TUFDownloader:
         # we use the same consistent snapshot to download targets.
         self.__updater.refresh()
 
-    def __download_with_tuf(self, target_relpath):
+    def __compute_target_paths(self, target_relpath):
         # The path used to query TUF needs to be a path-relative-URL string
         # (https://url.spec.whatwg.org/#path-relative-url-string), which means the path
         # separator *must* be `/` and only `/`.
         # This is a defensive measure to make things work even if the provided `target_relpath`
         # is a platform-specific filesystem path.
         tuf_target_path = pathlib.PurePath(target_relpath).as_posix()
+        target_abspath = os.path.join(self.__targets_dir, tuf_target_path)
+
+        return tuf_target_path, target_abspath
+
+    def __download_without_tuf(self, target_relpath):
+        assert isinstance(self.__updater._target_base_url, str), self.__updater._target_base_url
+
+        tuf_target_path, target_abspath = self.__compute_target_paths(target_relpath)
+
+        # reproducing how the "self.__updater.download_target" method computes the URL
+        target_base_url = self.__updater._target_base_url
+        full_url = (
+            target_base_url
+            + ('/' if not target_base_url.endswith('/') else '')
+            + tuf_target_path
+        )
+
+        with urllib.request.urlopen(full_url) as resp:
+            with open(target_abspath, 'wb') as dest:
+                dest.write(resp)
+
+        return target_abspath
+
+    def __download_with_tuf(self, target_relpath):
+        tuf_target_path, target_abspath = self.__compute_target_paths(target_relpath)
+
         target = self.__updater.get_targetinfo(tuf_target_path)
         if target is None:
             raise TargetNotFoundError(f'Target at {tuf_target_path} not found')
 
-        target_abspath = os.path.join(self.__targets_dir, tuf_target_path)
         local_relpath = self.__updater.find_cached_target(target, target_abspath)
 
         # Either the target has not been updated...
@@ -270,7 +299,10 @@ class TUFDownloader:
             If download over TUF and in-toto is successful, this function will
             return the complete filepath to the desired target.
         """
-        target_abspath = self.__download_with_tuf_in_toto(target_relpath)
+        if self.__disable_verification:
+            target_abspath = self.__download_without_tuf(target_relpath)
+        else:
+            target_abspath = self.__download_with_tuf_in_toto(target_relpath)
         # Always return the posix version of the path for consistency across platforms
         return pathlib.Path(target_abspath).as_posix()
 
@@ -282,11 +314,14 @@ class TUFDownloader:
         # version: {python_tag: href}
         wheels = collections.defaultdict(dict)
 
-        try:
-            # NOTE: We do not perform in-toto inspection for simple indices; only for wheels.
-            index_abspath, _ = self.__download_with_tuf(index_relpath)
-        except TargetNotFoundError:
-            raise NoSuchDatadogPackage(standard_distribution_name)
+        if self.__disable_verification:
+            index_abspath = self.__download_without_tuf(index_relpath)
+        else:
+            try:
+                # NOTE: We do not perform in-toto inspection for simple indices; only for wheels.
+                index_abspath, _ = self.__download_with_tuf(index_relpath)
+            except TargetNotFoundError:
+                raise NoSuchDatadogPackage(standard_distribution_name)
 
         with open(index_abspath) as simple_index:
             for line in simple_index:

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -12,6 +12,7 @@ import shutil
 import sys
 import tempfile
 import urllib.error
+import urllib.parse
 import urllib.request
 
 from in_toto import verifylib
@@ -79,6 +80,12 @@ class TUFDownloader:
         self.__root_layout = ROOT_LAYOUTS[self.__root_layout_type]
 
         self.__disable_verification = disable_verification
+
+        if self.__disable_verification:
+            logger.warning(
+                'Running with TUF and in-toto verification disabled. '
+                'Integrity is only protected with TLS (HTTPS).'
+            )
 
         # NOTE: The directory where the targets for *this* repository is
         # cached. We hard-code this keep this to a subdirectory dedicated to

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -125,7 +125,7 @@ class TUFDownloader:
 
         return tuf_target_path, target_abspath
 
-    def _download_without_tuf(self, target_relpath):
+    def _download_without_tuf_in_toto(self, target_relpath):
         assert isinstance(self.__updater._target_base_url, str), self.__updater._target_base_url
 
         tuf_target_path, target_abspath = self.__compute_target_paths(target_relpath)
@@ -311,7 +311,7 @@ class TUFDownloader:
             return the complete filepath to the desired target.
         """
         if self.__disable_verification:
-            target_abspath = self._download_without_tuf(target_relpath)
+            target_abspath = self._download_without_tuf_in_toto(target_relpath)
         else:
             target_abspath = self._download_with_tuf_in_toto(target_relpath)
         # Always return the posix version of the path for consistency across platforms
@@ -326,7 +326,7 @@ class TUFDownloader:
         wheels = collections.defaultdict(dict)
 
         if self.__disable_verification:
-            index_abspath = self._download_without_tuf(index_relpath)
+            index_abspath = self._download_without_tuf_in_toto(index_relpath)
         else:
             try:
                 # NOTE: We do not perform in-toto inspection for simple indices; only for wheels.

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -11,8 +11,8 @@ import re
 import shutil
 import sys
 import tempfile
-import urllib.request
 import urllib.error
+import urllib.request
 
 from in_toto import verifylib
 from in_toto.exceptions import LinkNotFoundError
@@ -134,7 +134,7 @@ class TUFDownloader:
                 with open(target_abspath, 'wb') as dest:
                     dest.write(resp.read())
         except urllib.error.HTTPError as err:
-            logger.error(f'GET {full_url}: {err}')
+            logger.error('GET %s: %s', full_url, err)
             raise
 
         return target_abspath

--- a/datadog_checks_downloader/datadog_checks/downloader/download.py
+++ b/datadog_checks_downloader/datadog_checks/downloader/download.py
@@ -83,8 +83,7 @@ class TUFDownloader:
 
         if self.__disable_verification:
             logger.warning(
-                'Running with TUF and in-toto verification disabled. '
-                'Integrity is only protected with TLS (HTTPS).'
+                'Running with TUF and in-toto verification disabled. Integrity is only protected with TLS (HTTPS).'
             )
 
         # NOTE: The directory where the targets for *this* repository is
@@ -126,7 +125,7 @@ class TUFDownloader:
 
         return tuf_target_path, target_abspath
 
-    def __download_without_tuf(self, target_relpath):
+    def _download_without_tuf(self, target_relpath):
         assert isinstance(self.__updater._target_base_url, str), self.__updater._target_base_url
 
         tuf_target_path, target_abspath = self.__compute_target_paths(target_relpath)
@@ -146,7 +145,7 @@ class TUFDownloader:
 
         return target_abspath
 
-    def __download_with_tuf(self, target_relpath):
+    def _download_with_tuf(self, target_relpath):
         tuf_target_path, target_abspath = self.__compute_target_paths(target_relpath)
 
         target = self.__updater.get_targetinfo(tuf_target_path)
@@ -174,7 +173,7 @@ class TUFDownloader:
         # can introduce new parameters w/o breaking old downloaders that don't
         # know how to substitute them.
         target_relpath = f'{IN_TOTO_METADATA_DIR}/{self.__root_layout}'
-        return self.__download_with_tuf(target_relpath)
+        return self._download_with_tuf(target_relpath)
 
     def __download_custom(self, target, extension):
         # A set to collect where in-toto pubkeys / links live.
@@ -198,7 +197,7 @@ class TUFDownloader:
             # for in-toto metadata themselves, and so on ad
             # infinitum.
             if target_relpath.endswith(extension):
-                target_abspath, _ = self.__download_with_tuf(target_relpath)
+                target_abspath, _ = self._download_with_tuf(target_relpath)
 
                 # Add this file to the growing collection of where
                 # in-toto pubkeys / links live.
@@ -289,8 +288,8 @@ class TUFDownloader:
         inspection_packet |= pubkey_abspaths | link_abspaths
         self.__in_toto_verify(inspection_packet, target_relpath)
 
-    def __download_with_tuf_in_toto(self, target_relpath):
-        target_abspath, target = self.__download_with_tuf(target_relpath)
+    def _download_with_tuf_in_toto(self, target_relpath):
+        target_abspath, target = self._download_with_tuf(target_relpath)
 
         # Next, we use in-toto to verify the supply chain of the target.
         # NOTE: We use a flag to avoid recursively downloading in-toto
@@ -312,9 +311,9 @@ class TUFDownloader:
             return the complete filepath to the desired target.
         """
         if self.__disable_verification:
-            target_abspath = self.__download_without_tuf(target_relpath)
+            target_abspath = self._download_without_tuf(target_relpath)
         else:
-            target_abspath = self.__download_with_tuf_in_toto(target_relpath)
+            target_abspath = self._download_with_tuf_in_toto(target_relpath)
         # Always return the posix version of the path for consistency across platforms
         return pathlib.Path(target_abspath).as_posix()
 
@@ -327,11 +326,11 @@ class TUFDownloader:
         wheels = collections.defaultdict(dict)
 
         if self.__disable_verification:
-            index_abspath = self.__download_without_tuf(index_relpath)
+            index_abspath = self._download_without_tuf(index_relpath)
         else:
             try:
                 # NOTE: We do not perform in-toto inspection for simple indices; only for wheels.
-                index_abspath, _ = self.__download_with_tuf(index_relpath)
+                index_abspath, _ = self._download_with_tuf(index_relpath)
             except TargetNotFoundError:
                 raise NoSuchDatadogPackage(standard_distribution_name)
 

--- a/datadog_checks_downloader/tests/conftest.py
+++ b/datadog_checks_downloader/tests/conftest.py
@@ -58,6 +58,11 @@ def distribution_version(request):
     return request.config.getoption("--distribution-version")
 
 
+def pytest_generate_tests(metafunc):
+    if "disable_verification" in metafunc.fixturenames:
+        metafunc.parametrize("disable_verification", [False, True])
+
+
 @pytest.fixture(autouse=True)
 def temporary_local_repo(monkeypatch, tmp_path):
     """

--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -71,9 +71,12 @@ def _do_run_downloader(argv):
 
 
 @pytest.mark.online
-def test_download(capfd, distribution_name, distribution_version, temporary_local_repo):
+def test_download(capfd, distribution_name, distribution_version, temporary_local_repo, disable_verification):
     """Test datadog-checks-downloader successfully downloads and validates a wheel file."""
     argv = [distribution_name, "--version", distribution_version]
+
+    if disable_verification:
+        argv.append('--unsafe-disable-verification')
 
     _do_run_downloader(argv)
     stdout, stderr = capfd.readouterr()
@@ -123,7 +126,7 @@ def test_non_datadog_distribution():
     ],
 )
 @freeze_time(_LOCAL_TESTS_DATA_TIMESTAMP)
-def test_local_download(capfd, distribution_name, distribution_version, target):
+def test_local_download(capfd, distribution_name, distribution_version, target, disable_verification):
     """Test local verification of a wheel file."""
 
     with local_http_server("{}-{}".format(distribution_name, distribution_version)) as http_url:
@@ -134,6 +137,10 @@ def test_local_download(capfd, distribution_name, distribution_version, target):
             "--repository",
             http_url,
         ]
+
+        if disable_verification:
+            argv.append('--unsafe-disable-verification')
+
         _do_run_downloader(argv)
 
     stdout, _ = capfd.readouterr()

--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -246,7 +246,6 @@ def test_local_wheels_signer_signature_leaf_error(distribution_name, distributio
 @pytest.mark.offline
 @freeze_time(_LOCAL_TESTS_DATA_TIMESTAMP)
 def test_local_tampered_target_triggers_failure():
-
     distribution_name = "datadog-active-directory"
     distribution_version = "1.10.0"
 

--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -2,7 +2,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-from contextlib import contextmanager
 import json
 import logging
 import os
@@ -14,6 +13,7 @@ import string
 import subprocess
 import sys
 from collections import defaultdict, namedtuple
+from contextlib import contextmanager
 from datetime import datetime
 from urllib.parse import urljoin
 

--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -90,15 +90,18 @@ def test_download(capfd, distribution_name, distribution_version, temporary_loca
         tuf_downloader, standard_distribution_name, version, ignore_python_version = instantiate_downloader()
 
         spy_with_tuf = mocker.spy(tuf_downloader, '_download_with_tuf')
-        spy_without_tuf = mocker.spy(tuf_downloader, '_download_without_tuf')
+        spy_with_tuf_in_toto = mocker.spy(tuf_downloader, '_download_with_tuf_in_toto')
+        spy_without_tuf_in_toto = mocker.spy(tuf_downloader, '_download_without_tuf_in_toto')
 
         run_downloader(tuf_downloader, standard_distribution_name, version, ignore_python_version)
 
         if disable_verification:
             spy_with_tuf.assert_not_called()
-            spy_without_tuf.assert_called()
+            spy_with_tuf_in_toto.assert_not_called()
+            spy_without_tuf_in_toto.assert_called()
         else:
-            spy_without_tuf.assert_not_called()
+            spy_without_tuf_in_toto.assert_not_called()
+            spy_with_tuf_in_toto.assert_called()
             spy_with_tuf.assert_called()
 
     stdout, stderr = capfd.readouterr()


### PR DESCRIPTION
### What does this PR do?

Add an option in the checks downloader to disable TUF and in-toto verification

### Motivation

https://datadoghq.atlassian.net/browse/SINT-845

In case TUF or in-toto verification fails during the downloading of an integration and the user is sure that this is due to a bug and not to an attack, this option will make the user able to install the integration nonetheless.

### Additional Notes

An additional pull request may be necessary in the Agent repository for the user to able to use this option through the `datadog-agent integration install` command.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.