### PR TITLE
Update model generation with no default value

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model/model_info.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model/model_info.py
@@ -67,8 +67,11 @@ class ModelInfo:
         """
         default_value = self._get_default_value(type_data)
         function_name = f'{model_id}_{normalized_option_name}'
-        function_definition = f'def {function_name}(_field, _value):'\
-            if default_value is not NO_DEFAULT else f'def {function_name}(field, value):'
+        function_definition = (
+            f'def {function_name}(_field, _value):'
+            if default_value is not NO_DEFAULT
+            else f'def {function_name}(field, value):'
+        )
         self.defaults_file_lines.extend(['', '', function_definition])
         if default_value is not NO_DEFAULT:
             self.defaults_file_needs_value_normalization = True

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model/model_info.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model/model_info.py
@@ -67,7 +67,8 @@ class ModelInfo:
         """
         default_value = self._get_default_value(type_data)
         function_name = f'{model_id}_{normalized_option_name}'
-        function_definition = f'def {function_name}(_field, _value):' if default_value is not NO_DEFAULT else f'def {function_name}(field, value):'
+        function_definition = f'def {function_name}(_field, _value):'\
+            if default_value is not NO_DEFAULT else f'def {function_name}(field, value):'
         self.defaults_file_lines.extend(['', '', function_definition])
         if default_value is not NO_DEFAULT:
             self.defaults_file_needs_value_normalization = True

--- a/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model/model_info.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/configuration/consumers/model/model_info.py
@@ -65,9 +65,10 @@ class ModelInfo:
         :param normalized_option_name: Used to build the function name
         :type_data: dict containing all the relevant information to build the function
         """
-        self.defaults_file_lines.extend(['', '', f'def {model_id}_{normalized_option_name}(field, value):'])
-
         default_value = self._get_default_value(type_data)
+        function_name = f'{model_id}_{normalized_option_name}'
+        function_definition = f'def {function_name}(_field, _value):' if default_value is not NO_DEFAULT else f'def {function_name}(field, value):'
+        self.defaults_file_lines.extend(['', '', function_definition])
         if default_value is not NO_DEFAULT:
             self.defaults_file_needs_value_normalization = True
             self.defaults_file_lines.append(f'    return {default_value!r}')

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_defaults.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_defaults.py
@@ -97,11 +97,11 @@ def test():
         from datadog_checks.base.utils.models.fields import get_default_field_value
 
 
-        def instance_default_precedence(field, value):
+        def instance_default_precedence(_field, _value):
             return 'baz'
 
 
-        def instance_example(field, value):
+        def instance_example(_field, _value):
             return 'bar'
 
 
@@ -113,7 +113,7 @@ def test():
             return get_default_field_value(field, value)
 
 
-        def instance_long_default_formatted(field, value):
+        def instance_long_default_formatted(_field, _value):
             return [
                 ['01', '02', '03', '04', '05'],
                 ['06', '07', '08', '09', '10'],

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_duplicate_hidden.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_duplicate_hidden.py
@@ -64,7 +64,7 @@ def test():
         """
 
 
-        def instance_password(field, value):
+        def instance_password(_field, _value):
             return 'secret'
         """
     )

--- a/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_enum.py
+++ b/datadog_checks_dev/tests/tooling/configuration/consumers/model/test_enum.py
@@ -58,7 +58,7 @@ def test_enum_of_strings():
     assert not defaults_errors
     assert defaults_contents == normalize_yaml(
         """
-        def instance_my_str(field, value):
+        def instance_my_str(_field, _value):
             return 'a'
         """
     )
@@ -163,7 +163,7 @@ def test_enum_of_ints():
     assert not defaults_errors
     assert defaults_contents == normalize_yaml(
         """
-        def instance_my_int(field, value):
+        def instance_my_int(_field, _value):
             return 1
         """
     )


### PR DESCRIPTION
### What does this PR do?
In an effort to transition our existing linter from flake8 to ruff, one of the most common violations is:

```
ARG001 Unused function argument: `field`
ARG001 Unused function argument: `value`
```
This PR addresses this by changing `field` and `value` to `_field` and `_value` respectively so this rule violation can be avoided.


A change the in the datadog_checks_dev is also included for the generation of this file.

Another PR is for the application of these changes:
https://github.com/DataDog/integrations-core/pull/14171
