### PR TITLE
Increase command_timeout default from 5s to 10s to prevent timeouts on instances with large SQL caches

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -460,7 +460,7 @@ files:
       description: Timeout in seconds for the connection and each command run
       value:
         type: integer
-        example: 5
+        example: 10
     - template: instances/db
     - name: stored_procedure
       description: |

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -55,7 +55,7 @@ def instance_azure(field, value):
 
 
 def instance_command_timeout(field, value):
-    return 5
+    return 10
 
 
 def instance_connection_string(field, value):

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -129,7 +129,7 @@ def parse_connection_string_properties(cs):
 class Connection(object):
     """Manages the connection to a SQL Server instance."""
 
-    DEFAULT_COMMAND_TIMEOUT = 5
+    DEFAULT_COMMAND_TIMEOUT = 10
     DEFAULT_DATABASE = 'master'
     DEFAULT_DRIVER = '{ODBC Driver 18 for SQL Server}'
     DEFAULT_DB_KEY = 'database'

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -384,10 +384,10 @@ instances:
         #
         # keep_sql_alias: true
 
-    ## @param command_timeout - integer - optional - default: 5
+    ## @param command_timeout - integer - optional - default: 10
     ## Timeout in seconds for the connection and each command run
     #
-    # command_timeout: 5
+    # command_timeout: 10
 
     ## @param only_custom_queries - boolean - optional - default: false
     ## Set this parameter to `true` if you want to skip the integration's default metrics collection.

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -323,6 +323,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             normalized_rows.append(row)
         return normalized_rows
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_metrics_rows(self, cursor):
         rows = self._load_raw_query_metrics_rows(cursor)
         rows = self._normalize_queries(rows)

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -323,7 +323,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             normalized_rows.append(row)
         return normalized_rows
 
-    @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_metrics_rows(self, cursor):
         rows = self._load_raw_query_metrics_rows(cursor)
         rows = self._normalize_queries(rows)


### PR DESCRIPTION
### What does this PR do?

Changes a default value for the `command_timeout` to prevent instances with large SQL caches from timing out. 10s should still provide reasonable protection from "runaway" SQL queries.

This change becomes more important in the context of https://github.com/DataDog/integrations-core/pull/14033, which results in a larger number of results scanned, which happens 6X less frequently.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.