### PR TITLE
Add a flag to avoid updating the agent image when starting an e2e environment

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -68,8 +68,9 @@ base_option = click.option(
 @click.option('--org-name', '-o', help='The org to use for data submission.')
 @click.option('--profile-memory', '-pm', is_flag=True, help='Whether to collect metrics about memory usage')
 @click.option('--dogstatsd', is_flag=True, help='Enable dogstatsd port on agent')
+@click.option('--disable-agent-update', is_flag=True, help='Do not try to update the agent image')
 @click.pass_context
-def start(ctx, check, env, agent, python, dev, base, env_vars, org_name, profile_memory, dogstatsd):
+def start(ctx, check, env, agent, python, dev, base, env_vars, org_name, profile_memory, dogstatsd, disable_agent_update):
     """Start an environment."""
 
     on_ci = running_on_ci()
@@ -77,9 +78,10 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, org_name, profile
         ctx, base, check, env, python, org_name, profile_memory, agent, env_vars, dogstatsd, dev, on_ci
     )
 
-    echo_waiting(f'Updating `{environment.agent_build}`... ', nl=False)
-    environment.update_agent()
-    echo_success('success!')
+    if not disable_agent_update:
+        echo_waiting(f'Updating `{environment.agent_build}`... ', nl=False)
+        environment.update_agent()
+        echo_success('success!')
 
     echo_waiting('Detecting the major version... ', nl=False)
     environment.detect_agent_version()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a flag to avoid updating the agent image when starting an e2e environment

### Motivation
<!-- What inspired you to submit this pull request? -->

I'm running an e2e env with a very custom agent build (using the `-a` option) I have locally and by default the `start` command tries to pull a newer version, which does not exist. I used to comment the line but adding a new parameter sounds like a better option.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Looks like there's no easy way to write a test for that atm, this will be done during the ddev refactor

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.