### PR TITLE
[SQL Server] Update MSOLEDBSQL provider details

### DIFF
--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -73,7 +73,7 @@ To configure this check for an Agent running on a host:
 
     See the [example check configuration][6] for a comprehensive description of all options, including how to use custom queries to create your own metrics.
 
-    **Note**: The (default) provider `SQLOLEDB` is being deprecated. To use the newer `MSOLEDBSQL` provider, set the `adoprovider` variable to `MSOLEDBSQL` in your `sqlserver.d/conf.yaml` file after having downloaded the new provider from [Microsoft][7]. It is also possible to use the Windows Authentication and not specify the username/password with:
+    **Note**: The (default) provider `SQLOLEDB` is being deprecated. To use the newer `MSOLEDBSQL` provider, set the `adoprovider` variable to `MSOLEDBSQL19` in your `sqlserver.d/conf.yaml` file after having downloaded the new provider from [Microsoft][7]. If you're using `MSOLEDBSQL` version 18 or lower, set the `adoprovider` variable to `MSOLEDBSQL` instead. It is also possible to use the Windows Authentication and not specify the username/password with:
 
       ```yaml
       connection_string: "Trusted_Connection=yes"


### PR DESCRIPTION
### What does this PR do?
Update adoprovider parameter to use MSOLEDBSQL19 instead of MSOLEDBSQL.

### Motivation
Microsoft OLE DB Driver for SQL Server 19 is now the default download on Microsoft's [Microsoft ODBC Driver](https://docs.microsoft.com/en-us/sql/connect/odbc/download-odbc-driver-for-sql-server) page, meaning that without this change Datadog's SQL Server integration will always fail with an error "Provider cannot be found. It may not be properly installed". This follows the same changes made to spec.yaml and conf.yaml.example in https://github.com/DataDog/integrations-core/pull/12916

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.