### PR TITLE
Bump datadog-checks-dev to 18.x

### DIFF
--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
 ]
 dependencies = [
-    "datadog-checks-dev[cli]==17.9.0",
+    "datadog-checks-dev[cli]~=18.0",
     "hatch>=1.6.3",
     "httpx",
     "jsonpointer",


### PR DESCRIPTION
### Motivation

We require new features for the CI migration