### PR TITLE
Remove manifest validation from CI

### DIFF
--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -50,10 +50,6 @@ jobs:
       run: |
         ddev validate config $CHANGED
 
-    - name: Run manifest validation
-      run: |
-        ddev validate manifest $CHANGED
-
     - name: Run dashboard validation
       run: |
         ddev validate dashboards $CHANGED


### PR DESCRIPTION
### Motivation

We have close parity with validations in the `datadog-assets` github check that runs the manifest validations and reports errors back. Now we can stop double running validations and allow this type of error to only come back through the `datadog-assets` check. 