### PR TITLE
Add job to publish pull request test results

### DIFF
--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,0 +1,49 @@
+name: Test results
+
+on:
+  workflow_run:
+    workflows:
+    - PR test
+    types:
+    - completed
+
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test results
+    runs-on: ubuntu-22.04
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    permissions:
+      checks: write
+      pull-requests: write
+      actions: read
+
+      # Only needed for private repositories
+      contents: read
+      issues: read
+
+    steps:
+    - name: Download and extract artifacts
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        mkdir -p artifacts && cd artifacts
+
+        artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+        gh api --paginate "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+        do
+          IFS=$'\t' read name url <<< "$artifact"
+          gh api $url > "$name.zip"
+          unzip -d "$name" "$name.zip"
+        done
+
+    - name: Publish test results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      with:
+        commit: ${{ github.event.workflow_run.head_sha }}
+        event_file: artifacts/save-event/event.json
+        event_name: ${{ github.event.workflow_run.event }}
+        files: "artifacts/**/*.xml"


### PR DESCRIPTION
### Motivation

The workflow must be on master first in order to test:

- https://github.com/DataDog/integrations-core/pull/14187
- https://github.com/EnricoMi/publish-unit-test-result-action#support-fork-repositories-and-dependabot-branches