### PR TITLE
Add minimal workflows for CI testing

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,0 +1,17 @@
+name: PR test
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        required: true
+        type: string
+
+jobs:
+  run:
+    name: Run tests
+    runs-on: ubuntu-22.04
+
+    steps:
+    - name: Test
+      run: echo "${{ inputs.repo }}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,17 @@
+name: PR
+
+on:
+  pull_request:
+    branches:
+    - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    uses: ./.github/workflows/pr-test.yml
+    with:
+      repo: core
+    secrets: inherit


### PR DESCRIPTION
### Motivation

The trigger I'm testing requires that the called workflows are already on the default branch https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run

> This event will only trigger a workflow run if the workflow file is on the default branch.