### PR TITLE
Remove `distutils` dependency from python 3 version of the check

### DIFF
--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -6,7 +6,6 @@
 Collects network metrics.
 """
 
-import distutils.spawn
 import re
 import socket
 
@@ -24,6 +23,19 @@ except ImportError:
 
 if PY3:
     long = int
+
+
+# Use a different find_executable implementation depending on Python version,
+# because we want to avoid depending on distutils.
+if PY3:
+    import shutil
+
+    def find_executable(name):
+        return shutil.which(name)
+
+else:
+    # Fallback to distutils for Python 2 as shutil.which was added on Python 3.3
+    from distutils.spawn import find_executable
 
 
 class Network(AgentCheck):
@@ -294,7 +306,7 @@ class Network(AgentCheck):
 
         if proc_location != "/proc":
             # If we have `ss`, we're fine with a non-standard `/proc` location
-            if distutils.spawn.find_executable("ss") is None:
+            if find_executable("ss") is None:
                 self.warning(
                     "Cannot collect connection state: `ss` cannot be found and "
                     "currently with a custom /proc path: %s",

--- a/network/datadog_checks/network/network.py
+++ b/network/datadog_checks/network/network.py
@@ -296,8 +296,6 @@ class Network(AgentCheck):
     def is_collect_cx_state_runnable(self, proc_location):
         """
         Determine if collect_connection_state is set and can effectively run.
-        If self._collect_cx_state is True and a custom proc_location is provided, the system cannot
-         run `ss` or `netstat` over a custom proc_location
         :param proc_location: str
         :return: bool
         """

--- a/network/tests/test_linux.py
+++ b/network/tests/test_linux.py
@@ -306,7 +306,7 @@ def test_proc_permissions_error(aggregator, caplog):
         assert 'Unable to read /proc/net/snmp.' in caplog.text
 
 
-@mock.patch('distutils.spawn.find_executable', return_value='/bin/ss')
+@mock.patch('datadog_checks.network.network.find_executable', return_value='/bin/ss')
 def test_ss_with_custom_procfs(aggregator):
     instance = copy.deepcopy(common.INSTANCE)
     instance['collect_connection_state'] = True

--- a/network/tests/test_network.py
+++ b/network/tests/test_network.py
@@ -48,5 +48,5 @@ def test_is_collect_cx_state_runnable(aggregator, check, proc_location, ss_found
     instance = copy.deepcopy(common.INSTANCE)
     instance['collect_connection_state'] = True
     check_instance = check(instance)
-    with mock.patch('distutils.spawn.find_executable', lambda x: "/bin/ss" if ss_found else None):
+    with mock.patch('datadog_checks.network.network.find_executable', lambda x: "/bin/ss" if ss_found else None):
         assert check_instance.is_collect_cx_state_runnable(proc_location) == expected


### PR DESCRIPTION
### What does this PR do?

Uses `shutil.which` in place of `distutils.spawn.find_executable` for Python 3 to remove dependency on `distutils`

### Motivation

[AI-2974](https://datadoghq.atlassian.net/browse/AI-2974). We want to get rid of `distutils` because its version in the stdlib is essentially deprecated, and the replacement used by `setuptools` increases the agent's memory footprint. This is the only place in core integrations that uses `distutils` _directly_.

### Additional Notes

The reason that `distutils` is still used for Python 2 is that `shutil.which` was added on Python 3.3. There are less concerns about the use of `distutils` in Python 2, so missing a simple stand-in, it's fine to keep the statu quo there.

I haven't found a good way to add an integration test for this, so I've done a simple manual sanity check on the e2e environment to ensure this is doing what we expect:

```
root@docker-desktop:/# /opt/datadog-agent/embedded/bin/python
  Python 3.8.16 (default, Mar 27 2023, 11:47:24)
  [GCC 5.4.0 20160609] on linux
  Type "help", "copyright", "credits" or "license" for more information.
  >>> from datadog_checks.network.network import find_executable
  >>> find_executable('ss')
  '/usr/bin/ss'
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.

[AI-2974]: https://datadoghq.atlassian.net/browse/AI-2974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ