### PR TITLE
fix(kubernetes-node): "Nodes not ready": use last

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_nodes.json
+++ b/kubernetes/assets/dashboards/kubernetes_nodes.json
@@ -1447,7 +1447,7 @@
                 "requests": [
                     {
                         "q": "sum:kubernetes_state.node.by_condition{$cluster,status:false,$host,condition:ready}",
-                        "aggregator": "avg",
+                        "aggregator": "last",
                         "conditional_formats": [
                             {
                                 "comparator": ">",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use `last` instead of `avg` as an aggregator so it's immediately known how many nodes aren't ready in `Nodes not ready`'s `Query Value` widget.

### Motivation
<!-- What inspired you to submit this pull request? -->
This is because the number of nodes in not ready are always averaged which is not the current value. If we use `last`, it will always reflect the most current and actionable value.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.