### PR TITLE
Add a krb5 config file to run the tests locally

### DIFF
--- a/kafka_consumer/tests/conftest.py
+++ b/kafka_consumer/tests/conftest.py
@@ -11,6 +11,7 @@ from confluent_kafka.cimpl import NewTopic
 
 from datadog_checks.dev import TempDir, WaitFor, docker_run
 from datadog_checks.dev._env import e2e_testing
+from datadog_checks.dev.ci import running_on_ci
 from datadog_checks.kafka_consumer import KafkaCheck
 
 from .common import (
@@ -122,7 +123,9 @@ def dd_environment():
             DOCKER_IMAGE_PATH,
             conditions=conditions,
             env_vars={
-                "KRB5_CONFIG": f"{HERE}/docker/kerberos/kdc/krb5_agent.conf",
+                "KRB5_CONFIG": f"{HERE}/docker/kerberos/kdc/krb5_agent.conf"
+                if running_on_ci()
+                else f"{HERE}/docker/kerberos/kdc/krb5_local.conf",
                 "SECRET_DIR": secret_dir,
             },
             build=True,

--- a/kafka_consumer/tests/docker/kerberos/kdc/krb5_local.conf
+++ b/kafka_consumer/tests/docker/kerberos/kdc/krb5_local.conf
@@ -1,0 +1,20 @@
+# This is a separate file since kdc = localhost:88 is necessary to access the kdc from the Agent container
+[libdefaults]
+default_realm = TEST.CONFLUENT.IO
+forwardable = true
+rdns = false
+dns_lookup_kdc   = yes
+dns_lookup_realm = yes
+
+[realms]
+TEST.CONFLUENT.IO = {
+      kdc            = tcp/localhost:88
+      admin_server   = tcp/localhost:749
+      default_domain = test.confluent.io
+      kpasswd_port = 464
+}
+
+[logging]
+kdc = FILE:/var/log/kerberos/krb5kdc.log
+admin_server = FILE:/var/log/kerberos/kadmin.log
+default = FILE:/var/log/kerberos/krb5lib.log


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a krb5 config file to run the tests locally

### Motivation
<!-- What inspired you to submit this pull request? -->

The agent conf file does not work on my end when I run the tests

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.