### PR TITLE
Added (integration) unit test which validates Case Insensitivity for …

### DIFF
--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/test_integration.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/test_integration.py
@@ -289,3 +289,34 @@ def test_skip_typo_counter(aggregator, dd_run_check):
     aggregator.assert_metric('test.mem.available_bytes')
     aggregator.assert_metric('test.mem.committed_bytes')
     aggregator.assert_metric('test.mem.commit_limit')
+
+    # Run check with different counter names of different casing to make sure
+    # the check is not affected since Windows Performance counters API
+    # are case insensitive.
+    aggregator.reset()
+    check = get_check(
+        {
+            'metrics': {
+                'mEmOrY': {
+                    'name': 'mem',
+                    'tag_name': 'memory',
+                    'instance_counts': {
+                        'total': 'memory.total',
+                        'monitored': 'memory.monitored',
+                        'unique': 'memory.unique',
+                    },
+                    'counters': [
+                        {'available bytes': 'available_bytes'},
+                        {'committeD byteS': 'committed_bytes'},
+                        {'cOmMiT lImIt': 'commit_limit'},
+                    ],
+                }
+            },
+            'server_tag': 'machine',
+        }
+    )
+
+    dd_run_check(check)
+    aggregator.assert_metric('test.mem.available_bytes')
+    aggregator.assert_metric('test.mem.committed_bytes')
+    aggregator.assert_metric('test.mem.commit_limit')

--- a/datadog_checks_base/tests/base/checks/windows/perf_counters/test_integration.py
+++ b/datadog_checks_base/tests/base/checks/windows/perf_counters/test_integration.py
@@ -290,6 +290,7 @@ def test_skip_typo_counter(aggregator, dd_run_check):
     aggregator.assert_metric('test.mem.committed_bytes')
     aggregator.assert_metric('test.mem.commit_limit')
 
+def test_validate_counter_names_sensitivity(aggregator, dd_run_check):
     # Run check with different counter names of different casing to make sure
     # the check is not affected since Windows Performance counters API
     # are case insensitive.


### PR DESCRIPTION
…Counterset and Counter names in configuration

It is done to confirm that even if the Counterset or Counter names are entered in wrong case the Check will continue to properly function, because Windows Performance Counters API access any case for such names.

### What does this PR do?
Added additional test to formalize implied assumptions regarding Counterset or Counter names case sensitivity and to guard against inadvertent regressions if their implementation are changed.

### Motivation
One of the older version deployments had that problem

### Additional Notes
It is only test case change, the code which test validates in the current version works and worked correctly.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.