### PR TITLE
Add missing tags when the service check is critical

### DIFF
--- a/gitlab/datadog_checks/gitlab/gitlab.py
+++ b/gitlab/datadog_checks/gitlab/gitlab.py
@@ -58,6 +58,7 @@ class GitlabCheck(OpenMetricsBaseCheck):
             self.service_check(
                 self.PROMETHEUS_SERVICE_CHECK_NAME,
                 OpenMetricsBaseCheck.CRITICAL,
+                self._tags,
                 message="Unable to retrieve Prometheus metrics from endpoint {}: {}".format(self.endpoint, e),
             )
 

--- a/gitlab/tests/test_integration.py
+++ b/gitlab/tests/test_integration.py
@@ -32,19 +32,14 @@ def test_connection_failure(aggregator, gitlab_check, bad_config):
     with pytest.raises(ConnectionError):
         check.check(None)
 
-    aggregator.assert_service_check(
-        'gitlab.prometheus_endpoint_up',
-        status=GitlabCheck.CRITICAL,
-        count=1,
-    )
-
     # We should get only one extra failed service check, the first (readiness)
-    aggregator.assert_service_check(
-        'gitlab.readiness',
-        status=GitlabCheck.CRITICAL,
-        tags=['gitlab_host:{}'.format(HOST), 'gitlab_port:1234'] + CUSTOM_TAGS,
-        count=1,
-    )
+    for service_check in ("prometheus_endpoint_up", "readiness"):
+        aggregator.assert_service_check(
+            'gitlab.{}'.format(service_check),
+            status=GitlabCheck.CRITICAL,
+            tags=['gitlab_host:{}'.format(HOST), 'gitlab_port:1234'] + CUSTOM_TAGS,
+            count=1,
+        )
 
     for service_check in ('liveness', 'health'):
         aggregator.assert_service_check(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add tags to the main service check even when its status is critical

### Motivation
<!-- What inspired you to submit this pull request? -->

Spotted working on the revamp.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.