### PR TITLE
Add the `prometheus_endpoint` option to the models

### DIFF
--- a/gitlab/assets/configuration/spec.yaml
+++ b/gitlab/assets/configuration/spec.yaml
@@ -19,7 +19,7 @@ files:
         type: string
     - name: prometheus_endpoint
       description: |
-        Alias for `prometheus_url`.
+        Deprecated alias for `prometheus_url`.
       hidden: true
       value:
         type: string

--- a/gitlab/assets/configuration/spec.yaml
+++ b/gitlab/assets/configuration/spec.yaml
@@ -17,6 +17,12 @@ files:
         used to collect the GitLab version.
       value:
         type: string
+    - name: prometheus_endpoint
+      description: |
+        Alias for `prometheus_url`.
+      hidden: true
+      value:
+        type: string
     - template: instances/openmetrics_legacy
       overrides:
         prometheus_url.value.example: http://<GITLAB_URL>/-/metrics

--- a/gitlab/datadog_checks/gitlab/config_models/defaults.py
+++ b/gitlab/datadog_checks/gitlab/config_models/defaults.py
@@ -190,6 +190,10 @@ def instance_persist_connections(field, value):
     return False
 
 
+def instance_prometheus_endpoint(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_prometheus_metrics_prefix(field, value):
     return get_default_field_value(field, value)
 

--- a/gitlab/datadog_checks/gitlab/config_models/instance.py
+++ b/gitlab/datadog_checks/gitlab/config_models/instance.py
@@ -111,6 +111,7 @@ class InstanceConfig(BaseModel):
     ntlm_domain: Optional[str]
     password: Optional[str]
     persist_connections: Optional[bool]
+    prometheus_endpoint: Optional[str]
     prometheus_metrics_prefix: Optional[str]
     prometheus_url: str
     proxy: Optional[Proxy]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add the `prometheus_endpoint` option to the models but not to the config file. 

### Motivation
<!-- What inspired you to submit this pull request? -->

There's a super secret not documented alias for the `prometheus_url` option called `prometheus_endpoint` (see [this](https://github.com/DataDog/integrations-core/blob/26ad0e95a12582220390d04dd3faf9bb76687ee2/gitlab/datadog_checks/gitlab/gitlab.py#L82)). It's not a big deal but with the revamp we will validate the config with `pydantic` so I'll need to have this field in the models. We do not want to make it appear in the official config file though.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.