### PR TITLE
Port mistake in annotations

### DIFF
--- a/nginx/README.md
+++ b/nginx/README.md
@@ -291,7 +291,7 @@ metadata:
     ad.datadoghq.com/nginx.instances: |
       [
         {
-          "nginx_status_url":"http://%%host%%:81/nginx_status/"
+          "nginx_status_url":"http://%%host%%:18080/nginx_status/"
         }
       ]
   labels:
@@ -312,7 +312,7 @@ metadata:
           "init_config": {},
           "instances": [
             {
-              "nginx_status_url":"http://%%host%%:81/nginx_status/"
+              "nginx_status_url":"http://%%host%%:18080/nginx_status/"
             }
           ]
         }


### PR DESCRIPTION

### What does this PR do?
In K8s pod annotations, change from port 81 to port 18080

### Motivation
Port is not the correct one for K8s annotations. Indeed port 81 is the service port whereas it is here proposed to use pod annotations. Thus, it is necessary to implement the port 18080 if we want the configuration to work.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.