### PR TITLE
Fix the url descriptions in the config file

### DIFF
--- a/coredns/assets/configuration/spec.yaml
+++ b/coredns/assets/configuration/spec.yaml
@@ -18,7 +18,7 @@ files:
           and enable the plugin within coredns.
           See: https://coredns.io/plugins/metrics/
 
-          Either `prometheus_url` or `openmetrics_url` must be specified.
+          Either `prometheus_url` or `openmetrics_endpoint` must be specified.
           See documentation: https://docs.datadoghq.com/integrations/coredns
         tags.display_priority: 1
         tags.value.example:
@@ -39,7 +39,7 @@ files:
           and enable the plugin within coredns.
           See: https://coredns.io/plugins/metrics/
 
-          Either `prometheus_url` or `openmetrics_url` must be specified.
+          Either `prometheus_url` or `openmetrics_endpoint` must be specified.
           See documentation: https://docs.datadoghq.com/integrations/coredns
 - name: auto_conf.yaml
   options:
@@ -57,7 +57,7 @@ files:
         and enable the plugin within coredns.
         See: https://coredns.io/plugins/metrics/
 
-        Either `prometheus_url` or `openmetrics_url` must be specified.
+        Either `prometheus_url` or `openmetrics_endpoint` must be specified.
         See documentation: https://docs.datadoghq.com/integrations/coredns
 
       enabled: true
@@ -108,7 +108,7 @@ files:
         and enable the plugin within coredns.
         See: https://coredns.io/plugins/metrics/
 
-        Either `prometheus_url` or `openmetrics_url` must be specified.
+        Either `prometheus_url` or `openmetrics_endpoint` must be specified.
         See documentation: https://docs.datadoghq.com/integrations/coredns
       value:
         type: string

--- a/coredns/datadog_checks/coredns/data/auto_conf.yaml
+++ b/coredns/datadog_checks/coredns/data/auto_conf.yaml
@@ -19,7 +19,7 @@ instances:
     ## and enable the plugin within coredns.
     ## See: https://coredns.io/plugins/metrics/
     ##
-    ## Either `prometheus_url` or `openmetrics_url` must be specified.
+    ## Either `prometheus_url` or `openmetrics_endpoint` must be specified.
     ## See documentation: https://docs.datadoghq.com/integrations/coredns
     #
   - prometheus_url: http://%%host%%:9153/metrics
@@ -59,7 +59,7 @@ instances:
     ## and enable the plugin within coredns.
     ## See: https://coredns.io/plugins/metrics/
     ##
-    ## Either `prometheus_url` or `openmetrics_url` must be specified.
+    ## Either `prometheus_url` or `openmetrics_endpoint` must be specified.
     ## See documentation: https://docs.datadoghq.com/integrations/coredns
     #
     # openmetrics_endpoint: http://%%host%%:9153/metrics

--- a/coredns/datadog_checks/coredns/data/conf.yaml.example
+++ b/coredns/datadog_checks/coredns/data/conf.yaml.example
@@ -50,7 +50,7 @@ instances:
     ## and enable the plugin within coredns.
     ## See: https://coredns.io/plugins/metrics/
     ##
-    ## Either `prometheus_url` or `openmetrics_url` must be specified.
+    ## Either `prometheus_url` or `openmetrics_endpoint` must be specified.
     ## See documentation: https://docs.datadoghq.com/integrations/coredns
     #
   - openmetrics_endpoint: http://%%host%%:9153/metrics
@@ -60,7 +60,7 @@ instances:
     ## and enable the plugin within coredns.
     ## See: https://coredns.io/plugins/metrics/
     ##
-    ## Either `prometheus_url` or `openmetrics_url` must be specified.
+    ## Either `prometheus_url` or `openmetrics_endpoint` must be specified.
     ## See documentation: https://docs.datadoghq.com/integrations/coredns
     #
     # prometheus_url: http://%%host%%:9153/metrics


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix the `prometheus_url` and `openmetrics_endpoint` descriptions.

### Motivation
<!-- What inspired you to submit this pull request? -->

There's no `openmetrics_url` config option (not even as an alias), only `openmetrics_endpoint`.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.