### PR TITLE
Fix the `health_service_check` config option

### DIFF
--- a/gitlab/assets/configuration/spec.yaml
+++ b/gitlab/assets/configuration/spec.yaml
@@ -28,6 +28,8 @@ files:
         prometheus_url.value.example: http://<GITLAB_URL>/-/metrics
         send_distribution_counts_as_monotonic.enabled: true
         send_distribution_counts_as_monotonic.value.example: true
+        health_service_check.value.example: false
+        health_service_check.value.default: false
         send_monotonic_counter.enabled: true
         send_monotonic_counter.value.example: true
         send_monotonic_counter.value.default: false

--- a/gitlab/datadog_checks/gitlab/config_models/defaults.py
+++ b/gitlab/datadog_checks/gitlab/config_models/defaults.py
@@ -99,7 +99,7 @@ def instance_headers(field, value):
 
 
 def instance_health_service_check(field, value):
-    return True
+    return False
 
 
 def instance_ignore_metrics(field, value):

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -26,11 +26,11 @@ instances:
     #
     # prometheus_metrics_prefix: <PREFIX>_
 
-    ## @param health_service_check - boolean - optional - default: true
+    ## @param health_service_check - boolean - optional - default: false
     ## Send a service check reporting about the health of the Prometheus endpoint.
     ## The service check is named <NAMESPACE>.prometheus.health
     #
-    # health_service_check: true
+    # health_service_check: false
 
     ## @param label_to_hostname - string - optional
     ## Override the hostname with the value of one label.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix the `health_service_check` config option to `False` by default in the config file.

### Motivation
<!-- What inspired you to submit this pull request? -->

Because this is its default value in the code: https://github.com/DataDog/integrations-core/blob/d66a31a9a9fe2cd3d45e2a433f57b329747345ac/gitlab/datadog_checks/gitlab/gitlab.py#L94

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.