### PR TITLE
Only cancel concurrent workflows for pull requests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -5,10 +5,6 @@ on:
     branches:
     - master
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     uses: ./.github/workflows/test-all.yml

--- a/.github/workflows/nightly-base-package.yml
+++ b/.github/workflows/nightly-base-package.yml
@@ -5,10 +5,6 @@ on:
   # 5 AM UTC
   - cron: "0 5 * * *"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     uses: ./.github/workflows/test-all.yml

--- a/.github/workflows/nightly-py2.yml
+++ b/.github/workflows/nightly-py2.yml
@@ -5,10 +5,6 @@ on:
   # 4 AM UTC
   - cron: "0 4 * * *"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     uses: ./.github/workflows/test-all.yml

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/weekly-latest.yml
+++ b/.github/workflows/weekly-latest.yml
@@ -5,10 +5,6 @@ on:
   # Weekly on Sunday night (America/New_York)
   - cron: "0 5 * * 1"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
-  cancel-in-progress: true
-
 jobs:
   test:
     uses: ./.github/workflows/test-all.yml


### PR DESCRIPTION
### Motivation

I noticed master kept getting canceled, this was unintentional