### PR TITLE
Fix SingleStore CI script for Azure Pipelines

### DIFF
--- a/.ddev/ci/scripts/singlestore/linux/55_set_license_secret.sh
+++ b/.ddev/ci/scripts/singlestore/linux/55_set_license_secret.sh
@@ -3,6 +3,6 @@ set -euo pipefail
 
 set +x
 
-echo "SINGLESTORE_LICENSE=$SINGLESTORE_LICENSE" >> "$GITHUB_ENV"
+echo "SINGLESTORE_LICENSE=$SINGLESTORE_LICENSE" >> "${GITHUB_ENV:-/tmp/gh-output}"
 
 set -x


### PR DESCRIPTION
### Motivation

We want both CI pipelines to run successfully in parallel for a day or two in order to accurately compare stats