### PR TITLE
Fix caching of mitmproxy dependencies

### DIFF
--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -177,7 +177,7 @@ jobs:
     - name: Set up trace capturing
       if: inputs.repo == 'core'
       run: |-
-        pipx install mitmproxy --python $(which python)
+        pip install mitmproxy
         mkdir .trace-captures
         mitmdump -p "${{ inputs.trace-agent-port }}" -w "${{ env.TRACE_CAPTURE_FILE }}" > "${{ env.TRACE_CAPTURE_LOG }}" 2>&1 &
 


### PR DESCRIPTION
### Motivation

pipx somehow is not respecting the cache. removing it is fine since we already install ddev this way also