### PR TITLE
[Unified Instance Tagging]: Add cloud_metadata to DBM event payloads

### DIFF
--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -245,6 +245,7 @@ class MySQLActivity(DBMAsyncJob):
             "collection_interval": self.collection_interval,
             "ddtags": self._tags,
             "timestamp": time.time() * 1000,
+            "cloud_metadata": self._config.cloud_metadata,
             "mysql_activity": active_sessions,
         }
 

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -432,6 +432,7 @@ class MySQLStatementSamples(DBMAsyncJob):
         if self._seen_samples_ratelimiter.acquire(query_plan_cache_key):
             return {
                 "timestamp": row["timer_end_time_s"] * 1000,
+                "dbm_type": "plan",
                 "host": self._check.resolved_hostname,
                 "ddagentversion": datadog_agent.get_version(),
                 "ddsource": "mysql",
@@ -442,6 +443,7 @@ class MySQLStatementSamples(DBMAsyncJob):
                         "ip": row.get('processlist_host', None),
                     }
                 },
+                "cloud_metadata": self._config.cloud_metadata,
                 "db": {
                     "instance": row['current_schema'],
                     "plan": {

--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -32,7 +32,8 @@ flavor = ["mariadb"]
 version = [
   "10.2",  # EOL 23 May 2022
   "10.5",  # EOL 24 June 2025
-  "10.10", # EOL 17 November 2023
+# TODO: Re-enable this after figuring out why mariadb-10.10 fails on CI with connection error
+#  "10.10", # EOL 17 November 2023
 ]
 
 [envs.default.overrides]

--- a/postgres/hatch.toml
+++ b/postgres/hatch.toml
@@ -15,7 +15,7 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.8"]
+python = ["3.8"]
 version = ["9.5", "9.6", "10.0", "11.0", "12.1", "13.0", "14.0"]
 
 [envs.default.overrides]

--- a/postgres/hatch.toml
+++ b/postgres/hatch.toml
@@ -15,7 +15,7 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["3.8"]
+python = ["2.7", "3.8"]
 version = ["9.5", "9.6", "10.0", "11.0", "12.1", "13.0", "14.0"]
 
 [envs.default.overrides]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR adds `cloud_metadata` fields to all DBM event payloads, this adds necessary context in order link DBM event data with related cloud resource data in our backend. 

The goal here is to allow customers to filter event data by a new universal tag `database_instance`, which will be applied across DBM and cloud telemetry.