### PR TITLE
[Unified Instance Tagging]: Add cloud_metadata to DBM event payloads

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -273,6 +273,7 @@ class SqlserverActivity(DBMAsyncJob):
             "collection_interval": self.collection_interval,
             "ddtags": self.check.tags,
             "timestamp": time.time() * 1000,
+            "cloud_metadata": self.check.cloud_metadata,
             "sqlserver_activity": active_sessions,
             "sqlserver_connections": active_connections,
         }

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -498,6 +498,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     "ddtags": ",".join(tags),
                     "timestamp": time.time() * 1000,
                     "dbm_type": "plan",
+                    "cloud_metadata": self.check.cloud_metadata,
                     "db": {
                         "instance": row.get("database_name", None),
                         "plan": {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR adds cloud_metadata fields to all DBM event payloads, this adds necessary context in order link DBM event data with related cloud resource data in our backend.

The goal here is to allow customers to filter event data by a new universal tag database_instance, which will be applied across DBM and cloud telemetry.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.