### PR TITLE
Send resource_type/name for sqlserver integration metrics

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -113,6 +113,8 @@ class SqlserverActivity(DBMAsyncJob):
 
     def __init__(self, check):
         self.check = check
+        # do not emit any dd.internal metrics for DBM specific check code
+        self.tags = [t for t in self.check.tags if not t.startswith('dd.internal')]
         self.log = check.log
         collection_interval = float(check.activity_config.get('collection_interval', DEFAULT_COLLECTION_INTERVAL))
         if collection_interval <= 0:
@@ -271,7 +273,7 @@ class SqlserverActivity(DBMAsyncJob):
             "ddsource": "sqlserver",
             "dbm_type": "activity",
             "collection_interval": self.collection_interval,
-            "ddtags": self.check.tags,
+            "ddtags": self.tags,
             "timestamp": time.time() * 1000,
             "sqlserver_activity": active_sessions,
             "sqlserver_connections": active_connections,

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -25,6 +25,16 @@ ENGINE_EDITION_AZURE_SYNAPSE_SERVERLESS_POOL = 11
 STATIC_INFO_VERSION = 'version'
 STATIC_INFO_MAJOR_VERSION = 'major_version'
 STATIC_INFO_ENGINE_EDITION = 'engine_edition'
+AWS_RDS_HOSTNAME_SUFFIX = ".rds.amazonaws.com"
+AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPES = {
+    # azure sql database has a special case, where we should emit
+    # a resource for both the server and the database because
+    # azure treats these as two separate entities, and both can have
+    # related tags and metrics
+    "sql_database": "azure_sql_server_database,azure_sql_server",
+    "managed_instance": "azure_sql_server_managed_instance",
+    "virtual_machine": "azure_virtual_machine_instance"
+}
 
 # Metric discovery queries
 COUNTER_TYPE_QUERY = """select distinct cntr_type

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -33,7 +33,7 @@ AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPES = {
     # related tags and metrics
     "sql_database": "azure_sql_server_database,azure_sql_server",
     "managed_instance": "azure_sql_server_managed_instance",
-    "virtual_machine": "azure_virtual_machine_instance"
+    "virtual_machine": "azure_virtual_machine_instance",
 }
 
 # Metric discovery queries

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -222,7 +222,7 @@ class SQLServer(AgentCheck):
                     self.cloud_metadata.get("aws")["instance_endpoint"],
                 )
             )
-        elif AWS_RDS_HOSTNAME_SUFFIX in self.hostname:
+        elif AWS_RDS_HOSTNAME_SUFFIX in resolved_hostname:
             # allow for detecting if the host is an RDS host, and emit
             # the resource properly even if the `aws` config is unset
             self.tags.append(

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -244,13 +244,12 @@ class SQLServer(AgentCheck):
                         r_type, name
                     )
                 )
-            # finally, emit a `database_instance` resource for this instance
-            self.tags.append(
-                "dd.internal.resource:database_instance:{}".format(
-                    resolved_hostname,
-                )
+        # finally, emit a `database_instance` resource for this instance
+        self.tags.append(
+            "dd.internal.resource:database_instance:{}".format(
+                resolved_hostname,
             )
-            # TODO: also set database_instance tag to resolved_hostname? (check with Dusan)
+        )
 
     @property
     def resolved_hostname(self):

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -132,7 +132,7 @@ def test_collect_load_activity(
     executor.shutdown(wait=True)
 
     instance_tags = set(dbm_instance.get('tags', []))
-    expected_instance_tags = set([t for t in instance_tags if not t.startswith('dd.internal')])
+    expected_instance_tags = {t for t in instance_tags if not t.startswith('dd.internal')}
 
     dbm_activity = aggregator.get_event_platform_events("dbm-activity")
     assert len(dbm_activity) == 1, "should have collected exactly one dbm-activity payload"

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -131,7 +131,8 @@ def test_collect_load_activity(
     fred_conn.close()
     executor.shutdown(wait=True)
 
-    expected_instance_tags = set(dbm_instance.get('tags', []))
+    instance_tags = set(dbm_instance.get('tags', []))
+    expected_instance_tags = set([t for t in instance_tags if not t.startswith('dd.internal')])
 
     dbm_activity = aggregator.get_event_platform_events("dbm-activity")
     assert len(dbm_activity) == 1, "should have collected exactly one dbm-activity payload"

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -110,9 +110,7 @@ def test_custom_metrics_object_name(aggregator, dd_run_check, init_config_object
     instance_tags = instance_docker.get('tags', []) + ['optional_tag:tag1']
 
     aggregator.assert_metric('sqlserver.cache.hit_ratio', tags=instance_tags, count=1)
-    aggregator.assert_metric(
-        'sqlserver.broker_activation.tasks_running', tags=instance_tags, count=1
-    )
+    aggregator.assert_metric('sqlserver.broker_activation.tasks_running', tags=instance_tags, count=1)
 
 
 @pytest.mark.integration
@@ -214,9 +212,7 @@ def test_autodiscovery_db_service_checks(
     # to match against, so this assertion does not require the exact string
     sc = aggregator.service_checks('sqlserver.database.can_connect')
     db_critical_exists = False
-    critical_tags = instance_tags + [
-        'db:unavailable_db', 'sqlserver_host:{}'.format(check.resolved_hostname)
-    ]
+    critical_tags = instance_tags + ['db:unavailable_db', 'sqlserver_host:{}'.format(check.resolved_hostname)]
     for c in sc:
         if c.status == SQLServer.CRITICAL:
             db_critical_exists = True
@@ -361,8 +357,8 @@ def test_custom_queries(aggregator, dd_run_check, instance_docker, custom_query,
     "cloud_metadata,metric_names",
     [
         (
-                {},
-                [],
+            {},
+            [],
         ),
         (
             {
@@ -384,32 +380,32 @@ def test_custom_queries(aggregator, dd_run_check, instance_docker, custom_query,
             ],
         ),
         (
-                {
-                    'gcp': {
-                        'project_id': 'foo-project',
-                        'instance_id': 'bar',
-                        'extra_field': 'included',
-                    },
+            {
+                'gcp': {
+                    'project_id': 'foo-project',
+                    'instance_id': 'bar',
+                    'extra_field': 'included',
                 },
-                [
-                    "dd.internal.resource:gcp_sql_database_instance:foo-project:bar",
-                ],
+            },
+            [
+                "dd.internal.resource:gcp_sql_database_instance:foo-project:bar",
+            ],
         ),
         (
-                {
-                    'aws': {
-                        'instance_endpoint': 'foo.aws.com',
-                    },
-                    'azure': {
-                        'deployment_type': 'sql_database',
-                        'name': 'my-instance',
-                    },
+            {
+                'aws': {
+                    'instance_endpoint': 'foo.aws.com',
                 },
-                [
-                    "dd.internal.resource:aws_rds_instance:foo.aws.com",
-                    "dd.internal.resource:azure_sql_server_database:my-instance",
-                    "dd.internal.resource:azure_sql_server:my-instance",
-                ],
+                'azure': {
+                    'deployment_type': 'sql_database',
+                    'name': 'my-instance',
+                },
+            },
+            [
+                "dd.internal.resource:aws_rds_instance:foo.aws.com",
+                "dd.internal.resource:azure_sql_server_database:my-instance",
+                "dd.internal.resource:azure_sql_server:my-instance",
+            ],
         ),
     ],
 )

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -321,7 +321,7 @@ def test_statement_metrics_and_plans(
             )
 
     instance_tags = dbm_instance.get('tags', [])
-    expected_instance_tags = set([t for t in instance_tags if not t.startswith('dd.internal')])
+    expected_instance_tags = {t for t in instance_tags if not t.startswith('dd.internal')}
     expected_instance_tags_with_db = expected_instance_tags | {"db:{}".format(database)}
 
     # dbm-metrics

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -320,8 +320,9 @@ def test_statement_metrics_and_plans(
                 cursor, SQL_SERVER_QUERY_METRICS_COLUMNS
             )
 
-    expected_instance_tags = set(dbm_instance.get('tags', []))
-    expected_instance_tags_with_db = set(dbm_instance.get('tags', [])) | {"db:{}".format(database)}
+    instance_tags = dbm_instance.get('tags', [])
+    expected_instance_tags = set([t for t in instance_tags if not t.startswith('dd.internal')])
+    expected_instance_tags_with_db = expected_instance_tags | {"db:{}".format(database)}
 
     # dbm-metrics
     dbm_metrics = aggregator.get_event_platform_events("dbm-metrics")
@@ -331,7 +332,9 @@ def test_statement_metrics_and_plans(
     assert payload['sqlserver_version'].startswith("Microsoft SQL Server"), "invalid version"
     assert payload['host'] == "stubbed.hostname", "wrong hostname"
     assert payload['ddagenthostname'] == datadog_agent.get_hostname()
-    assert set(payload['tags']) == expected_instance_tags, "wrong instance tags for dbm-metrics event"
+    tags = set(payload['tags'])
+    assert tags == expected_instance_tags, "wrong instance tags for dbm-metrics event"
+    assert not any("dd.internal" in m for m in tags), "emitted dd.internal metrics from check"
     assert type(payload['min_collection_interval']) in (float, int), "invalid min_collection_interval"
     # metrics rows
     sqlserver_rows = payload.get('sqlserver_rows', [])
@@ -505,7 +508,7 @@ def test_statement_metadata(
         {
             'azure': {
                 'deployment_type': 'managed_instance',
-                'database_name': 'my-instance',
+                'name': 'my-instance',
             },
         },
         {
@@ -514,7 +517,7 @@ def test_statement_metadata(
             },
             'azure': {
                 'deployment_type': 'managed_instance',
-                'database_name': 'my-instance',
+                'name': 'my-instance',
             },
         },
         {
@@ -560,7 +563,7 @@ def test_statement_cloud_metadata(aggregator, dd_run_check, dbm_instance, bob_co
     # cloud metadata
     assert payload['cloud_metadata'] == cloud_metadata, "wrong cloud_metadata"
     # test that we're reading the edition out of the db instance. Note that this edition is what
-    # is running in our test docker containers so it's not expected to match the test cloud metadata
+    # is running in our test docker containers, so it's not expected to match the test cloud metadata
     assert payload['sqlserver_engine_edition'] in SELF_HOSTED_ENGINE_EDITIONS, "wrong edition"
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This change builds off of the work that was done in https://github.com/DataDog/datadog-agent/pull/16102 to support the unified instance tagging effort. The change does the following:

1. Parses the `cloud_metadata` config, if set by users, and adds the related `dd.internal.resource:<resource_type>:<resource_name>` tag to all metrics emitted by the default integration.
2. Emits a `database_instance` resource tag (`dd.internal.resource:database_instance:<resolved_hostname>`) regardless, which allows us to relate all DBM, system, etc metrics to the default integration metrics emitted.

**Note:** these metrics are _internal_ to datadog && metrics-intake will use them to resolve resources as well as set the `database_instance` (and `<resource_type>`, if applicable) tag on all metrics ingested with these tags applied 

### Motivation
<!-- What inspired you to submit this pull request? -->


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.