### PR TITLE
Send resource_type/name for mysql integration metrics

### DIFF
--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -158,16 +158,18 @@ class MySQLActivity(DBMAsyncJob):
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_activity(self):
         # type: () -> None
+        # do not emit any dd.internal metrics for DBM specific check code
+        tags = [t for t in self._tags if not t.startswith('dd.internal')]
         with closing(self._get_db_connection().cursor(pymysql.cursors.DictCursor)) as cursor:
             rows = self._get_activity(cursor)
             rows = self._normalize_rows(rows)
-            event = self._create_activity_event(rows)
+            event = self._create_activity_event(rows, tags)
             payload = json.dumps(event, default=self._json_event_encoding)
             self._check.database_monitoring_query_activity(payload)
             self._check.histogram(
                 "dd.mysql.activity.collect_activity.payload_size",
                 len(payload),
-                tags=self._tags + self._check._get_debug_tags(),
+                tags=tags + self._check._get_debug_tags(),
             )
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
@@ -235,7 +237,7 @@ class MySQLActivity(DBMAsyncJob):
         # type: (Dict[str]) -> int
         return len(str(row))
 
-    def _create_activity_event(self, active_sessions):
+    def _create_activity_event(self, active_sessions, tags):
         # type: (List[Dict[str]], List[Dict[str]]) -> Dict[str]
         return {
             "host": self._check.resolved_hostname,
@@ -243,7 +245,7 @@ class MySQLActivity(DBMAsyncJob):
             "ddsource": "mysql",
             "dbm_type": "activity",
             "collection_interval": self.collection_interval,
-            "ddtags": self._tags,
+            "ddtags": tags,
             "timestamp": time.time() * 1000,
             "cloud_metadata": self._config.cloud_metadata,
             "mysql_activity": active_sessions,

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -14,7 +14,6 @@ class MySQLConfig(object):
         self.host = instance.get('host', instance.get('server', ''))
         self.port = int(instance.get('port', 0))
         self.reported_hostname = instance.get('reported_hostname', '')
-        self.tags = list(instance.get('tags', []))
         self.mysql_sock = instance.get('sock', '')
         self.defaults_file = instance.get('defaults_file', '')
         self.user = instance.get('username', instance.get('user', ''))

--- a/mysql/datadog_checks/mysql/const.py
+++ b/mysql/datadog_checks/mysql/const.py
@@ -7,6 +7,12 @@ RATE = "rate"
 COUNT = "count"
 MONOTONIC = "monotonic_count"
 PROC_NAME = 'mysqld'
+AWS_RDS_HOSTNAME_SUFFIX = ".rds.amazonaws.com"
+AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPE = {
+    "flexible_server": "azure_mysql_flexible_server",
+    "single_server": "azure_mysql_server",
+    "virtual_machine": "azure_virtual_machine_instance",
+}
 
 # Vars found in "SHOW STATUS;"
 STATUS_VARS = {

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -152,7 +152,6 @@ class MySql(AgentCheck):
         return self._agent_hostname
 
     def set_resource_tags(self):
-        self.log.warning("setting resource tags...")
         if self.cloud_metadata.get("gcp") is not None:
             self.tags.append(
                 "dd.internal.resource:gcp_sql_database_instance:{}:{}".format(
@@ -183,7 +182,6 @@ class MySql(AgentCheck):
                 self.resolved_hostname,
             )
         )
-        self.log.warning("resource tags are %s", self.tags)
 
     def _check_database_configuration(self, db):
         self._check_performance_schema_enabled(db)

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -100,7 +100,7 @@ class MySql(AgentCheck):
         self._agent_hostname = None
         self._is_aurora = None
         self._config = MySQLConfig(self.instance)
-        self.tags = self._config.tags
+        self.tags = copy.copy(self._config.tags)
         self.cloud_metadata = self._config.cloud_metadata
 
         # Create a new connection on every check run
@@ -374,7 +374,7 @@ class MySql(AgentCheck):
             server = self._config.mysql_sock if self._config.mysql_sock != '' else self._config.host
         service_check_tags = [
             'port:{}'.format(self._config.port if self._config.port else 'unix_socket'),
-        ] + self.tags
+        ] + self._config.tags
         if not self.disable_generic_tags:
             service_check_tags.append('server:{0}'.format(server))
         return service_check_tags

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -152,6 +152,7 @@ class MySql(AgentCheck):
         return self._agent_hostname
 
     def set_resource_tags(self):
+        self.log.warning("setting resource tags...")
         if self.cloud_metadata.get("gcp") is not None:
             self.tags.append(
                 "dd.internal.resource:gcp_sql_database_instance:{}:{}".format(
@@ -182,6 +183,7 @@ class MySql(AgentCheck):
                 self.resolved_hostname,
             )
         )
+        self.log.warning("resource tags are %s", self.tags)
 
     def _check_database_configuration(self, db):
         self._check_performance_schema_enabled(db)

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -21,6 +21,8 @@ from .activity import MySQLActivity
 from .collection_utils import collect_all_scalars, collect_scalar, collect_string, collect_type
 from .config import MySQLConfig
 from .const import (
+    AWS_RDS_HOSTNAME_SUFFIX,
+    AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPE,
     BINLOG_VARS,
     COUNT,
     GALERA_VARS,
@@ -98,6 +100,8 @@ class MySql(AgentCheck):
         self._agent_hostname = None
         self._is_aurora = None
         self._config = MySQLConfig(self.instance)
+        self.tags = self._config.tags
+        self.cloud_metadata = self._config.cloud_metadata
 
         # Create a new connection on every check run
         self._conn = None
@@ -115,6 +119,7 @@ class MySql(AgentCheck):
         self._query_activity = MySQLActivity(self, self._config, self._get_connection_args())
 
         self._runtime_queries = None
+        self.set_resource_tags()
 
     def execute_query_raw(self, query):
         with closing(self._conn.cursor(pymysql.cursors.SSCursor)) as cursor:
@@ -145,6 +150,38 @@ class MySql(AgentCheck):
         if self._agent_hostname is None:
             self._agent_hostname = datadog_agent.get_hostname()
         return self._agent_hostname
+
+    def set_resource_tags(self):
+        if self.cloud_metadata.get("gcp") is not None:
+            self.tags.append(
+                "dd.internal.resource:gcp_sql_database_instance:{}:{}".format(
+                    self.cloud_metadata.get("gcp")["project_id"], self.cloud_metadata.get("gcp")["instance_id"]
+                )
+            )
+        if self.cloud_metadata.get("aws") is not None:
+            self.tags.append(
+                "dd.internal.resource:aws_rds_instance:{}".format(
+                    self.cloud_metadata.get("aws")["instance_endpoint"],
+                )
+            )
+        elif AWS_RDS_HOSTNAME_SUFFIX in self.resolved_hostname:
+            # allow for detecting if the host is an RDS host, and emit
+            # the resource properly even if the `aws` config is unset
+            self.tags.append("dd.internal.resource:aws_rds_instance:{}".format(self.resolved_hostname))
+        if self.cloud_metadata.get("azure") is not None:
+            deployment_type = self.cloud_metadata.get("azure")["deployment_type"]
+            # some `deployment_type`s map to multiple `resource_type`s
+            resource_type = AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPE.get(deployment_type)
+            if resource_type:
+                self.tags.append(
+                    "dd.internal.resource:{}:{}".format(resource_type, self.cloud_metadata.get("azure")["name"])
+                )
+        # finally, emit a `database_instance` resource for this instance
+        self.tags.append(
+            "dd.internal.resource:database_instance:{}".format(
+                self.resolved_hostname,
+            )
+        )
 
     def _check_database_configuration(self, db):
         self._check_performance_schema_enabled(db)
@@ -206,7 +243,7 @@ class MySql(AgentCheck):
         if self.instance.get('pass'):
             self._log_deprecation('_config_renamed', 'pass', 'password')
 
-        tags = list(self._config.tags)
+        tags = list(self.tags)
         self._set_qcache_stats()
         with self._connect() as db:
             try:
@@ -337,7 +374,7 @@ class MySql(AgentCheck):
             server = self._config.mysql_sock if self._config.mysql_sock != '' else self._config.host
         service_check_tags = [
             'port:{}'.format(self._config.port if self._config.port else 'unix_socket'),
-        ] + self._config.tags
+        ] + self.tags
         if not self.disable_generic_tags:
             service_check_tags.append('server:{0}'.format(server))
         return service_check_tags
@@ -564,7 +601,7 @@ class MySql(AgentCheck):
                         'member_state:{}'.format(replica_results[1]),
                         'member_role:{}'.format(replica_results[2]),
                     ]
-                    self.gauge('mysql.replication.group.member_status', 1, tags=additional_tags + self._config.tags)
+                    self.gauge('mysql.replication.group.member_status', 1, tags=additional_tags + self.tags)
 
                 self.service_check(
                     self.GROUP_REPLICATION_SERVICE_CHECK_NAME,
@@ -589,10 +626,8 @@ class MySql(AgentCheck):
                     'Transactions_local_proposed': r[7],
                     'Transactions_local_rollback': r[8],
                 }
-                # Submit metrics now so it's possible to attach `channel_name` tag
-                self._submit_metrics(
-                    GROUP_REPLICATION_VARS, results, self._config.tags + ['channel_name:{}'.format(r[0])]
-                )
+                # Submit metrics now, so it's possible to attach `channel_name` tag
+                self._submit_metrics(GROUP_REPLICATION_VARS, results, self.tags + ['channel_name:{}'.format(r[0])])
 
                 return GROUP_REPLICATION_VARS
         except Exception as e:
@@ -655,7 +690,7 @@ class MySql(AgentCheck):
         self.gauge(
             name=self.SLAVE_SERVICE_CHECK_NAME,
             value=1 if status == AgentCheck.OK else 0,
-            tags=self._config.tags + additional_tags,
+            tags=self.tags + additional_tags,
             hostname=self.resolved_hostname,
         )
         # deprecated in favor of service_check("mysql.replication.replica_running")

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -136,6 +136,8 @@ class MySQLStatementMetrics(DBMAsyncJob):
         rows = self._collect_per_statement_metrics()
         if not rows:
             return
+        # Omit internal tags for dbm payloads since those are only relevant to metrics processed directly
+        # by the agent
         tags = [t for t in self._tags if not t.startswith('dd.internal')]
         for event in self._rows_to_fqt_events(rows, tags):
             self._check.database_monitoring_query_sample(json.dumps(event, default=default_json_event_encoding))

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -136,10 +136,9 @@ class MySQLStatementMetrics(DBMAsyncJob):
         rows = self._collect_per_statement_metrics()
         if not rows:
             return
-
-        for event in self._rows_to_fqt_events(rows):
+        tags = [t for t in self._tags if not t.startswith('dd.internal')]
+        for event in self._rows_to_fqt_events(rows, tags):
             self._check.database_monitoring_query_sample(json.dumps(event, default=default_json_event_encoding))
-
         payload = {
             'host': self._check.resolved_hostname,
             'timestamp': time.time() * 1000,
@@ -148,7 +147,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
             "ddagenthostname": self._check.agent_hostname,
             'ddagentversion': datadog_agent.get_version(),
             'min_collection_interval': self._metric_collection_interval,
-            'tags': self._tags,
+            'tags': tags,
             'cloud_metadata': self._config.cloud_metadata,
             'mysql_rows': rows,
         }
@@ -156,7 +155,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
         self._check.count(
             "dd.mysql.collect_per_statement_metrics.rows",
             len(rows),
-            tags=self._tags + self._check._get_debug_tags(),
+            tags=tags + self._check._get_debug_tags(),
             hostname=self._check.resolved_hostname,
         )
 
@@ -223,13 +222,13 @@ class MySQLStatementMetrics(DBMAsyncJob):
 
         return normalized_rows
 
-    def _rows_to_fqt_events(self, rows):
+    def _rows_to_fqt_events(self, rows, tags):
         for row in rows:
             query_cache_key = _row_key(row)
             if query_cache_key in self._full_statement_text_cache:
                 continue
             self._full_statement_text_cache[query_cache_key] = True
-            row_tags = self._tags + ["schema:{}".format(row['schema_name'])] if row['schema_name'] else self._tags
+            row_tags = tags + ["schema:{}".format(row['schema_name'])] if row['schema_name'] else tags
             yield {
                 "timestamp": time.time() * 1000,
                 "host": self._check.resolved_hostname,

--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -15,19 +15,19 @@ mypy-deps = [
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.8"]
+python = ["3.8"]
 version = [
   "5.7",  # EOL October 21, 2023
   "8.0",  # EOL April, 2026
 ]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.8"]
+python = ["3.8"]
 version = ["8.0"]
 replication = ["group"]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.8"]
+python = ["3.8"]
 flavor = ["mariadb"]
 version = [
   "10.2",  # EOL 23 May 2022

--- a/mysql/tests/tags.py
+++ b/mysql/tests/tags.py
@@ -3,19 +3,23 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from . import common
 
+DATABASE_INSTANCE_RESOURCE_TAG = 'dd.internal.resource:database_instance:{hostname}'
 METRIC_TAGS = ['tag1:value1', 'tag2:value2']
-METRIC_TAGS_WITH_RESOURCE = ['tag1:value1', 'tag2:value2', 'dd.internal.resource:database_instance:stubbed.hostname']
+METRIC_TAGS_WITH_RESOURCE = [
+    'tag1:value1',
+    'tag2:value2',
+    DATABASE_INSTANCE_RESOURCE_TAG.format(hostname='stubbed.hostname'),
+]
 SC_TAGS = [
     'port:' + str(common.PORT),
     'tag1:value1',
     'tag2:value2',
-    'dd.internal.resource:database_instance:stubbed.hostname',
 ]
-SC_TAGS_MIN = ['port:' + str(common.PORT), 'dd.internal.resource:database_instance:stubbed.hostname']
+SC_TAGS_MIN = ['port:' + str(common.PORT), DATABASE_INSTANCE_RESOURCE_TAG.format(hostname='stubbed.hostname')]
 SC_TAGS_REPLICA = [
     'port:' + str(common.SLAVE_PORT),
     'tag1:value1',
     'tag2:value2',
     'dd.internal.resource:database_instance:stubbed.hostname',
 ]
-SC_FAILURE_TAGS = ['port:unix_socket', 'dd.internal.resource:database_instance:stubbed.hostname']
+SC_FAILURE_TAGS = ['port:unix_socket', DATABASE_INSTANCE_RESOURCE_TAG.format(hostname='stubbed.hostname')]

--- a/mysql/tests/tags.py
+++ b/mysql/tests/tags.py
@@ -15,11 +15,10 @@ SC_TAGS = [
     'tag1:value1',
     'tag2:value2',
 ]
-SC_TAGS_MIN = ['port:' + str(common.PORT), DATABASE_INSTANCE_RESOURCE_TAG.format(hostname='stubbed.hostname')]
+SC_TAGS_MIN = ['port:' + str(common.PORT)]
 SC_TAGS_REPLICA = [
     'port:' + str(common.SLAVE_PORT),
     'tag1:value1',
     'tag2:value2',
-    'dd.internal.resource:database_instance:stubbed.hostname',
 ]
-SC_FAILURE_TAGS = ['port:unix_socket', DATABASE_INSTANCE_RESOURCE_TAG.format(hostname='stubbed.hostname')]
+SC_FAILURE_TAGS = ['port:unix_socket']

--- a/mysql/tests/tags.py
+++ b/mysql/tests/tags.py
@@ -4,7 +4,18 @@
 from . import common
 
 METRIC_TAGS = ['tag1:value1', 'tag2:value2']
-SC_TAGS = ['port:' + str(common.PORT), 'tag1:value1', 'tag2:value2']
-SC_TAGS_MIN = ['port:' + str(common.PORT)]
-SC_TAGS_REPLICA = ['port:' + str(common.SLAVE_PORT), 'tag1:value1', 'tag2:value2']
-SC_FAILURE_TAGS = ['port:unix_socket']
+METRIC_TAGS_WITH_RESOURCE = ['tag1:value1', 'tag2:value2', 'dd.internal.resource:database_instance:stubbed.hostname']
+SC_TAGS = [
+    'port:' + str(common.PORT),
+    'tag1:value1',
+    'tag2:value2',
+    'dd.internal.resource:database_instance:stubbed.hostname',
+]
+SC_TAGS_MIN = ['port:' + str(common.PORT), 'dd.internal.resource:database_instance:stubbed.hostname']
+SC_TAGS_REPLICA = [
+    'port:' + str(common.SLAVE_PORT),
+    'tag1:value1',
+    'tag2:value2',
+    'dd.internal.resource:database_instance:stubbed.hostname',
+]
+SC_FAILURE_TAGS = ['port:unix_socket', 'dd.internal.resource:database_instance:stubbed.hostname']

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -71,7 +71,7 @@ def test_complex_config(aggregator, dd_run_check, instance_complex):
     mysql_check = MySql(common.CHECK_NAME, {}, [instance_complex])
     dd_run_check(mysql_check)
 
-    _assert_complex_config(aggregator, instance_complex)
+    _assert_complex_config(aggregator)
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(), check_submission_type=True, exclude=['alice.age', 'bob.age'] + variables.STATEMENT_VARS
     )
@@ -80,20 +80,19 @@ def test_complex_config(aggregator, dd_run_check, instance_complex):
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, instance_complex):
     aggregator = dd_agent_check(instance_complex)
-    _assert_complex_config(aggregator, instance_complex, hostname=None)  # Do not assert hostname
+    mysql_check = MySql(common.CHECK_NAME, {}, [instance_complex])
+    _assert_complex_config(aggregator, hostname=mysql_check.resolved_hostname)  # Do not assert hostname
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(), exclude=['alice.age', 'bob.age'] + variables.STATEMENT_VARS
     )
 
 
-def _assert_complex_config(aggregator, instance_complex, hostname='stubbed.hostname'):
-    mysql_check = MySql(common.CHECK_NAME, {}, [instance_complex])
-
+def _assert_complex_config(aggregator, hostname='stubbed.hostname'):
     # Test service check
     aggregator.assert_service_check(
         'mysql.can_connect',
         status=MySql.OK,
-        tags=tags.SC_TAGS + [tags.DATABASE_INSTANCE_RESOURCE_TAG.format(hostname=mysql_check.resolved_hostname)],
+        tags=tags.SC_TAGS + [tags.DATABASE_INSTANCE_RESOURCE_TAG.format(hostname=hostname)],
         hostname=hostname,
         count=1,
     )

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -78,9 +78,10 @@ def test_complex_config(aggregator, dd_run_check, instance_complex):
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, instance_complex):
+def test_e2e(dd_agent_check, dd_run_check, instance_complex):
     aggregator = dd_agent_check(instance_complex)
     mysql_check = MySql(common.CHECK_NAME, {}, [instance_complex])
+    dd_run_check(mysql_check)
     _assert_complex_config(aggregator, hostname=mysql_check.resolved_hostname)  # Do not assert hostname
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(), exclude=['alice.age', 'bob.age'] + variables.STATEMENT_VARS

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -103,7 +103,7 @@ def _assert_complex_config(aggregator, hostname='stubbed.hostname'):
             tags=tags.SC_TAGS
             + [
                 'replication_mode:source',
-                tags.DATABASE_INSTANCE_RESOURCE_TAG.format(hostname=mysql_check.resolved_hostname),
+                tags.DATABASE_INSTANCE_RESOURCE_TAG.format(hostname=hostname),
             ],
             hostname=hostname,
             at_least=1,
@@ -129,7 +129,7 @@ def _assert_complex_config(aggregator, hostname='stubbed.hostname'):
             'mysql.replication.group.status',
             status=MySql.OK,
             tags=tags.SC_TAGS
-            + [tags.DATABASE_INSTANCE_RESOURCE_TAG.format(hostname=mysql_check.resolved_hostname)]
+            + [tags.DATABASE_INSTANCE_RESOURCE_TAG.format(hostname=hostname)]
             + ['channel_name:group_replication_applier', 'member_role:PRIMARY', 'member_state:ONLINE'],
             count=1,
         )
@@ -148,9 +148,7 @@ def _assert_complex_config(aggregator, hostname='stubbed.hostname'):
         if mname == 'mysql.performance.cpu_time' and Platform.is_windows():
             continue
 
-        base_tags = tags.METRIC_TAGS + [
-            tags.DATABASE_INSTANCE_RESOURCE_TAG.format(hostname=mysql_check.resolved_hostname)
-        ]
+        base_tags = tags.METRIC_TAGS + [tags.DATABASE_INSTANCE_RESOURCE_TAG.format(hostname=hostname)]
         if mname == 'mysql.performance.query_run_time.avg':
             aggregator.assert_metric(mname, tags=base_tags + ['schema:testdb'], count=1)
             aggregator.assert_metric(mname, tags=base_tags + ['schema:mysql'], count=1)

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -78,11 +78,9 @@ def test_complex_config(aggregator, dd_run_check, instance_complex):
 
 
 @pytest.mark.e2e
-def test_e2e(dd_agent_check, dd_run_check, instance_complex):
+def test_e2e(dd_agent_check, dd_default_hostname, instance_complex):
     aggregator = dd_agent_check(instance_complex)
-    mysql_check = MySql(common.CHECK_NAME, {}, [instance_complex])
-    dd_run_check(mysql_check)
-    _assert_complex_config(aggregator, hostname=mysql_check.resolved_hostname)  # Do not assert hostname
+    _assert_complex_config(aggregator, hostname=dd_default_hostname)
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(), exclude=['alice.age', 'bob.age'] + variables.STATEMENT_VARS
     )

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -82,13 +82,13 @@ def test_complex_config(aggregator, dd_run_check, instance_complex):
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, dd_default_hostname, instance_complex):
     aggregator = dd_agent_check(instance_complex)
-    _assert_complex_config(aggregator, hostname=dd_default_hostname)
+    _assert_complex_config(aggregator, [], hostname=dd_default_hostname)
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(), exclude=['alice.age', 'bob.age'] + variables.STATEMENT_VARS
     )
 
 
-def _assert_complex_config(aggregator, expected_internal_tags=[], hostname='stubbed.hostname'):
+def _assert_complex_config(aggregator, expected_internal_tags, hostname='stubbed.hostname'):
     # Test service check
     aggregator.assert_service_check(
         'mysql.can_connect',
@@ -125,8 +125,14 @@ def _assert_complex_config(aggregator, expected_internal_tags=[], hostname='stub
         aggregator.assert_service_check(
             'mysql.replication.group.status',
             status=MySql.OK,
-            tags=tags.METRIC_TAGS + expected_internal_tags
-                 + ['port:' + str(common.PORT), 'channel_name:group_replication_applier', 'member_role:PRIMARY', 'member_state:ONLINE'],
+            tags=tags.METRIC_TAGS
+            + expected_internal_tags
+            + [
+                'port:' + str(common.PORT),
+                'channel_name:group_replication_applier',
+                'member_role:PRIMARY',
+                'member_state:ONLINE',
+            ],
             count=1,
         )
 
@@ -149,8 +155,12 @@ def _assert_complex_config(aggregator, expected_internal_tags=[], hostname='stub
             aggregator.assert_metric(mname, tags=tags.METRIC_TAGS + expected_internal_tags + ['schema:mysql'], count=1)
         elif mname == 'mysql.info.schema.size':
             aggregator.assert_metric(mname, tags=tags.METRIC_TAGS + expected_internal_tags + ['schema:testdb'], count=1)
-            aggregator.assert_metric(mname, tags=tags.METRIC_TAGS + expected_internal_tags + ['schema:information_schema'], count=1)
-            aggregator.assert_metric(mname, tags=tags.METRIC_TAGS + expected_internal_tags + ['schema:performance_schema'], count=1)
+            aggregator.assert_metric(
+                mname, tags=tags.METRIC_TAGS + expected_internal_tags + ['schema:information_schema'], count=1
+            )
+            aggregator.assert_metric(
+                mname, tags=tags.METRIC_TAGS + expected_internal_tags + ['schema:performance_schema'], count=1
+            )
         else:
             aggregator.assert_metric(mname, tags=tags.METRIC_TAGS + expected_internal_tags, at_least=0)
 

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -126,7 +126,6 @@ def _assert_complex_config(aggregator, expected_internal_tags, hostname='stubbed
             'mysql.replication.group.status',
             status=MySql.OK,
             tags=tags.METRIC_TAGS
-            + expected_internal_tags
             + [
                 'port:' + str(common.PORT),
                 'channel_name:group_replication_applier',

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -294,10 +294,14 @@ def test__get_is_aurora():
 @pytest.mark.parametrize(
     'disable_generic_tags, hostname, expected_tags',
     [
-        (True, None, {'port:unix_socket'}),
-        (False, None, {'port:unix_socket', 'server:localhost'}),
-        (True, 'foo', {'port:unix_socket'}),
-        (False, 'foo', {'port:unix_socket', 'server:foo'}),
+        (True, None, {'port:unix_socket', 'dd.internal.resource:database_instance:stubbed.hostname'}),
+        (
+            False,
+            None,
+            {'port:unix_socket', 'server:localhost', 'dd.internal.resource:database_instance:stubbed.hostname'},
+        ),
+        (True, 'foo', {'port:unix_socket', 'dd.internal.resource:database_instance:stubbed.hostname'}),
+        (False, 'foo', {'port:unix_socket', 'server:foo', 'dd.internal.resource:database_instance:stubbed.hostname'}),
     ],
 )
 def test_service_check(disable_generic_tags, expected_tags, hostname):

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -294,14 +294,14 @@ def test__get_is_aurora():
 @pytest.mark.parametrize(
     'disable_generic_tags, hostname, expected_tags',
     [
-        (True, None, {'port:unix_socket', 'dd.internal.resource:database_instance:stubbed.hostname'}),
+        (True, None, {'port:unix_socket'}),
         (
             False,
             None,
-            {'port:unix_socket', 'server:localhost', 'dd.internal.resource:database_instance:stubbed.hostname'},
+            {'port:unix_socket', 'server:localhost'},
         ),
-        (True, 'foo', {'port:unix_socket', 'dd.internal.resource:database_instance:stubbed.hostname'}),
-        (False, 'foo', {'port:unix_socket', 'server:foo', 'dd.internal.resource:database_instance:stubbed.hostname'}),
+        (True, 'foo', {'port:unix_socket'}),
+        (False, 'foo', {'port:unix_socket', 'server:foo'}),
     ],
 )
 def test_service_check(disable_generic_tags, expected_tags, hostname):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This change builds off of the work that was done in https://github.com/DataDog/datadog-agent/pull/16102 to support the unified instance tagging effort. The change does the following:

1. Parses the `cloud_metadata` config, if set by users, and adds the related `dd.internal.resource:<resource_type>:<resource_name>` tag to all metrics emitted by the default integration.
2. Emits a `database_instance` resource tag (`dd.internal.resource:database_instance:<resolved_hostname>`) regardless, which allows us to relate all DBM, system, etc metrics to the default integration metrics emitted.

**Note:** these metrics are _internal_ to datadog && metrics-intake will use them to resolve resources as well as set the `database_instance` (and `<resource_type>`, if applicable) tag on all metrics ingested with these tags applied 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.