### PR TITLE
Update Cilium Agent Port in Autoconfiguration yaml

### DIFF
--- a/cilium/CHANGELOG.md
+++ b/cilium/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.3.1 / 2023-04-10
 
-* [Changed] Update Cilium Agent port for autoconfiguration  
+* [Changed] Update Cilium Agent port for autoconfiguration. See [#14339](https://github.com/DataDog/integrations-core/pull/14339)
 
 ## 2.3.0 / 2022-09-16 / Agent 7.40.0
 

--- a/cilium/CHANGELOG.md
+++ b/cilium/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - Cilium
 
+## 2.3.1 / 2023-04-10
+
+* [Changed] Update Cilium Agent port for autoconfiguration  
+
 ## 2.3.0 / 2022-09-16 / Agent 7.40.0
 
 * [Added] Refactor tooling for getting the current env name. See [#12939](https://github.com/DataDog/integrations-core/pull/12939).

--- a/cilium/datadog_checks/cilium/data/auto_conf.yaml
+++ b/cilium/datadog_checks/cilium/data/auto_conf.yaml
@@ -20,7 +20,7 @@ instances:
     ## By default, the Cilium integration collects `cilium-agent` metrics.
     ## One of agent_endpoint or operator_endpoint must be provided.
     #
-  - agent_endpoint: http://%%host%%:9090/metrics
+  - agent_endpoint: http://%%host%%:9962/metrics
 
     ## @param tags - list of strings - optional
     ## List of tags to attach to every metrics, events and service checks emitted by this integration.


### PR DESCRIPTION
### What does this PR do?
Update the autoconfiguration template for cilium to use the updated port configuration noted here:
https://github.com/prometheus/prometheus/wiki/Default-port-allocations

### Motivation
https://datadoghq.atlassian.net/browse/AI-2976?atlOrigin=eyJpIjoiOTE4MWM1MmQzOTBmNGE3Y2ExZDA4ZDM0YWRmMWU5YzMiLCJwIjoiaiJ9

### Additional Notes
Port changed from 9090 to 9962

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.