### PR TITLE
Update singlestore to pass docs validation

### DIFF
--- a/singlestore/README.md
+++ b/singlestore/README.md
@@ -31,9 +31,11 @@ No additional installation is needed on your server.
 
 ##### Log collection
 
+<!-- partial
 {{< site-region region="us3" >}}
 **Log collection is not supported for this site.**
 {{< /site-region >}}
+partial -->
 
 1. Collecting logs is disabled by default in the Datadog Agent, enable it in your `datadog.yaml` file:
 
@@ -69,9 +71,11 @@ For containerized environments, see the [Autodiscovery Integration Templates][2]
 
 ##### Log collection
 
+<!-- partial
 {{< site-region region="us3" >}}
 **Log collection is not supported for this site.**
 {{< /site-region >}}
+partial -->
 
 Collecting logs is disabled by default in the Datadog Agent. To enable it, see [Kubernetes Log Collection][6].
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes a docs validation violation that all region shortcodes must be wrapped in HTML partial comments

### Motivation
<!-- What inspired you to submit this pull request? -->
As we start to allow more strict validations, docs has put in place this validation and this was the only integration in this repo that didn't comply. 

Here's an example of another integration that does have this - https://github.com/DataDog/integrations-core/blob/fca5670cf5d56df3f8ba197cb3aa4fa26a903e74/twistlock/README.md?plain=1#L72

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.