### PR TITLE
Check for new version of ddev periodically

### DIFF
--- a/ddev/src/ddev/cli/__init__.py
+++ b/ddev/src/ddev/cli/__init__.py
@@ -27,6 +27,7 @@ from ddev.plugin import specs
 from ddev.utils.ci import running_in_ci
 from ddev.utils.fs import Path
 
+
 @click.group(context_settings={'help_option_names': ['-h', '--help']}, invoke_without_command=True)
 @click.option('--core', '-c', is_flag=True, help='Work on `integrations-core`.')
 @click.option('--extras', '-e', is_flag=True, help='Work on `integrations-extras`.')
@@ -114,7 +115,7 @@ def ddev(ctx: click.Context, core, extras, marketplace, agent, here, color, inte
     except OSError as e:  # no cov
         app.abort(f'Error loading configuration: {e}')
 
-    if app.config.check_update:    
+    if app.config.check_update:
         upgrade.check_upgrade(app, __version__)
 
     if not ctx.invoked_subcommand:

--- a/ddev/src/ddev/cli/__init__.py
+++ b/ddev/src/ddev/cli/__init__.py
@@ -12,6 +12,7 @@ from datadog_checks.dev.tooling.commands.run import run
 from datadog_checks.dev.tooling.commands.test import test
 
 from ddev.__about__ import __version__
+from ddev.cli import upgrade
 from ddev.cli.application import Application
 from ddev.cli.ci import ci
 from ddev.cli.config import config
@@ -25,7 +26,6 @@ from ddev.config.constants import AppEnvVars, ConfigEnvVars
 from ddev.plugin import specs
 from ddev.utils.ci import running_in_ci
 from ddev.utils.fs import Path
-
 
 @click.group(context_settings={'help_option_names': ['-h', '--help']}, invoke_without_command=True)
 @click.option('--core', '-c', is_flag=True, help='Work on `integrations-core`.')
@@ -106,10 +106,6 @@ def ddev(ctx: click.Context, core, extras, marketplace, agent, here, color, inte
                 f'Unable to create config file located at `{str(app.config_file.path)}`. Please check your permissions.'
             )
 
-    if not ctx.invoked_subcommand:
-        app.display_info(ctx.get_help(), highlight=False)
-        return
-
     # Persist app data for sub-commands
     ctx.obj = app
 
@@ -117,6 +113,13 @@ def ddev(ctx: click.Context, core, extras, marketplace, agent, here, color, inte
         app.config_file.load()
     except OSError as e:  # no cov
         app.abort(f'Error loading configuration: {e}')
+
+    if app.config.check_update:    
+        upgrade.check_upgrade(app, __version__)
+
+    if not ctx.invoked_subcommand:
+        app.display_info(ctx.get_help(), highlight=False)
+        return
 
     app.set_repo(core, extras, marketplace, agent, here)
 

--- a/ddev/src/ddev/cli/upgrade.py
+++ b/ddev/src/ddev/cli/upgrade.py
@@ -8,6 +8,8 @@ from semver import VersionInfo
 PACKAGE_NAME = 'ddev'
 
 def read_last_run(file_path):
+    # Read the last run the file registry.json and returns a version and a date. 
+    # Format: {"version": "1.6.0", "date": "2023-04-11T10:56:39.786412"}
     try:
         with open(file_path, 'r') as f:
             data = json.load(f)
@@ -20,6 +22,7 @@ def read_last_run(file_path):
     return "0.0.1", datetime.now() - timedelta(days=7)
 
 def write_last_run(file_path, version_value, date):
+    # Records/overwrites the run in the registry.json. If the file isn't there, it will be created
     data = {'version': version_value, 'date': date.isoformat()}
     with open(file_path, 'w') as f:
         json.dump(data, f)
@@ -28,14 +31,17 @@ def exit_handler(app, msg):
     return app.display_info(msg, highlight=False)   
 
 def check_upgrade(app, version):
+    # Finds the current location of the config file to put the registry.json in the same directory
     file_path = app.config_file.path
     dir_path, _file_name = os.path.split(file_path)
     registry_name = 'registry.json'
     registry_file_path = os.path.join(dir_path, registry_name)
+
     current_version = VersionInfo.parse(version)
     last_checked_version, last_run = read_last_run(registry_file_path)
     date_now = datetime.now()
     
+    # Check from last run to see if the data inside the registry.json is older than 7 days and if the last checked version is newer than current.
     if date_now - last_run < timedelta(days=7) and last_checked_version < current_version:
         msg = f'\n!!An upgrade to version {last_checked_version} is available for {PACKAGE_NAME}. Your current version is {current_version}!!'
         atexit.register(exit_handler, app, msg)
@@ -43,6 +49,7 @@ def check_upgrade(app, version):
     
     url = 'https://pypi.org/pypi/ddev/json'
 
+    # Get latest version from PyPI and check with current version. Record the latest version and date.
     try:
         response = requests.get(url, timeout=2)
         response.raise_for_status()

--- a/ddev/src/ddev/cli/upgrade.py
+++ b/ddev/src/ddev/cli/upgrade.py
@@ -48,7 +48,7 @@ def check_upgrade(app, version):
 
     # Check from last run to see if the data inside the registry.json is older than 7 days
     # If the last checked version is newer than current.
-    if date_now - last_run < timedelta(days=7) and latest_version < current_version:
+    if date_now - last_run < timedelta(days=7) and latest_version > current_version:
         msg = (
             f'\n!!An upgrade to version {latest_version} is available for {PACKAGE_NAME}. '
             f'Your current version is {current_version}!!'
@@ -65,7 +65,7 @@ def check_upgrade(app, version):
         data = response.json()
         latest_version = data['info']['version']
         write_last_run(registry_file_path, latest_version, date_now)
-        if VersionInfo.parse(latest_version) < current_version:
+        if VersionInfo.parse(latest_version) > current_version:
             msg = (
                 f'\n!!An upgrade to version {latest_version} is available for {PACKAGE_NAME}. '
                 f'Your current version is {current_version}!!'

--- a/ddev/src/ddev/cli/upgrade.py
+++ b/ddev/src/ddev/cli/upgrade.py
@@ -1,0 +1,56 @@
+import atexit
+import json
+import os
+import requests
+from datetime import datetime, timedelta
+from semver import VersionInfo
+
+PACKAGE_NAME = 'ddev'
+
+def read_last_run(file_path):
+    try:
+        with open(file_path, 'r') as f:
+            data = json.load(f)
+            version = data.get('version')
+            date = data.get('date')
+            if version and date:
+                return version, datetime.fromisoformat(date)
+    except:
+        pass
+    return "0.0.1", datetime.now() - timedelta(days=7)
+
+def write_last_run(file_path, version_value, date):
+    data = {'version': version_value, 'date': date.isoformat()}
+    with open(file_path, 'w') as f:
+        json.dump(data, f)
+
+def exit_handler(app, msg):
+    return app.display_info(msg, highlight=False)   
+
+def check_upgrade(app, version):
+    file_path = app.config_file.path
+    dir_path, _file_name = os.path.split(file_path)
+    registry_name = 'registry.json'
+    registry_file_path = os.path.join(dir_path, registry_name)
+    current_version = VersionInfo.parse(version)
+    last_checked_version, last_run = read_last_run(registry_file_path)
+    date_now = datetime.now()
+    
+    if date_now - last_run < timedelta(days=7) and last_checked_version < current_version:
+        msg = f'\n!!An upgrade to version {last_checked_version} is available for {PACKAGE_NAME}. Your current version is {current_version}!!'
+        atexit.register(exit_handler, app, msg)
+        return
+    
+    url = 'https://pypi.org/pypi/ddev/json'
+
+    try:
+        response = requests.get(url, timeout=2)
+        response.raise_for_status()
+        data = response.json()
+        latest_version = data['info']['version']
+        write_last_run(registry_file_path, latest_version, date_now)
+        if VersionInfo.parse(latest_version) < current_version:
+            msg = f'\n!!An upgrade to version {latest_version} is available for {PACKAGE_NAME}. Your current version is {current_version}!!'
+            atexit.register(exit_handler, app, msg)
+    except:
+        return

--- a/ddev/src/ddev/cli/upgrade.py
+++ b/ddev/src/ddev/cli/upgrade.py
@@ -8,6 +8,7 @@ from semver import VersionInfo
 
 PACKAGE_NAME = 'ddev'
 
+
 def read_last_run(file_path):
     # Read the last run the file registry.json and returns a version and a date.
     # Format: {"version": "1.6.0", "date": "2023-04-11T10:56:39.786412"}
@@ -22,14 +23,17 @@ def read_last_run(file_path):
         pass
     return "0.0.1", datetime.now() - timedelta(days=7)
 
+
 def write_last_run(file_path, version_value, date):
     # Records/overwrites the run in the registry.json. If the file isn't there, it will be created
     data = {'version': version_value, 'date': date.isoformat()}
     with open(file_path, 'w') as f:
         json.dump(data, f)
 
+
 def exit_handler(app, msg):
     return app.display_info(msg, highlight=False)
+
 
 def check_upgrade(app, version):
     # Finds the current location of the config file to put the registry.json in the same directory
@@ -45,8 +49,10 @@ def check_upgrade(app, version):
     # Check from last run to see if the data inside the registry.json is older than 7 days
     # If the last checked version is newer than current.
     if date_now - last_run < timedelta(days=7) and latest_version < current_version:
-        msg = f'\n!!An upgrade to version {latest_version} is available for {PACKAGE_NAME}. ' \
-              f'Your current version is {current_version}!!'
+        msg = (
+            f'\n!!An upgrade to version {latest_version} is available for {PACKAGE_NAME}. '
+            f'Your current version is {current_version}!!'
+        )
         atexit.register(exit_handler, app, msg)
         return
 
@@ -60,8 +66,10 @@ def check_upgrade(app, version):
         latest_version = data['info']['version']
         write_last_run(registry_file_path, latest_version, date_now)
         if VersionInfo.parse(latest_version) < current_version:
-            msg = f'\n!!An upgrade to version {latest_version} is available for {PACKAGE_NAME}. ' \
-                  f'Your current version is {current_version}!!'
+            msg = (
+                f'\n!!An upgrade to version {latest_version} is available for {PACKAGE_NAME}. '
+                f'Your current version is {current_version}!!'
+            )
             atexit.register(exit_handler, app, msg)
     except:
         return

--- a/ddev/src/ddev/config/model.py
+++ b/ddev/src/ddev/config/model.py
@@ -72,9 +72,9 @@ class RootConfig(LazilyParsedConfig):
                 elif raw_update.lower() == 'false':
                     check_update = False
                 else:
-                    raise ValueError('Invalid value for check_update, it should be True or False: {}'.format(raw_update))
+                    raise ValueError('Invalid value for check_update, it must be True or False: {}'.format(raw_update))
             else:
-                raise TypeError('Invalid value for check_update, it should be True or False: {}'.format(type(raw_update)))
+                raise TypeError('Invalid value for check_update, it must be True or False: {}'.format(type(raw_update)))
             return check_update
 
     @check_update.setter

--- a/ddev/src/ddev/config/model.py
+++ b/ddev/src/ddev/config/model.py
@@ -58,6 +58,29 @@ class RootConfig(LazilyParsedConfig):
         self._field_pypi = FIELD_TO_PARSE
         self._field_trello = FIELD_TO_PARSE
         self._field_terminal = FIELD_TO_PARSE
+        self._field_check_update = FIELD_TO_PARSE
+
+    @property
+    def check_update(self):
+        if self._field_check_update is FIELD_TO_PARSE:
+            raw_update = self.raw_data.get('check_update', True)
+            if isinstance(raw_update, bool):
+                check_update = raw_update
+            elif isinstance(raw_update, str):
+                if raw_update.lower() == 'true':
+                    check_update = True
+                elif raw_update.lower() == 'false':
+                    check_update = False
+                else:
+                    raise ValueError('Invalid value for check_update, it should be True or False: {}'.format(raw_update))
+            else:
+                raise TypeError('Invalid value for check_update, it should be True or False: {}'.format(type(raw_update)))
+            return check_update
+
+    @check_update.setter
+    def check_update(self, value):
+        self.raw_data['check_update'] = value
+        self._field_check_update = FIELD_TO_PARSE
 
     @property
     def repo(self):


### PR DESCRIPTION
### What does this PR do?
Implements logic that allows ddev to check on pypi for a package update. 

### Motivation
To help keep ddev of users up to date

### Specs
- Introduces a new param in the config.toml called check_update. Takes in a boolean. Defaults to True (False to disable)
- Create/reads/updates a file in the same directory as config.toml called registry.json
- Keeps a record of the last check version and date it was update in the registry.json
- Registry is updated every 7 days when running ddev
- Compares the current version with newest version if will output an upgrade message when possible
- Will not break if there's no internet connection
- 7 days right now is not configureable. But open to suggestion for longer durations


https://a.cl.ly/OAuojGdY
