### PR TITLE
TLS check: implement StartTLS protocol for Mysql

### DIFF
--- a/tls/assets/configuration/spec.yaml
+++ b/tls/assets/configuration/spec.yaml
@@ -145,5 +145,6 @@ files:
         type: string
         enum:
         - postgres
+        - mysql
     - template: instances/default
     - template: instances/tls

--- a/tls/assets/configuration/spec.yaml
+++ b/tls/assets/configuration/spec.yaml
@@ -140,7 +140,7 @@ files:
         irc, postgres, mysql, lmtp, nntp, sieve, and ldap.
 
         Currently this checks supports only the below protocols:
-          postgres
+          postgres, mysql
       value:
         type: string
         enum:

--- a/tls/datadog_checks/tls/config_models/instance.py
+++ b/tls/datadog_checks/tls/config_models/instance.py
@@ -49,7 +49,7 @@ class InstanceConfig(BaseModel):
     server: str
     server_hostname: Optional[str]
     service: Optional[str]
-    start_tls: Optional[Literal['postgres']]
+    start_tls: Optional[Literal['postgres', 'mysql']]
     tags: Optional[Sequence[str]]
     timeout: Optional[int]
     tls_ca_cert: Optional[str]

--- a/tls/datadog_checks/tls/data/conf.yaml.example
+++ b/tls/datadog_checks/tls/data/conf.yaml.example
@@ -133,7 +133,7 @@ instances:
     ## irc, postgres, mysql, lmtp, nntp, sieve, and ldap.
     ##
     ## Currently this checks supports only the below protocols:
-    ##   postgres
+    ##   postgres, mysql
     #
     # start_tls: <START_TLS>
 

--- a/tls/tests/compose/Dockerfile
+++ b/tls/tests/compose/Dockerfile
@@ -36,3 +36,8 @@ RUN openssl genrsa -out expired.mock.key 2048 \
 ENV PSQL_UID=70
 ENV PSQL_GUID=70
 RUN for file in valid.mock.key valid.mock.crt; do cp $file postgres.$file; chown $PSQL_UID:$PSQL_GUID postgres.$file; done
+
+## Prepare mysql certificates
+ENV MYSQL_UID=999
+ENV MYSQL_GUID=999
+RUN for file in valid.mock.key valid.mock.crt; do cp $file mysql.$file; chown $MYSQL_UID:$MYSQL_GUID mysql.$file; done

--- a/tls/tests/compose/docker-compose.yml
+++ b/tls/tests/compose/docker-compose.yml
@@ -58,5 +58,19 @@ services:
     depends_on:
       - cert-builder
 
+  # mysql serving valid.mysql.mock
+  starttls-mysql:
+    container_name: mysql-valid
+    image: mysql
+    volumes:
+      - certs:/var/lib/certs/:ro
+    ports:
+      - "3306:3306"
+    command: --default-authentication-plugin=mysql_native_password --ssl-cert=/var/lib/certs/mysql.valid.mock.crt --ssl-key=/var/lib/certs/mysql.valid.mock.key
+    environment:
+      - MYSQL_ROOT_PASSWORD=MysqlR00tpass
+    depends_on:
+      - cert-builder
+
 volumes:
   certs:

--- a/tls/tests/conftest.py
+++ b/tls/tests/conftest.py
@@ -32,7 +32,7 @@ HOSTNAME_TO_PORT_MAPPING = {
 
 @pytest.fixture(scope='session', autouse=True)
 def dd_environment(instance_e2e, mock_local_tls_dns):
-    with docker_run(os.path.join(HERE, 'compose', 'docker-compose.yml'), build=True, sleep=5):
+    with docker_run(os.path.join(HERE, 'compose', 'docker-compose.yml'), build=True, sleep=20):
         e2e_metadata = {'docker_volumes': ['{}:{}'.format(CA_CERT, CA_CERT_MOUNT_PATH)]}
         yield instance_e2e, e2e_metadata
 
@@ -256,5 +256,16 @@ def instance_remote_postgresql_valid():
         'port': 55432,
         'server_hostname': 'valid.mock',
         'start_tls': 'postgres',
+        'tls_ca_cert': CA_CERT,
+    }
+
+
+@pytest.fixture
+def instance_remote_mysql_valid():
+    return {
+        'server': 'localhost',
+        'port': 3306,
+        'server_hostname': 'valid.mock',
+        'start_tls': 'mysql',
         'tls_ca_cert': CA_CERT,
     }

--- a/tls/tests/test_remote.py
+++ b/tls/tests/test_remote.py
@@ -321,3 +321,17 @@ def test_postgres_ok(aggregator, instance_remote_postgresql_valid):
     aggregator.assert_metric('tls.days_left', count=1)
     aggregator.assert_metric('tls.seconds_left', count=1)
     aggregator.assert_all_metrics_covered()
+
+
+def test_mysql_ok(aggregator, instance_remote_mysql_valid):
+    c = TLSCheck('tls', {}, [instance_remote_mysql_valid])
+    c.check(None)
+
+    aggregator.assert_service_check(SERVICE_CHECK_CAN_CONNECT, status=c.OK, tags=c._tags, count=1)
+    aggregator.assert_service_check(SERVICE_CHECK_VERSION, status=c.OK, tags=c._tags, count=1)
+    aggregator.assert_service_check(SERVICE_CHECK_VALIDATION, status=c.OK, tags=c._tags, count=1)
+    aggregator.assert_service_check(SERVICE_CHECK_EXPIRATION, status=c.OK, tags=c._tags, count=1)
+
+    aggregator.assert_metric('tls.days_left', count=1)
+    aggregator.assert_metric('tls.seconds_left', count=1)
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds support for StartTLS implementation of Mysql protocol
### Motivation
<!-- What inspired you to submit this pull request? -->
Similar to PR https://github.com/DataDog/integrations-core/pull/12596 we need to monitor SSL/TLS certificate expiration dates on remote Mysql servers

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Had to increase sleep from 5 to 20 seconds in tls/tests/conftest.py to give Mysql docker container time to initialize default database. More details on https://hub.docker.com/_/mysql in section "No connections until MySQL init completes"

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.