### PR TITLE
Fix edge case in CI matrix construction

### DIFF
--- a/.github/workflows/submit-traces.yml
+++ b/.github/workflows/submit-traces.yml
@@ -32,11 +32,14 @@ jobs:
     - uses: actions/checkout@v3
 
     - uses: actions/download-artifact@v3
+      id: download
       with:
         name: "${{ inputs.artifact-name }}"
         path: captured-traces
+      continue-on-error: true
 
     - name: Replay
+      if: steps.download.outcome == 'success'
       run: |-
         cd captured-traces
         for request in *; do
@@ -49,9 +52,11 @@ jobs:
         done
 
     - name: Show Agent status
+      if: steps.download.outcome == 'success'
       run: docker exec $(docker ps --format "{{.ID}}") agent status
 
     - uses: geekyeggo/delete-artifact@v2
+      if: steps.download.outcome == 'success'
       with:
         name: "${{ inputs.artifact-name }}"
         failOnError: false


### PR DESCRIPTION
### Motivation

https://docs.python.org/3/library/fnmatch.html

> Note that the filename separator ('/' on Unix) is not special to this module.