### PR TITLE
Fix length check in release-hash-check.py script

### DIFF
--- a/.github/workflows/release-hash-check.py
+++ b/.github/workflows/release-hash-check.py
@@ -19,7 +19,7 @@ def error(*args):
 
 
 updated_link_files = [f for f in sys.argv[1:] if fnmatch(f, '.in-toto/tag.*.link')]
-if len(updated_link_files) < 0:
+if not updated_link_files:
     error("The release-hash-check should only run upon modification of a link file.")
 if len(updated_link_files) > 1:
     error("There should never be two different link files modified at the same time.")


### PR DESCRIPTION
### What does this PR do?

Fixes a check for an empty list in the `release-hash-check.py` script that runs on CI.

### Motivation

I've encountered this error on CI more than once:

```
Traceback (most recent call last):
  File ".github/workflows/release-hash-check.py", line 27, in <module>
    link_file = updated_link_files[0]
IndexError: list index out of range
```

Looking at the code I saw that the check that's supposed to check if the `updated_link_files` is empty was actually checking for negative length (!) so it wasn't really capturing this error condition. This way at least we'll get a more meaningful error message.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.