### PR TITLE
Sync third-party licenses metadata

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -9,13 +9,14 @@ Pyro4,PyPI,MIT,Copyright (c) 2016 Irmen de Jong
 aerospike,PyPI,Apache-2.0,"Copyright Aerospike, Inc."
 aws-requests-auth,PyPI,BSD-3-Clause,Copyright (c) David Muller.
 beautifulsoup4,PyPI,MIT,Copyright (c) 2004-2017 Leonard Richardson
-beautifulsoup4,PyPI,MIT,Copyright (c) Leonard Richardson
+beautifulsoup4,PyPI,MIT,Copyright (c) 2004-2022 Leonard Richardson
 binary,PyPI,Apache-2.0,Copyright 2018 Ofek Lev
-binary,PyPI,MIT,Copyright (c) 2018 Ofek Lev
+binary,PyPI,MIT,Copyright 2018 Ofek Lev
 boto,PyPI,MIT,Copyright (c) 2010 Mitch Garnaat
 boto3,PyPI,Apache-2.0,"Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved."
-botocore,PyPI,Apache-2.0,"Copyright 2012-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved."
+boto3,PyPI,Apache-2.0,Copyright 2014 Amazon Web Services
 botocore,PyPI,Apache-2.0,"Copyright 2012-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved."
+botocore,PyPI,Apache-2.0,Copyright 2012 Amazon Web Services
 cachetools,PyPI,MIT,Copyright (c) 2014-2019 Thomas Kemmer
 cachetools,PyPI,MIT,Copyright (c) 2014-2022 Thomas Kemmer
 check-postgres,"https://github.com/bucardo/",BSD-2-Clause,Copyright 2007 - 2023 Greg Sabino Mullane
@@ -27,8 +28,9 @@ cryptography,PyPI,Apache-2.0,Copyright (c) Individual contributors.
 cryptography,PyPI,BSD-3-Clause,Copyright (c) Individual contributors.
 cryptography,PyPI,PSF,Copyright (c) Individual contributors.
 ddtrace,PyPI,BSD-3-Clause,"Copyright (c) 2016, Datadog <info@datadoghq.com>"
+ddtrace,PyPI,BSD-3-Clause,"Copyright 2016 Datadog, Inc."
 dnspython,PyPI,ISC,Copyright (C) Dnspython Contributors
-enum34,PyPI,BSD-3-Clause,"Copyright (c) 2013, Ethan Furman."
+enum34,PyPI,BSD-3-Clause,Copyright Ethan Furman
 flup,Vendor,BSD-3-Clause,Copyright (c) 2005 Allan Saddi. All Rights Reserved.
 flup-py3,Vendor,BSD-3-Clause,"Copyright (c) 2005, 2006 Allan Saddi <allan@saddi.com> All rights reserved."
 foundationdb,PyPI,Apache-2.0,Copyright 2017 FoundationDB
@@ -43,7 +45,7 @@ jellyfish,PyPI,BSD-3-Clause,"Copyright (c) 2015, James Turk"
 kafka-python,PyPI,Apache-2.0,Copyright 2015 David Arthur
 kazoo,PyPI,Apache-2.0,Copyright 2012 Kazoo team
 kubernetes,PyPI,Apache-2.0,Copyright 2014 The Kubernetes Authors.
-ldap3,PyPI,LGPL-3.0-only,Copyright (C) 2014 Giovanni Cannata
+ldap3,PyPI,LGPL-3.0-only,Copyright 2013 - 2020 Giovanni Cannata
 lxml,PyPI,BSD-3-Clause,Copyright (c) 2004 Infrae. All rights reserved.
 lz4,PyPI,BSD-3-Clause,"Copyright (c) 2012-2013, Steeve Morin"
 mmh3,PyPI,CC0-1.0,Hajime Senuma. mmh3 is dedicated to the public domain under CC0-1.0.
@@ -55,9 +57,11 @@ orjson,PyPI,MIT,Copyright (c) 2018 ijl <ijl@mailbox.org>
 packaging,PyPI,Apache-2.0,Copyright (c) Donald Stufft and individual contributors.
 packaging,PyPI,BSD-3-Clause,Copyright (c) Donald Stufft and individual contributors.
 paramiko,PyPI,LGPL-2.1-only,Copyright (C) 2009 Jeff Forcier
-ply,PyPI,BSD-3-Clause,Copyright David Beazley
+ply,PyPI,BSD-3-Clause,Copyright (C) 2001-2018
+prometheus-client,PyPI,Apache-2.0,Copyright 2015 Brian Brazil
 prometheus-client,PyPI,Apache-2.0,Copyright 2015 The Prometheus Authors
-protobuf,PyPI,BSD-3-Clause,Copyright 2014 protobuf@googlegroups.com
+protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.
+protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.  All rights reserved.
 psutil,PyPI,BSD-3-Clause,"Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola'"
 psycopg2-binary,PyPI,BSD-3-Clause,Copyright 2013 Federico Di Gregorio
 psycopg2-binary,PyPI,LGPL-3.0-only,Copyright (C) 2013 Federico Di Gregorio
@@ -71,7 +75,7 @@ pymysql,PyPI,MIT,"Copyright (c) 2010, 2013 PyMySQL contributors"
 pyodbc,PyPI,MIT,Copyright (c) 2008 Michael Kleehammer
 pysmi,PyPI,BSD-3-Clause,Copyright (c) 2015-2019 Ilya Etingof <etingof@gmail.com>
 pysnmp,PyPI,BSD-3-Clause,"Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>"
-pysnmp-mibs,PyPI,BSD-3-Clause,Copyright Ilya Etingof <ilya@glas.net>
+pysnmp-mibs,PyPI,BSD-3-Clause,"Copyright (c) 2005-2016, Ilya Etingof <ilya@glas.net>"
 python-binary-memcached,PyPI,MIT,Copyright (c) 2011 Jayson Reis
 python-binary-memcached,PyPI,MIT,Copyright (c) 2011 Jayson Reis <santosdosreis@gmail.com>
 python-dateutil,PyPI,Apache-2.0,Copyright 2017- Paul Ganssle <paul@ganssle.io>
@@ -81,10 +85,9 @@ pyvmomi,PyPI,Apache-2.0,"Copyright (c) 2005-2021 VMware, Inc. All Rights Reserve
 pywin32,PyPI,PSF,Copyright 2002-2003 by Blackdog Software Pty Ltd.
 redis,PyPI,MIT,"Copyright (c) 2022, Redis, inc."
 redis,PyPI,MIT,Copyright (c) 2012 Andy McCurdy
-requests,PyPI,Apache-2.0,Copyright 2011 Kenneth Reitz
-requests-kerberos,PyPI,ISC,"Copyright 2012 Ian Cordasco, Cory Benfield, Michael Komitee"
+requests,PyPI,Apache-2.0,Copyright 2019 Kenneth Reitz
 requests-kerberos,PyPI,ISC,Copyright (c) 2012 Kenneth Reitz
-requests-ntlm,PyPI,ISC,Copyright 2012 Ben Toews
+requests-ntlm,PyPI,ISC,Copyright (c) 2013 Ben Toews
 requests-oauthlib,PyPI,BSD-3-Clause,Copyright (c) 2014 Kenneth Reitz.
 requests-oauthlib,PyPI,ISC,Copyright (c) 2014 Kenneth Reitz.
 requests-toolbelt,PyPI,Apache-2.0,"Copyright 2014 Ian Cordasco, Cory Benfield"
@@ -100,8 +103,8 @@ simplejson,PyPI,MIT,Copyright (c) 2006 Bob Ippolito
 six,PyPI,MIT,Copyright (c) 2010-2020 Benjamin Peterson
 snowflake-connector-python,PyPI,Apache-2.0,"Copyright (c) 2013-2019 Snowflake Computing, Inc."
 supervisor,PyPI,BSD-3-Clause-Modification,"Copyright (c) 2002-2005, Daniel Krech, http://eikeon.com/"
-tuf,PyPI,Apache-2.0,Copyright 2013 theupdateframework@googlegroups.com
-tuf,PyPI,MIT,Copyright (c) 2013 theupdateframework@googlegroups.com
+tuf,PyPI,Apache-2.0,Copyright (c) 2010 New York University
+tuf,PyPI,MIT,Copyright (c) 2010 New York University
 typing,PyPI,PSF,"Copyright (c) 1991 - 1995, Stichting Mathematisch Centrum Amsterdam"
 uptime,PyPI,BSD-2-Clause,"Copyright (c) 2012, Koen Crolla"
 vertica-python,PyPI,Apache-2.0,"Copyright 2013 Justin Berka, Alex Kim, Siting Ren"


### PR DESCRIPTION
### Motivation

This fix https://github.com/DataDog/integrations-core/pull/14358 was not available when this https://github.com/DataDog/integrations-core/pull/14354 was open and since the config validation happens first the license error was not seen