### PR TITLE
add rabbitmq /metrics/detailed example

### DIFF
--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -38,8 +38,15 @@ Configure the `prometheus_plugin` section in your instance configuration. When u
        url: http://<HOST>:15692
  ```
 
- This enables scraping of the [`/metrics` endpoint][20] on one RabbitMQ node. We can also collect data from the [`/metrics/detailed` endpoint][22].
+ This enables scraping of the [`/metrics` endpoint][20] on one RabbitMQ node. We can also collect data from the [`/metrics/detailed` endpoint][22]. 
 
+ ```yaml
+ instances:
+   - prometheus_plugin:
+       url: http://<HOST>:15692
+       unaggregated_endpoint: detailed?family=queue_coarse_metrics
+ ```
+ This enables scraping of the [`/metrics/detailed` endpoint][22] and collect `queue coarse metrics`.
 
 ##### [RabbitMQ Management Plugin][4].
 

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -46,7 +46,7 @@ Configure the `prometheus_plugin` section in your instance configuration. When u
        url: http://<HOST>:15692
        unaggregated_endpoint: detailed?family=queue_coarse_metrics
  ```
- This enables scraping of the [`/metrics/detailed` endpoint][22] and collect `queue coarse metrics`.
+ This enables scraping of the [`/metrics/detailed` endpoint][22] to collect queue coarse metrics.
 
 ##### [RabbitMQ Management Plugin][4].
 


### PR DESCRIPTION

### What does this PR do?
Add an example of how to scrap the /metrics/detailed endpoint of rabbitmq prometheus plugin in the documentation;

### Motivation
The documentation lacks this information; 

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.