### PR TITLE
Upgrade psycopg2-binary on Python 3 to 2.9.6

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -58,7 +58,8 @@ prometheus-client==0.15.0; python_version > '3.0'
 protobuf==3.17.3; python_version < '3.0'
 protobuf==3.20.2; python_version > '3.0'
 psutil==5.9.0
-psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'
+psycopg2-binary==2.8.6; python_version < '3.0'
+psycopg2-binary==2.9.6; python_version > '3.0'
 pyasn1==0.4.6
 pycryptodomex==3.10.1
 pydantic==1.10.4; python_version > '3.0'

--- a/pgbouncer/pyproject.toml
+++ b/pgbouncer/pyproject.toml
@@ -41,7 +41,8 @@ text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "psycopg2-binary==2.8.6; python_version < '3.0'",
+    "psycopg2-binary==2.9.6; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -44,7 +44,8 @@ deps = [
     "cachetools==3.1.1; python_version < '3.0'",
     "cachetools==5.2.1; python_version > '3.0'",
     "futures==3.4.0; python_version < '3.0'",
-    "psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "psycopg2-binary==2.8.6; python_version < '3.0'",
+    "psycopg2-binary==2.9.6; python_version > '3.0'",
     "semver==2.13.0",
 ]
 


### PR DESCRIPTION
This was unblocked by https://github.com/DataDog/integrations-core/pull/13818