### PR TITLE
DOCS-3931 fix region-param tags showing on in-app docs

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -41,6 +41,9 @@ The instructions below show you how to configure the task using the [Amazon Web 
 <!-- xxx tab "Web UI" xxx -->
 ##### Web UI Task Definition
 
+<!-- partial
+{{< site-region region="us,us3,us5,eu,ap1,gov" >}}
+
 1. Log in to your [AWS Web Console][4] and navigate to the ECS section.
 2. Click on **Task Definitions** in the left menu, then click the **Create new Task Definition** button or choose an existing Fargate task definition.
 3. For new task definitions:
@@ -58,13 +61,26 @@ The instructions below show you how to configure the task using the [Amazon Web 
 5. Add your other application containers to the task definition. For details on collecting integration metrics, see [Integration Setup for ECS Fargate][12].
 6. Click **Create** to create the task definition.
 
+[4]: https://aws.amazon.com/console
+[12]: http://docs.datadoghq.com/integrations/faq/integration-setup-ecs-fargate
+[41]: https://app.datadoghq.com/organization-settings/api-keys
+
+{{< /site-region >}}
+partial -->
+
 <!-- xxz tab xxx -->
 
 <!-- xxx tab "AWS CLI" xxx -->
 ##### AWS CLI Task Definition
 
 1. Download [datadog-agent-ecs-fargate.json][42]. **Note**: If you are using Internet Explorer, this may download as gzip file, which contains the JSON file mentioned below.**
+<!-- partial
+{{< site-region region="us,us3,us5,eu,ap1,gov" >}}
 2. Update the JSON with a `TASK_NAME`, your [Datadog API Key][41], and the appropriate `DD_SITE` ({{< region-param key="dd_site" code="true" >}}). **Note**: The environment variable `ECS_FARGATE` is already set to `"true"`.
+
+[41]: https://app.datadoghq.com/organization-settings/api-keys
+{{< /site-region >}}
+partial -->
 3. Add your other application containers to the task definition. For details on collecting integration metrics, see [Integration Setup for ECS Fargate][12].
 4. Optionally - Add an Agent health check.
 
@@ -92,7 +108,13 @@ aws ecs register-task-definition --cli-input-json file://<PATH_TO_FILE>/datadog-
 
 You can use [AWS CloudFormation][6] templating to configure your Fargate containers. Use the `AWS::ECS::TaskDefinition` resource within your CloudFormation template to set the Amazon ECS task and specify `FARGATE` as the required launch type for that task.
 
+<!-- partial
+{{< site-region region="us,us3,us5,eu,ap1,gov" >}}
 Update this CloudFormation template below with your [Datadog API Key][41]. As well as include the appropriate `DD_SITE` ({{< region-param key="dd_site" code="true" >}}) environment variable if necessary, as this defaults to `datadoghq.com` if you don't set it.
+
+[41]: https://app.datadoghq.com/organization-settings/api-keys
+{{< /site-region >}}
+partial -->
 
 ```yaml
 Resources:
@@ -434,7 +456,14 @@ partial -->
   ```
 {{< /site-region >}}
 partial -->
-  **Note**: Set your `apikey` as well as the `Host` relative to your respective site `http-intake.logs.{{< region-param key="dd_site" code="true" >}}`. The full list of available parameters is described in the [Datadog Fluent Bit documentation][24].
+
+<!-- partial
+{{< site-region region="us,us3,us5,eu,ap1,gov" >}}
+**Note**: Set your `apikey` as well as the `Host` relative to your respective site `http-intake.logs.`{{< region-param key="dd_site" code="true" >}}. The full list of available parameters is described in the [Datadog Fluent Bit documentation][24].
+
+[24]: https://docs.datadoghq.com/integrations/fluentbit/#configuration-parameters
+{{< /site-region >}}
+partial -->
 
   The `dd_service`, `dd_source`, and `dd_tags` can be adjusted for your desired tags.
 
@@ -690,7 +719,11 @@ Monitor Fargate logs by using the `awslogs` log driver and a Lambda function to 
 
 ### Trace collection
 
+<!-- partial
+{{< site-region region="us,us3,us5,eu,ap1,gov" >}}
 1. Follow the [instructions above](#installation) to add the Datadog Agent container to your task definition with the additional environment variable `DD_APM_ENABLED` set to `true`. Set the `DD_SITE` variable to {{< region-param key="dd_site" code="true" >}}. It defaults to `datadoghq.com` if you don't set it.
+{{< /site-region >}}
+partial -->
 
 2. [Instrument your application][32] based on your setup. With Fargate APM applications do **not** set `DD_AGENT_HOST`, the default of `localhost` works.
 


### PR DESCRIPTION
### What does this PR do?
Fixes ecs_fargate readme so that it shows up correctly in app as well as on docs site

### Motivation
DOCS-3931

### Additional Notes
In-app: https://app.datadoghq.com/integrations/aws-fargate
Docs: https://docs.datadoghq.com/integrations/ecs_fargate/

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.