### PR TITLE
Be specific about the exposition formats supported

### DIFF
--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -2,9 +2,11 @@
 
 ## Overview
 
-Extract custom metrics from any OpenMetrics endpoints.
+Extract custom metrics from any OpenMetrics or Prometheus endpoints.
 
 <div class="alert alert-warning">All the metrics retrieved by this integration are considered <a href="https://docs.datadoghq.com/developers/metrics/custom_metrics">custom metrics</a>.</div>
+
+The integration is compatible with both the [Prometheus exposition format][12] (by default) as well as with the [OpenMetrics specification][13] (via configuration).
 
 ## Setup
 
@@ -22,9 +24,11 @@ For each instance the following parameters are required:
 
 | Parameter        | Description                                                                                                                                                                                                                                                              |
 | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `openmetrics_endpoint` | The URL where your application metrics are exposed by OpenMetrics (must be unique).                                                                                                                         |
+| `openmetrics_endpoint` | The URL where your application metrics are exposed in Prometheus or OpenMetrics format (must be unique).                                                                                                                         |
 | `namespace`      | The namespace to prepend to all metrics.                                                                                                                                                                                                                                 |
 | `metrics`        | A list of metrics to retrieve as custom metrics. Add each metric to the list as `metric_name` or `metric_name: renamed` to rename it. The metrics are interpreted as regular expressions. Use `.*` as a wildcard (`metric.*`) to fetch all matching metrics. **Note**: Regular expressions can potentially send a lot of custom metrics. |
+
+The integration assumes the metrics to be exposed in the [Prometheus exposition format][12] by default. Set the `use_latest_spec` option to `true` if the metrics you want to retrieve follow the [OpenMetrics specification][13] instead.
 
 **Note**: This is a new default OpenMetrics check example as of Datadog Agent version 7.32.0. If you previously implemented this integration, see the [legacy example][5].
 
@@ -78,3 +82,5 @@ Need help? Contact [Datadog support][8].
 [9]: https://docs.datadoghq.com/agent/openmetrics/
 [10]: https://docs.datadoghq.com/developers/openmetrics/
 [11]: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#suffixes
+[12]: https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
+[13]: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#suffixes

--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -6,7 +6,7 @@ Extract custom metrics from any OpenMetrics or Prometheus endpoints.
 
 <div class="alert alert-warning">All the metrics retrieved by this integration are considered <a href="https://docs.datadoghq.com/developers/metrics/custom_metrics">custom metrics</a>.</div>
 
-The integration is compatible with both the [Prometheus exposition format][12] (by default) as well as with the [OpenMetrics specification][13] (via configuration).
+The integration is compatible with both the [Prometheus exposition format][12] as well as with the [OpenMetrics specification][13].
 
 ## Setup
 
@@ -27,8 +27,6 @@ For each instance the following parameters are required:
 | `openmetrics_endpoint` | The URL where your application metrics are exposed in Prometheus or OpenMetrics format (must be unique).                                                                                                                         |
 | `namespace`      | The namespace to prepend to all metrics.                                                                                                                                                                                                                                 |
 | `metrics`        | A list of metrics to retrieve as custom metrics. Add each metric to the list as `metric_name` or `metric_name: renamed` to rename it. The metrics are interpreted as regular expressions. Use `.*` as a wildcard (`metric.*`) to fetch all matching metrics. **Note**: Regular expressions can potentially send a lot of custom metrics. |
-
-The integration assumes the metrics to be exposed in the [Prometheus exposition format][12] by default. Set the `use_latest_spec` option to `true` if the metrics you want to retrieve follow the [OpenMetrics specification][13] instead.
 
 **Note**: This is a new default OpenMetrics check example as of Datadog Agent version 7.32.0. If you previously implemented this integration, see the [legacy example][5].
 


### PR DESCRIPTION
### What does this PR do?

Clarifies what formats are supported by the OpenMetrics check ~~and how to configure which format is used.~~


### Motivation

[AI-2416](https://datadoghq.atlassian.net/browse/AI-2416).

The docs don't provide any clarity as to what the actual format that we support by default in the OpenMetrics check is and  the name of the check (OpenMetrics, when we already have a check called Prometheus) doesn't help, considering we're actually assuming Prometheus format by default and not OpenMetrics. It's also not obvious how to enable OpenMetrics spec support (I'll be updating the config template to add some documentation in there as well).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.

[AI-2416]: https://datadoghq.atlassian.net/browse/AI-2416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ