### PR TITLE
Fix e2e test due to subnet being now optional

### DIFF
--- a/snmp/tests/test_e2e_core_metadata.py
+++ b/snmp/tests/test_e2e_core_metadata.py
@@ -151,7 +151,6 @@ def test_e2e_core_metadata_f5(dd_agent_check):
                 {"interface_id": "default:{}:32".format(device_ip), "ip_address": "10.164.0.51", "prefixlen": 32}
             ],
             u'namespace': u'default',
-            u'subnet': u'',
         },
     ]
     assert_metadata_events(aggregator, events)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix e2e test due to subnet being now optional

### Motivation
<!-- What inspired you to submit this pull request? -->


We added `omitempty` to subnet field here:
https://github.com/DataDog/datadog-agent/pull/16360/files#diff-e7320c03af9cecaf5519e47796b924d474112f6d1c07c4b457b042145f2371d5R35

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.