### PR TITLE
Implement regex for consumer_groups

### DIFF
--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -62,8 +62,28 @@ files:
       - name: consumer_groups
         description: |
           Each level is optional. Any empty values are fetched from the Kafka cluster.
-          You can have empty partitions (example: <CONSUMER_NAME_2>), topics (example: <CONSUMER_NAME_3>),
-          and even consumer_groups. If you omit consumer_groups, you must set `monitor_unlisted_consumer_groups` to true.
+          You can have empty partitions (example: <CONSUMER_NAME_2>), topics
+          (example: <CONSUMER_NAME_3>),
+          and even consumer_groups. If you do not specify `consumer_groups`,
+          you must set `monitor_unlisted_consumer_groups` to true. 
+          
+          If both `consumer_groups` and `monitor_unlisted_consumer_groups` are used,
+          then `consumer_groups` is ignored.
+        value:
+          type: object
+          example:
+            <CONSUMER_NAME_1>:
+              <TOPIC_NAME_1>: [0, 1, 4, 12]
+            <CONSUMER_NAME_2>:
+              <TOPIC_NAME_2>: []
+            <CONSUMER_NAME_3>: {}
+      - name: consumer_groups_regex
+        description: |
+          Set consumer groups and topics as regex strings.
+          If both `consumer_groups_regex` and `consumer_groups` are filled out,
+          both configuration options will be used. 
+          If `monitor_unlisted_consumer_groups` is enabled, then
+          `consumer_groups_regex` is ignored.
         value:
           type: object
           example:

--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -94,8 +94,8 @@ files:
             <CONSUMER_NAME_3>: {}
       - name: monitor_unlisted_consumer_groups
         description: |
-          Setting monitor_unlisted_consumer_groups to `true` tells the check to discover all consumer groups
-          and fetch all their known offsets. If this is not set to true, you must specify consumer_groups.
+          Setting `monitor_unlisted_consumer_groups` to `true` tells the check to discover all consumer groups
+          and fetch all their known offsets. If this is not set to true, you must specify `consumer_groups`.
 
           WARNING: This feature requires that your Kafka brokers be version >= 0.10.2. It is impossible to
           support this feature on older brokers because they do not provide a way to determine the mapping

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -302,4 +302,4 @@ class KafkaClient:
                         )
                         continue
 
-                yield (topic, partition)
+                    yield (topic, partition)

--- a/kafka_consumer/datadog_checks/kafka_consumer/config.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config.py
@@ -20,11 +20,11 @@ class KafkaConfig:
             instance.get('monitor_all_broker_highwatermarks', False)
         )
         self._consumer_groups = instance.get('consumer_groups', {})
-
-        self._kafka_connect_str = instance.get('kafka_connect_str')
         self._consumer_groups_regex = instance.get('consumer_groups_regex', {})
 
         self._consumer_groups_compiled_regex = self._compile_regex(self._consumer_groups_regex)
+
+        self._kafka_connect_str = instance.get('kafka_connect_str')
         self._kafka_version = instance.get('kafka_client_api_version')
         if isinstance(self._kafka_version, str):
             self._kafka_version = tuple(map(int, self._kafka_version.split(".")))

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/defaults.py
@@ -22,6 +22,10 @@ def instance_consumer_groups(field, value):
     return get_default_field_value(field, value)
 
 
+def instance_consumer_groups_regex(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_disable_generic_tags(field, value):
     return False
 

--- a/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config_models/instance.py
@@ -41,6 +41,7 @@ class InstanceConfig(BaseModel):
         allow_mutation = False
 
     consumer_groups: Optional[Mapping[str, Any]]
+    consumer_groups_regex: Optional[Mapping[str, Any]]
     disable_generic_tags: Optional[bool]
     empty_default_hostname: Optional[bool]
     kafka_client_api_version: Optional[str]

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -94,8 +94,8 @@ instances:
     #   <CONSUMER_NAME_3>: {}
 
     ## @param monitor_unlisted_consumer_groups - boolean - optional - default: false
-    ## Setting monitor_unlisted_consumer_groups to `true` tells the check to discover all consumer groups
-    ## and fetch all their known offsets. If this is not set to true, you must specify consumer_groups.
+    ## Setting `monitor_unlisted_consumer_groups` to `true` tells the check to discover all consumer groups
+    ## and fetch all their known offsets. If this is not set to true, you must specify `consumer_groups`.
     ##
     ## WARNING: This feature requires that your Kafka brokers be version >= 0.10.2. It is impossible to
     ## support this feature on older brokers because they do not provide a way to determine the mapping

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -56,10 +56,33 @@ instances:
 
     ## @param consumer_groups - mapping - optional
     ## Each level is optional. Any empty values are fetched from the Kafka cluster.
-    ## You can have empty partitions (example: <CONSUMER_NAME_2>), topics (example: <CONSUMER_NAME_3>),
-    ## and even consumer_groups. If you omit consumer_groups, you must set `monitor_unlisted_consumer_groups` to true.
+    ## You can have empty partitions (example: <CONSUMER_NAME_2>), topics
+    ## (example: <CONSUMER_NAME_3>),
+    ## and even consumer_groups. If you do not specify `consumer_groups`,
+    ## you must set `monitor_unlisted_consumer_groups` to true. 
+    ##
+    ## If both `consumer_groups` and `monitor_unlisted_consumer_groups` are used,
+    ## then `consumer_groups` is ignored.
     #
     # consumer_groups:
+    #   <CONSUMER_NAME_1>:
+    #     <TOPIC_NAME_1>:
+    #     - 0
+    #     - 1
+    #     - 4
+    #     - 12
+    #   <CONSUMER_NAME_2>:
+    #     <TOPIC_NAME_2>: []
+    #   <CONSUMER_NAME_3>: {}
+
+    ## @param consumer_groups_regex - mapping - optional
+    ## Set consumer groups and topics as regex strings.
+    ## If both `consumer_groups_regex` and `consumer_groups` are filled out,
+    ## both configuration options will be used. 
+    ## If `monitor_unlisted_consumer_groups` is enabled, then
+    ## `consumer_groups_regex` is ignored.
+    #
+    # consumer_groups_regex:
     #   <CONSUMER_NAME_1>:
     #     <TOPIC_NAME_1>:
     #     - 0

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -23,7 +23,7 @@ class KafkaCheck(AgentCheck):
 
     def __init__(self, name, init_config, instances):
         super(KafkaCheck, self).__init__(name, init_config, instances)
-        self.config = KafkaConfig(self.init_config, self.instance)
+        self.config = KafkaConfig(self.init_config, self.instance, self.log)
         self._context_limit = self.config._context_limit
         self.client = KafkaClient(self.config, self.get_tls_context(), self.log)
         self.check_initializations.append(self.config.validate_config)


### PR DESCRIPTION
Remake of https://github.com/DataDog/integrations-core/pull/14193

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds a new config option called `consumer_groups_regex`. This functions similarly to `consumer_groups` to allow configuration of consumer groups, topics, and partitions to monitor, however this allows regex strings to be used. 

This will be merged to `master` after https://github.com/DataDog/integrations-core/pull/13918 is merged.
### Motivation
<!-- What inspired you to submit this pull request? -->
Feature request
### Additional Notes
<!-- Anything else we should know when reviewing? -->
When `monitor_unlisted_consumer_groups` is set to `True`, then both `consumer_groups` and `consumer_groups_regex` will be ignored. 

When `consumer_groups` and `consumer_groups_regex` are both used, then consumer groups from both config options will be collected.
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.