### PR TITLE
Change tested versions on confluent platform

### DIFF
--- a/confluent_platform/hatch.toml
+++ b/confluent_platform/hatch.toml
@@ -2,17 +2,17 @@
 
 [[envs.default.matrix]]
 python = ["2.7", "3.8"]
-version = ["5.4", "6.2"]
+version = ["6.2", "7.0"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
-  { key = "CONFLUENT_VERSION", value = "5.4.0", if = ["5.4"] },
-  { key = "CONFLUENT_VERSION_CONNECT", value = "0.2.0-5.4.0", if = ["5.4"] },
-  { key = "CONFLUENT_KSQLDB_NAME", value = "ksql", if = ["5.4"] },
-
   { key = "CONFLUENT_VERSION", value = "6.2.0", if = ["6.2"] },
   { key = "CONFLUENT_VERSION_CONNECT", value = "0.5.0-6.2.0", if = ["6.2"] },
   { key = "CONFLUENT_KSQLDB_NAME", value = "ksqldb", if = ["6.2"] },
+
+  { key = "CONFLUENT_VERSION", value = "7.0.9", if = ["7.0"] },
+  { key = "CONFLUENT_VERSION_CONNECT", value = "0.5.0-6.2.0", if = ["7.0"] },
+  { key = "CONFLUENT_KSQLDB_NAME", value = "ksqldb", if = ["7.0"] },
 ]
 
 [envs.default.env-vars]


### PR DESCRIPTION
5.4 ended platinum support on January, 5.5 will end support next week.