### PR TITLE
Fix the `prepare script`

### DIFF
--- a/.ddev/ci/scripts/kafka_consumer/linux/32_install_kerberos.sh
+++ b/.ddev/ci/scripts/kafka_consumer/linux/32_install_kerberos.sh
@@ -2,14 +2,15 @@
 
 set -ex
 
-sudo apt-get update
-sudo apt install build-essential
-sudo apt-get install -y --no-install-recommends libkrb5-dev wget software-properties-common lsb-release gcc make python3 python3-pip python3-dev libsasl2-modules-gssapi-mit krb5-user
-
-# Install the latest version of librdkafka:
-wget -qO - https://packages.confluent.io/deb/7.3/archive.key | sudo apt-key add -
-sudo add-apt-repository "deb https://packages.confluent.io/clients/deb $(lsb_release -cs) main"
 sudo apt update
-sudo apt install -y librdkafka-dev
+sudo apt install -y --no-install-recommends build-essential libkrb5-dev wget software-properties-common lsb-release gcc make python3 python3-pip python3-dev libsasl2-modules-gssapi-mit krb5-user
+
+# Install librdkafka from source since no binaries are available for the distribution we use on the CI:
+git clone https://github.com/confluentinc/librdkafka
+cd librdkafka
+git checkout v2.0.2
+sudo ./configure --install-deps --prefix=/usr
+make
+sudo make install
 
 set +ex

--- a/kafka_consumer/hatch.toml
+++ b/kafka_consumer/hatch.toml
@@ -5,6 +5,7 @@ dependencies = [
   "datadog_checks_tests_helper @ {root:uri}/../datadog_checks_tests_helper",
 ]
 e2e-env = false
+# If you bump the `confluent-kafka` version, also bump the `librdkafka` version in the `32_install_kerberos.sh` file
 post-install-commands = [
   "python -m pip uninstall -y confluent-kafka",
   "python -m pip install --no-binary confluent-kafka confluent-kafka==2.0.2",

--- a/kafka_consumer/tests/README.md
+++ b/kafka_consumer/tests/README.md
@@ -14,6 +14,8 @@ For other systems, you can follow the instructions [here](https://github.com/con
 
 Once done, you can run `ddev test kafka_consumer`, the `confluent-kafka` will be built from source.
 
+Note: On CI, the dependencies are built in the `32_install_kerberos.sh` script.
+
 ## Troubleshooting
 
 ### fatal error: 'librdkafka/rdkafka.h' file not found


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Build librdkafka from source to run the tests in the CI. 

### Motivation
<!-- What inspired you to submit this pull request? -->

- It seems that we no longer have OOTB binaries for ubuntu 22.04 that we are using in the CI (GitHub actions). It was working well on azure but I think we were using a different version
- It's needed to be able to run the tests, especially the kerberos tests.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Also works on azure

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.