### PR TITLE
Improve pg tests speed

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -574,7 +574,7 @@ class PostgreSql(AgentCheck):
                     try:
                         db.close()
                     except Exception:
-                        self._log.exception("failed to close DB connection for db=%s", dbname)
+                        self.log.exception("failed to close DB connection for db=%s", dbname)
                 self._db_pool[dbname] = None
 
     def _collect_custom_queries(self, tags):

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -337,11 +337,11 @@ def bob_conn():
 @pytest.fixture
 def dbm_instance(pg_instance):
     pg_instance['dbm'] = True
-    pg_instance['min_collection_interval'] = 1
+    pg_instance['min_collection_interval'] = 0.2
     pg_instance['pg_stat_activity_view'] = "datadog.pg_stat_activity()"
-    pg_instance['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 1}
-    pg_instance['query_activity'] = {'enabled': True, 'collection_interval': 1}
-    pg_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 10}
+    pg_instance['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.2}
+    pg_instance['query_activity'] = {'enabled': True, 'collection_interval': 0.2}
+    pg_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.2}
     return pg_instance
 
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -337,11 +337,11 @@ def bob_conn():
 @pytest.fixture
 def dbm_instance(pg_instance):
     pg_instance['dbm'] = True
-    pg_instance['min_collection_interval'] = 0.2
+    pg_instance['min_collection_interval'] = 0.1
     pg_instance['pg_stat_activity_view'] = "datadog.pg_stat_activity()"
-    pg_instance['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.2}
-    pg_instance['query_activity'] = {'enabled': True, 'collection_interval': 0.2}
-    pg_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.2}
+    pg_instance['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    pg_instance['query_activity'] = {'enabled': True, 'collection_interval': 0.1}
+    pg_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
     return pg_instance
 
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1294,7 +1294,7 @@ def _check_until_time(check, dbm_instance, sleep_time, check_interval):
     start_time = time.time()
     elapsed = 0
     # Keep calling check to avoid triggering check inactivity
-    while elapsed < 1:
+    while elapsed < sleep_time:
         check.check(dbm_instance)
         time.sleep(check_interval)
         elapsed = time.time() - start_time

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1311,7 +1311,7 @@ def test_statement_samples_main_collection_rate_limit(aggregator, integration_ch
     check = integration_check(dbm_instance)
     check._connect()
     sleep_time = 1
-    _check_until_time(check, dbm_instance, sleep_time, collection_interval / 2.0)
+    _check_until_time(check, dbm_instance, sleep_time, collection_interval / 5.0)
     max_collections = int(1 / collection_interval * sleep_time) + 1
     check.cancel()
     metrics = aggregator.metrics("dd.postgres.collect_statement_samples.time")
@@ -1331,7 +1331,7 @@ def test_activity_collection_rate_limit(aggregator, integration_check, dbm_insta
     check._connect()
     check.check(dbm_instance)
     sleep_time = 1
-    _check_until_time(check, dbm_instance, sleep_time, collection_interval / 2.0)
+    _check_until_time(check, dbm_instance, sleep_time, collection_interval / 5.0)
     max_activity_collections = int(1 / activity_interval * sleep_time) + 1
     check.cancel()
     activity_metrics = aggregator.metrics("dd.postgres.collect_activity_snapshot.time")

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -988,7 +988,7 @@ def test_activity_snapshot_collection(
         # close blocking_bob's tx
         blocking_conn.close()
         # Wait collection interval to make sure dbm events are reported
-        time.sleep(0.2)
+        time.sleep(dbm_instance['query_activity']['collection_interval'])
         check.check(dbm_instance)
         dbm_activity_event = aggregator.get_event_platform_events("dbm-activity")
         event = dbm_activity_event[1]

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1311,7 +1311,7 @@ def test_statement_samples_main_collection_rate_limit(aggregator, integration_ch
     check = integration_check(dbm_instance)
     check._connect()
     sleep_time = 1
-    _check_until_time(check, dbm_instance, sleep_time, collection_interval)
+    _check_until_time(check, dbm_instance, sleep_time, collection_interval / 2.0)
     max_collections = int(1 / collection_interval * sleep_time) + 1
     check.cancel()
     metrics = aggregator.metrics("dd.postgres.collect_statement_samples.time")
@@ -1331,7 +1331,7 @@ def test_activity_collection_rate_limit(aggregator, integration_check, dbm_insta
     check._connect()
     check.check(dbm_instance)
     sleep_time = 1
-    _check_until_time(check, dbm_instance, sleep_time, collection_interval)
+    _check_until_time(check, dbm_instance, sleep_time, collection_interval / 2.0)
     max_activity_collections = int(1 / activity_interval * sleep_time) + 1
     check.cancel()
     activity_metrics = aggregator.metrics("dd.postgres.collect_activity_snapshot.time")

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1311,7 +1311,10 @@ def test_statement_samples_main_collection_rate_limit(aggregator, integration_ch
     check = integration_check(dbm_instance)
     check._connect()
     sleep_time = 1
-    _check_until_time(check, dbm_instance, sleep_time, collection_interval / 5.0)
+    # We do 5 check per collection interval to make sure we exit
+    # the loop and trigger cancel before another job_loop is triggered
+    check_frequency = collection_interval / 5.0
+    _check_until_time(check, dbm_instance, sleep_time, check_frequency)
     max_collections = int(1 / collection_interval * sleep_time) + 1
     check.cancel()
     metrics = aggregator.metrics("dd.postgres.collect_statement_samples.time")
@@ -1331,7 +1334,10 @@ def test_activity_collection_rate_limit(aggregator, integration_check, dbm_insta
     check._connect()
     check.check(dbm_instance)
     sleep_time = 1
-    _check_until_time(check, dbm_instance, sleep_time, collection_interval / 5.0)
+    # We do 5 check per collection interval to make sure we exit
+    # the loop and trigger cancel before another job_loop is triggered
+    check_frequency = collection_interval / 5.0
+    _check_until_time(check, dbm_instance, sleep_time, check_frequency)
     max_activity_collections = int(1 / activity_interval * sleep_time) + 1
     check.cancel()
     activity_metrics = aggregator.metrics("dd.postgres.collect_activity_snapshot.time")

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -437,6 +437,8 @@ def test_failed_explain_handling(
     skip_on_versions,
 ):
     dbname = "datadog_test"
+    # Don't need metrics for this one
+    dbm_instance['query_metrics']['enabled'] = False
     if explain_function_override:
         dbm_instance['query_samples']['explain_function'] = explain_function_override
     check = integration_check(dbm_instance)
@@ -583,6 +585,7 @@ def test_statement_samples_collect(
     expected_warnings,
 ):
     dbm_instance['pg_stat_activity_view'] = pg_stat_activity_view
+    dbm_instance['query_metrics']['enabled'] = False
     check = integration_check(dbm_instance)
     check._connect()
 
@@ -672,8 +675,8 @@ def test_statement_metadata(
 ):
     """Tests for metadata in both samples and metrics"""
     dbm_instance['pg_stat_statements_view'] = pg_stat_statements_view
-    dbm_instance['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
-    dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    dbm_instance['query_samples']['run_sync'] = True
+    dbm_instance['query_metrics']['run_sync'] = True
 
     # If query or normalized_query changes, the query_signatures for both will need to be updated as well.
     query = '''
@@ -756,8 +759,8 @@ def test_statement_reported_hostname(
     reported_hostname,
     expected_hostname,
 ):
-    dbm_instance['query_samples'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
-    dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    dbm_instance['query_samples']['run_sync'] = True
+    dbm_instance['query_metrics']['run_sync'] = True
     dbm_instance['reported_hostname'] = reported_hostname
 
     check = integration_check(dbm_instance)
@@ -1020,6 +1023,8 @@ def test_activity_reported_hostname(
     reported_hostname,
     expected_hostname,
 ):
+    # Don't need metrics for this one
+    dbm_instance['query_metrics']['enabled'] = False
     dbm_instance['reported_hostname'] = reported_hostname
     check = integration_check(dbm_instance)
     check._connect()
@@ -1169,6 +1174,8 @@ def test_statement_run_explain_errors(
     expected_explain_err_code,
     expected_err,
 ):
+    dbm_instance['query_activity']['enabled'] = False
+    dbm_instance['query_metrics']['enabled'] = False
     check = integration_check(dbm_instance)
     check._connect()
 
@@ -1203,6 +1210,8 @@ def test_statement_run_explain_errors(
 
 @pytest.mark.parametrize("dbstrict", [True, False])
 def test_statement_samples_dbstrict(aggregator, integration_check, dbm_instance, dbstrict):
+    dbm_instance['query_activity']['enabled'] = False
+    dbm_instance['query_metrics']['enabled'] = False
     dbm_instance["dbstrict"] = dbstrict
     check = integration_check(dbm_instance)
     check._connect()
@@ -1435,6 +1444,8 @@ def test_async_job_cancel_cancel(aggregator, integration_check, dbm_instance):
 def test_statement_samples_invalid_activity_view(aggregator, integration_check, dbm_instance):
     dbm_instance['pg_stat_activity_view'] = "wrong_view"
 
+    # don't need metrics for this test
+    dbm_instance['query_metrics']['enabled'] = False
     # run synchronously, so we expect it to blow up right away
     dbm_instance['query_samples'] = {'enabled': True, 'run_sync': True}
     check = integration_check(dbm_instance)
@@ -1574,7 +1585,7 @@ def test_statement_metrics_database_errors(
     aggregator, integration_check, dbm_instance, error, metric_columns, expected_error_tag, expected_warnings
 ):
     # don't need samples for this test
-    dbm_instance['query_samples'] = {'enabled': False}
+    dbm_instance['query_samples']['enabled'] = False
     check = integration_check(dbm_instance)
     check._connect()
 
@@ -1622,6 +1633,8 @@ def test_statement_metrics_database_errors(
 def test_pg_stat_statements_max_warning(
     integration_check, dbm_instance, pg_stat_statements_max_threshold, expected_warnings
 ):
+    # don't need samples for this test
+    dbm_instance['query_samples']['enabled'] = False
     dbm_instance['query_metrics']['pg_stat_statements_max_warning_threshold'] = pg_stat_statements_max_threshold
     check = integration_check(dbm_instance)
     check._connect()


### PR DESCRIPTION
### What does this PR do?
Improve Postgres test speed. 

### Motivation
Most of the time is spent sleeping as the job rate limiter will sleep until the next collection interval in test_statements.py tests. By reducing the collection interval, tests for a specific PG + python version goes from ~120s to ~20s. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.