### PR TITLE
Remove the reno releasenotes folder

### DIFF
--- a/releasenotes/notes/remove-time-scope-dashboard-panels-17d19bddd5365517.yaml
+++ b/releasenotes/notes/remove-time-scope-dashboard-panels-17d19bddd5365517.yaml
@@ -1,9 +1,0 @@
----
-fixes:
-  - | 
-    Update dashboards to synchronize with global time. 
-    * Kubernetes Nodes Overview: Unlock time scope for Disk I/O & Network panels, 
-    events graph, and CPU & memory request graphs
-    * Kubernetes - Overview: Unlock time scope for Most CPU & memory intensive pods, pods status 
-    panels, network panels, CPU & memory request graphs, and disk panels. 
-    * Kubernetes Pods Overview: Unlock time scope for CPU & memory intensive pods panels.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove the reno releasenotes folder

### Motivation
<!-- What inspired you to submit this pull request? -->

We do not use reno in this repository. `ddev` generates the release notes for each integration based on the PRs and their labels.

This was added on [this PR](https://github.com/DataDog/integrations-core/pull/14091).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.