### PR TITLE
Add the ability to use a different image to run the tests

### DIFF
--- a/gitlab/hatch.toml
+++ b/gitlab/hatch.toml
@@ -7,7 +7,6 @@ version = ["13.12", "14.10", "15.10"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
-GITLAB_IMAGE = "gitlab/gitlab-ce"
 
 [envs.default.overrides]
 matrix.version.env-vars = [
@@ -20,9 +19,7 @@ matrix.version.env-vars = [
 [envs.bench.env-vars]
 GITLAB_VERSION = "13.0.6-ce.0"
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
-GITLAB_IMAGE = "gitlab/gitlab-ce"
 
 [envs.latest.env-vars]
 GITLAB_VERSION = "latest"
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
-GITLAB_IMAGE = "gitlab/gitlab-ce"

--- a/gitlab/hatch.toml
+++ b/gitlab/hatch.toml
@@ -7,19 +7,23 @@ version = ["13.12", "14.10", "15.10"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
+# If you're running the tests on an M1, you can use `yrzr/gitlab-ce-arm64v8` instead.
+# The official image works but is way slower because it's an amd64 one.
+GITLAB_IMAGE = "gitlab/gitlab-ce"
 
 [envs.default.overrides]
 matrix.version.env-vars = [
   { key = "GITLAB_VERSION", value = "13.12.15-ce.0", if = ["13.12"] },
   { key = "GITLAB_VERSION", value = "14.10.5-ce.0", if = ["14.10"] },
   { key = "GITLAB_VERSION", value = "15.10.0-ce.0", if = ["15.10"] },
-  { key = "GITLAB_IMAGE", value = "yrzr/gitlab-ce-arm64v8", platform_machine = "arm64"}
 ]
 
 [envs.bench.env-vars]
 GITLAB_VERSION = "13.0.6-ce.0"
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
+GITLAB_IMAGE = "gitlab/gitlab-ce"
 
 [envs.latest.env-vars]
 GITLAB_VERSION = "latest"
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
+GITLAB_IMAGE = "gitlab/gitlab-ce"

--- a/gitlab/hatch.toml
+++ b/gitlab/hatch.toml
@@ -7,6 +7,9 @@ version = ["13.12", "14.10", "15.10"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
+# If you're running the tests on an M1, you can use `yrzr/gitlab-ce-arm64v8` instead.
+# The official image works but is way slower because it's an amd64 one.
+GITLAB_IMAGE = "gitlab/gitlab-ce"
 
 [envs.default.overrides]
 matrix.version.env-vars = [
@@ -18,7 +21,9 @@ matrix.version.env-vars = [
 [envs.bench.env-vars]
 GITLAB_VERSION = "13.0.6-ce.0"
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
+GITLAB_IMAGE = "gitlab/gitlab-ce"
 
 [envs.latest.env-vars]
 GITLAB_VERSION = "latest"
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
+GITLAB_IMAGE = "gitlab/gitlab-ce"

--- a/gitlab/hatch.toml
+++ b/gitlab/hatch.toml
@@ -7,23 +7,19 @@ version = ["13.12", "14.10", "15.10"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
-# If you're running the tests on an M1, you can use `yrzr/gitlab-ce-arm64v8` instead.
-# The official image works but is way slower because it's an amd64 one.
-GITLAB_IMAGE = "gitlab/gitlab-ce"
 
 [envs.default.overrides]
 matrix.version.env-vars = [
   { key = "GITLAB_VERSION", value = "13.12.15-ce.0", if = ["13.12"] },
   { key = "GITLAB_VERSION", value = "14.10.5-ce.0", if = ["14.10"] },
   { key = "GITLAB_VERSION", value = "15.10.0-ce.0", if = ["15.10"] },
+  { key = "GITLAB_IMAGE", value = "yrzr/gitlab-ce-arm64v8", platform_machine = "arm64"}
 ]
 
 [envs.bench.env-vars]
 GITLAB_VERSION = "13.0.6-ce.0"
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
-GITLAB_IMAGE = "gitlab/gitlab-ce"
 
 [envs.latest.env-vars]
 GITLAB_VERSION = "latest"
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
-GITLAB_IMAGE = "gitlab/gitlab-ce"

--- a/gitlab/hatch.toml
+++ b/gitlab/hatch.toml
@@ -7,6 +7,7 @@ version = ["13.12", "14.10", "15.10"]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
+GITLAB_IMAGE = "gitlab/gitlab-ce"
 
 [envs.default.overrides]
 matrix.version.env-vars = [
@@ -19,7 +20,9 @@ matrix.version.env-vars = [
 [envs.bench.env-vars]
 GITLAB_VERSION = "13.0.6-ce.0"
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
+GITLAB_IMAGE = "gitlab/gitlab-ce"
 
 [envs.latest.env-vars]
 GITLAB_VERSION = "latest"
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
+GITLAB_IMAGE = "gitlab/gitlab-ce"

--- a/gitlab/tests/compose/docker-compose.yml
+++ b/gitlab/tests/compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   gitlab:
-    image: gitlab/gitlab-ce:${GITLAB_VERSION}
+    image: ${GITLAB_IMAGE:-gitlab/gitlab-ce}:${GITLAB_VERSION}
     healthcheck:
       test: curl -f http://localhost:80/-/health | grep "GitLab OK" || exit 1
       interval: 3s


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add the ability to use a different image to run the tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

The official image takes forever to spin up on our M1s. Switching to a arm64 works fine, from ~10 minutes to ~2 minutes.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

It's not yet possible to define an environment variable based on the architecture with hatch and I'd like to avoid having some if in the python code so I'm not adding anything to do it automatically

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.