### PR TITLE
Add another condition to the e2e environment

### DIFF
--- a/gitlab/tests/conftest.py
+++ b/gitlab/tests/conftest.py
@@ -60,6 +60,7 @@ def dd_environment():
         conditions=[
             CheckEndpoints(GITLAB_URL, attempts=100, wait=6),
             CheckEndpoints(GITLAB_PROMETHEUS_ENDPOINT, attempts=100, wait=6),
+            CheckEndpoints(PROMETHEUS_ENDPOINT, attempts=100, wait=6),
         ],
     ):
         # run pre-test commands


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add another condition to the e2e environment.

### Motivation
<!-- What inspired you to submit this pull request? -->

The environment is a bit flaky, running the tests locally I got this error from time to time: 

```
E   Exception: 
E   Traceback (most recent call last):
E     File "/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/checks/base.py", line 1135, in run
E       self.check(instance)
E     File "/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/gitlab/datadog_checks/gitlab/gitlab_v2.py", line 51, in check
E       super().check(_)
E     File "/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py", line 67, in check
E       raise_from(type(e)("There was an error scraping endpoint {}: {}".format(endpoint, e)), None)
E     File "<string>", line 3, in raise_from
E   requests.exceptions.ConnectionError: There was an error scraping endpoint http://localhost:8088/metrics: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.