### PR TITLE
Fix gitlab documentation

### DIFF
--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -25,7 +25,8 @@ To configure this check for an Agent running on a host:
 
 ##### Metric collection
 
-1. Edit the `gitlab.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3], to point to the GitLab's metrics [endpoint][4]. See the [sample gitlab.d/conf.yaml][5] for all available configuration options.
+1. Edit the `gitlab.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][3], to point to the GitLab's metrics [endpoint][4].
+See the [sample gitlab.d/conf.yaml][5] for all available configuration options. If you previously implemented this integration, see the [legacy example][16].
 
 2. In the GitLab settings page, ensure that the option `Enable Prometheus Metrics` is enabled (administrator access is required). For more information on how to enable metric collection, see [GitLab Prometheus metrics][6].
 
@@ -129,3 +130,4 @@ Need help? Contact [Datadog support][14].
 [13]: https://github.com/DataDog/integrations-core/blob/master/gitlab/assets/service_checks.json
 [14]: https://docs.datadoghq.com/help/
 [15]: https://docs.gitlab.com/ee/user/admin_area/monitoring/health_check.html#readiness
+[16]: https://github.com/DataDog/integrations-core/blob/7.43.x/gitlab/datadog_checks/gitlab/data/conf.yaml.example

--- a/gitlab/assets/configuration/spec.yaml
+++ b/gitlab/assets/configuration/spec.yaml
@@ -34,25 +34,12 @@ files:
         openmetrics_endpoint.enabled: true
         openmetrics_endpoint.display_priority: 4
         openmetrics_endpoint.value.example: http://<GITLAB_URL>/-/metrics
-        openmetrics_endpoint.description: |
-          To enable GitLab metrics using OpenMetricsBaseCheckV2 you must specify the 
-          `openmetrics_endpoint` option.
-
-          Either `prometheus_url` or `openmetrics_endpoint` must be specified.
-          See documentation: https://docs.datadoghq.com/integrations/gitlab
+        openmetrics_endpoint.description: The URL where GitLab exposes Prometheus metrics.
         tags.display_priority: 1
     - template: instances/openmetrics_legacy_base
       hidden: true
       overrides:
         prometheus_url.required: false
-        prometheus_url.hidden: false
-        prometheus_url.display_priority: 3
-        prometheus_url.value.example: http://<GITLAB_URL>/-/metrics
-        prometheus_url.description: |
-          To enable GitLab metrics using the legacy OpenMetricsBaseCheckV1 you must specify the `prometheus_url` option.
-
-          Either `prometheus_url` or `openmetrics_endpoint` must be specified.
-          See documentation: https://docs.datadoghq.com/integrations/gitlab
         health_service_check.value.example: false
         health_service_check.value.default: false
   - template: logs

--- a/gitlab/datadog_checks/gitlab/config_models/defaults.py
+++ b/gitlab/datadog_checks/gitlab/config_models/defaults.py
@@ -247,7 +247,7 @@ def instance_prometheus_metrics_prefix(field, value):
 
 
 def instance_prometheus_url(field, value):
-    return 'http://<GITLAB_URL>/-/metrics'
+    return get_default_field_value(field, value)
 
 
 def instance_proxy(field, value):

--- a/gitlab/datadog_checks/gitlab/data/conf.yaml.example
+++ b/gitlab/datadog_checks/gitlab/data/conf.yaml.example
@@ -46,21 +46,9 @@ init_config:
 instances:
 
     ## @param openmetrics_endpoint - string - optional - default: http://<GITLAB_URL>/-/metrics
-    ## To enable GitLab metrics using OpenMetricsBaseCheckV2 you must specify the 
-    ## `openmetrics_endpoint` option.
-    ##
-    ## Either `prometheus_url` or `openmetrics_endpoint` must be specified.
-    ## See documentation: https://docs.datadoghq.com/integrations/gitlab
+    ## The URL where GitLab exposes Prometheus metrics.
     #
   - openmetrics_endpoint: http://<GITLAB_URL>/-/metrics
-
-    ## @param prometheus_url - string - optional - default: http://<GITLAB_URL>/-/metrics
-    ## To enable GitLab metrics using the legacy OpenMetricsBaseCheckV1 you must specify the `prometheus_url` option.
-    ##
-    ## Either `prometheus_url` or `openmetrics_endpoint` must be specified.
-    ## See documentation: https://docs.datadoghq.com/integrations/gitlab
-    #
-    # prometheus_url: http://<GITLAB_URL>/-/metrics
 
     ## @param gitlab_url - string - optional
     ## The GitLab external URL to probe for service health status


### PR DESCRIPTION
QA for https://github.com/DataDog/integrations-core/pull/14273
Reference to the legacy implementation should be just on the README.

Related fix on coredns where I believe the example was taken from https://github.com/DataDog/integrations-core/pull/14401