### PR TITLE
Re-vamps kube_apiserver_metrics tests to match 14147

### DIFF
--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics.py
@@ -1,8 +1,6 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
-# stdlib
 import os
 import tempfile
 
@@ -11,7 +9,9 @@ import pytest
 
 from datadog_checks.kube_apiserver_metrics import KubeAPIServerMetricsCheck
 
-from .common import APISERVER_INSTANCE_BEARER_TOKEN
+from .common import APISERVER_INSTANCE_BEARER_TOKEN, HERE
+
+OM_RESPONSE_FIXTURES = os.path.join(HERE, 'fixtures', 'metrics.txt')
 
 customtag = "custom:tag"
 
@@ -32,22 +32,6 @@ instanceSecure = {
 
 
 @pytest.fixture()
-def mock_get():
-    f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    with mock.patch(
-        'requests.get',
-        return_value=mock.MagicMock(
-            status_code=200,
-            iter_lines=lambda **kwargs: text_data.split("\n"),
-            headers={'Content-Type': "text/plain", 'Authorization': "Bearer XXX"},
-        ),
-    ):
-        yield
-
-
-@pytest.fixture()
 def mock_read_bearer_token():
     with mock.patch('datadog_checks.checks.openmetrics.OpenMetricsBaseCheck._get_bearer_token', return_value="XXX"):
         yield
@@ -56,51 +40,50 @@ def mock_read_bearer_token():
 class TestKubeAPIServerMetrics:
     """Basic Test for kube_apiserver integration."""
 
-    CHECK_NAME = 'kube_apiserver_metrics'
-    NAMESPACE = 'kube_apiserver'
     METRICS = [
-        NAMESPACE + '.longrunning_gauge',
-        NAMESPACE + '.current_inflight_requests',
-        NAMESPACE + '.audit_event',
-        NAMESPACE + '.go_threads',
-        NAMESPACE + '.go_goroutines',
-        NAMESPACE + '.APIServiceRegistrationController_depth',
-        NAMESPACE + '.etcd_object_counts',
-        NAMESPACE + '.rest_client_requests_total',
-        NAMESPACE + '.apiserver_request_count',
-        NAMESPACE + '.apiserver_dropped_requests_total',
-        NAMESPACE + '.http_requests_total',
-        NAMESPACE + '.authenticated_user_requests',
-        NAMESPACE + '.rest_client_request_latency_seconds.sum',
-        NAMESPACE + '.rest_client_request_latency_seconds.count',
-        NAMESPACE + '.admission_webhook_admission_latencies_seconds.sum',
-        NAMESPACE + '.admission_webhook_admission_latencies_seconds.count',
-        NAMESPACE + '.admission_step_admission_latencies_seconds.sum',
-        NAMESPACE + '.admission_step_admission_latencies_seconds.count',
-        NAMESPACE + '.admission_step_admission_latencies_seconds_summary.sum',
-        NAMESPACE + '.admission_step_admission_latencies_seconds_summary.count',
-        NAMESPACE + '.admission_step_admission_latencies_seconds_summary.quantile',
-        NAMESPACE + '.admission_controller_admission_duration_seconds.sum',
-        NAMESPACE + '.admission_controller_admission_duration_seconds.count',
-        NAMESPACE + '.request_latencies.sum',
-        NAMESPACE + '.request_latencies.count',
-        NAMESPACE + '.process_resident_memory_bytes',
-        NAMESPACE + '.process_virtual_memory_bytes',
+        'longrunning_gauge',
+        'current_inflight_requests',
+        'audit_event',
+        'go_threads',
+        'go_goroutines',
+        'APIServiceRegistrationController_depth',
+        'etcd_object_counts',
+        'rest_client_requests_total',
+        'apiserver_request_count',
+        'apiserver_dropped_requests_total',
+        'http_requests_total',
+        'authenticated_user_requests',
+        'rest_client_request_latency_seconds.sum',
+        'rest_client_request_latency_seconds.count',
+        'admission_webhook_admission_latencies_seconds.sum',
+        'admission_webhook_admission_latencies_seconds.count',
+        'admission_step_admission_latencies_seconds.sum',
+        'admission_step_admission_latencies_seconds.count',
+        'admission_step_admission_latencies_seconds_summary.sum',
+        'admission_step_admission_latencies_seconds_summary.count',
+        'admission_step_admission_latencies_seconds_summary.quantile',
+        'admission_controller_admission_duration_seconds.sum',
+        'admission_controller_admission_duration_seconds.count',
+        'request_latencies.sum',
+        'request_latencies.count',
+        'process_resident_memory_bytes',
+        'process_virtual_memory_bytes',
     ]
     COUNT_METRICS = [
-        NAMESPACE + '.audit_event.count',
-        NAMESPACE + '.rest_client_requests_total.count',
-        NAMESPACE + '.apiserver_request_count.count',
-        NAMESPACE + '.apiserver_dropped_requests_total.count',
-        NAMESPACE + '.http_requests_total.count',
-        NAMESPACE + '.authenticated_user_requests.count',
+        'audit_event.count',
+        'rest_client_requests_total.count',
+        'apiserver_request_count.count',
+        'apiserver_dropped_requests_total.count',
+        'http_requests_total.count',
+        'authenticated_user_requests.count',
     ]
 
-    def test_check(self, dd_run_check, aggregator, mock_get):
+    def test_check(self, dd_run_check, aggregator, mock_http_response):
         """
         Testing kube_apiserver_metrics metrics collection.
         """
-
+        NAMESPACE = 'kube_apiserver'
+        mock_http_response(file_path=OM_RESPONSE_FIXTURES)
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, [instance])
         dd_run_check(check)
 
@@ -108,8 +91,9 @@ class TestKubeAPIServerMetrics:
         dd_run_check(check)
 
         for metric in self.METRICS + self.COUNT_METRICS:
-            aggregator.assert_metric(metric)
-            aggregator.assert_metric_has_tag(metric, customtag)
+            metric_to_assert = NAMESPACE + "." + metric
+            aggregator.assert_metric(metric_to_assert)
+            aggregator.assert_metric_has_tag(metric_to_assert, customtag)
         aggregator.assert_all_metrics_covered()
 
     def test_bearer(self):

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_19.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_19.py
@@ -1,14 +1,13 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
-# stdlib
 import os
 
-import mock
-import pytest
-
 from datadog_checks.kube_apiserver_metrics import KubeAPIServerMetricsCheck
+
+from .common import HERE
+
+OM_RESPONSE_FIXTURES = os.path.join(HERE, 'fixtures', 'metrics_1.19.7.txt')
 
 customtag = "custom:tag"
 
@@ -19,79 +18,62 @@ instance = {
 }
 
 
-@pytest.fixture()
-def mock_get():
-    f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics_1.19.7.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    with mock.patch(
-        'requests.get',
-        return_value=mock.MagicMock(
-            status_code=200,
-            iter_lines=lambda **kwargs: text_data.split("\n"),
-            headers={'Content-Type': "text/plain", 'Authorization': "Bearer XXX"},
-        ),
-    ):
-        yield
-
-
 class TestKubeAPIServerMetrics:
     """Basic Test for kube_apiserver integration."""
 
-    CHECK_NAME = 'kube_apiserver_metrics'
-    NAMESPACE = 'kube_apiserver'
     METRICS = [
-        NAMESPACE + '.longrunning_gauge',
-        NAMESPACE + '.current_inflight_requests',
-        NAMESPACE + '.audit_event',
-        NAMESPACE + '.go_threads',
-        NAMESPACE + '.go_goroutines',
-        NAMESPACE + '.etcd_object_counts',
-        NAMESPACE + '.etcd.db.total_size',
-        NAMESPACE + '.rest_client_requests_total',
-        NAMESPACE + '.authenticated_user_requests',
-        NAMESPACE + '.apiserver_request_total',
-        NAMESPACE + '.apiserver_request_terminations_total',
-        NAMESPACE + '.grpc_client_handled_total',
-        NAMESPACE + '.grpc_client_msg_received_total',
-        NAMESPACE + '.grpc_client_msg_sent_total',
-        NAMESPACE + '.grpc_client_started_total',
-        NAMESPACE + '.rest_client_request_latency_seconds.sum',
-        NAMESPACE + '.rest_client_request_latency_seconds.count',
-        NAMESPACE + '.admission_step_admission_latencies_seconds.sum',
-        NAMESPACE + '.admission_step_admission_latencies_seconds.count',
-        NAMESPACE + '.admission_step_admission_latencies_seconds_summary.sum',
-        NAMESPACE + '.admission_step_admission_latencies_seconds_summary.count',
-        NAMESPACE + '.admission_step_admission_latencies_seconds_summary.quantile',
-        NAMESPACE + '.admission_controller_admission_duration_seconds.sum',
-        NAMESPACE + '.admission_controller_admission_duration_seconds.count',
-        NAMESPACE + '.request_duration_seconds.sum',
-        NAMESPACE + '.request_duration_seconds.count',
-        NAMESPACE + '.registered_watchers',
-        NAMESPACE + '.process_resident_memory_bytes',
-        NAMESPACE + '.process_virtual_memory_bytes',
-        NAMESPACE + '.etcd_request_duration_seconds.sum',
-        NAMESPACE + '.etcd_request_duration_seconds.count',
-        NAMESPACE + '.watch_events_sizes.sum',
-        NAMESPACE + '.watch_events_sizes.count',
-        NAMESPACE + '.authentication_duration_seconds.sum',
-        NAMESPACE + '.authentication_duration_seconds.count',
-        NAMESPACE + '.authentication_attempts',
-        NAMESPACE + '.requested_deprecated_apis',
+        'longrunning_gauge',
+        'current_inflight_requests',
+        'audit_event',
+        'go_threads',
+        'go_goroutines',
+        'etcd_object_counts',
+        'etcd.db.total_size',
+        'rest_client_requests_total',
+        'authenticated_user_requests',
+        'apiserver_request_total',
+        'apiserver_request_terminations_total',
+        'grpc_client_handled_total',
+        'grpc_client_msg_received_total',
+        'grpc_client_msg_sent_total',
+        'grpc_client_started_total',
+        'rest_client_request_latency_seconds.sum',
+        'rest_client_request_latency_seconds.count',
+        'admission_step_admission_latencies_seconds.sum',
+        'admission_step_admission_latencies_seconds.count',
+        'admission_step_admission_latencies_seconds_summary.sum',
+        'admission_step_admission_latencies_seconds_summary.count',
+        'admission_step_admission_latencies_seconds_summary.quantile',
+        'admission_controller_admission_duration_seconds.sum',
+        'admission_controller_admission_duration_seconds.count',
+        'request_duration_seconds.sum',
+        'request_duration_seconds.count',
+        'registered_watchers',
+        'process_resident_memory_bytes',
+        'process_virtual_memory_bytes',
+        'etcd_request_duration_seconds.sum',
+        'etcd_request_duration_seconds.count',
+        'watch_events_sizes.sum',
+        'watch_events_sizes.count',
+        'authentication_duration_seconds.sum',
+        'authentication_duration_seconds.count',
+        'authentication_attempts',
+        'requested_deprecated_apis',
     ]
     COUNT_METRICS = [
-        NAMESPACE + '.audit_event.count',
-        NAMESPACE + '.rest_client_requests_total.count',
-        NAMESPACE + '.authenticated_user_requests.count',
-        NAMESPACE + '.apiserver_request_total.count',
-        NAMESPACE + '.apiserver_request_terminations_total.count',
+        'audit_event.count',
+        'rest_client_requests_total.count',
+        'authenticated_user_requests.count',
+        'apiserver_request_total.count',
+        'apiserver_request_terminations_total.count',
     ]
 
-    def test_check(self, dd_run_check, aggregator, mock_get):
+    def test_check(self, dd_run_check, aggregator, mock_http_response):
         """
         Testing kube_apiserver_metrics metrics collection.
         """
-
+        NAMESPACE = 'kube_apiserver'
+        mock_http_response(file_path=OM_RESPONSE_FIXTURES)
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, [instance])
         dd_run_check(check)
 
@@ -99,6 +81,7 @@ class TestKubeAPIServerMetrics:
         dd_run_check(check)
 
         for metric in self.METRICS + self.COUNT_METRICS:
-            aggregator.assert_metric(metric)
-            aggregator.assert_metric_has_tag(metric, customtag)
+            metric_to_assert = NAMESPACE + "." + metric
+            aggregator.assert_metric(metric_to_assert)
+            aggregator.assert_metric_has_tag(metric_to_assert, customtag)
         aggregator.assert_all_metrics_covered()

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_23.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_23.py
@@ -1,14 +1,13 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
-# stdlib
 import os
 
-import mock
-import pytest
-
 from datadog_checks.kube_apiserver_metrics import KubeAPIServerMetricsCheck
+
+from .common import HERE
+
+OM_RESPONSE_FIXTURES = os.path.join(HERE, 'fixtures', 'metrics_1.23.0.txt')
 
 customtag = "custom:tag"
 
@@ -19,83 +18,66 @@ instance = {
 }
 
 
-@pytest.fixture()
-def mock_get():
-    f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics_1.23.0.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    with mock.patch(
-        'requests.get',
-        return_value=mock.MagicMock(
-            status_code=200,
-            iter_lines=lambda **kwargs: text_data.split("\n"),
-            headers={'Content-Type': "text/plain", 'Authorization': "Bearer XXX"},
-        ),
-    ):
-        yield
-
-
 class TestKubeAPIServerMetrics:
     """Basic Test for kube_apiserver integration."""
 
-    CHECK_NAME = 'kube_apiserver_metrics'
-    NAMESPACE = 'kube_apiserver'
     METRICS = [
-        NAMESPACE + '.longrunning_gauge',
-        NAMESPACE + '.current_inflight_requests',
-        NAMESPACE + '.audit_event',
-        NAMESPACE + '.go_threads',
-        NAMESPACE + '.go_goroutines',
-        NAMESPACE + '.etcd.db.total_size',
-        NAMESPACE + '.rest_client_requests_total',
-        NAMESPACE + '.authenticated_user_requests',
-        NAMESPACE + '.apiserver_request_total',
-        NAMESPACE + '.apiserver_request_terminations_total',
-        NAMESPACE + '.grpc_client_handled_total',
-        NAMESPACE + '.grpc_client_msg_received_total',
-        NAMESPACE + '.grpc_client_msg_sent_total',
-        NAMESPACE + '.grpc_client_started_total',
-        NAMESPACE + '.rest_client_request_latency_seconds.sum',
-        NAMESPACE + '.rest_client_request_latency_seconds.count',
-        NAMESPACE + '.admission_step_admission_latencies_seconds.sum',
-        NAMESPACE + '.admission_step_admission_latencies_seconds.count',
-        NAMESPACE + '.admission_step_admission_latencies_seconds_summary.sum',
-        NAMESPACE + '.admission_step_admission_latencies_seconds_summary.count',
-        NAMESPACE + '.admission_step_admission_latencies_seconds_summary.quantile',
-        NAMESPACE + '.admission_controller_admission_duration_seconds.sum',
-        NAMESPACE + '.admission_controller_admission_duration_seconds.count',
-        NAMESPACE + '.request_duration_seconds.sum',
-        NAMESPACE + '.request_duration_seconds.count',
-        NAMESPACE + '.registered_watchers',
-        NAMESPACE + '.process_resident_memory_bytes',
-        NAMESPACE + '.process_virtual_memory_bytes',
-        NAMESPACE + '.etcd_request_duration_seconds.sum',
-        NAMESPACE + '.etcd_request_duration_seconds.count',
-        NAMESPACE + '.watch_events_sizes.sum',
-        NAMESPACE + '.watch_events_sizes.count',
-        NAMESPACE + '.authentication_duration_seconds.sum',
-        NAMESPACE + '.authentication_duration_seconds.count',
-        NAMESPACE + '.authentication_attempts',
-        NAMESPACE + '.storage_objects',
-        NAMESPACE + '.storage_list_total',
-        NAMESPACE + '.storage_list_fetched_objects_total',
-        NAMESPACE + '.storage_list_evaluated_objects_total',
-        NAMESPACE + '.storage_list_returned_objects_total',
-        NAMESPACE + '.requested_deprecated_apis',
+        'longrunning_gauge',
+        'current_inflight_requests',
+        'audit_event',
+        'go_threads',
+        'go_goroutines',
+        'etcd.db.total_size',
+        'rest_client_requests_total',
+        'authenticated_user_requests',
+        'apiserver_request_total',
+        'apiserver_request_terminations_total',
+        'grpc_client_handled_total',
+        'grpc_client_msg_received_total',
+        'grpc_client_msg_sent_total',
+        'grpc_client_started_total',
+        'rest_client_request_latency_seconds.sum',
+        'rest_client_request_latency_seconds.count',
+        'admission_step_admission_latencies_seconds.sum',
+        'admission_step_admission_latencies_seconds.count',
+        'admission_step_admission_latencies_seconds_summary.sum',
+        'admission_step_admission_latencies_seconds_summary.count',
+        'admission_step_admission_latencies_seconds_summary.quantile',
+        'admission_controller_admission_duration_seconds.sum',
+        'admission_controller_admission_duration_seconds.count',
+        'request_duration_seconds.sum',
+        'request_duration_seconds.count',
+        'registered_watchers',
+        'process_resident_memory_bytes',
+        'process_virtual_memory_bytes',
+        'etcd_request_duration_seconds.sum',
+        'etcd_request_duration_seconds.count',
+        'watch_events_sizes.sum',
+        'watch_events_sizes.count',
+        'authentication_duration_seconds.sum',
+        'authentication_duration_seconds.count',
+        'authentication_attempts',
+        'storage_objects',
+        'storage_list_total',
+        'storage_list_fetched_objects_total',
+        'storage_list_evaluated_objects_total',
+        'storage_list_returned_objects_total',
+        'requested_deprecated_apis',
     ]
     COUNT_METRICS = [
-        NAMESPACE + '.audit_event.count',
-        NAMESPACE + '.rest_client_requests_total.count',
-        NAMESPACE + '.authenticated_user_requests.count',
-        NAMESPACE + '.apiserver_request_total.count',
-        NAMESPACE + '.apiserver_request_terminations_total.count',
+        'audit_event.count',
+        'rest_client_requests_total.count',
+        'authenticated_user_requests.count',
+        'apiserver_request_total.count',
+        'apiserver_request_terminations_total.count',
     ]
 
-    def test_check(self, dd_run_check, aggregator, mock_get):
+    def test_check(self, dd_run_check, aggregator, mock_http_response):
         """
         Testing kube_apiserver_metrics metrics collection.
         """
-
+        NAMESPACE = 'kube_apiserver'
+        mock_http_response(file_path=OM_RESPONSE_FIXTURES)
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, [instance])
         dd_run_check(check)
 
@@ -103,6 +85,7 @@ class TestKubeAPIServerMetrics:
         dd_run_check(check)
 
         for metric in self.METRICS + self.COUNT_METRICS:
-            aggregator.assert_metric(metric)
-            aggregator.assert_metric_has_tag(metric, customtag)
+            metric_to_assert = NAMESPACE + "." + metric
+            aggregator.assert_metric(metric_to_assert)
+            aggregator.assert_metric_has_tag(metric_to_assert, customtag)
         aggregator.assert_all_metrics_covered()

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_24.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_24.py
@@ -1,14 +1,13 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
-# stdlib
 import os
 
-import mock
-import pytest
-
 from datadog_checks.kube_apiserver_metrics import KubeAPIServerMetricsCheck
+
+from .common import HERE
+
+OM_RESPONSE_FIXTURES = os.path.join(HERE, 'fixtures', 'metrics_1.24.0.txt')
 
 customtag = "custom:tag"
 
@@ -19,85 +18,68 @@ instance = {
 }
 
 
-@pytest.fixture()
-def mock_get():
-    f_name = os.path.join(os.path.dirname(__file__), 'fixtures', 'metrics_1.24.0.txt')
-    with open(f_name, 'r') as f:
-        text_data = f.read()
-    with mock.patch(
-        'requests.get',
-        return_value=mock.MagicMock(
-            status_code=200,
-            iter_lines=lambda **kwargs: text_data.split("\n"),
-            headers={'Content-Type': "text/plain", 'Authorization': "Bearer XXX"},
-        ),
-    ):
-        yield
-
-
 class TestKubeAPIServerMetrics:
     """Basic Test for kube_apiserver integration."""
 
-    CHECK_NAME = 'kube_apiserver_metrics'
-    NAMESPACE = 'kube_apiserver'
     METRICS = [
-        NAMESPACE + '.current_inflight_requests',
-        NAMESPACE + '.audit_event',
-        NAMESPACE + '.go_threads',
-        NAMESPACE + '.go_goroutines',
-        NAMESPACE + '.etcd.db.total_size',
-        NAMESPACE + '.rest_client_requests_total',
-        NAMESPACE + '.authenticated_user_requests',
-        NAMESPACE + '.apiserver_request_total',
-        NAMESPACE + '.apiserver_request_terminations_total',
-        NAMESPACE + '.grpc_client_handled_total',
-        NAMESPACE + '.grpc_client_msg_received_total',
-        NAMESPACE + '.grpc_client_msg_sent_total',
-        NAMESPACE + '.grpc_client_started_total',
-        NAMESPACE + '.rest_client_request_latency_seconds.sum',
-        NAMESPACE + '.rest_client_request_latency_seconds.count',
-        NAMESPACE + '.admission_step_admission_latencies_seconds.sum',
-        NAMESPACE + '.admission_step_admission_latencies_seconds.count',
-        NAMESPACE + '.admission_step_admission_latencies_seconds_summary.sum',
-        NAMESPACE + '.admission_step_admission_latencies_seconds_summary.count',
-        NAMESPACE + '.admission_step_admission_latencies_seconds_summary.quantile',
-        NAMESPACE + '.admission_controller_admission_duration_seconds.sum',
-        NAMESPACE + '.admission_controller_admission_duration_seconds.count',
-        NAMESPACE + '.request_duration_seconds.sum',
-        NAMESPACE + '.request_duration_seconds.count',
-        NAMESPACE + '.process_resident_memory_bytes',
-        NAMESPACE + '.process_virtual_memory_bytes',
-        NAMESPACE + '.etcd_request_duration_seconds.sum',
-        NAMESPACE + '.etcd_request_duration_seconds.count',
-        NAMESPACE + '.watch_events_sizes.sum',
-        NAMESPACE + '.watch_events_sizes.count',
-        NAMESPACE + '.authentication_duration_seconds.sum',
-        NAMESPACE + '.authentication_duration_seconds.count',
-        NAMESPACE + '.authentication_attempts',
-        NAMESPACE + '.storage_objects',
-        NAMESPACE + '.storage_list_total',
-        NAMESPACE + '.storage_list_fetched_objects_total',
-        NAMESPACE + '.storage_list_evaluated_objects_total',
-        NAMESPACE + '.storage_list_returned_objects_total',
-        NAMESPACE + '.requested_deprecated_apis',
-        NAMESPACE + '.apiserver_admission_webhook_fail_open_count',
-        NAMESPACE + '.admission_webhook_admission_latencies_seconds.sum',
-        NAMESPACE + '.admission_webhook_admission_latencies_seconds.count',
+        'current_inflight_requests',
+        'audit_event',
+        'go_threads',
+        'go_goroutines',
+        'etcd.db.total_size',
+        'rest_client_requests_total',
+        'authenticated_user_requests',
+        'apiserver_request_total',
+        'apiserver_request_terminations_total',
+        'grpc_client_handled_total',
+        'grpc_client_msg_received_total',
+        'grpc_client_msg_sent_total',
+        'grpc_client_started_total',
+        'rest_client_request_latency_seconds.sum',
+        'rest_client_request_latency_seconds.count',
+        'admission_step_admission_latencies_seconds.sum',
+        'admission_step_admission_latencies_seconds.count',
+        'admission_step_admission_latencies_seconds_summary.sum',
+        'admission_step_admission_latencies_seconds_summary.count',
+        'admission_step_admission_latencies_seconds_summary.quantile',
+        'admission_controller_admission_duration_seconds.sum',
+        'admission_controller_admission_duration_seconds.count',
+        'request_duration_seconds.sum',
+        'request_duration_seconds.count',
+        'process_resident_memory_bytes',
+        'process_virtual_memory_bytes',
+        'etcd_request_duration_seconds.sum',
+        'etcd_request_duration_seconds.count',
+        'watch_events_sizes.sum',
+        'watch_events_sizes.count',
+        'authentication_duration_seconds.sum',
+        'authentication_duration_seconds.count',
+        'authentication_attempts',
+        'storage_objects',
+        'storage_list_total',
+        'storage_list_fetched_objects_total',
+        'storage_list_evaluated_objects_total',
+        'storage_list_returned_objects_total',
+        'requested_deprecated_apis',
+        'apiserver_admission_webhook_fail_open_count',
+        'admission_webhook_admission_latencies_seconds.sum',
+        'admission_webhook_admission_latencies_seconds.count',
     ]
     COUNT_METRICS = [
-        NAMESPACE + '.audit_event.count',
-        NAMESPACE + '.rest_client_requests_total.count',
-        NAMESPACE + '.authenticated_user_requests.count',
-        NAMESPACE + '.apiserver_request_total.count',
-        NAMESPACE + '.apiserver_request_terminations_total.count',
-        NAMESPACE + '.apiserver_admission_webhook_fail_open_count.count',
+        'audit_event.count',
+        'rest_client_requests_total.count',
+        'authenticated_user_requests.count',
+        'apiserver_request_total.count',
+        'apiserver_request_terminations_total.count',
+        'apiserver_admission_webhook_fail_open_count.count',
     ]
 
-    def test_check(self, dd_run_check, aggregator, mock_get):
+    def test_check(self, dd_run_check, aggregator, mock_http_response):
         """
         Testing kube_apiserver_metrics metrics collection.
         """
-
+        NAMESPACE = 'kube_apiserver'
+        mock_http_response(file_path=OM_RESPONSE_FIXTURES)
         check = KubeAPIServerMetricsCheck('kube_apiserver_metrics', {}, [instance])
         dd_run_check(check)
 
@@ -105,6 +87,7 @@ class TestKubeAPIServerMetrics:
         dd_run_check(check)
 
         for metric in self.METRICS + self.COUNT_METRICS:
-            aggregator.assert_metric(metric)
-            aggregator.assert_metric_has_tag(metric, customtag)
+            metric_to_assert = NAMESPACE + "." + metric
+            aggregator.assert_metric(metric_to_assert)
+            aggregator.assert_metric_has_tag(metric_to_assert, customtag)
         aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
* Changes the OpenMetrics test to use a pre-defined fixture
* Cleans the code to remove a lot of `NAMESPACE` entries by modifying the metric during the loop

### Motivation
* Review from @iliakur to clean tests in https://github.com/DataDog/integrations-core/pull/14147

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.