### PR TITLE
Change ecs_fargate min_collection_interval.enabled to boolean

### DIFF
--- a/ecs_fargate/assets/configuration/spec.yaml
+++ b/ecs_fargate/assets/configuration/spec.yaml
@@ -13,7 +13,7 @@ files:
             overrides:
               min_collection_interval.display_default: 20
               min_collection_interval.value.example: 20
-              min_collection_interval.enabled: 20
+              min_collection_interval.enabled: true
   - name: default.yaml
     example_name: conf.yaml.default
     options:
@@ -32,4 +32,4 @@ files:
             overrides:
               min_collection_interval.display_default: 20
               min_collection_interval.value.example: 20
-              min_collection_interval.enabled: 20
+              min_collection_interval.enabled: true


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Small PR to change `min_collection_interval.enabled` to `true` instead of `20`.

### Motivation
<!-- What inspired you to submit this pull request? -->
This value should be `true` or `false`, not an int.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.