### PR TITLE
mysql: fix tracking references to self.check

### DIFF
--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -32,7 +32,7 @@ from .util import DatabaseConfigurationError, StatementTruncationState, get_trun
 
 
 def agent_check_getter(self):
-    return self.check
+    return self._check
 
 
 SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update', 'with'})

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -31,7 +31,6 @@ from datadog_checks.base.utils.tracking import tracked_method
 
 from .util import DatabaseConfigurationError, StatementTruncationState, get_truncation_state, warning_with_tags
 
-
 SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update', 'with'})
 
 EVENTS_STATEMENTS_TABLE = 'events_statements_current'

--- a/mysql/datadog_checks/mysql/statement_samples.py
+++ b/mysql/datadog_checks/mysql/statement_samples.py
@@ -7,6 +7,7 @@ import time
 from collections import namedtuple
 from contextlib import closing
 from enum import Enum
+from operator import attrgetter
 
 import pymysql
 from cachetools import TTLCache
@@ -29,10 +30,6 @@ from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 
 from .util import DatabaseConfigurationError, StatementTruncationState, get_truncation_state, warning_with_tags
-
-
-def agent_check_getter(self):
-    return self._check
 
 
 SUPPORTED_EXPLAIN_STATEMENTS = frozenset({'select', 'table', 'delete', 'insert', 'replace', 'update', 'with'})
@@ -321,7 +318,7 @@ class MySQLStatementSamples(DBMAsyncJob):
             )
             raise
 
-    @tracked_method(agent_check_getter=agent_check_getter)
+    @tracked_method(agent_check_getter=attrgetter('_check'))
     def _get_new_events_statements_current(self):
         start = time.time()
         with closing(self._get_db_connection().cursor(pymysql.cursors.DictCursor)) as cursor:
@@ -464,7 +461,7 @@ class MySQLStatementSamples(DBMAsyncJob):
                 'mysql': {k: v for k, v in row.items() if k not in EVENTS_STATEMENTS_SAMPLE_EXCLUDE_KEYS},
             }
 
-    @tracked_method(agent_check_getter=agent_check_getter)
+    @tracked_method(agent_check_getter=attrgetter('_check'))
     def _collect_plans_for_statements(self, rows):
         for row in rows:
             try:

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -4,6 +4,7 @@
 import copy
 import time
 from contextlib import closing
+from operator import attrgetter
 from typing import Any, Callable, Dict, List, Tuple
 
 import pymysql
@@ -44,10 +45,6 @@ METRICS_COLUMNS = {
     'sum_no_index_used',
     'sum_no_good_index_used',
 }
-
-
-def agent_check_getter(self):
-    return self._check
 
 
 def _row_key(row):
@@ -115,7 +112,7 @@ class MySQLStatementMetrics(DBMAsyncJob):
     def run_job(self):
         self.collect_per_statement_metrics()
 
-    @tracked_method(agent_check_getter=agent_check_getter)
+    @tracked_method(agent_check_getter=attrgetter('_check'))
     def collect_per_statement_metrics(self):
         # Detect a database misconfiguration by checking if the performance schema is enabled since mysql
         # just returns no rows without errors if the performance schema is disabled

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -47,7 +47,7 @@ METRICS_COLUMNS = {
 
 
 def agent_check_getter(self):
-    return self.check
+    return self._check
 
 
 def _row_key(row):


### PR DESCRIPTION
### What does this PR do?
Fix invalid references to `MySQLStatementMetrics.check` and `MySQLStatementSamples.check`

Also incorporating the suggestion from @iliakur in the original PR to use `operator.attrgetter` instead of a custom getter function duplicated in both files.

### Motivation
PR #14146 sets the `_check` attribute in the `MySQLStatementMetrics` and `MySQLStatementSamples` classes, but the original PR #13202 references the `check` attribute, causing the agent to flood the logs with errors:

```
Apr 19 20:12:35 replica1 agent: [collect_per_statement_metrics] invalid tracked_method. failed to get check reference.
Apr 19 20:12:35 replica1 agent: [_get_new_events_statements_current] invalid tracked_method. failed to get check reference.
Apr 19 20:12:35 replica1 agent: [_collect_plans_for_statements] invalid tracked_method. failed to get check reference.
```

Dumping the exception from `datadog_checks.base.utils.tracking.tracked_method`, I got this:
```
Apr 19 20:12:35 replica1 agent: 'MySQLStatementMetrics' object has no attribute 'check'
Apr 19 20:12:35 replica1 agent: 'MySQLStatementSamples' object has no attribute 'check'
```


### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.