### PR TITLE
Fix resources not sent on service check metrics

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -100,7 +100,7 @@ class MySql(AgentCheck):
         self._agent_hostname = None
         self._is_aurora = None
         self._config = MySQLConfig(self.instance)
-        self.tags = copy.copy(self._config.tags)
+        self.tags = self._config.tags
         self.cloud_metadata = self._config.cloud_metadata
 
         # Create a new connection on every check run
@@ -374,7 +374,7 @@ class MySql(AgentCheck):
             server = self._config.mysql_sock if self._config.mysql_sock != '' else self._config.host
         service_check_tags = [
             'port:{}'.format(self._config.port if self._config.port else 'unix_socket'),
-        ] + self._config.tags
+        ] + self.tags
         if not self.disable_generic_tags:
             service_check_tags.append('server:{0}'.format(server))
         return service_check_tags

--- a/mysql/tests/tags.py
+++ b/mysql/tests/tags.py
@@ -15,10 +15,11 @@ SC_TAGS = [
     'tag1:value1',
     'tag2:value2',
 ]
-SC_TAGS_MIN = ['port:' + str(common.PORT)]
+SC_TAGS_MIN = ['port:' + str(common.PORT), DATABASE_INSTANCE_RESOURCE_TAG.format(hostname='stubbed.hostname')]
 SC_TAGS_REPLICA = [
     'port:' + str(common.SLAVE_PORT),
     'tag1:value1',
     'tag2:value2',
+    'dd.internal.resource:database_instance:stubbed.hostname',
 ]
-SC_FAILURE_TAGS = ['port:unix_socket']
+SC_FAILURE_TAGS = ['port:unix_socket', DATABASE_INSTANCE_RESOURCE_TAG.format(hostname='stubbed.hostname')]

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -70,9 +70,11 @@ def test_minimal_config(aggregator, dd_run_check, instance_basic):
 def test_complex_config(aggregator, dd_run_check, instance_complex):
     mysql_check = MySql(common.CHECK_NAME, {}, [instance_complex])
     dd_run_check(mysql_check)
+
     _assert_complex_config(
         aggregator,
-        [tags.DATABASE_INSTANCE_RESOURCE_TAG.format(hostname='stubbed.hostname')],
+        tags.SC_TAGS + [tags.DATABASE_INSTANCE_RESOURCE_TAG.format(hostname='stubbed.hostname')],
+        tags.METRIC_TAGS_WITH_RESOURCE,
     )
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(), check_submission_type=True, exclude=['alice.age', 'bob.age'] + variables.STATEMENT_VARS
@@ -82,18 +84,23 @@ def test_complex_config(aggregator, dd_run_check, instance_complex):
 @pytest.mark.e2e
 def test_e2e(dd_agent_check, dd_default_hostname, instance_complex):
     aggregator = dd_agent_check(instance_complex)
-    _assert_complex_config(aggregator, [], hostname=dd_default_hostname)
+    _assert_complex_config(
+        aggregator,
+        tags.SC_TAGS + [tags.DATABASE_INSTANCE_RESOURCE_TAG.format(hostname=dd_default_hostname)],
+        tags.METRIC_TAGS,
+        hostname=dd_default_hostname,
+    )
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(), exclude=['alice.age', 'bob.age'] + variables.STATEMENT_VARS
     )
 
 
-def _assert_complex_config(aggregator, expected_internal_tags, hostname='stubbed.hostname'):
+def _assert_complex_config(aggregator, service_check_tags, metric_tags, hostname='stubbed.hostname'):
     # Test service check
     aggregator.assert_service_check(
         'mysql.can_connect',
         status=MySql.OK,
-        tags=tags.METRIC_TAGS + ['port:' + str(common.PORT)],
+        tags=service_check_tags,
         hostname=hostname,
         count=1,
     )
@@ -101,7 +108,10 @@ def _assert_complex_config(aggregator, expected_internal_tags, hostname='stubbed
         aggregator.assert_service_check(
             'mysql.replication.slave_running',
             status=MySql.OK,
-            tags=tags.METRIC_TAGS + ['port:' + str(common.PORT), 'replication_mode:source'],
+            tags=service_check_tags
+            + [
+                'replication_mode:source',
+            ],
             hostname=hostname,
             at_least=1,
         )
@@ -125,13 +135,8 @@ def _assert_complex_config(aggregator, expected_internal_tags, hostname='stubbed
         aggregator.assert_service_check(
             'mysql.replication.group.status',
             status=MySql.OK,
-            tags=tags.METRIC_TAGS
-            + [
-                'port:' + str(common.PORT),
-                'channel_name:group_replication_applier',
-                'member_role:PRIMARY',
-                'member_state:ONLINE',
-            ],
+            tags=service_check_tags
+            + ['channel_name:group_replication_applier', 'member_role:PRIMARY', 'member_state:ONLINE'],
             count=1,
         )
 
@@ -150,18 +155,14 @@ def _assert_complex_config(aggregator, expected_internal_tags, hostname='stubbed
             continue
 
         if mname == 'mysql.performance.query_run_time.avg':
-            aggregator.assert_metric(mname, tags=tags.METRIC_TAGS + expected_internal_tags + ['schema:testdb'], count=1)
-            aggregator.assert_metric(mname, tags=tags.METRIC_TAGS + expected_internal_tags + ['schema:mysql'], count=1)
+            aggregator.assert_metric(mname, tags=metric_tags + ['schema:testdb'], count=1)
+            aggregator.assert_metric(mname, tags=metric_tags + ['schema:mysql'], count=1)
         elif mname == 'mysql.info.schema.size':
-            aggregator.assert_metric(mname, tags=tags.METRIC_TAGS + expected_internal_tags + ['schema:testdb'], count=1)
-            aggregator.assert_metric(
-                mname, tags=tags.METRIC_TAGS + expected_internal_tags + ['schema:information_schema'], count=1
-            )
-            aggregator.assert_metric(
-                mname, tags=tags.METRIC_TAGS + expected_internal_tags + ['schema:performance_schema'], count=1
-            )
+            aggregator.assert_metric(mname, tags=metric_tags + ['schema:testdb'], count=1)
+            aggregator.assert_metric(mname, tags=metric_tags + ['schema:information_schema'], count=1)
+            aggregator.assert_metric(mname, tags=metric_tags + ['schema:performance_schema'], count=1)
         else:
-            aggregator.assert_metric(mname, tags=tags.METRIC_TAGS + expected_internal_tags, at_least=0)
+            aggregator.assert_metric(mname, tags=metric_tags, at_least=0)
 
     # TODO: test this if it is implemented
     # Assert service metadata
@@ -318,6 +319,7 @@ def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, agg
     expected_tags = [
         'server:{}'.format(HOST),
         'port:{}'.format(PORT),
+        'dd.internal.resource:database_instance:{}'.format(expected_hostname),
     ]
     aggregator.assert_service_check(
         'mysql.can_connect', status=MySql.OK, tags=expected_tags, count=1, hostname=expected_hostname

--- a/mysql/tests/test_unit.py
+++ b/mysql/tests/test_unit.py
@@ -294,14 +294,14 @@ def test__get_is_aurora():
 @pytest.mark.parametrize(
     'disable_generic_tags, hostname, expected_tags',
     [
-        (True, None, {'port:unix_socket'}),
+        (True, None, {'port:unix_socket', 'dd.internal.resource:database_instance:stubbed.hostname'}),
         (
             False,
             None,
-            {'port:unix_socket', 'server:localhost'},
+            {'port:unix_socket', 'server:localhost', 'dd.internal.resource:database_instance:stubbed.hostname'},
         ),
-        (True, 'foo', {'port:unix_socket'}),
-        (False, 'foo', {'port:unix_socket', 'server:foo'}),
+        (True, 'foo', {'port:unix_socket', 'dd.internal.resource:database_instance:stubbed.hostname'}),
+        (False, 'foo', {'port:unix_socket', 'server:foo', 'dd.internal.resource:database_instance:stubbed.hostname'}),
     ],
 )
 def test_service_check(disable_generic_tags, expected_tags, hostname):


### PR DESCRIPTION
### What does this PR do?
While taking over PR [14333](https://github.com/DataDog/integrations-core/pull/14333), I made the wrong call when addressing the end to end test failure related to the internal resource tags. Instead of removing the resources from service checks that we emit, we actually want to keep the resource tags so that the service check metrics like `check_run.postgres.can_connect.ok` have resources set on them. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.