### PR TITLE
Adding remote/local tag for devices in disk check

### DIFF
--- a/disk/datadog_checks/disk/disk.py
+++ b/disk/datadog_checks/disk/disk.py
@@ -9,6 +9,7 @@ import re
 from xml.etree import ElementTree as ET
 
 import psutil
+import win32file
 from six import iteritems, string_types
 
 from datadog_checks.base import AgentCheck, ConfigurationError, is_affirmative
@@ -181,9 +182,15 @@ class Disk(AgentCheck):
         # legacy check names c: vs psutil name C:\\
         if Platform.is_win32():
             device_name = device_name.strip('\\').lower()
+            isNetworkDrive = win32file.GetDriveType('How to get device?') == win32file.DRIVE_REMOTE
+            if isNetworkDrive:
+                device_location = 'remote'
+            else:
+                device_location = 'local'
 
         tags.append('device:{}'.format(device_name))
         tags.append('device_name:{}'.format(_base_device_name(part.device)))
+        tags.append('device_location:{}'.format(device_location))
         return tags
 
     def exclude_disk(self, part):


### PR DESCRIPTION
### What does this PR do?
This PR will add a tag for remote/local tags for devices picked up by the disk check

### Motivation
https://datadoghq.atlassian.net/browse/AI-2734?atlOrigin=eyJpIjoiNTZhYzk0ZDgxY2FiNDBjN2IwZDUwMGRlOWFhMGM2ODAiLCJwIjoiaiJ9

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.