### PR TITLE
Switch a log from `warn` to `debug`

### DIFF
--- a/sonarqube/datadog_checks/sonarqube/check.py
+++ b/sonarqube/datadog_checks/sonarqube/check.py
@@ -125,7 +125,7 @@ class SonarqubeCheck(AgentCheck):
                 key = metric['key']
                 category = CATEGORIES.get(domain)
                 if category is None:
-                    self.log.warning('Unknown metric category: %s', domain)
+                    self.log.debug('Unknown metric category: %s', domain)
                     continue
                 available_metrics[key] = '{}.{}'.format(category, key)
             page += 1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Switch a log from `warn` to `debug`.

### Motivation
<!-- What inspired you to submit this pull request? -->

We scrape all the metrics available in the `/api/metrics/search` endpoint and have a look at the domain field for each element in the metrics block. If this category is not declared [here](https://github.com/DataDog/integrations-core/blob/master/sonarqube/datadog_checks/sonarqube/constants.py#L8-L24) then the metric won't be collected by the integration and we generate a WARN log. This log is written each time the integration run and spams the log file.  

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.