### PR TITLE
Limit the version of `virtualenv` to continue testing Python 2

### DIFF
--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -86,7 +86,7 @@ cli = [
     "tomli-w>=1.0.0",
     "tox>=3.12.1, <4.0.0",
     "twine>=1.11.0",
-    "virtualenv",
+    "virtualenv<20.22.0",
     # TODO: Remove once every check has a pyproject.toml
     "setuptools>=66; python_version > '3.0'",
     "setuptools; python_version < '3.0'",


### PR DESCRIPTION
### Motivation

Python 2 is no longer supported and our tests are failing https://virtualenv.pypa.io/en/latest/changelog.html#v20-22-0-2023-04-19