### PR TITLE
Add the ability to use a different image to run the tests

### DIFF
--- a/gitlab_runner/hatch.toml
+++ b/gitlab_runner/hatch.toml
@@ -2,6 +2,7 @@
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
+GITLAB_IMAGE = "gitlab/gitlab-ce"
 
 [[envs.default.matrix]]
 python = ["2.7", "3.8"]
@@ -9,3 +10,4 @@ version = ["10.8.0"]
 
 [envs.default.overrides]
 matrix.version.env-vars = "GITLAB_RUNNER_VERSION"
+GITLAB_IMAGE = "gitlab/gitlab-ce"

--- a/gitlab_runner/tests/compose/docker-compose.yml
+++ b/gitlab_runner/tests/compose/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     entrypoint:
       - /support/wait_for_master.sh
   gitlab:
-    image: gitlab/gitlab-ce:${GITLAB_RUNNER_VERSION}-ce.0
+    image: ${GITLAB_IMAGE:-gitlab/gitlab-ce}:${GITLAB_RUNNER_VERSION}-ce.0
     ports:
       - "${GITLAB_LOCAL_MASTER_PORT}:80"
     environment:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add the ability to use a different image to run the tests.

### Motivation
<!-- What inspired you to submit this pull request? -->

- The official image takes forever to spin up on our M1s. Switching to a arm64 works fine, from ~10 minutes to ~2 minutes.
- Similar to https://github.com/DataDog/integrations-core/pull/14397

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.