### PR TITLE
Fix query sampler producing constant errors about undefined parameters

### DIFF
--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -577,7 +577,6 @@ class PostgresStatementSamples(DBMAsyncJob):
 
         return db_explain_error, err
 
-    @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _run_explain(self, dbname, statement, obfuscated_statement):
         start_time = time.time()
         with self._conn_pool.get_connection(dbname, ttl_ms=self._conn_ttl_ms).cursor() as cursor:
@@ -615,6 +614,7 @@ class PostgresStatementSamples(DBMAsyncJob):
             )
         return plan_dict, explain_err_code, err_msg
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def _run_explain_safe(self, dbname, statement, obfuscated_statement, query_signature):
         # type: (str, str, str, str) -> Tuple[Optional[Dict], Optional[DBExplainError], Optional[str]]
         if not self._can_explain_statement(obfuscated_statement):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Fixes DBM's query sampler which produces constant errors about undefined parameters.
e.g.
```
ERROR | (pkg/collector/python/datadog_agent.go:130 in LogMessage) | postgres:5579dc5d4143c336 | (tracking.py:84) | dd.trace_id=14998057449499886562 dd.span_id=15167319973303942127 | operation _run_explain error
Traceback (most recent call last):
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/utils/tracking.py", line 71, in wrapper
    result = function(self, *args, **kwargs)
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/postgres/statement_samples.py", line 585, in _run_explain
    cursor.execute(
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/ddtrace/contrib/dbapi/__init__.py", line 110, in execute
    return self._trace_method(self.__wrapped__.execute, self._self_datadog_name, query, {}, query, *args, **kwargs)
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/ddtrace/contrib/psycopg/patch.py", line 59, in _trace_method
    return super(Psycopg2TracedCursor, self)._trace_method(method, name, resource, extra_tags, *args, **kwargs)
  File "/opt/datadog-agent/embedded/lib/python3.8/site-packages/ddtrace/contrib/dbapi/__init__.py", line 73, in _trace_method
    return method(*args, **kwargs)
psycopg2.errors.UndefinedParameter: there is no parameter $1
LINE 1: SELECT * FROM foo WHERE id = $1
```

This is happening because the decorator on the `_run_explain()` method will log any errors produced. We don't handle errors in this method because it should be done by the parent caller. The solution is to remove the decorator and place it on the parent caller.

### Motivation
<!-- What inspired you to submit this pull request? -->
Addresses this issue: https://github.com/DataDog/integrations-core/issues/13840

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.