### PR TITLE
Clearer instructions for migrating to prometheus plugin

### DIFF
--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -171,7 +171,7 @@ Additional helpful documentation, links, and articles:
 
 When migrating from the *Management Plugin* to the *Prometheus Plugin* check the metrics that you rely on most. Some may have new names, some may not be available anymore.
 
-Look up your metrics in [this table](23). If a metric's description contains an `[OpenMetricsV2]` tag, then it is available in the *Prometheus Plugin*.
+Look up your metrics in [this table][23]. If a metric's description contains an `[OpenMetricsV2]` tag, then it is available in the *Prometheus Plugin*.
 
 
 ### FAQ

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -167,91 +167,12 @@ Additional helpful documentation, links, and articles:
 - [Collecting metrics with RabbitMQ monitoring tools][16]
 - [Monitoring RabbitMQ performance with Datadog][17]
 
-### Prometheus Plugin Migration Guide
+### Migrating to Prometheus Plugin
 
-The following table maps metrics coming from the Management plugin to their Prometheus plugin equivalents.
+When migrating from the *Management Plugin* to the *Prometheus Plugin* check the metrics that you rely on most. Some may have new names, some may not be available anymore.
 
-| Management Plugin metric                                                    | Prometheus Plugin Equivalent                                                                                                                | Endpoint            |
-|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|---------------------|
-| rabbitmq.connections                                           | rabbitmq\_connections                                                                                                         |                     |
-| rabbitmq.node.disk\_alarm                                      | rabbitmq\_alarms\_free\_disk\_space\_watermark                                                                                | /metrics            |
-| rabbitmq.node.disk\_free                                       | rabbitmq\_disk\_space\_available\_bytes                                                                                       |                     |
-| rabbitmq.node.fd\_used                                         | rabbitmq\_process\_open\_fds                                                                                                  |                     |
-| rabbitmq.node.mem\_alarm                                       | rabbitmq\_alarms\_memory\_used\_watermark                                                                                     | /metrics            |
-| rabbitmq.node.mem\_limit                                       | rabbitmq\_resident\_memory\_limit\_bytes                                                                                      |                     |
-| rabbitmq.node.mem\_used                                        | rabbitmq\_process\_resident\_memory\_bytes                                                                                    |                     |
-| rabbitmq.node.sockets\_used                                    | erlang\_vm\_port\_count                                                                                                       |                     |
-| rabbitmq.overview.messages.confirm.count                       | rabbitmq\_global\_messages\_confirmed\_total                                                                                  |                     |
-| rabbitmq.overview.messages.deliver\_get.count                  | rabbitmq\_global\_messages\_delivered\_get\_auto\_ack\_total + rabbitmq\_global\_messages\_delivered\_get\_manual\_ack\_total |                     |
-| rabbitmq.overview.messages.publish.count                       | rabbitmq\_queue\_messages\_published\_total                                                                                   | /metrics            |
-| rabbitmq.overview.messages.redeliver.count                     | rabbitmq\_global\_messages\_redelivered\_total                                                                                |                     |
-| rabbitmq.overview.messages.return\_unroutable.count            | rabbitmq\_global\_messages\_unroutable\_returned\_total                                                                       |                     |
-| rabbitmq.overview.object\_totals.channels                      | rabbitmq\_channels                                                                                                            |                     |
-| rabbitmq.overview.object\_totals.connections                   | rabbitmq\_connections                                                                                                         |                     |
-| rabbitmq.overview.object\_totals.consumers                     | rabbitmq\_global\_consumers                                                                                                   |                     |
-| rabbitmq.overview.object\_totals.queues                        | rabbitmq\_queues                                                                                                              |                     |
-| rabbitmq.overview.queue\_totals.messages.count                 | rabbitmq\_queue\_messages                                                                                                     | /metrics            |
-| rabbitmq.overview.queue\_totals.messages\_ready.count          | rabbitmq\_queue\_messages\_ready                                                                                              | /metrics            |
-| rabbitmq.overview.queue\_totals.messages\_unacknowledged.count | rabbitmq\_queue\_messages\_unacked                                                                                            | /metrics            |
-| rabbitmq.queue.consumers                                       | rabbitmq\_queue\_consumers                                                                                                    | /metrics            |
-| rabbitmq.queue.head\_message\_timestamp                        | rabbitmq\_queue\_head\_message\_timestamp                                                                                     | /metrics/per-object |
-| rabbitmq.queue.memory                                          | rabbitmq\_queue\_process\_memory\_bytes                                                                                       | /metrics/per-object |
-| rabbitmq.queue.message\_bytes                                  | rabbitmq\_queue\_messages\_ready\_bytes                                                                                       | /metrics/per-object |
-| rabbitmq.queue.messages                                        | rabbitmq\_queue\_messages                                                                                                     | /metrics/per-object |
-| rabbitmq.queue.messages.publish.count                          | rabbitmq\_queue\_messages\_published\_total                                                                                   | /metrics            |
-| rabbitmq.queue.messages.redeliver.count                        | rabbitmq\_global\_messages\_redelivered\_total                                                                                |                     |
-| rabbitmq.queue.messages\_ready                                 | rabbitmq\_queue\_messages\_ready                                                                                              |                     |
-| rabbitmq.queue.messages\_unacknowledged                        | rabbitmq\_queue\_messages\_unacked                                                                                            |                     |
+Look up your metrics in [this table](23). If a metric's description contains an `[OpenMetricsV2]` tag, then it is available in the *Prometheus Plugin*.
 
-The following Management plugin metrics to our knowledge have no equivalent in the Prometheus plugin.
-
-- rabbitmq.connections.state
-- rabbitmq.exchange.messages.ack.count
-- rabbitmq.exchange.messages.ack.rate
-- rabbitmq.exchange.messages.confirm.count
-- rabbitmq.exchange.messages.confirm.rate
-- rabbitmq.exchange.messages.deliver\_get.count
-- rabbitmq.exchange.messages.deliver\_get.rate
-- rabbitmq.exchange.messages.publish.count
-- rabbitmq.exchange.messages.publish.rate
-- rabbitmq.exchange.messages.publish\_in.count
-- rabbitmq.exchange.messages.publish\_in.rate
-- rabbitmq.exchange.messages.publish\_out.count
-- rabbitmq.exchange.messages.publish\_out.rate
-- rabbitmq.exchange.messages.redeliver.count
-- rabbitmq.exchange.messages.redeliver.rate
-- rabbitmq.exchange.messages.return\_unroutable.count
-- rabbitmq.exchange.messages.return\_unroutable.rate
-- rabbitmq.node.partitions
-- rabbitmq.node.run\_queue
-- rabbitmq.node.running
-- rabbitmq.overview.messages.ack.count
-- rabbitmq.overview.messages.ack.rate
-- rabbitmq.overview.messages.confirm.rate
-- rabbitmq.overview.messages.deliver\_get.rate
-- rabbitmq.overview.messages.publish.rate
-- rabbitmq.overview.messages.publish\_in.count
-- rabbitmq.overview.messages.publish\_in.rate
-- rabbitmq.overview.messages.publish\_out.count
-- rabbitmq.overview.messages.publish\_out.rate
-- rabbitmq.overview.messages.redeliver.rate
-- rabbitmq.overview.messages.return\_unroutable.rate
-- rabbitmq.overview.queue\_totals.messages.rate
-- rabbitmq.overview.queue\_totals.messages\_ready.rate
-- rabbitmq.overview.queue\_totals.messages\_unacknowledged.rate
-- rabbitmq.queue.active\_consumers
-- rabbitmq.queue.bindings.count
-- rabbitmq.queue.messages.ack.count
-- rabbitmq.queue.messages.ack.rate
-- rabbitmq.queue.messages.deliver.count
-- rabbitmq.queue.messages.deliver.rate
-- rabbitmq.queue.messages.deliver\_get.count
-- rabbitmq.queue.messages.deliver\_get.rate
-- rabbitmq.queue.messages.publish.rate
-- rabbitmq.queue.messages.rate
-- rabbitmq.queue.messages.redeliver.rate
-- rabbitmq.queue.messages\_ready.rate
-- rabbitmq.queue.messages\_unacknowledged.rate
 
 ### FAQ
 

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -173,6 +173,8 @@ When migrating from the *Management Plugin* to the *Prometheus Plugin* check the
 
 Look up your metrics in [this table][23]. If a metric's description contains an `[OpenMetricsV2]` tag, then it is available in the *Prometheus Plugin*.
 
+Metrics only available in the *Management Plugin* have no tags in their descriptions.
+
 
 ### FAQ
 

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -169,11 +169,11 @@ Additional helpful documentation, links, and articles:
 
 ### Migrating to Prometheus Plugin
 
-When migrating from the *Management Plugin* to the *Prometheus Plugin* check the metrics that you rely on most. Some may have new names, some may not be available anymore.
+When migrating from the Management Plugin to the Prometheus Plugin, review the metrics that you use because some of them might have new names or might not be available anymore.
 
-Look up your metrics in [this table][23]. If a metric's description contains an `[OpenMetricsV2]` tag, then it is available in the *Prometheus Plugin*.
+Look up your metrics in [this table][23]. If a metric's description contains an `[OpenMetricsV2]` tag, then it is available in the Prometheus Plugin.
 
-Metrics only available in the *Management Plugin* have no tags in their descriptions.
+Metrics available only in the Management Plugin do not have tags in their descriptions.
 
 
 ### FAQ


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

The mapping from management cli to prometheus metrics led to a lot of confusion. Customers found the switch between raw prometheus metric names and datadog metric names for the legacy integration particularly confusing. 

At the end of the day customers just wanted to know if a particular metric from the legacy integration was also present in the new integration. This question can be answered just as well by consulting the metadata.csv-generated table with metric descriptions.

This PR removes the confusing table and points the customers to metadata.csv with clear instructions what to look for.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.