### PR TITLE
Fix metric name for persistentvolume.by_phase

### DIFF
--- a/kubernetes_state/metadata.csv
+++ b/kubernetes_state/metadata.csv
@@ -49,7 +49,7 @@ kubernetes_state.node.gpu.cards_allocatable,gauge,,,,The GPU resources of a node
 kubernetes_state.node.gpu.cards_capacity,gauge,,,,The total GPU resources of the node,0,kubernetes,k8s_state.node.gpu.cards_capacity,
 kubernetes_state.persistentvolumeclaim.status,gauge,,,,The phase the persistent volume claim is currently in,-1,kubernetes,k8s_state.pvc.status,
 kubernetes_state.persistentvolumeclaim.request_storage,gauge,,byte,,Storage space request for a given pvc,0,kubernetes,k8s_state.pvc.request,
-kubernetes_state.persistentvolume.by_phase,gauge,,,,Number of persistent volumes to sum by phase and storageclass,0,kubernetes,k8s_state.pv.by_phase,
+kubernetes_state.persistentvolumes.by_phase,gauge,,,,Number of persistent volumes to sum by phase and storageclass,0,kubernetes,k8s_state.pv.by_phase,
 kubernetes_state.namespace.count,gauge,,cpu,,The number of namespaces,0,kubernetes,k8s_state.namespace.count,
 kubernetes_state.node.cpu_allocatable,gauge,,cpu,,The CPU resources of a node that are available for scheduling,0,kubernetes,k8s_state.node.cpu_allocatable,
 kubernetes_state.node.memory_allocatable,gauge,,byte,,The memory resources of a node that are available for scheduling,0,kubernetes,k8s_state.node.memory_allocatable,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This is a quick PR to change the name of the metric `kubernetes_state.persistentvolume.by_phase` to `kubernetes_state.persistentvolumes.by_phase` (added "s"). This is because the metric appears to have been added without an "s" when it was first noted in the docs in 2018 ([see here](https://github.com/DataDog/integrations-core/commit/e4b533a319e889ea3f34e610fb54845a2bb2d5b0#diff-46e3085ae5f9101b2cf8b9b89e73ea5e483c463bab0da11c55d9bce7229feb8f)) the metric had an "s" but the docs showed no "s."

### Motivation
<!-- What inspired you to submit this pull request? -->
This has gotten confusing because there _is_ a `kubernetes_state.persistentvolume.by_phase` in KSM core. Customer reached out asking about this seeming disrepency ([card here](https://datadoghq.atlassian.net/browse/CONS-5522)).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.