### PR TITLE
[APW] Fix more integration dashboards' json definition

### DIFF
--- a/foundationdb/assets/dashboards/foundationdb_latency_probe.json
+++ b/foundationdb/assets/dashboards/foundationdb_latency_probe.json
@@ -50,7 +50,7 @@
                 "max":"auto"
              },
              "markers":[
-                
+
              ]
           },
           "layout":{
@@ -126,7 +126,7 @@
                 "max":"auto"
              },
              "markers":[
-                
+
              ]
           },
           "layout":{
@@ -184,7 +184,7 @@
                 "max":"auto"
              },
              "markers":[
-                
+
              ]
           },
           "layout":{
@@ -222,15 +222,14 @@
           "default":"*",
           "prefix":"service",
           "available_values":[
-             
+
           ]
        }
     ],
     "layout_type":"ordered",
     "is_read_only":false,
     "notify_list":[
-       
+
     ],
-    "reflow_type":"fixed",
-    "id":"e9c-35y-64x"
+    "reflow_type":"fixed"
  }

--- a/foundationdb/assets/dashboards/foundationdb_processes_and_utilization.json
+++ b/foundationdb/assets/dashboards/foundationdb_processes_and_utilization.json
@@ -446,7 +446,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -522,7 +522,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -598,7 +598,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -673,7 +673,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -731,7 +731,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -789,7 +789,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -882,7 +882,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -908,15 +908,13 @@
           "default":"*",
           "prefix":"service",
           "available_values":[
-             
+
           ]
        }
     ],
     "layout_type":"ordered",
     "is_read_only":false,
     "notify_list":[
-       
     ],
-    "reflow_type":"fixed",
-    "id":"8us-bdk-r7h"
+    "reflow_type":"fixed"
  }

--- a/foundationdb/assets/dashboards/foundationdb_transactions_and_queues.json
+++ b/foundationdb/assets/dashboards/foundationdb_transactions_and_queues.json
@@ -116,7 +116,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -175,7 +175,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -255,7 +255,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -313,7 +313,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -449,7 +449,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -589,7 +589,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -760,7 +760,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -845,7 +845,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -912,7 +912,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -979,7 +979,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -1054,7 +1054,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -1112,7 +1112,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -1170,7 +1170,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -1228,7 +1228,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -1286,7 +1286,7 @@
                          "max":"auto"
                       },
                       "markers":[
-                         
+
                       ]
                    },
                    "layout":{
@@ -1333,15 +1333,14 @@
           "default":"*",
           "prefix":"service",
           "available_values":[
-             
+
           ]
        }
     ],
     "layout_type":"ordered",
     "is_read_only":false,
     "notify_list":[
-       
+
     ],
-    "reflow_type":"fixed",
-    "id":"6vn-5wq-k3i"
+    "reflow_type":"fixed"
  }

--- a/nginx/assets/dashboards/NGINX-Overview_dashboard.json
+++ b/nginx/assets/dashboards/NGINX-Overview_dashboard.json
@@ -836,6 +836,5 @@
     }
   ],
   "layout_type": "ordered",
-  "is_read_only": true,
-  "id": 21
+  "is_read_only": true
 }

--- a/sqlserver/assets/dashboards/SQLServer-AlwaysOn_dashboard.json
+++ b/sqlserver/assets/dashboards/SQLServer-AlwaysOn_dashboard.json
@@ -551,7 +551,7 @@
           "name":"host",
           "prefix":"host",
           "available_values":[
-             
+
           ],
           "default":"*"
        },
@@ -559,7 +559,7 @@
           "name":"replica_server",
           "prefix":"replica_server_name",
           "available_values":[
-             
+
           ],
           "default":"*"
        },
@@ -567,15 +567,13 @@
           "name":"availability_group",
           "prefix":"availability_group_name",
           "available_values":[
-             
+
           ],
           "default":"*"
        }
     ],
     "layout_type":"ordered",
     "notify_list":[
-       
     ],
-    "reflow_type":"fixed",
-    "id":"hhu-5vj-tjv"
+    "reflow_type":"fixed"
  }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR removes the `id` field from all our integration dashboards' JSON definitions so that they pass the dashboard validation that we are introducing in the Asset Publishing Workflow (see #apw-dashboard-reporting on Slack)
Note that we only accept string `id`s in our dashboard validators, but integration dashboards ids are integer and they are autogenerated on Postgres).

### Motivation
<!-- What inspired you to submit this pull request? -->
We want to add asset validation for the Asset Publishing Workflow.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.