### PR TITLE
[DBM-2376] - Update sqlserver integration for Azure Elastic Pool improvements

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -632,9 +632,6 @@ class SQLServer(AgentCheck):
                 )
             except SQLConnectionError:
                 raise
-            except (ProgrammingError, DatabaseError) as permissions_error:
-                self.log.warning("The agent cannot execute this query due to missing permissions: %s", permissions_error)
-                raise
             except Exception:
                 self.log.warning("Can't load the metric %s, ignoring", name, exc_info=True)
                 continue

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -632,6 +632,11 @@ class SQLServer(AgentCheck):
                 )
             except SQLConnectionError:
                 raise
+
+            except (pyodbc.ProgrammingError, adodbapi.DatabaseError) as permissions_error:
+                self.log.warning("The agent cannot execute this query due to missing permissions: %s", permissions_error)
+                raise
+
             except Exception:
                 self.log.warning("Can't load the metric %s, ignoring", name, exc_info=True)
                 continue

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -636,7 +636,11 @@ class SQLServer(AgentCheck):
 
             except Exception as e:
                 if e.args[0] == '42000':
-                    self.log.warning("Can't load the metric %s.The configured user is missing the VIEW SERVER STATE permissions or ##MS_ServerStateReader## server role.", name)
+                    self.log.warning(
+                        "Can't load the metric %s.The configured user is missing the \
+                        VIEW SERVER STATE permissions or ##MS_ServerStateReader## server role.",
+                        name,
+                    )
                 else:
                     self.log.warning("Can't load the metric %s, ignoring", name, exc_info=True)
                 continue
@@ -790,12 +794,19 @@ class SQLServer(AgentCheck):
 
                         except Exception as e:
                             if e.args[0] == '42000':
-                                self.log.warning("Cannot run `fetch_all` for metrics %s \
+                                self.log.warning(
+                                    "Cannot run `fetch_all` for metrics %s \
                                     The configured user is missing the VIEW SERVER STATE permissions or \
-                                    ##MS_ServerStateReader## server role.", cls)
+                                    ##MS_ServerStateReader## server role.",
+                                    cls,
+                                )
                             else:
-                                self.log.error("Error running `fetch_all` for metrics %s - skipping.  \
-                                    Error: %s", cls, e)
+                                self.log.error(
+                                    "Error running `fetch_all` for metrics %s - skipping.  \
+                                    Error: %s",
+                                    cls,
+                                    e,
+                                )
                             rows, cols = None, None
 
                         instance_results[cls] = rows, cols
@@ -824,7 +835,7 @@ class SQLServer(AgentCheck):
             try:
                 # Server state queries require VIEW SERVER STATE permissions, which some managed database
                 # versions do not support.
-                # Update 04/2023 - This info might be incorrect because you can use the 
+                # Update 04/2023 - This info might be incorrect because you can use the
                 # ##MS_ServerStateReader## server role as well.
                 # to double check and potentially remove compltely.
 
@@ -832,12 +843,14 @@ class SQLServer(AgentCheck):
                     self.server_state_queries.execute()
                 except Exception as e:
                     if e.args[0] == '42000':
-                        #To Do: improve QueryManager exception to raise so that we can send these logs. (core:80)
-                        #Leaving for now since they could potentially trigger should there be a real exception raised.
-                        self.log.warning("Cannot get Server State information. The configured user is missing the \
-                            VIEW SERVER STATE permissions or ##MS_ServerStateReader## server role.")
+                        # To Do: improve QueryManager exception to raise so that we can send these logs. (core:80)
+                        # Leaving for now since they could potentially trigger should there be a real exception raised.
+                        self.log.warning(
+                            "Cannot get Server State information. The configured user is missing the \
+                            VIEW SERVER STATE permissions or ##MS_ServerStateReader## server role."
+                        )
                     else:
-                        self.log.error("Cannot execute query:%s",e)
+                        self.log.error("Cannot execute query:%s", e)
 
                 if self.dynamic_queries:
                     self.dynamic_queries.execute()

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -790,9 +790,12 @@ class SQLServer(AgentCheck):
 
                         except Exception as e:
                             if e.args[0] == '42000':
-                                self.log.warning("Cannot run `fetch_all` for metrics %s The configured user is missing the VIEW SERVER STATE permissions or ##MS_ServerStateReader## server role.", cls)
+                                self.log.warning("Cannot run `fetch_all` for metrics %s \
+                                    The configured user is missing the VIEW SERVER STATE permissions or \
+                                    ##MS_ServerStateReader## server role.", cls)
                             else:
-                                self.log.error("Error running `fetch_all` for metrics %s - skipping.  Error: %s", cls, e)
+                                self.log.error("Error running `fetch_all` for metrics %s - skipping.  \
+                                    Error: %s", cls, e)
                             rows, cols = None, None
 
                         instance_results[cls] = rows, cols
@@ -821,7 +824,8 @@ class SQLServer(AgentCheck):
             try:
                 # Server state queries require VIEW SERVER STATE permissions, which some managed database
                 # versions do not support.
-                # Update 04/2023 - This info might be incorrect because you can use the ##MS_ServerStateReader## server role as well.
+                # Update 04/2023 - This info might be incorrect because you can use the 
+                # ##MS_ServerStateReader## server role as well.
                 # to double check and potentially remove compltely.
 
                 try:
@@ -830,7 +834,8 @@ class SQLServer(AgentCheck):
                     if e.args[0] == '42000':
                         #To Do: improve QueryManager exception to raise so that we can send these logs. (core:80)
                         #Leaving for now since they could potentially trigger should there be a real exception raised.
-                        self.log.warning("Cannot get Server State information. The configured user is missing the VIEW SERVER STATE permissions or ##MS_ServerStateReader## server role.")
+                        self.log.warning("Cannot get Server State information. The configured user is missing the \
+                            VIEW SERVER STATE permissions or ##MS_ServerStateReader## server role.")
                     else:
                         self.log.error("Cannot execute query:%s",e)
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -632,6 +632,9 @@ class SQLServer(AgentCheck):
                 )
             except SQLConnectionError:
                 raise
+            except (ProgrammingError, DatabaseError) as permissions_error:
+                self.log.warning("The agent cannot execute this query due to missing permissions: %s", permissions_error)
+                raise
             except Exception:
                 self.log.warning("Can't load the metric %s, ignoring", name, exc_info=True)
                 continue

--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -53,7 +53,7 @@ platform.windows.env-vars = [
 matrix.os.platforms = [
   { value = "windows", if = ["windows"] },
   { value = "linux", if = ["linux"] },
-  { value = "macos", if = ["linux"] },
+  { value = "macos", if = ["linux"] }
 ]
 matrix.setup.env-vars = [
   { key = "COMPOSE_FOLDER", value = "compose-ha", if = ["ha"] },
@@ -62,6 +62,7 @@ matrix.version.env-vars = [
   { key = "SQLSERVER_MAJOR_VERSION" },
   { key = "SQLSERVER_IMAGE_TAG", value = "2017-CU24-ubuntu-16.04", if = ["2017"], platform = ["linux"] },
   { key = "SQLSERVER_IMAGE_TAG", value = "2019-CU11-ubuntu-16.04", if = ["2019"], platform = ["linux"] },
+  { key = "SQLSERVER_IMAGE_TAG", value = "2019-CU11-ubuntu-16.04", if = ["2019"], platform = ["macos"] },
   { key = "SQLSERVER_BASE_IMAGE", value = "datadog/docker-library:sqlserver_{matrix:version}", platform = ["windows"] },
 ]
 matrix.driver.env-vars = [


### PR DESCRIPTION
### What does this PR do?

Based on [this initial escalation](https://datadoghq.atlassian.net/browse/SDBM-441) when using Elastic Pools, customers seem to have a value returned for the engine edition that makes us skip one of the main queries that we run to collect several metrics like Server Uptime. Base on the investigation with the customer, they do indeed have the correct permissions to run this query.

We need to update the integration to avoid incorrectly skipping over the collection of these metrics.

### Motivation

- [Support Escalation](https://datadoghq.atlassian.net/browse/SDBM-441)
- [Support Request](https://datadog.zendesk.com/agent/tickets/1166395)

### Additional Notes

Also touched up the hatch file so that ddev could launch the instance on macos.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.