### PR TITLE
Create `postgresql.uptime` metric

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -28,6 +28,7 @@ from .util import (
     QUERY_PG_STAT_DATABASE,
     QUERY_PG_STAT_DATABASE_CONFLICTS,
     QUERY_PG_STAT_WAL_RECEIVER,
+    QUERY_PG_UPTIME,
     REPLICATION_METRICS,
     SLRU_METRICS,
     DatabaseConfigurationError,  # noqa: F401
@@ -153,7 +154,7 @@ class PostgreSql(AgentCheck):
                 q_pg_stat_database["query"] += " AND datname in('{}')".format(self._config.dbname)
                 q_pg_stat_database_conflicts["query"] += " AND datname in('{}')".format(self._config.dbname)
 
-            queries.extend([q_pg_stat_database, q_pg_stat_database_conflicts])
+            queries.extend([q_pg_stat_database, q_pg_stat_database_conflicts, QUERY_PG_UPTIME])
 
         if self.version >= V10:
             queries.append(QUERY_PG_STAT_WAL_RECEIVER)

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -139,6 +139,14 @@ QUERY_PG_STAT_DATABASE_CONFLICTS = {
     ],
 }
 
+QUERY_PG_UPTIME = {
+    'name': 'pg_uptime',
+    'query': "SELECT FLOOR(EXTRACT(EPOCH FROM current_timestamp - pg_postmaster_start_time()))",
+    'columns': [
+        {'name': 'postgresql.uptime', 'type': 'gauge'},
+    ],
+}
+
 COMMON_BGW_METRICS = {
     'checkpoints_timed': ('postgresql.bgwriter.checkpoints_timed', AgentCheck.monotonic_count),
     'checkpoints_req': ('postgresql.bgwriter.checkpoints_requested', AgentCheck.monotonic_count),

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -109,6 +109,7 @@ postgresql.slru.flushes,count,,,,"Number of flush of dirty data for this SLRU (s
 postgresql.slru.truncates,count,,,,"Number of truncates for this SLRU (simple least-recently-used) cache. For CommitTs, Xact and MultiXact, truncates will happen when the frozenID progresses. For Subtrans, a truncate can occur during restartpoint and a checkpoint.",0,postgres,postgres slru truncates,
 postgresql.transactions.duration.max,gauge,,nanosecond,,"The age of the longest running transaction per user, db and app. (DBM only)",0,postgres,postgres transactions duration max,
 postgresql.transactions.duration.sum,gauge,,nanosecond,,"The sum of the age of all running transactions per user, db and app. (DBM only)",0,postgres,postgres transactions duration sum,
+postgresql.uptime,gauge,,second,,"The uptime of the server in seconds.",0,postgres,postgres uptime,
 postgresql.wal_age,gauge,,second,,The age in seconds of the oldest WAL file.,0,postgres,wal age,
 postgresql.wal_receiver.connected,gauge,,,,"The status of the WAL receiver. This metric will be set to 1 with a 'status:disconnected' tag if the instance doesn't have a running WAL receiver. Otherwise it will use status value from pg_stat_wal_receiver.",0,postgres,wal receiver connected,
 postgresql.wal_receiver.received_timeline,gauge,,,,"Timeline number of last write-ahead log location received and flushed to disk, the initial value of this field being the timeline number of the first log location used when WAL receiver is started.",0,postgres,wal receiver tli,

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -13,6 +13,7 @@ from datadog_checks.postgres.util import (
     NEWER_14_METRICS,
     QUERY_PG_REPLICATION_SLOTS,
     QUERY_PG_STAT_WAL_RECEIVER,
+    QUERY_PG_UPTIME,
     REPLICATION_STATS_METRICS,
     SLRU_METRICS,
 )
@@ -206,6 +207,11 @@ def check_replication_delay(aggregator, metrics_cache, expected_tags, count=1):
     replication_metrics = metrics_cache.get_replication_metrics(VersionUtils.parse_version(POSTGRES_VERSION), False)
     for (metric_name, _) in replication_metrics.values():
         aggregator.assert_metric(metric_name, count=count, tags=expected_tags)
+
+
+def check_uptime_metrics(aggregator, expected_tags, count=1):
+    for column in QUERY_PG_UPTIME['columns']:
+        aggregator.assert_metric(column['name'], count=count, tags=expected_tags)
 
 
 def check_conflict_metrics(aggregator, expected_tags, count=1):

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -29,6 +29,7 @@ from .common import (
     check_replication_slots,
     check_slru_metrics,
     check_stat_replication,
+    check_uptime_metrics,
     check_wal_receiver_metrics,
     requires_static_version,
 )
@@ -55,6 +56,7 @@ def test_common_metrics(aggregator, integration_check, pg_instance):
     check_slru_metrics(aggregator, expected_tags=expected_tags)
     check_stat_replication(aggregator, expected_tags=expected_tags)
     check_wal_receiver_metrics(aggregator, expected_tags=expected_tags, connected=0)
+    check_uptime_metrics(aggregator, expected_tags=expected_tags)
 
     replication_slot_tags = expected_tags + [
         'slot_name:replication_slot',

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -14,6 +14,7 @@ from .common import (
     check_db_count,
     check_replication_delay,
     check_slru_metrics,
+    check_uptime_metrics,
     check_wal_receiver_metrics,
 )
 from .utils import _get_superconn, _wait_for_value, requires_over_10
@@ -38,6 +39,7 @@ def test_common_replica_metrics(aggregator, integration_check, metrics_cache_rep
     check_replication_delay(aggregator, metrics_cache_replica, expected_tags=expected_tags)
     check_wal_receiver_metrics(aggregator, expected_tags=expected_tags + ['status:streaming'])
     check_conflict_metrics(aggregator, expected_tags=expected_tags)
+    check_uptime_metrics(aggregator, expected_tags=expected_tags)
 
     aggregator.assert_all_metrics_covered()
 


### PR DESCRIPTION
### What does this PR do?
Create a `postgresql.uptime` metric.

### Motivation
Managed cloud databases will restart servers during maintenance window for minor upgrades. Having the uptime can help to know if a specific server has already been restarted or not. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.