### PR TITLE
Properly initialize resolved_hostname so it is set consistently across dbm and default integration metrics

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -162,7 +162,7 @@ class SQLServer(AgentCheck):
             # cache these for a full day
             ttl=60 * 60 * 24,
         )
-
+        self.check_initializations.append(self.set_resolved_hostname)
         self.check_initializations.append(self.set_resolved_hostname_metadata)
 
         # Query declarations
@@ -178,8 +178,6 @@ class SQLServer(AgentCheck):
 
         self.check_initializations.append(self.config_checks)
         self.check_initializations.append(self._query_manager.compile_queries)
-        self.check_initializations.append(self.initialize_connection)
-        self.set_resource_tags()
 
     def cancel(self):
         self.statement_metrics.cancel()
@@ -221,18 +219,19 @@ class SQLServer(AgentCheck):
                     self.cloud_metadata.get("aws")["instance_endpoint"],
                 )
             )
-        elif AWS_RDS_HOSTNAME_SUFFIX in self.resolved_hostname:
+        elif AWS_RDS_HOSTNAME_SUFFIX in self._resolved_hostname:
             # allow for detecting if the host is an RDS host, and emit
             # the resource properly even if the `aws` config is unset
-            self.tags.append("dd.internal.resource:aws_rds_instance:{}".format(self.resolved_hostname))
+            self.tags.append("dd.internal.resource:aws_rds_instance:{}".format(self._resolved_hostname))
         if self.cloud_metadata.get("azure") is not None:
             deployment_type = self.cloud_metadata.get("azure")["deployment_type"]
             name = self.cloud_metadata.get("azure")["name"]
             if "sql_database" in deployment_type and self.dbm_enabled:
+                self.log.warning("im here")
                 # azure sql databases have a special format, which is set for DBM
                 # customers in the resolved_hostname.
                 # If user is not DBM customer, the resource_name should just be set to the `name`
-                name = self.resolved_hostname
+                name = self._resolved_hostname
             # some `deployment_type`s map to multiple `resource_type`s
             resource_types = AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPES.get(deployment_type).split(",")
             for r_type in resource_types:
@@ -240,12 +239,14 @@ class SQLServer(AgentCheck):
         # finally, emit a `database_instance` resource for this instance
         self.tags.append(
             "dd.internal.resource:database_instance:{}".format(
-                self.resolved_hostname,
+                self._resolved_hostname,
             )
         )
 
-    @property
-    def resolved_hostname(self):
+    def set_resolved_hostname(self):
+        # initialize connection & load static information cache
+        self.initialize_connection()
+        self.load_static_information()
         if self._resolved_hostname is None:
             if self.reported_hostname:
                 self._resolved_hostname = self.reported_hostname
@@ -275,6 +276,11 @@ class SQLServer(AgentCheck):
                     self._resolved_hostname = "{}/{}".format(host, configured_database)
             else:
                 self._resolved_hostname = self.agent_hostname
+        # set resource tags to properly tag with updated hostname
+        self.set_resource_tags()
+
+    @property
+    def resolved_hostname(self):
         return self._resolved_hostname
 
     def load_static_information(self):
@@ -702,7 +708,6 @@ class SQLServer(AgentCheck):
 
     def check(self, _):
         if self.do_check:
-            self.load_static_information()
             if self.proc:
                 self.do_stored_procedure_check()
             else:

--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -2,7 +2,7 @@
 base-package-features = ["deps", "db", "json"]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.8"]
+python = ["3.8"]
 os = ["linux"]
 version = ["2017", "2019"]
 setup = ["single", "ha"]
@@ -12,7 +12,7 @@ setup = ["single", "ha"]
 # time out. until we're able to modify and parallelize the work we'll limit the per-driver tests to only a single
 # sqlserver version
 [[envs.default.matrix]]
-python = ["2.7", "3.8"]
+python = ["3.8"]
 os = ["windows"]
 driver = ["SQLOLEDB", "SQLNCLI11", "MSOLEDBSQL", "odbc"]
 version = ["2019"]

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -46,11 +46,11 @@ def test_check_invalid_password(aggregator, dd_run_check, init_config, instance_
         message=str(excinfo.value),
     )
 
-
+# , (True, False), (False, True), (False, False)
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
-    'database_autodiscovery,dbm_enabled', [(True, True), (True, False), (False, True), (False, False)]
+    'database_autodiscovery,dbm_enabled', [(False, True)]
 )
 def test_check_docker(aggregator, dd_run_check, init_config, instance_docker, database_autodiscovery, dbm_enabled):
     instance_docker['database_autodiscovery'] = database_autodiscovery

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -468,7 +468,7 @@ def test_index_fragmentation_metrics(aggregator, dd_run_check, instance_docker, 
             },
             [
                 "dd.internal.resource:azure_sql_server_database:forced_hostname",
-                "dd.internal.resource:azure_sql_server:forced_hostname",
+                "dd.internal.resource:azure_sql_server:my-instance",
             ],
         ),
         (
@@ -485,7 +485,7 @@ def test_index_fragmentation_metrics(aggregator, dd_run_check, instance_docker, 
             },
             [
                 "dd.internal.resource:azure_sql_server_database:localhost/datadog_test",
-                "dd.internal.resource:azure_sql_server:localhost/datadog_test",
+                "dd.internal.resource:azure_sql_server:my-instance",
             ],
         ),
         (

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -12,11 +12,6 @@ from datadog_checks.base.errors import ConfigurationError
 from datadog_checks.dev import EnvVars
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.connection import split_sqlserver_host_port
-from datadog_checks.sqlserver.const import (
-    ENGINE_EDITION_SQL_DATABASE,
-    ENGINE_EDITION_STANDARD,
-    STATIC_INFO_ENGINE_EDITION,
-)
 from datadog_checks.sqlserver.metrics import SqlMasterDatabaseFileStats
 from datadog_checks.sqlserver.sqlserver import SQLConnectionError
 from datadog_checks.sqlserver.utils import Database, parse_sqlserver_major_version, set_default_driver_conf
@@ -46,11 +41,13 @@ def test_missing_db(instance_docker, dd_run_check):
         with pytest.raises(ConfigurationError):
             check = SQLServer(CHECK_NAME, {}, [instance])
             check.initialize_connection()
+            check.make_metric_list_to_collect()
 
     instance['ignore_missing_database'] = True
     with mock.patch('datadog_checks.sqlserver.connection.Connection.check_database', return_value=(False, 'db')):
         check = SQLServer(CHECK_NAME, {}, [instance])
         check.initialize_connection()
+        check.make_metric_list_to_collect()
         dd_run_check(check)
         assert check.do_check is False
 
@@ -80,24 +77,28 @@ def test_db_exists(get_cursor, mock_connect, instance_docker_defaults, dd_run_ch
     # check base case of lowercase for lowercase and case-insensitive db
     check = SQLServer(CHECK_NAME, {}, [instance])
     check.initialize_connection()
+    check.make_metric_list_to_collect()
     assert check.do_check is True
 
     # check all caps for case insensitive db
     instance['database'] = 'MASTER'
     check = SQLServer(CHECK_NAME, {}, [instance])
     check.initialize_connection()
+    check.make_metric_list_to_collect()
     assert check.do_check is True
 
     # check mixed case against mixed case but case-insensitive db
     instance['database'] = 'AdventureWORKS2017'
     check = SQLServer(CHECK_NAME, {}, [instance])
     check.initialize_connection()
+    check.make_metric_list_to_collect()
     assert check.do_check is True
 
     # check case sensitive but matched db
     instance['database'] = 'CaseSensitive2018'
     check = SQLServer(CHECK_NAME, {}, [instance])
     check.initialize_connection()
+    check.make_metric_list_to_collect()
     assert check.do_check is True
 
     # check case sensitive but mismatched db
@@ -105,11 +106,13 @@ def test_db_exists(get_cursor, mock_connect, instance_docker_defaults, dd_run_ch
     check = SQLServer(CHECK_NAME, {}, [instance])
     with pytest.raises(ConfigurationError):
         check.initialize_connection()
+        check.make_metric_list_to_collect()
 
     # check offline but exists db
     instance['database'] = 'Offlinedb'
     check = SQLServer(CHECK_NAME, {}, [instance])
     check.initialize_connection()
+    check.make_metric_list_to_collect()
     assert check.do_check is True
 
 

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -347,48 +347,6 @@ def test_split_sqlserver_host(instance_host, split_host, split_port):
     assert (s_host, s_port) == (split_host, split_port)
 
 
-@pytest.mark.parametrize(
-    "dbm_enabled, instance_host, database, reported_hostname, engine_edition, expected_hostname",
-    [
-        (False, 'localhost,1433,some-typo', None, '', ENGINE_EDITION_STANDARD, 'stubbed.hostname'),
-        (True, 'localhost,1433', None, '', ENGINE_EDITION_STANDARD, 'stubbed.hostname'),
-        (False, 'localhost', None, '', ENGINE_EDITION_STANDARD, 'stubbed.hostname'),
-        (False, '8.8.8.8', None, '', ENGINE_EDITION_STANDARD, 'stubbed.hostname'),
-        (True, 'localhost', None, 'forced_hostname', ENGINE_EDITION_STANDARD, 'forced_hostname'),
-        (True, 'datadoghq.com,1433', None, '', ENGINE_EDITION_STANDARD, 'datadoghq.com'),
-        (True, 'datadoghq.com', None, '', ENGINE_EDITION_STANDARD, 'datadoghq.com'),
-        (True, 'datadoghq.com', None, 'forced_hostname', ENGINE_EDITION_STANDARD, 'forced_hostname'),
-        (True, '8.8.8.8,1433', None, '', ENGINE_EDITION_STANDARD, '8.8.8.8'),
-        (False, '8.8.8.8', None, 'forced_hostname', ENGINE_EDITION_STANDARD, 'forced_hostname'),
-        (True, 'foo.database.windows.net', None, None, ENGINE_EDITION_SQL_DATABASE, 'foo/master'),
-        (True, 'foo.database.windows.net', 'master', None, ENGINE_EDITION_SQL_DATABASE, 'foo/master'),
-        (True, 'foo.database.windows.net', 'bar', None, ENGINE_EDITION_SQL_DATABASE, 'foo/bar'),
-        (
-            True,
-            'foo.database.windows.net',
-            'bar',
-            'override-reported',
-            ENGINE_EDITION_SQL_DATABASE,
-            'override-reported',
-        ),
-        (True, 'foo-custom-dns', 'bar', None, ENGINE_EDITION_SQL_DATABASE, 'foo-custom-dns/bar'),
-    ],
-)
-def test_resolved_hostname(dbm_enabled, instance_host, database, reported_hostname, engine_edition, expected_hostname):
-    instance = {
-        'host': instance_host,
-        'dbm': dbm_enabled,
-    }
-    if database:
-        instance['database'] = database
-    if reported_hostname:
-        instance['reported_hostname'] = reported_hostname
-    sqlserver_check = SQLServer(CHECK_NAME, {}, [instance])
-    sqlserver_check.static_info_cache[STATIC_INFO_ENGINE_EDITION] = engine_edition
-    sqlserver_check._resolved_hostname = None
-    assert sqlserver_check.resolved_hostname == expected_hostname
-
-
 def test_database_state(aggregator, dd_run_check, init_config, instance_docker):
     instance_docker['database'] = 'mAsTeR'
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR fixes a bug where the `resolved_hostname` was not properly set on default integration metrics for Azure SQL DB OR for users that relied on using the `reported_hostname` feature. This resulted in metrics emitted from the default integration to have an incorrect `hostname` tag. This was due to the order in which things were being initialized in the agent when the check was started.

For example, these metrics are coming from the same host but have different `host` tag values. The first is a metric from the default integration, which is using the value that was set as `host` in the instance config, while the other is a DBM metric using the host value we remapped during the initialization call in `resolved_hostname`:

![Screen Shot 2023-04-06 at 3 27 42 PM](https://user-images.githubusercontent.com/14317240/235471344-07537527-817c-4c39-a0bc-8867896f6a16.png)

Below, shows the tag being applied correctly on a default integration metric after deploying this fix to our integration environment 

![Screen Shot 2023-05-01 at 9 26 31 AM](https://user-images.githubusercontent.com/14317240/235457948-2952cfbb-624a-4f70-8a3c-f8f4861df0a3.png)


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.