### PR TITLE
Remove CI support for sqlserver 2012 & odbc on windows

### DIFF
--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -21,12 +21,12 @@ setup = ["single"]
 # older sql server versions tested on only a single python version and driver
 # TODO: Investigate older versions causing CI to fail. Flaky version as of 7/12/2022.
 # py38-windows-odbc-{2012,2014,2016,2017}-single
-# [[envs.default.matrix]]
-# python = ["3.8"]
-# os = ["windows"]
-# driver = ["odbc"]
-# version = ["2012", "2014"]
-# setup = ["single"]
+[[envs.default.matrix]]
+python = ["3.8"]
+os = ["windows"]
+driver = ["odbc"]
+version = ["2014"]
+setup = ["single"]
 
 # temporarily exclude high cardinality windows env. to be fixed in a follow-up PR
 [[envs.default.matrix]]

--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -18,16 +18,6 @@ driver = ["SQLOLEDB", "SQLNCLI11", "MSOLEDBSQL", "odbc"]
 version = ["2019"]
 setup = ["single"]
 
-# older sql server versions tested on only a single python version and driver
-# TODO: Investigate older versions causing CI to fail. Flaky version as of 7/12/2022.
-# py38-windows-odbc-{2012,2014,2016,2017}-single
-[[envs.default.matrix]]
-python = ["3.8"]
-os = ["windows"]
-driver = ["odbc"]
-version = ["2014"]
-setup = ["single"]
-
 # temporarily exclude high cardinality windows env. to be fixed in a follow-up PR
 [[envs.default.matrix]]
 python = ["3.8"]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR removes SQL Server 2012 / odbc driver on Windows for our CI test matrix. We are doing this for the following reasons:

1. These tests were consistently causing our CI fail for `sqlserver.database.*` metrics -> user db tags (e.g. `datadog_test`) were not being properly added to these metrics. This means, this was failing for a small subset of metrics on a very old version of SQL Server, but it was blocking us from being able to **merge any PR** for the integration
2. SQL Server 2012 was officially EOL'd on [July 22, 2022](https://learn.microsoft.com/en-us/lifecycle/products/microsoft-sql-server-2012), and is no longer supported by AWS, Azure and other major cloud providers 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.