### PR TITLE
Disable Kraft by default

### DIFF
--- a/kafka_consumer/hatch.toml
+++ b/kafka_consumer/hatch.toml
@@ -38,7 +38,7 @@ matrix.version.e2e-env = { value = true, if = ["3.3"] }
 matrix.version.env-vars = [
   { key = "KAFKA_VERSION", value = "1.1.1", if = ["1.1"] },
   { key = "KAFKA_VERSION", value = "2.3.1", if = ["2.3"] },
-  { key = "KAFKA_VERSION", value = "3.3.2-debian-11-r26", if = ["3.3"] },
+  { key = "KAFKA_VERSION", value = "3.3.2", if = ["3.3"] },
 ]
 matrix.auth.env-vars = "AUTHENTICATION"
 

--- a/kafka_consumer/tests/docker/noauth/docker-compose.yaml
+++ b/kafka_consumer/tests/docker/noauth/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
       KAFKA_CFG_ADVERTISED_LISTENERS: INTERNAL://:19092,EXTERNAL://127.0.0.1:9092
       KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
       ALLOW_PLAINTEXT_LISTENER: "true"
+      KAFKA_ENABLE_KRAFT: false
     depends_on:
       zookeeper:
         condition: service_healthy

--- a/kafka_consumer/tests/docker/ssl/docker-compose.yaml
+++ b/kafka_consumer/tests/docker/ssl/docker-compose.yaml
@@ -39,6 +39,7 @@ services:
       KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: false
       KAFKA_CFG_SSL_PRINCIPAL_MAPPING_RULES: 'RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/,RULE:^CN=(.*?),OU=(.*?),O=(.*?),L=(.*?),ST=(.*?),C=(.*?)$/$1@$2/L,RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L,DEFAULT'
       ALLOW_PLAINTEXT_LISTENER: yes
+      KAFKA_ENABLE_KRAFT: false
     volumes:
       - ./truststore/kafka.truststore.jks:/bitnami/kafka/config/certs/kafka.truststore.jks
       - ./keystore/kafka1.server.keystore.jks:/bitnami/kafka/config/certs/kafka.keystore.jks
@@ -71,6 +72,7 @@ services:
       KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: false
       KAFKA_CFG_SSL_PRINCIPAL_MAPPING_RULES: 'RULE:^CN=(.*?),OU=ServiceUsers.*$/$1/,RULE:^CN=(.*?),OU=(.*?),O=(.*?),L=(.*?),ST=(.*?),C=(.*?)$/$1@$2/L,RULE:^.*[Cc][Nn]=([a-zA-Z0-9.]*).*$/$1/L,DEFAULT'
       ALLOW_PLAINTEXT_LISTENER: yes
+      KAFKA_ENABLE_KRAFT: false
     volumes:
       - ./truststore/kafka.truststore.jks:/bitnami/kafka/config/certs/kafka.truststore.jks
       - ./keystore/kafka2.server.keystore.jks:/bitnami/kafka/config/certs/kafka.keystore.jks


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Disable Kraft by default in the e2e environment
- Reverts https://github.com/DataDog/integrations-core/pull/14481 so we are still getting the system updates

### Motivation
<!-- What inspired you to submit this pull request? -->

- Kraft is now enabled by default with the containers we are using. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.