### PR TITLE
Bump `psycopg2-binary` to 2.9.6 for py3 and install it on arm macs

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -56,7 +56,8 @@ prometheus-client==0.16.0; python_version > '3.0'
 protobuf==3.17.3; python_version < '3.0'
 protobuf==3.20.2; python_version > '3.0'
 psutil==5.9.0
-psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'
+psycopg2-binary==2.8.6; python_version < '3.0' and (sys_platform != 'darwin' or platform_machine != 'arm64')
+psycopg2-binary==2.9.6; python_version > '3.0'
 pyasn1==0.4.6
 pycryptodomex==3.10.1
 pydantic==1.10.4; python_version > '3.0'

--- a/pgbouncer/pyproject.toml
+++ b/pgbouncer/pyproject.toml
@@ -41,7 +41,8 @@ text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "psycopg2-binary==2.8.6; python_version < '3.0' and (sys_platform != 'darwin' or platform_machine != 'arm64')",
+    "psycopg2-binary==2.9.6; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -44,7 +44,8 @@ deps = [
     "cachetools==3.1.1; python_version < '3.0'",
     "cachetools==5.3.0; python_version > '3.0'",
     "futures==3.4.0; python_version < '3.0'",
-    "psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "psycopg2-binary==2.8.6; python_version < '3.0' and (sys_platform != 'darwin' or platform_machine != 'arm64')",
+    "psycopg2-binary==2.9.6; python_version > '3.0'",
     "semver==2.13.0",
 ]
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump psycopg2-binary to 2.9.6 and install it on arm macs

### Motivation
<!-- What inspired you to submit this pull request? -->

- We now have an arm64 wheel, see the [changelog](https://www.psycopg.org/docs/news.html#what-s-new-in-psycopg-2-9-3)

```
❯ pip install psycopg2-binary==2.9.6
Collecting psycopg2-binary==2.9.6                                                                                                                                                                                                                                                                                                                         ─╯
  Downloading psycopg2_binary-2.9.6-cp38-cp38-macosx_11_0_arm64.whl (2.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.0/2.0 MB 12.6 MB/s eta 0:00:00
Installing collected packages: psycopg2-binary
Successfully installed psycopg2-binary-2.9.6
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- They dropped py2 support: https://www.psycopg.org/docs/news.html#what-s-new-in-psycopg-2-9

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.