### PR TITLE
Create `tag_not_null` type which doesn't set the tag when tag value is none

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -105,7 +105,7 @@ class QueryExecutor(object):
                         continue
                     elif column_type == 'tag':
                         tags.append(transformer(None, column_value))  # get_tag transformer
-                    elif column_type == 'tag_none':
+                    elif column_type == 'tag_not_none':
                         if column_value:
                             tags.append(transformer(None, column_value))  # get_tag transformer
                     elif column_type == 'tag_list':

--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -106,7 +106,7 @@ class QueryExecutor(object):
                     elif column_type == 'tag':
                         tags.append(transformer(None, column_value))  # get_tag transformer
                     elif column_type == 'tag_not_none':
-                        if column_value:
+                        if column_value is not None:
                             tags.append(transformer(None, column_value))  # get_tag transformer
                     elif column_type == 'tag_list':
                         tags.extend(transformer(None, column_value))  # get_tag_list transformer

--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -105,7 +105,7 @@ class QueryExecutor(object):
                         continue
                     elif column_type == 'tag':
                         tags.append(transformer(None, column_value))  # get_tag transformer
-                    elif column_type == 'tag_not_none':
+                    elif column_type == 'tag_not_null':
                         if column_value is not None:
                             tags.append(transformer(None, column_value))  # get_tag transformer
                     elif column_type == 'tag_list':

--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -105,6 +105,9 @@ class QueryExecutor(object):
                         continue
                     elif column_type == 'tag':
                         tags.append(transformer(None, column_value))  # get_tag transformer
+                    elif column_type == 'tag_none':
+                        if column_value:
+                            tags.append(transformer(None, column_value))  # get_tag transformer
                     elif column_type == 'tag_list':
                         tags.extend(transformer(None, column_value))  # get_tag_list transformer
                     else:

--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -124,7 +124,7 @@ class Query(object):
                 # this we set the context to None. https://www.python.org/dev/peps/pep-0409/
                 raise_from(type(e)(error), None)
             else:
-                if column_type in ('tag', 'tag_list', 'tag_none'):
+                if column_type in ('tag', 'tag_list', 'tag_not_none'):
                     column_data.append((column_name, (column_type, transformer)))
                 else:
                     # All these would actually submit data. As that is the default case, we represent it as
@@ -134,7 +134,7 @@ class Query(object):
         submission_transformers = column_transformers.copy()  # type: Dict[str, Transformer]
         submission_transformers.pop('tag')
         submission_transformers.pop('tag_list')
-        submission_transformers.pop('tag_none')
+        submission_transformers.pop('tag_not_none')
 
         extras = self.query_data.get('extras', [])  # type: List[Dict[str, Any]]
         if not isinstance(extras, list):

--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -124,7 +124,7 @@ class Query(object):
                 # this we set the context to None. https://www.python.org/dev/peps/pep-0409/
                 raise_from(type(e)(error), None)
             else:
-                if column_type in ('tag', 'tag_list', 'tag_not_none'):
+                if column_type in ('tag', 'tag_list', 'tag_not_null'):
                     column_data.append((column_name, (column_type, transformer)))
                 else:
                     # All these would actually submit data. As that is the default case, we represent it as
@@ -134,7 +134,7 @@ class Query(object):
         submission_transformers = column_transformers.copy()  # type: Dict[str, Transformer]
         submission_transformers.pop('tag')
         submission_transformers.pop('tag_list')
-        submission_transformers.pop('tag_not_none')
+        submission_transformers.pop('tag_not_null')
 
         extras = self.query_data.get('extras', [])  # type: List[Dict[str, Any]]
         if not isinstance(extras, list):

--- a/datadog_checks_base/datadog_checks/base/utils/db/query.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/query.py
@@ -124,7 +124,7 @@ class Query(object):
                 # this we set the context to None. https://www.python.org/dev/peps/pep-0409/
                 raise_from(type(e)(error), None)
             else:
-                if column_type in ('tag', 'tag_list'):
+                if column_type in ('tag', 'tag_list', 'tag_none'):
                     column_data.append((column_name, (column_type, transformer)))
                 else:
                     # All these would actually submit data. As that is the default case, we represent it as
@@ -134,6 +134,7 @@ class Query(object):
         submission_transformers = column_transformers.copy()  # type: Dict[str, Transformer]
         submission_transformers.pop('tag')
         submission_transformers.pop('tag_list')
+        submission_transformers.pop('tag_none')
 
         extras = self.query_data.get('extras', [])  # type: List[Dict[str, Any]]
         if not isinstance(extras, list):

--- a/datadog_checks_base/datadog_checks/base/utils/db/transform.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/transform.py
@@ -491,6 +491,7 @@ COLUMN_TRANSFORMERS = {
     'temporal_percent': get_temporal_percent,
     'monotonic_gauge': get_monotonic_gauge,
     'tag': get_tag,
+    'tag_none': get_tag,
     'tag_list': get_tag_list,
     'match': get_match,
     'service_check': get_service_check,

--- a/datadog_checks_base/datadog_checks/base/utils/db/transform.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/transform.py
@@ -491,7 +491,7 @@ COLUMN_TRANSFORMERS = {
     'temporal_percent': get_temporal_percent,
     'monotonic_gauge': get_monotonic_gauge,
     'tag': get_tag,
-    'tag_none': get_tag,
+    'tag_not_none': get_tag,
     'tag_list': get_tag_list,
     'match': get_match,
     'service_check': get_service_check,

--- a/datadog_checks_base/datadog_checks/base/utils/db/transform.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/transform.py
@@ -491,7 +491,7 @@ COLUMN_TRANSFORMERS = {
     'temporal_percent': get_temporal_percent,
     'monotonic_gauge': get_monotonic_gauge,
     'tag': get_tag,
-    'tag_not_none': get_tag,
+    'tag_not_null': get_tag,
     'tag_list': get_tag_list,
     'match': get_match,
     'service_check': get_service_check,


### PR DESCRIPTION
### What does this PR do?
Add a `tag_not_null` column type which doesn't report the tag if the value is none. 

### Motivation
This is needed for https://github.com/DataDog/integrations-core/pull/14500. This PR will add the `partition_of` tag to metrics but we only want to set this tag if the table is a partition. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.