### PR TITLE
Fix bug on empty openmetrics scrape response

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -285,7 +285,11 @@ class OpenMetricsScraper:
         # Since we determine `self.parse_metric_families` dynamically from the response and that's done as a
         # side effect inside the `line_streamer` generator, we need to consume the first line in order to
         # trigger that side effect.
-        line_streamer = chain([next(line_streamer)], line_streamer)
+        try:
+            line_streamer = chain([next(line_streamer)], line_streamer)
+        except StopIteration:
+            # If line_streamer is an empty iterator, next(line_streamer) fails.
+            return
 
         for metric in self.parse_metric_families(line_streamer):
             self.submit_telemetry_number_of_total_metric_samples(metric)

--- a/openmetrics/tests/test_openmetrics.py
+++ b/openmetrics/tests/test_openmetrics.py
@@ -101,3 +101,12 @@ def test_openmetrics_use_latest_spec(aggregator, dd_run_check, mock_http_respons
     assert scraper.http.options['headers']['Accept'] == (
         'application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1'
     )
+
+
+def test_openmetrics_empty_response(aggregator, dd_run_check, mock_http_response, openmetrics_payload, caplog):
+    mock_http_response("")
+
+    check = OpenMetricsCheck('openmetrics', {}, [instance_new])
+    dd_run_check(check)
+
+    aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
It looks like https://github.com/DataDog/integrations-core/pull/14445 introduced a bug that causes empty openmetrics scrapes to fail.

Without the fix, the added test fails as follows:
```
tests/test_openmetrics.py:110: in test_openmetrics_empty_response
    dd_run_check(check)
../datadog_checks_dev/datadog_checks/dev/plugin/pytest.py:228: in run_check
    raise Exception('\n'.join(exc_lines))
E   Exception:
E   Traceback (most recent call last):
E     File "/Users/ethan.lowman/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 289, in parse_metrics
E       line_streamer = chain([next(line_streamer)], line_streamer)
E   StopIteration
E
E   The above exception was the direct cause of the following exception:
E
E   Traceback (most recent call last):
E     File "/Users/ethan.lowman/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/checks/base.py", line 1135, in run
E       self.check(instance)
E     File "/Users/ethan.lowman/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/base.py", line 64, in check
E       scraper.scrape()
E     File "/Users/ethan.lowman/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 247, in scrape
E       for metric in self.consume_metrics(runtime_data):
E     File "/Users/ethan.lowman/go/src/github.com/DataDog/integrations-core/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py", line 267, in consume_metrics
E       for metric in metric_parser:
E   RuntimeError: generator raised StopIteration
```

### Motivation
Bug fix.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.