### PR TITLE
Use OMv2 by default in the e2e environment

### DIFF
--- a/gitlab/tests/conftest.py
+++ b/gitlab/tests/conftest.py
@@ -72,7 +72,7 @@ def dd_environment():
             requests.get(GITLAB_URL)
         sleep(2)
 
-        yield CONFIG
+        yield to_omv2_config(CONFIG)
 
 
 @pytest.fixture()
@@ -221,9 +221,10 @@ def get_auth_config():
 
 
 def to_omv2_config(config):
-    instance = config['instances'][0]
+    new_config = copy.deepcopy(config)
+    instance = new_config['instances'][0]
     instance["openmetrics_endpoint"] = instance["prometheus_url"]
-    return config
+    return new_config
 
 
 @pytest.fixture


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use OMv2 by default in the e2e environment.

### Motivation
<!-- What inspired you to submit this pull request? -->

When spinning up the e2e environment, we were using an OMv1 instance. We now want to move to OMv2 by default.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

It's still possible to edit the configuration once the environment is up and running with the `ddev env edit` and `ddev env reload` commands to switch back to OMv1 if needed

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.