### PR TITLE
Add ping latency metric

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -200,6 +200,10 @@ class Redis(AgentCheck):
         # Ping the database for info, and track the latency.
         # Process the service check: the check passes if we can connect to Redis
         try:
+            # By running a ping first, we get a recent connection in an attempt to
+            # reduce the chance of connection time affecting our latency measurements
+            conn.ping()
+
             info, info_latency_ms = _call_and_time(conn.info)
             _, ping_latency_ms = _call_and_time(conn.ping)
 

--- a/redisdb/metadata.csv
+++ b/redisdb/metadata.csv
@@ -49,6 +49,7 @@ redis.net.maxclients,gauge,,connection,,The maximum number of connected clients.
 redis.perf.latest_fork_usec,gauge,,microsecond,,The duration of the latest fork.,-1,redis,latest fork usec,
 redis.persist,gauge,,key,,The number of keys persisted (redis.keys - redis.expires).,0,redis,persist,
 redis.persist.percent,gauge,,percent,,Percentage of total keys that are persisted.,0,redis,persist pct,
+redis.ping.latency_ms,gauge,,millisecond,,The latency of the redis PING command.,0,redis,ping latency,
 redis.pubsub.channels,gauge,,,,The number of active pubsub channels.,0,redis,pubsub channels,
 redis.pubsub.patterns,gauge,,,,The number of active pubsub patterns.,0,redis,pubsub patterns,
 redis.rdb.bgsave,gauge,,,,One if a bgsave is in progress and zero otherwise.,0,redis,rdb bgsave,

--- a/redisdb/tests/test_default.py
+++ b/redisdb/tests/test_default.py
@@ -47,6 +47,7 @@ def test_aof_loading_metrics(aggregator, redis_instance):
         redis_check._check_db()
 
         aggregator.assert_metric('redis.info.latency_ms')
+        aggregator.assert_metric('redis.ping.latency_ms')
         aggregator.assert_metric('redis.net.commands', 0)
         aggregator.assert_metric('redis.key.length', 0)
 

--- a/redisdb/tests/test_e2e.py
+++ b/redisdb/tests/test_e2e.py
@@ -46,6 +46,7 @@ def assert_common_metrics(aggregator):
     aggregator.assert_metric('redis.pubsub.patterns', count=2, tags=tags)
     aggregator.assert_metric('redis.keys.expired', count=2, tags=tags)
     aggregator.assert_metric('redis.info.latency_ms', count=2, tags=tags)
+    aggregator.assert_metric('redis.ping.latency_ms', count=2, tags=tags)
     aggregator.assert_metric('redis.cpu.user', count=1, tags=tags)
     aggregator.assert_metric('redis.cpu.user_children', count=1, tags=tags)
     aggregator.assert_metric('redis.rdb.last_bgsave_time', count=2, tags=tags)


### PR DESCRIPTION
### What does this PR do?

Adds timing for the ping redis command as a new metric, which can provide a more accurate measure of the actual latency with less extra overhead.

This also changes the timer for the info latency from `process_time` to a proper monotonic wall clock, because the time we want to measure is mainly I/O which is "sleep time" which wouldn't be reflected on `process_time`. It also didn't seem to fix the original problem it was introduced for, as agent load has still been seen to influence this metric.

### Motivation

Possible solution for [AGENT-9517](https://datadoghq.atlassian.net/browse/AGENT-9517).

### Additional Notes

~~Using `timeit` for the ping command to run it 10 times should be reasonable in most cases and might give us a more accurate value than just doing it once.~~ I discarded this because it's not supported in py2 and I didn't want to make the code more complicated than necessary.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.

[AGENT-9517]: https://datadoghq.atlassian.net/browse/AGENT-9517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ