### PR TITLE
Add DEFAULT_METRIC_LIMIT for OpenMetrics-based checks

### DIFF
--- a/arangodb/datadog_checks/arangodb/check.py
+++ b/arangodb/datadog_checks/arangodb/check.py
@@ -13,6 +13,9 @@ from .metrics import METRIC_MAP
 
 class ArangodbCheck(OpenMetricsBaseCheckV2, ConfigMixin):
     __NAMESPACE__ = 'arangodb'
+
+    DEFAULT_METRIC_LIMIT = 0
+    
     SERVER_MODE_ENDPOINT = '/_admin/server/mode'
     SERVER_ID_ENDPOINT = '/_admin/server/id'
     SERVER_TAGS = {'mode': SERVER_MODE_ENDPOINT, 'id': SERVER_ID_ENDPOINT}

--- a/arangodb/datadog_checks/arangodb/check.py
+++ b/arangodb/datadog_checks/arangodb/check.py
@@ -15,7 +15,7 @@ class ArangodbCheck(OpenMetricsBaseCheckV2, ConfigMixin):
     __NAMESPACE__ = 'arangodb'
 
     DEFAULT_METRIC_LIMIT = 0
-    
+
     SERVER_MODE_ENDPOINT = '/_admin/server/mode'
     SERVER_ID_ENDPOINT = '/_admin/server/id'
     SERVER_TAGS = {'mode': SERVER_MODE_ENDPOINT, 'id': SERVER_ID_ENDPOINT}

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/check.py
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/check.py
@@ -12,6 +12,8 @@ from .types import Instance
 class AzureIoTEdgeCheck(OpenMetricsBaseCheck):
     __NAMESPACE__ = 'azure.iot_edge'  # Child of `azure.` namespace.
 
+    DEFAULT_METRIC_LIMIT = 0
+    
     def __init__(self, name, init_config, instances):
         self._config = Config(cast(Instance, instances[0]))
         super(AzureIoTEdgeCheck, self).__init__(

--- a/azure_iot_edge/datadog_checks/azure_iot_edge/check.py
+++ b/azure_iot_edge/datadog_checks/azure_iot_edge/check.py
@@ -13,7 +13,7 @@ class AzureIoTEdgeCheck(OpenMetricsBaseCheck):
     __NAMESPACE__ = 'azure.iot_edge'  # Child of `azure.` namespace.
 
     DEFAULT_METRIC_LIMIT = 0
-    
+
     def __init__(self, name, init_config, instances):
         self._config = Config(cast(Instance, instances[0]))
         super(AzureIoTEdgeCheck, self).__init__(

--- a/calico/datadog_checks/calico/check.py
+++ b/calico/datadog_checks/calico/check.py
@@ -8,6 +8,8 @@ from .metrics import METRIC_MAP
 
 
 class CalicoCheck(OpenMetricsBaseCheckV2):
+    DEFAULT_METRIC_LIMIT = 0
+    
     def __init__(self, name, init_config, instances=None):
 
         super(CalicoCheck, self).__init__(

--- a/calico/datadog_checks/calico/check.py
+++ b/calico/datadog_checks/calico/check.py
@@ -9,7 +9,7 @@ from .metrics import METRIC_MAP
 
 class CalicoCheck(OpenMetricsBaseCheckV2):
     DEFAULT_METRIC_LIMIT = 0
-    
+
     def __init__(self, name, init_config, instances=None):
 
         super(CalicoCheck, self).__init__(

--- a/cilium/datadog_checks/cilium/cilium.py
+++ b/cilium/datadog_checks/cilium/cilium.py
@@ -13,6 +13,8 @@ class CiliumCheck(OpenMetricsBaseCheck):
     This is a legacy implementation that will be removed at some point, refer to check.py for the new implementation.
     """
 
+    DEFAULT_METRIC_LIMIT = 0
+    
     def __new__(cls, name, init_config, instances):
         instance = instances[0]
 

--- a/cilium/datadog_checks/cilium/cilium.py
+++ b/cilium/datadog_checks/cilium/cilium.py
@@ -14,7 +14,7 @@ class CiliumCheck(OpenMetricsBaseCheck):
     """
 
     DEFAULT_METRIC_LIMIT = 0
-    
+
     def __new__(cls, name, init_config, instances):
         instance = instances[0]
 

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -43,7 +43,7 @@ NodeStatus = namedtuple('NodeStatus', ['node_id', 'service_name', 'service_tags_
 
 class ConsulCheck(OpenMetricsBaseCheck):
     DEFAULT_METRIC_LIMIT = 0
-    
+
     def __init__(self, name, init_config, instances):
         instance = instances[0]
         self.url = instance.get('url')

--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -42,6 +42,8 @@ NodeStatus = namedtuple('NodeStatus', ['node_id', 'service_name', 'service_tags_
 
 
 class ConsulCheck(OpenMetricsBaseCheck):
+    DEFAULT_METRIC_LIMIT = 0
+    
     def __init__(self, name, init_config, instances):
         instance = instances[0]
         self.url = instance.get('url')

--- a/coredns/datadog_checks/coredns/coredns.py
+++ b/coredns/datadog_checks/coredns/coredns.py
@@ -15,6 +15,8 @@ class CoreDNSCheck(OpenMetricsBaseCheck):
 
     METRIC_PREFIX = 'coredns.'
 
+    DEFAULT_METRIC_LIMIT = 0
+
     """
     Collect CoreDNS metrics from its Prometheus endpoint
     """

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -58,7 +58,7 @@ DEFAULT_METRICS = {
 
 class DatadogClusterAgentCheck(OpenMetricsBaseCheck):
     DEFAULT_METRIC_LIMIT = 0
-    
+
     def __init__(self, name, init_config, instances):
         super(DatadogClusterAgentCheck, self).__init__(
             name,

--- a/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
+++ b/datadog_cluster_agent/datadog_checks/datadog_cluster_agent/check.py
@@ -57,6 +57,8 @@ DEFAULT_METRICS = {
 
 
 class DatadogClusterAgentCheck(OpenMetricsBaseCheck):
+    DEFAULT_METRIC_LIMIT = 0
+    
     def __init__(self, name, init_config, instances):
         super(DatadogClusterAgentCheck, self).__init__(
             name,

--- a/etcd/datadog_checks/etcd/etcd.py
+++ b/etcd/datadog_checks/etcd/etcd.py
@@ -11,7 +11,8 @@ from .metrics import METRIC_MAP
 
 
 class Etcd(OpenMetricsBaseCheck):
-
+    DEFAULT_METRIC_LIMIT = 0
+    
     DEFAULT_TIMEOUT = 5
 
     SERVICE_CHECK_NAME = 'etcd.can_connect'

--- a/etcd/datadog_checks/etcd/etcd.py
+++ b/etcd/datadog_checks/etcd/etcd.py
@@ -12,7 +12,7 @@ from .metrics import METRIC_MAP
 
 class Etcd(OpenMetricsBaseCheck):
     DEFAULT_METRIC_LIMIT = 0
-    
+
     DEFAULT_TIMEOUT = 5
 
     SERVICE_CHECK_NAME = 'etcd.can_connect'

--- a/external_dns/datadog_checks/external_dns/external_dns.py
+++ b/external_dns/datadog_checks/external_dns/external_dns.py
@@ -10,6 +10,7 @@ class ExternalDNSCheck(OpenMetricsBaseCheck):
     """
     Collect ExternalDNS metrics from its Prometheus endpoint
     """
+
     DEFAULT_METRIC_LIMIT = 0
 
     def __init__(self, name, init_config, instances):

--- a/external_dns/datadog_checks/external_dns/external_dns.py
+++ b/external_dns/datadog_checks/external_dns/external_dns.py
@@ -10,6 +10,7 @@ class ExternalDNSCheck(OpenMetricsBaseCheck):
     """
     Collect ExternalDNS metrics from its Prometheus endpoint
     """
+    DEFAULT_METRIC_LIMIT = 0
 
     def __init__(self, name, init_config, instances):
         super(ExternalDNSCheck, self).__init__(

--- a/impala/datadog_checks/impala/check.py
+++ b/impala/datadog_checks/impala/check.py
@@ -15,6 +15,8 @@ TO_SNAKE_CASE_PATTERN = re.compile('(?!^)([A-Z]+)')
 class ImpalaCheck(OpenMetricsBaseCheckV2, ConfigMixin):
     __NAMESPACE__ = 'impala'
 
+    DEFAULT_METRIC_LIMIT = 0
+
     def __init__(self, name, init_config, instances):
         super().__init__(name, init_config, instances)
         self.check_initializations.append(self.configure_additional_transformers)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds missing `DEFAULT_METRIC_LIMIT = 0` for all OpenMetricsV1 and V2 checks.

### Motivation
<!-- What inspired you to submit this pull request? -->
There should be no metric limit for any non-custom OpenMetrics checks.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This is part 1 of adding validations for OpenMetrics metric limits. The actual validations are added in https://github.com/DataDog/integrations-core/pull/14528

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.