### PR TITLE
[FRSDBM-281] - create parameter allowing enabling/disabling explain plan collection

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -359,10 +359,33 @@ files:
         - name: collection_interval
           description: |
             Set the query sample collection interval (in seconds). Each collection involves a single query to
-            `pg_stat_activity` followed by at most one `EXPLAIN` query per unique normalized query seen.
+            `pg_stat_activity` followed by at most one `EXPLAIN` query per unique normalized query seen if 
+            collect_explains is activated.
           value:
             type: number
             example: 1
+        - name: samples_per_hour_per_query
+          description: |
+            Set the rate limit for how many query sample events will be ingested per hour per normalized execution
+            plan.
+          value:
+            type: integer
+            example: 15
+        - name: seen_samples_cache_maxsize
+          description: |
+            Set the max size of the cache used for the samples_per_hour_per_query rate limit. This should be increased
+            for databases with a very large number of unique normalized execution plans which exceed the cache's limit.
+          value:
+            type: integer
+            example: 10000
+    - name: explain_plans
+      description: |
+        Enable collection of explain plans for each unique normalized query. Calls explain_function for the query
+        in order to return the plan.
+      options:
+        - name: enabled
+          type: boolean
+          example: true
         - name: explain_function
           description: |
             Override the default function used to collect execution plans for queries.
@@ -375,13 +398,6 @@ files:
           value:
             type: integer
             example: 60
-        - name: samples_per_hour_per_query
-          description: |
-            Set the rate limit for how many query sample events will be ingested per hour per normalized execution
-            plan.
-          value:
-            type: integer
-            example: 15
         - name: explained_queries_cache_maxsize
           description: |
             Set the max size of the cache used for the explained_queries_per_hour_per_query rate limit. This should
@@ -390,13 +406,6 @@ files:
           value:
             type: integer
             example: 5000
-        - name: seen_samples_cache_maxsize
-          description: |
-            Set the max size of the cache used for the samples_per_hour_per_query rate limit. This should be increased
-            for databases with a very large number of unique normalized execution plans which exceed the cache's limit.
-          value:
-            type: integer
-            example: 10000
         - name: explain_parameterized_queries
           description: |
             Note, this is a BETA feature. This option will enable the ability to explain parameterized queries.

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -126,7 +126,7 @@ class ExplainParameterizedQueries:
             return self._execute_query_and_fetch_rows(
                 dbname,
                 EXPLAIN_QUERY.format(
-                    explain_function=self._config.statement_samples_config.get(
+                    explain_function=self._config.explain_plan_config.get(
                         'explain_function', 'datadog.explain_statement'
                     ),
                     statement=execute_prepared_statement_query,


### PR DESCRIPTION
### What does this PR do?
Add functionality to allow disabling collection of Explain Plans beyond the Query Sample settings

### Motivation
This [FR](https://datadoghq.atlassian.net/browse/FRSDBM-281) and [this ticket](https://datadog.zendesk.com/agent/tickets/1180939)
### Additional Notes
<!-- Anything else we should know when reviewing? -->
Outline of changes:

- add parameter to enable/disable collection of plans (enabled by default)
- refactor parameters to put all explain plan settings together
- modify code using sample collection where explain should be handled

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.