### PR TITLE
Rename azure.name configuration key to azure.fully_qualified_domain_name

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -504,6 +504,8 @@ files:
         - name: fully_qualified_domain_name
           description: |
             Equal to the full qualified domain name of the Azure PostgreSQL database.
+            
+            This value is optional if the value of `host` is already configured to the fully qualified domain name.
           value:
             type: string
             example: my-postgres-database.database.windows.net

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -501,12 +501,12 @@ files:
           value:
             type: string
             example: flexible_server
-        - name: name
+        - name: fully_qualified_domain_name
           description: |
-            Equal to the name of the Azure PostgreSQL database.
+            Equal to the full qualified domain name of the Azure PostgreSQL database.
           value:
             type: string
-            example: my-postgres-database
+            example: my-postgres-database.database.windows.net
 
     - name: obfuscator_options
       description: |

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -96,6 +96,8 @@ class PostgresConfig:
         aws = instance.get('aws', {})
         gcp = instance.get('gcp', {})
         azure = instance.get('azure', {})
+        # Remap fully_qualified_domain_name to name
+        azure = {k if k != 'fully_qualified_domain_name' else 'name': v for k, v in azure.items()}
         if aws:
             self.cloud_metadata.update({'aws': aws})
         if gcp:

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -31,7 +31,7 @@ class Azure(BaseModel):
         allow_mutation = False
 
     deployment_type: Optional[str]
-    name: Optional[str]
+    fully_qualified_domain_name: Optional[str]
 
 
 class Gcp(BaseModel):

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -412,10 +412,10 @@ instances:
         #
         # deployment_type: flexible_server
 
-        ## @param name - string - optional - default: my-postgres-database
-        ## Equal to the name of the Azure PostgreSQL database.
+        ## @param fully_qualified_domain_name - string - optional - default: my-postgres-database.database.windows.net
+        ## Equal to the full qualified domain name of the Azure PostgreSQL database.
         #
-        # name: my-postgres-database
+        # fully_qualified_domain_name: my-postgres-database.database.windows.net
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -414,6 +414,8 @@ instances:
 
         ## @param fully_qualified_domain_name - string - optional - default: my-postgres-database.database.windows.net
         ## Equal to the full qualified domain name of the Azure PostgreSQL database.
+        ##
+        ## This value is optional if the value of `host` is already configured to the fully qualified domain name.
         #
         # fully_qualified_domain_name: my-postgres-database.database.windows.net
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -221,41 +221,85 @@ def test_statement_metrics(
 
 
 @pytest.mark.parametrize(
-    "cloud_metadata",
+    "input_cloud_metadata,output_cloud_metadata",
     [
-        {},
-        {
-            'azure': {
-                'deployment_type': 'flexible_server',
-                'name': 'test-server',
+        ({}, {}),
+        (
+            {
+                'azure': {
+                    'deployment_type': 'flexible_server',
+                    'name': 'test-server.database.windows.net',
+                },
             },
-        },
-        {
-            'aws': {
-                'instance_endpoint': 'foo.aws.com',
+            {
+                'azure': {
+                    'deployment_type': 'flexible_server',
+                    'name': 'test-server.database.windows.net',
+                },
             },
-            'azure': {
-                'deployment_type': 'flexible_server',
-                'name': 'test-server',
+        ),
+        (
+            {
+                'azure': {
+                    'deployment_type': 'flexible_server',
+                    'fully_qualified_domain_name': 'test-server.database.windows.net',
+                },
             },
-        },
-        {
-            'gcp': {
-                'project_id': 'foo-project',
-                'instance_id': 'bar',
-                'extra_field': 'included',
+            {
+                'azure': {
+                    'deployment_type': 'flexible_server',
+                    'name': 'test-server.database.windows.net',
+                },
             },
-        },
+        ),
+        (
+            {
+                'aws': {
+                    'instance_endpoint': 'foo.aws.com',
+                },
+                'azure': {
+                    'deployment_type': 'flexible_server',
+                    'name': 'test-server',
+                },
+            },
+            {
+                'aws': {
+                    'instance_endpoint': 'foo.aws.com',
+                },
+                'azure': {
+                    'deployment_type': 'flexible_server',
+                    'name': 'test-server',
+                },
+            },
+        ),
+        (
+            {
+                'gcp': {
+                    'project_id': 'foo-project',
+                    'instance_id': 'bar',
+                    'extra_field': 'included',
+                },
+            },
+            {
+                'gcp': {
+                    'project_id': 'foo-project',
+                    'instance_id': 'bar',
+                    'extra_field': 'included',
+                },
+            },
+        ),
     ],
 )
-def test_statement_metrics_cloud_metadata(aggregator, integration_check, dbm_instance, cloud_metadata, datadog_agent):
+def test_statement_metrics_cloud_metadata(
+    aggregator, integration_check, dbm_instance, input_cloud_metadata, output_cloud_metadata, datadog_agent
+):
     dbm_instance['pg_stat_statements_view'] = "pg_stat_statements"
     # don't need samples for this test
     dbm_instance['query_samples'] = {'enabled': False}
     # very low collection interval for test purposes
     dbm_instance['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
-    if cloud_metadata:
-        for k, v in cloud_metadata.items():
+    if input_cloud_metadata:
+        for k, v in input_cloud_metadata.items():
             dbm_instance[k] = v
     connections = {}
 
@@ -283,7 +327,7 @@ def test_statement_metrics_cloud_metadata(aggregator, integration_check, dbm_ins
     assert event['ddagentversion'] == datadog_agent.get_version()
     assert event['ddagenthostname'] == datadog_agent.get_hostname()
     assert event['min_collection_interval'] == dbm_instance['query_metrics']['collection_interval']
-    assert event['cloud_metadata'] == cloud_metadata, "wrong cloud_metadata"
+    assert event['cloud_metadata'] == output_cloud_metadata, "wrong cloud_metadata"
 
     for conn in connections.values():
         conn.close()

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -259,7 +259,7 @@ def test_statement_metrics(
                 },
                 'azure': {
                     'deployment_type': 'flexible_server',
-                    'name': 'test-server',
+                    'name': 'test-server.database.windows.net',
                 },
             },
             {
@@ -268,7 +268,7 @@ def test_statement_metrics(
                 },
                 'azure': {
                     'deployment_type': 'flexible_server',
-                    'name': 'test-server',
+                    'name': 'test-server.database.windows.net',
                 },
             },
         ),


### PR DESCRIPTION
### What does this PR do?
This updates the `azure`'s `name` configuration to `fully_qualified_domain_name` which is a more accurate name for the information that should be set in that field. This also updates the documentation for that field so that it's clear on the value that is expected. 

Note that this change is backward compatible but for the functionality to work on prior releases, the `azure.name` has the same requirements as with this change and needs to be the instance's fully qualified domain name. 

### Motivation
While doing work to integrate all the pieces for database unified instance tagging, we realized that the configuration wasn't accurately reflecting the input required for the linking to happen. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.