### PR TITLE
Update kafka consumer consumer_groups_regex example to be more inform…

### DIFF
--- a/kafka_consumer/assets/configuration/spec.yaml
+++ b/kafka_consumer/assets/configuration/spec.yaml
@@ -88,10 +88,10 @@ files:
           type: object
           example:
             <CONSUMER_NAME_1>:
-              <TOPIC_NAME_1>: [0, 1, 4, 12]
-            <CONSUMER_NAME_2>:
+              ^(?!<TOPIC_NAME_1>): [0, 1, 4, 12]
+            my_cons.+:
               <TOPIC_NAME_2>: []
-            <CONSUMER_NAME_3>: {}
+            test_consumer.+: {}
       - name: monitor_unlisted_consumer_groups
         description: |
           Setting `monitor_unlisted_consumer_groups` to `true` tells the check to discover all consumer groups

--- a/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
+++ b/kafka_consumer/datadog_checks/kafka_consumer/data/conf.yaml.example
@@ -84,14 +84,14 @@ instances:
     #
     # consumer_groups_regex:
     #   <CONSUMER_NAME_1>:
-    #     <TOPIC_NAME_1>:
+    #     ^(?!<TOPIC_NAME_1>):
     #     - 0
     #     - 1
     #     - 4
     #     - 12
-    #   <CONSUMER_NAME_2>:
+    #   my_cons.+:
     #     <TOPIC_NAME_2>: []
-    #   <CONSUMER_NAME_3>: {}
+    #   test_consumer.+: {}
 
     ## @param monitor_unlisted_consumer_groups - boolean - optional - default: false
     ## Setting `monitor_unlisted_consumer_groups` to `true` tells the check to discover all consumer groups


### PR DESCRIPTION
…ative

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR updates the example used in `consumer_groups_regex` to be more realistic in how the option can be used.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/integrations-core/pull/14382#discussion_r1178458012
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.