### PR TITLE
Rename azure.name configuration key to azure.fully_qualified_domain_name

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -536,12 +536,14 @@ files:
                 value:
                   type: string
                   example: flexible_server
-              - name: name
+              - name: fully_qualified_domain_name
                 description: |
-                  Equal to the name of the Azure MySQL database instance.
+                  Equal to the full qualified domain name of the Azure MySQL database.
+                  
+                  This value is optional if the value of `host` is already configured to the fully qualified domain name.
                 value:
                   type: string
-                  example: mysql-database
+                  example: mysql-database.database.windows.net
 
           - name: obfuscator_options
             description: |

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -44,6 +44,8 @@ class MySQLConfig(object):
         aws = instance.get('aws', {})
         gcp = instance.get('gcp', {})
         azure = instance.get('azure', {})
+        # Remap fully_qualified_domain_name to name
+        azure = {k if k != 'fully_qualified_domain_name' else 'name': v for k, v in azure.items()}
         if aws:
             self.cloud_metadata.update({'aws': aws})
         if gcp:

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -31,7 +31,7 @@ class Azure(BaseModel):
         allow_mutation = False
 
     deployment_type: Optional[str]
-    name: Optional[str]
+    fully_qualified_domain_name: Optional[str]
 
 
 class CustomQuery(BaseModel):

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -492,10 +492,12 @@ instances:
         #
         # deployment_type: flexible_server
 
-        ## @param name - string - optional - default: mysql-database
-        ## Equal to the name of the Azure MySQL database instance.
+        ## @param fully_qualified_domain_name - string - optional - default: mysql-database.database.windows.net
+        ## Equal to the full qualified domain name of the Azure MySQL database.
+        ##
+        ## This value is optional if the value of `host` is already configured to the fully qualified domain name.
         #
-        # name: mysql-database
+        # fully_qualified_domain_name: mysql-database.database.windows.net
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -225,36 +225,85 @@ def test_statement_metrics_with_duplicates(aggregator, dd_run_check, dbm_instanc
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
-    "cloud_metadata",
+    "input_cloud_metadata,output_cloud_metadata",
     [
-        {},
-        {
-            'azure': {
-                'deployment_type': 'flexible_server',
-                'name': 'test-server',
+        ({}, {}),
+        (
+            {
+                'azure': {
+                    'deployment_type': 'flexible_server',
+                    'name': 'test-server.database.windows.net',
+                },
             },
-        },
-        {
-            'aws': {
-                'instance_endpoint': 'foo.aws.com',
+            {
+                'azure': {
+                    'deployment_type': 'flexible_server',
+                    'name': 'test-server.database.windows.net',
+                },
             },
-            'azure': {
-                'deployment_type': 'flexible_server',
-                'name': 'test-server',
+        ),
+        (
+            {
+                'azure': {
+                    'deployment_type': 'flexible_server',
+                    'fully_qualified_domain_name': 'test-server.database.windows.net',
+                },
             },
-        },
-        {
-            'gcp': {
-                'project_id': 'foo-project',
-                'instance_id': 'bar',
-                'extra_field': 'included',
+            {
+                'azure': {
+                    'deployment_type': 'flexible_server',
+                    'name': 'test-server.database.windows.net',
+                },
             },
-        },
+        ),
+        (
+            {
+                'aws': {
+                    'instance_endpoint': 'foo.aws.com',
+                },
+                'azure': {
+                    'deployment_type': 'flexible_server',
+                    'name': 'test-server.database.windows.net',
+                },
+            },
+            {
+                'aws': {
+                    'instance_endpoint': 'foo.aws.com',
+                },
+                'azure': {
+                    'deployment_type': 'flexible_server',
+                    'name': 'test-server.database.windows.net',
+                },
+            },
+        ),
+        (
+            {
+                'gcp': {
+                    'project_id': 'foo-project',
+                    'instance_id': 'bar',
+                    'extra_field': 'included',
+                },
+            },
+            {
+                'gcp': {
+                    'project_id': 'foo-project',
+                    'instance_id': 'bar',
+                    'extra_field': 'included',
+                },
+            },
+        ),
     ],
 )
-def test_statement_metrics_cloud_metadata(aggregator, dd_run_check, dbm_instance, cloud_metadata, datadog_agent):
-    if cloud_metadata:
-        for k, v in cloud_metadata.items():
+def test_statement_metrics_cloud_metadata(
+        aggregator,
+        dd_run_check,
+        dbm_instance,
+        input_cloud_metadata,
+        output_cloud_metadata,
+        datadog_agent
+):
+    if input_cloud_metadata:
+        for k, v in input_cloud_metadata.items():
             dbm_instance[k] = v
     mysql_check = MySql(common.CHECK_NAME, {}, [dbm_instance])
 
@@ -282,7 +331,7 @@ def test_statement_metrics_cloud_metadata(aggregator, dd_run_check, dbm_instance
     assert event['ddagenthostname'] == datadog_agent.get_hostname()
     assert event['mysql_version'] == mysql_check.version.version + '+' + mysql_check.version.build
     assert event['mysql_flavor'] == mysql_check.version.flavor
-    assert event['cloud_metadata'] == cloud_metadata, "wrong cloud_metadata"
+    assert event['cloud_metadata'] == output_cloud_metadata, "wrong cloud_metadata"
 
 
 @pytest.mark.integration

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -295,12 +295,7 @@ def test_statement_metrics_with_duplicates(aggregator, dd_run_check, dbm_instanc
     ],
 )
 def test_statement_metrics_cloud_metadata(
-        aggregator,
-        dd_run_check,
-        dbm_instance,
-        input_cloud_metadata,
-        output_cloud_metadata,
-        datadog_agent
+    aggregator, dd_run_check, dbm_instance, input_cloud_metadata, output_cloud_metadata, datadog_agent
 ):
     if input_cloud_metadata:
         for k, v in input_cloud_metadata.items():


### PR DESCRIPTION
### What does this PR do?
This updates the `azure`'s `name` configuration to `fully_qualified_domain_name` which is a more accurate name for the information that should be set in that field. This also updates the documentation for that field so that it's clear on the value that is expected. 

Note that this change is backward compatible but for the functionality to work on prior releases, the `azure.name` has the same requirements as with this change and needs to be the instance's fully qualified domain name. 

### Motivation
While doing work to integrate all the pieces for database unified instance tagging, we realized that the configuration wasn't accurately reflecting the input required for the linking to happen. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.