### PR TITLE
attempt to support clusterAllReplicas for clickhouse datadog agent

### DIFF
--- a/clickhouse/datadog_checks/clickhouse/clickhouse.py
+++ b/clickhouse/datadog_checks/clickhouse/clickhouse.py
@@ -28,6 +28,7 @@ class ClickhouseCheck(AgentCheck):
         self._compression = self.instance.get('compression', False)
         self._tls_verify = is_affirmative(self.instance.get('tls_verify', False))
         self._tags = self.instance.get('tags', [])
+        self._clustername = self.instance.get('clustername', '')
 
         # Add global tags
         self._tags.append('server:{}'.format(self._server))
@@ -43,14 +44,7 @@ class ClickhouseCheck(AgentCheck):
         self._query_manager = QueryManager(
             self,
             self.execute_query_raw,
-            queries=[
-                queries.SystemMetrics,
-                queries.SystemEvents,
-                queries.SystemAsynchronousMetrics,
-                queries.SystemParts,
-                queries.SystemReplicas,
-                queries.SystemDictionaries,
-            ],
+            queries=queries.QueryBuilder.get_queries(self._clustername),
             tags=self._tags,
             error_handler=self._error_sanitizer.clean,
         )

--- a/clickhouse/datadog_checks/clickhouse/config_models/instance.py
+++ b/clickhouse/datadog_checks/clickhouse/config_models/instance.py
@@ -58,6 +58,7 @@ class InstanceConfig(BaseModel):
     tls_verify: Optional[bool]
     use_global_custom_queries: Optional[str]
     username: Optional[str]
+    clustername: Optional[str]
 
     @root_validator(pre=True)
     def _initial_validation(cls, values):


### PR DESCRIPTION
### What does this PR do?
https://github.com/DataDog/integrations-core/issues/14199

Update clickhouse datadog agent client to have ability to specify a cluster name, and query system tables with clusterAllReplicas option.

### Motivation
Datadog agent currently is not working with clickhouse clusters running across more than one node. This PR is an attempt to support monitoring multi-node clickhouse deployment by datadog agent.

### Additional Notes
I am yet to build/test locally.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.