### PR TITLE
Rename azure.name configuration key to azure.fully_qualified_domain_name

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -378,12 +378,14 @@ files:
           value:
             type: string
             example: sql_database
-        - name: name
+        - name: fully_qualified_domain_name
           description: |
             Equal to the name of the SQL Database, Managed Instance (SQL MI) or virtual machine.
+            
+            This value is optional if the value of `host` is already configured to the fully qualified domain name.
           value:
             type: string
-            example: my-sqlserver-instance
+            example: my-sqlserver-database.database.windows.net
 
     - name: obfuscator_options
       description: |

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -31,7 +31,7 @@ class Azure(BaseModel):
         allow_mutation = False
 
     deployment_type: Optional[str]
-    name: Optional[str]
+    fully_qualified_domain_name: Optional[str]
 
 
 class CustomQuery(BaseModel):

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -335,10 +335,12 @@ instances:
         #
         # deployment_type: sql_database
 
-        ## @param name - string - optional - default: my-sqlserver-instance
+        ## @param fully_qualified_domain_name - string - optional - default: my-sqlserver-database.database.windows.net
         ## Equal to the name of the SQL Database, Managed Instance (SQL MI) or virtual machine.
+        ##
+        ## This value is optional if the value of `host` is already configured to the fully qualified domain name.
         #
-        # name: my-sqlserver-instance
+        # fully_qualified_domain_name: my-sqlserver-database.database.windows.net
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -126,6 +126,8 @@ class SQLServer(AgentCheck):
         aws = self.instance.get('aws', {})
         gcp = self.instance.get('gcp', {})
         azure = self.instance.get('azure', {})
+        # Remap fully_qualified_domain_name to name
+        azure = {k if k != 'fully_qualified_domain_name' else 'name': v for k, v in azure.items()}
         if aws:
             self.cloud_metadata.update({'aws': aws})
         if gcp:


### PR DESCRIPTION
### What does this PR do?
This updates the `azure`'s `name` configuration to `fully_qualified_domain_name` which is a more accurate name for the information that should be set in that field. This also updates the documentation for that field so that it's clear on the value that is expected. 

Note that this change is backward compatible but for the functionality to work on prior releases, the `azure.name` has the same requirements as with this change and needs to be the instance's fully qualified domain name. 

### Motivation
While doing work to integrate all the pieces for database unified instance tagging, we realized that the configuration wasn't accurately reflecting the input required for the linking to happen. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.