### PR TITLE
Don't try to collect wal receiver if aurora is detected

### DIFF
--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -116,6 +116,13 @@ def assert_metric_at_least(aggregator, metric_name, lower_bound=None, higher_bou
         )
 
 
+def get_expected_instance_tags(check, pg_instance):
+    return pg_instance['tags'] + [
+        'port:{}'.format(pg_instance['port']),
+        'dd.internal.resource:database_instance:{}'.format(check.resolved_hostname),
+    ]
+
+
 def check_common_metrics(aggregator, expected_tags, count=1):
     for db in COMMON_DBS:
         db_tags = expected_tags + ['db:{}'.format(db)]
@@ -183,6 +190,26 @@ def check_wal_receiver_metrics(aggregator, expected_tags, count=1, connected=1):
         if column['type'] == 'tag':
             continue
         aggregator.assert_metric(column['name'], count=count, tags=expected_tags)
+
+
+def check_physical_replication_slots(aggregator, expected_tags):
+    replication_slot_tags = expected_tags + [
+        'slot_name:replication_slot',
+        'slot_persistence:permanent',
+        'slot_state:active',
+        'slot_type:physical',
+    ]
+    check_replication_slots(aggregator, expected_tags=replication_slot_tags)
+
+
+def check_logical_replication_slots(aggregator, expected_tags):
+    logical_replication_slot_tags = expected_tags + [
+        'slot_name:logical_slot',
+        'slot_persistence:permanent',
+        'slot_state:inactive',
+        'slot_type:logical',
+    ]
+    check_replication_slots(aggregator, expected_tags=logical_replication_slot_tags)
 
 
 def check_replication_slots(aggregator, expected_tags, count=1):


### PR DESCRIPTION
### What does this PR do?
Don't use `pg_stat_get_wal_receiver` if an aurora instance is detected.

### Motivation
Calling `pg_stat_wal_receiver` on an aurora instance will return the following:
```
select * from pg_stat_wal_receiver;
ERROR:  Function pg_stat_get_wal_receiver() is currently not supported in Aurora
```
Which will be reported as an agent error
```
error: - | (core.py:80) | Error querying pg_stat_wal_receiver: Function pg_stat_get_wal_receiver() is currently not supported in Aurora
```
Fix https://github.com/DataDog/integrations-core/issues/14498

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.