### PR TITLE
Add metric limit for rabbitmq

### DIFF
--- a/rabbitmq/datadog_checks/rabbitmq/openmetrics/check.py
+++ b/rabbitmq/datadog_checks/rabbitmq/openmetrics/check.py
@@ -9,6 +9,8 @@ from . import metrics
 class RabbitMQOpenMetrics(OpenMetricsBaseCheckV2):
     __NAMESPACE__ = "rabbitmq"
 
+    DEFAULT_METRIC_LIMIT = 0
+
     def configure_scrapers(self):
         base_url = self.instance['prometheus_plugin']['url']
         self.scraper_configs.clear()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds `DEFAULT_METRIC_LIMIT = 0` to rabbitmq's OpenMetrics check.

### Motivation
<!-- What inspired you to submit this pull request? -->
This was originally missed since the [openmetrics validation CLI command](https://github.com/DataDog/integrations-core/pull/14528) didn't account for check files in subdirectories of the package directory. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.