### PR TITLE
Enable explain parameterized query feature by default

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -399,11 +399,11 @@ files:
             example: 10000
         - name: explain_parameterized_queries
           description: |
-            Note, this is a BETA feature. This option will enable the ability to explain parameterized queries.
+            This option will enable the ability to explain parameterized queries.
             This is useful if your SQL clients are using the extended query protocol or prepared statements.
           value:
             type: boolean
-            example: false
+            example: true
     - name: query_activity
       description: Configure collection of query activity
       options:

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -318,11 +318,11 @@ instances:
         #
         # seen_samples_cache_maxsize: 10000
 
-        ## @param explain_parameterized_queries - boolean - optional - default: false
-        ## Note, this is a BETA feature. This option will enable the ability to explain parameterized queries.
+        ## @param explain_parameterized_queries - boolean - optional - default: true
+        ## This option will enable the ability to explain parameterized queries.
         ## This is useful if your SQL clients are using the extended query protocol or prepared statements.
         #
-        # explain_parameterized_queries: false
+        # explain_parameterized_queries: true
 
     ## Configure collection of query activity
     #

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -645,7 +645,7 @@ class PostgresStatementSamples(DBMAsyncJob):
                 " can't be explained due to the separation of the parsed query and raw bind parameters: %s",
                 repr(e),
             )
-            if is_affirmative(self._config.statement_samples_config.get('explain_parameterized_queries', False)):
+            if is_affirmative(self._config.statement_samples_config.get('explain_parameterized_queries', True)):
                 plan = self._explain_parameterized_queries.explain_statement(dbname, statement, obfuscated_statement)
                 if plan:
                     return plan, DBExplainError.explained_with_prepared_statement, None

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1193,28 +1193,19 @@ def test_truncate_activity_rows(integration_check, dbm_instance, active_rows, ex
 
 
 @pytest.mark.parametrize(
-    "query,expected_err_tag,expected_explain_err_code,expected_err,explain_param_query",
+    "query,expected_err_tag,expected_explain_err_code,expected_err",
     [
         (
             "select * from fake_table",
             "error:explain-undefined_table-<class 'psycopg2.errors.UndefinedTable'>",
             DBExplainError.undefined_table,
             "<class 'psycopg2.errors.UndefinedTable'>",
-            False,
         ),
         (
             "select * from pg_settings where name = $1",
             "error:explain-parameterized_query-<class 'psycopg2.errors.UndefinedParameter'>",
             DBExplainError.parameterized_query,
             "<class 'psycopg2.errors.UndefinedParameter'>",
-            False,
-        ),
-        (
-            "select * from pg_settings where name = $1",
-            "",
-            DBExplainError.explained_with_prepared_statement,
-            None,
-            True,
         ),
         (
             "SELECT city as city0, city as city1, city as city2, city as city3, "
@@ -1232,7 +1223,6 @@ def test_truncate_activity_rows(integration_check, dbm_instance, active_rows, ex
             "error:explain-query_truncated-track_activity_query_size=1024",
             DBExplainError.query_truncated,
             "track_activity_query_size=1024",
-            False,
         ),
     ],
 )
@@ -1244,11 +1234,10 @@ def test_statement_run_explain_errors(
     expected_err_tag,
     expected_explain_err_code,
     expected_err,
-    explain_param_query,
 ):
     dbm_instance['query_activity']['enabled'] = False
     dbm_instance['query_metrics']['enabled'] = False
-    dbm_instance['query_samples']['explain_parameterized_queries'] = explain_param_query
+    dbm_instance['query_samples']['explain_parameterized_queries'] = False
     check = integration_check(dbm_instance)
     check._connect()
 
@@ -1265,13 +1254,12 @@ def test_statement_run_explain_errors(
         'agent_hostname:stubbed.hostname',
     ]
 
-    if expected_explain_err_code != DBExplainError.explained_with_prepared_statement:
-        aggregator.assert_metric(
-            'dd.postgres.statement_samples.error',
-            count=1,
-            tags=expected_tags + [expected_err_tag],
-            hostname='stubbed.hostname',
-        )
+    aggregator.assert_metric(
+        'dd.postgres.statement_samples.error',
+        count=1,
+        tags=expected_tags + [expected_err_tag],
+        hostname='stubbed.hostname',
+    )
 
     if expected_explain_err_code == DBExplainError.database_error:
         aggregator.assert_metric(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Enables the explain parameterized query feature introduced in this [PR](https://github.com/DataDog/integrations-core/pull/13434) by default. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.