### PR TITLE
Add error handling when getting tags from API

### DIFF
--- a/vsphere/datadog_checks/vsphere/api_rest.py
+++ b/vsphere/datadog_checks/vsphere/api_rest.py
@@ -90,6 +90,7 @@ class VSphereRestAPI(object):
             all_tag_ids.update(tag_asso["tag_ids"])
 
         tags = self._get_tags(all_tag_ids)
+        self.log.debug("Fetched tags: %s", tags)
 
         for tag_asso in tag_associations:
             mor_id = tag_asso["object_id"]["id"]
@@ -121,12 +122,21 @@ class VSphereRestAPI(object):
         tags = {}
         categories = {}
         for tag_id in tag_ids:
-            tag = self._client.tagging_tags_get(tag_id)
-            category_id = tag["category_id"]
-            if category_id not in categories:
-                categories[category_id] = self._client.tagging_category_get(category_id)
-            category_name = categories[category_id]["name"]
-            tags[tag_id] = "{}{}:{}".format(self.config.tags_prefix, category_name, tag['name'])
+            try:
+                tag = self._client.tagging_tags_get(tag_id)
+                self.log.debug("Tag information fetched for tag identifier `%s`: %s", tag_id, tag)
+                category_id = tag["category_id"]
+                if category_id not in categories:
+                    categories[category_id] = self._client.tagging_category_get(category_id)
+                    self.log.debug(
+                        "Category information fetched for category identifier `%s`: %s",
+                        category_id,
+                        categories[category_id],
+                    )
+                category_name = categories[category_id]["name"]
+                tags[tag_id] = "{}{}:{}".format(self.config.tags_prefix, category_name, tag['name'])
+            except Exception as e:
+                self.log.warning("Exception in get_tags for `%s`: %s", tag_id, e)
         return tags
 
 

--- a/vsphere/tests/test_api_rest.py
+++ b/vsphere/tests/test_api_rest.py
@@ -35,71 +35,63 @@ def test_get_resource_tags(realtime_instance):
     assert expected_resource_tags == resource_tags
 
 
-@pytest.mark.usefixtures("mock_rest_api", "mock_type", "mock_api")
+@pytest.mark.usefixtures("mock_rest_api", "mock_type", "mock_api", "mock_threadpool")
 def test_tagging_tags_get_exception(realtime_instance, dd_run_check, caplog, aggregator):
-    mock_connect = MagicMock()
-    with patch('pyVim.connect.SmartConnect', new=mock_connect):
 
-        instance = copy.deepcopy(realtime_instance)
-        instance['collect_tags'] = True
-        instance['excluded_host_tags'] = ['my_cat_name_1']
-        check = VSphereCheck('vsphere', {}, [instance])
+    instance = copy.deepcopy(realtime_instance)
+    instance['collect_tags'] = True
+    instance['excluded_host_tags'] = ['my_cat_name_1']
+    check = VSphereCheck('vsphere', {}, [instance])
 
-        with patch('datadog_checks.vsphere.api_rest.VSphereRestClient.tagging_tags_get', side_effect=Exception("test")):
-            dd_run_check(check)
-        assert "Exception in get_tags for `tag_id_1`: test" in caplog.text
-        assert "Result resource tags: {<class 'pyVmomi.VmomiSupport.vim.VirtualMachine'>: "
-        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.HostSystem'>: "
-        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.Datacenter'>: "
-        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.Datastore'>: "
-        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.ClusterComputeResource'>: "
-        "defaultdict(<class 'list'>, {})}" in caplog.text
-
-        aggregator.assert_metric_has_tag('vsphere.net.bytesTx.avg', 'my_cat_name_1:my_tag_name_1', count=0)
-
-
-@pytest.mark.usefixtures("mock_rest_api", "mock_type", "mock_api")
-def test_tagging_category_get_exception(realtime_instance, dd_run_check, caplog, aggregator):
-    mock_connect = MagicMock()
-    with patch('pyVim.connect.SmartConnect', new=mock_connect):
-
-        instance = copy.deepcopy(realtime_instance)
-        instance['collect_tags'] = True
-        instance['excluded_host_tags'] = ['my_cat_name_1']
-        check = VSphereCheck('vsphere', {}, [instance])
-
-        with patch(
-            'datadog_checks.vsphere.api_rest.VSphereRestClient.tagging_category_get', side_effect=Exception("test")
-        ):
-            dd_run_check(check)
-        assert "Exception in get_tags for `tag_id_1`: test" in caplog.text
-        assert "Result resource tags: {<class 'pyVmomi.VmomiSupport.vim.VirtualMachine'>: "
-        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.HostSystem'>: "
-        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.Datacenter'>: "
-        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.Datastore'>: "
-        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.ClusterComputeResource'>: "
-        "defaultdict(<class 'list'>, {})}" in caplog.text
-
-        aggregator.assert_metric_has_tag('vsphere.net.bytesTx.avg', 'my_cat_name_1:my_tag_name_1', count=0)
-
-
-@pytest.mark.usefixtures("mock_rest_api", "mock_type", "mock_api")
-def test_get_tags_log(realtime_instance, dd_run_check, caplog, aggregator):
-    mock_connect = MagicMock()
-    with patch('pyVim.connect.SmartConnect', new=mock_connect):
-
-        instance = copy.deepcopy(realtime_instance)
-        instance['collect_tags'] = True
-        instance['excluded_host_tags'] = ['my_cat_name_1']
-
-        check = VSphereCheck('vsphere', {}, [instance])
-
+    with patch('datadog_checks.vsphere.api_rest.VSphereRestClient.tagging_tags_get', side_effect=Exception("test")):
         dd_run_check(check)
+        assert "Exception in get_tags for `tag_id_1`: test" in caplog.text
         assert "Result resource tags: {<class 'pyVmomi.VmomiSupport.vim.VirtualMachine'>: "
-        "defaultdict(<class 'list'>, {'VM4-4-1': ['my_cat_name_1:my_tag_name_1', "
-        "'my_cat_name_2:my_tag_name_2']})" in caplog.text
+        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.HostSystem'>: "
+        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.Datacenter'>: "
+        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.Datastore'>: "
+        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.ClusterComputeResource'>: "
+        "defaultdict(<class 'list'>, {})}" in caplog.text
 
-        aggregator.assert_metric_has_tag('vsphere.net.bytesTx.avg', 'my_cat_name_1:my_tag_name_1')
+        aggregator.assert_metric_has_tag('vsphere.net.bytesTx.avg', 'my_cat_name_1:my_tag_name_1', count=0)
+
+
+@pytest.mark.usefixtures("mock_rest_api", "mock_type", "mock_api", "mock_threadpool")
+def test_tagging_category_get_exception(realtime_instance, dd_run_check, caplog, aggregator):
+
+    instance = copy.deepcopy(realtime_instance)
+    instance['collect_tags'] = True
+    instance['excluded_host_tags'] = ['my_cat_name_1']
+    check = VSphereCheck('vsphere', {}, [instance])
+
+    with patch('datadog_checks.vsphere.api_rest.VSphereRestClient.tagging_category_get', side_effect=Exception("test")):
+        dd_run_check(check)
+        assert "Exception in get_tags for `tag_id_1`: test" in caplog.text
+        assert "Result resource tags: {<class 'pyVmomi.VmomiSupport.vim.VirtualMachine'>: "
+        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.HostSystem'>: "
+        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.Datacenter'>: "
+        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.Datastore'>: "
+        "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.ClusterComputeResource'>: "
+        "defaultdict(<class 'list'>, {})}" in caplog.text
+
+        aggregator.assert_metric_has_tag('vsphere.net.bytesTx.avg', 'my_cat_name_1:my_tag_name_1', count=0)
+
+
+@pytest.mark.usefixtures("mock_rest_api", "mock_type", "mock_threadpool", "mock_api")
+def test_get_tags_log(realtime_instance, dd_run_check, caplog, aggregator):
+
+    instance = copy.deepcopy(realtime_instance)
+    instance['collect_tags'] = True
+    instance['excluded_host_tags'] = ['my_cat_name_1']
+
+    check = VSphereCheck('vsphere', {}, [instance])
+
+    dd_run_check(check)
+    assert "Result resource tags: {<class 'pyVmomi.VmomiSupport.vim.VirtualMachine'>: "
+    "defaultdict(<class 'list'>, {'VM4-4-1': ['my_cat_name_1:my_tag_name_1', "
+    "'my_cat_name_2:my_tag_name_2']})" in caplog.text
+
+    aggregator.assert_metric_has_tag('vsphere.net.bytesTx.avg', 'my_cat_name_1:my_tag_name_1')
 
 
 @pytest.mark.parametrize(

--- a/vsphere/tests/test_api_rest.py
+++ b/vsphere/tests/test_api_rest.py
@@ -55,7 +55,7 @@ def test_tagging_tags_get_exception(realtime_instance, dd_run_check, caplog, agg
         "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.ClusterComputeResource'>: "
         "defaultdict(<class 'list'>, {})}" in caplog.text
 
-        aggregator.assert_metric('vsphere.net.bytesTx.avg', tags=['vcenter_server:FAKE'], hostname='VM4-4')
+        aggregator.assert_metric('vsphere.net.bytesTx.avg', tags=['vcenter_server:FAKE'])
 
 
 @pytest.mark.usefixtures("mock_rest_api", "mock_type", "mock_api")
@@ -80,7 +80,7 @@ def test_tagging_category_get_exception(realtime_instance, dd_run_check, caplog,
         "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.ClusterComputeResource'>: "
         "defaultdict(<class 'list'>, {})}" in caplog.text
 
-        aggregator.assert_metric('vsphere.net.bytesTx.avg', tags=['vcenter_server:FAKE'], hostname='VM4-4')
+        aggregator.assert_metric('vsphere.net.bytesTx.avg', tags=['vcenter_server:FAKE'])
 
 
 @pytest.mark.usefixtures("mock_rest_api", "mock_type", "mock_api")
@@ -100,7 +100,8 @@ def test_get_tags_log(realtime_instance, dd_run_check, caplog, aggregator):
         "'my_cat_name_2:my_tag_name_2']})" in caplog.text
 
         aggregator.assert_metric(
-            'vsphere.net.bytesTx.avg', tags=['my_cat_name_1:my_tag_name_1', 'vcenter_server:FAKE'], hostname='VM4-4'
+            'vsphere.net.bytesTx.avg',
+            tags=['my_cat_name_1:my_tag_name_1', 'vcenter_server:FAKE'],
         )
 
 

--- a/vsphere/tests/test_api_rest.py
+++ b/vsphere/tests/test_api_rest.py
@@ -55,7 +55,7 @@ def test_tagging_tags_get_exception(realtime_instance, dd_run_check, caplog, agg
         "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.ClusterComputeResource'>: "
         "defaultdict(<class 'list'>, {})}" in caplog.text
 
-        aggregator.assert_metric('vsphere.net.bytesTx.avg', tags=['vcenter_server:FAKE'])
+        aggregator.assert_metric_has_tag('vsphere.net.bytesTx.avg', 'my_cat_name_1:my_tag_name_1', count=0)
 
 
 @pytest.mark.usefixtures("mock_rest_api", "mock_type", "mock_api")
@@ -80,7 +80,7 @@ def test_tagging_category_get_exception(realtime_instance, dd_run_check, caplog,
         "defaultdict(<class 'list'>, {}), <class 'pyVmomi.VmomiSupport.vim.ClusterComputeResource'>: "
         "defaultdict(<class 'list'>, {})}" in caplog.text
 
-        aggregator.assert_metric('vsphere.net.bytesTx.avg', tags=['vcenter_server:FAKE'])
+        aggregator.assert_metric_has_tag('vsphere.net.bytesTx.avg', 'my_cat_name_1:my_tag_name_1', count=0)
 
 
 @pytest.mark.usefixtures("mock_rest_api", "mock_type", "mock_api")
@@ -99,10 +99,7 @@ def test_get_tags_log(realtime_instance, dd_run_check, caplog, aggregator):
         "defaultdict(<class 'list'>, {'VM4-4-1': ['my_cat_name_1:my_tag_name_1', "
         "'my_cat_name_2:my_tag_name_2']})" in caplog.text
 
-        aggregator.assert_metric(
-            'vsphere.net.bytesTx.avg',
-            tags=['my_cat_name_1:my_tag_name_1', 'vcenter_server:FAKE'],
-        )
+        aggregator.assert_metric_has_tag('vsphere.net.bytesTx.avg', 'my_cat_name_1:my_tag_name_1')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What does this PR do?
Adds a try/catch around getting tags from the vsphere API

### Motivation
We found a case where this call can error and we don't want this to fully break metric collection 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.