### PR TITLE
Provide exhaustive mapping rules for Airflow StatsD Integration

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -177,19 +177,19 @@ Connect Airflow to DogStatsD (included in the Datadog Agent) by using the Airflo
            name: "airflow.task.instance_created"
            tags:
              task_class: "$1"
-        - match: airflow\.ti\.start\.(.+)\.(\w+)
-          match_type: regex
-          name: airflow.ti.start
-          tags: 
-            dagid: "$1"
-            taskid: "$2"
-        - match: airflow\.ti\.finish\.(\w+)\.(.+)\.(\w+)
-          name: airflow.ti.finish
-          match_type: regex
-          tags: 
-            dagid: "$1"
-            taskid: "$2"
-            state: "$3"
+         - match: 'airflow\.ti\.start\.(.+)\.(\w+)'
+           match_type: regex
+           name: airflow.ti.start
+           tags: 
+             dagid: "$1"
+             taskid: "$2"
+         - match: 'airflow\.ti\.finish\.(\w+)\.(.+)\.(\w+)'
+           name: airflow.ti.finish
+           match_type: regex
+           tags: 
+             dagid: "$1"
+             taskid: "$2"
+             state: "$3"
    ```
 
 ##### Restart Datadog Agent and Airflow

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -177,17 +177,19 @@ Connect Airflow to DogStatsD (included in the Datadog Agent) by using the Airflo
            name: "airflow.task.instance_created"
            tags:
              task_class: "$1"
-         - match: "airflow.ti.start.*.*"
-           name: "airflow.ti.start"
-           tags:
-             dag_id: "$1"
-             task_id: "$2"
-         - match: "airflow.ti.finish.*.*.*"
-           name: "airflow.ti.finish"
-           tags:
-             dag_id: "$1"
-             task_id: "$2"
-             state: "$3"
+        - match: airflow\.ti\.start\.(.+)\.(\w+)
+          match_type: regex
+          name: airflow.ti.start
+          tags: 
+            dagid: "$1"
+            taskid: "$2"
+        - match: airflow\.ti\.finish\.(\w+)\.(.+)\.(\w+)
+          name: airflow.ti.finish
+          match_type: regex
+          tags: 
+            dagid: "$1"
+            taskid: "$2"
+            state: "$3"
    ```
 
 ##### Restart Datadog Agent and Airflow


### PR DESCRIPTION
An Airflow user might choose to use dots in their DAG name. The Pattern will then not match and produce very expensive custom metrics in datadog.

With this change, all DAG names are accepted

### What does this PR do?
Update Airflow Statsd integration documentation

### Motivation
The original mapping rules cost us a lot of money

### Additional Notes
-

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.