### PR TITLE
Add `token` and `alert` as valid metric units

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -225,6 +225,8 @@ VALID_UNIT_NAMES = {
     'exception',
     'run',
     'hop',
+    'alert',
+    'token',
 }
 
 ALLOWED_PREFIXES = ['system', 'jvm', 'http', 'datadog', 'sftp', 'process', 'runtime']


### PR DESCRIPTION
### What does this PR do?
Alert was added previously to the [catalog.csv](https://github.com/DataDog/dogweb/blob/prod/integration/system/units_catalog.csv?plain=1#L162), token has also been added