### PR TITLE
Support ingesting pg_settings for `dbm` users

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/base.py
+++ b/datadog_checks_base/datadog_checks/base/checks/base.py
@@ -648,6 +648,13 @@ class AgentCheck(object):
 
         aggregator.submit_event_platform_event(self, self.check_id, to_native_string(raw_event), "dbm-activity")
 
+    def database_monitoring_metadata(self, raw_event):
+        # type: (str) -> None
+        if raw_event is None:
+            return
+
+        aggregator.submit_event_platform_event(self, self.check_id, to_native_string(raw_event), "dbm-metadata")
+
     def should_send_metric(self, metric_name):
         return not self._metric_excluded(metric_name) and self._metric_included(metric_name)
 

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -427,6 +427,22 @@ files:
           value:
             type: number
             example: 3500
+    - name: database_metadata
+      description: Configure collection of database metadata
+      options:
+        - name: collect_settings
+          description: |
+            Enable collection of pg_settings. Requires `dbm: true`.
+          value:
+            type: boolean
+            example: true
+        - name: settings_collection_interval
+          description: |
+            Set the database settings collection interval (in minutes). Each collection involves a single query to
+            `pg_settings`.
+          value:
+            type: number
+            example: 5
 
     - name: aws
       description: |

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -435,7 +435,7 @@ files:
             Enable collection of pg_settings. Requires `dbm: true`.
           value:
             type: boolean
-            example: true
+            example: false
         - name: settings_collection_interval
           description: |
             Set the database settings collection interval (in seconds). Each collection involves a single query to

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -427,16 +427,16 @@ files:
           value:
             type: number
             example: 3500
-    - name: database_metadata
+    - name: collect_settings
       description: Configure collection of pg_settings. This is an alpha feature.
       options:
-        - name: collect_settings
+        - name: enabled
           description: |
             Enable collection of pg_settings. Requires `dbm: true`.
           value:
             type: boolean
             example: false
-        - name: settings_collection_interval
+        - name: collection_interval
           description: |
             Set the database settings collection interval (in seconds). Each collection involves a single query to
             `pg_settings`.

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -428,7 +428,7 @@ files:
             type: number
             example: 3500
     - name: database_metadata
-      description: Configure collection of database metadata
+      description: Configure collection of pg_settings. This is an alpha feature.
       options:
         - name: collect_settings
           description: |
@@ -438,11 +438,11 @@ files:
             example: true
         - name: settings_collection_interval
           description: |
-            Set the database settings collection interval (in minutes). Each collection involves a single query to
+            Set the database settings collection interval (in seconds). Each collection involves a single query to
             `pg_settings`.
           value:
             type: number
-            example: 5
+            example: 600
 
     - name: aws
       description: |

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -90,7 +90,7 @@ class PostgresConfig:
         # statement samples & execution plans
         self.pg_stat_activity_view = instance.get('pg_stat_activity_view', 'pg_stat_activity')
         self.statement_samples_config = instance.get('query_samples', instance.get('statement_samples', {})) or {}
-        self.metadata_config = instance.get('query_metadata', {}) or {}
+        self.metadata_config = instance.get('database_metadata', {}) or {}
         self.statement_activity_config = instance.get('query_activity', {}) or {}
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}
         self.cloud_metadata = {}

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -90,7 +90,7 @@ class PostgresConfig:
         # statement samples & execution plans
         self.pg_stat_activity_view = instance.get('pg_stat_activity_view', 'pg_stat_activity')
         self.statement_samples_config = instance.get('query_samples', instance.get('statement_samples', {})) or {}
-        self.metadata_config = instance.get('database_metadata', {}) or {}
+        self.settings_metadata_config = instance.get('collect_settings', {}) or {}
         self.statement_activity_config = instance.get('query_activity', {}) or {}
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}
         self.cloud_metadata = {}

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -90,6 +90,7 @@ class PostgresConfig:
         # statement samples & execution plans
         self.pg_stat_activity_view = instance.get('pg_stat_activity_view', 'pg_stat_activity')
         self.statement_samples_config = instance.get('query_samples', instance.get('statement_samples', {})) or {}
+        self.metadata_config = instance.get('query_metadata', {}) or {}
         self.statement_activity_config = instance.get('query_activity', {}) or {}
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}
         self.cloud_metadata = {}

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -54,6 +54,10 @@ def instance_collect_function_metrics(field, value):
     return False
 
 
+def instance_collect_settings(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_collect_wal_metrics(field, value):
     return False
 
@@ -64,10 +68,6 @@ def instance_custom_queries(field, value):
 
 def instance_data_directory(field, value):
     return '/usr/local/pgsql/data'
-
-
-def instance_database_metadata(field, value):
-    return get_default_field_value(field, value)
 
 
 def instance_dbm(field, value):

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -66,6 +66,10 @@ def instance_data_directory(field, value):
     return '/usr/local/pgsql/data'
 
 
+def instance_database_metadata(field, value):
+    return get_default_field_value(field, value)
+
+
 def instance_dbm(field, value):
     return False
 

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -34,6 +34,14 @@ class Azure(BaseModel):
     fully_qualified_domain_name: Optional[str]
 
 
+class DatabaseMetadata(BaseModel):
+    class Config:
+        allow_mutation = False
+
+    collect_settings: Optional[bool]
+    settings_collection_interval: Optional[float]
+
+
 class Gcp(BaseModel):
     class Config:
         allow_mutation = False
@@ -123,6 +131,7 @@ class InstanceConfig(BaseModel):
     collect_wal_metrics: Optional[bool]
     custom_queries: Optional[Sequence[Mapping[str, Any]]]
     data_directory: Optional[str]
+    database_metadata: Optional[DatabaseMetadata]
     dbm: Optional[bool]
     dbname: Optional[str]
     dbstrict: Optional[bool]

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -34,12 +34,12 @@ class Azure(BaseModel):
     fully_qualified_domain_name: Optional[str]
 
 
-class DatabaseMetadata(BaseModel):
+class CollectSettings(BaseModel):
     class Config:
         allow_mutation = False
 
-    collect_settings: Optional[bool]
-    settings_collection_interval: Optional[float]
+    collection_interval: Optional[float]
+    enabled: Optional[bool]
 
 
 class Gcp(BaseModel):
@@ -128,10 +128,10 @@ class InstanceConfig(BaseModel):
     collect_database_size_metrics: Optional[bool]
     collect_default_database: Optional[bool]
     collect_function_metrics: Optional[bool]
+    collect_settings: Optional[CollectSettings]
     collect_wal_metrics: Optional[bool]
     custom_queries: Optional[Sequence[Mapping[str, Any]]]
     data_directory: Optional[str]
-    database_metadata: Optional[DatabaseMetadata]
     dbm: Optional[bool]
     dbname: Optional[str]
     dbstrict: Optional[bool]

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -347,18 +347,18 @@ instances:
 
     ## Configure collection of pg_settings. This is an alpha feature.
     #
-    # database_metadata:
+    # collect_settings:
 
-        ## @param collect_settings - boolean - optional - default: false
+        ## @param enabled - boolean - optional - default: false
         ## Enable collection of pg_settings. Requires `dbm: true`.
         #
-        # collect_settings: false
+        # enabled: false
 
-        ## @param settings_collection_interval - number - optional - default: 600
+        ## @param collection_interval - number - optional - default: 600
         ## Set the database settings collection interval (in seconds). Each collection involves a single query to
         ## `pg_settings`.
         #
-        # settings_collection_interval: 600
+        # collection_interval: 600
 
     ## This block defines the configuration for AWS RDS and Aurora instances. 
     ##

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -349,10 +349,10 @@ instances:
     #
     # database_metadata:
 
-        ## @param collect_settings - boolean - optional - default: true
+        ## @param collect_settings - boolean - optional - default: false
         ## Enable collection of pg_settings. Requires `dbm: true`.
         #
-        # collect_settings: true
+        # collect_settings: false
 
         ## @param settings_collection_interval - number - optional - default: 600
         ## Set the database settings collection interval (in seconds). Each collection involves a single query to

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -345,6 +345,21 @@ instances:
         #
         # payload_row_limit: 3500
 
+    ## Configure collection of database metadata
+    #
+    # database_metadata:
+
+        ## @param collect_settings - boolean - optional - default: true
+        ## Enable collection of pg_settings. Requires `dbm: true`.
+        #
+        # collect_settings: true
+
+        ## @param settings_collection_interval - number - optional - default: 5
+        ## Set the database settings collection interval (in minutes). Each collection involves a single query to
+        ## `pg_settings`.
+        #
+        # settings_collection_interval: 5
+
     ## This block defines the configuration for AWS RDS and Aurora instances. 
     ##
     ## Complete this section if you have installed the Datadog AWS Integration 

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -345,7 +345,7 @@ instances:
         #
         # payload_row_limit: 3500
 
-    ## Configure collection of database metadata
+    ## Configure collection of pg_settings. This is an alpha feature.
     #
     # database_metadata:
 
@@ -354,11 +354,11 @@ instances:
         #
         # collect_settings: true
 
-        ## @param settings_collection_interval - number - optional - default: 5
-        ## Set the database settings collection interval (in minutes). Each collection involves a single query to
+        ## @param settings_collection_interval - number - optional - default: 600
+        ## Set the database settings collection interval (in seconds). Each collection involves a single query to
         ## `pg_settings`.
         #
-        # settings_collection_interval: 5
+        # settings_collection_interval: 600
 
     ## This block defines the configuration for AWS RDS and Aurora instances. 
     ##

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -40,8 +40,8 @@ class PostgresMetadata(DBMAsyncJob):
     """
 
     def __init__(self, check, config, shutdown_callback):
-        self.pg_settings_collection_interval = config.metadata_config.get(
-            'settings_collection_interval', DEFAULT_SETTINGS_COLLECTION_INTERVAL
+        self.pg_settings_collection_interval = config.settings_metadata_config.get(
+            'collection_interval', DEFAULT_SETTINGS_COLLECTION_INTERVAL
         )
 
         # by default, send resources every 5 minutes
@@ -55,7 +55,7 @@ class PostgresMetadata(DBMAsyncJob):
         super(PostgresMetadata, self).__init__(
             check,
             rate_limit=1 / self.collection_interval,
-            run_sync=is_affirmative(config.metadata_config.get('run_sync', False)),
+            run_sync=is_affirmative(config.settings_metadata_config.get('run_sync', False)),
             enabled=True,
             dbms="postgres",
             min_collection_interval=self.collection_interval,
@@ -65,7 +65,7 @@ class PostgresMetadata(DBMAsyncJob):
         )
         self._check = check
         self._config = config
-        self._collect_pg_settings_enabled = is_affirmative(config.metadata_config.get('collect_settings', False))
+        self._collect_pg_settings_enabled = is_affirmative(config.settings_metadata_config.get('enabled', False))
         self._pg_settings_cached = None
         self._time_since_last_settings_query = 0
         self._conn_ttl_ms = self._config.idle_connection_timeout

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -99,7 +99,7 @@ class PostgresMetadata(DBMAsyncJob):
                 "host": self._check.resolved_hostname,
                 "agent_version": datadog_agent.get_version(),
                 "dbms": "postgres",
-                "kind": "metadata",
+                "kind": "pg_settings",
                 "tags": self._tags_no_db,
                 "timestamp": time.time() * 1000,
                 "cloud_metadata": self._config.cloud_metadata,

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -40,7 +40,6 @@ class PostgresMetadata(DBMAsyncJob):
     """
 
     def __init__(self, check, config, shutdown_callback):
-        # convert settings collection interval from minutes to seconds
         self.pg_settings_collection_interval = config.metadata_config.get(
             'settings_collection_interval', DEFAULT_SETTINGS_COLLECTION_INTERVAL
         )
@@ -123,7 +122,7 @@ class PostgresMetadata(DBMAsyncJob):
         with self._conn_pool.get_connection(self._config.dbname, ttl_ms=self._conn_ttl_ms).cursor(
             cursor_factory=psycopg2.extras.DictCursor
         ) as cursor:
-            self._log.debug("Running query [%s] %s", PG_SETTINGS_QUERY)
+            self._log.debug("Running query [%s]", PG_SETTINGS_QUERY)
             self._time_since_last_settings_query = time.time()
             cursor.execute(PG_SETTINGS_QUERY)
             rows = cursor.fetchall()

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -1,0 +1,121 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from typing import Dict, Optional, Tuple  # noqa: F401
+
+import time
+import json
+import psycopg2
+
+try:
+    import datadog_agent
+except ImportError:
+    from ..stubs import datadog_agent
+
+from datadog_checks.base import is_affirmative
+from datadog_checks.base.utils.db.utils import (
+    DBMAsyncJob,
+    RateLimitingTTLCache,
+    default_json_event_encoding,
+    obfuscate_sql_with_metadata,
+)
+from datadog_checks.postgres.connections import MultiDatabaseConnectionPool
+from datadog_checks.base.utils.tracking import tracked_method
+
+# default collection interval in minutes
+DEFAULT_COLLECTION_INTERVAL = 30
+
+PG_SETTINGS_QUERY = """
+SELECT name, setting, category, short_desc FROM pg_settings
+"""
+
+def agent_check_getter(self):
+    return self._check
+
+class PostgresMetadata(DBMAsyncJob):
+    """
+    Collects statement samples and execution plans.
+    """
+
+    def __init__(self, check, config, shutdown_callback):
+        collection_interval = float(
+            config.metadata_config.get('collection_interval', DEFAULT_COLLECTION_INTERVAL)
+        )
+        if collection_interval <= 0:
+            collection_interval = DEFAULT_COLLECTION_INTERVAL
+
+        # convert collection interval from minutes to seconds
+        collection_interval = collection_interval * 60
+
+        self._conn_pool = MultiDatabaseConnectionPool(check._new_connection)
+
+        def shutdown_cb():
+            self._conn_pool.close_all_connections()
+            return shutdown_callback()
+
+        # TODO: check this stuff, not sure if its correct
+        super(PostgresMetadata, self).__init__(
+            check,
+            rate_limit=1 / collection_interval,
+            run_sync=is_affirmative(config.metadata_config.get('run_sync', False)),
+            enabled=is_affirmative(config.metadata_config.get('enabled', False)),
+            dbms="postgres",
+            min_collection_interval=config.min_collection_interval,
+            expected_db_exceptions=(psycopg2.errors.DatabaseError,),
+            job_name="query-metadata",
+            shutdown_callback=shutdown_cb,
+        )
+        self._check = check
+        self._config = config
+        self._conn_ttl_ms = self._config.idle_connection_timeout
+        self._tags_no_db = None
+        self.tags = None
+
+    def _dbtags(self, db, *extra_tags):
+        """
+        Returns the default instance tags with the initial "db" tag replaced with the provided tag
+        """
+        t = ["db:" + db]
+        if extra_tags:
+            t.extend(extra_tags)
+        if self._tags_no_db:
+            t.extend(self._tags_no_db)
+        return t
+
+    def run_job(self):
+        # do not emit any dd.internal metrics for DBM specific check code
+        self.tags = [t for t in self._tags if not t.startswith('dd.internal')]
+        self._tags_no_db = [t for t in self.tags if not t.startswith('db:')]
+        self.report_postgres_settings()
+        self._conn_pool.prune_connections()
+
+    @tracked_method(agent_check_getter=agent_check_getter)
+    def report_postgres_settings(self):
+        rows = self._collect_postgres_settings()
+        if rows:
+            event = {
+                "host": self._check.resolved_hostname,
+                "ddagentversion": datadog_agent.get_version(),
+                "ddsource": "postgres",
+                "dbm_type": "metadata",
+                "ddtags": self._tags_no_db,
+                "timestamp": time.time() * 1000,
+                "cloud_metadata": self._config.cloud_metadata,
+                "pg_settings": rows,
+            }
+        self._check.database_monitoring_metadata(
+            json.dumps(event, default=default_json_event_encoding)
+        )
+
+    @tracked_method(agent_check_getter=agent_check_getter)
+    def _collect_postgres_settings(self):
+        with self._conn_pool.get_connection(self._config.dbname, ttl_ms=self._conn_ttl_ms).cursor(
+                cursor_factory=psycopg2.extras.DictCursor
+        ) as cursor:
+            self._log.debug("Running query [%s] %s", PG_SETTINGS_QUERY)
+            cursor.execute(PG_SETTINGS_QUERY)
+            rows = cursor.fetchall()
+            self._log.debug("Loaded %s rows from pg_settings", len(rows))
+            return [dict(row) for row in rows]
+

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -1,6 +1,6 @@
-# (C) Datadog, Inc. 2020-present
+# (C) Datadog, Inc. 2023-present
 # All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
+# Licensed under a 3-clause BSD style license (see LICENSE)
 from typing import Dict, Optional, Tuple  # noqa: F401
 
 import time

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -1,7 +1,6 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2020-present
 # All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-
+# Licensed under Simplified BSD License (see LICENSE)
 from typing import Dict, Optional, Tuple  # noqa: F401
 
 import time
@@ -16,19 +15,18 @@ except ImportError:
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.utils.db.utils import (
     DBMAsyncJob,
-    RateLimitingTTLCache,
     default_json_event_encoding,
-    obfuscate_sql_with_metadata,
 )
 from datadog_checks.postgres.connections import MultiDatabaseConnectionPool
 from datadog_checks.base.utils.tracking import tracked_method
 
 # default collection interval in minutes
-DEFAULT_COLLECTION_INTERVAL = 30
+DEFAULT_COLLECTION_INTERVAL = 5
 
 PG_SETTINGS_QUERY = """
-SELECT name, setting, category, short_desc FROM pg_settings
+SELECT name, setting FROM pg_settings
 """
+
 
 def agent_check_getter(self):
     return self._check
@@ -36,12 +34,14 @@ def agent_check_getter(self):
 
 class PostgresMetadata(DBMAsyncJob):
     """
-    Collects statement samples and execution plans.
+    Collects database metadata. Supports:
+        1. cloud metadata collection for resource creations
+        2. collection of pg_settings
     """
 
     def __init__(self, check, config, shutdown_callback):
         collection_interval = float(
-            config.metadata_config.get('collection_interval', DEFAULT_COLLECTION_INTERVAL)
+            config.metadata_config.get('settings_collection_interval', DEFAULT_COLLECTION_INTERVAL)
         )
         if collection_interval <= 0:
             collection_interval = DEFAULT_COLLECTION_INTERVAL
@@ -55,20 +55,20 @@ class PostgresMetadata(DBMAsyncJob):
             self._conn_pool.close_all_connections()
             return shutdown_callback()
 
-        # TODO: check this stuff, not sure if its correct
         super(PostgresMetadata, self).__init__(
             check,
             rate_limit=1 / collection_interval,
             run_sync=is_affirmative(config.metadata_config.get('run_sync', False)),
-            enabled=is_affirmative(config.metadata_config.get('enabled', False)),
+            enabled=True,
             dbms="postgres",
-            min_collection_interval=config.min_collection_interval,
+            min_collection_interval=collection_interval,
             expected_db_exceptions=(psycopg2.errors.DatabaseError,),
-            job_name="query-metadata",
+            job_name="database-metadata",
             shutdown_callback=shutdown_cb,
         )
         self._check = check
         self._config = config
+        self._collect_pg_settings_enabled = is_affirmative(config.metadata_config.get('collect_settings', False))
         self._conn_ttl_ms = self._config.idle_connection_timeout
         self._tags_no_db = None
         self.tags = None
@@ -88,35 +88,41 @@ class PostgresMetadata(DBMAsyncJob):
         # do not emit any dd.internal metrics for DBM specific check code
         self.tags = [t for t in self._tags if not t.startswith('dd.internal')]
         self._tags_no_db = [t for t in self.tags if not t.startswith('db:')]
-        self.report_postgres_settings()
+        self.report_postgres_metadata()
         self._conn_pool.prune_connections()
 
     @tracked_method(agent_check_getter=agent_check_getter)
-    def report_postgres_settings(self):
-        rows = self._collect_postgres_settings()
+    def report_postgres_metadata(self):
+        rows = []
+        if self._collect_pg_settings_enabled:
+            rows = self._collect_postgres_settings()
         if rows:
             event = {
                 "host": self._check.resolved_hostname,
                 "agent_version": datadog_agent.get_version(),
                 "dbms": "postgres",
                 "kind": "pg_settings",
+                'dbms_version': self._payload_pg_version(),
                 "tags": self._tags_no_db,
                 "timestamp": time.time() * 1000,
                 "cloud_metadata": self._config.cloud_metadata,
                 "metadata": rows,
             }
-            self._check.database_monitoring_metadata(
-                json.dumps(event, default=default_json_event_encoding)
-            )
+            self._check.database_monitoring_metadata(json.dumps(event, default=default_json_event_encoding))
+
+    def _payload_pg_version(self):
+        version = self._check.version
+        if not version:
+            return ""
+        return 'v{major}.{minor}.{patch}'.format(major=version.major, minor=version.minor, patch=version.patch)
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_postgres_settings(self):
         with self._conn_pool.get_connection(self._config.dbname, ttl_ms=self._conn_ttl_ms).cursor(
-                cursor_factory=psycopg2.extras.DictCursor
+            cursor_factory=psycopg2.extras.DictCursor
         ) as cursor:
             self._log.debug("Running query [%s] %s", PG_SETTINGS_QUERY)
             cursor.execute(PG_SETTINGS_QUERY)
             rows = cursor.fetchall()
             self._log.debug("Loaded %s rows from pg_settings", len(rows))
             return [dict(row) for row in rows]
-

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -33,6 +33,7 @@ SELECT name, setting, category, short_desc FROM pg_settings
 def agent_check_getter(self):
     return self._check
 
+
 class PostgresMetadata(DBMAsyncJob):
     """
     Collects statement samples and execution plans.
@@ -96,17 +97,17 @@ class PostgresMetadata(DBMAsyncJob):
         if rows:
             event = {
                 "host": self._check.resolved_hostname,
-                "ddagentversion": datadog_agent.get_version(),
-                "ddsource": "postgres",
-                "dbm_type": "metadata",
-                "ddtags": self._tags_no_db,
+                "agent_version": datadog_agent.get_version(),
+                "dbms": "postgres",
+                "kind": "metadata",
+                "tags": self._tags_no_db,
                 "timestamp": time.time() * 1000,
                 "cloud_metadata": self._config.cloud_metadata,
-                "pg_settings": rows,
+                "metadata": rows,
             }
-        self._check.database_monitoring_metadata(
-            json.dumps(event, default=default_json_event_encoding)
-        )
+            self._check.database_monitoring_metadata(
+                json.dumps(event, default=default_json_event_encoding)
+            )
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_postgres_settings(self):

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -48,6 +48,7 @@ class PostgresMetadata(DBMAsyncJob):
 
         # convert collection interval from minutes to seconds
         collection_interval = collection_interval * 60
+        self.collection_interval = collection_interval
 
         self._conn_pool = MultiDatabaseConnectionPool(check._new_connection)
 
@@ -57,11 +58,11 @@ class PostgresMetadata(DBMAsyncJob):
 
         super(PostgresMetadata, self).__init__(
             check,
-            rate_limit=1 / collection_interval,
+            rate_limit=1 / self.collection_interval,
             run_sync=is_affirmative(config.metadata_config.get('run_sync', False)),
             enabled=True,
             dbms="postgres",
-            min_collection_interval=collection_interval,
+            min_collection_interval=self.collection_interval,
             expected_db_exceptions=(psycopg2.errors.DatabaseError,),
             job_name="database-metadata",
             shutdown_callback=shutdown_cb,
@@ -102,6 +103,7 @@ class PostgresMetadata(DBMAsyncJob):
                 "agent_version": datadog_agent.get_version(),
                 "dbms": "postgres",
                 "kind": "pg_settings",
+                "collection_interval": self.collection_interval,
                 'dbms_version': self._payload_pg_version(),
                 "tags": self._tags_no_db,
                 "timestamp": time.time() * 1000,

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -17,6 +17,7 @@ from datadog_checks.postgres.metrics_cache import PostgresMetricsCache
 from datadog_checks.postgres.relationsmanager import INDEX_BLOAT, RELATION_METRICS, TABLE_BLOAT, RelationsManager
 from datadog_checks.postgres.statement_samples import PostgresStatementSamples
 from datadog_checks.postgres.statements import PostgresStatementMetrics
+from datadog_checks.postgres.metadata import PostgresMetadata
 
 from .config import PostgresConfig
 from .util import (
@@ -77,6 +78,7 @@ class PostgreSql(AgentCheck):
         self.metrics_cache = PostgresMetricsCache(self._config)
         self.statement_metrics = PostgresStatementMetrics(self, self._config, shutdown_callback=self._close_db_pool)
         self.statement_samples = PostgresStatementSamples(self, self._config, shutdown_callback=self._close_db_pool)
+        self.metadata_samples = PostgresMetadata(self, self._config, shutdown_callback=self._close_db_pool)
         self._relations_manager = RelationsManager(self._config.relations)
         self._clean_state()
         self.check_initializations.append(lambda: RelationsManager.validate_relations_config(self._config.relations))
@@ -716,6 +718,7 @@ class PostgreSql(AgentCheck):
             if self._config.dbm_enabled:
                 self.statement_metrics.run_job_loop(tags)
                 self.statement_samples.run_job_loop(tags)
+                self.metadata_samples.run_job_loop(tags)
             if self._config.collect_wal_metrics:
                 self._collect_wal_metrics(tags)
 

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -1,29 +1,9 @@
 # (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
-import datetime
-import re
-import select
-import time
-from collections import Counter
 from concurrent.futures.thread import ThreadPoolExecutor
-
-import mock
-import psycopg2
 import pytest
-from dateutil import parser
-from semver import VersionInfo
-from six import string_types
-
-from datadog_checks.base.utils.db.sql import compute_sql_signature
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
-from datadog_checks.base.utils.serialization import json
-from datadog_checks.base.utils.time import UTC
-from datadog_checks.postgres.statement_samples import DBExplainError, StatementTruncationState
-from datadog_checks.postgres.statements import PG_STAT_STATEMENTS_METRICS_COLUMNS, PG_STAT_STATEMENTS_TIMING_COLUMNS
-
-from .common import DB_NAME, HOST, PORT, PORT_REPLICA2, POSTGRES_VERSION
-from .utils import _get_conn, _get_superconn, requires_over_10
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
 

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -26,7 +26,8 @@ def stop_orphaned_threads():
     DBMAsyncJob.executor = ThreadPoolExecutor()
 
 
-def test_collect_metadata(integration_check, dbm_instance, aggregator):
+@pytest.mark.parametrize("collect_settings", [True, False])
+def test_collect_metadata(integration_check, dbm_instance, aggregator, collect_settings):
     check = integration_check(dbm_instance)
     check.check(dbm_instance)
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
@@ -34,4 +35,5 @@ def test_collect_metadata(integration_check, dbm_instance, aggregator):
     assert event['host'] == "stubbed.hostname"
     assert event['dbms'] == "postgres"
     assert event['kind'] == "pg_settings"
-    assert len(event["metadata"]) > 0
+    if collect_settings:
+        assert len(event["metadata"]) > 0

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -15,7 +15,7 @@ def dbm_instance(pg_instance):
     pg_instance['query_samples'] = {'enabled': False}
     pg_instance['query_activity'] = {'enabled': False}
     pg_instance['query_metrics'] = {'enabled': False}
-    pg_instance['database_metadata'] = {'collect_settings': True, 'run_sync': True, 'settings_collection_interval': 0.1}
+    pg_instance['collect_settings'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
     return pg_instance
 
 
@@ -28,6 +28,7 @@ def stop_orphaned_threads():
 
 @pytest.mark.parametrize("collect_settings", [True, False])
 def test_collect_metadata(integration_check, dbm_instance, aggregator, collect_settings):
+    dbm_instance['collect_settings'] = {'enabled': collect_settings}
     check = integration_check(dbm_instance)
     check.check(dbm_instance)
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -1,0 +1,69 @@
+# (C) Datadog, Inc. 2021-present
+# All rights reserved
+# Licensed under Simplified BSD License (see LICENSE)
+import datetime
+import re
+import select
+import time
+from collections import Counter
+from concurrent.futures.thread import ThreadPoolExecutor
+
+import mock
+import psycopg2
+import pytest
+from dateutil import parser
+from semver import VersionInfo
+from six import string_types
+
+from datadog_checks.base.utils.db.sql import compute_sql_signature
+from datadog_checks.base.utils.db.utils import DBMAsyncJob
+from datadog_checks.base.utils.serialization import json
+from datadog_checks.base.utils.time import UTC
+from datadog_checks.postgres.statement_samples import DBExplainError, StatementTruncationState
+from datadog_checks.postgres.statements import PG_STAT_STATEMENTS_METRICS_COLUMNS, PG_STAT_STATEMENTS_TIMING_COLUMNS
+
+from .common import DB_NAME, HOST, PORT, PORT_REPLICA2, POSTGRES_VERSION
+from .utils import _get_conn, _get_superconn, requires_over_10
+
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
+
+
+@pytest.fixture
+def dbm_instance(pg_instance):
+    pg_instance['dbm'] = True
+    pg_instance['min_collection_interval'] = 0.1
+    pg_instance['query_samples'] = {'enabled': False}
+    pg_instance['query_activity'] = {'enabled': False}
+    pg_instance['query_metrics'] = {'enabled': False}
+    pg_instance['query_metadata'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    return pg_instance
+
+
+@pytest.fixture(autouse=True)
+def stop_orphaned_threads():
+    # make sure we shut down any orphaned threads and create a new Executor for each test
+    DBMAsyncJob.executor.shutdown(wait=True)
+    DBMAsyncJob.executor = ThreadPoolExecutor()
+
+
+@pytest.mark.parametrize("metadata_enabled", [True, False])
+def test_metadata_enabled_config(
+        integration_check, dbm_instance, metadata_enabled
+):
+    dbm_instance["query_metadata"] = {'enabled': metadata_enabled}
+    check = integration_check(dbm_instance)
+    assert check.metadata_samples._enabled == metadata_enabled
+
+
+def test_collect_metadata(
+        integration_check, dbm_instance, aggregator
+):
+    check = integration_check(dbm_instance)
+    check.check(dbm_instance)
+    dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
+    event = dbm_metadata[0]
+    assert event['host'] == "stubbed.hostname"
+    assert event['dbms'] == "postgres"
+    assert event['kind'] == "metadata"
+    assert len(event["metadata"]) > 0
+

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -44,6 +44,6 @@ def test_collect_metadata(
     event = dbm_metadata[0]
     assert event['host'] == "stubbed.hostname"
     assert event['dbms'] == "postgres"
-    assert event['kind'] == "metadata"
+    assert event['kind'] == "pg_settings"
     assert len(event["metadata"]) > 0
 

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -1,6 +1,6 @@
-# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2023-present
 # All rights reserved
-# Licensed under Simplified BSD License (see LICENSE)
+# Licensed under a 3-clause BSD style license (see LICENSE)
 from concurrent.futures.thread import ThreadPoolExecutor
 import pytest
 from datadog_checks.base.utils.db.utils import DBMAsyncJob

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -15,7 +15,7 @@ def dbm_instance(pg_instance):
     pg_instance['query_samples'] = {'enabled': False}
     pg_instance['query_activity'] = {'enabled': False}
     pg_instance['query_metrics'] = {'enabled': False}
-    pg_instance['query_metadata'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    pg_instance['database_metadata'] = {'collect_settings': True, 'run_sync': True, 'settings_collection_interval': 0.1}
     return pg_instance
 
 
@@ -26,18 +26,7 @@ def stop_orphaned_threads():
     DBMAsyncJob.executor = ThreadPoolExecutor()
 
 
-@pytest.mark.parametrize("metadata_enabled", [True, False])
-def test_metadata_enabled_config(
-        integration_check, dbm_instance, metadata_enabled
-):
-    dbm_instance["query_metadata"] = {'enabled': metadata_enabled}
-    check = integration_check(dbm_instance)
-    assert check.metadata_samples._enabled == metadata_enabled
-
-
-def test_collect_metadata(
-        integration_check, dbm_instance, aggregator
-):
+def test_collect_metadata(integration_check, dbm_instance, aggregator):
     check = integration_check(dbm_instance)
     check.check(dbm_instance)
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
@@ -46,4 +35,3 @@ def test_collect_metadata(
     assert event['dbms'] == "postgres"
     assert event['kind'] == "pg_settings"
     assert len(event["metadata"]) > 0
-


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This feature adds a new job, `database-metadata`, which requires `dbm`. The job has two main features:

1. Sends cloud_metadata to the DBM backend for internal resource creation (important for unified host tagging)
2. Queries `pg_settings` && forwards this to the backend to be displayed in the DBM UI

An example of the settings in our UI is here:
![Screen Shot 2023-05-19 at 12 54 08 PM](https://github.com/DataDog/integrations-core/assets/14317240/d7cebe1a-9139-48fd-8bca-39d062ac826b)
 

### Motivation
<!-- What inspired you to submit this pull request? -->

There are a number of relevant use cases for this, for example:

1.  Engineer who is investigating a degraded database might want to check certain settings
2. Changes in certain settings could cause any number of issues for the database
3. Not all default settings are conducive to certain workloads, we can use this & other metrics to provide insights to users about how to tune/tweak them 