### PR TITLE
(DOCS-5505) Replace broken developer tool links in READMEs

### DIFF
--- a/calico/README.md
+++ b/calico/README.md
@@ -154,7 +154,7 @@ Additional helpful documentation, links, and articles:
 [7]: https://github.com/DataDog/integrations-core/blob/master/calico/assets/service_checks.json
 [8]: https://docs.datadoghq.com/help/
 [9]: https://docs.tigera.io/calico/3.25/operations/monitor/monitor-component-metrics
-[10]: https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit
+[10]: https://docs.datadoghq.com/developers/integrations/python/
 [11]: https://app.datadoghq.com/account/settings#agent
 [12]: https://docs.datadoghq.com/agent/kubernetes
 [13]: https://docs.datadoghq.com/agent/docker/integrations/?tab=docker

--- a/datadog_checks_dev/datadog_checks/dev/tooling/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/create.py
@@ -43,7 +43,7 @@ To install the {integration_name} check on your host:
 
 
 1. Install the [developer toolkit]
-(https://docs.datadoghq.com/developers/integrations/new_check_howto/#developer-toolkit)
+(https://docs.datadoghq.com/developers/integrations/python/)
  on any machine.
 
 2. Run `ddev release build {normalized_integration_name}` to build the package.


### PR DESCRIPTION
### What does this PR do?

Fixes some links to the developer tools documentation, which is now on a different page.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [x] PR must have `changelog/` and `integration/` labels attached
- [x] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.