### PR TITLE
No longer test postgres 9.5

### DIFF
--- a/postgres/hatch.toml
+++ b/postgres/hatch.toml
@@ -16,11 +16,11 @@ mypy-deps = [
 
 [[envs.default.matrix]]
 python = ["3.8"]
-version = ["9.5", "9.6", "10.0", "11.0", "12.1", "13.0", "14.0"]
+version = ["9.6", "10.0", "11.0", "12.1", "13.0", "14.0"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
-  { key = "POSTGRES_VERSION", if = ["9.5", "9.6", "12.1"] },
+  { key = "POSTGRES_VERSION", if = ["9.6", "12.1"] },
   { key = "POSTGRES_VERSION", value = "10", if = ["10.0"] },
   { key = "POSTGRES_VERSION", value = "11", if = ["11.0"] },
   { key = "POSTGRES_VERSION", value = "13", if = ["13.0"] },


### PR DESCRIPTION
### What does this PR do?

Postgres 9.5 was EOL Feb 2021. This is cleanup.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.