### PR TITLE
Add recommended monitor for OTel metrics

### DIFF
--- a/otel/assets/recommended_monitors/otel_refused_spans.json
+++ b/otel/assets/recommended_monitors/otel_refused_spans.json
@@ -1,0 +1,26 @@
+{
+	"name": "[OpenTelemetry Collector] Refused Spans",
+	"type": "query alert",
+	"query": "avg(last_1h):avg:otelcol_receiver_refused_spans{*} by {host,receiver}.as_rate() > 100",
+	"message": "The OpenTelemetry Collector receiver {{receiver.name}} is refusing {{value}} spans per second for host: {{host.name}}.",
+	"tags": [
+		"integration:opentelemetry"
+	],
+	"options": {
+		"thresholds": {
+			"critical": 100
+		},
+		"notify_audit": false,
+		"require_full_window": false,
+		"notify_no_data": false,
+		"renotify_interval": 0,
+		"include_tags": true,
+		"new_group_delay": 60,
+		"silenced": {}
+	},
+	"priority": null,
+	"restricted_roles": null,
+    "recommended_monitor_metadata": {
+		"description": "Notifies when the OpenTelemetry Collector receiver is refusing spans"
+	}
+}

--- a/otel/assets/recommended_monitors/otel_refused_spans.json
+++ b/otel/assets/recommended_monitors/otel_refused_spans.json
@@ -1,7 +1,7 @@
 {
 	"name": "[OTel Collector] Refused Spans",
 	"type": "query alert",
-	"query": "avg(last_1h):avg:otelcol_receiver_refused_spans{*} by {host,receiver}.as_rate() > 100",
+	"query": "avg(last_10m):avg:otelcol_receiver_refused_spans{*} by {host,receiver}.as_rate() > 100",
 	"message": "The OpenTelemetry Collector receiver {{receiver.name}} is refusing {{value}} spans per second for host: {{host.name}}.",
 	"tags": [
 		"integration:opentelemetry"

--- a/otel/assets/recommended_monitors/otel_refused_spans.json
+++ b/otel/assets/recommended_monitors/otel_refused_spans.json
@@ -1,5 +1,5 @@
 {
-	"name": "[OpenTelemetry Collector] Refused Spans",
+	"name": "[OTel Collector] Refused Spans",
 	"type": "query alert",
 	"query": "avg(last_1h):avg:otelcol_receiver_refused_spans{*} by {host,receiver}.as_rate() > 100",
 	"message": "The OpenTelemetry Collector receiver {{receiver.name}} is refusing {{value}} spans per second for host: {{host.name}}.",

--- a/otel/manifest.json
+++ b/otel/manifest.json
@@ -49,6 +49,9 @@
     "dashboards": {
       "OpenTelemetry Dashboard": "assets/dashboards/otel_host_metrics_dashboard.json",
       "OpenTelemetry Collector Metrics Dashboard": "assets/dashboards/otel_collector_metrics_dashboard.json"
+    },
+    "monitors": {
+      "OpenTelemetry Refused Spans": "assets/recommended_monitors/otel_refused_spans.json"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
This monitor alerts the user when there has been on average > 100 spans refused per second by a receiver in the past hour. The avg is used instead of sum in order to prevent alerting on "one-off" data losses, as this monitor should be used to scale the system after sustained data loss. The Defaults of 1 hour timeframe and 100 spans per second are high, but the user has the ability to change the value when they create the recommended monitor.

Several metrics were considered for this monitor, please see: https://docs.google.com/document/d/1P5gBaHacgc_UBrDIgNRlW2mF7BAX_ni6hfZK3j3GA4g/edit#.

### Motivation
R&D week project.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.