### PR TITLE
Continue directory traversal after errors

### DIFF
--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -195,7 +195,11 @@ class DirectoryCheck(AgentCheck):
         """
         Wraps walker iteration to handle errors and recursive option.
         """
-        walker = walk(self._config.abs_directory, self._config.follow_symlinks)
+
+        def log_error(e):
+            self.log.error("Error when traversing %s: %s", self._config.abs_directory, e)
+
+        walker = walk(self._config.abs_directory, onerror=log_error, followlinks=self._config.follow_symlinks)
 
         while True:
             try:
@@ -203,7 +207,7 @@ class DirectoryCheck(AgentCheck):
             except StopIteration:
                 break
             except OSError as e:
-                self.log.error("Error when traversing %s: %s", self._config.abs_directory, e)
+                log_error(e)
 
             # Only visit the first directory when we don't want recursive search
             if not self._config.recursive:

--- a/directory/datadog_checks/directory/directory.py
+++ b/directory/datadog_checks/directory/directory.py
@@ -206,8 +206,6 @@ class DirectoryCheck(AgentCheck):
                 yield next(walker)
             except StopIteration:
                 break
-            except OSError as e:
-                log_error(e)
 
             # Only visit the first directory when we don't want recursive search
             if not self._config.recursive:

--- a/directory/datadog_checks/directory/traverse.py
+++ b/directory/datadog_checks/directory/traverse.py
@@ -9,10 +9,27 @@ from scandir import scandir
 
 
 def _walk(top, onerror=None, followlinks=False):
-    """Modified version of https://docs.python.org/3/library/os.html#os.scandir
-    that returns https://docs.python.org/3/library/os.html#os.DirEntry for files
-    directly to take advantage of possible cached os.stat calls.
+    """A simplified and modified version of stdlib's `os.walk` that yields the
+    `os.DirEntry` objects that `scandir` produces during traversal instead of paths as
+    strings.
     """
+    # This implementation is based on https://github.com/python/cpython/blob/3.8/Lib/os.py#L280.
+
+    # This is a significant optimization for our use case (particularly on Windows) that
+    # justifies maintaining our own version of the function instead of using the
+    # stdlib's one directly. We need to stat every file to collect useful data, and the
+    # following quote from the docs
+    # (https://docs.python.org/3.8/library/os.html#os.scandir) explains very well why we
+    # want to keep those `os.DirEntry` objects:
+
+    # Using `scandir()` instead of `listdir()` can significantly increase the performance of
+    # code that also needs file type or file attribute information, because os.DirEntry
+    # objects expose this information if the operating system provides it when scanning a
+    # directory. All `os.DirEntry` methods may perform a system call, but is_dir() and
+    # is_file() usually only require a system call for symbolic links; os.DirEntry.stat()
+    # always requires a system call on Unix but only requires one for symbolic links on
+    # Windows.
+
     dirs = []
     nondirs = []
 

--- a/directory/tests/test_directory.py
+++ b/directory/tests/test_directory.py
@@ -331,31 +331,6 @@ def test_non_existent_directory_ignore_missing(aggregator):
     aggregator.assert_service_check('system.disk.directory.exists', DirectoryCheck.WARNING, tags=expected_tags)
 
 
-def test_os_error_mid_walk_emits_error(aggregator, monkeypatch, caplog):
-    caplog.set_level(logging.WARNING)
-
-    def mock_walk(folder, *args, **kwargs):
-        from datadog_checks.directory.traverse import walk
-
-        walker = walk(folder, *args, **kwargs)
-        yield next(walker)
-        raise OSError('Permission denied')
-
-    monkeypatch.setattr('datadog_checks.directory.directory.walk', mock_walk)
-
-    with temp_directory() as tdir:
-
-        # Create folder
-        mkdir(os.path.join(tdir, 'a_folder'))
-
-        # Run Check
-        instance = {'directory': tdir, 'recursive': True}
-        check = DirectoryCheck('directory', {}, [instance])
-        check.check(instance)
-
-    assert 'Permission denied' in caplog.text
-
-
 def test_os_error_mid_walk_emits_error_and_continues(aggregator, caplog):
     caplog.set_level(logging.WARNING)
 

--- a/directory/tests/test_directory.py
+++ b/directory/tests/test_directory.py
@@ -331,7 +331,7 @@ def test_non_existent_directory_ignore_missing(aggregator):
     aggregator.assert_service_check('system.disk.directory.exists', DirectoryCheck.WARNING, tags=expected_tags)
 
 
-def test_os_error_mid_walk_emits_error_and_continues(aggregator, monkeypatch, caplog):
+def test_os_error_mid_walk_emits_error(aggregator, monkeypatch, caplog):
     caplog.set_level(logging.WARNING)
 
     def mock_walk(folder, *args, **kwargs):
@@ -354,6 +354,42 @@ def test_os_error_mid_walk_emits_error_and_continues(aggregator, monkeypatch, ca
         check.check(instance)
 
     assert 'Permission denied' in caplog.text
+
+
+def test_os_error_mid_walk_emits_error_and_continues(aggregator, caplog):
+    caplog.set_level(logging.WARNING)
+
+    # Test that we continue on traversal by having more than a single error-producing entry.
+    # The stdlib's tests rename a file mid-walk to simulate this, but we can't do that since
+    # we're testing the walk function indirectly and can't control it.
+    #
+    # At least we can generate an error on folders by creating them without read permissions.
+    # This does leave one of the code paths untested (getting the next item from a folder,
+    # precisely, the scenario that the stdlib simulates).
+    #
+    # Finally, the order of traversal is not guaranteed. We get around that by introducing two
+    # problematic folders and checking that both errors are indeed logged.
+
+    with temp_directory() as tdir:
+        # Create two folders with no read permission
+        os.makedirs(os.path.join(tdir, 'bad_folder_a'), mode=0o377)
+        os.makedirs(os.path.join(tdir, 'bad_folder_b'), mode=0o377)
+        # Create a folder with normal permissions, and a file inside
+        os.makedirs(os.path.join(tdir, 'ok'))
+        with open(os.path.join(tdir, 'ok', 'file'), 'w') as f:
+            f.write('')
+
+        # Run Check
+        instance = {'directory': tdir, 'recursive': True}
+        check = DirectoryCheck('directory', {}, [instance])
+        check.check(instance)
+
+    aggregator.assert_metric("system.disk.directory.files", count=1, value=1)
+
+    permission_denied_log_lines = [line for line in caplog.text.splitlines() if 'Permission denied' in line]
+    assert len(permission_denied_log_lines) == 2
+    assert 'bad_folder_a' in caplog.text
+    assert 'bad_folder_b' in caplog.text
 
 
 def test_no_recursive_symlink_loop(aggregator):

--- a/directory/tests/test_directory.py
+++ b/directory/tests/test_directory.py
@@ -360,8 +360,8 @@ def test_os_error_mid_walk_emits_error_and_continues(aggregator, caplog):
         check.check(instance)
 
         # Reset permissions for folders to allow cleanup
-        os.chmod(os.path.join(tdir, 'bad_folder_a'), mode=0o777)
-        os.chmod(os.path.join(tdir, 'bad_folder_b'), mode=0o777)
+        os.chmod(os.path.join(tdir, 'bad_folder_a'), 0o777)
+        os.chmod(os.path.join(tdir, 'bad_folder_b'), 0o777)
 
     aggregator.assert_metric("system.disk.directory.files", count=1, value=1)
 

--- a/directory/tests/test_directory.py
+++ b/directory/tests/test_directory.py
@@ -359,6 +359,10 @@ def test_os_error_mid_walk_emits_error_and_continues(aggregator, caplog):
         check = DirectoryCheck('directory', {}, [instance])
         check.check(instance)
 
+        # Reset permissions for folders to allow cleanup
+        os.chmod(os.path.join(tdir, 'bad_folder_a'), mode=0o777)
+        os.chmod(os.path.join(tdir, 'bad_folder_b'), mode=0o777)
+
     aggregator.assert_metric("system.disk.directory.files", count=1, value=1)
 
     permission_denied_log_lines = [line for line in caplog.text.splitlines() if 'Permission denied' in line]


### PR DESCRIPTION
### What does this PR do?

Changes our custom traversal implementation so that it can keep traversing even when there's an error during the traversal (such as not being able to list the contents of a directory due to lack of permissions). I implemented this roughly following [what the stdlib does](https://github.com/python/cpython/blob/79e63e528795c700a8bd198c15f3322ee25ea786/Lib/os.py#L280).

I also tried to clarify futher why we're using our custom `walk` as opposed of directly using `os.walk`, as it required some research to re-discover the reason behind it.

### Motivation

An issue that has come up a few times in support cases.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.