### PR TITLE
Mount and collect the logs

### DIFF
--- a/gitlab/tests/compose/docker-compose.yml
+++ b/gitlab/tests/compose/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       timeout: 5s
     volumes:
       - ./config/gitlab.rb:/etc/gitlab/gitlab.rb
+      - ${LOGS_FOLDER}:/var/log/gitlab
     ports:
       - "${GITLAB_LOCAL_PORT}:80"
       - "${GITLAB_LOCAL_PROMETHEUS_PORT}:9090"

--- a/gitlab/tests/conftest.py
+++ b/gitlab/tests/conftest.py
@@ -245,7 +245,7 @@ def create_log_volumes():
 
     with TempDir("gitlab-logs") as d:
         os.chmod(d, 0o777)
-        docker_volumes.append(f'{d}:/var/log/gitlab')
+        docker_volumes.append('{}:/var/log/gitlab'.format(d))
         env_vars["LOGS_FOLDER"] = d
 
     save_state('logs_config', get_logs_config())
@@ -259,7 +259,7 @@ def get_logs_config():
     return [
         {
             'type': 'file',
-            'path': f'/var/log/gitlab/{service["name"]}/{service["file"]}',
+            'path': '/var/log/gitlab/{}/{}'.format(service["name"], service["file"]),
             'source': 'gitlab',
             'service': service["name"],
         }

--- a/gitlab/tests/conftest.py
+++ b/gitlab/tests/conftest.py
@@ -4,6 +4,7 @@
 import copy
 import json
 import os
+from contextlib import contextmanager
 from time import sleep
 
 import mock
@@ -11,7 +12,8 @@ import pytest
 import requests
 from six import PY2
 
-from datadog_checks.dev import docker_run
+from datadog_checks.dev import EnvVars, TempDir, docker_run
+from datadog_checks.dev._env import get_state, save_state
 from datadog_checks.dev.conditions import CheckEndpoints
 from datadog_checks.gitlab import GitlabCheck
 
@@ -66,6 +68,7 @@ def dd_environment():
             CheckEndpoints(PROMETHEUS_ENDPOINT, attempts=100, wait=6),
             CheckEndpoints(GITLAB_GITALY_PROMETHEUS_ENDPOINT, attempts=100, wait=10),
         ],
+        wrappers=[create_log_volumes()],
     ):
         # run pre-test commands
         for _ in range(100):
@@ -233,3 +236,44 @@ def use_openmetrics(request):
         pytest.skip('This version of the integration is only available when using Python 3.')
 
     return request.param
+
+
+@contextmanager
+def create_log_volumes():
+    env_vars = {}
+    docker_volumes = get_state('docker_volumes', [])
+
+    with TempDir("gitlab-logs") as d:
+        os.chmod(d, 0o777)
+        docker_volumes.append(f'{d}:/var/log/gitlab')
+        env_vars["LOGS_FOLDER"] = d
+
+    save_state('logs_config', get_logs_config())
+    save_state('docker_volumes', docker_volumes)
+
+    with EnvVars(env_vars):
+        yield
+
+
+def get_logs_config():
+    return [
+        {
+            'type': 'file',
+            'path': f'/var/log/gitlab/{service["name"]}/{service["file"]}',
+            'source': 'gitlab',
+            'service': service["name"],
+        }
+        for service in [
+            {"name": "gitlab-rails", "file": "api_json.log"},
+            {"name": "gitlab-rails", "file": "production.log"},
+            {"name": "gitlab-rails", "file": "production_json.log"},
+            {"name": "gitlab-rails", "file": "integrations_json.log"},
+            {"name": "gitlab-rails", "file": "application.log"},
+            {"name": "gitlab-rails", "file": "kubernetes.log"},
+            {"name": "gitlab-rails", "file": "audit_json.log"},
+            {"name": "gitlab-rails", "file": "sidekiq.log"},
+            {"name": "gitlab-rails", "file": "gitlab-shell.log"},
+            {"name": "gitlab-rails", "file": "graphql_json.log"},
+            {"name": "gitlab-rails", "file": "auth.log"},
+        ]
+    ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Mount and collect the gitlab logs

### Motivation
<!-- What inspired you to submit this pull request? -->

- The e2e env was not collecting the logs, so we could not easily test the dashboard with @anjaliDDog 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I could not use the `mount_logs` option from `docker_run` that does it automatically from the `spec.yaml` file because it first creates the files in a temp folder and then mount the files in both containers (here GitLab and the agent). However, GitLab drop the files we created and create other ones. So Here the idea is that I mount the whole temp folder and configure it manually so all files are available

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.