### PR TITLE
Support full `custom_queries` APIs for running custom queries

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -638,16 +638,16 @@ class PostgreSql(AgentCheck):
                 ]
                 self.tags_without_db.append(replication_role_tag)
 
-            self.log.debug("Running check against version %s: is_aurora: %s", str(self.version), str(self.is_aurora))
-            self._collect_stats(tags)
-            if self._config.dbm_enabled:
-                self.statement_metrics.run_job_loop(tags)
-                self.statement_samples.run_job_loop(tags)
-                self.metadata_samples.run_job_loop(tags)
-            if self._config.collect_wal_metrics:
-                self._collect_wal_metrics(tags)
+            if not self._config.only_custom_queries:
+                self.log.debug("Running check against version %s: is_aurora: %s", str(self.version), str(self.is_aurora))
+                self._collect_stats(tags)
+                if self._config.dbm_enabled:
+                    self.statement_metrics.run_job_loop(tags)
+                    self.statement_samples.run_job_loop(tags)
+                    self.metadata_samples.run_job_loop(tags)
+                if self._config.collect_wal_metrics:
+                    self._collect_wal_metrics(tags)
             
-            # Collect custom queries
             self.custom_queries.execute()
 
         except Exception as e:


### PR DESCRIPTION
### What does this PR do?

This PR removes the custom logic in the postgres check for the standardized logic of the QueryManager. This supports new APIs, but keeps the backwards-compatibility of the `metric_prefix` option.

The changelog is `/Added` because there should be no perceptible change to users except for the fact that `only_custom_queries` and `global_custom_queries` should now be supported.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.