### PR TITLE
Add the `jobs_total` metric in the metadata file

### DIFF
--- a/gitlab_runner/metadata.csv
+++ b/gitlab_runner/metadata.csv
@@ -13,6 +13,7 @@ gitlab_runner.ci_ssh_docker_machines_provider_machine_states,gauge,,request,seco
 gitlab_runner.gitlab_runner_autoscaling_machine_creation_duration_seconds,gauge,,request,second,A histogram of Docker machine creation time. Applies to GitLab Runner 1.11.0+,0,gitlab_runner,auto docker machine creation time,
 gitlab_runner.gitlab_runner_autoscaling_machine_states,gauge,,request,second,The current number of machines per state in this provider. Applies to GitLab Runner 1.11.0+,0,gitlab_runner,auto total docker machines per state,
 gitlab_runner.gitlab_runner_jobs,gauge,,,,The current number of running builds. Applies to GitLab Runner 1.11.0+,0,gitlab_runner,current running builds,
+gitlab_runner.gitlab_runner_jobs_total,count,,,,The total number of jobs executed.,1,gitlab_runner,total jobs,
 gitlab_runner.gitlab_runner_errors_total,count,,request,second,The number of caught errors. Applies to GitLab Runner 1.11.0+,0,gitlab_runner,errors,
 gitlab_runner.gitlab_runner_version_info,gauge,,request,,A metric with a constant '1' value labeled by different build stats fields. Applies to GitLab Runner 1.11.0+,0,gitlab_runner,version info,
 gitlab_runner.go_gc_duration_seconds,gauge,,request,second,A summary of the GC invocation durations,0,gitlab_runner,gc duration,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add the `jobs_total` metric in the metadata file

### Motivation
<!-- What inspired you to submit this pull request? -->

This metric is missing. It was added a long time ago ([here](https://gitlab.com/gitlab-org/gitlab-runner/-/merge_requests/1018))

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.