### PR TITLE
Fix some default values in the configuration file

### DIFF
--- a/gitlab_runner/assets/configuration/spec.yaml
+++ b/gitlab_runner/assets/configuration/spec.yaml
@@ -75,6 +75,10 @@ files:
       - template: instances/openmetrics_legacy
         overrides:
           prometheus_url.hidden: true
+          health_service_check.value.example: false
+          health_service_check.value.default: false
+          send_monotonic_counter.value.example: false
+          send_monotonic_counter.value.default: false
   - template: logs
     example:
       - type: journald

--- a/gitlab_runner/datadog_checks/gitlab_runner/config_models/defaults.py
+++ b/gitlab_runner/datadog_checks/gitlab_runner/config_models/defaults.py
@@ -87,7 +87,7 @@ def instance_headers(field, value):
 
 
 def instance_health_service_check(field, value):
-    return True
+    return False
 
 
 def instance_ignore_metrics(field, value):
@@ -211,7 +211,7 @@ def instance_send_histograms_buckets(field, value):
 
 
 def instance_send_monotonic_counter(field, value):
-    return True
+    return False
 
 
 def instance_send_monotonic_with_gauge(field, value):

--- a/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
+++ b/gitlab_runner/datadog_checks/gitlab_runner/data/conf.yaml.example
@@ -109,11 +109,11 @@ instances:
     #
     # prometheus_metrics_prefix: <PREFIX>_
 
-    ## @param health_service_check - boolean - optional - default: true
+    ## @param health_service_check - boolean - optional - default: false
     ## Send a service check reporting about the health of the Prometheus endpoint.
     ## The service check is named <NAMESPACE>.prometheus.health
     #
-    # health_service_check: true
+    # health_service_check: false
 
     ## @param label_to_hostname - string - optional
     ## Override the hostname with the value of one label.
@@ -157,10 +157,10 @@ instances:
     #
     # send_distribution_buckets: false
 
-    ## @param send_monotonic_counter - boolean - optional - default: true
+    ## @param send_monotonic_counter - boolean - optional - default: false
     ## Set send_monotonic_counter to true to send counters as monotonic counter.
     #
-    # send_monotonic_counter: true
+    # send_monotonic_counter: false
 
     ## @param send_distribution_counts_as_monotonic - boolean - optional - default: false
     ## If set to true, sends histograms and summary counters as monotonic counters (instead of gauges).


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix some default values in the configuration file for the options: 

- health_service_check
- send_monotonic_counter

### Motivation
<!-- What inspired you to submit this pull request? -->

the default values are `False`: https://github.com/DataDog/integrations-core/blob/master/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py#L90-L91

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.