### PR TITLE
Disable server info and version collection when collect_server_info is false

### DIFF
--- a/envoy/datadog_checks/envoy/check.py
+++ b/envoy/datadog_checks/envoy/check.py
@@ -101,6 +101,8 @@ class EnvoyCheckV2(OpenMetricsBaseCheckV2):
         super().__init__(name, init_config, instances)
         self.check_initializations.append(self.configure_additional_transformers)
         openmetrics_endpoint = self.instance.get('openmetrics_endpoint')
+        self.collect_server_info = self.instance.get('collect_server_info', True)
+
         self.base_url = None
         try:
             parts = urlparse(openmetrics_endpoint)
@@ -148,9 +150,11 @@ class EnvoyCheckV2(OpenMetricsBaseCheckV2):
         if not self.base_url:
             self.log.debug("Skipping server info collection due to malformed url: %s", self.base_url)
             return
+        raw_version = None
         # From http://domain/thing/stats to http://domain/thing/server_info
-        server_info_url = urljoin(self.base_url, 'server_info')
-        raw_version = _get_server_info(server_info_url, self.log, self.http)
+        if self.collect_server_info:
+            server_info_url = urljoin(self.base_url, 'server_info')
+            raw_version = _get_server_info(server_info_url, self.log, self.http)
 
         if raw_version:
             self.set_metadata('version', raw_version)

--- a/envoy/datadog_checks/envoy/check.py
+++ b/envoy/datadog_checks/envoy/check.py
@@ -150,12 +150,12 @@ class EnvoyCheckV2(OpenMetricsBaseCheckV2):
         if not self.base_url:
             self.log.debug("Skipping server info collection due to malformed url: %s", self.base_url)
             return
-        
+
         # From http://domain/thing/stats to http://domain/thing/server_info
         if not self.collect_server_info:
             self.log.debug("Skipping server info collection as it is disabled, collect_server_info")
             return
-        
+
         server_info_url = urljoin(self.base_url, 'server_info')
         raw_version = _get_server_info(server_info_url, self.log, self.http)
 

--- a/envoy/datadog_checks/envoy/check.py
+++ b/envoy/datadog_checks/envoy/check.py
@@ -150,11 +150,14 @@ class EnvoyCheckV2(OpenMetricsBaseCheckV2):
         if not self.base_url:
             self.log.debug("Skipping server info collection due to malformed url: %s", self.base_url)
             return
-        raw_version = None
+        
         # From http://domain/thing/stats to http://domain/thing/server_info
-        if self.collect_server_info:
-            server_info_url = urljoin(self.base_url, 'server_info')
-            raw_version = _get_server_info(server_info_url, self.log, self.http)
+        if not self.collect_server_info:
+            self.log.debug("Skipping server info collection as it is disabled, collect_server_info: %s", self.collect_server_info)
+            return
+        
+        server_info_url = urljoin(self.base_url, 'server_info')
+        raw_version = _get_server_info(server_info_url, self.log, self.http)
 
         if raw_version:
             self.set_metadata('version', raw_version)

--- a/envoy/datadog_checks/envoy/check.py
+++ b/envoy/datadog_checks/envoy/check.py
@@ -153,7 +153,7 @@ class EnvoyCheckV2(OpenMetricsBaseCheckV2):
         
         # From http://domain/thing/stats to http://domain/thing/server_info
         if not self.collect_server_info:
-            self.log.debug("Skipping server info collection as it is disabled, collect_server_info:")
+            self.log.debug("Skipping server info collection as it is disabled, collect_server_info")
             return
         
         server_info_url = urljoin(self.base_url, 'server_info')

--- a/envoy/datadog_checks/envoy/check.py
+++ b/envoy/datadog_checks/envoy/check.py
@@ -153,7 +153,7 @@ class EnvoyCheckV2(OpenMetricsBaseCheckV2):
         
         # From http://domain/thing/stats to http://domain/thing/server_info
         if not self.collect_server_info:
-            self.log.debug("Skipping server info collection as it is disabled, collect_server_info: %s", self.collect_server_info)
+            self.log.debug("Skipping server info collection as it is disabled, collect_server_info:")
             return
         
         server_info_url = urljoin(self.base_url, 'server_info')

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -192,11 +192,9 @@ class Envoy(AgentCheck):
         if not self.collect_server_info:
             self.log.debug("Skipping server info collection because collect_server_info was disabled")
             return
-        raw_version = None
         # From http://domain/thing/stats to http://domain/thing/server_info
-        if self.collect_server_info:
-            server_info_url = urljoin(self.stats_url, 'server_info')
-            raw_version = _get_server_info(server_info_url, self.log, self.http)
+        server_info_url = urljoin(self.stats_url, 'server_info')
+        raw_version = _get_server_info(server_info_url, self.log, self.http)
 
         if raw_version:
             self.set_metadata('version', raw_version)

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -192,9 +192,11 @@ class Envoy(AgentCheck):
         if not self.collect_server_info:
             self.log.debug("Skipping server info collection because collect_server_info was disabled")
             return
+        raw_version = None
         # From http://domain/thing/stats to http://domain/thing/server_info
-        server_info_url = urljoin(self.stats_url, 'server_info')
-        raw_version = _get_server_info(server_info_url, self.log, self.http)
+        if self.collect_server_info:
+            server_info_url = urljoin(self.stats_url, 'server_info')
+            raw_version = _get_server_info(server_info_url, self.log, self.http)
 
         if raw_version:
             self.set_metadata('version', raw_version)

--- a/envoy/tests/test_unit.py
+++ b/envoy/tests/test_unit.py
@@ -84,3 +84,17 @@ def test_collect_metadata_with_invalid_base_url(
     c._collect_metadata()
     datadog_agent.assert_metadata_count(0)
     c.log.debug.assert_called_with('Skipping server info collection due to malformed url: %s', b'')
+
+
+@requires_py3
+def test_collect_metadata_with_disabled_collect_server_info(
+    datadog_agent, fixture_path, mock_http_response, check, default_instance
+):
+    default_instance["collect_server_info"] = False
+    c = check(default_instance)
+    c.check_id = 'test:123'
+    c.log = mock.MagicMock()
+
+    c._collect_metadata()
+    datadog_agent.assert_metadata_count(0)
+    c.log.debug.assert_called_with('Skipping server info collection as it is disabled, collect_server_info: %s', b'')

--- a/envoy/tests/test_unit.py
+++ b/envoy/tests/test_unit.py
@@ -98,3 +98,4 @@ def test_collect_metadata_with_disabled_collect_server_info(
     c._collect_metadata()
     datadog_agent.assert_metadata_count(0)
     c.log.debug.assert_called_with('Skipping server info collection as it is disabled, collect_server_info: %s', False)
+    

--- a/envoy/tests/test_unit.py
+++ b/envoy/tests/test_unit.py
@@ -97,4 +97,4 @@ def test_collect_metadata_with_disabled_collect_server_info(
 
     c._collect_metadata()
     datadog_agent.assert_metadata_count(0)
-    c.log.debug.assert_called_with('Skipping server info collection as it is disabled, collect_server_info: %s', b'')
+    c.log.debug.assert_called_with('Skipping server info collection as it is disabled, collect_server_info: %s', False)

--- a/envoy/tests/test_unit.py
+++ b/envoy/tests/test_unit.py
@@ -97,4 +97,4 @@ def test_collect_metadata_with_disabled_collect_server_info(
 
     c._collect_metadata()
     datadog_agent.assert_metadata_count(0)
-    c.log.debug.assert_called_with('Skipping server info collection as it is disabled, collect_server_info: %s', b'')
+    c.log.debug.assert_called_with('Skipping server info collection as it is disabled, collect_server_info')

--- a/envoy/tests/test_unit.py
+++ b/envoy/tests/test_unit.py
@@ -97,4 +97,4 @@ def test_collect_metadata_with_disabled_collect_server_info(
 
     c._collect_metadata()
     datadog_agent.assert_metadata_count(0)
-    c.log.debug.assert_called_with('Skipping server info collection as it is disabled, collect_server_info: %s', b'False')
+    c.log.debug.assert_called_with('Skipping server info collection as it is disabled, collect_server_info: %s', b'')

--- a/envoy/tests/test_unit.py
+++ b/envoy/tests/test_unit.py
@@ -97,5 +97,4 @@ def test_collect_metadata_with_disabled_collect_server_info(
 
     c._collect_metadata()
     datadog_agent.assert_metadata_count(0)
-    c.log.debug.assert_called_with('Skipping server info collection as it is disabled, collect_server_info: %s', False)
-    
+    c.log.debug.assert_called_with('Skipping server info collection as it is disabled, collect_server_info: %s', b'False')


### PR DESCRIPTION
### What does this PR do?
When the collect_server_info is set to false, we shouldn't try to collect the server metadata, including the server version.

### Motivation
A customer complained about errors when attempting to collect server info and version, despite them setting the collect_server_info to false.
The log they see:
`(pkg/collector/python/datadog_agent.go:134 in LogMessage) | envoy:9e356679f384318e | (utils.py:55) | Envoy endpoint <endpoint>/server_info responded with HTTP status code 404
` 
[Jira card](https://datadoghq.atlassian.net/browse/AGENT-9667)

### Additional Notes
This was originally done here in this [PR-9298](https://github.com/DataDog/integrations-core/pull/9298) but later the raw_version was updated as part of this [PR-10752](https://github.com/DataDog/integrations-core/pull/10752) to make calls to the function generating the above log: [_get_server_info](https://github.com/DataDog/integrations-core/blob/master/envoy/datadog_checks/envoy/utils.py#L49)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.