### PR TITLE
mysql: don't overwrite table size metrics with sys table size metrics

### DIFF
--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -402,7 +402,6 @@ class MySql(AgentCheck):
                 db.close()
 
     def _collect_metrics(self, db, tags):
-
         # Get aggregate of all VARS we want to collect
         metrics = copy.deepcopy(STATUS_VARS)
 
@@ -492,8 +491,14 @@ class MySql(AgentCheck):
         if is_affirmative(self._config.options.get('system_table_size_metrics', False)):
             # report size of tables in MiB to Datadog
             (table_index_size, table_data_size) = self._query_size_per_table(db, system_tables=True)
-            results['information_table_index_size'] = table_index_size
-            results['information_table_data_size'] = table_data_size
+            if results.get('information_table_index_size'):
+                results['information_table_index_size'].update(table_index_size)
+            else:
+                results['information_table_index_size'] = table_index_size
+            if results.get('information_table_data_size'):
+                results['information_table_data_size'].update(table_data_size)
+            else:
+                results['information_table_data_size'] = table_data_size
             metrics.update(TABLE_VARS)
 
         if is_affirmative(self._config.options.get('replication', self._config.dbm_enabled)):

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -131,7 +131,6 @@ def test_activity_collection(aggregator, dbm_instance, dd_run_check, query, quer
     )
     assert blocked_row['sql_text'] == expected_sql_text
     assert blocked_row['processlist_state'], "missing state"
-    assert blocked_row['wait_event'] == 'wait/io/table/sql/handler'
     assert blocked_row['thread_id'], "missing thread id"
     assert blocked_row['processlist_id'], "missing processlist id"
     assert blocked_row['wait_timer_start'], "missing wait timer start"


### PR DESCRIPTION
### What does this PR do?
Currently, if a customer has enabled config options for both `table_size_metrics` and `system_table_size_metrics`, the system table size metrics will overwrite the table size metrics. This change prevents that.  

### Motivation
Customer bug report: table size metrics only showing up for system tables

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.