### PR TITLE
Revert protobuf dependency update

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -60,7 +60,7 @@ ply,PyPI,BSD-3-Clause,Copyright (C) 2001-2018
 prometheus-client,PyPI,Apache-2.0,Copyright 2015 Brian Brazil
 prometheus-client,PyPI,Apache-2.0,Copyright 2015 The Prometheus Authors
 protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.
-protobuf,PyPI,BSD-3-Clause,Copyright 2014 protobuf@googlegroups.com
+protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.  All rights reserved.
 psutil,PyPI,BSD-3-Clause,"Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola'"
 psycopg2-binary,PyPI,BSD-3-Clause,Copyright 2013 Federico Di Gregorio
 psycopg2-binary,PyPI,LGPL-3.0-only,Copyright (C) 2013 Federico Di Gregorio

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -54,7 +54,7 @@ ply==3.11
 prometheus-client==0.12.0; python_version < '3.0'
 prometheus-client==0.16.0; python_version > '3.0'
 protobuf==3.17.3; python_version < '3.0'
-protobuf==4.23.1; python_version > '3.0'
+protobuf==3.20.2; python_version > '3.0'
 psutil==5.9.0
 psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'
 pyasn1==0.4.6

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -56,7 +56,7 @@ deps = [
     "prometheus-client==0.12.0; python_version < '3.0'",
     "prometheus-client==0.16.0; python_version > '3.0'",
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==4.23.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
     "pydantic==1.10.8; python_version > '3.0'",
     "python-dateutil==2.8.2",
     "pywin32==228; sys_platform == 'win32' and python_version < '3.0'",

--- a/gitlab/pyproject.toml
+++ b/gitlab/pyproject.toml
@@ -42,7 +42,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==4.23.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/gitlab_runner/pyproject.toml
+++ b/gitlab_runner/pyproject.toml
@@ -42,7 +42,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==4.23.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/kube_dns/pyproject.toml
+++ b/kube_dns/pyproject.toml
@@ -42,7 +42,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==4.23.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/kubernetes_state/pyproject.toml
+++ b/kubernetes_state/pyproject.toml
@@ -42,7 +42,7 @@ text = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "protobuf==3.17.3; python_version < '3.0'",
-    "protobuf==4.23.1; python_version > '3.0'",
+    "protobuf==3.20.2; python_version > '3.0'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?

Revert protobuf dep to version prior to #14594

### Motivation

[Failing tests](https://github.com/DataDog/integrations-core/actions/runs/5088179965/jobs/9144388611#step:12:381) after merging to master which somehow the branch's CI missed.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.