### PR TITLE
Collect Gitaly metrics by default in the e2e environment

### DIFF
--- a/gitlab/tests/conftest.py
+++ b/gitlab/tests/conftest.py
@@ -75,7 +75,18 @@ def dd_environment():
             requests.get(GITLAB_URL)
         sleep(2)
 
-        yield to_omv2_config(CONFIG)
+        yield {
+                'init_config': {},
+                'instances': [
+                    {
+                        'openmetrics_endpoint': GITLAB_PROMETHEUS_ENDPOINT,
+                        'gitaly_server_endpoint': GITLAB_GITALY_PROMETHEUS_ENDPOINT,
+                        'gitlab_url': GITLAB_URL,
+                        'disable_ssl_validation': True,
+                        'tags': CUSTOM_TAGS,
+                    }
+                ],
+            }
 
 
 @pytest.fixture()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Collect Gitaly metrics by default in the e2e environment

### Motivation
<!-- What inspired you to submit this pull request? -->

Otherwise we always have to update and reload the config to get them

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.