### PR TITLE
Fix boto3 dep in postgres to match the Agent's

### DIFF
--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -41,7 +41,8 @@ text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "boto3==1.26.113",
+    "boto3==1.17.112; python_version < '3.0'",
+    "boto3==1.26.138; python_version > '3.0'",
     "cachetools==3.1.1; python_version < '3.0'",
     "cachetools==5.3.0; python_version > '3.0'",
     "futures==3.4.0; python_version < '3.0'",


### PR DESCRIPTION
### What does this PR do?



### Motivation

https://github.com/DataDog/integrations-core/pull/14581 introduced boto3 as a dep for postgres and wasn't matching the rest of the Agent environment (see https://github.com/DataDog/integrations-core/actions/runs/5092868979/jobs/9154780396)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.