### PR TITLE
Mock out httpbin.org responses to fix flaky tests

### DIFF
--- a/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_legacy/test_openmetrics.py
@@ -2678,7 +2678,7 @@ def test_ssl_verify_not_raise_warning(caplog, mocked_openmetrics_check_factory, 
     check = mocked_openmetrics_check_factory(instance)
     scraper_config = check.get_scraper_config(instance)
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.DEBUG), mock.patch('requests.get', return_value=MockResponse('httpbin.org')):
         resp = check.send_request('https://httpbin.org/get', scraper_config)
 
     assert "httpbin.org" in resp.content.decode('utf-8')
@@ -2703,7 +2703,7 @@ def test_send_request_with_dynamic_prometheus_url(caplog, mocked_openmetrics_che
     # `prometheus_url` changed just before calling `send_request`
     scraper_config['prometheus_url'] = 'https://www.example.com/foo/bar'
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.DEBUG), mock.patch('requests.get', return_value=MockResponse('httpbin.org')):
         resp = check.send_request('https://httpbin.org/get', scraper_config)
 
     assert "httpbin.org" in resp.content.decode('utf-8')

--- a/datadog_checks_base/tests/base/checks/prometheus/test_prometheus.py
+++ b/datadog_checks_base/tests/base/checks/prometheus/test_prometheus.py
@@ -1964,9 +1964,11 @@ def test_text_filter_input():
 
 
 def test_ssl_verify_not_raise_warning(caplog, mocked_prometheus_check, text_data):
+    from datadog_checks.dev.http import MockResponse
+
     check = mocked_prometheus_check
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.DEBUG), mock.patch('requests.get', return_value=MockResponse('httpbin.org')):
         resp = check.poll('https://httpbin.org/get')
 
     assert 'httpbin.org' in resp.content.decode('utf-8')
@@ -1977,10 +1979,12 @@ def test_ssl_verify_not_raise_warning(caplog, mocked_prometheus_check, text_data
 
 
 def test_ssl_verify_not_raise_warning_cert_false(caplog, mocked_prometheus_check, text_data):
+    from datadog_checks.dev.http import MockResponse
+
     check = mocked_prometheus_check
     check.ssl_ca_cert = False
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.DEBUG), mock.patch('requests.get', return_value=MockResponse('httpbin.org')):
         resp = check.poll('https://httpbin.org/get')
 
     assert 'httpbin.org' in resp.content.decode('utf-8')


### PR DESCRIPTION
### What does this PR do?

Mock out http calls on flaky tests.

### Motivation

We have been getting pretty consistent timeouts on tests relying on hitting httpbin.org ([example](https://github.com/DataDog/integrations-core/actions/runs/5091948690/jobs/9152666896#step:12:1548)). As it turns out, after a bit of research on what these tests actually test, doing the actual http request is not really necessary and can be mocked away without any loss in terms of what gets tested.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.