### PR TITLE
Correctly compute the `templates.count` metric

### DIFF
--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -36,6 +36,26 @@ ES_HEALTH_TO_DD_STATUS = {
     'red': DatadogESHealth(AgentCheck.CRITICAL, AgentCheck.OK, 'ALERT'),
 }
 
+# Skipping the following templates:
+#
+#   logs|metrics|synthetic: created by default by Elasticsearch, they can be disabled
+#   by setting stack.templates.enabled to false
+#
+#   .monitoring: shard monitoring templates.
+#
+#   .slm: snapshot lifecyle management
+#
+#   .deprecation: deprecation reports
+#
+TEMPLATE_EXCLUSION_LIST = (
+    'logs',
+    'metrics',
+    'synthetics',
+    '.monitoring',
+    '.slm-',
+    '.deprecation',
+)
+
 
 class AuthenticationError(requests.exceptions.HTTPError):
     """Authentication Error, unable to reach server"""
@@ -247,32 +267,10 @@ class ESCheck(AgentCheck):
 
     def _get_template_metrics(self, admin_forwarder, base_tags):
         template_resp = self._get_data(self._join_url('/_cat/templates?format=json', admin_forwarder))
-        for idx, tpl in enumerate(template_resp):
-            # Skipping the following templates:
-            #
-            #   logs|metrics|synthetic: created by default by Elasticsearch, they can be disabled
-            #   by setting stack.templates.enabled to false
-            #
-            #   .monitoring: shard monitoring templates.
-            #
-            #   .slm: snapshot lifecyle management
-            #
-            #   .deprecation: deprecation reports
-            #
-            if tpl['name'].startswith(
-                (
-                    'logs',
-                    'metrics',
-                    'synthetics',
-                    '.monitoring',
-                    '.slm-',
-                    '.deprecation',
-                )
-            ):
-                template_resp.pop(idx)
+        filtered_templates = [t for t in template_resp if not t['name'].startswith(TEMPLATE_EXCLUSION_LIST)]
 
         for metric, desc in iteritems(TEMPLATE_METRICS):
-            self._process_metric({'templates': template_resp}, metric, *desc, tags=base_tags)
+            self._process_metric({'templates': filtered_templates}, metric, *desc, tags=base_tags)
 
     def _get_index_search_stats(self, admin_forwarder, base_tags):
         """

--- a/elastic/tests/common.py
+++ b/elastic/tests/common.py
@@ -23,3 +23,7 @@ JVM_RATES = [
     'jvm.gc.collectors.old.rate',
     'jvm.gc.collectors.old.collection_time.rate',
 ]
+
+
+def get_fixture_path(filename):
+    return os.path.join(HERE, 'fixtures', filename)

--- a/elastic/tests/fixtures/templates.json
+++ b/elastic/tests/fixtures/templates.json
@@ -1,0 +1,149 @@
+[
+  {
+    "name": ".monitoring-logstash",
+    "index_patterns": "[.monitoring-logstash-7-*]",
+    "order": "0",
+    "version": "8010099",
+    "composed_of": ""
+  },
+  {
+    "name": ".monitoring-beats",
+    "index_patterns": "[.monitoring-beats-7-*]",
+    "order": "0",
+    "version": "8010099",
+    "composed_of": ""
+  },
+  {
+    "name": ".monitoring-alerts-7",
+    "index_patterns": "[.monitoring-alerts-7]",
+    "order": "0",
+    "version": "8010099",
+    "composed_of": ""
+  },
+  {
+    "name": ".monitoring-es",
+    "index_patterns": "[.monitoring-es-7-*]",
+    "order": "0",
+    "version": "8010099",
+    "composed_of": ""
+  },
+  {
+    "name": ".monitoring-kibana",
+    "index_patterns": "[.monitoring-kibana-7-*]",
+    "order": "0",
+    "version": "8010099",
+    "composed_of": ""
+  },
+  {
+    "name": ".watch-history-16",
+    "index_patterns": "[.watcher-history-16*]",
+    "order": "2147483647",
+    "version": "16",
+    "composed_of": "[]"
+  },
+  {
+    "name": ".monitoring-beats-mb",
+    "index_patterns": "[.monitoring-beats-8-*]",
+    "order": "0",
+    "version": "8000103",
+    "composed_of": "[]"
+  },
+  {
+    "name": ".monitoring-kibana-mb",
+    "index_patterns": "[.monitoring-kibana-8-*]",
+    "order": "0",
+    "version": "8000103",
+    "composed_of": "[]"
+  },
+  {
+    "name": ".monitoring-ent-search-mb",
+    "index_patterns": "[.monitoring-ent-search-8-*]",
+    "order": "0",
+    "version": "8000103",
+    "composed_of": "[]"
+  },
+  {
+    "name": "synthetics",
+    "index_patterns": "[synthetics-*-*]",
+    "order": "100",
+    "version": "2",
+    "composed_of": "[synthetics-mappings, data-streams-mappings, synthetics-settings]"
+  },
+  {
+    "name": "ilm-history",
+    "index_patterns": "[ilm-history-5*]",
+    "order": "2147483647",
+    "version": "5",
+    "composed_of": "[]"
+  },
+  {
+    "name": ".ml-state",
+    "index_patterns": "[.ml-state*]",
+    "order": "2147483647",
+    "version": "8060299",
+    "composed_of": "[]"
+  },
+  {
+    "name": ".monitoring-es-mb",
+    "index_patterns": "[.monitoring-es-8-*]",
+    "order": "0",
+    "version": "8000103",
+    "composed_of": "[]"
+  },
+  {
+    "name": ".slm-history",
+    "index_patterns": "[.slm-history-5*]",
+    "order": "2147483647",
+    "version": "5",
+    "composed_of": "[]"
+  },
+  {
+    "name": ".monitoring-logstash-mb",
+    "index_patterns": "[.monitoring-logstash-8-*]",
+    "order": "0",
+    "version": "8000103",
+    "composed_of": "[]"
+  },
+  {
+    "name": ".ml-anomalies-",
+    "index_patterns": "[.ml-anomalies-*]",
+    "order": "2147483647",
+    "version": "8060299",
+    "composed_of": "[]"
+  },
+  {
+    "name": "metrics",
+    "index_patterns": "[metrics-*-*]",
+    "order": "100",
+    "version": "2",
+    "composed_of": "[metrics-mappings, data-streams-mappings, metrics-settings]"
+  },
+  {
+    "name": ".ml-notifications-000002",
+    "index_patterns": "[.ml-notifications-000002]",
+    "order": "2147483647",
+    "version": "8060299",
+    "composed_of": "[]"
+  },
+  {
+    "name": ".deprecation-indexing-template",
+    "index_patterns": "[.logs-deprecation.*]",
+    "order": "1000",
+    "version": "1",
+    "composed_of": "[.deprecation-indexing-mappings, .deprecation-indexing-settings]"
+  },
+  {
+    "name": "logs",
+    "index_patterns": "[logs-*-*]",
+    "order": "100",
+    "version": "2",
+    "composed_of": "[logs-mappings, data-streams-mappings, logs-settings]"
+  },
+  {
+    "name": ".ml-stats",
+    "index_patterns": "[.ml-stats-*]",
+    "order": "2147483647",
+    "version": "8060299",
+    "composed_of": "[]"
+  }
+]

--- a/elastic/tests/test_elastic.py
+++ b/elastic/tests/test_elastic.py
@@ -25,7 +25,7 @@ from datadog_checks.elastic.metrics import (
     stats_for_version,
 )
 
-from .common import CLUSTER_TAG, IS_OPENSEARCH, JVM_RATES, PASSWORD, URL, USER
+from .common import CLUSTER_TAG, IS_OPENSEARCH, JVM_RATES, PASSWORD, URL, USER, get_fixture_path
 
 log = logging.getLogger('test_elastic')
 
@@ -542,3 +542,13 @@ def test_aws_auth_no_url(instance, expected_aws_host, expected_aws_service):
 def test_e2e(dd_agent_check, elastic_check, instance, cluster_tags, node_tags):
     aggregator = dd_agent_check(instance, rate=True)
     _test_check(elastic_check, instance, aggregator, cluster_tags, node_tags)
+
+
+@pytest.mark.unit
+def test_get_template_metrics(aggregator, instance, mock_http_response):
+    mock_http_response(file_path=get_fixture_path('templates.json'))
+    check = ESCheck('elastic', {}, instances=[instance])
+
+    check._get_template_metrics(False, [])
+
+    aggregator.assert_metric("elasticsearch.templates.count", value=6)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Correctly compute the templates.count metric

### Motivation
<!-- What inspired you to submit this pull request? -->

- QA for https://github.com/DataDog/integrations-core/pull/14569 which had no tests
- The previous implementation was dropping elements from the same list we were iterating on, so the index that were removed were not correct because the list was continuously updated. The previous implementation returned 12 instead of 6.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.