### PR TITLE
Update README.md to Modify Create User Section

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -26,17 +26,10 @@ On each MySQL server, create a database user for the Datadog Agent.
 
 The following instructions grant the Agent permission to login from any host using `datadog@'%'`. You can restrict the `datadog` user to be allowed to login only from localhost by using `datadog@'localhost'`. See [MySQL Adding Accounts, Assigning Privileges, and Dropping Accounts][5] for more info.
 
-For MySQL 5.6 or MySQL 5.7 create the `datadog` user with the following command:
+Create the `datadog` user with the following command:
 
 ```shell
 mysql> CREATE USER 'datadog'@'%' IDENTIFIED BY '<UNIQUEPASSWORD>';
-Query OK, 0 rows affected (0.00 sec)
-```
-
-For MySQL 8.0 or greater, create the `datadog` user with the native password hashing method:
-
-```shell
-mysql> CREATE USER 'datadog'@'%' IDENTIFIED WITH mysql_native_password by '<UNIQUEPASSWORD>';
 Query OK, 0 rows affected (0.00 sec)
 ```
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Modified Create User Section.

### Motivation
<!-- What inspired you to submit this pull request? -->
Before this PR, For MySQL 8.0 or greater, create user command let user to include unsecure Authentication Plugin "WITH mysql_native_password" and at some MySQL versions, it returns error.

Detail
1. This plugin is not recommended from security point of view

> MySQL documentation
> https://dev.mysql.com/doc/refman/8.0/en/native-pluggable-authentication.html
> MariaDB documentation
> https://mariadb.com/kb/en/authentication-plugin-mysql_native_password/ 

2. At MySQL Ver 15.1 , this command returned error and user need to remove this plugin.
```
$ mysql --version
mysql  Ver 15.1 Distrib 10.6.12-MariaDB, for Linux (x86_64) using readline 5.1
$
MariaDB [(none)]> CREATE USER datadog@'localhost' IDENTIFIED WITH mysql_native_password by 'password';
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'by 'password'' at line 1
MariaDB [(none)]>
```
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.