### PR TITLE
Backport pydantic 1.10.8 upgrade to 7.45

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -59,7 +59,7 @@ psutil==5.9.0
 psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'
 pyasn1==0.4.6
 pycryptodomex==3.10.1
-pydantic==1.10.4; python_version > '3.0'
+pydantic==1.10.8; python_version > '3.0'
 pyjwt==1.7.1; python_version < '3.0'
 pyjwt==2.6.0; python_version > '3.0'
 pymongo[srv]==4.3.3; python_version >= '3.8'

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -57,7 +57,7 @@ deps = [
     "prometheus-client==0.16.0; python_version > '3.0'",
     "protobuf==3.17.3; python_version < '3.0'",
     "protobuf==3.20.2; python_version > '3.0'",
-    "pydantic==1.10.4; python_version > '3.0'",
+    "pydantic==1.10.8; python_version > '3.0'",
     "python-dateutil==2.8.2",
     "pywin32==228; sys_platform == 'win32' and python_version < '3.0'",
     "pywin32==304; sys_platform == 'win32' and python_version > '3.0'",

--- a/datadog_checks_dev/datadog_checks/dev/plugin/hatch/environment_collector.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/hatch/environment_collector.py
@@ -120,7 +120,7 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
                 'black==22.12.0',
                 'ruff==0.0.257',
                 # Keep in sync with: /datadog_checks_base/pyproject.toml
-                'pydantic==1.10.4',
+                'pydantic==1.10.8',
             ],
         }
         config = {'lint': lint_env}

--- a/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/tox.py
@@ -32,7 +32,7 @@ TYPES_DEPS = [
     'types-simplejson==3.17.5',
 ]
 # Keep in sync with: /datadog_checks_base/datadog_checks/data/agent_requirements.in and ./hatch/environment_collector.py
-PYDANTIC_DEP = 'pydantic==1.10.4'
+PYDANTIC_DEP = 'pydantic==1.10.8'
 
 
 @tox.hookimpl


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Backport [pydantic upgrade](https://github.com/DataDog/integrations-core/pull/14594) from `1.10.4` to `1.10.8` to 7.45.x.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/pydantic/pydantic/issues/5824

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.