### PR TITLE
Fix NGINX overview dashboard

### DIFF
--- a/nginx/assets/dashboards/NGINX-Overview_dashboard.json
+++ b/nginx/assets/dashboards/NGINX-Overview_dashboard.json
@@ -280,43 +280,6 @@
         "layout_type": "ordered",
         "widgets": [
           {
-            "id": 2211250424739338,
-            "definition": {
-              "title": "Log count by status",
-              "title_size": "16",
-              "title_align": "left",
-              "type": "toplist",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "formula": "query1",
-                      "limit": {
-                        "count": 10,
-                        "order": "desc"
-                      }
-                    }
-                  ],
-                  "response_format": "scalar",
-                  "queries": [
-                    {
-                      "query": "avg:nginx_log_count_by_status{*} by {status}.as_count()",
-                      "data_source": "metrics",
-                      "name": "query1",
-                      "aggregator": "avg"
-                    }
-                  ]
-                }
-              ]
-            },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 3,
-              "height": 2
-            }
-          },
-          {
             "id": 518123602946722,
             "definition": {
               "type": "note",

--- a/nginx/assets/dashboards/NGINX-Overview_dashboard.json
+++ b/nginx/assets/dashboards/NGINX-Overview_dashboard.json
@@ -294,9 +294,9 @@
               "has_padding": true
             },
             "layout": {
-              "x": 3,
+              "x": 0,
               "y": 0,
-              "width": 3,
+              "width": 6,
               "height": 2
             }
           },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR updates the NGINX overview dashboard to remove `nginx_log_count_by_status`, since this is not a metric currently collected in the check.

Old:
<img width="732" alt="image" src="https://github.com/DataDog/integrations-core/assets/31313038/a94d6892-042c-435e-bec0-ca05615a536e">

New:
<img width="732" alt="image" src="https://github.com/DataDog/integrations-core/assets/31313038/de005f72-534f-4b35-80da-1d0c01787cab">

### Motivation
<!-- What inspired you to submit this pull request? -->
Customer request

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.