### PR TITLE
Update changelogs for 7.45 backport

### DIFF
--- a/AGENT_CHANGELOG.md
+++ b/AGENT_CHANGELOG.md
@@ -3,7 +3,7 @@
 * Amazon Kafka [3.3.0](https://github.com/DataDog/integrations-core/blob/master/amazon_msk/CHANGELOG.md)
 * Apache [4.2.1](https://github.com/DataDog/integrations-core/blob/master/apache/CHANGELOG.md)
 * Avi Vantage [3.2.1](https://github.com/DataDog/integrations-core/blob/master/avi_vantage/CHANGELOG.md)
-* datadog_checks_base [31.0.1](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/CHANGELOG.md) **BREAKING CHANGE**
+* datadog_checks_base [31.0.2](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_base/CHANGELOG.md) **BREAKING CHANGE**
 * CoreDNS [2.3.1](https://github.com/DataDog/integrations-core/blob/master/coredns/CHANGELOG.md)
 * Datadog Cluster Agent [2.6.0](https://github.com/DataDog/integrations-core/blob/master/datadog_cluster_agent/CHANGELOG.md)
 * Directory [1.14.2](https://github.com/DataDog/integrations-core/blob/master/directory/CHANGELOG.md)

--- a/AGENT_INTEGRATIONS.md
+++ b/AGENT_INTEGRATIONS.md
@@ -21,7 +21,7 @@
 * datadog-cassandra: 1.16.0
 * datadog-ceph: 2.7.0
 * datadog-cert-manager: 3.0.0
-* datadog-checks-base: 31.0.1
+* datadog-checks-base: 31.0.2
 * datadog-checks-dependency-provider: 1.3.0
 * datadog-checks-downloader: 4.1.0
 * datadog-cilium: 2.3.0

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -20,7 +20,11 @@
 
 * [Changed] Implement automatic exposition format detection. See [#14445](https://github.com/DataDog/integrations-core/pull/14445).
 
-## 31.0.1 / 2023-04-19 / Agent 7.45.0
+## 31.0.2 / 2023-05-31 / Agent 7.45.0
+
+* [Fixed] Backport pydantic 1.10.8 upgrade to 7.45. See [#14655](https://github.com/DataDog/integrations-core/pull/14655).
+
+## 31.0.1 / 2023-04-19 
 
 * [Fixed] Do not add `freezegun` dependency to agent. See [#14393](https://github.com/DataDog/integrations-core/pull/14393).
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Updating CHANGLOG information after https://github.com/DataDog/integrations-core/pull/14655 needed to be added to 7.45.0.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.