### PR TITLE
Fix metric type of some `docker.cpu.*` in doc

### DIFF
--- a/docker_daemon/metadata.csv
+++ b/docker_daemon/metadata.csv
@@ -1,6 +1,6 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 docker.cpu.limit,gauge,,percent,,"Limit on CPU available to the container, expressed as percentage of a core",0,docker,docker.cpu.limit,
-docker.cpu.system,gauge,,percent,,"The percent of time the CPU is executing system calls on behalf of processes of this container, unnormalized",0,docker,cpu system,
+docker.cpu.system,rate,,percent,,"The percent of time the CPU is executing system calls on behalf of processes of this container, unnormalized",0,docker,cpu system,
 docker.cpu.system.95percentile,gauge,,percent,,95th percentile of docker.cpu.system [deprecated in agent 6.0],0,docker,cpu system 95%,
 docker.cpu.system.avg,gauge,,percent,,Average value of docker.cpu.system [deprecated in agent 6.0],0,docker,cpu system avg,
 docker.cpu.system.count,rate,,sample,second,The rate that the value of docker.cpu.system was sampled [deprecated in agent 6.0],0,docker,cpu system count,
@@ -12,8 +12,8 @@ docker.cpu.user.avg,gauge,,percent,,Average value of docker.cpu.user [deprecated
 docker.cpu.user.count,rate,,sample,second,The rate that the value of docker.cpu.user was sampled [deprecated in agent 6.0],0,docker,cpu user count,
 docker.cpu.user.max,gauge,,percent,,Max value of docker.cpu.user [deprecated in agent 6.0],0,docker,cpu user max,
 docker.cpu.user.median,gauge,,percent,,Median value of docker.cpu.user [deprecated in agent 6.0],0,docker,cpu user median,
-docker.cpu.usage,gauge,,percent,,The percent of CPU time obtained by this container,0,docker,docker.cpu.usage,
-docker.cpu.throttled,gauge,,,,Number of times the cgroup has been throttled,-1,docker,cpu throttled,
+docker.cpu.usage,rate,,percent,,The percent of CPU time obtained by this container,0,docker,docker.cpu.usage,
+docker.cpu.throttled,rate,,,,Number of times the cgroup has been throttled,-1,docker,cpu throttled,
 docker.cpu.shares,gauge,,,,Shares of CPU usage allocated to the container,0,docker,cpu shares,
 docker.kmem.usage,gauge,,byte,,"The amount of kernel memory that belongs to the container's processes.",0,docker,kmem usage,
 docker.mem.cache,gauge,,byte,,The amount of memory that is being used to cache data from disk (e.g. memory contents that can be associated precisely with a block on a block device),0,docker,mem cache,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

The following metrics are reported as RATE.

- `docker.cpu.system`
- `docker.cpu.user`
- `docker.cpu.throttled`

https://github.com/DataDog/datadog-agent/blob/55d237f732fc2145ffeb83aec438736d49bdd739/pkg/collector/corechecks/containers/generic/processor.go#L147-L152

```go
		p.sendMetric(sender.Rate, "container.cpu.usage", containerStats.CPU.Total, tags)
		p.sendMetric(sender.Rate, "container.cpu.user", containerStats.CPU.User, tags)
		p.sendMetric(sender.Rate, "container.cpu.system", containerStats.CPU.System, tags)
		p.sendMetric(sender.Rate, "container.cpu.throttled", containerStats.CPU.ThrottledTime, tags)
		p.sendMetric(sender.Rate, "container.cpu.throttled.periods", containerStats.CPU.ThrottledPeriods, tags)
		p.sendMetric(sender.Rate, "container.cpu.partial_stall", containerStats.CPU.PartialStallTime, tags)
```

### Motivation
<!-- What inspired you to submit this pull request? -->

Doc fix.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.