### PR TITLE
Bump the confluent-kafka version

### DIFF
--- a/.ddev/ci/scripts/kafka_consumer/linux/32_install_kerberos.sh
+++ b/.ddev/ci/scripts/kafka_consumer/linux/32_install_kerberos.sh
@@ -8,7 +8,7 @@ sudo apt install -y --no-install-recommends build-essential libkrb5-dev wget sof
 # Install librdkafka from source since no binaries are available for the distribution we use on the CI:
 git clone https://github.com/confluentinc/librdkafka
 cd librdkafka
-git checkout v2.0.2
+git checkout v2.1.1
 sudo ./configure --install-deps --prefix=/usr
 make
 sudo make install

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -16,7 +16,7 @@ clickhouse-cityhash==1.0.2.4; python_version > '3.0'
 clickhouse-driver==0.2.0; python_version < '3.0'
 clickhouse-driver==0.2.3; python_version > '3.0'
 cm-client==45.0.4
-confluent-kafka==2.0.2; python_version > '3.0'
+confluent-kafka==2.1.1; python_version > '3.0'
 contextlib2==0.6.0.post1; python_version < '3.0'
 cryptography==3.3.2; python_version < '3.0'
 cryptography==39.0.1; python_version > '3.0'

--- a/kafka_consumer/hatch.toml
+++ b/kafka_consumer/hatch.toml
@@ -8,7 +8,7 @@ e2e-env = false
 # If you bump the `confluent-kafka` version, also bump the `librdkafka` version in the `32_install_kerberos.sh` file
 post-install-commands = [
   "python -m pip uninstall -y confluent-kafka",
-  "python -m pip install --no-binary confluent-kafka confluent-kafka==2.0.2",
+  "python -m pip install --no-binary confluent-kafka confluent-kafka==2.1.1",
 ]
 
 [envs.default.env-vars]

--- a/kafka_consumer/pyproject.toml
+++ b/kafka_consumer/pyproject.toml
@@ -40,7 +40,7 @@ text = "BSD-3-Clause"
 deps = [
     # confluent-kafka is built in omnibus, so bumping it here will have no real effect
     # if you bump this version, also bump the one in the `hatch.toml` file
-    "confluent-kafka==2.0.2; python_version > '3.0'",
+    "confluent-kafka==2.1.1; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/kafka_consumer/tests/README.md
+++ b/kafka_consumer/tests/README.md
@@ -29,4 +29,4 @@ If you face this issue:
 ```
 
 1. Make sure you installed `librdkafka` (see the previous section).
-2. You might need to set the `C_INCLUDE_PATH` and `LIBRARY_PATH` environments variable to load `librdkafka` when bulding `confluent-kafka`. For instance: `C_INCLUDE_PATH=/opt/homebrew/Cellar/librdkafka/2.0.2/include/ LIBRARY_PATH=/opt/homebrew/Cellar/librdkafka/2.0.2/lib ddev test kafka_consumer`. Setting these environment variables is only needed when the test environment is built (or rebuilt with the `--force-env-rebuild` option).  
+2. You might need to set the `C_INCLUDE_PATH` and `LIBRARY_PATH` environments variable to load `librdkafka` when building `confluent-kafka`. For instance: `C_INCLUDE_PATH=/opt/homebrew/Cellar/librdkafka/2.0.2/include/ LIBRARY_PATH=/opt/homebrew/Cellar/librdkafka/2.0.2/lib ddev test kafka_consumer`. (be sure to use the same version as declared in the `pyproject.toml` file). Setting these environment variables is only needed when the test environment is built (or rebuilt with the `--force-env-rebuild` option).  

--- a/kafka_consumer/tests/README.md
+++ b/kafka_consumer/tests/README.md
@@ -29,4 +29,4 @@ If you face this issue:
 ```
 
 1. Make sure you installed `librdkafka` (see the previous section).
-2. You might need to set the `C_INCLUDE_PATH` and `LIBRARY_PATH` environments variable to load `librdkafka` when building `confluent-kafka`. For instance: `C_INCLUDE_PATH=/opt/homebrew/Cellar/librdkafka/2.0.2/include/ LIBRARY_PATH=/opt/homebrew/Cellar/librdkafka/2.0.2/lib ddev test kafka_consumer`. (be sure to use the same version as declared in the `pyproject.toml` file). Setting these environment variables is only needed when the test environment is built (or rebuilt with the `--force-env-rebuild` option).  
+2. You might need to set the `C_INCLUDE_PATH` and `LIBRARY_PATH` environments variable to load `librdkafka` when building `confluent-kafka`. For instance: `C_INCLUDE_PATH=/opt/homebrew/Cellar/librdkafka/2.1.1/include/ LIBRARY_PATH=/opt/homebrew/Cellar/librdkafka/2.1.1/lib ddev test kafka_consumer`. (be sure to use the same version as declared in the `pyproject.toml` file). Setting these environment variables is only needed when the test environment is built (or rebuilt with the `--force-env-rebuild` option).  


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the confluent-kafka version. Also update the CI to be able to run the tests using this version.

### Motivation
<!-- What inspired you to submit this pull request? -->

We wanted to bump it in [this PR](https://github.com/DataDog/integrations-core/pull/14594) be we ran into some issues so we decided to leave this for later. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Tested with the agent image generated by omnibus:

```
❯ ddev env start -a 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent:v16364585-4a91d5b1-7-arm64 kafka_consumer py3.8-3.3-kerberos
Setting up environment `py3.8-3.3-kerberos`... success!
Updating `486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent:v16364585-4a91d5b1-7-arm64`... success!
Detecting the major version... Agent 7 detected
Writing configuration for `py3.8-3.3-kerberos`... success!
Starting the Agent... success!

To edit config file, do: ddev env edit kafka_consumer py3.8-3.3-kerberos
Config file (copied to your clipboard): /Users/florent.clarret/Library/Application Support/dd-checks-dev/envs/kafka_consumer/py3.8-3.3-kerberos/config/kafka_consumer.yaml
To reload the config file, do: ddev env reload kafka_consumer py3.8-3.3-kerberos
To run this check, do: ddev env check kafka_consumer py3.8-3.3-kerberos
To stop this check, do: ddev env stop kafka_consumer py3.8-3.3-kerberos

❯ ddev test --e2e kafka_consumer:py3.8-3.3-kerberos
Running only end-to-end tests for `kafka_consumer`os                                                                                                                          ─╯
--------------------------------------------------
────────────────────────────────────────────────────────────────────────────── py3.8-3.3-kerberos ───────────────────────────────────────────────────────────────────────────────
Finished checking dependencies
cmd [1] | pytest -v --benchmark-skip tests
============================================================================== test session starts ==============================================================================
platform darwin -- Python 3.8.14, pytest-7.3.1, pluggy-1.0.0 -- /Users/florent.clarret/Library/Application Support/hatch/env/virtual/datadog-kafka-consumer/KmLHgHe8/py3.8-3.3-kerberos/bin/python
cachedir: .pytest_cache
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/florent.clarret/go/src/github.com/DataDog/integrations-core/kafka_consumer
plugins: memray-1.4.0, datadog-checks-dev-19.3.1, asyncio-0.21.0, ddtrace-0.53.2, flaky-3.7.0, mock-3.10.0, cov-4.1.0, benchmark-4.0.0
asyncio: mode=strict
collected 46 items / 45 deselected / 1 selected                                                                                                                                 

tests/test_e2e.py::test_e2e PASSED                                                                                                                                        [100%]

======================================================================= 1 passed, 45 deselected in 7.56s ========================================================================

Passed!
```

Needs https://github.com/DataDog/datadog-agent/pull/17266 to be merged first as the dependency is built in omnibus.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.