### PR TITLE
Bug Fix: Support SQL Server file metrics for Azure SQL DB / MI

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -2,6 +2,9 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
+from datadog_checks.sqlserver.const import ENGINE_EDITION_SQL_DATABASE
+from datadog_checks.sqlserver.utils import is_azure_database
+
 QUERY_SERVER_STATIC_INFO = {
     'name': 'sys.dm_os_sys_info',
     'query': """
@@ -182,10 +185,11 @@ def get_query_ao_availability_groups(sqlserver_major_version):
     }
 
 
-def get_query_file_stats(sqlserver_major_version):
+def get_query_file_stats(sqlserver_major_version, sqlserver_engine_edition):
     """
     Construct the dm_io_virtual_file_stats QueryExecutor configuration based on the SQL Server major version
 
+    :param sqlserver_engine_edition: The engine version (i.e. 5 for Azure SQL DB...)
     :param sqlserver_major_version: SQL Server major version (i.e. 2012, 2019, ...)
     :return: a QueryExecutor query config object
     """
@@ -203,7 +207,7 @@ def get_query_file_stats(sqlserver_major_version):
         'io_stall': {'name': 'files.io_stall', 'type': 'monotonic_count'},
     }
 
-    if sqlserver_major_version <= 2012:
+    if sqlserver_major_version <= 2012 or not is_azure_database(sqlserver_engine_edition):
         column_definitions.pop("io_stall_queued_read_ms")
         column_definitions.pop("io_stall_queued_write_ms")
 
@@ -214,20 +218,36 @@ def get_query_file_stats(sqlserver_major_version):
         sql_columns.append("fs.{}".format(column))
         metric_columns.append(column_definitions[column])
 
-    return {
-        'name': 'sys.dm_io_virtual_file_stats',
-        'query': """
+    query = """
+    SELECT
+        DB_NAME(fs.database_id),
+        mf.state_desc,
+        mf.name,
+        mf.physical_name,
+        {sql_columns}
+    FROM sys.dm_io_virtual_file_stats(NULL, NULL) fs
+        LEFT JOIN sys.master_files mf
+            ON mf.database_id = fs.database_id
+            AND mf.file_id = fs.file_id;
+    """
+
+    if sqlserver_engine_edition == ENGINE_EDITION_SQL_DATABASE:
+        # Azure SQL DB does not have access to the sys.master_files view
+        query = """
         SELECT
-            DB_NAME(fs.database_id),
-            mf.state_desc,
-            mf.name,
-            mf.physical_name,
+            DB_NAME(DB_ID()),
+            df.state_desc,
+            df.name,
+            df.physical_name,
             {sql_columns}
         FROM sys.dm_io_virtual_file_stats(NULL, NULL) fs
-            LEFT JOIN sys.master_files mf
-                ON mf.database_id = fs.database_id
-                AND mf.file_id = fs.file_id;
-    """.strip().format(
+            LEFT JOIN sys.database_files df
+                ON df.file_id = fs.file_id;
+        """
+
+    return {
+        'name': 'sys.dm_io_virtual_file_stats',
+        'query': query.strip().format(
             sql_columns=", ".join(sql_columns)
         ),
         'columns': [

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -247,9 +247,7 @@ def get_query_file_stats(sqlserver_major_version, sqlserver_engine_edition):
 
     return {
         'name': 'sys.dm_io_virtual_file_stats',
-        'query': query.strip().format(
-            sql_columns=", ".join(sql_columns)
-        ),
+        'query': query.strip().format(sql_columns=", ".join(sql_columns)),
         'columns': [
             {'name': 'db', 'type': 'tag'},
             {'name': 'state', 'type': 'tag'},

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -42,6 +42,7 @@ from datadog_checks.sqlserver.const import (
     DATABASE_SERVICE_CHECK_NAME,
     DBM_MIGRATED_METRICS,
     DEFAULT_AUTODISCOVERY_INTERVAL,
+    ENGINE_EDITION_AZURE_MANAGED_INSTANCE,
     ENGINE_EDITION_SQL_DATABASE,
     INSTANCE_METRICS,
     INSTANCE_METRICS_DATABASE,
@@ -67,7 +68,7 @@ from datadog_checks.sqlserver.queries import (
     get_query_ao_availability_groups,
     get_query_file_stats,
 )
-from datadog_checks.sqlserver.utils import set_default_driver_conf
+from datadog_checks.sqlserver.utils import is_azure_database, set_default_driver_conf
 
 try:
     import adodbapi
@@ -295,6 +296,14 @@ class SQLServer(AgentCheck):
                             self.static_info_cache[STATIC_INFO_VERSION] = version
                             self.static_info_cache[STATIC_INFO_MAJOR_VERSION] = parse_sqlserver_major_version(version)
                             if not self.static_info_cache[STATIC_INFO_MAJOR_VERSION]:
+                                cursor.execute(
+                                    "SELECT CAST(ServerProperty('ProductMajorVersion') AS INT) AS MajorVersion"
+                                )
+                                result = cursor.fetchone()
+                                if result:
+                                    self.static_info_cache[STATIC_INFO_MAJOR_VERSION] = result[0]
+                                else:
+                                    self.log.warning("failed to load version static information due to empty results")
                                 self.log.warning("failed to parse SQL Server major version from version: %s", version)
                         else:
                             self.log.warning("failed to load version static information due to empty results")
@@ -744,14 +753,14 @@ class SQLServer(AgentCheck):
             return self._dynamic_queries
 
         major_version = self.static_info_cache.get(STATIC_INFO_MAJOR_VERSION)
-        if not major_version:
+        engine_edition = self.static_info_cache.get(STATIC_INFO_ENGINE_EDITION)
+        if not major_version and not is_azure_database(engine_edition):
             self.log.warning("missing major_version, cannot initialize dynamic queries")
             return None
-
-        queries = [get_query_file_stats(major_version)]
+        queries = [get_query_file_stats(major_version, engine_edition)]
 
         if is_affirmative(self.instance.get('include_ao_metrics', False)):
-            if major_version > 2012:
+            if major_version > 2012 or engine_edition == ENGINE_EDITION_AZURE_MANAGED_INSTANCE:
                 queries.extend(
                     [
                         get_query_ao_availability_groups(major_version),
@@ -762,7 +771,7 @@ class SQLServer(AgentCheck):
             else:
                 self.log.warning('AlwaysOn metrics are not supported on version 2012')
         if is_affirmative(self.instance.get('include_fci_metrics', False)):
-            if major_version > 2012:
+            if major_version > 2012 or engine_edition == ENGINE_EDITION_AZURE_MANAGED_INSTANCE:
                 queries.extend([QUERY_FAILOVER_CLUSTER_INSTANCE])
             else:
                 self.log.warning('Failover Cluster Instance metrics are not supported on version 2012')

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -754,6 +754,7 @@ class SQLServer(AgentCheck):
 
         major_version = self.static_info_cache.get(STATIC_INFO_MAJOR_VERSION)
         engine_edition = self.static_info_cache.get(STATIC_INFO_ENGINE_EDITION)
+        # need either major_version or engine_edition to generate queries
         if not major_version and not is_azure_database(engine_edition):
             self.log.warning("missing major_version, cannot initialize dynamic queries")
             return None

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -5,6 +5,7 @@ import os
 import re
 
 from datadog_checks.base.utils.platform import Platform
+from datadog_checks.sqlserver.const import ENGINE_EDITION_AZURE_MANAGED_INSTANCE, ENGINE_EDITION_SQL_DATABASE
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 DRIVER_CONFIG_DIR = os.path.join(CURRENT_DIR, 'data', 'driver_config')
@@ -114,3 +115,12 @@ def parse_sqlserver_major_version(version):
     if not match:
         return None
     return int(match.group(1))
+
+
+def is_azure_database(engine_edition):
+    """
+    Checks if engine edition matches Azure SQL MI or Azure SQL DB
+    :param engine_edition: The engine version of the database host
+    :return: bool
+    """
+    return engine_edition == ENGINE_EDITION_AZURE_MANAGED_INSTANCE or engine_edition == ENGINE_EDITION_SQL_DATABASE

--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -50,6 +50,7 @@ matrix.setup.env-vars = [
 ]
 matrix.version.env-vars = [
   { key = "SQLSERVER_MAJOR_VERSION" },
+  { key = "SQLSERVER_ENGINE_EDITION" },
   { key = "SQLSERVER_IMAGE_TAG", value = "2017-CU24-ubuntu-16.04", if = ["2017"], platform = ["linux"] },
   { key = "SQLSERVER_IMAGE_TAG", value = "2019-CU11-ubuntu-16.04", if = ["2019"], platform = ["linux"] },
   { key = "SQLSERVER_BASE_IMAGE", value = "datadog/docker-library:sqlserver_{matrix:version}", platform = ["windows"] },

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -54,10 +54,11 @@ SERVER_METRICS = [
 ]
 
 SQLSERVER_MAJOR_VERSION = int(os.environ.get('SQLSERVER_MAJOR_VERSION'))
+SQLSERVER_ENGINE_EDITION = int(os.environ.get('SQLSERVER_ENGINE_EDITION'))
 
 
 def get_expected_file_stats_metrics():
-    query_file_stats = get_query_file_stats(SQLSERVER_MAJOR_VERSION)
+    query_file_stats = get_query_file_stats(SQLSERVER_MAJOR_VERSION, SQLSERVER_ENGINE_EDITION)
     return ["sqlserver." + c["name"] for c in query_file_stats["columns"] if c["type"] != "tag"]
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR fixes [an issue](https://github.com/DataDog/integrations-core/issues/14565) we are seeing, where we were not able to properly get the SQL Server major version in some cases and so some metrics were not being collected. For example, if the major_version was not set [we would not collect any file stats queries](https://github.com/DataDog/integrations-core/blob/master/sqlserver/datadog_checks/sqlserver/sqlserver.py#L746-L751). 

In particular, this bug affected Azure SQL DB & Azure SQL MI because the query we use to set the major_version (`SELECT @@VERSION`) recently stopped returning results in [the expected format](https://github.com/DataDog/integrations-core/blob/master/sqlserver/datadog_checks/sqlserver/utils.py#L107-L116) & now returns this:
```
Microsoft SQL Azure (RTM) - 12.0.2000.8  	May 22 2023 22:22:02  	Copyright (C) 2022 Microsoft Corporation 
```

In order to fix this, we can check for the `major_version` OR use the engine version to verify the host is an Azure SQL DB/ Azure SQL MI instance. This will give us the necessary information we need to make decisions about running queries further down in that function.

Here is proof of the fix in our integration environment:
 
![Screen Shot 2023-06-07 at 2 06 04 PM](https://github.com/DataDog/integrations-core/assets/14317240/f8be74cc-2067-4412-b4ef-bb7a34bae116)


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.