### PR TITLE
[NDM] SNMP Trap recommended monitor

### DIFF
--- a/snmp/assets/monitors/traps_linkDown.json
+++ b/snmp/assets/monitors/traps_linkDown.json
@@ -54,7 +54,7 @@
 					}
 				],
 				"search": {
-					"query": "source:snmp-traps @snmpTrapName:linkDown device_namespace:mimic @ifAdminStatus:up"
+					"query": "source:snmp-traps @snmpTrapName:linkDown @ifAdminStatus:up"
 				},
 				"storage": "hot"
 			},
@@ -94,7 +94,7 @@
 					}
 				],
 				"search": {
-					"query": "source:snmp-traps @snmpTrapName:linkUp device_namespace:mimic @ifAdminStatus:up"
+					"query": "source:snmp-traps @snmpTrapName:linkUp @ifAdminStatus:up"
 				},
 				"storage": "hot"
 			}

--- a/snmp/assets/monitors/traps_linkDown.json
+++ b/snmp/assets/monitors/traps_linkDown.json
@@ -2,7 +2,7 @@
 	"name": "SNMP Interface went down on device {{snmp_device.name}}",
 	"type": "log alert",
 	"query": "formula(\"default_zero(query1) / default_zero(query1) - default_zero(query) / default_zero(query)\").last(\"1m\") > 0.5",
-	"message": "{{#is_alert}}\nThe interface with index {{@ifIndex.name}} went down on device {{snmp_device.name}} while it's expected to be up.\nThe previous OperStatus of the interface is \"{{log.attributes.ifOperStatus}}\".\n{{/is_alert}}\n\n{{#is_recovery}}\nThe status of the interface with index {{@ifIndex.name}} is back to the \"up\" on device {{snmp_device.name}}.\n{{/is_recovery}}",
+	"message": "{{#is_alert}} \nA network device with IP {{snmp_device.name}} in namespace {{device_namespace.name}} is reporting CRITICAL and can't be monitored anymore.\n{{/is_alert}}\n\n{{#is_alert_recovery}}\nA network device with IP {{snmp_device.name}} in namespace {{device_namespace.name}} is back online.\n{{/is_alert_recovery}}\n\nTo know more about the status of your device, you can have more information from the [NDM page for the device {{device_namespace.name}}:{{snmp_device.name}}](/infrastructure/devices/graph?inspectedDevice={{device_namespace.name}}%3A{{snmp_device.name}}).",
 	"tags": [
 		"integration:snmp"
 	],

--- a/snmp/assets/monitors/traps_linkDown.json
+++ b/snmp/assets/monitors/traps_linkDown.json
@@ -1,0 +1,112 @@
+{
+	"name": "SNMP Interface went down on device {{snmp_device.name}}",
+	"type": "log alert",
+	"query": "formula(\"default_zero(query1) / default_zero(query1) - default_zero(query) / default_zero(query)\").last(\"1m\") > 0.5",
+	"message": "{{#is_alert}}\nThe interface with index {{@ifIndex.name}} went down on device {{snmp_device.name}} while it's expected to be up.\nThe previous OperStatus of the interface is \"{{log.attributes.ifOperStatus}}\".\n{{/is_alert}}\n\n{{#is_recovery}}\nThe status of the interface with index {{@ifIndex.name}} is back to the \"up\" on device {{snmp_device.name}}.\n{{/is_recovery}}",
+	"tags": [
+		"integration:snmp"
+	],
+	"options": {
+		"thresholds": {
+			"critical": 0.5,
+			"critical_recovery": -0.5
+		},
+		"enable_logs_sample": true,
+		"notify_audit": false,
+		"restriction_query": null,
+		"on_missing_data": "default",
+		"include_tags": true,
+		"new_group_delay": 0,
+		"variables": [
+			{
+				"data_source": "logs",
+				"name": "query1",
+				"indexes": [
+					"*"
+				],
+				"compute": {
+					"aggregation": "count"
+				},
+				"group_by": [
+					{
+						"facet": "snmp_device",
+						"limit": 5,
+						"sort": {
+							"order": "desc",
+							"aggregation": "count"
+						}
+					},
+					{
+						"facet": "device_namespace",
+						"limit": 5,
+						"sort": {
+							"order": "desc",
+							"aggregation": "count"
+						}
+					},
+					{
+						"facet": "@ifIndex",
+						"limit": 5,
+						"sort": {
+							"order": "desc",
+							"aggregation": "count"
+						}
+					}
+				],
+				"search": {
+					"query": "source:snmp-traps @snmpTrapName:linkDown device_namespace:mimic @ifAdminStatus:up"
+				},
+				"storage": "hot"
+			},
+			{
+				"data_source": "logs",
+				"name": "query",
+				"indexes": [
+					"*"
+				],
+				"compute": {
+					"aggregation": "count"
+				},
+				"group_by": [
+					{
+						"facet": "snmp_device",
+						"limit": 5,
+						"sort": {
+							"order": "desc",
+							"aggregation": "count"
+						}
+					},
+					{
+						"facet": "device_namespace",
+						"limit": 5,
+						"sort": {
+							"order": "desc",
+							"aggregation": "count"
+						}
+					},
+					{
+						"facet": "@ifIndex",
+						"limit": 5,
+						"sort": {
+							"order": "desc",
+							"aggregation": "count"
+						}
+					}
+				],
+				"search": {
+					"query": "source:snmp-traps @snmpTrapName:linkUp device_namespace:mimic @ifAdminStatus:up"
+				},
+				"storage": "hot"
+			}
+		],
+		"evaluation_delay": 60,
+		"group_retention_duration": "3d",
+		"groupby_simple_monitor": false,
+		"silenced": {}
+	},
+	"priority": null,
+	"restricted_roles": null,
+    "recommended_monitor_metadata": {
+        "description": "Notify your team when a linkDown trap is received. You can use this monitor as a template for setting up any traps monitor."
+    }
+}

--- a/snmp/manifest.json
+++ b/snmp/manifest.json
@@ -52,7 +52,8 @@
     "monitors": {
       "[SNMP] Device Down Alert": "assets/monitors/device_down.json",
       "[SNMP] Device Unreachable Alert": "assets/monitors/device_unreachable.json",
-      "[SNMP] Interface Down Alert": "assets/monitors/interface_down.json"
+      "[SNMP] Interface Down Alert": "assets/monitors/interface_down.json",
+      "[SNMP] LinkDown Trap Alert": "assets/monitors/traps_linkDown.json"
     }
   }
 }


### PR DESCRIPTION
Add recommended monitor for setting up alerts on SNMP Traps linkDown.

Example Monitor: https://dd.datad0g.com/monitors/create/log?recommendedMonitorID=snmp_%5Bsnmp%5D_linkdown_trap_alert