### PR TITLE
Restore the test case with SQL comment

### DIFF
--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -8,7 +8,6 @@ GRANT SELECT on sys.dm_os_performance_counters to datadog;
 GRANT VIEW SERVER STATE to datadog;
 GRANT CONNECT ANY DATABASE to datadog;
 GRANT VIEW ANY DEFINITION to datadog;
-GRANT ALTER SERVER STATE TO datadog;
 
 -- test users
 CREATE LOGIN bob WITH PASSWORD = 'Password12!';

--- a/sqlserver/tests/compose-ha/sql/aoag_secondary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_secondary.sql
@@ -16,7 +16,6 @@ GRANT SELECT on sys.dm_os_performance_counters to datadog;
 GRANT VIEW SERVER STATE to datadog;
 GRANT CONNECT ANY DATABASE to datadog;
 GRANT VIEW ANY DEFINITION to datadog;
-GRANT ALTER SERVER STATE TO datadog;
 
 --create login for aoag
 -- this password could also be originate from an environemnt variable passed in to this script through SQLCMD

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -10,7 +10,6 @@ CREATE USER datadog FOR LOGIN datadog;
 GRANT SELECT on sys.dm_os_performance_counters to datadog;
 GRANT VIEW SERVER STATE to datadog;
 GRANT VIEW ANY DEFINITION to datadog;
-GRANT ALTER SERVER STATE TO datadog;
 
 -- test users
 CREATE LOGIN bob WITH PASSWORD = 'Password12!';

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -5,7 +5,6 @@ GRANT SELECT on sys.dm_os_performance_counters to datadog;
 GRANT VIEW SERVER STATE to datadog;
 GRANT CONNECT ANY DATABASE to datadog;
 GRANT VIEW ANY DEFINITION to datadog;
-GRANT ALTER SERVER STATE TO datadog;
 
 -- Test users
 CREATE LOGIN bob WITH PASSWORD = 'Password12!';

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -10,7 +10,6 @@ CREATE USER datadog FOR LOGIN datadog;
 GRANT SELECT on sys.dm_os_performance_counters to datadog;
 GRANT VIEW SERVER STATE to datadog;
 GRANT VIEW ANY DEFINITION to datadog;
-GRANT ALTER SERVER STATE TO datadog;
 
 -- test users
 CREATE LOGIN bob WITH PASSWORD = 'Password12!';

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -5,7 +5,6 @@ GRANT SELECT on sys.dm_os_performance_counters to datadog;
 GRANT VIEW SERVER STATE to datadog;
 GRANT CONNECT ANY DATABASE to datadog;
 GRANT VIEW ANY DEFINITION to datadog;
-GRANT ALTER SERVER STATE TO datadog;
 
 -- test users
 CREATE LOGIN bob WITH PASSWORD = 'Password12!';

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -452,7 +452,9 @@ def test_statement_metadata(
 ):
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
-    query = 'select * from sys.databases'
+    query = '''
+    -- Test comment
+    select * from sys.sysusers'''
     query_signature = '6d1d070f9b6c5647'
 
     def _run_query():
@@ -643,13 +645,8 @@ def test_statement_reported_hostname(
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_statement_basic_metrics_query(datadog_conn_docker, dbm_instance):
-    # with datadog_conn_docker.cursor() as cursor:
-    #     cursor.execute('DBCC FREEPROCCACHE')
-
     now = time.time()
-    test_query = '''
-        -- Test comment
-        select * from sys.databases'''
+    test_query = "select * from sys.databases"
 
     # run this test query to guarantee there's at least one application query in the query plan cache
     with datadog_conn_docker.cursor() as cursor:

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -643,11 +643,13 @@ def test_statement_reported_hostname(
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_statement_basic_metrics_query(datadog_conn_docker, dbm_instance):
-    with datadog_conn_docker.cursor() as cursor:
-        cursor.execute('DBCC FREEPROCCACHE')
+    # with datadog_conn_docker.cursor() as cursor:
+    #     cursor.execute('DBCC FREEPROCCACHE')
 
     now = time.time()
-    test_query = "select * from sys.databases"
+    test_query = '''
+        -- Test comment
+        select * from sys.databases'''
 
     # run this test query to guarantee there's at least one application query in the query plan cache
     with datadog_conn_docker.cursor() as cursor:


### PR DESCRIPTION
### What does this PR do?
In the PR https://github.com/DataDog/integrations-core/pull/14495 we fixed the bug that prevented the correct functioning of statement metrics on the databases with Asian collations. 

In the course of fixing the bug, the customer removed an SQL comment from a test case, because this comment was causing the test case to fail on the first version of the bug fix. In the meantime, we arrived at a better solution. This PR restores the original test case with the aforementioned SQL comment.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.