### PR TITLE
Tag `is_leader` properly across all supported versions

### DIFF
--- a/etcd/datadog_checks/etcd/etcd.py
+++ b/etcd/datadog_checks/etcd/etcd.py
@@ -123,7 +123,7 @@ class Etcd(OpenMetricsBaseCheck):
         return response
 
     def is_leader(self, scraper_config):
-        response = self.access_api(scraper_config, '/v3/maintenance/status')
+        response = self.access_api(scraper_config, '/v3beta/maintenance/status')
 
         leader = response.get('leader')
         member = response.get('header', {}).get('member_id')

--- a/etcd/tests/test_integration.py
+++ b/etcd/tests/test_integration.py
@@ -26,6 +26,8 @@ def test_check(aggregator, instance, openmetrics_metrics, dd_run_check):
 
     tags = ['is_leader:{}'.format('true' if is_leader(URL) else 'false')]
 
+    # Make sure we assert at least one metric to make sure the expected tags are being added
+    aggregator.assert_metric('etcd.process.cpu.seconds.total', tags=tags)
     for metric in openmetrics_metrics:
         aggregator.assert_metric('etcd.{}'.format(metric), tags=tags, at_least=0)
 
@@ -211,7 +213,7 @@ def test_config(instance, test_case, extra_config, expected_http_kwargs, dd_run_
             'allow_redirects': mock.ANY,
         }
         http_kwargs.update(expected_http_kwargs)
-        r.post.assert_called_with(URL + '/v3/maintenance/status', **http_kwargs)
+        r.post.assert_called_with(URL + '/v3beta/maintenance/status', **http_kwargs)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### What does this PR do?

It ensures that a test where we were supposed to be looking at the presence of a tag was actually failing to test that due to `at_least=0` assertions. As a result, I also had to switch the endpoint again (at least temporarily) to one that is supported by all versions in our current test matrix.

### Motivation

QA for #14459. Ideally we would have wanted to catch that bug by ourselves.

### Additional Notes

I might follow this up with:

- Reducing our testing matrix to just 3.5 and 3.4, as anything older than that is not [officially supported](https://etcd.io/docs/v3.5/op-guide/versioning/). We might also remove the code for supporting legacy versions at the same time.
- I'd also like to get rid of the `is_leader()` function that we use in the tests to get the value dynamically. Once tests are simplified by not needing to test legacy, we could simply test for the `is_leader:` tag prefix in the integration test and use mocks in a unit test to test the logic itself.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.