### PR TITLE
Allow typed-ast to work for python3.11

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/plugin/hatch/environment_collector.py
+++ b/datadog_checks_dev/datadog_checks/dev/plugin/hatch/environment_collector.py
@@ -133,7 +133,8 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
             lint_env['dependencies'].extend(
                 [
                     # TODO: remove extra when we drop Python 2
-                    'mypy[python2]==0.910',
+                    'mypy[python2]==0.910; python_version<"3"',
+                    'mypy[python2]==1.3.0; python_version>"3"',
                     # TODO: remove these when drop Python 2 and replace with --install-types --non-interactive
                     'types-python-dateutil==2.8.2',
                     'types-pyyaml==5.4.10',


### PR DESCRIPTION
### What does this PR do?
`typed-ast` previously only worked on older Python versions. I added a line that uses a newer version of `typed-ast` for newer Python versions.

### Motivation
I was unable to run the style checks on my computer because I was using python3.11 and it wasn't compatible.

### Additional Notes
https://github.com/python/typed_ast/issues/167 -- this is our use case

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.