### PR TITLE
Rtrieu/docs 5530 fix ecs fargate loop

### DIFF
--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -741,7 +741,7 @@ partial -->
    | [.NET Core][54] |
    | [.NET Framework][55] |
 
-   Learn more about [instrumenting your application][32].
+   See more general information about [Sending Traces to Datadog][32].
 
 3. Ensure your application is running in the same task definition as the Datadog Agent container.
 

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -741,6 +741,8 @@ partial -->
    | [.NET Core][54] |
    | [.NET Framework][55] |
 
+   Learn more about [instrumenting your application][32].
+
 3. Ensure your application is running in the same task definition as the Datadog Agent container.
 
 ## Out-of-the-box tags

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -843,13 +843,13 @@ Need help? Contact [Datadog support][18].
 [44]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html
 [45]: https://github.com/DataDog/integrations-core/blob/master/ecs_fargate/assets/service_checks.json
 [46]: https://github.com/DataDog/integrations-core/blob/master/ecs_fargate/metadata.csv
-[47]: /tracing/trace_collection/dd_libraries/java?tab=containers#automatic-instrumentation
-[48]: /tracing/trace_collection/dd_libraries/python?tab=containers#instrument-your-application
-[49]: /tracing/trace_collection/dd_libraries/ruby#instrument-your-application
-[50]: /tracing/trace_collection/dd_libraries/go/?tab=containers#activate-go-integrations-to-create-spans
-[51]: /tracing/trace_collection/dd_libraries/nodejs?tab=containers#instrument-your-application
-[52]: /tracing/trace_collection/dd_libraries/php?tab=containers#automatic-instrumentation
-[53]: /tracing/trace_collection/dd_libraries/cpp?tab=containers#instrument-your-application
-[54]: /tracing/trace_collection/dd_libraries/dotnet-core?tab=containers#custom-instrumentation
-[55]:/tracing/trace_collection/dd_libraries/dotnet-framework?tab=containers#custom-instrumentation
+[47]: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/java?tab=containers#automatic-instrumentation
+[48]: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/python?tab=containers#instrument-your-application
+[49]: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/ruby#instrument-your-application
+[50]: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/go/?tab=containers#activate-go-integrations-to-create-spans
+[51]: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/nodejs?tab=containers#instrument-your-application
+[52]: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/php?tab=containers#automatic-instrumentation
+[53]: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/cpp?tab=containers#instrument-your-application
+[54]: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core?tab=containers#custom-instrumentation
+[55]: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-framework?tab=containers#custom-instrumentation
 

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -727,7 +727,7 @@ partial -->
 
 2. Instrument your application based on your setup:
 
-   **Note**: With **Fargate** APM applications, do **not** set `DD_AGENT_HOST` - the default of `localhost` works.
+   **Note**: With Fargate APM applications, do **not** set `DD_AGENT_HOST` - the default of `localhost` works.
 
    | Language                           |
    |------------------------------------|
@@ -740,6 +740,8 @@ partial -->
    | [C++][53] |
    | [.NET Core][54] |
    | [.NET Framework][55] |
+
+   Learn more about [instrumenting your application][32].
 
 3. Ensure your application is running in the same task definition as the Datadog Agent container.
 

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -725,7 +725,22 @@ Monitor Fargate logs by using the `awslogs` log driver and a Lambda function to 
 {{< /site-region >}}
 partial -->
 
-2. [Instrument your application][32] based on your setup. With Fargate APM applications do **not** set `DD_AGENT_HOST`, the default of `localhost` works.
+2. [Instrument your application][32] based on your setup.
+
+   **Note**: With **Fargate APM applications**, do **not** set `DD_AGENT_HOST` - the default of `localhost` works.
+
+   | Language                           |
+   |------------------------------------|
+   | [Java][47] |
+   | [Python][48] |
+   | [Ruby][49] |
+   | [Go][50] |
+   | [Node.js][51] |
+   | [PHP][52] |
+   | [C++][53] |
+   | [.NET Core][54] |
+   | [.NET Framework][55] |
+
 
 3. Ensure your application is running in the same task definition as the Datadog Agent container.
 
@@ -827,3 +842,13 @@ Need help? Contact [Datadog support][18].
 [44]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-service.html
 [45]: https://github.com/DataDog/integrations-core/blob/master/ecs_fargate/assets/service_checks.json
 [46]: https://github.com/DataDog/integrations-core/blob/master/ecs_fargate/metadata.csv
+[47]: /tracing/trace_collection/dd_libraries/java?tab=containers#automatic-instrumentation
+[48]: /tracing/trace_collection/dd_libraries/python?tab=containers#instrument-your-application
+[49]: /tracing/trace_collection/dd_libraries/ruby#instrument-your-application
+[50]: /tracing/trace_collection/dd_libraries/go/?tab=containers#activate-go-integrations-to-create-spans
+[51]: /tracing/trace_collection/dd_libraries/nodejs?tab=containers#instrument-your-application
+[52]: /tracing/trace_collection/dd_libraries/php?tab=containers#automatic-instrumentation
+[53]: /tracing/trace_collection/dd_libraries/cpp?tab=containers#instrument-your-application
+[54]: /tracing/trace_collection/dd_libraries/dotnet-core?tab=containers#custom-instrumentation
+[55]:/tracing/trace_collection/dd_libraries/dotnet-framework?tab=containers#custom-instrumentation
+

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -741,8 +741,6 @@ partial -->
    | [.NET Core][54] |
    | [.NET Framework][55] |
 
-   Learn more about [instrumenting your application][32].
-
 3. Ensure your application is running in the same task definition as the Datadog Agent container.
 
 ## Out-of-the-box tags

--- a/ecs_fargate/README.md
+++ b/ecs_fargate/README.md
@@ -725,9 +725,9 @@ Monitor Fargate logs by using the `awslogs` log driver and a Lambda function to 
 {{< /site-region >}}
 partial -->
 
-2. [Instrument your application][32] based on your setup.
+2. Instrument your application based on your setup:
 
-   **Note**: With **Fargate APM applications**, do **not** set `DD_AGENT_HOST` - the default of `localhost` works.
+   **Note**: With **Fargate** APM applications, do **not** set `DD_AGENT_HOST` - the default of `localhost` works.
 
    | Language                           |
    |------------------------------------|
@@ -740,7 +740,6 @@ partial -->
    | [C++][53] |
    | [.NET Core][54] |
    | [.NET Framework][55] |
-
 
 3. Ensure your application is running in the same task definition as the Datadog Agent container.
 


### PR DESCRIPTION
### What does this PR do?
- Fixes a documentation loop by replacing a single link that takes users to [Sending Traces to Dataodg](https://docs.datadoghq.com/tracing/trace_collection/) with a table that includes links by language, since instrumentation steps are different for each one
- Edits a grammatically questionable sentence about Fargate

### Motivation
Reduce reader confusion, as per [DOCS-5530](https://datadoghq.atlassian.net/browse/DOCS-5530).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.

[DOCS-5530]: https://datadoghq.atlassian.net/browse/DOCS-5530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ