### PR TITLE
Disable type checking for integrations that support Python 2

### DIFF
--- a/aerospike/hatch.toml
+++ b/aerospike/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
     "--py2",
     "--follow-imports silent",

--- a/azure_iot_edge/hatch.toml
+++ b/azure_iot_edge/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
   "--py2",
   "--check-untyped-defs",

--- a/citrix_hypervisor/hatch.toml
+++ b/citrix_hypervisor/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
     "--disallow-untyped-defs",
     "--py2",

--- a/cloud_foundry_api/hatch.toml
+++ b/cloud_foundry_api/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
     "--py2",
     "--install-types",

--- a/datadog_checks_base/hatch.toml
+++ b/datadog_checks_base/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
   "--py2",
   "--check-untyped-defs",

--- a/dns_check/hatch.toml
+++ b/dns_check/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
     "--py2",
     "--follow-imports silent",

--- a/glusterfs/hatch.toml
+++ b/glusterfs/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
   "--py2",
   "--install-types",

--- a/ibm_mq/hatch.toml
+++ b/ibm_mq/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
   "--py2",
   "--install-types",

--- a/marklogic/hatch.toml
+++ b/marklogic/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
     "--disallow-untyped-defs",
     "--py2",

--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -1,6 +1,6 @@
 [env.collectors.datadog-checks]
 base-package-features = ["deps", "db", "json"]
-check-types = true
+check-types = false
 mypy-args = [
   "--py2",
   "--check-untyped-defs",

--- a/postgres/hatch.toml
+++ b/postgres/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 base-package-features = ["deps", "db", "json"]
 
-check-types = true
+check-types = false
 mypy-args = [
   "--py2",
   "datadog_checks/",

--- a/rethinkdb/hatch.toml
+++ b/rethinkdb/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
     "--py2",
     "--disallow-untyped-defs",

--- a/singlestore/hatch.toml
+++ b/singlestore/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
     "--py2",
     "--disallow-untyped-defs",

--- a/snmp/hatch.toml
+++ b/snmp/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
     "--py2",
     "--disallow-untyped-defs",

--- a/snowflake/hatch.toml
+++ b/snowflake/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
     "--py2",
     "--install-types",

--- a/voltdb/hatch.toml
+++ b/voltdb/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
     "--py2",
     "--install-types",

--- a/vsphere/hatch.toml
+++ b/vsphere/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
   "--py2",
   "--disallow-untyped-defs",

--- a/wmi_check/hatch.toml
+++ b/wmi_check/hatch.toml
@@ -1,5 +1,5 @@
 [env.collectors.datadog-checks]
-check-types = true
+check-types = false
 mypy-args = [
   "--py2",
   "--disallow-untyped-defs",


### PR DESCRIPTION
### Motivation

https://github.com/DataDog/integrations-core/pull/14689 was a necessary fix but new versions of Mypy do not support Python 2

### Additional Notes

This will be required soon anyway as part of the process to only support Python 3 and use actual type annotations