### PR TITLE
Drop support for etcd < v3.4

### DIFF
--- a/etcd/assets/configuration/spec.yaml
+++ b/etcd/assets/configuration/spec.yaml
@@ -9,7 +9,7 @@ files:
     options:
       - name: use_preview
         description: |
-          Deprecated and unused. The Prometheus-based check is now the default and only implementation.
+          Deprecated and unused. The Prometheus-based check is the default and only implementation.
         hidden: true
         value:
           type: boolean

--- a/etcd/assets/configuration/spec.yaml
+++ b/etcd/assets/configuration/spec.yaml
@@ -9,8 +9,8 @@ files:
     options:
       - name: use_preview
         description: |
-          Enable this option to run the Prometheus-based check of etcd.
-          Note: This requires etcd v3 or greater.
+          Deprecated and unused. The Prometheus-based check is now the default and only implementation.
+        hidden: true
         value:
           type: boolean
           example: true
@@ -22,13 +22,6 @@ files:
         value:
           type: boolean
           example: true
-      - name: url
-        description: |
-          Note: the following configuration option is only available when `use_preview` option is set to `false`.
-          The API endpoint of your etcd instance.
-        value:
-          type: string
-          example: https://server:port
 
   - template: logs
     example:
@@ -63,8 +56,6 @@ files:
       description: |
         Prometheus endpoint of your etcd instance.
         One of possible_prometheus_urls or prometheus_url parameter is required.
-
-        Note: To monitor ETCD versions pre-3.x.x, set `use_preview` to `false` and use the `url` configuration option.
       required: false
       value:
         example: http://%%host%%:2379/metrics

--- a/etcd/datadog_checks/etcd/config_models/defaults.py
+++ b/etcd/datadog_checks/etcd/config_models/defaults.py
@@ -270,10 +270,6 @@ def instance_type_overrides(field, value):
     return get_default_field_value(field, value)
 
 
-def instance_url(field, value):
-    return 'https://server:port'
-
-
 def instance_use_legacy_auth_encoding(field, value):
     return True
 

--- a/etcd/datadog_checks/etcd/config_models/instance.py
+++ b/etcd/datadog_checks/etcd/config_models/instance.py
@@ -133,7 +133,6 @@ class InstanceConfig(BaseModel):
     tls_use_host_header: Optional[bool]
     tls_verify: Optional[bool]
     type_overrides: Optional[Mapping[str, Any]]
-    url: Optional[str]
     use_legacy_auth_encoding: Optional[bool]
     use_preview: Optional[bool]
     use_process_start_time: Optional[bool]

--- a/etcd/datadog_checks/etcd/data/auto_conf.yaml
+++ b/etcd/datadog_checks/etcd/data/auto_conf.yaml
@@ -26,8 +26,6 @@ instances:
     ## @param prometheus_url - string - optional - default: http://%%host%%:2379/metrics
     ## Prometheus endpoint of your etcd instance.
     ## One of possible_prometheus_urls or prometheus_url parameter is required.
-    ##
-    ## Note: To monitor ETCD versions pre-3.x.x, set `use_preview` to `false` and use the `url` configuration option.
     #
     # prometheus_url: http://%%host%%:2379/metrics
 

--- a/etcd/datadog_checks/etcd/data/conf.yaml.example
+++ b/etcd/datadog_checks/etcd/data/conf.yaml.example
@@ -45,13 +45,6 @@ init_config:
 #
 instances:
 
-  -
-    ## @param use_preview - boolean - optional - default: true
-    ## Enable this option to run the Prometheus-based check of etcd.
-    ## Note: This requires etcd v3 or greater.
-    #
-    # use_preview: true
-
     ## @param prometheus_url - string - required
     ## The URL where your application metrics are exposed by Prometheus.
     #
@@ -542,12 +535,6 @@ instances:
     ## Enable to tag metrics with `is_leader:true` or `is_leader:false`.
     #
     # leader_tag: true
-
-    ## @param url - string - optional - default: https://server:port
-    ## Note: the following configuration option is only available when `use_preview` option is set to `false`.
-    ## The API endpoint of your etcd instance.
-    #
-    # url: https://server:port
 
 ## Log Section
 ##

--- a/etcd/datadog_checks/etcd/etcd.py
+++ b/etcd/datadog_checks/etcd/etcd.py
@@ -1,11 +1,9 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import requests
 from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base import ConfigurationError, OpenMetricsBaseCheck, is_affirmative
-from datadog_checks.base.errors import CheckException
 
 from .metrics import METRIC_MAP
 
@@ -65,25 +63,13 @@ class Etcd(OpenMetricsBaseCheck):
 
     def __init__(self, name, init_config, instances):
 
-        instance = instances[0]
-        if is_affirmative(instance.get('use_preview', True)):
-            self.HTTP_CONFIG_REMAPPER = {
-                'ssl_cert': {'name': 'tls_cert'},
-                'ssl_private_key': {'name': 'tls_private_key'},
-                'ssl_ca_cert': {'name': 'tls_ca_cert'},
-                'ssl_verify': {'name': 'tls_verify'},
-                'prometheus_timeout': {'name': 'timeout'},
-            }
-        else:
-            # For legacy check ensure prometheus_url is set so
-            # OpenMetricsBaseCheck instantiation succeeds
-            instance.setdefault('prometheus_url', '')
-            self.HTTP_CONFIG_REMAPPER = {
-                'ssl_keyfile': {'name': 'tls_private_key'},
-                'ssl_certfile': {'name': 'tls_cert'},
-                'ssl_cert_validation': {'name': 'tls_verify'},
-                'ssl_ca_certs': {'name': 'tls_ca_cert'},
-            }
+        self.HTTP_CONFIG_REMAPPER = {
+            'ssl_cert': {'name': 'tls_cert'},
+            'ssl_private_key': {'name': 'tls_private_key'},
+            'ssl_ca_cert': {'name': 'tls_ca_cert'},
+            'ssl_verify': {'name': 'tls_verify'},
+            'prometheus_timeout': {'name': 'timeout'},
+        }
 
         super(Etcd, self).__init__(
             name,
@@ -103,11 +89,7 @@ class Etcd(OpenMetricsBaseCheck):
         )
 
     def check(self, _):
-        if is_affirmative(self.instance.get('use_preview', True)):
-            self.check_post_v3()
-        else:
-            self.warning('In the future etcd check will only support ETCD v3+.')
-            self.check_pre_v3()
+        self.check_post_v3()
 
     def access_api(self, scraper_config, path, data='{}'):
         url = urlparse(scraper_config['prometheus_url'])
@@ -164,169 +146,5 @@ class Etcd(OpenMetricsBaseCheck):
         # Needed for backward compatibility, we continue to submit `etcd.server.version` metric
         self.submit_openmetric('server.version', metric, scraper_config)
 
-    def check_pre_v3(self):
-        if 'url' not in self.instance:
-            raise ConfigurationError('etcd instance missing "url" value.')
-
-        # Load values from the instance config
-        url = self.instance['url']
-        instance_tags = self.instance.get('tags', [])
-
-        # Get a copy of tags for the CRIT statuses
-        critical_tags = list(instance_tags)
-
-        # Append the instance's URL in case there are more than one, that
-        # way they can tell the difference!
-        instance_tags.append('url:{}'.format(url))
-        is_leader = False
-
-        # Gather self health status
-        sc_state = self.UNKNOWN
-        health_status = self._get_health_status(url)
-        if health_status is not None:
-            sc_state = self.OK if self._is_healthy(health_status) else self.CRITICAL
-        self.service_check(self.HEALTH_SERVICE_CHECK_NAME, sc_state, tags=instance_tags)
-
-        # Gather self metrics
-        self_response = self._get_self_metrics(url, critical_tags)
-        if self_response is not None:
-            if self_response['state'] == 'StateLeader':
-                is_leader = True
-                instance_tags.append('etcd_state:leader')
-                gauges = self.LEADER_GAUGES
-            else:
-                instance_tags.append('etcd_state:follower')
-                gauges = self.FOLLOWER_GAUGES
-
-            for key in self.SELF_RATES:
-                if key in self_response:
-                    self.rate(self.SELF_RATES[key], self_response[key], tags=instance_tags)
-                else:
-                    self.log.warning('Missing key %s in stats.', key)
-
-            for key in gauges:
-                if key in self_response:
-                    self.gauge(gauges[key], self_response[key], tags=instance_tags)
-                else:
-                    self.log.warning('Missing key %s in stats.', key)
-
-        # Gather store metrics
-        store_response = self._get_store_metrics(url, critical_tags)
-        if store_response is not None:
-            for key in self.STORE_RATES:
-                if key in store_response:
-                    self.rate(self.STORE_RATES[key], store_response[key], tags=instance_tags)
-                else:
-                    self.log.warning('Missing key %s in stats.', key)
-
-            for key in self.STORE_GAUGES:
-                if key in store_response:
-                    self.gauge(self.STORE_GAUGES[key], store_response[key], tags=instance_tags)
-                else:
-                    self.log.warning('Missing key %s in stats.', key)
-
-        # Gather leader metrics
-        if is_leader:
-            leader_response = self._get_leader_metrics(url, critical_tags)
-            if leader_response is not None and len(leader_response.get("followers", {})) > 0:
-                # Get the followers
-                followers = leader_response.get("followers")
-                for fol in followers:
-                    # counts
-                    for key in self.LEADER_COUNTS:
-                        self.rate(
-                            self.LEADER_COUNTS[key],
-                            followers[fol].get("counts").get(key),
-                            tags=instance_tags + ['follower:{}'.format(fol)],
-                        )
-                    # latency
-                    for key in self.LEADER_LATENCY:
-                        self.gauge(
-                            self.LEADER_LATENCY[key],
-                            followers[fol].get("latency").get(key),
-                            tags=instance_tags + ['follower:{}'.format(fol)],
-                        )
-
-        # Service check
-        if self_response is not None and store_response is not None:
-            self.service_check(self.SERVICE_CHECK_NAME, self.OK, tags=instance_tags)
-
-        self._collect_metadata(url, critical_tags)
-
-    def _get_health_status(self, url):
-        """
-        Don't send the "can connect" service check if we have troubles getting
-        the health status
-        """
-        try:
-            r = self._perform_request(url, "/health")
-            # we don't use get() here so we can report a KeyError
-            return r.json()[self.HEALTH_KEY]
-        except Exception as e:
-            self.log.debug("Can't determine health status: %s", e)
-
-    def _get_self_metrics(self, url, tags):
-        return self._get_json(url, "/v2/stats/self", tags)
-
-    def _get_store_metrics(self, url, tags):
-        return self._get_json(url, "/v2/stats/store", tags)
-
-    def _get_leader_metrics(self, url, tags):
-        return self._get_json(url, "/v2/stats/leader", tags)
-
     def _perform_request(self, url, path):
         return self.http.get(url + path)
-
-    def _get_json(self, url, path, tags):
-        try:
-            r = self._perform_request(url, path)
-        except requests.exceptions.Timeout:
-            self.service_check(
-                self.SERVICE_CHECK_NAME,
-                self.CRITICAL,
-                message='Timeout when hitting {}'.format(url),
-                tags=tags + ['url:{}'.format(url)],
-            )
-            raise
-        except Exception as e:
-            self.service_check(
-                self.SERVICE_CHECK_NAME,
-                self.CRITICAL,
-                message='Error hitting {}. Error: {}'.format(url, str(e)),
-                tags=tags + ['url:{}'.format(url)],
-            )
-            raise
-
-        if r.status_code != 200:
-            self.service_check(
-                self.SERVICE_CHECK_NAME,
-                self.CRITICAL,
-                message='Got {} when hitting {}'.format(r.status_code, url),
-                tags=tags + ['url:{}'.format(url)],
-            )
-            raise CheckException('Http status code {} on url {}'.format(r.status_code, url))
-
-        return r.json()
-
-    @classmethod
-    def _is_healthy(cls, status):
-        """
-        Version of etcd prior to 3.3 return this payload when you hit /health:
-          {"health": "true"}
-
-        which is wrong since the value is a `bool` on etcd.
-
-        Version 3.3 fixed this issue in https://github.com/coreos/etcd/pull/8312
-        but we need to support both.
-        """
-        if isinstance(status, bool):
-            return status
-
-        return status == "true"
-
-    def _collect_metadata(self, url, tags):
-        resp = self._get_json(url, "/version", tags)
-        server_version = resp.get('etcdserver')
-        self.log.debug("Agent version is `%s`", server_version)
-        if server_version:
-            self.set_metadata('version', server_version)

--- a/etcd/hatch.toml
+++ b/etcd/hatch.toml
@@ -2,15 +2,12 @@
 
 [[envs.default.matrix]]
 python = ["2.7", "3.8"]
-version = ["v3.3.8", "v3.3.9", "v3.3.10" , "v3.5.1"]
+version = ["v3.4.26" , "v3.5.9"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
     { key = "ETCD_VERSION" },
-    { key = "V3_PREVIEW", value = "false", if = ["v3.3.8", "v3.3.9"] },
-    { key = "DDEV_SKIP_GENERIC_TAGS_CHECK", value = "false", if = ["v3.3.8", "v3.3.9"] },
 ]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
-V3_PREVIEW = "true"

--- a/etcd/tests/common.py
+++ b/etcd/tests/common.py
@@ -9,7 +9,7 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 COMPOSE_FILE = os.path.join(HERE, 'docker', 'docker-compose.yaml')
 HOST = get_docker_hostname()
 PORT = '23790'
-V3_PREVIEW = os.getenv('V3_PREVIEW') == 'true'
+V3_PREVIEW = True
 URL = 'http://{}:{}'.format(HOST, PORT)
 
 LEGACY_INSTANCE = {'url': URL, 'use_preview': False}

--- a/etcd/tests/common.py
+++ b/etcd/tests/common.py
@@ -9,7 +9,6 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 COMPOSE_FILE = os.path.join(HERE, 'docker', 'docker-compose.yaml')
 HOST = get_docker_hostname()
 PORT = '23790'
-V3_PREVIEW = True
 URL = 'http://{}:{}'.format(HOST, PORT)
 
 LEGACY_INSTANCE = {'url': URL, 'use_preview': False}

--- a/etcd/tests/conftest.py
+++ b/etcd/tests/conftest.py
@@ -1,22 +1,16 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import copy
-
 import pytest
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckEndpoints
 from datadog_checks.etcd.metrics import METRIC_MAP
 
-from .common import COMPOSE_FILE, LEGACY_INSTANCE, URL
+from .common import COMPOSE_FILE, URL
 
 # Needed to mount volume for logging
 E2E_METADATA = {'docker_volumes': ['/var/run/docker.sock:/var/run/docker.sock:ro']}
-
-
-def add_key():
-    pass
 
 
 @pytest.fixture(scope='session')
@@ -24,13 +18,8 @@ def dd_environment(instance):
     endpoints = '{}/metrics'.format(URL)
 
     # Sleep a bit so all metrics are available
-    with docker_run(COMPOSE_FILE, conditions=[CheckEndpoints(endpoints), add_key], sleep=3):
+    with docker_run(COMPOSE_FILE, conditions=[CheckEndpoints(endpoints)], sleep=3):
         yield instance, E2E_METADATA
-
-
-@pytest.fixture(scope='session')
-def legacy_instance():
-    return copy.deepcopy(LEGACY_INSTANCE)
 
 
 @pytest.fixture(scope='session')

--- a/etcd/tests/conftest.py
+++ b/etcd/tests/conftest.py
@@ -4,29 +4,24 @@
 import copy
 
 import pytest
-import requests
 
 from datadog_checks.dev import docker_run
 from datadog_checks.dev.conditions import CheckEndpoints
 from datadog_checks.etcd.metrics import METRIC_MAP
 
-from .common import COMPOSE_FILE, LEGACY_INSTANCE, URL, V3_PREVIEW
+from .common import COMPOSE_FILE, LEGACY_INSTANCE, URL
 
 # Needed to mount volume for logging
 E2E_METADATA = {'docker_volumes': ['/var/run/docker.sock:/var/run/docker.sock:ro']}
 
 
 def add_key():
-    if not V3_PREVIEW:
-        requests.post('{}/v2/keys/message'.format(URL), data={'value': 'Hello world'})
+    pass
 
 
 @pytest.fixture(scope='session')
 def dd_environment(instance):
-    if V3_PREVIEW:
-        endpoints = '{}/metrics'.format(URL)
-    else:
-        endpoints = ('{}/v2/stats/self'.format(URL), '{}/v2/stats/store'.format(URL))
+    endpoints = '{}/metrics'.format(URL)
 
     # Sleep a bit so all metrics are available
     with docker_run(COMPOSE_FILE, conditions=[CheckEndpoints(endpoints), add_key], sleep=3):
@@ -40,10 +35,7 @@ def legacy_instance():
 
 @pytest.fixture(scope='session')
 def instance():
-    if V3_PREVIEW:
-        return {'use_preview': True, 'prometheus_url': '{}/metrics'.format(URL)}
-    else:
-        return copy.deepcopy(LEGACY_INSTANCE)
+    return {'use_preview': True, 'prometheus_url': '{}/metrics'.format(URL)}
 
 
 @pytest.fixture(scope='session')

--- a/etcd/tests/conftest.py
+++ b/etcd/tests/conftest.py
@@ -24,7 +24,7 @@ def dd_environment(instance):
 
 @pytest.fixture(scope='session')
 def instance():
-    return {'use_preview': True, 'prometheus_url': '{}/metrics'.format(URL)}
+    return {'prometheus_url': '{}/metrics'.format(URL)}
 
 
 @pytest.fixture(scope='session')

--- a/etcd/tests/test_integration.py
+++ b/etcd/tests/test_integration.py
@@ -5,20 +5,17 @@ from copy import deepcopy
 
 import mock
 import pytest
-import requests
 
-from datadog_checks.dev import run_command
 from datadog_checks.etcd import Etcd
 
-from .common import COMPOSE_FILE, ETCD_VERSION, HOST, REMAPED_DEBUGGING_METRICS, STORE_METRICS, URL
-from .utils import is_leader, legacy, preview
+from .common import ETCD_VERSION, REMAPED_DEBUGGING_METRICS, URL
+from .utils import is_leader
 
 CHECK_NAME = 'etcd'
 
 pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')]
 
 
-@preview
 @pytest.mark.integration
 def test_check(aggregator, instance, openmetrics_metrics, dd_run_check):
     check = Etcd('etcd', {}, [instance])
@@ -35,7 +32,6 @@ def test_check(aggregator, instance, openmetrics_metrics, dd_run_check):
     aggregator.assert_all_metrics_covered()
 
 
-@preview
 @pytest.mark.integration
 def test_check_no_leader_tag(aggregator, instance, openmetrics_metrics, dd_run_check):
     instance = deepcopy(instance)
@@ -53,7 +49,6 @@ def test_check_no_leader_tag(aggregator, instance, openmetrics_metrics, dd_run_c
     aggregator.assert_all_metrics_covered()
 
 
-@preview
 @pytest.mark.integration
 def test_service_check(aggregator, instance, dd_run_check):
     check = Etcd(CHECK_NAME, {}, [instance])
@@ -64,122 +59,6 @@ def test_service_check(aggregator, instance, dd_run_check):
     aggregator.assert_service_check('etcd.prometheus.health', Etcd.OK, tags=tags, count=1)
 
 
-@legacy
-@pytest.mark.integration
-def test_bad_config(aggregator, dd_run_check):
-    bad_url = '{}/test'.format(URL)
-    instance = {'url': bad_url, 'use_preview': False}
-    check = Etcd(CHECK_NAME, {}, [instance])
-
-    with pytest.raises(Exception):
-        dd_run_check(check)
-
-    aggregator.assert_service_check(check.SERVICE_CHECK_NAME, tags=['url:{}'.format(bad_url)], count=1)
-    aggregator.assert_service_check(check.HEALTH_SERVICE_CHECK_NAME)
-
-
-@legacy
-@pytest.mark.integration
-def test_legacy_metrics(legacy_instance, aggregator, dd_run_check):
-    check = Etcd(CHECK_NAME, {}, [legacy_instance])
-    dd_run_check(check)
-
-    tags = ['url:{}'.format(URL), 'etcd_state:{}'.format('leader' if is_leader(URL) else 'follower')]
-
-    for mname in STORE_METRICS:
-        aggregator.assert_metric('etcd.store.{}'.format(mname), tags=tags, count=1)
-
-    aggregator.assert_metric('etcd.self.send.appendrequest.count', tags=tags, count=1)
-    aggregator.assert_metric('etcd.self.recv.appendrequest.count', tags=tags, count=1)
-
-
-@legacy
-@pytest.mark.integration
-def test_legacy_service_checks(legacy_instance, aggregator, dd_run_check):
-    check = Etcd(CHECK_NAME, {}, [legacy_instance])
-    dd_run_check(check)
-
-    tags = ['url:{}'.format(URL), 'etcd_state:{}'.format('leader' if is_leader(URL) else 'follower')]
-
-    aggregator.assert_service_check(check.SERVICE_CHECK_NAME, tags=tags, count=1)
-    aggregator.assert_service_check(check.HEALTH_SERVICE_CHECK_NAME, tags=tags[:1], count=1)
-
-
-@legacy
-@pytest.mark.integration
-def test_followers(aggregator, dd_run_check):
-    urls = []
-    result = run_command('docker compose -f {} ps -q'.format(COMPOSE_FILE), capture='out', check=True)
-    container_ids = result.stdout.splitlines()
-
-    for container_id in container_ids:
-        result = run_command('docker port {} 2379/tcp'.format(container_id), capture='out', check=True)
-        port = result.stdout.strip().split(':')[-1]
-        urls.append('http://{}:{}'.format(HOST, port))
-
-    for url in urls:
-        if is_leader(url):
-            break
-    else:
-        raise Exception('No leader found')
-
-    response = requests.get('{}/v2/stats/leader'.format(url))
-    followers = list(response.json().get('followers', {}).keys())
-
-    instance = {'url': url, 'use_preview': False}
-    check = Etcd(CHECK_NAME, {}, [instance])
-    dd_run_check(check)
-
-    common_leader_tags = ['url:{}'.format(url), 'etcd_state:leader']
-    follower_tags = [
-        common_leader_tags + ['follower:{}'.format(followers[0])],
-        common_leader_tags + ['follower:{}'.format(followers[1])],
-    ]
-
-    for fol_tags in follower_tags:
-        aggregator.assert_metric('etcd.leader.counts.fail', count=1, tags=fol_tags)
-        aggregator.assert_metric('etcd.leader.counts.success', count=1, tags=fol_tags)
-        aggregator.assert_metric('etcd.leader.latency.avg', count=1, tags=fol_tags)
-        aggregator.assert_metric('etcd.leader.latency.min', count=1, tags=fol_tags)
-        aggregator.assert_metric('etcd.leader.latency.max', count=1, tags=fol_tags)
-        aggregator.assert_metric('etcd.leader.latency.stddev', count=1, tags=fol_tags)
-        aggregator.assert_metric('etcd.leader.latency.current', count=1, tags=fol_tags)
-
-
-@legacy
-@pytest.mark.parametrize(
-    'test_case, extra_config, expected_http_kwargs',
-    [
-        ("new auth config", {'username': 'new_foo', 'password': 'new_bar'}, {'auth': ('new_foo', 'new_bar')}),
-        ("legacy ssl config True", {'ssl_cert_validation': True}, {'verify': True}),
-        ("legacy ssl config False", {'ssl_cert_validation': False}, {'verify': False}),
-        ("legacy ssl config unset", {}, {'verify': False}),
-    ],
-)
-@pytest.mark.integration
-def test_config_legacy(legacy_instance, test_case, extra_config, expected_http_kwargs, dd_run_check):
-    legacy_instance.update(extra_config)
-    check = Etcd(CHECK_NAME, {}, [legacy_instance])
-
-    with mock.patch('datadog_checks.base.utils.http.requests') as r:
-        r.get.return_value = mock.MagicMock(status_code=200)
-
-        dd_run_check(check)
-
-        http_kwargs = {
-            'auth': mock.ANY,
-            'cert': mock.ANY,
-            'headers': mock.ANY,
-            'proxies': mock.ANY,
-            'timeout': mock.ANY,
-            'verify': mock.ANY,
-            'allow_redirects': mock.ANY,
-        }
-        http_kwargs.update(expected_http_kwargs)
-        r.get.assert_has_calls([mock.call(URL + '/v2/stats/store', **http_kwargs)])
-
-
-@preview
 @pytest.mark.parametrize(
     'test_case, extra_config, expected_http_kwargs',
     [

--- a/etcd/tests/test_integration.py
+++ b/etcd/tests/test_integration.py
@@ -23,6 +23,8 @@ def test_check(aggregator, instance, openmetrics_metrics, dd_run_check):
 
     tags = ['is_leader:{}'.format('true' if is_leader(URL) else 'false')]
 
+    # Make sure we assert at least one metric to make sure the expected tags are being added
+    aggregator.assert_metric('etcd.process.cpu.seconds.total', tags=tags)
     for metric in openmetrics_metrics:
         aggregator.assert_metric('etcd.{}'.format(metric), tags=tags, at_least=0)
 
@@ -40,6 +42,8 @@ def test_check_no_leader_tag(aggregator, instance, openmetrics_metrics, dd_run_c
     check = Etcd('etcd', {}, [instance])
     dd_run_check(check)
 
+    # Make sure we assert at least one metric to make sure the leader tag is indeed not there
+    aggregator.assert_metric('etcd.process.cpu.seconds.total', tags=[])
     for metric in openmetrics_metrics:
         aggregator.assert_metric('etcd.{}'.format(metric), tags=[], at_least=0)
 

--- a/etcd/tests/utils.py
+++ b/etcd/tests/utils.py
@@ -5,7 +5,7 @@ import requests
 
 
 def is_leader(url):
-    response = requests.post('{}/v3beta/maintenance/status'.format(url), data='{}').json()
+    response = requests.post('{}/v3/maintenance/status'.format(url), data='{}').json()
     leader = response.get('leader')
     member = response.get('header', {}).get('member_id')
 

--- a/etcd/tests/utils.py
+++ b/etcd/tests/utils.py
@@ -4,20 +4,15 @@
 import pytest
 import requests
 
-from .common import V3_PREVIEW
+V3_PREVIEW = True
 
 legacy = pytest.mark.skipif(V3_PREVIEW, reason='Requires < v3')
 preview = pytest.mark.skipif(not V3_PREVIEW, reason='Requires >= v3')
 
 
 def is_leader(url):
-    if V3_PREVIEW:
-        response = requests.post('{}/v3beta/maintenance/status'.format(url), data='{}').json()
-        leader = response.get('leader')
-        member = response.get('header', {}).get('member_id')
+    response = requests.post('{}/v3beta/maintenance/status'.format(url), data='{}').json()
+    leader = response.get('leader')
+    member = response.get('header', {}).get('member_id')
 
-        return leader and member and leader == member
-    else:
-        response = requests.get('{}/v2/stats/self'.format(url))
-
-        return response.json().get('state') == 'StateLeader'
+    return leader and member and leader == member

--- a/etcd/tests/utils.py
+++ b/etcd/tests/utils.py
@@ -1,13 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import pytest
 import requests
-
-V3_PREVIEW = True
-
-legacy = pytest.mark.skipif(V3_PREVIEW, reason='Requires < v3')
-preview = pytest.mark.skipif(not V3_PREVIEW, reason='Requires >= v3')
 
 
 def is_leader(url):


### PR DESCRIPTION
### What does this PR do?

Drops support for etcd versions below v3.4. Technically the code changes might actually drop support for just etcd v2, but we're removing everything below 3.4 from the testing matrix.

### Motivation

#14458 brought to our attention that the [etcd project only supports the current and previous release](https://etcd.io/docs/v3.5/op-guide/versioning/), which currently means v3.5 and v3.4.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.