### PR TITLE
Handle None return value from RetrievePropertiesEx

### DIFF
--- a/vsphere/datadog_checks/vsphere/api.py
+++ b/vsphere/datadog_checks/vsphere/api.py
@@ -213,6 +213,14 @@ class VSphereAPI(object):
 
             # Collect the objects and their properties
             res = content.propertyCollector.RetrievePropertiesEx([filter_spec], retr_opts)
+            if res is None:
+                self.log.warning(
+                    "Did not retrieve any properties from the vCenter. Metric collection cannot continue. "
+                    "Ensure your user has correct permissions."
+                )
+                obj_content_list = []
+                return obj_content_list
+
             obj_content_list = res.objects
             # Results can be paginated
             while res.token is not None:


### PR DESCRIPTION
### What does this PR do?
Handle a None return value from RetrievePropertiesEx: https://vdc-download.vmware.com/vmwb-repository/dcr-public/fe08899f-1eec-4d8d-b3bc-a6664c168c2c/7fdf97a1-4c0d-4be0-9d43-2ceebbc174d9/doc/vmodl.query.PropertyCollector.html#retrievePropertiesEx'
### Motivation
We have received a few support cases where an exception is thrown when retrieving the infrastructure data.

From the [documentation](https://vdc-download.vmware.com/vmwb-repository/dcr-public/fe08899f-1eec-4d8d-b3bc-a6664c168c2c/7fdf97a1-4c0d-4be0-9d43-2ceebbc174d9/doc/vmodl.query.PropertyCollector.html#retrievePropertiesEx), this method can return None. In our case, this is usually is due to lack of permissions to view all objects.

```
File "DataDog/integrations-core/vsphere/datadog_checks/vsphere/api.py", line 224, in _get_raw_infrastructure
E       obj_content_list = res.objects
E   AttributeError: 'NoneType' object has no attribute 'objects'
```
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.