### PR TITLE
Use the `driver-env.sh` file instead of `master-params`

### DIFF
--- a/databricks/README.md
+++ b/databricks/README.md
@@ -82,8 +82,8 @@ if [[ \${DB_IS_DRIVER} = "TRUE" ]]; then
 
   # WAITING UNTIL MASTER PARAMS ARE LOADED, THEN GRABBING IP AND PORT
   while [ -z \$gotparams ]; do
-    if [ -e "/tmp/master-params" ]; then
-      DB_DRIVER_PORT=\$(cat /tmp/master-params | cut -d' ' -f2)
+    if [ -e "/tmp/driver-env.sh" ]; then
+      DB_DRIVER_PORT=\$(cat /tmp/driver-env.sh | cut -d' ' -f2)
       gotparams=TRUE
     fi
     sleep 2


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use the `driver-env.sh` file instead of `master-params`

### Motivation
<!-- What inspired you to submit this pull request? -->

- The driver-only script was not using the correct file. The `all-node` and `job cluster` scripts are already correct. 
- https://docs.databricks.com/_extras/notebooks/source/datadog-init-script.html

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.