### PR TITLE
Fix labeler

### DIFF
--- a/.github/workflows/changelog-label-check.yml
+++ b/.github/workflows/changelog-label-check.yml
@@ -1,21 +1,19 @@
 name: Changelog label check
 on:
   pull_request:
-    types: [labeled, unlabeled]
+    types: [opened, labeled, unlabeled, synchronize]
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-      with:
-        ref: ${{ github.ref }}
+    - uses: actions/checkout@v3
 
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: '3.8'
-      
+
     - name: Check changelog label
       run: python .github/workflows/changelog-label-check.py
 

--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -15,7 +15,7 @@ dependencies:
 dependency_provider:
 - datadog_checks_dependency_provider/**/*
 dev/testing:
-- .azure-pipelines/**
+- .github/workflows/**
 - .codecov.yml
 dev/tooling:
 - .github/workflows/**

--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -8,7 +8,7 @@ changelog/no-changelog:
 - all:
   - '*/!(pyproject.toml)'
 - all:
-  - '*/(!ddev)/**'
+  - '*/!(ddev)/**'
 ddev:
 - ddev/**/*
 dependencies:

--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -1,14 +1,13 @@
 base_package:
 - datadog_checks_base/**/*
 changelog/no-changelog:
-- requirements-agent-release.txt
-- '*/__about__.py'
+- any:
+  - requirements-agent-release.txt
+  - '*/__about__.py'
 - all:
-  - '*/!(datadog_checks)/**'
-- all:
-  - '*/!(pyproject.toml)'
-- all:
-  - '*/!(ddev)/**'
+  - '!*/datadog_checks/**'
+  - '!*/pyproject.toml'
+  - '!*/ddev/**'
 ddev:
 - ddev/**/*
 dependencies:

--- a/ddev/hatch.toml
+++ b/ddev/hatch.toml
@@ -4,6 +4,7 @@ mypy-args = [
   "src/ddev",
 ]
 
+
 [envs.default]
 python = "3.8"
 e2e-env = false

--- a/ddev/hatch.toml
+++ b/ddev/hatch.toml
@@ -4,7 +4,6 @@ mypy-args = [
   "src/ddev",
 ]
 
-
 [envs.default]
 python = "3.8"
 e2e-env = false


### PR DESCRIPTION
### Motivation

- Check job was not running on commits
- `changelog/no-changelog`
   - ddev was always getting it
   - it was generally not working as expected due to the use of pseudo-regex syntax