### PR TITLE
Improve IBM WAS env startup detection to make tests more robust

### DIFF
--- a/ibm_was/tests/conftest.py
+++ b/ibm_was/tests/conftest.py
@@ -28,7 +28,7 @@ def dd_environment():
     with docker_run(
         compose_file,
         conditions=[
-            CheckDockerLogs(compose_file, 'Server server1 open for e-business', attempts=80, wait=2),
+            CheckDockerLogs(compose_file, 'The SSL configuration alias is NodeDefaultSSLSettings', attempts=80, wait=3),
             StartPerfServlet(),
             CheckEndpoints(common.INSTANCE['servlet_url']),
         ],


### PR DESCRIPTION
### What does this PR do?

Tries to avoid the test failures we were seeing by monitoring for a line that comes later in IBM WAS' startup process.

### Motivation

Tests had been failing for a while for IBM WAS, and the culprit seemed to be that the docker image startup wasn't completing properly. I was able to reproduce locally. I don't know what changed to start seeing this failure, though.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.