### PR TITLE
Update confluent-kafka dependency used in mapr tests

### DIFF
--- a/mapr/hatch.toml
+++ b/mapr/hatch.toml
@@ -2,7 +2,7 @@
 
 [envs.default]
 dependencies = [
-  "confluent_kafka==1.4.1",
+  "confluent_kafka==1.7.0",
 ]
 
 [[envs.default.matrix]]

--- a/mapr/tests/conftest.py
+++ b/mapr/tests/conftest.py
@@ -12,9 +12,8 @@ from . import common
 E2E_METADATA = {
     'post_install_commands': [
         'apt-get update',
-        'apt-get install -y gcc librdkafka-dev',
-        'pip install --global-option=build_ext --global-option="--library-dirs=/opt/mapr/lib"'
-        ' --global-option="--include-dirs=/opt/mapr/include/" mapr-streams-python',
+        'apt-get install -y gcc',
+        'pip install mapr-streams-python',
     ]
 }
 


### PR DESCRIPTION
### What does this PR do?

Updates confluent-kafka used in mapr tests to a version having binary wheels for both 2.7 and 3.9.

### Motivation

Tests were failing to run because it fails to install confluent-kafka during dependency installation (this dep is only used for tests).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.