### PR TITLE
Add support for list value paths in Elastic custom metrics.

### DIFF
--- a/elastic/README.md
+++ b/elastic/README.md
@@ -117,7 +117,7 @@ The custom query sends as a `GET` request. If you use an optional `payload` para
 }
 ```
 
-`value_path: foo.bar.1` would return the value `result1`.
+`value_path: foo.bar.1` returns the value `result1`.
 
 ##### Trace collection
 

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -105,6 +105,20 @@ custom_queries:
 ```
 The custom query sends as a `GET` request. If you use an optional `payload` parameter, the request sends as a `POST` request. 
 
+`value_path` may either be string keys or list indices. Example:
+```json
+{
+  "foo": {
+    "bar": [
+      "result0",
+      "result1"
+    ]
+  }
+}
+```
+
+`value_path: foo.bar.1` would return the value `result1`.
+
 ##### Trace collection
 
 Datadog APM integrates with Elasticsearch to see the traces across your distributed system. Trace collection is enabled by default in the Datadog Agent v6+. To start collecting traces:

--- a/elastic/assets/configuration/spec.yaml
+++ b/elastic/assets/configuration/spec.yaml
@@ -127,9 +127,9 @@ files:
 
         3. columns - The list representing the data to be collected from the JSON query. There are two required pieces
                      of data:
-                       a. value_path - This is the JSON path from the `data_path` to the metric. For example, if
-                                       querying for size of parent circuit breaker, the `value_path` is
-                                       `estimated_size_in_bytes`.
+                       a. value_path - This is the JSON path from the `data_path` to the metric. This path may include
+                                       string keys as well as list indices. For example, if querying for size of parent
+                                       circuit breaker, the `value_path` is `estimated_size_in_bytes`.
                        b. name - The full metric name sent to Datadog. If `type` is `tag`, this column is considered a
                                  tag and applied to every metric collected by this particular query.
 

--- a/elastic/datadog_checks/elastic/data/conf.yaml.example
+++ b/elastic/datadog_checks/elastic/data/conf.yaml.example
@@ -150,9 +150,9 @@ instances:
     ##
     ## 3. columns - The list representing the data to be collected from the JSON query. There are two required pieces
     ##              of data:
-    ##                a. value_path - This is the JSON path from the `data_path` to the metric. For example, if
-    ##                                querying for size of parent circuit breaker, the `value_path` is
-    ##                                `estimated_size_in_bytes`.
+    ##                a. value_path - This is the JSON path from the `data_path` to the metric. This path may include
+    ##                                string keys as well as list indices. For example, if querying for size of parent
+    ##                                circuit breaker, the `value_path` is `estimated_size_in_bytes`.
     ##                b. name - The full metric name sent to Datadog. If `type` is `tag`, this column is considered a
     ##                          tag and applied to every metric collected by this particular query.
     ##

--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -77,7 +77,11 @@ def get_value_from_path(value, path):
     # Traverse the nested dictionaries
     for key in re.split(REGEX, path):
         if result is not None:
-            result = result.get(key.replace('\\', ''))
+            key = key.replace('\\', '')
+            if key.isdigit() and isinstance(result, list):
+                result = result[int(key)]
+            else:
+                result = result.get(key)
         else:
             break
 

--- a/elastic/tests/test_integration.py
+++ b/elastic/tests/test_integration.py
@@ -109,33 +109,17 @@ def test_custom_queries_with_payload(dd_environment, dd_run_check, instance, agg
 
 
 @pytest.mark.skipif(
-    version.parse(ELASTIC_VERSION) < version.parse('8.0.0'),
-    reason='Test unavailable for Elasticsearch < 8.0.0'
+    version.parse(ELASTIC_VERSION) < version.parse('8.0.0'), reason='Test unavailable for Elasticsearch < 8.0.0'
 )
 def test_custom_queries_with_payload_multiterm(dd_environment, dd_run_check, instance, aggregator, cluster_tags):
     response = requests.put(
         "{}/multiterm_test".format(instance['url']),
-        json={
-            "mappings": {
-                "properties": {
-                    "field0": {
-                        "type": "keyword"
-                    },
-                    "field1": {
-                        "type": "keyword"
-                    }
-                }
-            }
-        }
+        json={"mappings": {"properties": {"field0": {"type": "keyword"}, "field1": {"type": "keyword"}}}},
     )
     response.raise_for_status()
 
     response = requests.post(
-        "{}/multiterm_test/_doc?refresh=wait_for".format(instance['url']),
-        json={
-            "field0": "foo",
-            "field1": "bar"
-        }
+        "{}/multiterm_test/_doc?refresh=wait_for".format(instance['url']), json={"field0": "foo", "field1": "bar"}
     )
     response.raise_for_status()
 
@@ -145,36 +129,15 @@ def test_custom_queries_with_payload_multiterm(dd_environment, dd_run_check, ins
             'data_path': 'aggregations.values.buckets',
             'payload': {
                 "size": 0,
-                "aggs": {
-                    "values": {
-                        "multi_terms": {
-                            "terms": [
-                                {
-                                    "field": "field0"
-                                },
-                                {
-                                    "field": "field1"
-                                }
-                            ]
-                        }
-                    }
-                }
+                "aggs": {"values": {"multi_terms": {"terms": [{"field": "field0"}, {"field": "field1"}]}}},
             },
             'columns': [
                 {
                     'value_path': 'doc_count',
                     'name': 'elasticsearch.custom.metric',
                 },
-                {
-                    'value_path': 'key.0',
-                    'name': 'dynamic_tag0',
-                    'type': 'tag'
-                },
-                {
-                    'value_path': 'key.1',
-                    'name': 'dynamic_tag1',
-                    'type': 'tag'
-                }
+                {'value_path': 'key.0', 'name': 'dynamic_tag0', 'type': 'tag'},
+                {'value_path': 'key.1', 'name': 'dynamic_tag1', 'type': 'tag'},
             ],
         },
     ]

--- a/elastic/tests/test_integration.py
+++ b/elastic/tests/test_integration.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 
+from packaging import version
 import pytest
 import requests
 from six import iteritems
@@ -20,7 +21,7 @@ from datadog_checks.elastic.metrics import (
     slm_stats_for_version,
 )
 
-from .common import CLUSTER_TAG, IS_OPENSEARCH, JVM_RATES, PASSWORD, URL, USER, _test_check
+from .common import CLUSTER_TAG, ELASTIC_VERSION, IS_OPENSEARCH, JVM_RATES, PASSWORD, URL, USER, _test_check
 
 log = logging.getLogger('test_elastic')
 
@@ -103,6 +104,85 @@ def test_custom_queries_with_payload(dd_environment, dd_run_check, instance, agg
     check = ESCheck('elastic', {}, instances=[instance])
     dd_run_check(check)
     tags = cluster_tags + ['dynamic_tag:eq']
+
+    aggregator.assert_metric('elasticsearch.custom.metric', metric_type=aggregator.GAUGE, tags=tags)
+
+
+@pytest.mark.skipif(
+    version.parse(ELASTIC_VERSION) < version.parse('8.0.0'),
+    reason='Test unavailable for Elasticsearch < 8.0.0'
+)
+def test_custom_queries_with_payload_multiterm(dd_environment, dd_run_check, instance, aggregator, cluster_tags):
+    response = requests.put(
+        "{}/multiterm_test".format(instance['url']),
+        json={
+            "mappings": {
+                "properties": {
+                    "field0": {
+                        "type": "keyword"
+                    },
+                    "field1": {
+                        "type": "keyword"
+                    }
+                }
+            }
+        }
+    )
+    response.raise_for_status()
+
+    response = requests.post(
+        "{}/multiterm_test/_doc?refresh=wait_for".format(instance['url']),
+        json={
+            "field0": "foo",
+            "field1": "bar"
+        }
+    )
+    response.raise_for_status()
+
+    custom_queries = [
+        {
+            'endpoint': '/_search',
+            'data_path': 'aggregations.values.buckets',
+            'payload': {
+                "size": 0,
+                "aggs": {
+                    "values": {
+                        "multi_terms": {
+                            "terms": [
+                                {
+                                    "field": "field0"
+                                },
+                                {
+                                    "field": "field1"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            'columns': [
+                {
+                    'value_path': 'doc_count',
+                    'name': 'elasticsearch.custom.metric',
+                },
+                {
+                    'value_path': 'key.0',
+                    'name': 'dynamic_tag0',
+                    'type': 'tag'
+                },
+                {
+                    'value_path': 'key.1',
+                    'name': 'dynamic_tag1',
+                    'type': 'tag'
+                }
+            ],
+        },
+    ]
+
+    instance['custom_queries'] = custom_queries
+    check = ESCheck('elastic', {}, instances=[instance])
+    dd_run_check(check)
+    tags = cluster_tags + ['dynamic_tag0:foo', "dynamic_tag1:bar"]
 
     aggregator.assert_metric('elasticsearch.custom.metric', metric_type=aggregator.GAUGE, tags=tags)
 

--- a/elastic/tests/test_integration.py
+++ b/elastic/tests/test_integration.py
@@ -3,9 +3,9 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 
-from packaging import version
 import pytest
 import requests
+from packaging import version
 from six import iteritems
 
 from datadog_checks.dev.utils import get_metadata_metrics

--- a/elastic/tests/test_unit.py
+++ b/elastic/tests/test_unit.py
@@ -129,19 +129,5 @@ def test_get_template_metrics(aggregator, instance, mock_http_response):
 
 
 def test_get_value_from_path():
-    value = get_value_from_path(
-        {
-            "5": {
-                "b": [
-                    0,
-                    1,
-                    2,
-                    {
-                        "a": ["foo"]
-                    }
-                ]
-            }
-        },
-        "5.b.3.a.0"
-    )
+    value = get_value_from_path({"5": {"b": [0, 1, 2, {"a": ["foo"]}]}}, "5.b.3.a.0")
     assert value == "foo"

--- a/elastic/tests/test_unit.py
+++ b/elastic/tests/test_unit.py
@@ -7,6 +7,7 @@ import pytest
 
 from datadog_checks.base import ConfigurationError
 from datadog_checks.elastic import ESCheck
+from datadog_checks.elastic.elastic import get_value_from_path
 
 from .common import URL, get_fixture_path
 
@@ -125,3 +126,22 @@ def test_get_template_metrics(aggregator, instance, mock_http_response):
     check._get_template_metrics(False, [])
 
     aggregator.assert_metric("elasticsearch.templates.count", value=6)
+
+
+def test_get_value_from_path():
+    value = get_value_from_path(
+        {
+            "5": {
+                "b": [
+                    0,
+                    1,
+                    2,
+                    {
+                        "a": ["foo"]
+                    }
+                ]
+            }
+        },
+        "5.b.3.a.0"
+    )
+    assert value == "foo"


### PR DESCRIPTION
### What does this PR do?
Elastic custom metric integration allows specifying a value path traversing a nested dictionary. Allow specifying a path that can also include list indices to traverse a path of nested dictionaries and lists.

Ex. value_path -> `a.0.b` of dictionary `{"a": [{"b": "c"}]}` should return `"c"`.

### Motivation
Desire for multiple tags pulled per aggregation bucket. This is able to be achieved with [Elasticsearch Multi Term Aggregations](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-multi-terms-aggregation.html) but the original implementation did not allow for specifying the key path as a list index.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.