### PR TITLE
Remove references to Mongo v2.x in instructions

### DIFF
--- a/mongo/README.md
+++ b/mongo/README.md
@@ -65,7 +65,7 @@ In a Mongo shell, authenticate to the primary and create a read-only user for th
 use admin
 db.auth("admin", "<YOUR_MONGODB_ADMIN_PASSWORD>")
 
-
+# Create the user for the Datadog Agent.
 db.createUser({
   "user": "datadog",
   "pwd": "<UNIQUEPASSWORD>",

--- a/mongo/README.md
+++ b/mongo/README.md
@@ -37,10 +37,7 @@ In a Mongo shell, create a read-only user for the Datadog Agent in the `admin` d
 use admin
 db.auth("admin", "<YOUR_MONGODB_ADMIN_PASSWORD>")
 
-# On MongoDB 2.x, use the addUser command.
-db.addUser("datadog", "<UNIQUEPASSWORD>", true)
-
-# On MongoDB 3.x or higher, use the createUser command.
+# Create the user for the Datadog Agent.
 db.createUser({
   "user": "datadog",
   "pwd": "<UNIQUEPASSWORD>",
@@ -68,10 +65,7 @@ In a Mongo shell, authenticate to the primary and create a read-only user for th
 use admin
 db.auth("admin", "<YOUR_MONGODB_ADMIN_PASSWORD>")
 
-# On MongoDB 2.x, use the addUser command.
-db.addUser("datadog", "<UNIQUEPASSWORD>", true)
 
-# On MongoDB 3.x or higher, use the createUser command.
 db.createUser({
   "user": "datadog",
   "pwd": "<UNIQUEPASSWORD>",
@@ -128,10 +122,7 @@ For each shard in your cluster, connect to the primary of the replica set and cr
 use admin
 db.auth("admin", "<YOUR_MONGODB_ADMIN_PASSWORD>")
 
-# On MongoDB 2.x, use the addUser command.
-db.addUser("datadog", "<UNIQUEPASSWORD>", true)
-
-# On MongoDB 3.x or higher, use the createUser command.
+# Create the user for the Datadog Agent.
 db.createUser({
   "user": "datadog",
   "pwd": "<UNIQUEPASSWORD>",


### PR DESCRIPTION
### What does this PR do?

Removes instructions for creating a user in Mongo v2.x.

### Motivation

Since we state in the README that the integration supports a minimum MongoDB version of v3.0+, having instructions for authenticating with v2.x are unnecessary and can be confusing.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.