### PR TITLE
fix the length of key of type stream

### DIFF
--- a/redisdb/datadog_checks/redisdb/redisdb.py
+++ b/redisdb/datadog_checks/redisdb/redisdb.py
@@ -381,8 +381,8 @@ class Redis(AgentCheck):
                         lengths_overall[text_key] += 1
                     elif key_type == 'stream':
                         keylen = db_conn.xlen(key)
-                        lengths[text_key]["length"] += 1
-                        lengths_overall[text_key] += 1
+                        lengths[text_key]["length"] += keylen
+                        lengths_overall[text_key] += keylen
                     else:
                         # If the type is unknown, it might be because the key doesn't exist,
                         # which can be because the list is empty. So always send 0 in that case.

--- a/redisdb/tests/conftest.py
+++ b/redisdb/tests/conftest.py
@@ -37,6 +37,8 @@ class CheckCluster(LazyFunction):
                     master.lpush('test_key1', 'test_value1')
                     master.lpush('test_key2', 'test_value2')
                     master.lpush('test_key3', 'test_value3')
+                    master.xadd('test_key4', {'test_value4b': 'test_value4a'})
+                    master.xadd('test_key4', {'test_value4b': 'test_value4b'})
                     break
             except redis.ConnectionError:
                 pass

--- a/redisdb/tests/test_e2e.py
+++ b/redisdb/tests/test_e2e.py
@@ -75,6 +75,9 @@ def assert_common_metrics(aggregator):
     aggregator.assert_metric('redis.key.length', count=2, tags=(['key:test_key1', 'key_type:list'] + tags_with_db))
     aggregator.assert_metric('redis.key.length', count=2, tags=(['key:test_key2', 'key_type:list'] + tags_with_db))
     aggregator.assert_metric('redis.key.length', count=2, tags=(['key:test_key3', 'key_type:list'] + tags_with_db))
+    aggregator.assert_metric(
+        'redis.key.length', count=2, value=2, tags=(['key:test_key4', 'key_type:stream'] + tags_with_db)
+    )
 
     aggregator.assert_metric('redis.replication.delay', count=2)
 


### PR DESCRIPTION
### What does this PR do?
Currently the code compute the len of the stream but report always 1

This change fixes this.

### Motivation

Fixing an annoying bug

### Additional Notes


### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [x] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.
