### PR TITLE
Remove US1 link from Kubernetes Dashboard

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_clusters.json
+++ b/kubernetes/assets/dashboards/kubernetes_clusters.json
@@ -569,12 +569,7 @@
                     },
                     {
                         "definition": {
-                            "custom_links": [
-                                {
-                                    "label": "View Pods overview",
-                                    "link": "https://app.datadoghq.com/screen/integration/30322/kubernetes-pods-overview"
-                                }
-                            ],
+                            "custom_links": [],
                             "precision": 0,
                             "requests": [
                                 {
@@ -597,12 +592,7 @@
                     },
                     {
                         "definition": {
-                            "custom_links": [
-                                {
-                                    "label": "View Pods overview",
-                                    "link": "https://app.datadoghq.com/screen/integration/30322/kubernetes-pods-overview"
-                                }
-                            ],
+                            "custom_links": [],
                             "precision": 0,
                             "requests": [
                                 {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Removes two links to a US1 specific dashboard that previously pointed to the Pods Overview dashboard. 

### Motivation
<!-- What inspired you to submit this pull request? -->
Two issues with these links. The first is that they do not link properly to any environment outside of US1, since the dashboard in question is specific to US1. The second is that they do not even work properly on US1 anymore, since they use the `/screen/` url instead of the modern `/dash/` url. So at the moment they are entirely broken.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.