### PR TITLE
Update the expvar port and enable telemetry

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/e2e/docker.py
@@ -302,8 +302,7 @@ class DockerInterface(object):
             'DD_API_KEY': self.api_key,
             # Set agent hostname for CI
             'DD_HOSTNAME': get_hostname(),
-            # Run expvar on a random port
-            'DD_EXPVAR_PORT': 0,
+            'DD_EXPVAR_PORT': 5000,
             # Run API on a random port
             'DD_CMD_PORT': find_free_port(get_ip()),
             # Disable trace agent
@@ -314,6 +313,7 @@ class DockerInterface(object):
             # More info: https://github.com/DataDog/integrations-core/pull/5454
             # TODO: Remove PYTHONDONTWRITEBYTECODE env var when Python 2 support is removed
             'PYTHONDONTWRITEBYTECODE': "1",
+            "DD_TELEMETRY_ENABLED": True,
         }
         if self.dd_site:
             env_vars['DD_SITE'] = self.dd_site


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the expvar port and enable telemetry

### Motivation
<!-- What inspired you to submit this pull request? -->

- This [PR enables](https://github.com/DataDog/datadog-agent/pull/16900) a openmetrics new check by default
- We do not configure telemetry by default and the port used is `6062` (not random as mentioned in the comment), so the default integration can't access the endpoint and our logs are full of: 

```
2023-06-09 17:44:42 UTC | CORE | ERROR | (pkg/collector/worker/check_logger.go:69 in Error) | check:openmetrics | Error running check: [{"message": "There was an error scraping endpoint http://localhost:5000/telemetry: HTTPConnectionPool(host='localhost', port=5000): Max retries exceeded with url: /telemetry (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xffff7419bbb0>: Failed to establish a new connection: [Errno 111] Connection refused'))", "traceback": "Traceback (most recent call last):\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/base.py\", line 1142, in run\n    self.check(instance)\n  File \"/opt/datadog-agent/embedded/lib/python3.8/site-packages/datadog_checks/base/checks/openmetrics/v2/base.py\", line 67, in check\n    raise_from(type(e)(\"There was an error scraping endpoint {}: {}\".format(endpoint, e)), None)\n  File \"<string>\", line 3, in raise_from\nrequests.exceptions.ConnectionError: There was an error scraping endpoint http://localhost:5000/telemetry: HTTPConnectionPool(host='localhost', port=5000): Max retries exceeded with url: /telemetry (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0xffff7419bbb0>: Failed to establish a new connection: [Errno 111] Connection refused'))\n"}]
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.