### PR TITLE
remove exclusions

### DIFF
--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -57,15 +57,7 @@ skip-string-normalization = true
 target-version = ["py38"]
 
 [tool.ruff]
-exclude = [
-    ".eggs",
-    ".tox",
-    "build",
-    "compat.py",
-    "__init__.py",
-    "**/datadog_checks/dev/tooling/templates/*",
-    "**/datadog_checks/*/vendor/*",
-]
+exclude = []
 target-version = "py38"
 line-length = 120
 # Rules were ported over from the legacy flake8 settings for parity

--- a/ddev/src/ddev/cli/release/list_versions/__init__.py
+++ b/ddev/src/ddev/cli/release/list_versions/__init__.py
@@ -19,14 +19,14 @@ def list_versions(ctx: click.Context, integration: str):
     import httpx
     from packaging.version import Version
 
-    integration = integration.replace('_', '-')
+    int_name = integration.replace('_', '-')
     ignored_prefix = 'datadog-'
-    if integration.startswith(ignored_prefix):
-        integration = integration[len(ignored_prefix) :]
+    if int_name.startswith(ignored_prefix):
+        int_name = int_name[len(ignored_prefix) :]
 
-    integration_url = f'https://dd-integrations-core-wheels-build-stable.datadoghq.com/targets/simple/datadog-{integration}/index.html'  # noqa: E501
+    url = f'https://dd-integrations-core-wheels-build-stable.datadoghq.com/targets/simple/datadog-{int_name}/index.html'
 
-    response = httpx.get(integration_url)
+    response = httpx.get(url)
     versions = response.text.splitlines()
 
     version_numbers = []

--- a/ddev/src/ddev/cli/release/list_versions/__init__.py
+++ b/ddev/src/ddev/cli/release/list_versions/__init__.py
@@ -24,7 +24,7 @@ def list_versions(ctx: click.Context, integration: str):
     if integration.startswith(ignored_prefix):
         integration = integration[len(ignored_prefix) :]
 
-    integration_url = f'https://dd-integrations-core-wheels-build-stable.datadoghq.com/targets/simple/datadog-{integration}/index.html'
+    integration_url = f'https://dd-integrations-core-wheels-build-stable.datadoghq.com/targets/simple/datadog-{integration}/index.html'  # noqa: E501
 
     response = httpx.get(integration_url)
     versions = response.text.splitlines()


### PR DESCRIPTION
### What does this PR do?
Remove exclusions from the ddev specific pyproject. The ddev exclusion was ported over from the parent, but doesn't make sense to keep since the files shouldn't exist there.