### PR TITLE
[ArgoCD] Removes argocd.app_controller.cluster.connection.status from metadata.csv

### DIFF
--- a/argocd/metadata.csv
+++ b/argocd/metadata.csv
@@ -51,7 +51,6 @@ argocd.app_controller.app.sync.count,count,,,,The total number of application sy
 argocd.app_controller.cluster.api.resource_objects,gauge,,object,,The number of Kubernetes resource objects in the cache,0,argocd,app_controller cluster api resource_objects,
 argocd.app_controller.cluster.api.resources,gauge,,resource,,The number of monitored kubernetes API resources.,0,argocd,app_controller cluster api resources,
 argocd.app_controller.cluster.cache.age.seconds,gauge,,second,,The age of the cluster cache in seconds,0,argocd,app_controller cluster cache age seconds,
-argocd.app_controller.cluster.connection.status,gauge,,,,The current Kubernetes cluster connection status,0,argocd,app_controller cluster connection status,
 argocd.app_controller.cluster.events.count,count,,event,,The number of processed Kubernetes resource events,0,argocd,app_controller cluster events,
 argocd.app_controller.cluster.info,gauge,,,,Information about cluster.,0,argocd,app_controller cluster info,
 argocd.app_controller.go.gc.duration.seconds.quantile,gauge,,second,,A summary of the pause duration of garbage collection cycles in the Application Controller,0,argocd,app_controller go gc duration seconds,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
* Removes `argocd.app_controller.cluster.connection.status` from `metadata.csv` as it is forwarded as a service check and not a metric : https://github.com/DataDog/integrations-core/blob/master/argocd/datadog_checks/argocd/check.py#L79-L92

### Motivation
* Support case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.