### PR TITLE
[kube_apiserver_metrics] Rename aggregator_unavailable_apiservice `name` tag to `apiservice_name`

### DIFF
--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -157,7 +157,7 @@ class KubeAPIServerMetricsCheck(OpenMetricsBaseCheck):
 
         return kube_apiserver_metrics_instance
 
-    def submit_as_gauge_and_monotonic_count(self, metric_suffix, metric, scraper_config):
+    def submit_as_gauge_and_monotonic_count(self, metric_suffix, metric, scraper_config, monotonic_count=True):
         """
         submit a kube_apiserver_metrics metric both as a gauge (for compatibility) and as a monotonic_count
         """
@@ -170,17 +170,18 @@ class KubeAPIServerMetricsCheck(OpenMetricsBaseCheck):
                 _tags.append('{}:{}'.format(label_name, label_value))
             # submit raw metric
             self.gauge(metric_name, sample[self.SAMPLE_VALUE], _tags)
-            # submit rate metric
-            self.monotonic_count(metric_name + '.count', sample[self.SAMPLE_VALUE], _tags)
+            if monotonic_count:
+                # submit rate metric
+                self.monotonic_count(metric_name + '.count', sample[self.SAMPLE_VALUE], _tags)
 
     def aggregator_unavailable_apiservice(self, metric, scraper_config):
         """
-            This function replaces the tag "name" by "apiservice_name".
-            It assumes that every sample is tagged with `name`.
+        This function replaces the tag "name" by "apiservice_name".
+        It assumes that every sample is tagged with `name`.
         """
         for sample in metric.samples:
             sample[self.SAMPLE_LABELS]["apiservice_name"] = sample[self.SAMPLE_LABELS].pop("name")
-        self.submit_as_gauge_and_monotonic_count('.aggregator_unavailable_apiservice', metric, scraper_config)
+        self.submit_as_gauge_and_monotonic_count('.aggregator_unavailable_apiservice', metric, scraper_config, False)
 
     def apiserver_audit_event_total(self, metric, scraper_config):
         self.submit_as_gauge_and_monotonic_count('.audit_event', metric, scraper_config)

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_19.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_19.py
@@ -69,7 +69,6 @@ class TestKubeAPIServerMetrics:
         'authenticated_user_requests.count',
         'apiserver_request_total.count',
         'apiserver_request_terminations_total.count',
-        'aggregator_unavailable_apiservice.count',
     ]
 
     def test_check(self, dd_run_check, aggregator, mock_http_response):

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_19.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_19.py
@@ -62,12 +62,14 @@ class TestKubeAPIServerMetrics:
         'aggregator_unavailable_apiservice',
         'envelope_encryption_dek_cache_fill_percent',
     ]
+
     COUNT_METRICS = [
         'audit_event.count',
         'rest_client_requests_total.count',
         'authenticated_user_requests.count',
         'apiserver_request_total.count',
         'apiserver_request_terminations_total.count',
+        'aggregator_unavailable_apiservice.count',
     ]
 
     def test_check(self, dd_run_check, aggregator, mock_http_response):
@@ -86,4 +88,6 @@ class TestKubeAPIServerMetrics:
             metric_to_assert = NAMESPACE + "." + metric
             aggregator.assert_metric(metric_to_assert)
             aggregator.assert_metric_has_tag(metric_to_assert, customtag)
+            if "aggregator_unavailable_apiservice" in metric:
+                aggregator.assert_metric_has_tag(metric_to_assert, "apiservice_name:v1.")
         aggregator.assert_all_metrics_covered()

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_23.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_23.py
@@ -74,6 +74,7 @@ class TestKubeAPIServerMetrics:
         'authenticated_user_requests.count',
         'apiserver_request_total.count',
         'apiserver_request_terminations_total.count',
+        'aggregator_unavailable_apiservice.count',
     ]
 
     def test_check(self, dd_run_check, aggregator, mock_http_response):
@@ -92,4 +93,6 @@ class TestKubeAPIServerMetrics:
             metric_to_assert = NAMESPACE + "." + metric
             aggregator.assert_metric(metric_to_assert)
             aggregator.assert_metric_has_tag(metric_to_assert, customtag)
+            if "aggregator_unavailable_apiservice" in metric:
+                aggregator.assert_metric_has_tag(metric_to_assert, "apiservice_name:v1.")
         aggregator.assert_all_metrics_covered()

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_23.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_23.py
@@ -74,7 +74,6 @@ class TestKubeAPIServerMetrics:
         'authenticated_user_requests.count',
         'apiserver_request_total.count',
         'apiserver_request_terminations_total.count',
-        'aggregator_unavailable_apiservice.count',
     ]
 
     def test_check(self, dd_run_check, aggregator, mock_http_response):

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_24.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_24.py
@@ -76,7 +76,6 @@ class TestKubeAPIServerMetrics:
         'apiserver_request_total.count',
         'apiserver_request_terminations_total.count',
         'apiserver_admission_webhook_fail_open_count.count',
-        'aggregator_unavailable_apiservice.count',
     ]
 
     def test_check(self, dd_run_check, aggregator, mock_http_response):

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_24.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_24.py
@@ -76,6 +76,7 @@ class TestKubeAPIServerMetrics:
         'apiserver_request_total.count',
         'apiserver_request_terminations_total.count',
         'apiserver_admission_webhook_fail_open_count.count',
+        'aggregator_unavailable_apiservice.count',
     ]
 
     def test_check(self, dd_run_check, aggregator, mock_http_response):
@@ -94,4 +95,6 @@ class TestKubeAPIServerMetrics:
             metric_to_assert = NAMESPACE + "." + metric
             aggregator.assert_metric(metric_to_assert)
             aggregator.assert_metric_has_tag(metric_to_assert, customtag)
+            if "aggregator_unavailable_apiservice" in metric:
+                aggregator.assert_metric_has_tag(metric_to_assert, "apiservice_name:v1.")
         aggregator.assert_all_metrics_covered()

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_25.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_25.py
@@ -97,6 +97,7 @@ class TestKubeAPIServerMetrics:
         NAMESPACE + '.apiserver_request_total.count',
         NAMESPACE + '.apiserver_request_terminations_total.count',
         NAMESPACE + '.apiserver_admission_webhook_fail_open_count.count',
+        NAMESPACE + '.aggregator_unavailable_apiservice.count',
     ]
 
     def test_check(self, dd_run_check, aggregator, mock_get):
@@ -113,4 +114,6 @@ class TestKubeAPIServerMetrics:
         for metric in self.METRICS + self.COUNT_METRICS:
             aggregator.assert_metric(metric)
             aggregator.assert_metric_has_tag(metric, customtag)
+            if "aggregator_unavailable_apiservice" in metric:
+                aggregator.assert_metric_has_tag(metric, "apiservice_name:v1.")
         aggregator.assert_all_metrics_covered()

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_25.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_25.py
@@ -97,7 +97,6 @@ class TestKubeAPIServerMetrics:
         NAMESPACE + '.apiserver_request_total.count',
         NAMESPACE + '.apiserver_request_terminations_total.count',
         NAMESPACE + '.apiserver_admission_webhook_fail_open_count.count',
-        NAMESPACE + '.aggregator_unavailable_apiservice.count',
     ]
 
     def test_check(self, dd_run_check, aggregator, mock_get):

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_26.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_26.py
@@ -72,7 +72,6 @@ class TestKubeAPIServerMetrics:
         'authenticated_user_requests.count',
         'apiserver_request_total.count',
         'apiserver_request_terminations_total.count',
-        'aggregator_unavailable_apiservice.count',
     ]
 
     def test_check(self, dd_run_check, aggregator, mock_http_response):

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_26.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_26.py
@@ -72,6 +72,7 @@ class TestKubeAPIServerMetrics:
         'authenticated_user_requests.count',
         'apiserver_request_total.count',
         'apiserver_request_terminations_total.count',
+        'aggregator_unavailable_apiservice.count',
     ]
 
     def test_check(self, dd_run_check, aggregator, mock_http_response):
@@ -90,4 +91,6 @@ class TestKubeAPIServerMetrics:
             metric_to_assert = NAMESPACE + "." + metric
             aggregator.assert_metric(metric_to_assert)
             aggregator.assert_metric_has_tag(metric_to_assert, customtag)
+            if "aggregator_unavailable_apiservice" in metric:
+                aggregator.assert_metric_has_tag(metric_to_assert, "apiservice_name:v1.")
         aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR renames aggregator_unavailable_apiservice `name` tag to `apiservice_name` to avoid conflicts.

### Motivation
<!-- What inspired you to submit this pull request? -->
Internally, we noticed that this tag was conflicting with another tag.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.