### PR TITLE
Sy/strimzi proc sigs

### DIFF
--- a/strimzi/manifest.json
+++ b/strimzi/manifest.json
@@ -14,7 +14,8 @@
     "classifier_tags": [
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS"
+      "Supported OS::macOS",
+      "Category::Log Collection"
     ]
   },
   "assets": {
@@ -35,6 +36,11 @@
         ],
         "metadata_path": "metadata.csv"
       },
+      "process_signatures": [
+        "io.strimzi.cluster-operator",
+        "io.strimzi.topic-operator",
+        "io.strimzi.user-operator"
+      ],
       "service_checks": {
         "metadata_path": "assets/service_checks.json"
       }

--- a/strimzi/manifest.json
+++ b/strimzi/manifest.json
@@ -37,9 +37,9 @@
         "metadata_path": "metadata.csv"
       },
       "process_signatures": [
-        "java io.strimzi.cluster-operator",
-        "java io.strimzi.topic-operator",
-        "java io.strimzi.user-operator"
+        "java io.strimzi.operator.cluster.Main",
+        "java io.strimzi.operator.topic.Main",
+        "java io.strimzi.operator.user.Main"
       ],
       "service_checks": {
         "metadata_path": "assets/service_checks.json"

--- a/strimzi/manifest.json
+++ b/strimzi/manifest.json
@@ -12,10 +12,10 @@
     "title": "Strimzi",
     "media": [],
     "classifier_tags": [
+      "Category::Log Collection",
       "Supported OS::Linux",
       "Supported OS::Windows",
-      "Supported OS::macOS",
-      "Category::Log Collection"
+      "Supported OS::macOS"
     ]
   },
   "assets": {
@@ -37,9 +37,9 @@
         "metadata_path": "metadata.csv"
       },
       "process_signatures": [
-        "io.strimzi.cluster-operator",
-        "io.strimzi.topic-operator",
-        "io.strimzi.user-operator"
+        "java io.strimzi.cluster-operator",
+        "java io.strimzi.topic-operator",
+        "java io.strimzi.user-operator"
       ],
       "service_checks": {
         "metadata_path": "assets/service_checks.json"


### PR DESCRIPTION
### What does this PR do?
Add process signature for Strimzi. Validation is failing when logs is left out of the classifier. I added anyways since I think we will collect logs for it anyways down the line.

dd-go entry:
https://github.com/DataDog/dd-go/pull/94873