### PR TITLE
Update requests-toolbelt version

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -86,7 +86,7 @@ requests-kerberos==0.12.0; python_version < '3.0'
 requests-kerberos==0.14.0; python_version > '3.0'
 requests-ntlm==1.1.0
 requests-oauthlib==1.3.1
-requests-toolbelt==0.10.1
+requests-toolbelt==1.0.0
 requests-unixsocket==0.3.0
 requests==2.27.1; python_version < '3.0'
 requests==2.31.0; python_version > '3.0'

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -63,7 +63,7 @@ deps = [
     "pywin32==304; sys_platform == 'win32' and python_version > '3.0'",
     "pyyaml==5.4.1; python_version < '3.0'",
     "pyyaml==6.0; python_version > '3.0'",
-    "requests-toolbelt==0.10.1",
+    "requests-toolbelt==1.0.0",
     "requests-unixsocket==0.3.0",
     "requests==2.27.1; python_version < '3.0'",
     "requests==2.31.0; python_version > '3.0'",


### PR DESCRIPTION
### What does this PR do?
This PR updates the `requests-toolbelt` version.

### Motivation
The requests library was [updated](https://github.com/DataDog/integrations-core/pull/14670) a few hours but led to CI tests failing, because the `requests-toolbelt` version was out of date. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.