### PR TITLE
Detach thread from JVM after connection

### DIFF
--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -151,6 +151,7 @@ class Oracle(AgentCheck):
     def _connection(self):
         if self._cached_connection is None:
             if self.can_use_jdbc():
+                self.log.debug('Detected that JDBC can be used to connect, will attempt first')
                 try:
                     self._cached_connection = self._jdbc_connect()
                 except Exception as e:
@@ -158,6 +159,7 @@ class Oracle(AgentCheck):
                     self._connection_errors += 1
             else:
                 if self._use_instant_client:
+                    self.log.debug('Connecting to Oracle using Oracle Instant Client')
                     self.init_instant_client()
                 else:
                     self.log.debug('Connecting to Oracle using the native client')
@@ -243,7 +245,7 @@ class Oracle(AgentCheck):
                 )
                 if jpype.isJVMStarted() and jpype.isThreadAttachedToJVM():
                     jpype.detachThreadFromJVM()
-                    self.log.info("Detaching thread from JVM after connection")
+                    self.log.debug("Detaching thread from JVM after connection")
 
             self.log.debug("Connected to Oracle DB using JDBC connector")
 
@@ -252,6 +254,7 @@ class Oracle(AgentCheck):
             if jpype.isJVMStarted() and jpype.isThreadAttachedToJVM():
                 jpype.detachThreadFromJVM()
                 self.log.debug("Thread detached from JVM after JDBC connection failure")
+
             self._connection_errors += 1
             if "Class {} not found".format(self.ORACLE_DRIVER_CLASS) in str(e):
                 msg = """Cannot run the Oracle check until either the Oracle instant client or the JDBC Driver

--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -233,6 +233,7 @@ class Oracle(AgentCheck):
         try:
             with jdbc_lock:
                 if jpype.isJVMStarted() and not jpype.isThreadAttachedToJVM():
+                    self.log.debug("JVM started but thread not attached to JVM.")
                     jpype.attachThreadToJVM()
                     jpype.java.lang.Thread.currentThread().setContextClassLoader(
                         jpype.java.lang.ClassLoader.getSystemClassLoader()
@@ -240,9 +241,17 @@ class Oracle(AgentCheck):
                 connection = jdb.connect(
                     self.ORACLE_DRIVER_CLASS, connect_string, jdbc_connect_properties, self._jdbc_driver
                 )
-            self.log.debug("Connected to Oracle DB using JDBC connector")
+                if jpype.isJVMStarted() and jpype.isThreadAttachedToJVM():
+                    jpype.detachThreadFromJVM()
+                    self.log.info("Detaching thread from JVM after connection")
+
+            self.log.info("Connected to Oracle DB using JDBC connector")
+
             return connection
         except Exception as e:
+            if jpype.isJVMStarted() and jpype.isThreadAttachedToJVM():
+                jpype.detachThreadFromJVM()
+                self.log.debug("Thread detached from JVM after JDBC connection failure")
             self._connection_errors += 1
             if "Class {} not found".format(self.ORACLE_DRIVER_CLASS) in str(e):
                 msg = """Cannot run the Oracle check until either the Oracle instant client or the JDBC Driver

--- a/oracle/datadog_checks/oracle/oracle.py
+++ b/oracle/datadog_checks/oracle/oracle.py
@@ -245,7 +245,7 @@ class Oracle(AgentCheck):
                     jpype.detachThreadFromJVM()
                     self.log.info("Detaching thread from JVM after connection")
 
-            self.log.info("Connected to Oracle DB using JDBC connector")
+            self.log.debug("Connected to Oracle DB using JDBC connector")
 
             return connection
         except Exception as e:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The oracle check may have a memory leak when it cannot connect to the Oracle DB via JDBC, since the thread is never detached from the JVM.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.