### PR TITLE
[Release] Bumped kube_apiserver_metrics version to 3.6.1

### DIFF
--- a/kube_apiserver_metrics/CHANGELOG.md
+++ b/kube_apiserver_metrics/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG - Kube_apiserver_metrics
 
+## 3.6.1 / 2023-06-14
+
+* [Fixed] [kube_apiserver_metrics] Rename aggregator_unavailable_apiservice `name` tag to `apiservice_name` (#14738). See [#14751](https://github.com/DataDog/integrations-core/pull/14751).
+
 ## 3.6.0 / 2023-05-26
 
 * [Added] Add `flowcontrol` metrics. See [#14480](https://github.com/DataDog/integrations-core/pull/14480).

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/__about__.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '3.6.0'
+__version__ = '3.6.1'

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -81,7 +81,7 @@ datadog-journald==1.1.0
 datadog-kafka-consumer==3.1.0
 datadog-kafka==2.13.1
 datadog-kong==2.4.0
-datadog-kube-apiserver-metrics==3.6.0
+datadog-kube-apiserver-metrics==3.6.1
 datadog-kube-controller-manager==4.3.0
 datadog-kube-dns==4.0.2
 datadog-kube-metrics-server==3.0.1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bumped kube_apiserver_metrics version to 3.6.1

### Motivation
<!-- What inspired you to submit this pull request? -->

Push https://github.com/DataDog/integrations-core/pull/14753 to master

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.