### PR TITLE
Add metrics for timeline id and checkpoint delay

### DIFF
--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -26,6 +26,7 @@ from .util import (
     AZURE_DEPLOYMENT_TYPE_TO_RESOURCE_TYPE,
     CONNECTION_METRICS,
     FUNCTION_METRICS,
+    QUERY_PG_CONTROL_CHECKPOINT,
     QUERY_PG_REPLICATION_SLOTS,
     QUERY_PG_STAT_DATABASE,
     QUERY_PG_STAT_DATABASE_CONFLICTS,
@@ -165,7 +166,9 @@ class PostgreSql(AgentCheck):
                 q_pg_stat_database["query"] += " AND datname in('{}')".format(self._config.dbname)
                 q_pg_stat_database_conflicts["query"] += " AND datname in('{}')".format(self._config.dbname)
 
-            queries.extend([q_pg_stat_database, q_pg_stat_database_conflicts, QUERY_PG_UPTIME])
+            queries.extend(
+                [q_pg_stat_database, q_pg_stat_database_conflicts, QUERY_PG_UPTIME, QUERY_PG_CONTROL_CHECKPOINT]
+            )
 
         if self.version >= V10:
             # Wal receiver is not supported on aurora

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -147,6 +147,19 @@ QUERY_PG_UPTIME = {
     ],
 }
 
+QUERY_PG_CONTROL_CHECKPOINT = {
+    'name': 'pg_control_checkpoint',
+    'query': """
+        SELECT timeline_id,
+               EXTRACT (EPOCH FROM now() - checkpoint_time)
+        FROM pg_control_checkpoint();
+""",
+    'columns': [
+        {'name': 'postgresql.control.timeline_id', 'type': 'gauge'},
+        {'name': 'postgresql.control.checkpoint_delay', 'type': 'gauge'},
+    ],
+}
+
 COMMON_BGW_METRICS = {
     'checkpoints_timed': ('postgresql.bgwriter.checkpoints_timed', AgentCheck.monotonic_count),
     'checkpoints_req': ('postgresql.bgwriter.checkpoints_requested', AgentCheck.monotonic_count),

--- a/postgres/metadata.csv
+++ b/postgres/metadata.csv
@@ -127,3 +127,5 @@ postgresql.replication_slot.xmin_age,gauge,,transaction,,"The age of the oldest 
 postgresql.replication_slot.restart_delay_bytes,gauge,,byte,,"The amount of WAL bytes that the consumer of this slot may require and won't be automatically removed during checkpoints unless it exceeds max_slot_wal_keep_size parameter. Nothing is reported if there's no WAL reservation for this slot.",-1,postgres,repslot restart,
 postgresql.replication_slot.confirmed_flush_delay_bytes,gauge,,byte,,"The delay in bytes between the current WAL position and last position this slot's consumer confirmed. This is only available for logical replication slots",-1,postgres,repslot flush,
 postgresql.pg_stat_statements.dealloc,count,,,,"The number of times pg_stat_statements had to evict least executed queries because pg_stat_statements.max was reached.",-1,postgres,pgss dealloc,
+postgresql.control.timeline_id,gauge,,,,"The current timeline id.",0,postgres,control tid,
+postgresql.control.checkpoint_delay,gauge,,second,,"The time since the last checkpoint.",0,postgres,control checkpoint,

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -11,6 +11,7 @@ from datadog_checks.dev import get_docker_hostname
 from datadog_checks.dev.docker import get_container_ip
 from datadog_checks.postgres.util import (
     NEWER_14_METRICS,
+    QUERY_PG_CONTROL_CHECKPOINT,
     QUERY_PG_REPLICATION_SLOTS,
     QUERY_PG_STAT_WAL_RECEIVER,
     QUERY_PG_UPTIME,
@@ -243,6 +244,11 @@ def check_replication_delay(aggregator, metrics_cache, expected_tags, count=1):
 
 def check_uptime_metrics(aggregator, expected_tags, count=1):
     for column in QUERY_PG_UPTIME['columns']:
+        aggregator.assert_metric(column['name'], count=count, tags=expected_tags)
+
+
+def check_control_metrics(aggregator, expected_tags, count=1):
+    for column in QUERY_PG_CONTROL_CHECKPOINT['columns']:
         aggregator.assert_metric(column['name'], count=count, tags=expected_tags)
 
 

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -55,6 +55,7 @@ def test_common_metrics(aggregator, integration_check, pg_instance, is_aurora):
 
     expected_tags = get_expected_instance_tags(check, pg_instance)
     check_common_metrics(aggregator, expected_tags=expected_tags)
+    check_control_metrics(aggregator, expected_tags=expected_tags)
     check_bgw_metrics(aggregator, expected_tags)
     check_connection_metrics(aggregator, expected_tags=expected_tags)
     check_conflict_metrics(aggregator, expected_tags=expected_tags)

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -11,6 +11,7 @@ from .common import (
     check_common_metrics,
     check_conflict_metrics,
     check_connection_metrics,
+    check_control_metrics,
     check_db_count,
     check_replication_delay,
     check_slru_metrics,
@@ -36,6 +37,7 @@ def test_common_replica_metrics(aggregator, integration_check, metrics_cache_rep
     check_common_metrics(aggregator, expected_tags=expected_tags)
     check_bgw_metrics(aggregator, expected_tags)
     check_connection_metrics(aggregator, expected_tags=expected_tags)
+    check_control_metrics(aggregator, expected_tags=expected_tags)
     check_db_count(aggregator, expected_tags=expected_tags)
     check_slru_metrics(aggregator, expected_tags=expected_tags)
     check_replication_delay(aggregator, metrics_cache_replica, expected_tags=expected_tags)


### PR DESCRIPTION
### What does this PR do?
[pg_control_checkpoint](https://pgpedia.info/p/pg_control_checkpoint.html) allows to get the current control state. Extract the timeline id and the checkpoint delay from this function.
This function is available since 9.6 and its content unchanged since this version.

### Motivation
Timeline id can give insight on when a failover happened and if there's a timeline mismatch between primary and replicas. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.