### PR TITLE
DOCS-4656 - Update kubelet metric to note it is cumulative

### DIFF
--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -50,7 +50,7 @@ kubernetes.kubelet.pleg.relist_duration.sum,gauge,,second,,The sum of duration i
 kubernetes.kubelet.pleg.relist_interval.count,gauge,,second,,The count of relisting pods in PLEG,0,kubernetes,k8s.pleg.relist_interv,
 kubernetes.kubelet.pleg.relist_interval.sum,gauge,,,,The sum of interval in seconds between relisting in PLEG,0,kubernetes,k8s.pleg.relist_interv,
 kubernetes.kubelet.runtime.operations,count,,operation,,The number of runtime operations,0,kubernetes,k8s.runtime.ops,
-kubernetes.kubelet.runtime.errors,count,,operation,,Cumulative number of runtime operations errors,-1,kubernetes,k8s.runtime.err,
+kubernetes.kubelet.runtime.errors,gauge,,operation,,Cumulative number of runtime operations errors,-1,kubernetes,k8s.runtime.err,
 kubernetes.kubelet.runtime.operations.duration.sum,gauge,,operation,,The sum of duration of operations,0,kubernetes,k8s.runtime.duration,
 kubernetes.kubelet.runtime.operations.duration.count,gauge,,,,The count of operations,0,kubernetes,k8s.runtime.duration,
 kubernetes.kubelet.network_plugin.latency.sum,gauge,,microsecond,,The sum of latency in microseconds of network plugin operations,1,kubernetes,k8s.net_plug.lat.sum,

--- a/kubelet/metadata.csv
+++ b/kubelet/metadata.csv
@@ -50,7 +50,7 @@ kubernetes.kubelet.pleg.relist_duration.sum,gauge,,second,,The sum of duration i
 kubernetes.kubelet.pleg.relist_interval.count,gauge,,second,,The count of relisting pods in PLEG,0,kubernetes,k8s.pleg.relist_interv,
 kubernetes.kubelet.pleg.relist_interval.sum,gauge,,,,The sum of interval in seconds between relisting in PLEG,0,kubernetes,k8s.pleg.relist_interv,
 kubernetes.kubelet.runtime.operations,count,,operation,,The number of runtime operations,0,kubernetes,k8s.runtime.ops,
-kubernetes.kubelet.runtime.errors,count,,operation,,The number of runtime operations errors,-1,kubernetes,k8s.runtime.err,
+kubernetes.kubelet.runtime.errors,count,,operation,,Cumulative number of runtime operations errors,-1,kubernetes,k8s.runtime.err,
 kubernetes.kubelet.runtime.operations.duration.sum,gauge,,operation,,The sum of duration of operations,0,kubernetes,k8s.runtime.duration,
 kubernetes.kubelet.runtime.operations.duration.count,gauge,,,,The count of operations,0,kubernetes,k8s.runtime.duration,
 kubernetes.kubelet.network_plugin.latency.sum,gauge,,microsecond,,The sum of latency in microseconds of network plugin operations,1,kubernetes,k8s.net_plug.lat.sum,


### PR DESCRIPTION
### What does this PR do?
Updates the description for a metric `kubernetes.kubelet.runtime.errors` to specify that it is cumulative

### Motivation
Found by @marielle-spiteri 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.