### PR TITLE
Internally compile the `include` patterns in the autodiscovery feature

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/discovery/filter.py
+++ b/datadog_checks_base/datadog_checks/base/utils/discovery/filter.py
@@ -10,6 +10,9 @@ class Filter:
         self._include = include
         self._exclude = re.compile('|'.join(exclude)) if exclude else None
         self._key = key
+        self._compiled_include_patterns = (
+            {pattern: re.compile(pattern) for pattern in include.keys()} if include is not None else None
+        )
 
     def get_items(self, items):
         if self._include is None:
@@ -26,7 +29,7 @@ class Filter:
                 if (
                     key(item) not in excluded_item_keys
                     and key(item) not in discovered_item_keys
-                    and re.search(pattern, key(item))
+                    and re.search(self._compiled_include_patterns[pattern], key(item))
                 ):
                     discovered_item_keys.add(key(item))
                     yield pattern, key(item), item, config

--- a/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
+++ b/datadog_checks_base/tests/base/utils/discovery/test_discovery.py
@@ -4,6 +4,7 @@
 import re
 
 import mock
+import pytest
 
 from datadog_checks.base.utils.discovery import Discovery
 
@@ -15,25 +16,23 @@ def test_include_empty():
     assert mock_get_items.call_count == 1
 
 
-def test_include_not_empty():
+@pytest.mark.parametrize(
+    'pattern',
+    [
+        pytest.param(
+            'a.*',
+            id='with string',
+        ),
+        pytest.param(
+            re.compile('a.*'),
+            id='with compiled pattern',
+        ),
+    ],
+)
+def test_include_not_empty(pattern):
     mock_get_items = mock.Mock(return_value=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
-    d = Discovery(mock_get_items, include={'a.*': None})
-    assert list(d.get_items()) == [('a.*', 'a', 'a', None)]
-    assert mock_get_items.call_count == 1
-
-
-def test_include_patterns_are_compiled_internally():
-    mock_get_items = mock.Mock(return_value=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
-    d = Discovery(mock_get_items, include={'a.*': None, 'b.*': None})
-    assert list(d.get_items()) == [('a.*', 'a', 'a', None), ('b.*', 'b', 'b', None)]
-    assert mock_get_items.call_count == 1
-    assert d._filter._compiled_include_patterns == {p: re.compile(p) for p in ['a.*', 'b.*']}
-
-
-def test_include_not_empty_with_already_compiled_patterns():
-    mock_get_items = mock.Mock(return_value=['a', 'b', 'c', 'd', 'e', 'f', 'g'])
-    d = Discovery(mock_get_items, include={re.compile('a.*'): None})
-    assert list(d.get_items()) == [(re.compile('a.*'), 'a', 'a', None)]
+    d = Discovery(mock_get_items, include={pattern: None})
+    assert list(d.get_items()) == [(pattern, 'a', 'a', None)]
     assert mock_get_items.call_count == 1
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

The autodiscovery feature added in [this PR](https://github.com/DataDog/integrations-core/pull/13656) allows us to provide an `include` pattern as a string or directly as a regular expression. If the pattern is a string, we do not compile it and always forward the string to `re.search` which in turn will compile the string and use an internal cache. This PR pre-compiles the string in the discovery class to avoid multiple compilations of the same pattern.

I also added a test to ensure the filter is working as expected if we directly provide a compile regular expression.

### Motivation
<!-- What inspired you to submit this pull request? -->

Even if there's an [internal cache](https://docs.python.org/3.9/library/re.html#re.compile), I think we should compile them on our side to be completely sure they're not going to be recompiled each time the check runs

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- I'm going to use this feature in [this PR](https://github.com/DataDog/integrations-core/pull/14608)
- The autodiscovery feature is already used in the cloudera integration

- This PR is a proposition, let me know what you think!

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.