### PR TITLE
Use Git for versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ benchmark_*.svg
 
 ## Direnv
 .envrc
+
+# Auto-generated during builds
+/ddev/src/ddev/_version.py

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -1,7 +1,5 @@
 [build-system]
-requires = [
-    "hatchling>=1.5.0",
-]
+requires = ["hatchling>=1.17.1", "hatch-vcs>=0.3.0"]
 build-backend = "hatchling.build"
 
 [project]
@@ -48,7 +46,17 @@ ddev-starship = "ddev.plugin.external.starship.prompt:main"
 Source = "https://github.com/DataDog/integrations-core"
 
 [tool.hatch.version]
-path = "src/ddev/__about__.py"
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+root = ".."
+version_scheme = "python-simplified-semver"
+local_scheme = "no-local-version"
+parentdir_prefix_version = "ddev-"
+git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "ddev-v*"]
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/ddev/_version.py"
 
 [tool.black]
 include = '\.pyi?$'

--- a/ddev/src/ddev/__about__.py
+++ b/ddev/src/ddev/__about__.py
@@ -1,4 +1,0 @@
-# (C) Datadog, Inc. 2022-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '2.1.0'

--- a/ddev/src/ddev/cli/__init__.py
+++ b/ddev/src/ddev/cli/__init__.py
@@ -10,7 +10,7 @@ from datadog_checks.dev.tooling.commands.dep import dep
 from datadog_checks.dev.tooling.commands.run import run
 from datadog_checks.dev.tooling.commands.test import test
 
-from ddev.__about__ import __version__
+from ddev._version import __version__
 from ddev.cli.application import Application
 from ddev.cli.ci import ci
 from ddev.cli.clean import clean
@@ -144,6 +144,10 @@ ddev.add_command(status)
 ddev.add_command(test)
 ddev.add_command(validate)
 
+__management_command = os.environ.get('PYAPP_COMMAND_NAME', '')
+if __management_command:
+    ddev.add_command(click.Command(name=__management_command, help='Manage this application'))
+
 
 def main():  # no cov
     manager = pluggy.PluginManager('ddev')
@@ -152,7 +156,7 @@ def main():  # no cov
     manager.hook.register_commands()
 
     try:
-        return ddev(windows_expand_args=False)
+        return ddev(prog_name='ddev', windows_expand_args=False)
     except Exception:
         from rich.console import Console
 


### PR DESCRIPTION
### Motivation

In preparation for https://github.com/DataDog/integrations-core/pull/14774, on releases the binaries will use the version and name only, downloading from PyPI. For commits between releases that won't reflect changes, therefore the wheel built will be embedded in the binary and installed. This however normally would have the same version because we never change the version between releases, so we use the plug-in which automatically uses the scheme `X.Y.Z.N` where the last component is the number of changes between releases.