### PR TITLE
Add VerbosityLevels class for ddev cli/terminal use

### DIFF
--- a/ddev/src/ddev/cli/application.py
+++ b/ddev/src/ddev/cli/application.py
@@ -7,7 +7,7 @@ import os
 from typing import cast
 
 from ddev.cli.terminal import Terminal
-from ddev.config.constants import AppEnvVars
+from ddev.config.constants import AppEnvVars, VerbosityLevels
 from ddev.config.file import ConfigFile, RootConfig
 from ddev.repo.core import Repository
 from ddev.utils.fs import Path
@@ -22,8 +22,8 @@ class Application(Terminal):
         self.__exit_func = exit_func
 
         self.config_file = ConfigFile()
-        self.quiet = self.verbosity < 0
-        self.verbose = self.verbosity > 0
+        self.quiet = self.verbosity < VerbosityLevels.NORMAL
+        self.verbose = self.verbosity > VerbosityLevels.NORMAL
 
         # Lazily set these as we acquire more knowledge about the desired environment
         self.__repo = cast(Repository, None)

--- a/ddev/src/ddev/cli/application.py
+++ b/ddev/src/ddev/cli/application.py
@@ -22,8 +22,8 @@ class Application(Terminal):
         self.__exit_func = exit_func
 
         self.config_file = ConfigFile()
-        self.quiet = self.verbosity < VerbosityLevels.NORMAL
-        self.verbose = self.verbosity > VerbosityLevels.NORMAL
+        self.quiet = self.verbosity < VerbosityLevels.INFO
+        self.verbose = self.verbosity > VerbosityLevels.INFO
 
         # Lazily set these as we acquire more knowledge about the desired environment
         self.__repo = cast(Repository, None)

--- a/ddev/src/ddev/cli/terminal.py
+++ b/ddev/src/ddev/cli/terminal.py
@@ -15,7 +15,6 @@ from rich.errors import StyleSyntaxError
 from rich.style import Style
 from rich.text import Text
 
-
 from ddev.config.constants import VerbosityLevels
 
 if TYPE_CHECKING:
@@ -197,33 +196,22 @@ class Terminal:
         self.output(text, self._style_level_warning, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_info(self, text='', stderr=True, indent=None, link=None, **kwargs):
-        if self.verbosity < VerbosityLevels.NORMAL:
+        if self.verbosity < VerbosityLevels.INFO:
             return
 
         self.output(text, self._style_level_info, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_success(self, text='', stderr=True, indent=None, link=None, **kwargs):
-        if self.verbosity < VerbosityLevels.NORMAL:
+        if self.verbosity < VerbosityLevels.INFO:
             return
 
         self.output(text, self._style_level_success, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_waiting(self, text='', stderr=True, indent=None, link=None, **kwargs):
-        if self.verbosity < VerbosityLevels.NORMAL:
+        if self.verbosity < VerbosityLevels.INFO:
             return
 
         self.output(text, self._style_level_waiting, stderr=stderr, indent=indent, link=link, **kwargs)
-
-    def display_debug(self, text='', level=VerbosityLevels.VERBOSE, stderr=True, indent=None, link=None, **kwargs):
-        if not VerbosityLevels.VERBOSE <= level <= VerbosityLevels.DEBUG:
-            raise ValueError(
-                f'Debug output can only have verbosity levels between {VerbosityLevels.VERBOSE} and \
-{VerbosityLevels.DEBUG} (inclusive)'
-            )
-        elif self.verbosity < level:
-            return
-
-        self.output(text, self._style_level_debug, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_header(self, title=''):
         self.console.rule(Text(title, self._style_level_success))

--- a/ddev/src/ddev/cli/terminal.py
+++ b/ddev/src/ddev/cli/terminal.py
@@ -103,7 +103,7 @@ class BorrowedStatus:
             return
 
         old_message, final_text = self.__messages.pop()
-        if self.__verbosity > 0:
+        if self.__verbosity > VerbosityLevels.INFO:
             if not final_text:
                 final_text = old_message.plain
                 final_text = f'Finished {final_text[:1].lower()}{final_text[1:]}'

--- a/ddev/src/ddev/cli/terminal.py
+++ b/ddev/src/ddev/cli/terminal.py
@@ -15,6 +15,9 @@ from rich.errors import StyleSyntaxError
 from rich.style import Style
 from rich.text import Text
 
+
+from ddev.config.constants import VerbosityLevels
+
 if TYPE_CHECKING:
     from rich.status import Status
 
@@ -182,38 +185,41 @@ class Terminal:
             self.console.stderr = False
 
     def display_error(self, text='', stderr=True, indent=None, link=None, **kwargs):
-        if self.verbosity < -2:
+        if self.verbosity < VerbosityLevels.ERROR:
             return
 
         self.output(text, self._style_level_error, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_warning(self, text='', stderr=True, indent=None, link=None, **kwargs):
-        if self.verbosity < -1:
+        if self.verbosity < VerbosityLevels.WARN:
             return
 
         self.output(text, self._style_level_warning, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_info(self, text='', stderr=True, indent=None, link=None, **kwargs):
-        if self.verbosity < 0:
+        if self.verbosity < VerbosityLevels.NORMAL:
             return
 
         self.output(text, self._style_level_info, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_success(self, text='', stderr=True, indent=None, link=None, **kwargs):
-        if self.verbosity < 0:
+        if self.verbosity < VerbosityLevels.NORMAL:
             return
 
         self.output(text, self._style_level_success, stderr=stderr, indent=indent, link=link, **kwargs)
 
     def display_waiting(self, text='', stderr=True, indent=None, link=None, **kwargs):
-        if self.verbosity < 0:
+        if self.verbosity < VerbosityLevels.NORMAL:
             return
 
         self.output(text, self._style_level_waiting, stderr=stderr, indent=indent, link=link, **kwargs)
 
-    def display_debug(self, text='', level=1, stderr=True, indent=None, link=None, **kwargs):
-        if not 1 <= level <= 3:
-            raise ValueError('Debug output can only have verbosity levels between 1 and 3 (inclusive)')
+    def display_debug(self, text='', level=VerbosityLevels.VERBOSE, stderr=True, indent=None, link=None, **kwargs):
+        if not VerbosityLevels.VERBOSE <= level <= VerbosityLevels.DEBUG:
+            raise ValueError(
+                f'Debug output can only have verbosity levels between {VerbosityLevels.VERBOSE} and \
+{VerbosityLevels.DEBUG} (inclusive)'
+            )
         elif self.verbosity < level:
             return
 

--- a/ddev/src/ddev/config/constants.py
+++ b/ddev/src/ddev/config/constants.py
@@ -1,9 +1,6 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from enum import Enum
-
-
 class AppEnvVars:
     REPO = 'DDEV_REPO'
     INTERACTIVE = 'DDEV_INTERACTIVE'
@@ -18,33 +15,9 @@ class ConfigEnvVars:
     CONFIG = 'DDEV_CONFIG'
 
 
-class VerbosityLevels(Enum):
-    ERROR: int = -2
-    WARN: int = -1
-    QUIET: int = -1
-    INFO: int = 0
-    NORMAL: int = 0
-    VERBOSE: int = 1
-    VERY_VERBOSE: int = 2
-    DEBUG: int = 3
-
-    def __eq__(self, __value: object) -> bool:
-        # Address mypy error: Unsupported operand types for == ("int" and "object")
-        if not isinstance(__value, int):
-            # If we return NotImplemented, Python will automatically try running __value.__eq__(self)
-            return NotImplemented
-        return self.value == __value
-
-    def __lt__(self, __value: object) -> bool:
-        # Address mypy error: Unsupported operand types for < ("int" and "object")
-        if not isinstance(__value, int):
-            # If we return NotImplemented, Python will automatically try running __value.__lt__(self)
-            return NotImplemented
-        return self.value < __value
-
-    def __gt__(self, __value: object) -> bool:
-        # Address mypy error: Unsupported operand types for > ("int" and "object")
-        if not isinstance(__value, int):
-            # If we return NotImplemented, Python will automatically try running __value.__gt__(self)
-            return NotImplemented
-        return self.value > __value
+class VerbosityLevels:
+    ERROR = -2
+    WARNING = -1
+    INFO = 0
+    DEBUG = 1
+    TRACE = 2

--- a/ddev/src/ddev/config/constants.py
+++ b/ddev/src/ddev/config/constants.py
@@ -1,6 +1,9 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from enum import Enum
+
+
 class AppEnvVars:
     REPO = 'DDEV_REPO'
     INTERACTIVE = 'DDEV_INTERACTIVE'
@@ -13,3 +16,35 @@ class AppEnvVars:
 
 class ConfigEnvVars:
     CONFIG = 'DDEV_CONFIG'
+
+
+class VerbosityLevels(Enum):
+    ERROR: int = -2
+    WARN: int = -1
+    QUIET: int = -1
+    INFO: int = 0
+    NORMAL: int = 0
+    VERBOSE: int = 1
+    VERY_VERBOSE: int = 2
+    DEBUG: int = 3
+
+    def __eq__(self, __value: object) -> bool:
+        # Address mypy error: Unsupported operand types for == ("int" and "object")
+        if not isinstance(__value, int):
+            # If we return NotImplemented, Python will automatically try running __value.__eq__(self)
+            return NotImplemented
+        return self.value == __value
+
+    def __lt__(self, __value: object) -> bool:
+        # Address mypy error: Unsupported operand types for < ("int" and "object")
+        if not isinstance(__value, int):
+            # If we return NotImplemented, Python will automatically try running __value.__lt__(self)
+            return NotImplemented
+        return self.value < __value
+
+    def __gt__(self, __value: object) -> bool:
+        # Address mypy error: Unsupported operand types for > ("int" and "object")
+        if not isinstance(__value, int):
+            # If we return NotImplemented, Python will automatically try running __value.__gt__(self)
+            return NotImplemented
+        return self.value > __value


### PR DESCRIPTION
### What does this PR do?
- Adds VerbosityLevels class for ddev/terminal use

### Motivation
Verbosity levels were checked as numeric values in cli/terminal setup, converting this to an enum with meaningful name will help future developers on the intent behind the relevant initialization and comparisons

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.