### PR TITLE
Remove `pyperclip` dependency and clipboard functionality

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/env/start.py
@@ -6,7 +6,6 @@ import platform
 import time
 
 import click
-import pyperclip
 
 from ....ci import running_on_ci
 from ....fs import dir_exists, path_join
@@ -105,18 +104,12 @@ def start(ctx, check, env, agent, python, dev, base, env_vars, org_name, profile
         _start_sampling(environment)
 
     click.echo()
-    try:
-        pyperclip.copy(environment.config_file)
-    except Exception:
-        config_message = 'Config file: '
-    else:
-        config_message = 'Config file (copied to your clipboard): '
+
+    echo_success('Config file: ', nl=False)
+    echo_info(environment.config_file)
 
     echo_success('To edit config file, do: ', nl=False)
     echo_info(f'ddev env edit {check} {env}')
-
-    echo_success(config_message, nl=False)
-    echo_info(environment.config_file)
 
     echo_success('To reload the config file, do: ', nl=False)
     echo_info(f'ddev env reload {check} {env}')

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/prometheus.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/prometheus.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from itertools import product
 
 import click
-import pyperclip
 import requests
 
 from ....fs import dir_exists, path_join, write_file_lines
@@ -243,5 +242,4 @@ def parse(ctx, endpoint, check, here):
         '}}'.format('\n'.join("    '{}': '{}',".format(metric, data['dd_name']) for metric, data in metric_items))
     )
 
-    pyperclip.copy(metric_map)
-    echo_success('\nThe metric map has been copied to your clipboard, paste it to any file you want!')
+    echo_info(metric_map)

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/metrics2md.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/scripts/metrics2md.py
@@ -5,10 +5,9 @@ import csv
 from io import StringIO
 
 import click
-import pyperclip
 
 from ....utils import read_metric_data_file
-from ...console import CONTEXT_SETTINGS, abort, echo_success
+from ...console import CONTEXT_SETTINGS, abort, echo_info
 
 VALID_FIELDS = {
     'metric_name',
@@ -52,10 +51,7 @@ def metrics2md(check, fields):
             fields.append(field)
             chosen_fields.discard(field)
 
-    if check == 'cb':
-        metric_data = pyperclip.paste()
-    else:
-        metric_data = read_metric_data_file(check)
+    metric_data = read_metric_data_file(check)
 
     reader = csv.DictReader(StringIO(metric_data), delimiter=',')
 
@@ -64,10 +60,7 @@ def metrics2md(check, fields):
         rows.append(' | '.join(csv_row[field] or 'N/A' for field in fields))
 
     rows.sort()
-    num_metrics = len(rows)
-
     md_table_rows = [' | '.join(fields), ' | '.join('---' for _ in fields)]
     md_table_rows.extend(rows)
 
-    pyperclip.copy('\n'.join(md_table_rows))
-    echo_success(f"Successfully copied table with {num_metrics} metric{'s' if num_metrics > 1 else ''}")
+    echo_info('\n'.join(md_table_rows))

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/status.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/trello/status.py
@@ -6,7 +6,6 @@ import json
 from typing import List
 
 import click
-import pyperclip
 
 from ....trello import TrelloClient
 from ...console import CONTEXT_SETTINGS, echo_info, echo_success
@@ -113,9 +112,8 @@ def _summary_status(counts: dict, as_json: bool) -> List[str]:
 @click.command(context_settings=CONTEXT_SETTINGS, short_help='Gather statistics from the Trello release board')
 @click.option('--verbose', '-v', is_flag=True, help='Return the detailed results instead of the aggregates')
 @click.option('--json', '-j', 'as_json', is_flag=True, help='Return as raw JSON instead')
-@click.option('--clipboard', '-c', is_flag=True, help='Copy output to clipboard')
 @click.pass_context
-def status(ctx: click.Context, verbose: bool, as_json: bool, clipboard: bool) -> None:
+def status(ctx: click.Context, verbose: bool, as_json: bool) -> None:
     """Print tabular status of Agent Release based on Trello columns.
 
     See trello subcommand for details on how to setup access:
@@ -133,15 +131,5 @@ def status(ctx: click.Context, verbose: bool, as_json: bool, clipboard: bool) ->
     else:
         output = _verbose_status(counts, as_json)
 
-    out = '\n'.join(output)
-
-    msg = '\nTrello Status Report:\n'
-    if clipboard:
-        try:
-            pyperclip.copy(out)
-            msg = '\nTrello Status Report (copied to your clipboard):\n'
-        except Exception:
-            pass
-
-    echo_success(msg)
-    echo_info(out)
+    echo_success('\nTrello Status Report:\n')
+    echo_info('\n'.join(output))

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -76,7 +76,6 @@ cli = [
     "pip-tools",
     "pathspec>=0.10.0",
     "platformdirs>=2.0.0a3",
-    "pyperclip>=1.7.0",
     "pysmi>=0.3.4",
     "securesystemslib[crypto]==0.20.1",
     "semver>=2.13.0",

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "hatch>=1.6.3",
     "httpx",
     "jsonpointer",
-    "pyperclip",
     "rich>=12.5.1",
     "tomli; python_version < '3.11'",
     "tomli-w",

--- a/ddev/src/ddev/cli/config/__init__.py
+++ b/ddev/src/ddev/cli/config/__init__.py
@@ -26,19 +26,10 @@ def explore(app):
 
 
 @config.command(short_help='Show the location of the config file')
-@click.option('--copy', '-c', is_flag=True, help='Copy the path to the config file to the clipboard')
 @click.pass_obj
-def find(app, copy):
+def find(app):
     """Show the location of the config file."""
-    config_path = str(app.config_file.path)
-    if copy:
-        import pyperclip
-
-        pyperclip.copy(config_path)
-    elif ' ' in config_path:
-        app.display(f'"{config_path}"')
-    else:
-        app.display(config_path)
+    app.display(str(app.config_file.path))
 
 
 @config.command(short_help='Show the contents of the config file')

--- a/ddev/tests/cli/config/test_find.py
+++ b/ddev/tests/cli/config/test_find.py
@@ -1,38 +1,10 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import os
-
-import pytest
-from ddev.config.constants import ConfigEnvVars
 
 
-def test_copy(ddev, config_file, mocker):
-    mock = mocker.patch('pyperclip.copy')
-    result = ddev('config', 'find', '-c')
-
-    assert result.exit_code == 0, result.output
-    mock.assert_called_once_with(str(config_file.path))
-
-
-def test_pipe_to_editor(ddev, config_file):
-    config_file.path = config_file.path.parent / 'a space' / 'config.toml'
-    config_file.path.ensure_parent_dir_exists()
-    config_file.restore()
-    os.environ[ConfigEnvVars.CONFIG] = str(config_file.path)
-
+def test(ddev, config_file):
     result = ddev('config', 'find')
 
     assert result.exit_code == 0, result.output
-    assert result.output == f'"{str(config_file.path)}"\n'
-
-
-def test_standard(ddev, config_file):
-    config_path = str(config_file.path)
-    if ' ' in config_path:  # no cov
-        pytest.xfail('Path to system temporary directory contains spaces')
-
-    result = ddev('config', 'find')
-
-    assert result.exit_code == 0, result.output
-    assert result.output == f'{config_path}\n'
+    assert result.output == f'{config_file.path}\n'


### PR DESCRIPTION
### Motivation

In an effort to make installation faster, we should try to use versions of dependencies for which there are binary wheels. https://github.com/asweigart/pyperclip/issues/238

### Additional Notes

Largely, these features were not well received anyway