### PR TITLE
Update license path for ddev binary builds

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -7,6 +7,8 @@ on:
     branches:
     - master
   pull_request:
+    paths:
+    - ddev/**
     branches:
     - master
 
@@ -211,6 +213,8 @@ jobs:
     if: >-
       github.event_name == 'push'
       &&
+      github.event.pull_request.head.repo.full_name == github.repository
+      &&
       (github.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags'))
     needs: binaries
     runs-on: windows-2022
@@ -283,6 +287,8 @@ jobs:
     name: Build macOS installer and sign/notarize artifacts
     if: >-
       github.event_name == 'push'
+      &&
+      github.event.pull_request.head.repo.full_name == github.repository
       &&
       (github.ref == 'refs/heads/master' || startsWith(github.event.ref, 'refs/tags'))
     needs: binaries

--- a/ddev/pyoxidizer.bzl
+++ b/ddev/pyoxidizer.bzl
@@ -25,7 +25,7 @@ def make_msi(target):
     )
     msi.msi_filename = DISPLAY_NAME + "-" + VERSION + "-" + arch + ".msi"
     msi.help_url = "https://github.com/DataDog/integrations-core/tree/master/ddev"
-    msi.license_path = CWD + "/../LICENSE.txt"
+    msi.license_path = CWD + "/../LICENSE"
 
     # https://gregoryszorc.com/docs/pyoxidizer/main/tugger_starlark_type_file_manifest.html
     m = FileManifest()


### PR DESCRIPTION
### What does this PR do?
Fix LICENSE path for `build standalone binaries for ddev` workflow, which I missed in https://github.com/DataDog/integrations-core/pull/14774. Modified workflows so they only run when ddev files are modified, and windows and macos binaries run only when master is modified. 

### Motivation
`Build Windows installers` job was broken on the `build standalone binaries for ddev` workflow because the LICENSE path was incorrect.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.