### PR TITLE
Bump the minimum version of datadog-checks-dev

### DIFF
--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
 ]
 dependencies = [
-    "datadog-checks-dev[cli]~=19.0",
+    "datadog-checks-dev[cli]~=20.0",
     "hatch>=1.6.3",
     "httpx",
     "jsonpointer",

--- a/ddev/src/ddev/cli/clean/__init__.py
+++ b/ddev/src/ddev/cli/clean/__init__.py
@@ -18,4 +18,6 @@ def clean(app: Application):
     Remove build and test artifacts for the entire repository.
     """
     with app.repo.path.as_cwd():
-        app.platform.run_command(["git", "clean", "-fdX", "-e", "!.vscode", "-e", "!.idea"])
+        app.platform.run_command(
+            ["git", "clean", "-fdX", "-e", "!.vscode", "-e", "!.idea", "-e", "!ddev/src/ddev/_version.py"]
+        )


### PR DESCRIPTION
### Additional Notes

Also fixes https://github.com/DataDog/integrations-core/pull/14778, cleaning currently is breaking editable installations