### PR TITLE
Temporarily disable py2 tests on PRs

### DIFF
--- a/.github/workflows/pr-all.yml
+++ b/.github/workflows/pr-all.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Options
       standard: true
-      test-py2: true
+      test-py2: false
     secrets: inherit
 
   save-event:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -37,7 +37,7 @@ jobs:
 
       # Options
       standard: true
-      test-py2: ${{ !matrix.python-support || contains(matrix.python-support, '2') }}
+      test-py2: false
       test-py3: ${{ !matrix.python-support || contains(matrix.python-support, '3') }}
 
       # For other repositories


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Temporarily disable py2 tests on PRs, we need to figure out how we are going to test our integrations with py2

### Motivation
<!-- What inspired you to submit this pull request? -->

- `setup-python` finally dropped support for py2.7, which we use
- We do not run any tests on PRs because of that, not even the py3 ones (example: https://github.com/DataDog/integrations-core/actions/runs/5310764140/jobs/9613140975)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

The daily/weekly py2 pipeline on master will continue to fail.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.