### PR TITLE
Fix a bug importing the version when running ddev locally

### DIFF
--- a/ddev/src/ddev/cli/__init__.py
+++ b/ddev/src/ddev/cli/__init__.py
@@ -10,7 +10,12 @@ from datadog_checks.dev.tooling.commands.dep import dep
 from datadog_checks.dev.tooling.commands.run import run
 from datadog_checks.dev.tooling.commands.test import test
 
-from ddev._version import __version__
+try:
+    # If we're running the local version of ddev, this file does not exist
+    from ddev._version import __version__
+except ModuleNotFoundError:
+    __version__ = "local"
+
 from ddev.cli.application import Application
 from ddev.cli.ci import ci
 from ddev.cli.clean import clean


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix a bug importing the version when running ddev locally

### Motivation
<!-- What inspired you to submit this pull request? -->

With https://github.com/DataDog/integrations-core/pull/14778, the `_version` no longer exists in the repo and we can't run the local ddev version anymore, we would get: 

```
❯ ddev --version
Traceback (most recent call last):                                                                                                                                                                                                     ─╯
  File "/Users/florent.clarret/.pyenv/versions/3.8.14/bin/ddev", line 5, in <module>
    from ddev.cli import main
  File "/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/ddev/src/ddev/cli/__init__.py", line 13, in <module>
    from ddev._version import __version__
ModuleNotFoundError: No module named 'ddev._version' 
```

(same error with any command)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.