### PR TITLE
Set the `marker` option to `not e2e` by default

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -35,7 +35,7 @@ from .console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, echo_succes
 @click.option('--cov', '-c', 'coverage', is_flag=True, help='Measure code coverage')
 @click.option('--cov-missing', '-cm', is_flag=True, help='Show line numbers of statements that were not executed')
 @click.option('--junit', '-j', 'junit', is_flag=True, help='Generate junit reports')
-@click.option('--marker', '-m', help='Only run tests matching given marker expression')
+@click.option('--marker', '-m', default="not e2e", help='Only run tests matching given marker expression')
 @click.option('--filter', '-k', 'test_filter', help='Only run tests matching given substring expression')
 @click.option('--pdb', 'enter_pdb', is_flag=True, help='Drop to PDB on first failure, then end test session')
 @click.option('--debug', '-d', is_flag=True, help='Set the log level to debug')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Set the `marker` option to `not e2e` by default in the `ddev test <INTEGRATION>` command.

### Motivation
<!-- What inspired you to submit this pull request? -->

We do not run the e2e tests when using this command by default. However, pytest does try to run them and we skip them at runtime in the `dd_agent_check` fixture [here](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_dev/datadog_checks/dev/plugin/pytest.py#L141-L144). It means that the other fixtures can also run before we skip the test. In my case, the fixture `dd_environment` runs before we skip the test, leading us to spin up a whole environment that is not needed at all. This modification will speed up the tests for users and in the CI too.

Example with the DCGM integration: 

Before (but with the docker image already pulled): 

```
❯ ddev test dcgm
Running tests for `dcgm`                                                                                                                                                                                                                              ─╯
------------------------
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── py3.9 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Finished checking dependencies
cmd [1] | pytest -v --benchmark-skip tests
================================================================================================================== test session starts ==================================================================================================================
platform darwin -- Python 3.9.16, pytest-7.3.2, pluggy-1.0.0 -- /Users/florent.clarret/Library/Application Support/hatch/env/virtual/datadog-dcgm/P4npWWzG/py3.9/bin/python
cachedir: .pytest_cache
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/florent.clarret/go/src/github.com/DataDog/integrations-core/dcgm
plugins: asyncio-0.21.0, ddtrace-0.53.2, flaky-3.7.0, memray-1.4.1, mock-3.10.0, cov-4.1.0, datadog-checks-dev-19.4.0, benchmark-4.0.0
asyncio: mode=strict
collected 2 items                                                                                                                                                                                                                                       

tests/test_dcgm.py::test_check PASSED                                                                                                                                                                                                             [ 50%]
tests/test_e2e.py::test_e2e SKIPPED (Not running E2E tests)                                                                                                                                                                                       [100%]

============================================================================================================= 1 passed, 1 skipped in 1.71s ==============================================================================================================
cmd [1] | black --config ../pyproject.toml --check --diff .
All done! ✨ 🍰 ✨
15 files would be left unchanged.
cmd [2] | ruff --config ../pyproject.toml .

Passed!
```

After: 

```
❯ ddev test dcgm
Running tests for `dcgm`                                                                                                                                                                                                                              ─╯
------------------------
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── py3.9 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Finished checking dependencies
cmd [1] | pytest -v --benchmark-skip tests
================================================================================================================== test session starts ==================================================================================================================
platform darwin -- Python 3.9.16, pytest-7.3.2, pluggy-1.0.0 -- /Users/florent.clarret/Library/Application Support/hatch/env/virtual/datadog-dcgm/P4npWWzG/py3.9/bin/python
cachedir: .pytest_cache
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/florent.clarret/go/src/github.com/DataDog/integrations-core/dcgm
plugins: asyncio-0.21.0, ddtrace-0.53.2, flaky-3.7.0, memray-1.4.1, mock-3.10.0, cov-4.1.0, datadog-checks-dev-19.4.0, benchmark-4.0.0
asyncio: mode=strict
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                                                           

tests/test_dcgm.py::test_check PASSED                                                                                                                                                                                                             [100%]

============================================================================================================ 1 passed, 1 deselected in 0.03s ============================================================================================================
cmd [1] | black --config ../pyproject.toml --check --diff .
All done! ✨ 🍰 ✨
15 files would be left unchanged.
cmd [2] | ruff --config ../pyproject.toml .

Passed!
```

This integration is probably not the best example because the environment starts very quickly, but it can take much more time for other integrations

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- It will allow you to avoid pulling all kind of images if not needed, making the tests even faster
- There's no integration tests in the DCGM integration because the e2e env is a fake one using Caddy

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.