### PR TITLE
Update changelog generation to use a better formatting

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -129,7 +129,7 @@ def changelog(
 
         author = payload.get('user', {}).get('login')
         author_url = payload.get('user', {}).get('html_url')
-        title = f"[{changelog_type}] {payload.get('title')}"
+        title = f"{payload.get('title')}"
 
         entry = ChangelogEntry(pr_num, title, payload.get('html_url'), author, author_url, from_contributor(payload))
 
@@ -143,8 +143,9 @@ def changelog(
     new_entry.write(header)
 
     # one bullet point for each PR
-    new_entry.write('\n')
     for changelog_type in CHANGELOG_TYPES_ORDERED:
+        if entries[changelog_type]:
+            new_entry.write(f"\n***{changelog_type}***:\n\n")
         for entry in entries[changelog_type]:
             thanks_note = ''
             if entry.from_contributor:


### PR DESCRIPTION
### What does this PR do?
Modifies script to generate integration changelogs to its updated format

example: 
<img width="1011" alt="Screenshot 2023-06-20 at 1 57 53 PM" src="https://github.com/DataDog/integrations-core/assets/24441980/0572b12f-b38f-4e14-b997-7bee68b26b39">

### Motivation
Current changelogs are not as intuitive to read 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.