### PR TITLE
Require Python 3 for Postgres integration

### DIFF
--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -10,6 +10,7 @@ build-backend = "hatchling.build"
 name = "datadog-postgres"
 description = "The Postgres check"
 readme = "README.md"
+requires-python = ">=3.8"
 keywords = [
     "datadog",
     "datadog agent",
@@ -24,7 +25,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.9",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
@@ -41,11 +41,8 @@ text = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "boto3==1.17.112; python_version < '3.0'",
     "boto3==1.26.138; python_version > '3.0'",
-    "cachetools==3.1.1; python_version < '3.0'",
     "cachetools==5.3.0; python_version > '3.0'",
-    "futures==3.4.0; python_version < '3.0'",
     "psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'",
     "semver==2.13.0",
 ]


### PR DESCRIPTION
### What does this PR do?
This PR updates the dependencies for the Postgres agent check to require Python 3.8. 

### Motivation
I want to use some python 3 specific syntax in this PR: https://github.com/DataDog/integrations-core/pull/14786
and we are bumping the requirements in the next agent release anyway, so these dependencies should be updated.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.