### PR TITLE
Revert "Set the `marker` option to `not e2e` by default (#14804)"

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/test.py
@@ -35,7 +35,7 @@ from .console import CONTEXT_SETTINGS, abort, echo_debug, echo_info, echo_succes
 @click.option('--cov', '-c', 'coverage', is_flag=True, help='Measure code coverage')
 @click.option('--cov-missing', '-cm', is_flag=True, help='Show line numbers of statements that were not executed')
 @click.option('--junit', '-j', 'junit', is_flag=True, help='Generate junit reports')
-@click.option('--marker', '-m', default="not e2e", help='Only run tests matching given marker expression')
+@click.option('--marker', '-m', help='Only run tests matching given marker expression')
 @click.option('--filter', '-k', 'test_filter', help='Only run tests matching given substring expression')
 @click.option('--pdb', 'enter_pdb', is_flag=True, help='Drop to PDB on first failure, then end test session')
 @click.option('--debug', '-d', is_flag=True, help='Set the log level to debug')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This reverts commit https://github.com/DataDog/integrations-core/pull/14804.

### Motivation
<!-- What inspired you to submit this pull request? -->

Some integrations only have e2e tests 😢 which makes the CI fail because there's no tests to run. We missed that in the original PR because not all the integration tests ran. Example: https://github.com/DataDog/integrations-core/actions/runs/5330550724/jobs/9657370490

For ActiveMQ: 

```
============================= test session starts ==============================
platform linux -- Python 3.9.17, pytest-7.3.2, pluggy-1.0.0 -- /home/runner/.local/share/hatch/env/virtual/datadog-activemq/C9F59Roh/py3.9-2.15.0-artemis.yaml/bin/python
cachedir: .pytest_cache
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/runner/work/integrations-core/integrations-core/activemq
plugins: ddtrace-0.53.2, memray-1.4.1, asyncio-0.21.0, benchmark-4.0.0, datadog-checks-dev-20.0.1, mock-3.11.1, flaky-3.7.0, cov-4.1.0
asyncio: mode=strict
collecting ... collected 2 items / 2 deselected / 0 selected

- generated xml file: /home/runner/work/integrations-core/integrations-core/activemq/.junit/test-unit-py3.9-2.15.0-artemis.yaml$TOX_ENV_NAME.xml -
============================ 2 deselected in 0.04s =============================

Failed!
Error: Process completed with exit code 5.
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

If you have an alternative to not make the step fail, let me know!

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.