### PR TITLE
Allow non-443 port to be used in intermediate certs

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -427,7 +427,8 @@ class RequestsWrapper(object):
             # fetch the intermediate certs
             parsed_url = urlparse(url)
             hostname = parsed_url.hostname
-            certs = self.fetch_intermediate_certs(hostname)
+            port = parsed_url.port
+            certs = self.fetch_intermediate_certs(hostname, port)
             if not certs:
                 raise e
             # retry the connection via session object
@@ -454,12 +455,12 @@ class RequestsWrapper(object):
 
         return options
 
-    def fetch_intermediate_certs(self, hostname):
+    def fetch_intermediate_certs(self, hostname, port=443):
         # TODO: prefer stdlib implementation when available, see https://bugs.python.org/issue18617
         certs = []
 
         try:
-            sock = create_socket_connection(hostname)
+            sock = create_socket_connection(hostname, port)
         except Exception as e:
             self.logger.error('Error occurred while connecting to socket to discover intermediate certificates: %s', e)
             return certs

--- a/datadog_checks_base/tests/base/utils/http/test_tls_and_certs.py
+++ b/datadog_checks_base/tests/base/utils/http/test_tls_and_certs.py
@@ -5,6 +5,7 @@ import logging
 
 import mock
 import pytest
+from requests.exceptions import SSLError
 
 from datadog_checks.base.utils.http import RequestsWrapper
 
@@ -207,3 +208,27 @@ class TestAIAChasing:
         with caplog.at_level(logging.ERROR), pytest.raises(Exception):
             http.get("https://incomplete-chain.badssl.com/")
             assert "Protocol version `TLSv1.2` not in the allowed list ['TLSv1.1']" in caplog.text
+
+    @pytest.mark.parametrize(
+        "port",
+        [
+            pytest.param(443, id="443 default https port"),
+            pytest.param(444, id="444 non-default https port"),
+        ],
+    )
+    def test_fetch_intermediate_certs(self, port):
+        instance = {
+            'auth_token': {
+                'reader': {'type': 'oauth', 'url': 'foo', 'client_id': 'bar', 'client_secret': 'baz'},
+                'writer': {'type': 'header', 'name': 'Authorization', 'value': 'Bearer <TOKEN>'},
+            }
+        }
+        http = RequestsWrapper(instance, {})
+
+        with mock.patch('datadog_checks.base.utils.http.create_socket_connection') as mock_create_socket_connection:
+            with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.handle_auth_token'):
+                with pytest.raises(SSLError):
+                    with mock.patch('requests.get', side_effect=SSLError):
+                        http.get(f"https://localhost:{port}")
+
+        mock_create_socket_connection.assert_called_with('localhost', port)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds the feature for non-443 ports to be used when getting intermediate certs.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/integrations-core/issues/14734

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Currently [looking into setting up E2E testing](https://github.com/chromium/badssl.com/commit/3fdc123eccaeaf0a5e30827bdd5d7804a3f11408) for this and other intermediate cert features, since badssl.com no longer has valid certs, so [we are skipping some tests](https://github.com/DataDog/integrations-core/blob/2546231d9b6c4367745ed8adbd9012137469a6c9/datadog_checks_base/tests/base/utils/http/test_tls_and_certs.py#L188).
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.