### PR TITLE
Add python vs core test for user profiles feature

### DIFF
--- a/snmp/tests/fixtures/user_profiles/apc_ups_user.yaml
+++ b/snmp/tests/fixtures/user_profiles/apc_ups_user.yaml
@@ -13,5 +13,5 @@ metadata:
 metrics:
   - MIB: PowerNet-MIB
     symbol:
-      OID: 1.3.6.1.4.1.318.1.1.1.2.2.5.0
-      name: upsAdvBatteryNumOfBattPacks_userMetric
+      OID: 1.3.6.1.4.1.318.1.1.1.2.2.11.0
+      name: upsAdvBatteryFullCapacity_userMetric

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -411,7 +411,7 @@ def test_e2e_core_detect_metrics_using_apc_ups_metrics(dd_agent_check):
     for metric in metrics.APC_UPS_METRICS:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags, count=2)
     aggregator.assert_metric(
-        'snmp.upsAdvBatteryNumOfBattPacks_userMetric', metric_type=aggregator.GAUGE, tags=tags, count=2
+        'snmp.upsAdvBatteryFullCapacity_userMetric', metric_type=aggregator.GAUGE, tags=tags, count=2
     )
     aggregator.assert_metric(
         'snmp.upsOutletGroupStatusGroupState',

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -91,7 +91,7 @@ def test_e2e_user_profiles(dd_agent_check):
 
     aggregator.assert_metric('snmp.upsAdvBatteryNumOfBattPacks', metric_type=aggregator.GAUGE, tags=tags, count=2)
     aggregator.assert_metric(
-        'snmp.upsAdvBatteryNumOfBattPacks_userMetric', metric_type=aggregator.GAUGE, tags=tags, count=2
+        'snmp.upsAdvBatteryFullCapacity_userMetric', metric_type=aggregator.GAUGE, tags=tags, count=2
     )
 
     device = {

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -286,7 +286,7 @@ def test_e2e_profile_apc_ups(dd_agent_check):
 
 def test_e2e_profile_apc_ups_user(dd_agent_check):
     config = common.generate_container_profile_config('apc_ups_user')
-    assert_python_vs_core(dd_agent_check, config, expected_total_count=64 + 5)
+    assert_python_vs_core(dd_agent_check, config, expected_total_count=66 + 5)
 
 
 def test_e2e_profile_arista(dd_agent_check):

--- a/snmp/tests/test_e2e_core_vs_python.py
+++ b/snmp/tests/test_e2e_core_vs_python.py
@@ -284,6 +284,11 @@ def test_e2e_profile_apc_ups(dd_agent_check):
     assert_python_vs_core(dd_agent_check, config, expected_total_count=64 + 5)
 
 
+def test_e2e_profile_apc_ups_user(dd_agent_check):
+    config = common.generate_container_profile_config('apc_ups_user')
+    assert_python_vs_core(dd_agent_check, config, expected_total_count=64 + 5)
+
+
 def test_e2e_profile_arista(dd_agent_check):
     config = common.generate_container_profile_config('arista')
     assert_python_vs_core(dd_agent_check, config, expected_total_count=16 + 5)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add test_e2e_profile_apc_ups_user

### Motivation
<!-- What inspired you to submit this pull request? -->

Make sure that python integration also partially support user profiles.

Python user profiles support is implemented here: https://github.com/DataDog/integrations-core/pull/14752

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.