### PR TITLE
Update link to pods dashboard from kubernetes cluster dashboard

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_clusters.json
+++ b/kubernetes/assets/dashboards/kubernetes_clusters.json
@@ -569,7 +569,12 @@
                     },
                     {
                         "definition": {
-                            "custom_links": [],
+                            "custom_links": [
+                                {
+                                    "label": "View Pods overview",
+                                    "link": "https://app.datadoghq.com/dash/integration/Kubernetes%20-%20Pods"
+                                }
+                            ],
                             "precision": 0,
                             "requests": [
                                 {
@@ -592,7 +597,12 @@
                     },
                     {
                         "definition": {
-                            "custom_links": [],
+                            "custom_links": [
+                                {
+                                    "label": "View Pods overview",
+                                    "link": "https://app.datadoghq.com/dash/integration/Kubernetes%20-%20Pods"
+                                }
+                            ],
                             "precision": 0,
                             "requests": [
                                 {


### PR DESCRIPTION
### What does this PR do?
Re-adds custom links to the kubernetes pods overview dashboard from the kubernetes cluster dashboard

### Motivation
This is a follow-up to this PR which originally removed the links because they were broken: https://github.com/DataDog/integrations-core/pull/14727

The original broken link was: https://app.datadoghq.com/screen/integration/30322/kubernetes-pods-overview

When the working version of that link would have been: https://app.datadoghq.com/dash/integration/30322/kubernetes-pods-overview

The new link is account independent: https://app.datadoghq.com/dash/integration/Kubernetes%20-%20Pods

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.