### PR TITLE
Refactor hp-ilo profile vendor

### DIFF
--- a/snmp/datadog_checks/snmp/data/default_profiles/hp-ilo.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/hp-ilo.yaml
@@ -7,15 +7,14 @@ extends:
   - _hp-compaq-health.yaml
   - _hp-driver-stats.yaml
 
-device:
-  vendor: "hp"
-
 sysobjectid:
   - 1.3.6.1.4.1.232.9.4.*     # HP iLO
 
 metadata:
   device:
     fields:
+      vendor:
+        value: "hp"
       product_name:
         value: Integrated Lights-Out
 

--- a/snmp/tests/test_e2e_core_profiles/test_profile_hp_ilo.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_hp_ilo.py
@@ -27,7 +27,6 @@ def test_e2e_profile_hp_ilo(dd_agent_check):
         'snmp_host:hp-ilo.device.name',
         'device_namespace:default',
         'snmp_device:' + ip_address,
-        'device_vendor:hp',
     ]
 
     # --- TEST METRICS ---
@@ -175,7 +174,6 @@ def test_e2e_profile_hp_ilo(dd_agent_check):
         'version': 'A04-08/12/2018',
         'tags': [
             'device_namespace:default',
-            'device_vendor:hp',
             'snmp_device:' + ip_address,
             'snmp_host:hp-ilo.device.name',
             'snmp_profile:hp-ilo',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Refactor hp-ilo profile vendor to use `metadata` section instead of older `device.vendor`.

It's safe to remove `device.vendor` (that also removes `snmp_vendor` tag) since the profile is new and not released in a new agent version yet: https://github.com/DataDog/integrations-core/pull/14771

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.