### PR TITLE
Update remaining links to pods dashboard from kubernetes dashboards

### DIFF
--- a/datadog_operator/assets/dashboards/operator_overview.json
+++ b/datadog_operator/assets/dashboards/operator_overview.json
@@ -550,7 +550,7 @@
                             ],
                             "custom_links": [
                                 {
-                                    "link": "/dash/integration/30322/kubernetes-pods-overview",
+                                    "link": "/dash/integration/Kubernetes%20-%20Pods",
                                     "label": "View Pods overview"
                                 }
                             ],

--- a/kubernetes/assets/dashboards/kubernetes_clusters.json
+++ b/kubernetes/assets/dashboards/kubernetes_clusters.json
@@ -3170,7 +3170,7 @@
                     {
                         "definition": {
                             "background_color": "white",
-                            "content": "View more in the [Kubernetes Pods Overview Dashboard](https://app.datadoghq.com/dash/integration/30322/kubernetes-pods-overview?tpl_var_cluster=$cluster.value&tpl_var_scope=$scope.value)",
+                            "content": "View more in the [Kubernetes Pods Overview Dashboard](/dash/integration/Kubernetes%20-%20Pods?tpl_var_cluster=$cluster.value&tpl_var_scope=$scope.value)",
                             "font_size": "14",
                             "has_padding": true,
                             "show_tick": false,

--- a/kubernetes/assets/dashboards/kubernetes_dashboard.json
+++ b/kubernetes/assets/dashboards/kubernetes_dashboard.json
@@ -1482,7 +1482,7 @@
                 ],
                 "custom_links": [
                     {
-                        "link": "https://app.datadoghq.com/screen/integration/30322/kubernetes-pods-overview",
+                        "link": "/dash/integration/Kubernetes%20-%20Pods",
                         "label": "View Pods overview"
                     }
                 ],


### PR DESCRIPTION
### What does this PR do?
Updates remaining references to the Kubernetes Pods dashboard to use generic link

### Motivation
A follow-up to https://github.com/DataDog/integrations-core/pull/14822, there were a couple of other references to the old, us1 specific dashboard.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.