### PR TITLE
Remove ddev script from datadog_checks_dev

### DIFF
--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -92,9 +92,6 @@ cli = [
     "wheel>=0.31.0",
 ]
 
-[project.scripts]
-ddev = "datadog_checks.dev.tooling.cli:ddev"
-
 [project.entry-points.pytest11]
 datadog_checks = "datadog_checks.dev.plugin.pytest"
 


### PR DESCRIPTION
### What does this PR do?
Remove ddev script from `datadog_checks_dev`. The new CLI package provides that and therefore this is a duplicate that can potentially cause conflicts

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.