### PR TITLE
Replace datadog-checks-dev with ddev in tagger-image-builder

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -232,12 +232,12 @@ tagger-image-builder:
   only:
     changes:
       - .gitlab/tagger/**/*
-      - datadog_checks_dev/**/*
+      - ddev/**/*
       - .gitlab-ci.yaml
     refs:
       - master
   script:
-    - docker build --tag $TAGGER_IMAGE -f .gitlab/tagger/Dockerfile ./datadog_checks_dev/
+    - docker build --tag $TAGGER_IMAGE -f .gitlab/tagger/Dockerfile ./ddev/
     - docker images $TAGGER_IMAGE
     - docker push $TAGGER_IMAGE
   except: [ tags, schedules ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We need to update the `tagger-image-builder` script to swap out `datadog-checks-dev` with `ddev`.

### Motivation
<!-- What inspired you to submit this pull request? -->
https://github.com/DataDog/integrations-core/pull/14844

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.