### PR TITLE
Remove `kube_metrics_server.process.cpu_seconds_total` from the doc

### DIFF
--- a/kube_metrics_server/metadata.csv
+++ b/kube_metrics_server/metadata.csv
@@ -12,6 +12,5 @@ kube_metrics_server.manager_tick_duration.sum,gauge,,,second,"The total time spe
 kube_metrics_server.scraper_duration.count,gauge,,,,"Time spent scraping sources",0,kube_metrics_server,scraper_duration.count,
 kube_metrics_server.scraper_duration.sum,gauge,,,second,"Time spent scraping sources",0,kube_metrics_server,scraper_duration.sum,
 kube_metrics_server.scraper_last_time,gauge,,,second,"Last time metrics-server performed a scrape since unix epoch",0,kube_metrics_server,scraper_last_time,
-kube_metrics_server.process.cpu_seconds_total,count,,,second,"Total user and system CPU time spent",0,kube_metrics_server,process.cpu_seconds_total,
 kube_metrics_server.process.max_fds,gauge,,,,"Maximum number of open file descriptors",0,kube_metrics_server,process.max_fds,
 kube_metrics_server.process.open_fds,gauge,,,,"Number of open file descriptors",0,kube_metrics_server,process.open_fds,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR removes `kube_metrics_server.process.cpu_seconds_total` from the doc which is not captured by the check.

### Motivation
<!-- What inspired you to submit this pull request? -->
Keep doc up to date.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
N/A

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.