### PR TITLE
Do not stop collecting metrics if the templates endpoint is not reachable

### DIFF
--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -270,7 +270,13 @@ class ESCheck(AgentCheck):
         self._get_index_search_stats(admin_forwarder, base_tags)
 
     def _get_template_metrics(self, admin_forwarder, base_tags):
-        template_resp = self._get_data(self._join_url('/_cat/templates?format=json', admin_forwarder))
+
+        try:
+            template_resp = self._get_data(self._join_url('/_cat/templates?format=json', admin_forwarder))
+        except Exception as e:
+            self.log.error("Error reading templates info from servers (%s) - template metrics will be missing", e)
+            return
+
         filtered_templates = [t for t in template_resp if not t['name'].startswith(TEMPLATE_EXCLUSION_LIST)]
 
         for metric, desc in iteritems(TEMPLATE_METRICS):

--- a/elastic/tests/test_unit.py
+++ b/elastic/tests/test_unit.py
@@ -3,9 +3,11 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import logging
 
+import mock
 import pytest
 
 from datadog_checks.base import ConfigurationError
+from datadog_checks.dev.http import MockResponse
 from datadog_checks.elastic import ESCheck
 from datadog_checks.elastic.elastic import get_value_from_path
 
@@ -126,6 +128,18 @@ def test_get_template_metrics(aggregator, instance, mock_http_response):
     check._get_template_metrics(False, [])
 
     aggregator.assert_metric("elasticsearch.templates.count", value=6)
+
+
+def test_get_template_metrics_raise_exception(aggregator, instance):
+    with mock.patch(
+        'requests.get',
+        return_value=MockResponse(status_code=403),
+    ):
+        check = ESCheck('elastic', {}, instances=[instance])
+        # Make sure we do not throw an exception and move on
+        check._get_template_metrics(False, [])
+
+    aggregator.assert_metric("elasticsearch.templates.count", count=0)
 
 
 def test_get_value_from_path():


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not stop collecting metrics if the templates endpoint is not reachable. This was introduced in https://github.com/DataDog/integrations-core/pull/14569

### Motivation
<!-- What inspired you to submit this pull request? -->

In some cases we can get a 403 on this endpoint. The check should continue collecting the other metrics.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This will be backported to 7.46

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.