### PR TITLE
Do not stop collecting metrics if the templates endpoint is not reachable

### DIFF
--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -266,7 +266,13 @@ class ESCheck(AgentCheck):
         self._get_index_search_stats(admin_forwarder, base_tags)
 
     def _get_template_metrics(self, admin_forwarder, base_tags):
-        template_resp = self._get_data(self._join_url('/_cat/templates?format=json', admin_forwarder))
+
+        try:
+            template_resp = self._get_data(self._join_url('/_cat/templates?format=json', admin_forwarder))
+        except Exception as e:
+            self.log.error("Error reading templates info from servers (%s) - template metrics will be missing", e)
+            return
+
         filtered_templates = [t for t in template_resp if not t['name'].startswith(TEMPLATE_EXCLUSION_LIST)]
 
         for metric, desc in iteritems(TEMPLATE_METRICS):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not stop collecting metrics if the templates endpoint is not reachable

### Motivation
<!-- What inspired you to submit this pull request? -->

Backport https://github.com/DataDog/integrations-core/pull/15050

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.