### PR TITLE
Updating query for the CrashloopBackOff recommended monitor

### DIFF
--- a/kubernetes/assets/monitors/monitor_pod_crashloopbackoff.json
+++ b/kubernetes/assets/monitors/monitor_pod_crashloopbackoff.json
@@ -1,7 +1,7 @@
 {
 	"name": "[kubernetes] Pod {{pod_name.name}} is CrashloopBackOff on namespace {{kube_namespace.name}}",
 	"type": "query alert",
-	"query": "max(last_10m):max:kubernetes_state.container.status_report.count.waiting{reason:crashloopbackoff} by {kube_cluster_name,kube_namespace,pod_name} >= 1",
+	"query": "max(last_10m):default_zero(max:kubernetes_state.container.status_report.count.waiting{reason:crashloopbackoff} by {kube_cluster_name,kube_namespace,pod_name}) >= 1",
 	"message": "pod {{pod_name.name}} is in CrashloopBackOff on {{kube_namespace.name}} \n This alert could generate several alerts for a bad deployment. Adjust the thresholds of the query to suit your infrastructure.",
 	"tags": [
 		"integration:kubernetes"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Updates the CrashloopBackOff recommended monitor by adding the default_zero() function

### Motivation
<!-- What inspired you to submit this pull request? -->

A change that has been recommended by the Monitors team, see more information in this escalation: https://datadoghq.atlassian.net/browse/CONS-5639?focusedCommentId=1129240

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.