### PR TITLE
Add metadata for OTel Python runtime metrics

### DIFF
--- a/otel/metadata.csv
+++ b/otel/metadata.csv
@@ -143,15 +143,9 @@ otel.process.runtime.dotnet.thread_pool.queue.length,gauge,10,item,,The number o
 otel.process.runtime.dotnet.timer.count,gauge,10,unit,,The number of timer instances that are currently active,0,otel,otel timer.count,
 otel.process.runtime.dotnet.assemblies.count,gauge,10,unit,,The number of .NET assemblies that are currently loaded,0,otel,otel assemblies.count,
 otel.process.runtime.dotnet.gc.committed_memory.size,gauge,10,byte,,The amount of committed virtual memory for the managed GC heap as observed during the latest garbage collection,0,otel,otel gc.committed_memory.size,
-process.runtime.cpython.cpu_time,count,10,second,,Number of seconds executing in the kernel,0,otel,cpu_time
-process.runtime.cpython.gc_count,count,10,resource,,Number of completed garbage collection cycles,0,otel,gc_count
-process.runtime.cpython.memory,gauge,10,byte,,Resident set memory,0,otel,memory
-runtime.cpython.cpu_time,count,10,second,,Number of seconds executing in the kernel,0,otel,cpu_time
-runtime.cpython.gc_count,count,10,resource,,Number of completed garbage collection cycles,0,otel,gc_count
-runtime.cpython.memory,gauge,10,byte,,Resident set memory,0,otel,memory
-otel.process.runtime.cpython.cpu_time,count,10,second,,Number of seconds executing in the kernel,0,otel,otel cpu_time
-otel.process.runtime.cpython.gc_count,count,10,resource,,Number of completed garbage collection cycles,0,otel,otel gc_count
-otel.process.runtime.cpython.memory,gauge,10,byte,,Resident set memory,0,otel,otel memory
-otel.runtime.cpython.cpu_time,count,10,second,,Number of seconds executing in the kernel,0,otel,otel cpu_time
-otel.runtime.cpython.gc_count,count,10,resource,,Number of completed garbage collection cycles,0,otel,otel gc_count
-otel.runtime.cpython.memory,gauge,10,byte,,Resident set memory,0,otel,otel memory
+process.runtime.cpython.cpu_time,count,10,second,,Number of seconds executing in the kernel,0,otel,cpu_time,
+process.runtime.cpython.gc_count,count,10,resource,,Number of completed garbage collection cycles,0,otel,gc_count,
+process.runtime.cpython.memory,gauge,10,byte,,Resident set memory,0,otel,memory,
+otel.process.runtime.cpython.cpu_time,count,10,second,,Number of seconds executing in the kernel,0,otel,otel cpu_time,
+otel.process.runtime.cpython.gc_count,count,10,resource,,Number of completed garbage collection cycles,0,otel,otel gc_count,
+otel.process.runtime.cpython.memory,gauge,10,byte,,Resident set memory,0,otel,otel memory,

--- a/otel/metadata.csv
+++ b/otel/metadata.csv
@@ -143,3 +143,15 @@ otel.process.runtime.dotnet.thread_pool.queue.length,gauge,10,item,,The number o
 otel.process.runtime.dotnet.timer.count,gauge,10,unit,,The number of timer instances that are currently active,0,otel,otel timer.count,
 otel.process.runtime.dotnet.assemblies.count,gauge,10,unit,,The number of .NET assemblies that are currently loaded,0,otel,otel assemblies.count,
 otel.process.runtime.dotnet.gc.committed_memory.size,gauge,10,byte,,The amount of committed virtual memory for the managed GC heap as observed during the latest garbage collection,0,otel,otel gc.committed_memory.size,
+process.runtime.cpython.cpu_time,count,10,second,,Number of seconds executing in the kernel,0,otel,cpu_time
+process.runtime.cpython.gc_count,count,10,resource,,Number of completed garbage collection cycles,0,otel,gc_count
+process.runtime.cpython.memory,gauge,10,byte,,Resident set memory,0,otel,memory
+runtime.cpython.cpu_time,count,10,second,,Number of seconds executing in the kernel,0,otel,cpu_time
+runtime.cpython.gc_count,count,10,resource,,Number of completed garbage collection cycles,0,otel,gc_count
+runtime.cpython.memory,gauge,10,byte,,Resident set memory,0,otel,memory
+otel.process.runtime.cpython.cpu_time,count,10,second,,Number of seconds executing in the kernel,0,otel,otel cpu_time
+otel.process.runtime.cpython.gc_count,count,10,resource,,Number of completed garbage collection cycles,0,otel,otel gc_count
+otel.process.runtime.cpython.memory,gauge,10,byte,,Resident set memory,0,otel,otel memory
+otel.runtime.cpython.cpu_time,count,10,second,,Number of seconds executing in the kernel,0,otel,otel cpu_time
+otel.runtime.cpython.gc_count,count,10,resource,,Number of completed garbage collection cycles,0,otel,otel gc_count
+otel.runtime.cpython.memory,gauge,10,byte,,Resident set memory,0,otel,otel memory


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We're adding support for OTel Python runtime metrics so this PR adds metadata entries for all of the new OTel runtime metrics from the [OTel Python SDK](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/instrumentation/opentelemetry-instrumentation-system-metrics/src/opentelemetry/instrumentation/system_metrics/__init__.py).
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.