### PR TITLE
SQL Server query metrics: avoid sending procedure text twice

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -88,7 +88,7 @@ select
             - statement_start_offset) / 2) + 1) AS statement_text,
     qt.text,
     encrypted as is_encrypted,
-    * from qstats_aggr_split
+    s.* from qstats_aggr_split s
     cross apply sys.dm_exec_sql_text(plan_handle) qt
 """
 
@@ -120,7 +120,7 @@ select
     END - statement_start_offset) / 2) + 1) AS statement_text,
     qt.text,
     encrypted as is_encrypted,
-    * from qstats_aggr_split
+    s.* from qstats_aggr_split s
     cross apply sys.dm_exec_sql_text(plan_handle) qt
 """
 


### PR DESCRIPTION
### What does this PR do?
Currently, because of `select *` procedure text gets sent twice for each row in query metrics. We are removing this redundancy.

### Motivation
Some customer have been experiencing timeouts when collecting query metrics. The query was waiting on "Network":

![image](https://github.com/DataDog/integrations-core/assets/18366081/6d3d6b25-32cb-4f3f-ac6a-c6419cd9485d)

The biggest contributor to the network traffic is the procedure text. It's worth noting that not only do we send the query text, but we also send the complete source code of the procedure which is executing the query. If we have a large procedure executing many queries, we will select the procedure source code many times. This PR halves the network traffic.

### Additional Notes
https://datadoghq.atlassian.net/browse/DBM-2535

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.