### PR TITLE
sqlserver: remove unused `procedure_text` from metrics payloads

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -344,6 +344,10 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         # to the backend
         if 'statement_text' in row:
             del row['statement_text']
+        # we're already able to link to the procedure via procedure_name and procedure_signature so we don't need
+        # the text in metrics payloads
+        if 'procedure_text' in row:
+            del row['procedure_text']
         return row
 
     def _to_metrics_payload(self, rows):


### PR DESCRIPTION
### What does this PR do?

We're already able to link to the procedure via procedure_name and procedure_signature so we don't need the text in metrics payloads.

### Motivation

Reduce the size of metrics payloads. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.