### PR TITLE
Fix tests on Python 2

### DIFF
--- a/datadog_checks_base/tests/base/utils/http/test_tls_and_certs.py
+++ b/datadog_checks_base/tests/base/utils/http/test_tls_and_certs.py
@@ -229,6 +229,6 @@ class TestAIAChasing:
             with mock.patch('datadog_checks.base.utils.http.RequestsWrapper.handle_auth_token'):
                 with pytest.raises(SSLError):
                     with mock.patch('requests.get', side_effect=SSLError):
-                        http.get(f"https://localhost:{port}")
+                        http.get('https://localhost:{}'.format(port))
 
         mock_create_socket_connection.assert_called_with('localhost', port)


### PR DESCRIPTION
### Motivation

Python 2 tests were disabled temporarily when this was merged https://github.com/DataDog/integrations-core/pull/14817