### PR TITLE
Lower snmp coverage to 50

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -467,7 +467,7 @@ coverage:
         flags:
         - sap_hana
       SNMP:
-        target: 75
+        target: 50
         flags:
         - snmp
       SQL_Server:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Lower snmp coverage to 50

### Motivation
<!-- What inspired you to submit this pull request? -->

Codecov doesn't take into account tests run via ddev env test and snmp integration have a lot of them.
[this codecov report for snmp integration](https://app.codecov.io/gh/DataDog/integrations-core/pull/15102/blob/snmp/tests/test_e2e_core_profiles/test_profile_brother_net_printer.py) e2e test file, and it says the file is mostly not reached.

Hence we are seeing codecov check fail due to coverage (without e2e tests) below 75.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.