### PR TITLE
Add a limit on the number of queries in the query metrics payload at the Agent

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -285,11 +285,15 @@ files:
             example: True
           hidden: true
         - name: max_queries
-          description: Limit the number of queries sent to the backend.
+          description: |
+            Limit the number of queries sent to the backend. 
+            Note: The only time this value would need to be set is in special cases where the query limit
+            applied on the backend is being modified.
           value:
             type: integer
             example: 250
             display_default: 250
+          hidden: true
     - name: query_activity
       description: Configure collection of active sessions monitoring
       options:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -284,6 +284,12 @@ files:
             type: boolean
             example: True
           hidden: true
+        - name: max_queries
+          description: Limit the number of queries sent to the backend.
+          value:
+            type: integer
+            example: 250
+            display_default: 250
     - name: query_activity
       description: Configure collection of active sessions monitoring
       options:

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -88,6 +88,7 @@ class QueryMetrics(BaseModel):
     dm_exec_query_stats_row_limit: Optional[int]
     enabled: Optional[bool]
     enforce_collection_interval_deadline: Optional[bool]
+    max_queries: Optional[int]
     samples_per_hour_per_query: Optional[int]
 
 

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -249,6 +249,11 @@ instances:
         #
         # samples_per_hour_per_query: 4
 
+        ## @param max_queries - integer - optional - default: 250
+        ## Limit the number of queries sent to the backend.
+        #
+        # max_queries: 250
+
     ## Configure collection of active sessions monitoring
     #
     # query_activity:

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -249,11 +249,6 @@ instances:
         #
         # samples_per_hour_per_query: 4
 
-        ## @param max_queries - integer - optional - default: 250
-        ## Limit the number of queries sent to the backend.
-        #
-        # max_queries: 250
-
     ## Configure collection of active sessions monitoring
     #
     # query_activity:

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -353,7 +353,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
 
     def _to_metrics_payload(self, rows, max_queries):
         # sort by total_elapsed_time and return the top max_queries
-        sorted(rows, key=lambda i: i['total_elapsed_time'], reverse=True)
+        rows.sort(key=lambda i: i['total_elapsed_time'], reverse=True)
         return {
             'host': self.check.resolved_hostname,
             'timestamp': time.time() * 1000,

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -353,14 +353,15 @@ class SqlserverStatementMetrics(DBMAsyncJob):
 
     def _to_metrics_payload(self, rows, max_queries):
         # sort by total_elapsed_time and return the top max_queries
-        rows.sort(key=lambda i: i['total_elapsed_time'], reverse=True)
+        rows = rows.sorted(key=lambda i: i['total_elapsed_time'], reverse=True)
+        rows = rows[:max_queries]
         return {
             'host': self.check.resolved_hostname,
             'timestamp': time.time() * 1000,
             'min_collection_interval': self.collection_interval,
             'tags': self.tags,
             'cloud_metadata': self.check.cloud_metadata,
-            'sqlserver_rows': [self._to_metrics_payload_row(r) for r in rows[:max_queries]],
+            'sqlserver_rows': [self._to_metrics_payload_row(r) for r in rows],
             'sqlserver_version': self.check.static_info_cache.get(STATIC_INFO_VERSION, ""),
             'sqlserver_engine_edition': self.check.static_info_cache.get(STATIC_INFO_ENGINE_EDITION, ""),
             'ddagentversion': datadog_agent.get_version(),

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -353,7 +353,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
 
     def _to_metrics_payload(self, rows, max_queries):
         # sort by total_elapsed_time and return the top max_queries
-        rows = rows.sorted(key=lambda i: i['total_elapsed_time'], reverse=True)
+        rows = sorted(rows, key=lambda i: i['total_elapsed_time'], reverse=True)
         rows = rows[:max_queries]
         return {
             'host': self.check.resolved_hostname,

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2021-present
+﻿# (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -464,13 +464,6 @@ def test_statement_metrics_limit(
     aggregator.reset()
     bob_conn.execute_with_retries(query, (), database=database)
     dd_run_check(check)
-
-    # _conn_key_prefix = "dbm-"
-    # with check.connection.open_managed_default_connection(key_prefix=_conn_key_prefix):
-    #     with check.connection.get_managed_cursor(key_prefix=_conn_key_prefix) as cursor:
-    #         available_query_metrics_columns = check.statement_metrics._get_available_query_metrics_columns(
-    #             cursor, SQL_SERVER_QUERY_METRICS_COLUMNS
-    #         )
 
     instance_tags = dbm_instance.get('tags', [])
     expected_instance_tags = {t for t in instance_tags if not t.startswith('dd.internal')}

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -1,4 +1,4 @@
-﻿# (C) Datadog, Inc. 2021-present
+# (C) Datadog, Inc. 2021-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
@@ -269,22 +269,6 @@ test_statement_metrics_and_plans_parameterized = (
             True,
             True,
         ],
-        [
-            "datadog_test",
-            "EXEC bobProcParams @P1 = ?, @P2 = ?",
-            [
-                r"SELECT \* FROM ϑings WHERE id = @P1",
-                r"SELECT id FROM ϑings WHERE name = @P2",
-            ],
-            (
-                (1, "foo"),
-                (2, "bar"),
-            ),
-            5,
-            False,
-            True,
-            True,
-        ],
     ],
 )
 
@@ -447,25 +431,25 @@ def test_statement_metrics_and_plans(
         + _expected_dbm_instance_tags(dbm_instance),
     )
 
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-@pytest.mark.parametrize("database,query,expected_queries_patterns,",
-            [["master",
+@pytest.mark.parametrize(
+    "database,query,expected_queries_patterns,",
+    [
+        [
+            "master",
             "EXEC multiQueryProc",
             [
                 r"select @total = @total \+ count\(\*\) from sys\.databases where name like '%_'",
                 r"select @total = @total \+ count\(\*\) from sys\.sysobjects where type = 'U'",
             ],
-            ]]
-        )
+        ]
+    ],
+)
 def test_statement_metrics_limit(
-    aggregator,
-    dd_run_check,
-    dbm_instance,
-    bob_conn,
-    database,
-    query,
-    expected_queries_patterns):
+    aggregator, dd_run_check, dbm_instance, bob_conn, database, query, expected_queries_patterns
+):
     dbm_instance['query_metrics']['max_queries'] = 5
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
@@ -488,10 +472,9 @@ def test_statement_metrics_limit(
     #             cursor, SQL_SERVER_QUERY_METRICS_COLUMNS
     #         )
 
-    
     instance_tags = dbm_instance.get('tags', [])
     expected_instance_tags = {t for t in instance_tags if not t.startswith('dd.internal')}
-    expected_instance_tags_with_db = expected_instance_tags | {"db:{}".format(database)}
+    expected_instance_tags | {"db:{}".format(database)}
 
     # dbm-metrics
     dbm_metrics = aggregator.get_event_platform_events("dbm-metrics")
@@ -504,7 +487,6 @@ def test_statement_metrics_limit(
 
     # check that it's sorted
     assert sqlserver_rows == sorted(sqlserver_rows, key=lambda i: i['total_elapsed_time'], reverse=True)
-        
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### What does this PR do?
This PR adds a config option for query-metrics that allows the user to specify an amount of `max-queries` to send to the backend. 

### Motivation
https://datadoghq.atlassian.net/browse/DBM-2563

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.