### PR TITLE
Bump torchserve version in tests

### DIFF
--- a/torchserve/hatch.toml
+++ b/torchserve/hatch.toml
@@ -6,5 +6,5 @@ version = ["0.8"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
-  { key = "TORCHSERVE_VERSION", value = "0.8.0", if = ["0.8"] },
+  { key = "TORCHSERVE_VERSION", value = "0.8.1", if = ["0.8"] },
 ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump torchserve version in tests

### Motivation
<!-- What inspired you to submit this pull request? -->

[A new version is out](https://github.com/pytorch/serve/releases/tag/v0.8.1) that improves some tests and significantly reduces the docker image size: 

```
pytorch/torchserve   0.8.1-cpu   68a3fcae81af   4 hours ago     662MB
pytorch/torchserve   0.8.0-cpu   958ef6dacea2   4 weeks ago     2.37GB
```

This will speed up the tests a bit:

- Master: unit/integration-> 2m 3s, e2e -> 1m 21s
- This branch: unit/integration-> 1m 24s, e2e -> 1m 22s (the image was already downloaded during unit/integration tests so no change)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.