### PR TITLE
Add crd.count to kubernetes_state core metrics

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_clusters.json
+++ b/kubernetes/assets/dashboards/kubernetes_clusters.json
@@ -786,6 +786,41 @@
                             "x": 10,
                             "y": 2
                         }
+                    },
+                    {
+                        "id": 112162236360634,
+                        "definition": {
+                            "title": "CRDs",
+                            "title_size": "16",
+                            "title_align": "left",
+                            "type": "query_value",
+                            "requests": [
+                                {
+                                    "response_format": "scalar",
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:kubernetes_state.crd.count{$scope,$cluster}",
+                                            "aggregator": "last"
+                                        }
+                                    ],
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "custom_links": [],
+                            "precision": 0
+                        },
+                        "layout": {
+                            "x": 0,
+                            "y": 4,
+                            "width": 2,
+                            "height": 2
+                        }
                     }
                 ]
             },

--- a/kubernetes_state_core/metadata.csv
+++ b/kubernetes_state_core/metadata.csv
@@ -130,3 +130,4 @@ kubernetes_state.service.count,gauge,,,,Number of services. Tags:`kube_namespace
 kubernetes_state.service.type,gauge,,,,Service types. Tags:`kube_namespace` `kube_service` `type`.,0,kubernetes_state_core,k8s_state.svc.type,
 kubernetes_state.ingress.count,gauge,,,,Number of ingresses. Tags:`kube_namespace`.,0,kubernetes_state_core,k8s_state.ingress.count,
 kubernetes_state.ingress.path,gauge,,,,Information about the ingress path. Tags:`kube_namespace` `kube_ingress_path` `kube_ingress` `kube_service` `kube_service_port` `kube_ingress_host` .,0,kubernetes_state_core,k8s_state.ingress.path,
+kubernetes_state.crd.count,gauge,,,,Number of crds. Tags:`kube_namespace`.,0,kubernetes_state_core,k8s_state.crd.count,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
kubernetes_state.crd.count has been supported recently. See: https://github.com/DataDog/datadog-agent/pull/16141
and https://github.com/DataDog/helm-charts/pull/1040
This pr will update the document for this metric and update OOTB dashboard

### Motivation
<!-- What inspired you to submit this pull request? -->
Update OOTB dashboard and document to expose this metric to clients

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.