### PR TITLE
Bump the minimum supported version of datadog-checks-dev

### DIFF
--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
 ]
 dependencies = [
-    "datadog-checks-dev[cli]~=21.0",
+    "datadog-checks-dev[cli]~=22.0",
     "hatch>=1.6.3",
     "httpx",
     "jsonpointer",


### PR DESCRIPTION
### Motivation

A release will happen after this since there will be a very short period where no package provides our Hatch plugin