### PR TITLE
Drop testing for kafka 2.5 and below

### DIFF
--- a/kafka_consumer/hatch.toml
+++ b/kafka_consumer/hatch.toml
@@ -4,7 +4,7 @@
 dependencies = [
   "datadog_checks_tests_helper @ {root:uri}/../datadog_checks_tests_helper",
 ]
-e2e-env = false
+e2e-env = true
 # If you bump the `confluent-kafka` version, also bump the `librdkafka` version in the `32_install_kerberos.sh` file
 post-install-commands = [
   "python -m pip uninstall -y confluent-kafka",
@@ -17,16 +17,7 @@ AUTHENTICATION = "noauth"
 
 [[envs.default.matrix]]
 python = ["3.9"]
-version = ["1.1", "2.3", "3.3"]
-
-[[envs.default.matrix]]
-python = ["3.9"]
-version = ["1.1", "2.3", "3.3"]
-
-[[envs.default.matrix]]
-python = ["3.9"]
-version = ["3.3"]
-auth = ["ssl"]
+version = ["2.6", "3.3"]
 
 [[envs.default.matrix]]
 python = ["3.9"]
@@ -34,10 +25,8 @@ version = ["3.3"]
 auth = ["ssl", "kerberos"]
 
 [envs.default.overrides]
-matrix.version.e2e-env = { value = true, if = ["3.3"] }
 matrix.version.env-vars = [
-  { key = "KAFKA_VERSION", value = "1.1.1", if = ["1.1"] },
-  { key = "KAFKA_VERSION", value = "2.3.1", if = ["2.3"] },
+  { key = "KAFKA_VERSION", value = "2.6.0", if = ["2.6"] },
   { key = "KAFKA_VERSION", value = "3.3.2", if = ["3.3"] },
 ]
 matrix.auth.env-vars = "AUTHENTICATION"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
We are currently running test environments for Kafka 1.1 (released March 28, 2018) and 2.3 (released Jun 25, 2019). The `kafka_consumer` check uses the `confluent-kafka-python` library call `list_consumer_group_offsets` which [doesn't work as expected for Kafka 2.3 and below](https://github.com/confluentinc/confluent-kafka-python/issues/1600). Since Confluent itself [no longer supports Kafka versions older than 2.5](https://docs.confluent.io/platform/current/installation/versions-interoperability.html), I think it makes sense to drop them in our test environment.

This PR also cleans up a few additional things that were unnecessary in the `hatch.toml` file and re-enables e2e tests for non-v3.3 environment. They were [originally disabled since e2e tests were timing out](https://github.com/DataDog/integrations-core/pull/7141), but this isn't an issue anymore ([e2e tests take around 5 minutes](https://github.com/DataDog/integrations-core/actions/runs/5475641162/jobs/9972086060))

### Motivation
<!-- What inspired you to submit this pull request? -->
Keep the check updated and in a healthy state.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.