### PR TITLE
Add `hr_device_index` tag to `snmp.hrProcessorLoad` metric

### DIFF
--- a/snmp/datadog_checks/snmp/data/default_profiles/_generic-host-resources-base.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_generic-host-resources-base.yaml
@@ -61,6 +61,8 @@ metrics:
       - OID: 1.3.6.1.2.1.25.3.3.1.2
         name: hrProcessorLoad
     metric_tags:
+      - index: 1  # hrDeviceIndex
+        tag: hr_device_index
       - tag: processorid
         column:
           OID: 1.3.6.1.2.1.25.3.3.1.1

--- a/snmp/tests/test_e2e_core_profiles/utils.py
+++ b/snmp/tests/test_e2e_core_profiles/utils.py
@@ -112,10 +112,13 @@ def assert_extend_cisco_cpu_memory(aggregator, common_tags):
 def assert_extend_generic_host_resources_base(aggregator, common_tags):
     aggregator.assert_metric("snmp.hrSystemUptime", metric_type=aggregator.GAUGE, tags=common_tags)
 
-    cpu_rows = ['10', '21']
+    cpu_rows = [('10', '10'), ('21', '21')]
     for cpu_row in cpu_rows:
+        processorid, hr_device_index = cpu_row
         aggregator.assert_metric(
-            'snmp.hrProcessorLoad', metric_type=aggregator.GAUGE, tags=common_tags + ['processorid:' + cpu_row]
+            'snmp.hrProcessorLoad',
+            metric_type=aggregator.GAUGE,
+            tags=common_tags + ['processorid:' + processorid, 'hr_device_index:' + hr_device_index],
         )
 
     hr_mem_rows = [

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -1708,11 +1708,11 @@ def test_generic_host_resources(aggregator):
         aggregator.assert_metric('snmp.hrStorageAllocationFailures', count=1, tags=tags)
 
     processors = [
-        '1.3.6.1.3.81.16',
-        '1.3.6.1.3.95.73.140.186.121.144.199',
+        ('1.3.6.1.3.81.16', '5'),
+        ('1.3.6.1.3.95.73.140.186.121.144.199', '10'),
     ]
-    for proc in processors:
-        tags = common_tags + ['processorid:{}'.format(proc)]
+    for proc, hr_device_index in processors:
+        tags = common_tags + ['processorid:{}'.format(proc), 'hr_device_index:{}'.format(hr_device_index)]
         aggregator.assert_metric('snmp.hrProcessorLoad', count=1, tags=tags)
 
     aggregator.assert_all_metrics_covered()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add `hr_device_index` tag to `snmp.hrProcessorLoad` metric

### Motivation
<!-- What inspired you to submit this pull request? -->

`snmp.hrProcessorLoad` is currently only tagged with `processorid`:
```
      - tag: processorid
        column:
          OID: 1.3.6.1.2.1.25.3.3.1.1
          name: hrProcessorFrwID
```

But based on real device `snmpwalk`(s), the value of  1.3.6.1.2.1.25.3.3.1.1/hrProcessorFrwID is often `0.0` for all rows, which make it unsuitable as unique tag for this table.

```
1.3.6.1.2.1.25.3.3.1.1.768|6|0.0
1.3.6.1.2.1.25.3.3.1.1.769|6|0.0
1.3.6.1.2.1.25.3.3.1.1.770|6|0.0
1.3.6.1.2.1.25.3.3.1.1.771|6|0.0
```


```
1.3.6.1.2.1.25.3.3.1.1.196608|6|0.0
1.3.6.1.2.1.25.3.3.1.1.196609|6|0.0
1.3.6.1.2.1.25.3.3.1.1.196610|6|0.0
1.3.6.1.2.1.25.3.3.1.1.196611|6|0.0
1.3.6.1.2.1.25.3.3.1.1.196612|6|0.0
1.3.6.1.2.1.25.3.3.1.1.196613|6|0.0
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.