### PR TITLE
Speed up the kind and docker tests

### DIFF
--- a/datadog_checks_dev/tests/test_docker.py
+++ b/datadog_checks_dev/tests/test_docker.py
@@ -56,8 +56,6 @@ class TestDockerRun:
         ],
     )
     def test_retry_on_failed_conditions(self, attempts, expected_call_count):
-        compose_file = os.path.join(DOCKER_DIR, "test_default.yaml")
-
         condition = mock.MagicMock()
         condition.side_effect = Exception("exception")
 
@@ -69,16 +67,19 @@ class TestDockerRun:
                 expected_exception = Exception
 
         with pytest.raises(expected_exception):
-            with docker_run(compose_file, attempts=attempts, conditions=[condition]):
+            with docker_run(
+                up=mock.MagicMock(), down=mock.MagicMock(), attempts=attempts, conditions=[condition], attempts_wait=0
+            ):
                 pass
 
         assert condition.call_count == expected_call_count
 
     def test_retry_condition_failed_only_on_first_run(self):
-        compose_file = os.path.join(DOCKER_DIR, "test_default.yaml")
+        up = mock.MagicMock()
+        up.return_value = ""
 
         condition = mock.MagicMock()
         condition.side_effect = [Exception("exception"), None, None]
 
-        with docker_run(compose_file, attempts=3, conditions=[condition]):
+        with docker_run(up=up, down=mock.MagicMock(), attempts=3, conditions=[condition], attempts_wait=0):
             assert condition.call_count == 2

--- a/datadog_checks_dev/tests/test_kind.py
+++ b/datadog_checks_dev/tests/test_kind.py
@@ -1,10 +1,9 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-
-import mock
 import pytest
 import tenacity
+from mock.mock import MagicMock, patch
 
 from datadog_checks.dev.ci import running_on_ci
 from datadog_checks.dev.kind import kind_run
@@ -24,7 +23,7 @@ class TestKindRun:
     )
     @not_windows_ci
     def test_retry_on_failed_conditions(self, attempts, expected_call_count):
-        condition = mock.MagicMock()
+        condition = MagicMock()
         condition.side_effect = Exception("exception")
 
         expected_exception = tenacity.RetryError
@@ -34,16 +33,25 @@ class TestKindRun:
             else:
                 expected_exception = Exception
 
-        with pytest.raises(expected_exception):
-            with kind_run(attempts=attempts, conditions=[condition]):
+        with pytest.raises(expected_exception), patch('datadog_checks.dev.kind.KindUp'), patch(
+            'datadog_checks.dev.kind.KindDown'
+        ):
+            with kind_run(attempts=attempts, conditions=[condition], attempts_wait=0):
                 pass
 
         assert condition.call_count == expected_call_count
 
     @not_windows_ci
     def test_retry_condition_failed_only_on_first_run(self):
-        condition = mock.MagicMock()
+        condition = MagicMock()
         condition.side_effect = [Exception("exception"), None, None]
+        up = MagicMock()
+        up.return_value = ""
 
-        with kind_run(attempts=3, conditions=[condition]):
-            assert condition.call_count == 2
+        with patch('datadog_checks.dev.kind.KindUp', return_value=up), patch(
+            'datadog_checks.dev.kind.KindDown', return_value=MagicMock()
+        ):
+            with kind_run(attempts=3, conditions=[condition], attempts_wait=0):
+                pass
+
+        assert condition.call_count == 2


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Speed up the kind and docker tests mocking the KindRun/KindDown classes and up/down functions because we do not need to spin up a real environment, we just want to make sure our retry mechanism on conditions work. 

Also lowers the `attempts_wait` parameter.

### Motivation
<!-- What inspired you to submit this pull request? -->

Working on a unrelated issue I noticed the tests were taking forever on that part.

Running the command `ddev test datadog_checks_dev -k test_retry_` locally:

| Before | After |
|--------|--------|
| `10 passed, 414 deselected in 163.05s (0:02:43)` | `10 passed, 414 deselected in 0.83s` |

For only one environment.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

CI is failing because of an unrelated issue I was trying to fix on master

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.