### PR TITLE
Add logs config example to readme

### DIFF
--- a/temporal/README.md
+++ b/temporal/README.md
@@ -35,7 +35,14 @@ See the [sample temporal.d/conf.yaml][4] for all available configuration options
 
 2. Configure your Temporal Cluster to output logs to a file by following the [official documentation][11].
 
-3. Uncomment and edit the logs configuration block in your `temporal.d/conf.yaml` file, and set the `path` to point to the file you configured on your Temporal Cluster.
+3. Uncomment and edit the logs configuration block in your `temporal.d/conf.yaml` file, and set the `path` to point to the file you configured on your Temporal Cluster:
+
+  ```yaml
+  logs:
+    - type: file
+      path: /var/log/temporal/temporal-server.log
+      source: temporal
+  ```
 
 4. [Restart the Agent][5].
 


### PR DESCRIPTION
### What does this PR do?

Adds a log config example to the README.

### Motivation

Failing validation on weekly job: https://gitlab.ddbuild.io/DataDog/integrations-core/-/jobs/291376473

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.