### PR TITLE
Weaviate Docs

### DIFF
--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -20,7 +20,7 @@ Weaviate can be configured to expose Prometheus-formatted metrics. The Datadog A
 
 In addition, a small subset of metrics can be collected by communicating with different [API endpoints][11]. Specifically:
 - `/v1/meta`: Version information
-- `/v1/nodes`: Node specific metrics such as objects and shards
+- `/v1/nodes`: Node-specific metrics such as objects and shards
 - `/v1/.well-known`: HTTP response time and service liveness
 
 **Note**: This check uses [OpenMetrics][12] for metric collection, which requires Python 3.

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -16,7 +16,7 @@ The Weaviate check is included in the [Datadog Agent][2] package. No additional 
 
 ### Configuration
 
-Weaviate can be configured to expose Prometheus-formatted metrics. The Datadog Agent can collect these metrics using the integration described below. Follow the instructions to configure data collection for your Weaviate instances. For the required configurations to expose the Prometheus metrics, please refer to the [Monitoring][10] page in the Weaviate documentation.
+Weaviate can be configured to expose Prometheus-formatted metrics. The Datadog Agent can collect these metrics using the integration described below. Follow the instructions to configure data collection for your Weaviate instances. For the required configurations to expose the Prometheus metrics, see the [Monitoring][10] page in the Weaviate documentation.
 
 In addition, a small subset of metrics can be collected by communicating with different [API endpoints][11]. Specifically the /v1/meta, /v1/nodes and /v1/.well-known endpoints.
 

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -31,7 +31,7 @@ Prometheus-formatted metrics must be exposed in your Weaviate cluster. You can c
 
 The two most important parameters for configuring the Weaviate check are as follows:
 - `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `2112`, but it can be configured using the `PROMETHEUS_MONITORING_PORT` [environment variable][10]. In containerized environments, `%%host%%` can be used for [host autodetection][3]. 
-- `weaviate_api_endpoint`: This parameter is optional. By default, this parameter is set to <hostname>:8080 and it specifies the configuration of the [RESTful API][11].
+- `weaviate_api_endpoint`: This parameter is optional. By default, this parameter is set to `<hostname>:8080` and it specifies the configuration of the [RESTful API][11].
 
 If authentication is required for the RESTful API endpoints, the check can be configured to provide an API key as part of the [request header][13].
 

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -28,7 +28,7 @@ In addition, a small subset of metrics can be collected by communicating with di
 #### Containerized
 ##### Metric collection
 
-Make sure that the Prometheus-formatted metrics are exposed in your Weaviate cluster. You can configure and customize this by following the instructions on the [Monitoring][10] page in the Weaviate documentation. In order for the Agent to start collecting metrics, the Weaviate pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample weaviate.d/conf.yaml][4]
+Make sure that the Prometheus-formatted metrics are exposed in your Weaviate cluster. You can configure and customize this by following the instructions on the [Monitoring][10] page in the Weaviate documentation. For the Agent to start collecting metrics, the Weaviate pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample weaviate.d/conf.yaml][4]
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the object deletion metric is exposed only when an object is deleted.
 

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -25,7 +25,7 @@ In addition, a small subset of metrics can be collected by communicating with di
 #### Containerized
 ##### Metric collection
 
-Make sure that the Prometheus-formatted metrics are exposed in your Weaviate cluster. You can configure and customize this by following the [Weaviate documentation][11]. In order for the Agent to start collecting metrics, the Weaviate pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample weaviate.d/conf.yaml][4]
+Prometheus-formatted metrics must be exposed in your Weaviate cluster. You can configure and customize this by following the [RESTful API page][11] in the Weaviate documentation. In order for the Agent to start collecting metrics, the Weaviate pods need to be annotated. Refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options in the [sample weaviate.d/conf.yaml][4] file.
 
 Note: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the object deletion metric will be exposed only when an object is deleted.
 

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -12,7 +12,7 @@ Follow the instructions below to install and configure this check for an Agent r
 
 The Weaviate check is included in the [Datadog Agent][2] package. No additional installation is needed on your server.
 
-**Note**: This check requires Agent v7.47.0+.
+**Note**: This check requires Agent v7.47.0 or later.
 
 ### Configuration
 

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -16,7 +16,7 @@ The Weaviate check is included in the [Datadog Agent][2] package. No additional 
 
 ### Configuration
 
-Weaviate can be configured to expose Prometheus-formatted metrics. The Datadog Agent can collect these metrics using the integration described below. Follow the instructions to configure data collection for your Weaviate instances. For the required configurations to expose the Prometheus metrics, please refer to the [Monitoring][10] page in the Weaviate documentation..
+Weaviate can be configured to expose Prometheus-formatted metrics. The Datadog Agent can collect these metrics using the integration described below. Follow the instructions to configure data collection for your Weaviate instances. For the required configurations to expose the Prometheus metrics, please refer to the [Monitoring][10] page in the Weaviate documentation.
 
 In addition, a small subset of metrics can be collected by communicating with different [API endpoints][11]. Specifically the /v1/meta, /v1/nodes and /v1/.well-known endpoints.
 

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -10,14 +10,58 @@ Follow the instructions below to install and configure this check for an Agent r
 
 ### Installation
 
-The Weaviate check is included in the [Datadog Agent][2] package.
-No additional installation is needed on your server.
+The Weaviate check is included in the [Datadog Agent][2] package. No additional installation is needed on your server.
+
+**Note**: This check requires Agent v7.47.0+.
 
 ### Configuration
 
-1. Edit the `weaviate.d/conf.yaml` file, in the `conf.d/` folder at the root of your Agent's configuration directory to start collecting your weaviate performance data. See the [sample weaviate.d/conf.yaml][4] for all available configuration options.
+Weaviate can be configured to expose Prometheus-formatted metrics. The Datadog Agent can collect these metrics using the integration described below. Follow the instructions to configure data collection from any or all of the components. For the required configurations, please refer to the [Weaviate documentation][11].
 
-2. [Restart the Agent][5].
+In addition, a small subset of metrics can be collected by communicating with different [API endpoints][12].
+
+**Note**: This check uses [OpenMetrics][12] for metric collection, which requires Python 3.
+
+#### Containerized
+##### Metric collection
+
+Make sure that the Prometheus-formatted metrics are exposed in your Weaviate cluster. You can configure and customize this by following the [Weaviate documentation][11]. In order for the Agent to start collecting metrics, the Weaviate pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample weaviate.d/conf.yaml][4]
+
+Note: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the object deletion metric will be exposed only when an object is deleted.
+
+The two most important parameters for configuring the Weaviate check are as follows:
+- `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is 2112, but it can be configured using the PROMETHEUS_MONITORING_PORT [environment variable][10]. In containerized environments, `%%host%%` can be used for host autodetection [3]. 
+- `weaviate_api_endpoint`: This parameter is optional. By default, this parameter is set to <hostname>:8080 and it specifies the configuration of the [RESTful API][11].
+
+If authentication is required for the RESTful API endpoints, the check can be configured to provide an API key as part of the [request header][13].
+
+
+```yaml
+apiVersion: v1
+kind: Pod
+# (...)
+metadata:
+  name: '<POD_NAME>'
+  annotations:
+    ad.datadoghq.com/weaviate.checks: |
+      {
+        "weaviate": {
+          "init_config": {},
+          "instances": [
+            {
+              "openmetrics_endpoint": "http://%%host%%:2112/metrics",
+              "weaviate_api_endpoint": "http://%%host%%:8080",
+              "headers": {'Authorization': 'Bearer if_needed_for_auth'}
+            }
+          ]
+        }
+      }
+    # (...)
+spec:
+  containers:
+    - name: 'weaviate'
+# (...)
+```
 
 ### Validation
 
@@ -53,3 +97,7 @@ Need help? Contact [Datadog support][9].
 [7]: https://github.com/DataDog/integrations-core/blob/master/weaviate/metadata.csv
 [8]: https://github.com/DataDog/integrations-core/blob/master/weaviate/assets/service_checks.json
 [9]: https://docs.datadoghq.com/help/
+[10]: https://weaviate.io/developers/weaviate/configuration/monitoring
+[11]: https://weaviate.io/developers/weaviate/api/rest
+[12]: https://docs.datadoghq.com/integrations/openmetrics/
+[13]: https://github.com/DataDog/integrations-core/blob/7.46.x/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example#L544-L546

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -18,7 +18,7 @@ The Weaviate check is included in the [Datadog Agent][2] package. No additional 
 
 Weaviate can be configured to expose Prometheus-formatted metrics. The Datadog Agent can collect these metrics using the integration described below. Follow the instructions to configure data collection for your Weaviate instances. For the required configurations to expose the Prometheus metrics, see the [Monitoring][10] page in the Weaviate documentation.
 
-In addition, a small subset of metrics can be collected by communicating with different [API endpoints][11]. Specifically the /v1/meta, /v1/nodes and /v1/.well-known endpoints.
+In addition, a small subset of metrics can be collected by communicating with different [API endpoints][11]. Specifically the `/v1/meta`, `/v1/nodes` and `/v1/.well-known` endpoints.
 
 **Note**: This check uses [OpenMetrics][12] for metric collection, which requires Python 3.
 

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -16,7 +16,7 @@ The Weaviate check is included in the [Datadog Agent][2] package. No additional 
 
 ### Configuration
 
-Weaviate can be configured to expose Prometheus-formatted metrics. The Datadog Agent can collect these metrics using the integration described below. Follow the instructions to configure data collection for your Weaviate instances. For the required configurations to expose metrics on the Weaviate side, please refer to the [Weaviate documentation][10].
+Weaviate can be configured to expose Prometheus-formatted metrics. The Datadog Agent can collect these metrics using the integration described below. Follow the instructions to configure data collection for your Weaviate instances. For the required configurations to expose the Prometheus metrics, please refer to the [Monitoring][10] page in the Weaviate documentation..
 
 In addition, a small subset of metrics can be collected by communicating with different [API endpoints][11]. Specifically the /v1/meta, /v1/nodes and /v1/.well-known endpoints.
 

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -27,7 +27,7 @@ In addition, a small subset of metrics can be collected by communicating with di
 
 Prometheus-formatted metrics must be exposed in your Weaviate cluster. You can configure and customize this by following the [RESTful API page][11] in the Weaviate documentation. In order for the Agent to start collecting metrics, the Weaviate pods need to be annotated. Refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options in the [sample weaviate.d/conf.yaml][4] file.
 
-Note: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the object deletion metric will be exposed only when an object is deleted.
+**Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the object deletion metric is exposed only when an object is deleted.
 
 The two most important parameters for configuring the Weaviate check are as follows:
 - `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is 2112, but it can be configured using the PROMETHEUS_MONITORING_PORT [environment variable][10]. In containerized environments, `%%host%%` can be used for host autodetection [3]. 

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -16,16 +16,16 @@ The Weaviate check is included in the [Datadog Agent][2] package. No additional 
 
 ### Configuration
 
-Weaviate can be configured to expose Prometheus-formatted metrics. The Datadog Agent can collect these metrics using the integration described below. Follow the instructions to configure data collection from any or all of the components. For the required configurations, please refer to the [Weaviate documentation][11].
+Weaviate can be configured to expose Prometheus-formatted metrics. The Datadog Agent can collect these metrics using the integration described below. Follow the instructions to configure data collection for your Weaviate instances. For the required configurations to expose metrics on the Weaviate side, please refer to the [Weaviate documentation][10].
 
-In addition, a small subset of metrics can be collected by communicating with different [API endpoints][12].
+In addition, a small subset of metrics can be collected by communicating with different [API endpoints][11]. Specifically the /v1/meta, /v1/nodes and /v1/.well-known endpoints.
 
 **Note**: This check uses [OpenMetrics][12] for metric collection, which requires Python 3.
 
 #### Containerized
 ##### Metric collection
 
-Prometheus-formatted metrics must be exposed in your Weaviate cluster. You can configure and customize this by following the [RESTful API page][11] in the Weaviate documentation. In order for the Agent to start collecting metrics, the Weaviate pods need to be annotated. Refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options in the [sample weaviate.d/conf.yaml][4] file.
+Make sure that the Prometheus-formatted metrics are exposed in your Weaviate cluster. You can configure and customize this by following the [Weaviate documentation][10]. In order for the Agent to start collecting metrics, the Weaviate pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample weaviate.d/conf.yaml][4]
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the object deletion metric is exposed only when an object is deleted.
 

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -25,7 +25,7 @@ In addition, a small subset of metrics can be collected by communicating with di
 #### Containerized
 ##### Metric collection
 
-Make sure that the Prometheus-formatted metrics are exposed in your Weaviate cluster. You can configure and customize this by following the [Weaviate documentation][10]. In order for the Agent to start collecting metrics, the Weaviate pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample weaviate.d/conf.yaml][4]
+Make sure that the Prometheus-formatted metrics are exposed in your Weaviate cluster. You can configure and customize this by following the instructions on the [Monitoring][10] page in the Weaviate documentation. In order for the Agent to start collecting metrics, the Weaviate pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample weaviate.d/conf.yaml][4]
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the object deletion metric is exposed only when an object is deleted.
 

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -30,7 +30,7 @@ Prometheus-formatted metrics must be exposed in your Weaviate cluster. You can c
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the object deletion metric is exposed only when an object is deleted.
 
 The two most important parameters for configuring the Weaviate check are as follows:
-- `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is 2112, but it can be configured using the PROMETHEUS_MONITORING_PORT [environment variable][10]. In containerized environments, `%%host%%` can be used for host autodetection [3]. 
+- `openmetrics_endpoint`: This parameter should be set to the location where the Prometheus-formatted metrics are exposed. The default port is `2112`, but it can be configured using the `PROMETHEUS_MONITORING_PORT` [environment variable][10]. In containerized environments, `%%host%%` can be used for [host autodetection][3]. 
 - `weaviate_api_endpoint`: This parameter is optional. By default, this parameter is set to <hostname>:8080 and it specifies the configuration of the [RESTful API][11].
 
 If authentication is required for the RESTful API endpoints, the check can be configured to provide an API key as part of the [request header][13].

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -18,7 +18,10 @@ The Weaviate check is included in the [Datadog Agent][2] package. No additional 
 
 Weaviate can be configured to expose Prometheus-formatted metrics. The Datadog Agent can collect these metrics using the integration described below. Follow the instructions to configure data collection for your Weaviate instances. For the required configurations to expose the Prometheus metrics, see the [Monitoring][10] page in the Weaviate documentation.
 
-In addition, a small subset of metrics can be collected by communicating with different [API endpoints][11]. Specifically the `/v1/meta`, `/v1/nodes` and `/v1/.well-known` endpoints.
+In addition, a small subset of metrics can be collected by communicating with different [API endpoints][11]. Specifically:
+- `/v1/meta`: Version information
+- `/v1/nodes`: Node specific metrics such as objects and shards
+- `/v1/.well-known`: HTTP response time and service liveness
 
 **Note**: This check uses [OpenMetrics][12] for metric collection, which requires Python 3.
 


### PR DESCRIPTION
### What does this PR do?
Weaviate Docs that didn't make it into the integration release.

For the docs team, can you review the metadata.csv for the metric description and the conf.yaml.example as well? It's mostly from templates the only unique parameter would be the `weaviate_api_endpoint` parameter that is new. 