### PR TITLE
[NDM] Add bgpPeerRemoteAs as tag

### DIFF
--- a/snmp/datadog_checks/snmp/data/default_profiles/_generic-bgp4.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_generic-bgp4.yaml
@@ -41,6 +41,10 @@ metrics:
       - OID: 1.3.6.1.2.1.15.3.1.22
         name: bgpPeerMinASOriginationInterval
     metric_tags:
+      - tag: remote_as
+        column:
+          OID: 1.3.6.1.2.1.15.3.1.9
+          name: bgpPeerRemoteAs
       - tag: admin_status
         column:
           OID: 1.3.6.1.2.1.15.3.1.3

--- a/snmp/tests/test_e2e_core.py
+++ b/snmp/tests/test_e2e_core.py
@@ -504,7 +504,12 @@ def test_e2e_core_cisco_csr(dd_agent_check):
 
     common.assert_common_metrics(aggregator, global_tags, is_e2e=True, loader='core')
 
-    metric_tags = global_tags + ['neighbor:244.12.239.177', 'admin_status:start', 'peer_state:established']
+    metric_tags = global_tags + [
+        'neighbor:244.12.239.177',
+        'admin_status:start',
+        'peer_state:established',
+        'remote_as:26',
+    ]
 
     for metric in metrics.PEER_GAUGES:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=metric_tags, count=2)

--- a/snmp/tests/test_profiles.py
+++ b/snmp/tests/test_profiles.py
@@ -2844,7 +2844,7 @@ def _check_bgp4(aggregator, common_tags):
     """
     Shared testing function for profiles supporting BGP4 metrics.
     """
-    tags = ['neighbor:244.12.239.177', 'admin_status:2', 'peer_state:6'] + common_tags
+    tags = ['neighbor:244.12.239.177', 'remote_as:26', 'admin_status:2', 'peer_state:6'] + common_tags
     for metric in PEER_GAUGES:
         aggregator.assert_metric('snmp.{}'.format(metric), metric_type=aggregator.GAUGE, tags=tags)
 


### PR DESCRIPTION
The remote AS identifier is a number but that is not expected to change for a given device and bgp peer. Submitting this only as a gauge makes it complicated to use it in queries so let's add it as a tag as well.