### PR TITLE
Fix service check with correct name and version

### DIFF
--- a/argocd/assets/service_checks.json
+++ b/argocd/assets/service_checks.json
@@ -60,9 +60,9 @@
         "description": "Returns `CRITICAL` if not connected to the cluster, otherwise returns `OK`."
     },
     {
-        "agent_version": "7.42.0",
+        "agent_version": "7.47.0",
         "integration": "ArgoCD",
-        "check": "argocd.notifications_controller.cluster.connection.status",
+        "check": "argocd.notifications_controller.openmetrics.health",
         "statuses": [
             "ok",
             "critical"
@@ -71,7 +71,7 @@
             "host",
             "endpoint"
         ],
-        "name": "Notifications Controller cluster connection status",
-        "description": "Returns `CRITICAL` if not connected to the cluster, otherwise returns `OK`."
+        "name": "Notifications Controller OpenMetrics endpoint health",
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to the Repo Server OpenMetrics endpoint, otherwise returns `OK`."
     }
 ]


### PR DESCRIPTION
### What does this PR do?
Changes the service check to the generic openmetrics health check and also set it to the correct agent version.