### PR TITLE
Do not check consumer_groups if the offset is invalid

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -154,14 +154,16 @@ class KafkaClient:
                             str(topic_partition.partition),
                         )
                         continue
+
+                    if offset == OFFSET_INVALID:
+                        continue
+
                     if self.config._monitor_unlisted_consumer_groups or not self.config._consumer_groups_compiled_regex:
-                        if offset != OFFSET_INVALID:
-                            consumer_offsets[(consumer_group, topic, partition)] = offset
+                        consumer_offsets[(consumer_group, topic, partition)] = offset
                     else:
                         to_match = f"{consumer_group},{topic},{partition}"
                         if self.config._consumer_groups_compiled_regex.match(to_match):
-                            if offset != OFFSET_INVALID:
-                                consumer_offsets[(consumer_group, topic, partition)] = offset
+                            consumer_offsets[(consumer_group, topic, partition)] = offset
 
         return consumer_offsets
 
@@ -206,7 +208,6 @@ class KafkaClient:
                 continue
 
             for topic in topics:
-                topic_partitions = []
                 # If partitions are defined
                 if partitions := topics[topic]:
                     topic_partitions = [TopicPartition(topic, partition) for partition in partitions]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not check consumer_groups if the offset is invalid

### Motivation
<!-- What inspired you to submit this pull request? -->

- QA for https://github.com/DataDog/integrations-core/pull/15106
- We don't need to test the regex if the offset is not valid

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- This will improve performance for this check in some cases with a very large regex and a high number of groups
- This is a refactor, existing tests are enough to validate everything is still working

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.