### PR TITLE
Simplify regex compilation

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/config.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config.py
@@ -103,31 +103,29 @@ class KafkaConfig:
     def _compile_regex(self, consumer_groups_regex, consumer_groups):
         # Turn the dict of regex dicts into a single string and compile
         # (<CONSUMER_REGEX>,(TOPIC_REGEX),(PARTITION_REGEX))|(...)
-        patterns = ""
-        patterns += self.make_pattern(consumer_groups)
-        patterns += self.make_pattern(consumer_groups_regex)
+        patterns = self.get_patterns(consumer_groups)
+        patterns.extend(self.get_patterns(consumer_groups_regex))
 
-        # Remove last "|"
-        patterns = patterns.rstrip(patterns[-1])
-        final_pattern = re.compile(patterns)
-        return final_pattern
+        return re.compile("|".join(patterns))
 
-    def make_pattern(self, consumer_groups):
-        template = "({0},{1},{2})|"
-        patterns = ""
+    @staticmethod
+    def get_patterns(consumer_groups):
+        template = "({0},{1},{2})"
+        patterns = []
+
         for consumer_group in consumer_groups:
-            topics = consumer_groups.get(consumer_group)
-
-            if not topics:
-                patterns += template.format(consumer_group, ".+", ".+")
-            else:
+            if topics := consumer_groups.get(consumer_group):
                 for topic in topics:
-                    partitions = consumer_groups[consumer_group][topic]
-                    if not partitions:
-                        patterns += template.format(consumer_group, topic, ".+")
+                    if partitions := consumer_groups[consumer_group][topic]:
+                        patterns.extend(
+                            template.format(consumer_group, topic, partition)
+                            for partition in partitions
+                        )
                     else:
-                        for partition in partitions:
-                            patterns += template.format(consumer_group, topic, partition)
+                        patterns.append(template.format(consumer_group, topic, ".+"))
+            else:
+                patterns.append(template.format(consumer_group, ".+", ".+"))
+
         return patterns
 
     def _validate_consumer_groups(self):

--- a/kafka_consumer/datadog_checks/kafka_consumer/config.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/config.py
@@ -117,10 +117,7 @@ class KafkaConfig:
             if topics := consumer_groups.get(consumer_group):
                 for topic in topics:
                     if partitions := consumer_groups[consumer_group][topic]:
-                        patterns.extend(
-                            template.format(consumer_group, topic, partition)
-                            for partition in partitions
-                        )
+                        patterns.extend(template.format(consumer_group, topic, partition) for partition in partitions)
                     else:
                         patterns.append(template.format(consumer_group, topic, ".+"))
             else:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Simplify regex compilation to avoid using `rstrip`

### Motivation
<!-- What inspired you to submit this pull request? -->

- The regex is continuously build and the extra `|` get stripped at the very end in another function.  This pr uses `"|".join` instead to avoid that 
- QA for https://github.com/DataDog/integrations-core/pull/15106

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- This is a refactor, existing tests are enough to validate everything is still working

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.