### PR TITLE
NDM: Renamed forced_type to metric_type

### DIFF
--- a/snmp/datadog_checks/snmp/data/default_profiles/_checkpoint-firewall-cpu-memory.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_checkpoint-firewall-cpu-memory.yaml
@@ -19,13 +19,13 @@ metrics:
       name: multiProcTable
     # Memory
   - MIB: CHECKPOINT-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.2620.1.6.7.4.3.0
         # core check only
       name: memory.total
   - MIB: CHECKPOINT-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.2620.1.6.7.4.4.0
         # core check only

--- a/snmp/datadog_checks/snmp/data/default_profiles/_cisco-asa.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_cisco-asa.yaml
@@ -33,7 +33,7 @@ metrics:
       OID: 1.3.6.1.4.1.9.9.392.1.3.3.0
       name: crasNumUsers
   - MIB: CISCO-REMOTE-ACCESS-MONITOR-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       # session setup failed
       OID: 1.3.6.1.4.1.9.9.392.1.4.1.3.0
@@ -43,12 +43,12 @@ metrics:
       OID: 1.3.6.1.4.1.9.9.171.1.3.1.1.0
       name: cipSecGlobalActiveTunnels
   - MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.9.9.171.1.3.1.4.0
       name: cipSecGlobalHcInOctets
   - MIB: CISCO-IPSEC-FLOW-MONITOR-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.9.9.171.1.3.1.17.0
       name: cipSecGlobalHcOutOctets

--- a/snmp/datadog_checks/snmp/data/default_profiles/_cisco-catalyst.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_cisco-catalyst.yaml
@@ -38,7 +38,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.9.9.276.1.1.1
       name: cieIfPacketStatsTable
-    forced_type: gauge
+    metric_type: gauge
     symbols:
       - OID: 1.3.6.1.4.1.9.9.276.1.1.1.1.1
         name: cieIfLastInTime

--- a/snmp/datadog_checks/snmp/data/default_profiles/_cisco-generic.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_cisco-generic.yaml
@@ -96,7 +96,7 @@ metrics:
       - index: 1
         tag: cpu
   - MIB: CISCO-IF-EXTENSION-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     table:
       OID: 1.3.6.1.4.1.9.9.276.1.1.2
       name: cieIfInterfaceTable

--- a/snmp/datadog_checks/snmp/data/default_profiles/_cisco-voice.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_cisco-voice.yaml
@@ -54,7 +54,7 @@ metrics:
         tag: service_index
 
   - MIB: CISCO-CVP-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       name: ccvpLicAggMaxPortsInUse
       OID: 1.3.6.1.4.1.9.9.590.1.2.12.0
@@ -64,12 +64,12 @@ metrics:
       OID: 1.3.6.1.4.1.9.9.590.1.2.2.0
 
   - MIB: CISCO-CCM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       name: ccmRegisteredGateways
       OID: 1.3.6.1.4.1.9.9.156.1.5.8.0
   - MIB: CISCO-CCM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       name: ccmRegisteredPhones
       OID: 1.3.6.1.4.1.9.9.156.1.5.5.0
@@ -113,7 +113,7 @@ metrics:
         tag: peer_index
 
   - MIB: DIAL-CONTROL-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     table:
       name: dialCtlPeerStatsTable
       OID: 1.3.6.1.2.1.10.21.1.2.2

--- a/snmp/datadog_checks/snmp/data/default_profiles/_cisco-wlc.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_cisco-wlc.yaml
@@ -112,7 +112,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.14179.2.2.2
       name: bsnAPIfTable
-    forced_type: gauge
+    metric_type: gauge
     symbols:
       - OID: 1.3.6.1.4.1.14179.2.2.2.1.15
         name: bsnApIfNoOfUsers
@@ -249,7 +249,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.14179.2.1.1
       name: bsnDot11EssTable
-    forced_type: gauge
+    metric_type: gauge
     symbols:
       - OID: 1.3.6.1.4.1.14179.2.1.1.1.38
         name: bsnDot11EssNumberOfMobileStations

--- a/snmp/datadog_checks/snmp/data/default_profiles/_dell-rac.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_dell-rac.yaml
@@ -530,7 +530,7 @@ metrics:
           name: drsPSUIndex
         tag: drs_psu_index
   - MIB: DELL-RAC-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     table:
       OID: 1.3.6.1.4.1.674.10892.2.4.1
       name: drsCMCPowerTable

--- a/snmp/datadog_checks/snmp/data/default_profiles/_f5-big-ip-cpu-memory.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_f5-big-ip-cpu-memory.yaml
@@ -3,13 +3,13 @@
 metrics:
   # Memory stats
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.1.44.0
         # core check only
       name: memory.total
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.1.45.0
         # core check only
@@ -19,7 +19,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.3375.2.1.7.5.2
       name: sysMultiHostCpuTable
-    forced_type: gauge
+    metric_type: gauge
     symbols:
       - OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.27
         name: cpu.usage # sysMultiHostCpuUsageRatio1m

--- a/snmp/datadog_checks/snmp/data/default_profiles/_generic-if.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_generic-if.yaml
@@ -46,7 +46,7 @@ metrics:
   table:
     OID: 1.3.6.1.2.1.2.2
     name: ifTable
-  forced_type: monotonic_count_and_rate
+  metric_type: monotonic_count_and_rate
   symbols:
   - OID: 1.3.6.1.2.1.2.2.1.14
     name: ifInErrors
@@ -93,7 +93,7 @@ metrics:
   table:
     OID: 1.3.6.1.2.1.31.1.1
     name: ifXTable
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbols:
   - OID: 1.3.6.1.2.1.31.1.1.1.7
     name: ifHCInUcastPkts
@@ -121,7 +121,7 @@ metrics:
   table:
     OID: 1.3.6.1.2.1.31.1.1
     name: ifXTable
-  forced_type: monotonic_count_and_rate
+  metric_type: monotonic_count_and_rate
   symbols:
   - OID: 1.3.6.1.2.1.31.1.1.1.6
     name: ifHCInOctets

--- a/snmp/datadog_checks/snmp/data/default_profiles/_generic-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_generic-ip.yaml
@@ -5,7 +5,7 @@ metrics:
   table:
     OID: 1.3.6.1.2.1.4.31.1
     name: ipSystemStatsTable
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbols:
   - OID: 1.3.6.1.2.1.4.31.1.1.4
     name: ipSystemStatsHCInReceives
@@ -79,7 +79,7 @@ metrics:
   table:
     OID: 1.3.6.1.2.1.4.31.3
     name: ipIfStatsTable
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbols:
   - OID: 1.3.6.1.2.1.4.31.3.1.6
     name: ipIfStatsHCInOctets

--- a/snmp/datadog_checks/snmp/data/default_profiles/_generic-tcp.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_generic-tcp.yaml
@@ -2,22 +2,22 @@
 
 metrics:
 - MIB: TCP-MIB
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbol:
     OID: 1.3.6.1.2.1.6.5.0
     name: tcpActiveOpens
 - MIB: TCP-MIB
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbol:
     OID: 1.3.6.1.2.1.6.6.0
     name: tcpPassiveOpens
 - MIB: TCP-MIB
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbol:
     OID: 1.3.6.1.2.1.6.7.0
     name: tcpAttemptFails
 - MIB: TCP-MIB
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbol:
     OID: 1.3.6.1.2.1.6.8.0
     name: tcpEstabResets
@@ -26,27 +26,27 @@ metrics:
     OID: 1.3.6.1.2.1.6.9.0
     name: tcpCurrEstab
 - MIB: TCP-MIB
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbol:
     OID: 1.3.6.1.2.1.6.17.0
     name: tcpHCInSegs
 - MIB: TCP-MIB
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbol:
     OID: 1.3.6.1.2.1.6.18.0
     name: tcpHCOutSegs
 - MIB: TCP-MIB
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbol:
     OID: 1.3.6.1.2.1.6.12.0
     name: tcpRetransSegs
 - MIB: TCP-MIB
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbol:
     OID: 1.3.6.1.2.1.6.14.0
     name: tcpInErrs
 - MIB: TCP-MIB
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbol:
     OID: 1.3.6.1.2.1.6.15.0
     name: tcpOutRsts

--- a/snmp/datadog_checks/snmp/data/default_profiles/_generic-ucd.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_generic-ucd.yaml
@@ -114,34 +114,34 @@ metrics:
     symbol:
       name: ucd.ssCpuRawUser
       OID: 1.3.6.1.4.1.2021.11.50.0
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: UCD-SNMP-MIB
     symbol:
       name: ucd.ssCpuRawNice
       OID: 1.3.6.1.4.1.2021.11.51.0
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: UCD-SNMP-MIB
     symbol:
       name: ucd.ssCpuRawSystem
       OID: 1.3.6.1.4.1.2021.11.52.0
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: UCD-SNMP-MIB
     symbol:
       name: ucd.ssCpuRawIdle
       OID: 1.3.6.1.4.1.2021.11.53.0
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: UCD-SNMP-MIB
     symbol:
       name: ucd.ssCpuRawWait
       OID: 1.3.6.1.4.1.2021.11.54.0
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: UCD-SNMP-MIB
     symbol:
       name: ucd.ssCpuRawKernel
       OID: 1.3.6.1.4.1.2021.11.55.0
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: UCD-SNMP-MIB
     symbol:
       name: ucd.ssCpuRawInterrupt
       OID: 1.3.6.1.4.1.2021.11.56.0
-    forced_type: monotonic_count
+    metric_type: monotonic_count

--- a/snmp/datadog_checks/snmp/data/default_profiles/_generic-udp.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_generic-udp.yaml
@@ -2,22 +2,22 @@
 
 metrics:
 - MIB: UDP-MIB
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbol:
     OID: 1.3.6.1.2.1.7.8.0
     name: udpHCInDatagrams
 - MIB: UDP-MIB
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbol:
     OID: 1.3.6.1.2.1.7.2.0
     name: udpNoPorts
 - MIB: UDP-MIB
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbol:
     OID: 1.3.6.1.2.1.7.3.0
     name: udpInErrors
 - MIB: UDP-MIB
-  forced_type: monotonic_count
+  metric_type: monotonic_count
   symbol:
     OID: 1.3.6.1.2.1.7.9.0
     name: udpHCOutDatagrams

--- a/snmp/datadog_checks/snmp/data/default_profiles/_generic-ups.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_generic-ups.yaml
@@ -38,7 +38,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.2.1.33.1.3.1.0
       name: upsInputLineBads
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: UPS-MIB
     symbol:
       OID: 1.3.6.1.2.1.33.1.3.2.0

--- a/snmp/datadog_checks/snmp/data/default_profiles/_hp-compaq-health.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_hp-compaq-health.yaml
@@ -47,7 +47,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.232.6.2.3.3.0
       name: cpqHeCorrMemTotalErrs
-    forced_type: monotonic_count
+    metric_type: monotonic_count
 
   # ASR (Automatic Server Recovery)
 
@@ -71,7 +71,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.232.6.2.5.10.0
       name: cpqHeAsrRebootCount
-    forced_type: monotonic_count
+    metric_type: monotonic_count
 
   - # Overall condition of the ASR feature.
     # NOTE: other(1), notAvailable(2), disabled(3), enabled(4)

--- a/snmp/datadog_checks/snmp/data/default_profiles/_hp-driver-stats.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_hp-driver-stats.yaml
@@ -1,7 +1,7 @@
 metrics:
   # Physical drives statistical information
   - MIB: CPQIDA-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     table:
       OID: 1.3.6.1.4.1.232.3.2.5.1
       name: cpqDaPhyDrvTable

--- a/snmp/datadog_checks/snmp/data/default_profiles/_intel-lan-adapters.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_intel-lan-adapters.yaml
@@ -5,7 +5,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.343.2.7.2.2.1.3
       name: genericAdaptersTrafficStatsAttrTable
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbols:
       - OID: 1.3.6.1.4.1.343.2.7.2.2.1.3.1.1
         name: adapterRxPackets

--- a/snmp/datadog_checks/snmp/data/default_profiles/_juniper-cos.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_juniper-cos.yaml
@@ -5,7 +5,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.2636.3.15.10
       name: jnxCosIfsetQstatTable
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbols:
     # The total number of packets queued at the output queue.
     - OID: 1.3.6.1.4.1.2636.3.15.10.1.3
@@ -99,7 +99,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.2636.3.15.10
       name: jnxCosIfsetQstatTable
-    forced_type: gauge
+    metric_type: gauge
     symbols:
     # The rate (expressed in packets per second) at which packets were queued at the output queue.
     - OID: 1.3.6.1.4.1.2636.3.15.10.1.4

--- a/snmp/datadog_checks/snmp/data/default_profiles/_juniper-dcu.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_juniper-dcu.yaml
@@ -5,7 +5,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.2636.3.6.2
       name: jnxDcuStatsTable
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbols:
     # The number of packets received on this interface, belonging to this address family that match this Destination Class.
     - OID: 1.3.6.1.4.1.2636.3.6.2.1.4

--- a/snmp/datadog_checks/snmp/data/default_profiles/_juniper-firewall.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_juniper-firewall.yaml
@@ -5,7 +5,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.2636.3.5.2
       name: jnxFirewallCounterTable
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbols:
     - OID: 1.3.6.1.4.1.2636.3.5.2.1.4
       name: jnxFWCounterPacketCount

--- a/snmp/datadog_checks/snmp/data/default_profiles/_juniper-scu.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_juniper-scu.yaml
@@ -5,7 +5,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.2636.3.16.1.1
       name: jnxScuStatsTable
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbols:
     # The number of packets sent out of jnxScuStatsDstIfIndex that match the source class (jnxScuStatsClassName) and match the address type (jnxScuStatsAddrFamily) defined for this table entry. 
     - OID: 1.3.6.1.4.1.2636.3.16.1.1.1.4

--- a/snmp/datadog_checks/snmp/data/default_profiles/_juniper-userfirewall.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_juniper-userfirewall.yaml
@@ -4,7 +4,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.2636.3.89.1.1.3
       name: jnxUserFwLDAPTable
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbols:
     #  Total LDAP query number.
     - OID: 1.3.6.1.4.1.2636.3.89.1.1.3.1.3

--- a/snmp/datadog_checks/snmp/data/default_profiles/_juniper-virtualchassis.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/_juniper-virtualchassis.yaml
@@ -7,7 +7,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.2636.3.40.1.4.1.2
       name: jnxVirtualChassisPortTable
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbols:
     # Indicates the total number of packets received on the virtual-chassis port.
     - OID: 1.3.6.1.4.1.2636.3.40.1.4.1.2.1.5
@@ -50,7 +50,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.2636.3.40.1.4.1.2
       name: jnxVirtualChassisPortTable
-    forced_type: gauge
+    metric_type: gauge
     symbols:
     # Indicates the total number of packets received per second on the virtual-chassis port.
     - OID: 1.3.6.1.4.1.2636.3.40.1.4.1.2.1.11

--- a/snmp/datadog_checks/snmp/data/default_profiles/a10-thunder.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/a10-thunder.yaml
@@ -40,32 +40,32 @@ metrics:
     symbol:
       name: axAppGlobalTotalNewConnections
       OID: 1.3.6.1.4.1.22610.2.4.3.1.2.2.0
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: A10-AX-MIB
     symbol:
       name: axAppGlobalTotalNewL4Connections
       OID: 1.3.6.1.4.1.22610.2.4.3.1.2.3.0
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: A10-AX-MIB
     symbol:
       name: axAppGlobalTotalNewL7Connections
       OID: 1.3.6.1.4.1.22610.2.4.3.1.2.4.0
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: A10-AX-MIB
     symbol:
       name: axAppGlobalTotalNewIPNatConnections
       OID: 1.3.6.1.4.1.22610.2.4.3.1.2.5.0
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: A10-AX-MIB
     symbol:
       name: axAppGlobalTotalSSLConnections
       OID: 1.3.6.1.4.1.22610.2.4.3.1.2.6.0
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: A10-AX-MIB
     symbol:
       name: axAppGlobalTotalL7Requests
       OID: 1.3.6.1.4.1.22610.2.4.3.1.2.7.0
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: A10-AX-MIB
     symbol:
       name: axGlobalAppPacketDrop

--- a/snmp/datadog_checks/snmp/data/default_profiles/apc_ups.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/apc_ups.yaml
@@ -152,7 +152,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.11.1.1.0
       name: upsBasicStateOutputState
-    forced_type: flag_stream
+    metric_type: flag_stream
     options:
       placement: 4
       metric_suffix: OnLine
@@ -160,7 +160,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.11.1.1.0
       name: upsBasicStateOutputState
-    forced_type: flag_stream
+    metric_type: flag_stream
     options:
       placement: 5
       metric_suffix: ReplaceBattery
@@ -168,7 +168,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.11.1.1.0
       name: upsBasicStateOutputState
-    forced_type: flag_stream
+    metric_type: flag_stream
     options:
       placement: 8
       metric_suffix: AVRTrimActive
@@ -176,7 +176,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.11.1.1.0
       name: upsBasicStateOutputState
-    forced_type: flag_stream
+    metric_type: flag_stream
     options:
       placement: 11
       metric_suffix: BatteriesDischarged
@@ -184,7 +184,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.11.1.1.0
       name: upsBasicStateOutputState
-    forced_type: flag_stream
+    metric_type: flag_stream
     options:
       placement: 19
       metric_suffix: "On"
@@ -192,7 +192,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.11.1.1.0
       name: upsBasicStateOutputState
-    forced_type: flag_stream
+    metric_type: flag_stream
     options:
       placement: 30
       metric_suffix: LowBatteryOnBattery
@@ -200,7 +200,7 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.318.1.1.1.11.1.1.0
       name: upsBasicStateOutputState
-    forced_type: flag_stream
+    metric_type: flag_stream
     options:
       placement: 33
       metric_suffix: NoBatteriesAttached

--- a/snmp/datadog_checks/snmp/data/default_profiles/arista.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/arista.yaml
@@ -103,7 +103,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.30065.3.6.1.1
       name: aristaIngressQueueTable
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbols:
       - OID: 1.3.6.1.4.1.30065.3.6.1.1.1.3
         name: aristaIngressQueuePktsDropped
@@ -122,7 +122,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.30065.3.6.1.2
       name: aristaEgressQueueTable
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbols:
       - OID: 1.3.6.1.4.1.30065.3.6.1.2.1.6
         name: aristaEgressQueuePktsDropped

--- a/snmp/datadog_checks/snmp/data/default_profiles/chatsworth_pdu.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/chatsworth_pdu.yaml
@@ -175,32 +175,32 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.11.1.0
       name: energyxy1s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.11.2.0
       name: energyyz1s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.11.3.0
       name: energyzx1s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.11.4.0
       name: energyxy2s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.11.5.0
       name: energyyz2s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.11.6.0
       name: energyzx2s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
 
 
   ### [Legacy] Outlets
@@ -305,122 +305,122 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.1.0
       name: receptacleEnergyoutlet1s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.2.0
       name: receptacleEnergyoutlet2s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.3.0
       name: receptacleEnergyoutlet3s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.4.0
       name: receptacleEnergyoutlet4s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.5.0
       name: receptacleEnergyoutlet5s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.6.0
       name: receptacleEnergyoutlet6s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.7.0
       name: receptacleEnergyoutlet7s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.8.0
       name: receptacleEnergyoutlet8s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.9.0
       name: receptacleEnergyoutlet9s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.10.0
       name: receptacleEnergyoutlet10s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.11.0
       name: receptacleEnergyoutlet11s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.12.0
       name: receptacleEnergyoutlet12s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.13.0
       name: receptacleEnergyoutlet13s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.14.0
       name: receptacleEnergyoutlet14s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.15.0
       name: receptacleEnergyoutlet15s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.16.0
       name: receptacleEnergyoutlet16s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.17.0
       name: receptacleEnergyoutlet17s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.18.0
       name: receptacleEnergyoutlet18s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.19.0
       name: receptacleEnergyoutlet19s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.20.0
       name: receptacleEnergyoutlet20s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.21.0
       name: receptacleEnergyoutlet21s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.22.0
       name: receptacleEnergyoutlet22s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.23.0
       name: receptacleEnergyoutlet23s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: CPI-UNITY-MIB
     symbol:
       OID: 1.3.6.1.4.1.30932.1.1.3.12.24.0
       name: receptacleEnergyoutlet24s
-    forced_type: monotonic_count
+    metric_type: monotonic_count
 
   ### PDU
 
@@ -598,7 +598,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.30932.1.10.1.3.110
       name: cpiPduBranchTable
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbols:
       - # Get the branch energy accumulated in decaVA-secs, divide by 360 to obtain VA-hr.
         OID: 1.3.6.1.4.1.30932.1.10.1.3.110.1.9
@@ -668,7 +668,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.30932.1.10.1.4.10
       name: cpiPduOutletTable
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbols:
       - # Get the outlet energy accumulated in decaWatt-secs, divide by 360 to obtain Watt-hr.
         OID: 1.3.6.1.4.1.30932.1.10.1.4.10.1.10

--- a/snmp/datadog_checks/snmp/data/default_profiles/checkpoint.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/checkpoint.yaml
@@ -88,33 +88,33 @@ metrics:
       name: procNum
     # Memory
   - MIB: CHECKPOINT-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.2620.1.6.7.4.3.0
       name: memTotalReal64
   - MIB: CHECKPOINT-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.2620.1.6.7.4.4.0
       name: memActiveReal64
   - MIB: CHECKPOINT-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.2620.1.6.7.4.5.0
       name: memFreeReal64
   - MIB: CHECKPOINT-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.2620.1.6.7.4.1.0
       name: memTotalVirtual64
   - MIB: CHECKPOINT-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.2620.1.6.7.4.2.0
       name: memActiveVirtual64
     # Disk
   - MIB: CHECKPOINT-MIB
-    forced_type: gauge
+    metric_type: gauge
     metric_tags:
       - column:
           OID: 1.3.6.1.4.1.2620.1.6.7.6.1.1
@@ -179,17 +179,17 @@ metrics:
       name: tempertureSensorTable
     # Network
   - MIB: CHECKPOINT-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.2620.1.1.4.0
       name: fwAccepted
   - MIB: CHECKPOINT-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.2620.1.1.6.0
       name: fwDropped
   - MIB: CHECKPOINT-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.2620.1.1.5.0
       name: fwRejected

--- a/snmp/datadog_checks/snmp/data/default_profiles/cisco-firepower-asa.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/cisco-firepower-asa.yaml
@@ -68,4 +68,4 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.9.9.392.1.4.1.3.0
       name: crasNumSetupFailInsufResources
-    forced_type: monotonic_count
+    metric_type: monotonic_count

--- a/snmp/datadog_checks/snmp/data/default_profiles/dell-poweredge.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/dell-poweredge.yaml
@@ -198,7 +198,7 @@ metrics:
           name: amperageProbeIndex
         tag: amperage_probe_index
   - MIB: MIB-Dell-10892
-    forced_type: gauge # Sent as integers
+    metric_type: gauge # Sent as integers
     table:
       OID: 1.3.6.1.4.1.674.10892.1.600.12
       name: powerSupplyTable
@@ -291,7 +291,7 @@ metrics:
           name: coolingDeviceLocationName
         tag: cooling_device_location_name
   - MIB: MIB-Dell-10892
-    forced_type: gauge # Sent as integers
+    metric_type: gauge # Sent as integers
     table:
       OID: 1.3.6.1.4.1.674.10892.1.700.20
       name: temperatureProbeTable
@@ -318,7 +318,7 @@ metrics:
           name: temperatureProbeLocationName
         tag: temperature_probe_location_name
   - MIB: MIB-Dell-10892
-    forced_type: gauge # Sent as integers
+    metric_type: gauge # Sent as integers
     table:
       OID: 1.3.6.1.4.1.674.10892.1.1100.30
       name: processorDeviceTable
@@ -359,7 +359,7 @@ metrics:
           name: processorDeviceStatusLocationName
         tag: processor_device_status_location_name
   - MIB: MIB-Dell-10892
-    forced_type: gauge # Sent as integers
+    metric_type: gauge # Sent as integers
     table:
       OID: 1.3.6.1.4.1.674.10892.1.1100.40
       name: cacheDeviceTable
@@ -380,7 +380,7 @@ metrics:
           name: cacheDeviceIndex
         tag: index
   - MIB: MIB-Dell-10892
-    forced_type: gauge # Sent as integers
+    metric_type: gauge # Sent as integers
     table:
       OID: 1.3.6.1.4.1.674.10892.1.1100.50
       name: memoryDeviceTable
@@ -410,7 +410,7 @@ metrics:
           name: memoryDeviceSerialNumberName
         tag: serial_number_name
   - MIB: MIB-Dell-10892
-    forced_type: gauge # Sent as integers
+    metric_type: gauge # Sent as integers
     table:
       OID: 1.3.6.1.4.1.674.10892.1.1100.90
       name: networkDeviceTable

--- a/snmp/datadog_checks/snmp/data/default_profiles/f5-big-ip.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/f5-big-ip.yaml
@@ -55,42 +55,42 @@ metadata:
 metrics:
   # Memory stats
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.1.44.0
       name: sysStatMemoryTotal
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.1.45.0
       name: sysStatMemoryUsed
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.21.28.0
       name: sysGlobalTmmStatMemoryTotal
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.21.29.0
       name: sysGlobalTmmStatMemoryUsed
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.20.44.0
       name: sysGlobalHostOtherMemoryTotal
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.20.45.0
       name: sysGlobalHostOtherMemoryUsed
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.20.46.0
       name: sysGlobalHostSwapTotal
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: gauge
+    metric_type: gauge
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.20.47.0
       name: sysGlobalHostSwapUsed
@@ -99,7 +99,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.3375.2.1.7.5.2
       name: sysMultiHostCpuTable
-    forced_type: gauge
+    metric_type: gauge
     symbols:
       - OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.11
         name: sysMultiHostCpuUsageRatio
@@ -112,7 +112,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.3375.2.1.7.5.2
       name: sysMultiHostCpuTable
-    forced_type: percent
+    metric_type: percent
     symbols:
       - OID: 1.3.6.1.4.1.3375.2.1.7.5.2.1.4
         name: sysMultiHostCpuUser
@@ -152,22 +152,22 @@ metrics:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.12.5.0
       name: sysTcpStatTimeWait
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.12.6.0
       name: sysTcpStatAccepts
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.12.7.0
       name: sysTcpStatAcceptfails
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.12.8.0
       name: sysTcpStatConnects
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.12.9.0
       name: sysTcpStatConnfails
@@ -177,22 +177,22 @@ metrics:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.13.2.0
       name: sysUdpStatOpen
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.13.3.0
       name: sysUdpStatAccepts
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.13.4.0
       name: sysUdpStatAcceptfails
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.13.5.0
       name: sysUdpStatConnects
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.13.6.0
       name: sysUdpStatConnfails
@@ -201,27 +201,27 @@ metrics:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.9.2.0
       name: sysClientsslStatCurConns
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.9.10.0
       name: sysClientsslStatEncryptedBytesIn
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.9.11.0
       name: sysClientsslStatEncryptedBytesOut
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.9.12.0
       name: sysClientsslStatDecryptedBytesIn
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.9.13.0
       name: sysClientsslStatDecryptedBytesOut
   - MIB: F5-BIGIP-SYSTEM-MIB
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbol:
       OID: 1.3.6.1.4.1.3375.2.1.1.2.9.29.0
       name: sysClientsslStatHandshakeFailures
@@ -338,7 +338,7 @@ metrics:
         name: ltmVirtualServStatClientEvictedConns
       - OID: 1.3.6.1.4.1.3375.2.2.10.2.3.1.41
         name: ltmVirtualServStatClientSlowKilled
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     metric_tags:
       - tag: server
         column:
@@ -414,7 +414,7 @@ metrics:
         name: ltmNodeAddrStatServerTotConns
       - OID: 1.3.6.1.4.1.3375.2.2.4.2.3.1.17
         name: ltmNodeAddrStatTotRequests
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     metric_tags:
       - tag: node
         column:
@@ -486,7 +486,7 @@ metrics:
         name: ltmPoolStatConnqServiced
       - OID: 1.3.6.1.4.1.3375.2.2.5.2.3.1.30
         name: ltmPoolStatTotRequests
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     metric_tags:
       - tag: pool
         column:
@@ -576,7 +576,7 @@ metrics:
         name: ltmPoolMemberStatTotRequests
       - OID: 1.3.6.1.4.1.3375.2.2.5.4.3.1.27
         name: ltmPoolMemberStatConnqServiced
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     metric_tags:
       - tag: pool
         column:

--- a/snmp/datadog_checks/snmp/data/default_profiles/fireeye.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/fireeye.yaml
@@ -109,47 +109,47 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.25597.13.1.1.0
       name: feTotalEmailCount
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: FE-FIREEYE-MIB
     symbol:
       OID: 1.3.6.1.4.1.25597.13.1.4.0
       name: feInfectedEmailCount
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: FE-FIREEYE-MIB
     symbol:
       OID: 1.3.6.1.4.1.25597.13.1.7.0
       name: feAnalyzedEmailCount
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: FE-FIREEYE-MIB
     symbol:
       OID: 1.3.6.1.4.1.25597.13.1.10.0
       name: feTotalUrlCount
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: FE-FIREEYE-MIB
     symbol:
       OID: 1.3.6.1.4.1.25597.13.1.13.0
       name: feInfectedUrlCount
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: FE-FIREEYE-MIB
     symbol:
       OID: 1.3.6.1.4.1.25597.13.1.16.0
       name: feAnalyzedUrlCount
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: FE-FIREEYE-MIB
     symbol:
       OID: 1.3.6.1.4.1.25597.13.1.19.0
       name: feTotalAttachmentCount
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: FE-FIREEYE-MIB
     symbol:
       OID: 1.3.6.1.4.1.25597.13.1.22.0
       name: feInfectedAttachmentCount
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: FE-FIREEYE-MIB
     symbol:
       OID: 1.3.6.1.4.1.25597.13.1.25.0
       name: feAnalyzedAttachmentCount
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: FE-FIREEYE-MIB
     symbol:
       OID: 1.3.6.1.4.1.25597.13.1.40.0
@@ -166,12 +166,12 @@ metrics:
     symbol:
       OID: 1.3.6.1.4.1.25597.15.1.1.0
       name: feTotalObjectAnalyzedCount
-    forced_type: monotonic_count
+    metric_type: monotonic_count
   - MIB: FE-FIREEYE-MIB
     symbol:
       OID: 1.3.6.1.4.1.25597.15.1.4.0
       name: feTotalMaliciousObjectCount
-    forced_type: monotonic_count
+    metric_type: monotonic_count
 metric_tags:
   - tag: fe_hardware_model
     OID: 1.3.6.1.4.1.25597.11.1.1.2.0

--- a/snmp/datadog_checks/snmp/data/default_profiles/fortinet-fortigate.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/fortinet-fortigate.yaml
@@ -81,7 +81,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.12356.101.4.4.2
       name: fgProcessorTable
-    forced_type: monotonic_count_and_rate
+    metric_type: monotonic_count_and_rate
     symbols:
       # The total number of packets received by this processor.
       - OID: 1.3.6.1.4.1.12356.101.4.4.2.1.6
@@ -257,7 +257,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.12356.101.5.1.2.1
       name: fgFwPolStatsTable
-    forced_type: monotonic_count_and_rate
+    metric_type: monotonic_count_and_rate
     symbols:
       # Number of packets matched to policy (passed or blocked, depending on policy action). Count is from the time the policy became active.
       - OID: 1.3.6.1.4.1.12356.101.5.1.2.1.1.2
@@ -277,7 +277,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.12356.101.5.1.2.2
       name: fgFwPol6StatsTable
-    forced_type: monotonic_count_and_rate
+    metric_type: monotonic_count_and_rate
     symbols:
       # Number of packets matched to policy (passed or blocked, depending on policy action). Count is from the time the policy became active.
       - OID: 1.3.6.1.4.1.12356.101.5.1.2.2.1.2

--- a/snmp/datadog_checks/snmp/data/default_profiles/hp-ilo.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/hp-ilo.yaml
@@ -98,7 +98,7 @@ metrics:
         name: cpqSm2NicRecvErrorPackets
       - OID: 1.3.6.1.4.1.232.9.2.5.2.1.15
         name: cpqSm2NicRecvUnknownPackets
-    forced_type: monotonic_count # Sent as Counter (would be ingested as rates if not forced).
+    metric_type: monotonic_count # Sent as Counter (would be ingested as rates if not forced).
     metric_tags:
       - # Location of the controller (embedded controller vs. PC card).
         # NOTE: other(1), embedded(2), pcmcia(3)
@@ -135,7 +135,7 @@ metrics:
       - # Number of octets sent.
         OID: 1.3.6.1.4.1.232.18.2.3.1.1.38
         name: cpqNicIfPhysAdapterOutOctets
-    forced_type: monotonic_count  # Sent as Counters (not forcing would make us ingest them as rates).
+    metric_type: monotonic_count  # Sent as Counters (not forcing would make us ingest them as rates).
     metric_tags:
       - tag: interface
         column:

--- a/snmp/datadog_checks/snmp/data/default_profiles/meraki-cloud-controller.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/meraki-cloud-controller.yaml
@@ -18,7 +18,7 @@ metrics:
       OID: 1.3.6.1.4.1.29671.1.1.4
       name: devTable
       # devTable INDEX is: devMac
-    forced_type: gauge
+    metric_type: gauge
     symbols:
       - OID: 1.3.6.1.4.1.29671.1.1.4.1.3
         name: devStatus
@@ -48,7 +48,7 @@ metrics:
       OID: 1.3.6.1.4.1.29671.1.1.5
       name: devInterfaceTable
       # devInterfaceTable INDEX is: devInterfaceDevMac, devInterfaceIndex
-    forced_type: gauge
+    metric_type: gauge
     symbols:
       - OID: 1.3.6.1.4.1.29671.1.1.5.1.4
         name: devInterfaceSentPkts

--- a/snmp/datadog_checks/snmp/data/default_profiles/netapp.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/netapp.yaml
@@ -70,7 +70,7 @@ metrics:
   - MIB: NETAPP-MIB
     OID: 1.3.6.1.4.1.789.1.26.8.0
     name: extcache64Hits  # Indicates number of wafl buffers read from the external cache
-    forced_type: monotonic_count
+    metric_type: monotonic_count
 
   # Snap vaults
 
@@ -81,7 +81,7 @@ metrics:
     symbols:
       - OID: 1.3.6.1.4.1.789.1.19.11.1.9
         name: svTotalFailures
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     metric_tags:
       - tag: index
         column:
@@ -102,7 +102,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.789.1.9.20
       name: snapmirrorStatusTable
-    forced_type: gauge
+    metric_type: gauge
     symbols:
       - OID: 1.3.6.1.4.1.789.1.9.20.1.6
         name: snapmirrorLag # SNMP type is TimeTicks
@@ -120,7 +120,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.789.1.9.20
       name: snapmirrorStatusTable
-    forced_type: monotonic_count
+    metric_type: monotonic_count
     symbols:
       - OID: 1.3.6.1.4.1.789.1.9.20.1.9
         name: snapmirrorTotalFailures
@@ -140,7 +140,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.789.1.5.4
       name: dfTable
-    forced_type: gauge
+    metric_type: gauge
     symbols:
       - OID: 1.3.6.1.4.1.789.1.5.4.1.14
         name: dfHighTotalKBytes
@@ -166,7 +166,7 @@ metrics:
     table:
       OID: 1.3.6.1.4.1.789.1.22.1.2
       name: netifTable
-    forced_type: monotonic_count_and_rate
+    metric_type: monotonic_count_and_rate
     symbols:
       - OID: 1.3.6.1.4.1.789.1.22.1.2.1.3
         name: ifHighInOctets


### PR DESCRIPTION
Let's verify that the profile tests are still passing. Follow up to https://github.com/DataDog/datadog-agent/pull/17900/