### PR TITLE
Run the legacy tests on py3 too

### DIFF
--- a/aspdotnet/tests/test_aspdotnet.py
+++ b/aspdotnet/tests/test_aspdotnet.py
@@ -1,15 +1,16 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import copy
+
 import pytest
 from datadog_test_libs.win.pdh_mocks import initialize_pdh_tests, pdh_mocks_fixture  # noqa: F401
 
 from datadog_checks.aspdotnet import AspdotnetCheck
-from datadog_checks.dev.testing import requires_py2
 
 from . import common
 
-pytestmark = [requires_py2, pytest.mark.usefixtures('pdh_mocks_fixture')]
+pytestmark = [pytest.mark.usefixtures('pdh_mocks_fixture')]
 
 
 @pytest.fixture(autouse=True)
@@ -18,7 +19,8 @@ def setup_check():
 
 
 def test_basic_check(aggregator):
-    instance = common.MINIMAL_INSTANCE
+    instance = copy.deepcopy(common.MINIMAL_INSTANCE)
+    instance["use_legacy_check_version"] = True
     c = AspdotnetCheck('aspdotnet', {}, [instance])
     c.check(instance)
 
@@ -33,7 +35,8 @@ def test_basic_check(aggregator):
 
 
 def test_with_tags(aggregator):
-    instance = common.INSTANCE_WITH_TAGS
+    instance = copy.deepcopy(common.INSTANCE_WITH_TAGS)
+    instance["use_legacy_check_version"] = True
     c = AspdotnetCheck('aspdotnet', {}, [instance])
     c.check(instance)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Run the legacy tests on py3 too

### Motivation
<!-- What inspired you to submit this pull request? -->

- These tests are not running on py3, which is too bad because they are literally there and working. 
- Improve test coverage on master too because we do not run py2 tests on master, only on the nightly build

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- We don't remember why this was not enabled on py3
- Adding the option is needed because we automatically switch to the new implementation when running on py3, unless this option is provided

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.