### PR TITLE
Add `snmp/data/default_profiles` to matrix TESTABLE_FILE_PATTERN

### DIFF
--- a/ddev/src/ddev/utils/scripts/ci_matrix.py
+++ b/ddev/src/ddev/utils/scripts/ci_matrix.py
@@ -48,6 +48,7 @@ TESTABLE_FILE_PATTERN = re.compile(
   | hatch\.toml
   | metadata\.csv
   | pyproject\.toml
+  | snmp/data/default_profiles/.+
     """,
     re.VERBOSE,
 )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add `snmp/data/default_profiles` to matrix TESTABLE_FILE_PATTERN

### Motivation
<!-- What inspired you to submit this pull request? -->

SNMP tests need be run on CI again when files in `snmp/data/default_profiles` changes.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.