### PR TITLE
Process query rows one at a time to reduce memory footprint

### DIFF
--- a/snowflake/tests/snowflake_connector_patch/_snowflake_connector_patch/connector.py
+++ b/snowflake/tests/snowflake_connector_patch/_snowflake_connector_patch/connector.py
@@ -4,6 +4,7 @@
 import re
 
 import requests
+from snowflake.connector.cursor import SnowflakeCursor
 
 from . import tables
 
@@ -49,7 +50,7 @@ class Cursor(object):
             if self.schema == 'ORGANIZATION_USAGE':
                 table_prefix = 'ORGANIZATION_'
             table_attr = "{}{}".format(table_prefix, table_name)
-            self.__data = getattr(tables, table_attr, [])
+            self.__data = list(getattr(tables, table_attr, []))
         elif query == 'select current_version();':
             self.__data = [('4.30.2',)]
         else:
@@ -58,5 +59,14 @@ class Cursor(object):
     def fetchall(self):
         return self.__data
 
+    def fetchone(self):
+        try:
+            return self.__data.pop(0)
+        except IndexError:
+            return None
+
+    def __iter__(self):
+        return SnowflakeCursor.__iter__(self)
+
     def close(self):
-        pass
+        self.__data = []

--- a/snowflake/tests/snowflake_connector_patch/_snowflake_connector_patch/connector.py
+++ b/snowflake/tests/snowflake_connector_patch/_snowflake_connector_patch/connector.py
@@ -56,9 +56,6 @@ class Cursor(object):
         else:
             self.__data = []
 
-    def fetchall(self):
-        return self.__data
-
     def fetchone(self):
         try:
             return self.__data.pop(0)

--- a/snowflake/tests/test_snowflake.py
+++ b/snowflake/tests/test_snowflake.py
@@ -123,7 +123,7 @@ def test_version_metadata(dd_run_check, instance, datadog_agent):
         'version.raw': '4.30.2',
         'version.scheme': 'semver',
     }
-    with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=expected_version):
+    with mock.patch('datadog_checks.snowflake.SnowflakeCheck.execute_query_raw', return_value=iter(expected_version)):
         check = SnowflakeCheck(CHECK_NAME, {}, [instance])
         check.check_id = 'test:123'
         check._conn = mock.MagicMock()


### PR DESCRIPTION
### What does this PR do?

Changes `fetchall()` with iterating on the cursor, which is equivalent to fetching the results one by one.

### Motivation

A support case reported running into increased memory usages when the queries return a large number of row. The snowflake [docs](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#using-cursor-to-fetch-values) indicate that this is the way to go when `fetchall()` results in memory usage issues.

### Additional Notes

- As far as I know, this should not result in any performance regression, as under the hood `fetchall()` [is using `fetchone()` in a loop](https://github.com/snowflakedb/snowflake-connector-python/blob/7ac23578fa906cf9e969a6fff2ed4a202a7b69b0/src/snowflake/connector/cursor.py#L1296-L1304).
- [Reference](https://github.com/snowflakedb/snowflake-connector-python/blob/7ac23578fa906cf9e969a6fff2ed4a202a7b69b0/src/snowflake/connector/cursor.py#L1363-L1369) to what's called when iterating over cursor to see how it's uses `fetchone`.
- I haven't benchmarked the difference in memory usage of the change, and I'm instead relying on what's documented and on understanding our code, snowflake_connector's code, and the description of the issue from a support case.
- I've tested this against a real snowflake instance, and I've made the necessary adjustments to our mock to try to follow the expected behavior as closely as possible.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.