### PR TITLE
[AGENT-9940] Optimize highwater offset collection

### DIFF
--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -77,34 +77,81 @@ class KafkaClient:
 
     def get_highwater_offsets(self, consumer_offsets):
         self.log.debug('Getting highwater offsets')
+
         highwater_offsets = {}
-        topics_with_consumer_offset = {}
+        topics_with_consumer_offset = set()
+        topic_partition_with_consumer_offset = set()
+
         if not self.config._monitor_all_broker_highwatermarks:
-            topics_with_consumer_offset = {(topic, partition) for (_, topic, partition) in consumer_offsets}
+            for (_, topic, partition) in consumer_offsets:
+                topics_with_consumer_offset.add(topic)
+                topic_partition_with_consumer_offset.add((topic, partition))
 
-        for consumer_group in consumer_offsets.items():
-            consumer = self.__create_consumer(consumer_group)
-            topics = consumer.list_topics(timeout=self.config._request_timeout)
+        clusters_queried = set()
+        consumer_groups_checked = set()
+
+        for consumer_group, _, _ in consumer_offsets:
             self.log.debug('CONSUMER GROUP: %s', consumer_group)
+            topic_partitions_for_highwater_offsets = set()
+            if consumer_group in consumer_groups_checked:
+                self.log.debug('Consumer group %s topics already queried, skipping it', consumer_group)
+                continue
+            consumer = self.__create_consumer(consumer_group)
+            cluster_metadata = consumer.list_topics(timeout=self.config._request_timeout)
 
-            for topic in topics.topics:
-                topic_partitions = [
-                    TopicPartition(topic, partition) for partition in list(topics.topics[topic].partitions.keys())
-                ]
+            # Cluster id string, if supported by the broker, else None
+            cluster_id = cluster_metadata.cluster_id
 
-                for topic_partition in topic_partitions:
-                    partition = topic_partition.partition
-                    if topic not in KAFKA_INTERNAL_TOPICS and (
+            # Avoid querying the same cluster multiple times
+            if cluster_id in clusters_queried:
+                self.log.debug("Cluster %s topics already queried. Skipping it", cluster_metadata.cluster_id)
+                continue
+            # Check for existence as cluster_id is an optional value
+            elif cluster_id is not None:
+                clusters_queried.add(cluster_metadata.cluster_id)
+
+            topics = cluster_metadata.topics
+
+            for topic in topics:
+                if topic in KAFKA_INTERNAL_TOPICS:
+                    self.log.debug("Skipping internal topic %s", topic)
+                    continue
+                if not self.config._monitor_all_broker_highwatermarks and topic not in topics_with_consumer_offset:
+                    self.log.debug("Skipping non-relevant topic %s", topic)
+                    continue
+
+                for partition in topics[topic].partitions:
+                    if (
                         self.config._monitor_all_broker_highwatermarks
-                        or (topic, partition) in topics_with_consumer_offset
+                        or (topic, partition) in topic_partition_with_consumer_offset
                     ):
-                        _, high_offset = consumer.get_watermark_offsets(topic_partition)
-
+                        # Setting offset to -1 will return the latest highwater offset while calling offsets_for_times
+                        #   Reference: https://github.com/fede1024/rust-rdkafka/issues/460
+                        topic_partitions_for_highwater_offsets.add(
+                            TopicPartition(topic=topic, partition=partition, offset=-1)
+                        )
                         self.log.debug('TOPIC: %s', topic)
                         self.log.debug('PARTITION: %s', partition)
-                        self.log.debug('HIGHWATER OFFSET: %s', high_offset)
+                    else:
+                        self.log.debug("Skipping non-relevant partition %s of topic %s", partition, topic)
+            consumer_groups_checked.add(consumer_group)
 
-                        highwater_offsets[(topic, partition)] = high_offset
+            if len(topic_partitions_for_highwater_offsets) > 0:
+                self.log.debug(
+                    'Querying %s highwater offsets for consumer group %s',
+                    len(topic_partitions_for_highwater_offsets),
+                    consumer_group,
+                )
+                for topic_partition_with_highwater_offset in consumer.offsets_for_times(
+                    partitions=list(topic_partitions_for_highwater_offsets)
+                ):
+                    self.log.debug('%s', topic_partition_with_highwater_offset)
+                    topic = topic_partition_with_highwater_offset.topic
+                    partition = topic_partition_with_highwater_offset.partition
+                    offset = topic_partition_with_highwater_offset.offset
+                    highwater_offsets[(topic, partition)] = offset
+            else:
+                self.log.debug('No new highwater offsets to query for consumer group %s', consumer_group)
 
         self.log.debug('Got %s highwater offsets', len(highwater_offsets))
         return highwater_offsets

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -76,6 +76,7 @@ class KafkaClient:
         return config
 
     def get_highwater_offsets(self, consumer_offsets):
+        self.log.debug('Getting highwater offsets')
         highwater_offsets = {}
         topics_with_consumer_offset = {}
         if not self.config._monitor_all_broker_highwatermarks:
@@ -84,6 +85,7 @@ class KafkaClient:
         for consumer_group in consumer_offsets.items():
             consumer = self.__create_consumer(consumer_group)
             topics = consumer.list_topics(timeout=self.config._request_timeout)
+            self.log.debug('CONSUMER GROUP: %s', consumer_group)
 
             for topic in topics.topics:
                 topic_partitions = [
@@ -98,8 +100,13 @@ class KafkaClient:
                     ):
                         _, high_offset = consumer.get_watermark_offsets(topic_partition)
 
+                        self.log.debug('TOPIC: %s', topic)
+                        self.log.debug('PARTITION: %s', partition)
+                        self.log.debug('HIGHWATER OFFSET: %s', high_offset)
+
                         highwater_offsets[(topic, partition)] = high_offset
 
+        self.log.debug('Got %s highwater offsets', len(highwater_offsets))
         return highwater_offsets
 
     def get_partitions_for_topic(self, topic):
@@ -119,11 +126,14 @@ class KafkaClient:
 
     def get_consumer_offsets(self):
         # {(consumer_group, topic, partition): offset}
+        self.log.debug('Getting consumer offsets')
         consumer_offsets = {}
 
         consumer_groups = self._get_consumer_groups()
+        self.log.debug('Identified %s consumer groups', len(consumer_groups))
 
         futures = self._get_consumer_offset_futures(consumer_groups)
+        self.log.debug('%s futures to be waited on', len(futures))
 
         for future in as_completed(futures):
             try:
@@ -165,6 +175,7 @@ class KafkaClient:
                         if self.config._consumer_groups_compiled_regex.match(to_match):
                             consumer_offsets[(consumer_group, topic, partition)] = offset
 
+        self.log.debug('Got %s consumer offsets', len(consumer_offsets))
         return consumer_offsets
 
     def _get_consumer_groups(self):

--- a/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/kafka_consumer.py
@@ -57,6 +57,12 @@ class KafkaCheck(AgentCheck):
             raise
 
         total_contexts = len(consumer_offsets) + len(highwater_offsets)
+        self.log.debug(
+            "Total contexts: %s, Consumer offsets: %s, Highwater offsets: %s",
+            total_contexts,
+            consumer_offsets,
+            highwater_offsets,
+        )
         if total_contexts >= self._context_limit:
             self.warning(
                 """Discovered %s metric contexts - this exceeds the maximum number of %s contexts permitted by the
@@ -79,9 +85,11 @@ class KafkaCheck(AgentCheck):
             broker_tags = ['topic:%s' % topic, 'partition:%s' % partition]
             broker_tags.extend(self.config._custom_tags)
             self.gauge('broker_offset', highwater_offset, tags=broker_tags)
+            self.log.debug('%s highwater offset reported with %s tags', highwater_offset, broker_tags)
             reported_contexts += 1
             if reported_contexts == contexts_limit:
                 return
+        self.log.debug('%s highwater offsets reported', reported_contexts)
 
     def report_consumer_offsets_and_lag(self, consumer_offsets, highwater_offsets, contexts_limit):
         """Report the consumer offsets and consumer lag."""
@@ -94,6 +102,7 @@ class KafkaCheck(AgentCheck):
                     str(reported_contexts),
                     str(contexts_limit),
                 )
+                self.log.debug('%s consumer offsets reported', reported_contexts)
                 return
             consumer_group_tags = ['topic:%s' % topic, 'partition:%s' % partition, 'consumer_group:%s' % consumer_group]
             consumer_group_tags.extend(self.config._custom_tags)
@@ -104,6 +113,7 @@ class KafkaCheck(AgentCheck):
                 # report consumer offset if the partition is valid because even if leaderless the consumer offset will
                 # be valid once the leader failover completes
                 self.gauge('consumer_offset', consumer_offset, tags=consumer_group_tags)
+                self.log.debug('%s consumer offset reported with %s tags', consumer_offset, consumer_group_tags)
                 reported_contexts += 1
 
                 if (topic, partition) not in highwater_offsets:
@@ -119,6 +129,7 @@ class KafkaCheck(AgentCheck):
                 consumer_lag = producer_offset - consumer_offset
                 if reported_contexts < contexts_limit:
                     self.gauge('consumer_lag', consumer_lag, tags=consumer_group_tags)
+                    self.log.debug('%s consumer lag reported with %s tags', consumer_lag, consumer_group_tags)
                     reported_contexts += 1
 
                 if consumer_lag < 0:
@@ -145,6 +156,7 @@ class KafkaCheck(AgentCheck):
                     )
                 self.log.warning(msg, consumer_group, topic, partition)
                 self.client.request_metadata_update()  # force metadata update on next poll()
+        self.log.debug('%s consumer offsets reported', reported_contexts)
 
     def send_event(self, title, text, tags, event_type, aggregation_key, severity='info'):
         """Emit an event to the Datadog Event Stream."""


### PR DESCRIPTION
### What does this PR do?
- Highwater offsets were collected in a loop with one call made to the broker for every topic partition. This was causing a large number of calls (tens of thousands as per the debug flare from AGENT-9940) to the broker and the highwater offset collection was taking more than 2min
- This change introduces the ability to query the highwater offsets of all topic partitions within a kafka cluster in a single call
- Also multiple early exits have been configured while fetching highwater offsets as performance optimization
- Improved debug logs

### Motivation
[AGENT-9940](https://datadoghq.atlassian.net/browse/AGENT-9940)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.

[AGENT-9940]: https://datadoghq.atlassian.net/browse/AGENT-9940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ