### PR TITLE
Revert to requesting Prometheus format by default

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/scraper.py
@@ -221,15 +221,10 @@ class OpenMetricsScraper:
 
         self._content_type = ''
         self._use_latest_spec = is_affirmative(config.get('use_latest_spec', False))
-        # Accept headers are taken from:
-        # https://github.com/prometheus/prometheus/blob/v2.43.0/scrape/scrape.go#L787
         if self._use_latest_spec:
             accept_header = 'application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1'
         else:
-            accept_header = (
-                'application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1;q=0.75,'
-                'text/plain;version=0.0.4;q=0.5,*/*;q=0.1'
-            )
+            accept_header = 'text/plain'
 
         # Request the appropriate exposition format
         if self.http.options['headers'].get('Accept') == '*/*':

--- a/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_config.py
+++ b/datadog_checks_base/tests/base/checks/openmetrics/test_v2/test_config.py
@@ -429,7 +429,4 @@ class TestUseLatestSpec:
         check = get_check({'use_latest_spec': False})
         check.configure_scrapers()
         scraper = check.scrapers['test']
-        assert scraper.http.options['headers']['Accept'] == (
-            'application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1;q=0.75,'
-            'text/plain;version=0.0.4;q=0.5,*/*;q=0.1'
-        )
+        assert scraper.http.options['headers']['Accept'] == 'text/plain'

--- a/openmetrics/tests/test_openmetrics.py
+++ b/openmetrics/tests/test_openmetrics.py
@@ -69,10 +69,7 @@ def test_openmetrics(aggregator, dd_run_check, request, poll_mock_fixture):
     aggregator.assert_all_metrics_covered()
 
     assert check.http.options['headers']['Accept'] == '*/*'
-    assert scraper.http.options['headers']['Accept'] == (
-        'application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1;q=0.75,'
-        'text/plain;version=0.0.4;q=0.5,*/*;q=0.1'
-    )
+    assert scraper.http.options['headers']['Accept'] == 'text/plain'
 
 
 def test_openmetrics_use_latest_spec(aggregator, dd_run_check, mock_http_response, openmetrics_payload, caplog):


### PR DESCRIPTION
### What does this PR do?

It reverts the default accept header to request `text/plain` (i.e. prometheus format) that was introduced by #14445.

### Motivation

It looks like the library support for OpenMetrics format generation and parsing is somewhat immature (e.g. https://github.com/prometheus/client_golang/issues/829) which made setting the accept header to request the OpenMetrics format if available more disturbing than we anticipated.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.