### PR TITLE
Remove legacy metric from metadata.csv

### DIFF
--- a/gitlab/metadata.csv
+++ b/gitlab/metadata.csv
@@ -267,7 +267,6 @@ gitlab.go_memstats_sys_bytes,gauge,,byte,,The number of bytes obtained by system
 gitlab.go_threads,gauge,,request,second,The number of OS threads create,0,gitlab,go threads,
 gitlab.http_request_duration_microseconds,gauge,,request,second,The HTTP request latencies in microseconds,0,gitlab,HTTP req latencies,
 gitlab.http_request_size_bytes,gauge,,byte,,The HTTP request sizes in bytes,0,gitlab,HTTP req sizes,
-gitlab.http_requests_total,count,,request,second,[Legacy] The total number of HTTP requests made,0,gitlab,total HTTP reqs,
 gitlab.http_response_size_bytes,gauge,,byte,,The HTTP response sizes in bytes,0,gitlab,HTTP resp sizes,
 gitlab.process_cpu_seconds_total,count,,request,second,[OpenMetrics V1] The total user and system CPU time spent in seconds,0,gitlab,user and system cpu time,
 gitlab.process_cpu_seconds.count,count,,request,second,[OpenMetrics V2] The total user and system CPU time spent in seconds,0,gitlab,user and system cpu time,


### PR DESCRIPTION
### What does this PR do?

Removes a metric that is no longer collected by any officially documented method from the metadata.csv.

### Motivation

Partly due to #15085, which intends to use the term "legacy" for referring to OMv1, resulting in an overload for the term, and generally being impossible to tell from a user's perspective what `[Legacy]` indicates here. Since new users are not going to encounter this metric, it looks safe to delete it and removes noise.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.