### PR TITLE
Changelog spacing fix

### DIFF
--- a/kubernetes/CHANGELOG.md
+++ b/kubernetes/CHANGELOG.md
@@ -22,6 +22,7 @@
 ## 1.5.0 / 2017-10-10
 
 ***Fixed***:
+
 * remove namespace from pod_name tag. See [#770](https://github.com/DataDog/integrations-core/issues/770)
 * stop reporting cAdvisor metrics about non-container objects. See [#770](https://github.com/DataDog/integrations-core/issues/770)
 


### PR DESCRIPTION
### What does this PR do?

While validating the formatting of changelogs I realized that I missed one spacing case, where I didn't check if there was an empty line between the version/date header and bullet points. This PR fixes the case that I missed