### PR TITLE
Enable integrations targeted for dash'23 with python3.8

### DIFF
--- a/.github/workflows/build-ddev.yml
+++ b/.github/workflows/build-ddev.yml
@@ -23,7 +23,7 @@ defaults:
 
 env:
   APP_NAME: ddev
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "3.8"
   PYOXIDIZER_VERSION: "0.24.0"
 
 jobs:

--- a/.github/workflows/cache-shared-deps.yml
+++ b/.github/workflows/cache-shared-deps.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-22.04, windows-2022]
 
     env:
-      PYTHON_VERSION: "3.9"
+      PYTHON_VERSION: "3.8"
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/run-validations.yml
+++ b/.github/workflows/run-validations.yml
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     env:
-      PYTHON_VERSION: "3.9"
+      PYTHON_VERSION: "3.8"
       TARGET: ${{ github.event_name == 'pull_request' && 'changed' || '' }}
 
     steps:

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -21,7 +21,7 @@ on:
 
       python-version:
         required: false
-        default: ""
+        default: "3.8"
         type: string
       standard:
         required: false
@@ -86,7 +86,7 @@ jobs:
     runs-on: ${{ fromJson(inputs.runner) }}
 
     env:
-      PYTHON_VERSION: "${{ inputs.python-version || '3.9' }}"
+      PYTHON_VERSION: "${{ inputs.python-version || '3.8' }}"
       SKIP_ENV_NAME: "${{ (inputs.test-py2 && !inputs.test-py3) && 'py3.*' || (!inputs.test-py2 && inputs.test-py3) && 'py2.*' || '' }}"
       # Windows E2E requires Windows containers
       DDEV_E2E_AGENT: "${{ inputs.platform == 'windows' && (inputs.agent-image-windows || 'datadog/agent-dev:master-py3-win-servercore') || inputs.agent-image }}"

--- a/dcgm/CHANGELOG.md
+++ b/dcgm/CHANGELOG.md
@@ -5,3 +5,9 @@
 ***Added***:
 
 * Add the DCGM integration. See [#14589](https://github.com/DataDog/integrations-core/pull/14589).
+
+## 0.1.0 / 2023-07-20
+
+***Added***:
+
+* Add the DCGM integration for python 3.8. See [#14589](https://github.com/DataDog/integrations-core/pull/14589).

--- a/dcgm/datadog_checks/dcgm/__about__.py
+++ b/dcgm/datadog_checks/dcgm/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.0.0'
+__version__ = '0.1.0'

--- a/dcgm/hatch.toml
+++ b/dcgm/hatch.toml
@@ -1,4 +1,4 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.9"]
+python = ["3.8"]

--- a/dcgm/pyproject.toml
+++ b/dcgm/pyproject.toml
@@ -10,7 +10,7 @@ name = "datadog-dcgm"
 description = "The dcgm-exporter check"
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 keywords = [
     "datadog",
     "datadog agent",
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "ddev"
 description = "The Datadog Agent integration developer tool"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 license = "BSD-3-Clause"
 keywords = [
     "datadog",
@@ -23,7 +23,7 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.8",
 ]
 dependencies = [
     "click~=8.1.6",

--- a/torchserve/CHANGELOG.md
+++ b/torchserve/CHANGELOG.md
@@ -5,3 +5,9 @@
 ***Added***:
 
 * Add the TorchServe integration. See [#14608](https://github.com/DataDog/integrations-core/pull/14608).
+
+## 0.1.0 / 2023-07-20
+
+***Added***:
+
+* Add the TorchServe integration for python 3.8 See [#14608](https://github.com/DataDog/integrations-core/pull/14608).

--- a/torchserve/datadog_checks/torchserve/__about__.py
+++ b/torchserve/datadog_checks/torchserve/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.0.0'
+__version__ = '0.1.0'

--- a/torchserve/hatch.toml
+++ b/torchserve/hatch.toml
@@ -1,7 +1,7 @@
 [env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["3.9"]
+python = ["3.8"]
 version = ["0.8"]
 
 [envs.default.overrides]

--- a/torchserve/pyproject.toml
+++ b/torchserve/pyproject.toml
@@ -10,7 +10,7 @@ name = "datadog-torchserve"
 description = "The TorchServe check"
 readme = "README.md"
 license = "BSD-3-Clause"
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 keywords = [
     "datadog",
     "datadog agent",
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [

--- a/weaviate/CHANGELOG.md
+++ b/weaviate/CHANGELOG.md
@@ -5,3 +5,9 @@
 ***Added***:
 
 * Add the Weaviate integration. See [#15081](https://github.com/DataDog/integrations-core/pull/15081).
+
+## 0.1.0 / 2023-07-20
+
+***Added***:
+
+* Add the Weaviate integration for python 3.8. See [#15081](https://github.com/DataDog/integrations-core/pull/15081).

--- a/weaviate/datadog_checks/weaviate/__about__.py
+++ b/weaviate/datadog_checks/weaviate/__about__.py
@@ -1,4 +1,4 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-__version__ = '1.0.0'
+__version__ = '0.1.0'

--- a/weaviate/hatch.toml
+++ b/weaviate/hatch.toml
@@ -4,7 +4,7 @@
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 
 [[envs.default.matrix]]
-python = ["3.9"]
+python = ["3.8"]
 version = ["1.19"]
 auth = ["no-auth", "auth"]
 

--- a/weaviate/pyproject.toml
+++ b/weaviate/pyproject.toml
@@ -10,7 +10,7 @@ name = "datadog-weaviate"
 description = "The Weaviate check"
 readme = "README.md"
 license = {text = "BSD-3-Clause"}
-requires-python = ">=3.9"
+requires-python = ">=3.8"
 keywords = [
     "datadog",
     "datadog agent",
@@ -26,11 +26,11 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Private :: Do Not Upload",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.8",
     "Topic :: System :: Monitoring",
 ]
 dependencies = [
-    "datadog-checks-base>=32.4.0",
+    "datadog-checks-base>=32.3.1",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
These integrations have to be functional with agent 7.46 which has python3.8

- DCGM Exporter
- Torchserve
- Weaviate

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
DASH 2023

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.