### PR TITLE
Add new release notes below the Unreleased section of changelogs

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/changelog.py
@@ -157,8 +157,15 @@ def changelog(
     # write the new changelog in memory
     changelog_buffer = StringIO()
 
-    # preserve the title
-    changelog_buffer.write(''.join(old[:2]))
+    # find the first header below the Unreleased section
+    header_index = 2
+    for index in range(2, len(old)):
+        if old[index].startswith("##") and "## Unreleased" not in old[index]:
+            header_index = index
+            break
+
+    # preserve the title and unreleased section
+    changelog_buffer.write(''.join(old[:header_index]))
 
     # prepend the new changelog to the old contents
     # make the command idempotent
@@ -166,7 +173,7 @@ def changelog(
         changelog_buffer.write(new_entry.getvalue())
 
     # append the rest of the old changelog
-    changelog_buffer.write(''.join(old[2:]))
+    changelog_buffer.write(''.join(old[header_index:]))
 
     write_result(dry_run, changelog_path, changelog_buffer.getvalue(), generated_changelogs)
 


### PR DESCRIPTION
### What does this PR do?
Changed changelog generation so that the new version and changelog entries are added below the 'Unreleased' section of the changelog

### Motivation
In preparation for enforcing manual changelog entries in integrations, the 'Unreleased' section of the changelog should always stay at the top of the file. 

### Additional Notes
example (with blank Unreleased section): 
<img width="911" alt="Screenshot 2023-07-20 at 4 03 48 PM" src="https://github.com/DataDog/integrations-core/assets/24441980/ff765a3a-06c1-4240-a92f-a0efe73e97cd">

example (with content in Unreleased section):
<img width="929" alt="Screenshot 2023-07-20 at 4 06 56 PM" src="https://github.com/DataDog/integrations-core/assets/24441980/80bfb740-c890-4b8b-bc5e-71a61b6a8f87">


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.