### PR TITLE
Document the `WARNING` status for the `*.can_connect` service checks in JMX integrations

### DIFF
--- a/activemq/assets/service_checks.json
+++ b/activemq/assets/service_checks.json
@@ -9,9 +9,10 @@
         "check": "activemq.can_connect",
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored ActiveMQ instance. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored ActiveMQ instance, `WARNING` if no metrics are collected, `OK` otherwise."
     }
 ]

--- a/activemq/assets/service_checks.json
+++ b/activemq/assets/service_checks.json
@@ -13,6 +13,6 @@
             "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored ActiveMQ instance, `WARNING` if no metrics are collected, `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored ActiveMQ instance, `WARNING` if no metrics are collected, and `OK` otherwise."
     }
 ]

--- a/cassandra/assets/service_checks.json
+++ b/cassandra/assets/service_checks.json
@@ -9,9 +9,10 @@
         "check": "cassandra.can_connect",
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Cassandra instance. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Cassandra instance, `WARNING` if no metrics are collected, `OK` otherwise."
     }
 ]

--- a/cassandra/assets/service_checks.json
+++ b/cassandra/assets/service_checks.json
@@ -13,6 +13,6 @@
             "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Cassandra instance, `WARNING` if no metrics are collected, `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Cassandra instance, `WARNING` if no metrics are collected, and `OK` otherwise."
     }
 ]

--- a/hazelcast/assets/service_checks.json
+++ b/hazelcast/assets/service_checks.json
@@ -13,7 +13,7 @@
         ],
         "check": "hazelcast.can_connect",
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to Hazelcast, `WARNING` if no metrics are collected, `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to Hazelcast, `WARNING` if no metrics are collected, and `OK` otherwise."
     },
     {
         "agent_version": "6.20.0",

--- a/hazelcast/assets/service_checks.json
+++ b/hazelcast/assets/service_checks.json
@@ -8,11 +8,12 @@
         ],
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "warning"
         ],
         "check": "hazelcast.can_connect",
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to Hazelcast, otherwise returns `OK`."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to Hazelcast, `WARNING` if no metrics are collected, `OK` otherwise."
     },
     {
         "agent_version": "6.20.0",

--- a/hive/assets/service_checks.json
+++ b/hive/assets/service_checks.json
@@ -13,6 +13,6 @@
             "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored HiveServer2/Hive Metastore instance, `WARNING` if no metrics are collected, `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored HiveServer2/Hive Metastore instance, `WARNING` if no metrics are collected, and `OK` otherwise."
     }
 ]

--- a/hive/assets/service_checks.json
+++ b/hive/assets/service_checks.json
@@ -9,9 +9,10 @@
         "check": "hive.can_connect",
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored HiveServer2/Hive Metastore instance, otherwise returns `OK`."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored HiveServer2/Hive Metastore instance, `WARNING` if no metrics are collected, `OK` otherwise."
     }
 ]

--- a/hivemq/assets/service_checks.json
+++ b/hivemq/assets/service_checks.json
@@ -8,10 +8,11 @@
         ],
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "warning"
         ],
         "check": "hivemq.can_connect",
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to HiveMQ, otherwise returns `OK`."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to HiveMQ, `WARNING` if no metrics are collected, `OK` otherwise."
     }
 ]

--- a/hivemq/assets/service_checks.json
+++ b/hivemq/assets/service_checks.json
@@ -13,6 +13,6 @@
         ],
         "check": "hivemq.can_connect",
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to HiveMQ, `WARNING` if no metrics are collected, `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to HiveMQ, `WARNING` if no metrics are collected, and `OK` otherwise."
     }
 ]

--- a/hudi/assets/service_checks.json
+++ b/hudi/assets/service_checks.json
@@ -13,6 +13,6 @@
             "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Hudi instance, `WARNING` if no metrics are collected, `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Hudi instance, `WARNING` if no metrics are collected, and `OK` otherwise."
     }
 ]

--- a/hudi/assets/service_checks.json
+++ b/hudi/assets/service_checks.json
@@ -9,9 +9,10 @@
         "check": "hudi.can_connect",
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Hudi instance. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Hudi instance, `WARNING` if no metrics are collected, `OK` otherwise."
     }
 ]

--- a/ignite/assets/service_checks.json
+++ b/ignite/assets/service_checks.json
@@ -13,6 +13,6 @@
             "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Ignite instance, `WARNING` if no metrics are collected, `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Ignite instance, `WARNING` if no metrics are collected, and `OK` otherwise."
     }
 ]

--- a/ignite/assets/service_checks.json
+++ b/ignite/assets/service_checks.json
@@ -9,9 +9,10 @@
         "check": "ignite.can_connect",
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Ignite instance. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Ignite instance, `WARNING` if no metrics are collected, `OK` otherwise."
     }
 ]

--- a/jboss_wildfly/assets/service_checks.json
+++ b/jboss_wildfly/assets/service_checks.json
@@ -13,6 +13,6 @@
             "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored JBoss/WildFly instance, `WARNING` if no metrics are collected, `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored JBoss/WildFly instance, `WARNING` if no metrics are collected, and `OK` otherwise."
     }
 ]

--- a/jboss_wildfly/assets/service_checks.json
+++ b/jboss_wildfly/assets/service_checks.json
@@ -9,9 +9,10 @@
         "check": "jboss.can_connect",
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored JBoss/WildFly instance. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored JBoss/WildFly instance, `WARNING` if no metrics are collected, `OK` otherwise."
     }
 ]

--- a/kafka/assets/service_checks.json
+++ b/kafka/assets/service_checks.json
@@ -13,6 +13,6 @@
             "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Kafka instance, `WARNING` if no metrics are collected, `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Kafka instance, `WARNING` if no metrics are collected, and `OK` otherwise."
     }
 ]

--- a/kafka/assets/service_checks.json
+++ b/kafka/assets/service_checks.json
@@ -9,9 +9,10 @@
         "check": "kafka.can_connect",
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Kafka instance. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Kafka instance, `WARNING` if no metrics are collected, `OK` otherwise."
     }
 ]

--- a/presto/assets/service_checks.json
+++ b/presto/assets/service_checks.json
@@ -9,9 +9,10 @@
         "check": "presto.can_connect",
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Presto instance. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Presto instance, `WARNING` if no metrics are collected, `OK` otherwise."
     }
 ]

--- a/presto/assets/service_checks.json
+++ b/presto/assets/service_checks.json
@@ -13,6 +13,6 @@
             "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Presto instance, `WARNING` if no metrics are collected, `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Presto instance, `WARNING` if no metrics are collected, and `OK` otherwise."
     }
 ]

--- a/solr/assets/service_checks.json
+++ b/solr/assets/service_checks.json
@@ -13,6 +13,6 @@
             "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored SolR instance, `WARNING` if no metrics are collected, `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored SolR instance, `WARNING` if no metrics are collected, and `OK` otherwise."
     }
 ]

--- a/solr/assets/service_checks.json
+++ b/solr/assets/service_checks.json
@@ -9,9 +9,10 @@
         "check": "solr.can_connect",
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored SolR instance. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored SolR instance, `WARNING` if no metrics are collected, `OK` otherwise."
     }
 ]

--- a/sonarqube/assets/service_checks.json
+++ b/sonarqube/assets/service_checks.json
@@ -13,7 +13,7 @@
         ],
         "check": "sonarqube.can_connect",
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored SonarQube instance's JMX endpoint, `WARNING` if no metrics are collected, `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored SonarQube instance's JMX endpoint, `WARNING` if no metrics are collected, and `OK` otherwise."
     },
     {
         "agent_version": "7.25.0",

--- a/sonarqube/assets/service_checks.json
+++ b/sonarqube/assets/service_checks.json
@@ -8,11 +8,12 @@
         ],
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "warning"
         ],
         "check": "sonarqube.can_connect",
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored SonarQube instance's JMX endpoint, otherwise returns `OK`."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored SonarQube instance's JMX endpoint, `WARNING` if no metrics are collected, `OK` otherwise."
     },
     {
         "agent_version": "7.25.0",

--- a/tomcat/assets/service_checks.json
+++ b/tomcat/assets/service_checks.json
@@ -13,6 +13,6 @@
             "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Tomcat instance, `WARNING` if no metrics are collected, `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Tomcat instance, `WARNING` if no metrics are collected, and `OK` otherwise."
     }
 ]

--- a/tomcat/assets/service_checks.json
+++ b/tomcat/assets/service_checks.json
@@ -9,9 +9,10 @@
         "check": "tomcat.can_connect",
         "statuses": [
             "ok",
-            "critical"
+            "critical",
+            "warning"
         ],
         "name": "Can Connect",
-        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Tomcat instance. Returns `OK` otherwise."
+        "description": "Returns `CRITICAL` if the Agent is unable to connect to and collect metrics from the monitored Tomcat instance, `WARNING` if no metrics are collected, `OK` otherwise."
     }
 ]

--- a/weblogic/assets/service_checks.json
+++ b/weblogic/assets/service_checks.json
@@ -13,6 +13,6 @@
       "warning"
     ],
     "name": "Can Connect",
-    "description": "Returns `OK` if the Agent is able to connect to and collect metrics from the monitored WebLogic instance, `WARNING` if no metrics are collected, `OK` otherwise."
+    "description": "Returns `OK` if the Agent is able to connect to and collect metrics from the monitored WebLogic instance, `WARNING` if no metrics are collected, and `OK` otherwise."
   }
 ]

--- a/weblogic/assets/service_checks.json
+++ b/weblogic/assets/service_checks.json
@@ -9,9 +9,10 @@
     "check": "weblogic.can_connect",
     "statuses": [
       "ok",
-      "critical"
+      "critical",
+      "warning"
     ],
     "name": "Can Connect",
-    "description": "Returns `OK` if the Agent is able to connect to and collect metrics from the monitored WebLogic instance. Returns `CRITICAL` otherwise."
+    "description": "Returns `OK` if the Agent is able to connect to and collect metrics from the monitored WebLogic instance, `WARNING` if no metrics are collected, `OK` otherwise."
   }
 ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Document the WARNING status for the *.can_connect service checks in JMX integrations

### Motivation
<!-- What inspired you to submit this pull request? -->

See https://github.com/DataDog/integrations-core/pull/15351

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.