### PR TITLE
Update containerd working_set metric

### DIFF
--- a/containerd/metadata.csv
+++ b/containerd/metadata.csv
@@ -12,7 +12,7 @@ containerd.mem.cache,gauge,,byte,,The cache amount used (Linux only),0,container
 containerd.mem.rss,gauge,,byte,,The rss amount used (Linux only),0,containerd, mem_rss,
 containerd.mem.commit,gauge,,byte,,The committed memory (Windows only),0,containerd,mem_commit,
 containerd.mem.commit_peak,gauge,,byte,,The peak committed memory (Windows only),0,containerd,mem_commit_peak,
-containerd.mem.private_working_set,gauge,,byte,,The private working set usage (Windows only),0,containerd,mem_private_working_set,
+containerd.mem.working_set,gauge,,byte,,The container working set usage,0,containerd,mem_working_set,
 containerd.cpu.throttled.periods,rate,,nanosecond,,The total CPU throttled time (Linux only),0,containerd,cpu_throttled_time,
 containerd.cpu.system,rate,,nanosecond,,The total CPU time,0,containerd,cpu_system,
 containerd.cpu.total,rate,,nanosecond,,The total CPU time,0,containerd,cpu_total,


### PR DESCRIPTION
### What does this PR do?
PR [#16659](https://github.com/DataDog/datadog-agent/pull/16659) renamed `containerd.mem.private_working_set` to `containerd.mem.working_set`. It is now available for both Linux and windows. 

This PR updates the metadata.csv so the documentation can be up to date.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.