### PR TITLE
Remove `legal_email` field from Ecosystem template

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -133,14 +133,13 @@ def create(ctx, name, integration_type, location, non_interactive, quiet, dry_ru
             author_name = click.prompt('Your Company Name')
             homepage = click.prompt('The product or company homepage')
             sales_email = click.prompt('Email used for subscription notifications')
-            legal_email = click.prompt('The Legal email used to receive subscription notifications')
 
             template_fields['author'] = author_name
 
             eula = 'assets/eula.pdf'
             template_fields[
                 'terms'
-            ] = f'\n  "terms": {{\n    "eula": "{eula}",\n    "legal_email": "{legal_email}"\n  }},'
+            ] = f'\n  "terms": {{\n    "eula": "{eula}"\n  }},'
             template_fields[
                 'author_info'
             ] = f'\n  "author": {{\n    "name": "{author_name}",\n    "homepage": "{homepage}",\n    "vendor_id": "{TODO_FILL_IN}",\n    "sales_email": "{sales_email}",\n    "support_email": "{support_email}"\n  }},'  # noqa

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/create.py
@@ -137,9 +137,7 @@ def create(ctx, name, integration_type, location, non_interactive, quiet, dry_ru
             template_fields['author'] = author_name
 
             eula = 'assets/eula.pdf'
-            template_fields[
-                'terms'
-            ] = f'\n  "terms": {{\n    "eula": "{eula}"\n  }},'
+            template_fields['terms'] = f'\n  "terms": {{\n    "eula": "{eula}"\n  }},'
             template_fields[
                 'author_info'
             ] = f'\n  "author": {{\n    "name": "{author_name}",\n    "homepage": "{homepage}",\n    "vendor_id": "{TODO_FILL_IN}",\n    "sales_email": "{sales_email}",\n    "support_email": "{support_email}"\n  }},'  # noqa


### PR DESCRIPTION
### What does this PR do?
An unsupported field was added with the create scaffolding. This PR is to remove that field because it causes validations to fail. 