### PR TITLE
Lower logging level if there's an error scraping the template endpoint to DEBUG

### DIFF
--- a/elastic/datadog_checks/elastic/elastic.py
+++ b/elastic/datadog_checks/elastic/elastic.py
@@ -274,7 +274,7 @@ class ESCheck(AgentCheck):
         try:
             template_resp = self._get_data(self._join_url('/_cat/templates?format=json', admin_forwarder))
         except requests.exceptions.RequestException as e:
-            self.log.error("Error reading templates info from servers (%s) - template metrics will be missing", e)
+            self.log.debug("Error reading templates info from servers (%s) - template metrics will be missing", e)
             return
 
         filtered_templates = [t for t in template_resp if not t['name'].startswith(TEMPLATE_EXCLUSION_LIST)]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Lower logging level if there's an error scraping the template endpoint to DEBUG

### Motivation
<!-- What inspired you to submit this pull request? -->

- Support case
- This endpoint does not exist in older versions of elastic search that are still supported. In that case we just spams the log file with this error

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.