### PR TITLE
Updating Kubernetes recommended monitors to add default_zero() function

### DIFF
--- a/kubernetes/assets/monitors/monitor_node_unavailable.json
+++ b/kubernetes/assets/monitors/monitor_node_unavailable.json
@@ -1,7 +1,7 @@
 {
 	"name": "[kubernetes] Monitor Unschedulable Kubernetes Nodes",
 	"type": "query alert",
-	"query": "max(last_15m):sum:kubernetes_state.node.status{status:schedulable} by {kube_cluster_name} * 100 / sum:kubernetes_state.node.status{*} by {kube_cluster_name} < 80",
+	"query": "max(last_15m):default_zero(sum:kubernetes_state.node.status{status:schedulable} by {kube_cluster_name} * 100 / sum:kubernetes_state.node.status{*} by {kube_cluster_name}) < 80",
 	"message": "More than 20% of nodes are unschedulable on ({{kube_cluster_name.name}} cluster). \n Keep in mind that this might be expected based on your infrastructure.",
 	"tags": [
 		"integration:kubernetes"

--- a/kubernetes/assets/monitors/monitor_pod_imagepullbackoff.json
+++ b/kubernetes/assets/monitors/monitor_pod_imagepullbackoff.json
@@ -1,7 +1,7 @@
 {
 	"name": "[kubernetes] Pod {{pod_name.name}} is ImagePullBackOff on namespace {{kube_namespace.name}}",
 	"type": "query alert",
-	"query": "max(last_10m):max:kubernetes_state.container.status_report.count.waiting{reason:imagepullbackoff} by {kube_cluster_name,kube_namespace,pod_name} >= 1",
+	"query": "max(last_10m):default_zero(max:kubernetes_state.container.status_report.count.waiting{reason:imagepullbackoff} by {kube_cluster_name,kube_namespace,pod_name}) >= 1",
 	"message": "pod {{pod_name.name}} is in ImagePullBackOff on {{kube_namespace.name}} \n This could happen for several reasons, for example a bad image path or tag or if the credentials for pulling images are not configured properly.",
 	"tags": [
 		"integration:kubernetes"

--- a/kubernetes/assets/monitors/monitor_pods_failed_state.json
+++ b/kubernetes/assets/monitors/monitor_pods_failed_state.json
@@ -1,7 +1,7 @@
 {
 	"name": "[kubernetes] Monitor Kubernetes Failed Pods in Namespaces",
 	"type": "query alert",
-	"query": "change(avg(last_5m),last_5m):sum:kubernetes_state.pod.status_phase{pod_phase:failed} by {kube_cluster_name,kube_namespace} > 10",
+	"query": "change(avg(last_5m),last_5m):default_zero(sum:kubernetes_state.pod.status_phase{pod_phase:failed} by {kube_cluster_name,kube_namespace}) > 10",
 	"message": "More than ten pods are failing in ({{kube_cluster_name.name}} cluster). \n The threshold of ten pods varies depending on your infrastructure. Change the threshold to suit your needs.",
 	"tags": [
 		"integration:kubernetes"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR updates the following Kubernetes recommended monitors to add the default_zero() function:

[kubernetes] Monitor Kubernetes Failed Pods in Namespaces (monitor_pods_failed_state.json)
[kubernetes] Pod {{pod_name.name}} is ImagePullBackOff on namespace {{kube_namespace.name}} (monitor_pod_imagepullbackoff.json)
[kubernetes] Monitor Unschedulable Kubernetes Nodes (monitor_node_unavailable.json)

### Motivation
<!-- What inspired you to submit this pull request? -->

This has been asked by the Monitors team, you can find more details in this escalation card: https://datadoghq.atlassian.net/browse/CONS-5669

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.