### PR TITLE
Fix SNI support with `tls_use_host_header`

### DIFF
--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -529,10 +529,10 @@ class RequestsWrapper(object):
         if self._session is None:
             self._session = requests.Session()
 
-            # Enables HostHeaderSSLAdapter
+            # Enables HostHeaderSSLSNIAdapter(HostHeaderSSLAdapter)
             # https://toolbelt.readthedocs.io/en/latest/adapters.html#hostheaderssladapter
             if self.tls_use_host_header:
-                self._session.mount('https://', host_header_ssl.HostHeaderSSLAdapter())
+                self._session.mount('https://', HostHeaderSSLSNIAdapter())
             # Enable Unix Domain Socket (UDS) support.
             # See: https://github.com/msabramo/requests-unixsocket
             self._session.mount('{}://'.format(UDS_SCHEME), requests_unixsocket.UnixAdapter())

--- a/datadog_checks_base/datadog_checks/base/utils/http.py
+++ b/datadog_checks_base/datadog_checks/base/utils/http.py
@@ -993,3 +993,42 @@ class StandardFields(object):
 
 if not PY2:
     StandardFields.__doc__ = '\n'.join('- `{}`'.format(field) for field in STANDARD_FIELDS)
+
+class HostHeaderSSLSNIAdapter(host_header_ssl.HostHeaderSSLAdapter):
+    """
+    # HostHeaderSSLSNIAdapter is a variation of requests_toolbelt.adapters.host_header_ssl
+    # that includes an SNI related fix: https://github.com/requests/toolbelt/pull/293
+    
+    # https://toolbelt.readthedocs.io/en/latest/adapters.html#hostheaderssladapter
+
+    A HTTPS Adapter for Python Requests that sets the hostname for certificate
+    verification based on the Host header.
+
+    This allows requesting the IP address directly via HTTPS without getting
+    a "hostname doesn't match" exception.
+
+    Example usage:
+
+        >>> s.mount('https://', HostHeaderSSLSNIAdapter())
+        >>> s.get("https://93.184.216.34", headers={"Host": "example.org"})
+
+    """
+    def send(self, request, **kwargs):
+        # HTTP headers are case-insensitive (RFC 7230)
+        host_header = None
+        for header in request.headers:
+            if header.lower() == "host":
+                host_header = request.headers[header]
+                break
+
+        connection_pool_kwargs = self.poolmanager.connection_pool_kw
+
+        if host_header:
+            connection_pool_kwargs["assert_hostname"] = host_header
+            connection_pool_kwargs["server_hostname"] = host_header
+        elif "assert_hostname" in connection_pool_kwargs:
+            # an assert_hostname from a previous request may have been left
+            connection_pool_kwargs.pop("assert_hostname", None)
+            connection_pool_kwargs.pop("server_hostname", None)
+
+        return super(HostHeaderSSLSNIAdapter, self).send(request, **kwargs)


### PR DESCRIPTION
### What does this PR do?
Uses the Host header for SNI. This is a variation of `requests_toolbelt.adapters.host_header_ssl` that includes an SNI fix https://github.com/requests/toolbelt/pull/293

### Motivation
- AGENT-9830
- https://github.com/requests/toolbelt/issues/159

### Additional Notes
- I think we can drop `requests_toolbelt` library and just use below but I'm not sure how to handle licenses involved.
```
from requests.adapters import HTTPAdapter

class HostHeaderSSLSNIAdapter(HTTPAdapter):
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.