### PR TITLE
Small edits for torchserve dashboard

### DIFF
--- a/torchserve/assets/dashboards/overview.json
+++ b/torchserve/assets/dashboards/overview.json
@@ -1,1701 +1,1700 @@
 {
-  "title": "TorchServe Overview",
-  "description": "**TorchServe**\n\nThis dashboard provides insights into your TorchServe services. You can use the dashboard to track health status, performance, and resource utilization metrics from all your services. You can also get in-depth information on the models that are currently running in your instance, and the workers they leverage. \n\n**Useful Links**\n\n* [Integration Docs](https://docs.datadoghq.com/integrations/torchserve)\n* [How Datadog monitors TorchServe and other AI stack technologies](https://www.datadoghq.com/blog/ai-integrations)",
-  "widgets": [
-    {
-      "id": 6955576996753366,
-      "definition": {
-        "title": "New group",
-        "banner_img": "",
-        "show_title": false,
-        "type": "group",
-        "layout_type": "ordered",
-        "widgets": [
-          {
-            "id": 3838651690068190,
+    "author_name": "Datadog",
+    "description": "**TorchServe**\n\nThis dashboard provides insights into your TorchServe services. You can use the dashboard to track health status, performance, and resource utilization metrics from all your services. You can also get in-depth information on the models that are currently running in your instance, and the workers they leverage. \n\n**Useful Links**\n\n* [Integration Docs](https://docs.datadoghq.com/integrations/torchserve)\n* [How Datadog monitors TorchServe and other AI stack technologies](https://www.datadoghq.com/blog/ai-integrations)",
+    "layout_type": "ordered",
+    "template_variables": [
+        {
+            "available_values": [],
+            "default": "*",
+            "name": "service"
+        },
+        {
+            "available_values": [],
+            "default": "*",
+            "name": "host"
+        },
+        {
+            "available_values": [],
+            "default": "*",
+            "name": "model_name",
+            "prefix": "model_name"
+        },
+        {
+            "available_values": [],
+            "default": "*",
+            "name": "model_version",
+            "prefix": "model_version"
+        }
+    ],
+    "title": "TorchServe Overview",
+    "widgets": [
+        {
             "definition": {
-              "type": "image",
-              "url": "/static/images/logos/torchserve_large.svg",
-              "url_dark_theme": "/static/images/logos/torchserve_reversed_large.svg",
-              "sizing": "cover",
-              "has_background": true,
-              "has_border": true,
-              "vertical_align": "center",
-              "horizontal_align": "center"
-            },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 12,
-              "height": 3
-            }
-          },
-          {
-            "id": 5765057495183900,
-            "definition": {
-              "type": "note",
-              "content": "**TorchServe**\n\nThis dashboard provides insights into your TorchServe services. You can use the dashboard to track health status, performance, and resource utilization metrics from all your services. You can also get in-depth information on the models that are currently running in your instance, and the workers they leverage. ",
-              "background_color": "white",
-              "font_size": "14",
-              "text_align": "left",
-              "vertical_align": "top",
-              "show_tick": false,
-              "tick_pos": "50%",
-              "tick_edge": "left",
-              "has_padding": true
-            },
-            "layout": {
-              "x": 0,
-              "y": 3,
-              "width": 7,
-              "height": 3
-            }
-          },
-          {
-            "id": 607314244154516,
-            "definition": {
-              "type": "note",
-              "content": "**Useful Links**\n\n* [Integration Docs](https://docs.datadoghq.com/integrations/torchserve)\n* [How Datadog monitors TorchServe and other AI stack technologies](https://www.datadoghq.com/blog/ai-integrations)",
-              "background_color": "white",
-              "font_size": "16",
-              "text_align": "left",
-              "vertical_align": "top",
-              "show_tick": false,
-              "tick_pos": "50%",
-              "tick_edge": "left",
-              "has_padding": true
-            },
-            "layout": {
-              "x": 7,
-              "y": 3,
-              "width": 5,
-              "height": 3
-            }
-          }
-        ]
-      },
-      "layout": {
-        "x": 0,
-        "y": 0,
-        "width": 12,
-        "height": 7
-      }
-    },
-    {
-      "id": 8178300534998464,
-      "definition": {
-        "title": "Overview",
-        "background_color": "vivid_pink",
-        "show_title": true,
-        "type": "group",
-        "layout_type": "ordered",
-        "widgets": [
-          {
-            "id": 2501952917707794,
-            "definition": {
-              "type": "note",
-              "content": "The monitor summary shows you any active alerts for the most crucial TorchServe Metrics. The events stream informs you of model specific events (e.g. new model added). The clusters of service checks at the bottom of this section speak to the health of your system. ",
-              "background_color": "pink",
-              "font_size": "14",
-              "text_align": "center",
-              "vertical_align": "center",
-              "show_tick": false,
-              "tick_pos": "50%",
-              "tick_edge": "left",
-              "has_padding": true
-            },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 12,
-              "height": 1
-            }
-          },
-          {
-            "id": 8740824674228522,
-            "definition": {
-              "title": "TorchServe Monitor Summary",
-              "type": "manage_status",
-              "display_format": "countsAndList",
-              "color_preference": "text",
-              "hide_zero_counts": true,
-              "query": "torchserve",
-              "sort": "status,asc",
-              "count": 50,
-              "start": 0,
-              "summary_type": "monitors",
-              "show_priority": false,
-              "show_last_triggered": false
-            },
-            "layout": {
-              "x": 0,
-              "y": 1,
-              "width": 4,
-              "height": 6
-            }
-          },
-          {
-            "id": 5675839700531460,
-            "definition": {
-              "title": "Events",
-              "title_size": "16",
-              "title_align": "left",
-              "requests": [
-                {
-                  "query": {
-                    "data_source": "event_stream",
-                    "query_string": "source:torchserve",
-                    "event_size": "s"
-                  },
-                  "response_format": "event_list",
-                  "columns": []
-                }
-              ],
-              "type": "list_stream"
-            },
-            "layout": {
-              "x": 4,
-              "y": 1,
-              "width": 8,
-              "height": 3
-            }
-          },
-          {
-            "id": 4220545334262462,
-            "definition": {
-              "title": "Response codes",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
+                "banner_img": "",
+                "layout_type": "ordered",
+                "show_title": false,
+                "title": "New group",
+                "type": "group",
+                "widgets": [
                     {
-                      "alias": "2xx",
-                      "formula": "query1"
-                    },
-                    {
-                      "alias": "4xx",
-                      "formula": "query2"
-                    },
-                    {
-                      "alias": "5xx",
-                      "formula": "query3"
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "name": "query1",
-                      "data_source": "metrics",
-                      "query": "sum:torchserve.openmetrics.requests.2xx.count{$service,$host}.as_count()"
-                    },
-                    {
-                      "name": "query2",
-                      "data_source": "metrics",
-                      "query": "sum:torchserve.openmetrics.requests.4xx.count{$service,$host}.as_count()"
-                    },
-                    {
-                      "name": "query3",
-                      "data_source": "metrics",
-                      "query": "sum:torchserve.openmetrics.requests.5xx.count{$service,$host}.as_count()"
-                    }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "dog_classic",
-                    "line_type": "solid",
-                    "line_width": "normal"
-                  },
-                  "display_type": "line"
-                }
-              ]
-            },
-            "layout": {
-              "x": 4,
-              "y": 4,
-              "width": 8,
-              "height": 3
-            }
-          },
-          {
-            "id": 6987039090862476,
-            "definition": {
-              "title": "Inference API Health",
-              "title_size": "16",
-              "title_align": "left",
-              "time": {
-                "live_span": "1d"
-              },
-              "type": "check_status",
-              "check": "torchserve.inference_api.health",
-              "grouping": "cluster",
-              "group_by": [],
-              "tags": []
-            },
-            "layout": {
-              "x": 0,
-              "y": 7,
-              "width": 4,
-              "height": 1
-            }
-          },
-          {
-            "id": 3431939964933534,
-            "definition": {
-              "title": "OpenMetrics",
-              "title_size": "16",
-              "title_align": "left",
-              "time": {
-                "live_span": "1d"
-              },
-              "type": "check_status",
-              "check": "torchserve.openmetrics.health",
-              "grouping": "cluster",
-              "group_by": [],
-              "tags": []
-            },
-            "layout": {
-              "x": 4,
-              "y": 7,
-              "width": 4,
-              "height": 1
-            }
-          },
-          {
-            "id": 5502861672310260,
-            "definition": {
-              "title": "Management API Health",
-              "title_size": "16",
-              "title_align": "left",
-              "time": {
-                "live_span": "1d"
-              },
-              "type": "check_status",
-              "check": "torchserve.management_api.health",
-              "grouping": "cluster",
-              "group_by": [],
-              "tags": []
-            },
-            "layout": {
-              "x": 8,
-              "y": 7,
-              "width": 4,
-              "height": 1
-            }
-          }
-        ]
-      },
-      "layout": {
-        "x": 0,
-        "y": 7,
-        "width": 12,
-        "height": 9
-      }
-    },
-    {
-      "id": 4965434358555720,
-      "definition": {
-        "title": "Inferences",
-        "background_color": "vivid_pink",
-        "show_title": true,
-        "type": "group",
-        "layout_type": "ordered",
-        "widgets": [
-          {
-            "id": 3886077082488710,
-            "definition": {
-              "type": "note",
-              "content": "The following graphs show you the volume of inference requests as well as the handler and prediction time for your models. You can zoom out to an average per all models by removing the \"sum by model_name\" tag in the query.",
-              "background_color": "pink",
-              "font_size": "14",
-              "text_align": "center",
-              "vertical_align": "center",
-              "show_tick": false,
-              "tick_pos": "50%",
-              "tick_edge": "left",
-              "has_padding": true
-            },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 12,
-              "height": 1
-            }
-          },
-          {
-            "id": 5082627944789452,
-            "definition": {
-              "title": "Number of Inference Request per Model",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "vertical",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "alias": "Inference Count",
-                      "formula": "query1"
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "query": "sum:torchserve.openmetrics.inference.count{$service,$host} by {model_name}.as_count()",
-                      "data_source": "metrics",
-                      "name": "query1"
-                    }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "area"
-                }
-              ],
-              "markers": []
-            },
-            "layout": {
-              "x": 0,
-              "y": 1,
-              "width": 12,
-              "height": 5
-            }
-          },
-          {
-            "id": 7833942874724070,
-            "definition": {
-              "title": "Prediction time",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "auto",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "alias": "Handler time",
-                      "formula": "query1"
-                    },
-                    {
-                      "alias": "Prediction time",
-                      "formula": "query2"
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "query": "sum:torchserve.openmetrics.handler_time{$service,$host} by {model_name}",
-                      "data_source": "metrics",
-                      "name": "query1"
-                    },
-                    {
-                      "query": "sum:torchserve.openmetrics.prediction_time{$service,$host} by {model_name}",
-                      "data_source": "metrics",
-                      "name": "query2"
-                    }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "line"
-                }
-              ]
-            },
-            "layout": {
-              "x": 0,
-              "y": 6,
-              "width": 12,
-              "height": 3
-            }
-          }
-        ]
-      },
-      "layout": {
-        "x": 0,
-        "y": 16,
-        "width": 12,
-        "height": 10
-      }
-    },
-    {
-      "id": 5719118412081720,
-      "definition": {
-        "title": "Logs",
-        "title_align": "left",
-        "background_color": "vivid_pink",
-        "show_title": true,
-        "type": "group",
-        "layout_type": "ordered",
-        "widgets": [
-          {
-            "id": 6085927965988954,
-            "definition": {
-              "type": "note",
-              "content": "When investigating logs, you can refer to the time-series data to see the ratio of a certain log status to other expected statuses. In situations where you notice an increase in the ratio of error logs, you can refer to the log stream of erroneous logs for your perusal.",
-              "background_color": "pink",
-              "font_size": "14",
-              "text_align": "center",
-              "vertical_align": "center",
-              "show_tick": false,
-              "tick_pos": "50%",
-              "tick_edge": "left",
-              "has_padding": true
-            },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 12,
-              "height": 1
-            }
-          },
-          {
-            "id": 972406572464752,
-            "definition": {
-              "title": "Volume by Status",
-              "title_size": "16",
-              "title_align": "left",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "formula": "query1",
-                      "limit": {
-                        "order": "desc"
-                      }
-                    }
-                  ],
-                  "response_format": "scalar",
-                  "queries": [
-                    {
-                      "data_source": "logs",
-                      "name": "query1",
-                      "indexes": [
-                        "*"
-                      ],
-                      "compute": {
-                        "aggregation": "count"
-                      },
-                      "group_by": [
-                        {
-                          "facet": "status",
-                          "limit": 10,
-                          "sort": {
-                            "order": "desc",
-                            "aggregation": "count"
-                          }
-                        }
-                      ],
-                      "search": {
-                        "query": "source:torchserve"
-                      },
-                      "storage": "hot"
-                    }
-                  ],
-                  "style": {
-                    "palette": "semantic"
-                  }
-                }
-              ],
-              "type": "sunburst",
-              "hide_total": false,
-              "legend": {
-                "type": "table"
-              }
-            },
-            "layout": {
-              "x": 0,
-              "y": 1,
-              "width": 12,
-              "height": 3
-            }
-          },
-          {
-            "id": 2882736407867586,
-            "definition": {
-              "title": "Volume by Status over Time",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "max",
-                "value"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "formula": "query2"
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "data_source": "logs",
-                      "name": "query2",
-                      "indexes": [
-                        "*"
-                      ],
-                      "compute": {
-                        "aggregation": "count"
-                      },
-                      "group_by": [
-                        {
-                          "facet": "status",
-                          "limit": 10,
-                          "sort": {
-                            "order": "desc",
-                            "aggregation": "count"
-                          }
-                        }
-                      ],
-                      "search": {
-                        "query": "source:torchserve"
-                      },
-                      "storage": "hot"
-                    }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "semantic",
-                    "line_type": "solid",
-                    "line_width": "normal"
-                  },
-                  "display_type": "bars"
-                }
-              ],
-              "yaxis": {
-                "include_zero": true,
-                "scale": "linear",
-                "label": "",
-                "min": "auto",
-                "max": "auto"
-              },
-              "markers": []
-            },
-            "layout": {
-              "x": 0,
-              "y": 4,
-              "width": 12,
-              "height": 3
-            }
-          },
-          {
-            "id": 3297077839160356,
-            "definition": {
-              "title": "Logs by Host and Service",
-              "title_size": "16",
-              "title_align": "left",
-              "type": "query_table",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "alias": "Logs",
-                      "cell_display_mode": "bar",
-                      "formula": "query2",
-                      "limit": {
-                        "count": 100,
-                        "order": "desc"
-                      }
-                    }
-                  ],
-                  "response_format": "scalar",
-                  "queries": [
-                    {
-                      "data_source": "logs",
-                      "name": "query2",
-                      "indexes": [
-                        "*"
-                      ],
-                      "compute": {
-                        "aggregation": "count"
-                      },
-                      "group_by": [
-                        {
-                          "facet": "host",
-                          "limit": 10,
-                          "sort": {
-                            "order": "desc",
-                            "aggregation": "count"
-                          }
+                        "definition": {
+                            "has_background": true,
+                            "has_border": false,
+                            "horizontal_align": "center",
+                            "sizing": "cover",
+                            "type": "image",
+                            "url": "/static/images/logos/torchserve_large.svg",
+                            "url_dark_theme": "/static/images/logos/torchserve_reversed_large.svg",
+                            "vertical_align": "center"
                         },
-                        {
-                          "facet": "service",
-                          "limit": 10,
-                          "sort": {
-                            "order": "desc",
-                            "aggregation": "count"
-                          }
+                        "id": 3838651690068190,
+                        "layout": {
+                            "height": 3,
+                            "width": 4,
+                            "x": 0,
+                            "y": 0
                         }
-                      ],
-                      "search": {
-                        "query": "source:torchserve"
-                      },
-                      "storage": "hot"
-                    }
-                  ]
-                }
-              ]
-            },
-            "layout": {
-              "x": 0,
-              "y": 7,
-              "width": 12,
-              "height": 2
-            }
-          },
-          {
-            "id": 6999445441381676,
-            "definition": {
-              "title": "Error Logs",
-              "title_size": "16",
-              "requests": [
-                {
-                  "query": {
-                    "query_string": "status:(error OR critical) source:torchserve",
-                    "sort": {
-                      "column": "timestamp",
-                      "order": "desc"
-                    },
-                    "data_source": "logs_stream",
-                    "storage": "hot",
-                    "indexes": []
-                  },
-                  "columns": [
-                    {
-                      "field": "status_line",
-                      "width": "auto"
                     },
                     {
-                      "field": "timestamp",
-                      "width": "auto"
+                        "definition": {
+                            "background_color": "white",
+                            "content": "**TorchServe**\n\nThis dashboard provides insights into your TorchServe services. You can use the dashboard to track health status, performance, and resource utilization metrics from all your services. You can also get in-depth information on the models that are currently running in your instance, and the workers they leverage. ",
+                            "font_size": "14",
+                            "has_padding": true,
+                            "show_tick": false,
+                            "text_align": "left",
+                            "tick_edge": "left",
+                            "tick_pos": "50%",
+                            "type": "note",
+                            "vertical_align": "top"
+                        },
+                        "id": 5765057495183900,
+                        "layout": {
+                            "height": 2,
+                            "width": 4,
+                            "x": 0,
+                            "y": 3
+                        }
                     },
                     {
-                      "field": "host",
-                      "width": "auto"
+                        "definition": {
+                            "background_color": "white",
+                            "content": "**Useful Links**\n\n* [Integration Docs](https://docs.datadoghq.com/integrations/torchserve)\n* [How Datadog monitors TorchServe and other AI stack technologies](https://www.datadoghq.com/blog/ai-integrations)",
+                            "font_size": "16",
+                            "has_padding": true,
+                            "show_tick": false,
+                            "text_align": "left",
+                            "tick_edge": "left",
+                            "tick_pos": "50%",
+                            "type": "note",
+                            "vertical_align": "top"
+                        },
+                        "id": 607314244154516,
+                        "layout": {
+                            "height": 2,
+                            "width": 4,
+                            "x": 0,
+                            "y": 5
+                        }
+                    }
+                ]
+            },
+            "id": 6955576996753366,
+            "layout": {
+                "height": 8,
+                "width": 4,
+                "x": 0,
+                "y": 0
+            }
+        },
+        {
+            "definition": {
+                "background_color": "vivid_pink",
+                "layout_type": "ordered",
+                "show_title": true,
+                "title": "Overview",
+                "type": "group",
+                "widgets": [
+                    {
+                        "definition": {
+                            "background_color": "pink",
+                            "content": "The monitor summary shows you any active alerts for the most crucial TorchServe Metrics. The events stream informs you of model specific events (e.g. new model added). The clusters of service checks at the bottom of this section speak to the health of your system. ",
+                            "font_size": "14",
+                            "has_padding": true,
+                            "show_tick": false,
+                            "text_align": "center",
+                            "tick_edge": "left",
+                            "tick_pos": "50%",
+                            "type": "note",
+                            "vertical_align": "center"
+                        },
+                        "id": 2501952917707794,
+                        "layout": {
+                            "height": 1,
+                            "width": 8,
+                            "x": 0,
+                            "y": 0
+                        }
                     },
                     {
-                      "field": "service_type",
-                      "width": "auto"
+                        "definition": {
+                            "color_preference": "text",
+                            "count": 50,
+                            "display_format": "countsAndList",
+                            "hide_zero_counts": true,
+                            "query": "torchserve",
+                            "show_last_triggered": false,
+                            "show_priority": false,
+                            "sort": "status,asc",
+                            "start": 0,
+                            "summary_type": "monitors",
+                            "title": "TorchServe Monitor Summary",
+                            "type": "manage_status"
+                        },
+                        "id": 8740824674228522,
+                        "layout": {
+                            "height": 3,
+                            "width": 3,
+                            "x": 0,
+                            "y": 1
+                        }
                     },
                     {
-                      "field": "content",
-                      "width": "auto"
-                    }
-                  ],
-                  "response_format": "event_list"
-                }
-              ],
-              "type": "list_stream"
-            },
-            "layout": {
-              "x": 0,
-              "y": 9,
-              "width": 12,
-              "height": 3
-            }
-          },
-          {
-            "id": 2613469200354810,
-            "definition": {
-              "title": "All Logs",
-              "title_size": "16",
-              "requests": [
-                {
-                  "query": {
-                    "query_string": "source:torchserve",
-                    "sort": {
-                      "column": "timestamp",
-                      "order": "desc"
-                    },
-                    "data_source": "logs_stream",
-                    "storage": "hot",
-                    "indexes": []
-                  },
-                  "columns": [
-                    {
-                      "field": "status_line",
-                      "width": "auto"
+                        "definition": {
+                            "requests": [
+                                {
+                                    "columns": [],
+                                    "query": {
+                                        "data_source": "event_stream",
+                                        "event_size": "s",
+                                        "query_string": "source:torchserve"
+                                    },
+                                    "response_format": "event_list"
+                                }
+                            ],
+                            "title": "Events",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "list_stream"
+                        },
+                        "id": 5675839700531460,
+                        "layout": {
+                            "height": 3,
+                            "width": 5,
+                            "x": 3,
+                            "y": 1
+                        }
                     },
                     {
-                      "field": "timestamp",
-                      "width": "auto"
+                        "definition": {
+                            "check": "torchserve.management_api.health",
+                            "group_by": [],
+                            "grouping": "cluster",
+                            "tags": [],
+                            "time": {
+                                "live_span": "1d"
+                            },
+                            "title": "Management API Health",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "check_status"
+                        },
+                        "id": 5502861672310260,
+                        "layout": {
+                            "height": 1,
+                            "width": 3,
+                            "x": 0,
+                            "y": 4
+                        }
                     },
                     {
-                      "field": "host",
-                      "width": "auto"
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "horizontal",
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "2xx",
+                                            "formula": "query1"
+                                        },
+                                        {
+                                            "alias": "4xx",
+                                            "formula": "query2"
+                                        },
+                                        {
+                                            "alias": "5xx",
+                                            "formula": "query3"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.openmetrics.requests.2xx.count{$service,$host}.as_count()"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query2",
+                                            "query": "sum:torchserve.openmetrics.requests.4xx.count{$service,$host}.as_count()"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query3",
+                                            "query": "sum:torchserve.openmetrics.requests.5xx.count{$service,$host}.as_count()"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "dog_classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Response codes",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 4220545334262462,
+                        "layout": {
+                            "height": 3,
+                            "width": 5,
+                            "x": 3,
+                            "y": 4
+                        }
                     },
                     {
-                      "field": "service_type",
-                      "width": "auto"
+                        "definition": {
+                            "check": "torchserve.inference_api.health",
+                            "group_by": [],
+                            "grouping": "cluster",
+                            "tags": [],
+                            "time": {
+                                "live_span": "1d"
+                            },
+                            "title": "Inference API Health",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "check_status"
+                        },
+                        "id": 6987039090862476,
+                        "layout": {
+                            "height": 1,
+                            "width": 3,
+                            "x": 0,
+                            "y": 5
+                        }
                     },
                     {
-                      "field": "content",
-                      "width": "auto"
+                        "definition": {
+                            "check": "torchserve.openmetrics.health",
+                            "group_by": [],
+                            "grouping": "cluster",
+                            "tags": [],
+                            "time": {
+                                "live_span": "1d"
+                            },
+                            "title": "OpenMetrics",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "check_status"
+                        },
+                        "id": 3431939964933534,
+                        "layout": {
+                            "height": 1,
+                            "width": 3,
+                            "x": 0,
+                            "y": 6
+                        }
                     }
-                  ],
-                  "response_format": "event_list"
-                }
-              ],
-              "type": "list_stream"
+                ]
             },
+            "id": 8178300534998464,
             "layout": {
-              "x": 0,
-              "y": 12,
-              "width": 12,
-              "height": 5
+                "height": 8,
+                "width": 8,
+                "x": 4,
+                "y": 0
             }
-          }
-        ]
-      },
-      "layout": {
-        "x": 0,
-        "y": 26,
-        "width": 12,
-        "height": 18
-      }
-    },
-    {
-      "id": 829473847316232,
-      "definition": {
-        "title": "General Resource Utilization",
-        "background_color": "vivid_pink",
-        "show_title": true,
-        "type": "group",
-        "layout_type": "ordered",
-        "widgets": [
-          {
-            "id": 1428047045674138,
+        },
+        {
             "definition": {
-              "type": "note",
-              "content": "This section provides insights into Torchserve Resource Utilization. Monitoring disk and memory utilization ensure there is sufficient storage capacity and no memory leaks, preventing the service from crashing and providing optimal model inferencing performance. Viewing CPU usage helps you gauge the system's processing power and ensure that TorchServe can handle the computation demands of serving multiple requests efficiently. High CPU usage can indicate the need for better resource scaling. ",
-              "background_color": "pink",
-              "font_size": "14",
-              "text_align": "center",
-              "vertical_align": "center",
-              "show_tick": false,
-              "tick_pos": "50%",
-              "tick_edge": "left",
-              "has_padding": true
-            },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 12,
-              "height": 2
-            }
-          },
-          {
-            "id": 3343195027683784,
-            "definition": {
-              "title": "CPU usage",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
+                "background_color": "vivid_pink",
+                "layout_type": "ordered",
+                "show_title": true,
+                "title": "Models",
+                "type": "group",
+                "widgets": [
                     {
-                      "formula": "query1"
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "query": "sum:torchserve.openmetrics.cpu.utilization{$service,$host}",
-                      "data_source": "metrics",
-                      "name": "query1"
-                    }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "line"
-                }
-              ]
-            },
-            "layout": {
-              "x": 0,
-              "y": 2,
-              "width": 12,
-              "height": 3
-            }
-          },
-          {
-            "id": 7609329522497346,
-            "definition": {
-              "title": "Memory utilization",
-              "title_size": "16",
-              "title_align": "left",
-              "type": "query_value",
-              "requests": [
-                {
-                  "response_format": "scalar",
-                  "queries": [
-                    {
-                      "name": "query1",
-                      "data_source": "metrics",
-                      "query": "avg:torchserve.openmetrics.memory.utilization{*}",
-                      "aggregator": "avg"
-                    }
-                  ],
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ]
-                }
-              ],
-              "autoscale": true,
-              "precision": 2,
-              "timeseries_background": {
-                "type": "area"
-              }
-            },
-            "layout": {
-              "x": 0,
-              "y": 5,
-              "width": 3,
-              "height": 3
-            }
-          },
-          {
-            "id": 133805488297576,
-            "definition": {
-              "title": "Memory usage",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "alias": "Used",
-                      "formula": "query1"
+                        "definition": {
+                            "background_color": "pink",
+                            "content": "The Models section speaks to the number of each type of model that TorchServe is deploying, and the versions that are actively used. Essentially, you have a holistic overview of your model deployment across TorchServe. ",
+                            "font_size": "14",
+                            "has_padding": true,
+                            "show_tick": false,
+                            "text_align": "center",
+                            "tick_edge": "left",
+                            "tick_pos": "50%",
+                            "type": "note",
+                            "vertical_align": "center"
+                        },
+                        "id": 2329456956867396,
+                        "layout": {
+                            "height": 1,
+                            "width": 12,
+                            "x": 0,
+                            "y": 0
+                        }
                     },
                     {
-                      "alias": "Available",
-                      "formula": "query2"
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "query": "sum:torchserve.openmetrics.memory.used{$service,$host}",
-                      "data_source": "metrics",
-                      "name": "query1"
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "horizontal",
+                            "requests": [
+                                {
+                                    "display_type": "bars",
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.management_api.model.version.is_default{$service,$host} by {model_name}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Models",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 4814938111516716,
+                        "layout": {
+                            "height": 3,
+                            "width": 12,
+                            "x": 0,
+                            "y": 1
+                        }
                     },
                     {
-                      "query": "sum:torchserve.openmetrics.memory.available{$service,$host}",
-                      "data_source": "metrics",
-                      "name": "query2"
-                    }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "line"
-                }
-              ]
-            },
-            "layout": {
-              "x": 3,
-              "y": 5,
-              "width": 9,
-              "height": 3
-            }
-          },
-          {
-            "id": 7416709962165464,
-            "definition": {
-              "title": "Disk usage",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "alias": "Used",
-                      "formula": "query1"
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "horizontal",
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "Total Number of Models",
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.management_api.models{$service,$host}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Models",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 1915999910071562,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 0,
+                            "y": 4
+                        }
                     },
                     {
-                      "alias": "Available",
-                      "formula": "query2"
+                        "definition": {
+                            "requests": [
+                                {
+                                    "formulas": [
+                                        {
+                                            "formula": "query1",
+                                            "limit": {
+                                                "count": 500,
+                                                "order": "desc"
+                                            }
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "aggregator": "last",
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "max:torchserve.management_api.model.versions{$service,$host,$model_name,$model_version} by {service,host,model_name}"
+                                        }
+                                    ],
+                                    "response_format": "scalar"
+                                }
+                            ],
+                            "title": "Versions",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "query_table"
+                        },
+                        "id": 3603091054372162,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 6,
+                            "y": 4
+                        }
                     }
-                  ],
-                  "queries": [
+                ]
+            },
+            "id": 7032632848077256,
+            "layout": {
+                "height": 8,
+                "width": 12,
+                "x": 0,
+                "y": 8
+            }
+        },
+        {
+            "definition": {
+                "background_color": "vivid_pink",
+                "layout_type": "ordered",
+                "show_title": true,
+                "title": "Inferences",
+                "type": "group",
+                "widgets": [
                     {
-                      "query": "sum:torchserve.openmetrics.disk.used{$service,$host}",
-                      "data_source": "metrics",
-                      "name": "query1"
+                        "definition": {
+                            "background_color": "pink",
+                            "content": "The following graphs show you the volume of inference requests as well as the handler and prediction time for your models. You can zoom out to an average per all models by removing the \"sum by model_name\" tag in the query.",
+                            "font_size": "14",
+                            "has_padding": true,
+                            "show_tick": false,
+                            "text_align": "center",
+                            "tick_edge": "left",
+                            "tick_pos": "50%",
+                            "type": "note",
+                            "vertical_align": "center"
+                        },
+                        "id": 3886077082488710,
+                        "layout": {
+                            "height": 1,
+                            "width": 12,
+                            "x": 0,
+                            "y": 0
+                        }
                     },
                     {
-                      "query": "sum:torchserve.openmetrics.disk.available{$service,$host}",
-                      "data_source": "metrics",
-                      "name": "query2"
-                    }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "line"
-                }
-              ]
-            },
-            "layout": {
-              "x": 0,
-              "y": 8,
-              "width": 9,
-              "height": 3
-            }
-          },
-          {
-            "id": 3716928526646146,
-            "definition": {
-              "title": "Disk utilization",
-              "title_size": "16",
-              "title_align": "left",
-              "type": "query_value",
-              "requests": [
-                {
-                  "response_format": "scalar",
-                  "queries": [
-                    {
-                      "name": "query1",
-                      "data_source": "metrics",
-                      "query": "avg:torchserve.openmetrics.disk.utilization{$service,$host}",
-                      "aggregator": "avg"
-                    }
-                  ],
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ]
-                }
-              ],
-              "autoscale": true,
-              "precision": 2,
-              "timeseries_background": {
-                "type": "area"
-              }
-            },
-            "layout": {
-              "x": 9,
-              "y": 8,
-              "width": 3,
-              "height": 3
-            }
-          }
-        ]
-      },
-      "layout": {
-        "x": 0,
-        "y": 0,
-        "width": 12,
-        "height": 12,
-        "is_column_break": true
-      }
-    },
-    {
-      "id": 7032632848077256,
-      "definition": {
-        "title": "Models",
-        "background_color": "vivid_pink",
-        "show_title": true,
-        "type": "group",
-        "layout_type": "ordered",
-        "widgets": [
-          {
-            "id": 2329456956867396,
-            "definition": {
-              "type": "note",
-              "content": "The Models section speaks to the number of each type of model that TorchServe is deploying, and the versions that are actively used. Essentially, you have a holistic overview of your model deployment across TorchServe. ",
-              "background_color": "pink",
-              "font_size": "14",
-              "text_align": "center",
-              "vertical_align": "center",
-              "show_tick": false,
-              "tick_pos": "50%",
-              "tick_edge": "left",
-              "has_padding": true
-            },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 12,
-              "height": 1
-            }
-          },
-          {
-            "id": 4814938111516716,
-            "definition": {
-              "title": "Models",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "query": "sum:torchserve.management_api.model.version.is_default{$service,$host} by {model_name}",
-                      "data_source": "metrics",
-                      "name": "query1"
-                    }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "bars"
-                }
-              ]
-            },
-            "layout": {
-              "x": 0,
-              "y": 1,
-              "width": 12,
-              "height": 3
-            }
-          },
-          {
-            "id": 1915999910071562,
-            "definition": {
-              "title": "Models",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "alias": "Total Number of Models",
-                      "formula": "query1"
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "query": "sum:torchserve.management_api.models{$service,$host}",
-                      "data_source": "metrics",
-                      "name": "query1"
-                    }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "line"
-                }
-              ]
-            },
-            "layout": {
-              "x": 0,
-              "y": 4,
-              "width": 6,
-              "height": 3
-            }
-          },
-          {
-            "id": 3603091054372162,
-            "definition": {
-              "title": "Versions",
-              "title_size": "16",
-              "title_align": "left",
-              "type": "query_table",
-              "requests": [
-                {
-                  "response_format": "scalar",
-                  "formulas": [
-                    {
-                      "formula": "query1",
-                      "limit": {
-                        "count": 500,
-                        "order": "desc"
-                      }
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "query": "max:torchserve.management_api.model.versions{$service,$host,$model_name,$model_version} by {service,host,model_name}",
-                      "data_source": "metrics",
-                      "name": "query1",
-                      "aggregator": "last"
-                    }
-                  ]
-                }
-              ]
-            },
-            "layout": {
-              "x": 6,
-              "y": 4,
-              "width": 6,
-              "height": 3
-            }
-          }
-        ]
-      },
-      "layout": {
-        "x": 0,
-        "y": 12,
-        "width": 12,
-        "height": 8
-      }
-    },
-    {
-      "id": 2613069221392938,
-      "definition": {
-        "title": "Workers",
-        "background_color": "vivid_pink",
-        "show_title": true,
-        "type": "group",
-        "layout_type": "ordered",
-        "widgets": [
-          {
-            "id": 653444785072872,
-            "definition": {
-              "type": "note",
-              "content": "TorchServe workers handle concurrent processing of request and enable higher throughput and improved responsiveness of the model serving system. The following section shows thread time, load time and memory usage by workers. ",
-              "background_color": "pink",
-              "font_size": "14",
-              "text_align": "center",
-              "vertical_align": "center",
-              "show_tick": false,
-              "tick_pos": "50%",
-              "tick_edge": "left",
-              "has_padding": true
-            },
-            "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 12,
-              "height": 1
-            }
-          },
-          {
-            "id": 1417746590607762,
-            "definition": {
-              "title": "Worker thread time",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "query": "sum:torchserve.openmetrics.worker.thread_time{$service,$host}",
-                      "data_source": "metrics",
-                      "name": "query1"
-                    }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "line"
-                }
-              ]
-            },
-            "layout": {
-              "x": 0,
-              "y": 1,
-              "width": 12,
-              "height": 3
-            }
-          },
-          {
-            "id": 7739021837639330,
-            "definition": {
-              "title": "Workers",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "alias": "Current",
-                      "formula": "query1"
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "vertical",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "area",
+                                    "formulas": [
+                                        {
+                                            "alias": "Inference Count",
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.openmetrics.inference.count{$service,$host} by {model_name}.as_count()"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Number of Inference Request per Model",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 5082627944789452,
+                        "layout": {
+                            "height": 5,
+                            "width": 12,
+                            "x": 0,
+                            "y": 1
+                        }
                     },
                     {
-                      "alias": "Max",
-                      "formula": "query2"
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "auto",
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "Handler time",
+                                            "formula": "query1"
+                                        },
+                                        {
+                                            "alias": "Prediction time",
+                                            "formula": "query2"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.openmetrics.handler_time{$service,$host} by {model_name}"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query2",
+                                            "query": "sum:torchserve.openmetrics.prediction_time{$service,$host} by {model_name}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Prediction time",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 7833942874724070,
+                        "layout": {
+                            "height": 3,
+                            "width": 12,
+                            "x": 0,
+                            "y": 6
+                        }
+                    }
+                ]
+            },
+            "id": 4965434358555720,
+            "layout": {
+                "height": 10,
+                "width": 12,
+                "x": 0,
+                "y": 16
+            }
+        },
+        {
+            "definition": {
+                "background_color": "vivid_pink",
+                "layout_type": "ordered",
+                "show_title": true,
+                "title": "Workers",
+                "type": "group",
+                "widgets": [
+                    {
+                        "definition": {
+                            "background_color": "pink",
+                            "content": "TorchServe workers handle concurrent processing of request and enable higher throughput and improved responsiveness of the model serving system. The following section shows thread time, load time and memory usage by workers. ",
+                            "font_size": "14",
+                            "has_padding": true,
+                            "show_tick": false,
+                            "text_align": "center",
+                            "tick_edge": "left",
+                            "tick_pos": "50%",
+                            "type": "note",
+                            "vertical_align": "center"
+                        },
+                        "id": 653444785072872,
+                        "layout": {
+                            "height": 1,
+                            "width": 12,
+                            "x": 0,
+                            "y": 0
+                        }
                     },
                     {
-                      "alias": "Min",
-                      "formula": "query3"
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "query": "sum:torchserve.management_api.model.workers.current{$service,$host,$model_name,$model_version}",
-                      "data_source": "metrics",
-                      "name": "query1"
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "horizontal",
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.openmetrics.worker.thread_time{$service,$host}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Worker thread time",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 1417746590607762,
+                        "layout": {
+                            "height": 3,
+                            "width": 12,
+                            "x": 0,
+                            "y": 1
+                        }
                     },
                     {
-                      "query": "sum:torchserve.management_api.model.workers.max{$service,$host,$model_name,$model_version}",
-                      "data_source": "metrics",
-                      "name": "query2"
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "horizontal",
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "Current",
+                                            "formula": "query1"
+                                        },
+                                        {
+                                            "alias": "Max",
+                                            "formula": "query2"
+                                        },
+                                        {
+                                            "alias": "Min",
+                                            "formula": "query3"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.management_api.model.workers.current{$service,$host,$model_name,$model_version}"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query2",
+                                            "query": "sum:torchserve.management_api.model.workers.max{$service,$host,$model_name,$model_version}"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query3",
+                                            "query": "sum:torchserve.management_api.model.workers.min{$service,$host,$model_name,$model_version}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Workers",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 7739021837639330,
+                        "layout": {
+                            "height": 3,
+                            "width": 4,
+                            "x": 0,
+                            "y": 4
+                        }
                     },
                     {
-                      "query": "sum:torchserve.management_api.model.workers.min{$service,$host,$model_name,$model_version}",
-                      "data_source": "metrics",
-                      "name": "query3"
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "horizontal",
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.openmetrics.worker.load_time{$service,$host}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Worker load time",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 8507161449664792,
+                        "layout": {
+                            "height": 3,
+                            "width": 4,
+                            "x": 4,
+                            "y": 4
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "horizontal",
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.management_api.model.worker.memory_usage{$service,$host,$model_name,$model_version}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Worker memory usage",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 5210480509552942,
+                        "layout": {
+                            "height": 3,
+                            "width": 4,
+                            "x": 8,
+                            "y": 4
+                        }
                     }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "line"
-                }
-              ]
+                ]
             },
+            "id": 2613069221392938,
             "layout": {
-              "x": 0,
-              "y": 4,
-              "width": 4,
-              "height": 3
+                "height": 8,
+                "width": 12,
+                "x": 0,
+                "y": 26
             }
-          },
-          {
-            "id": 8507161449664792,
+        },
+        {
             "definition": {
-              "title": "Worker load time",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
+                "background_color": "vivid_pink",
+                "layout_type": "ordered",
+                "show_title": true,
+                "title": "GPU",
+                "type": "group",
+                "widgets": [
                     {
-                      "formula": "query1"
-                    }
-                  ],
-                  "queries": [
+                        "definition": {
+                            "background_color": "pink",
+                            "content": "If you are relying on GPU resources in your AI stack, Torchserve's usage of GPU memory, and the list of models using GPU (as a worker) will appear here. ",
+                            "font_size": "14",
+                            "has_padding": true,
+                            "show_tick": false,
+                            "text_align": "center",
+                            "tick_edge": "left",
+                            "tick_pos": "50%",
+                            "type": "note",
+                            "vertical_align": "center"
+                        },
+                        "id": 6620916186424168,
+                        "layout": {
+                            "height": 1,
+                            "width": 12,
+                            "x": 0,
+                            "y": 0
+                        }
+                    },
                     {
-                      "query": "sum:torchserve.openmetrics.worker.load_time{$service,$host}",
-                      "data_source": "metrics",
-                      "name": "query1"
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "horizontal",
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.openmetrics.gpu.memory.used{$service,$host}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Memory usage",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 1223374758670872,
+                        "layout": {
+                            "height": 3,
+                            "width": 9,
+                            "x": 0,
+                            "y": 1
+                        }
+                    },
+                    {
+                        "definition": {
+                            "autoscale": true,
+                            "precision": 2,
+                            "requests": [
+                                {
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "aggregator": "avg",
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "avg:torchserve.gpu.memory.utilization{$service,$host}"
+                                        }
+                                    ],
+                                    "response_format": "scalar"
+                                }
+                            ],
+                            "timeseries_background": {
+                                "type": "area"
+                            },
+                            "title": "Memory utilization",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "query_value"
+                        },
+                        "id": 3943683997022512,
+                        "layout": {
+                            "height": 3,
+                            "width": 3,
+                            "x": 9,
+                            "y": 1
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "horizontal",
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.openmetrics.gpu.memory.utilization{$service,$host}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "GPU utilization",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 383800795128260,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 0,
+                            "y": 4
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "horizontal",
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.management_api.model.worker.is_gpu{$service,$host}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "GPU workers",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 6462277535549286,
+                        "layout": {
+                            "height": 3,
+                            "width": 6,
+                            "x": 6,
+                            "y": 4
+                        }
                     }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "line"
-                }
-              ]
+                ]
             },
+            "id": 888836297341870,
             "layout": {
-              "x": 4,
-              "y": 4,
-              "width": 4,
-              "height": 3
+                "height": 8,
+                "width": 12,
+                "x": 0,
+                "y": 34
             }
-          },
-          {
-            "id": 5210480509552942,
+        },
+        {
             "definition": {
-              "title": "Worker memory usage",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
+                "background_color": "vivid_pink",
+                "layout_type": "ordered",
+                "show_title": true,
+                "title": "General Resource Utilization",
+                "type": "group",
+                "widgets": [
                     {
-                      "formula": "query1"
-                    }
-                  ],
-                  "queries": [
+                        "definition": {
+                            "background_color": "pink",
+                            "content": "This section provides insights into Torchserve Resource Utilization. Monitoring disk and memory utilization ensure there is sufficient storage capacity and no memory leaks, preventing the service from crashing and providing optimal model inferencing performance. Viewing CPU usage helps you gauge the system's processing power and ensure that TorchServe can handle the computation demands of serving multiple requests efficiently. High CPU usage can indicate the need for better resource scaling. ",
+                            "font_size": "14",
+                            "has_padding": true,
+                            "show_tick": false,
+                            "text_align": "center",
+                            "tick_edge": "left",
+                            "tick_pos": "50%",
+                            "type": "note",
+                            "vertical_align": "center"
+                        },
+                        "id": 1428047045674138,
+                        "layout": {
+                            "height": 2,
+                            "width": 12,
+                            "x": 0,
+                            "y": 0
+                        }
+                    },
                     {
-                      "query": "sum:torchserve.management_api.model.worker.memory_usage{$service,$host,$model_name,$model_version}",
-                      "data_source": "metrics",
-                      "name": "query1"
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "horizontal",
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.openmetrics.cpu.utilization{$service,$host}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "CPU usage",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 3343195027683784,
+                        "layout": {
+                            "height": 3,
+                            "width": 12,
+                            "x": 0,
+                            "y": 2
+                        }
+                    },
+                    {
+                        "definition": {
+                            "autoscale": true,
+                            "precision": 2,
+                            "requests": [
+                                {
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "aggregator": "avg",
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "avg:torchserve.openmetrics.memory.utilization{*}"
+                                        }
+                                    ],
+                                    "response_format": "scalar"
+                                }
+                            ],
+                            "timeseries_background": {
+                                "type": "area"
+                            },
+                            "title": "Memory utilization",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "query_value"
+                        },
+                        "id": 7609329522497346,
+                        "layout": {
+                            "height": 3,
+                            "width": 3,
+                            "x": 0,
+                            "y": 5
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "horizontal",
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "Used",
+                                            "formula": "query1"
+                                        },
+                                        {
+                                            "alias": "Available",
+                                            "formula": "query2"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.openmetrics.memory.used{$service,$host}"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query2",
+                                            "query": "sum:torchserve.openmetrics.memory.available{$service,$host}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Memory usage",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 133805488297576,
+                        "layout": {
+                            "height": 3,
+                            "width": 9,
+                            "x": 3,
+                            "y": 5
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "min",
+                                "max",
+                                "value",
+                                "sum"
+                            ],
+                            "legend_layout": "horizontal",
+                            "requests": [
+                                {
+                                    "display_type": "line",
+                                    "formulas": [
+                                        {
+                                            "alias": "Used",
+                                            "formula": "query1"
+                                        },
+                                        {
+                                            "alias": "Available",
+                                            "formula": "query2"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "sum:torchserve.openmetrics.disk.used{$service,$host}"
+                                        },
+                                        {
+                                            "data_source": "metrics",
+                                            "name": "query2",
+                                            "query": "sum:torchserve.openmetrics.disk.available{$service,$host}"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "palette": "classic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Disk usage",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries"
+                        },
+                        "id": 7416709962165464,
+                        "layout": {
+                            "height": 3,
+                            "width": 9,
+                            "x": 0,
+                            "y": 8
+                        }
+                    },
+                    {
+                        "definition": {
+                            "autoscale": true,
+                            "precision": 2,
+                            "requests": [
+                                {
+                                    "formulas": [
+                                        {
+                                            "formula": "query1"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "aggregator": "avg",
+                                            "data_source": "metrics",
+                                            "name": "query1",
+                                            "query": "avg:torchserve.openmetrics.disk.utilization{$service,$host}"
+                                        }
+                                    ],
+                                    "response_format": "scalar"
+                                }
+                            ],
+                            "timeseries_background": {
+                                "type": "area"
+                            },
+                            "title": "Disk utilization",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "query_value"
+                        },
+                        "id": 3716928526646146,
+                        "layout": {
+                            "height": 3,
+                            "width": 3,
+                            "x": 9,
+                            "y": 8
+                        }
                     }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "line"
-                }
-              ]
+                ]
             },
+            "id": 829473847316232,
             "layout": {
-              "x": 8,
-              "y": 4,
-              "width": 4,
-              "height": 3
+                "height": 12,
+                "is_column_break": true,
+                "width": 12,
+                "x": 0,
+                "y": 42
             }
-          }
-        ]
-      },
-      "layout": {
-        "x": 0,
-        "y": 20,
-        "width": 12,
-        "height": 8
-      }
-    },
-    {
-      "id": 888836297341870,
-      "definition": {
-        "title": "GPU",
-        "background_color": "vivid_pink",
-        "show_title": true,
-        "type": "group",
-        "layout_type": "ordered",
-        "widgets": [
-          {
-            "id": 6620916186424168,
+        },
+        {
             "definition": {
-              "type": "note",
-              "content": "If you are relying on GPU resources in your AI stack, Torchserve's usage of GPU memory, and the list of models using GPU (as a worker) will appear here. ",
-              "background_color": "pink",
-              "font_size": "14",
-              "text_align": "center",
-              "vertical_align": "center",
-              "show_tick": false,
-              "tick_pos": "50%",
-              "tick_edge": "left",
-              "has_padding": true
+                "background_color": "vivid_pink",
+                "layout_type": "ordered",
+                "show_title": true,
+                "title": "Logs",
+                "title_align": "left",
+                "type": "group",
+                "widgets": [
+                    {
+                        "definition": {
+                            "background_color": "pink",
+                            "content": "When investigating logs, you can refer to the time-series data to see the ratio of a certain log status to other expected statuses. In situations where you notice an increase in the ratio of error logs, you can refer to the log stream of erroneous logs for your perusal.",
+                            "font_size": "14",
+                            "has_padding": true,
+                            "show_tick": false,
+                            "text_align": "center",
+                            "tick_edge": "left",
+                            "tick_pos": "50%",
+                            "type": "note",
+                            "vertical_align": "center"
+                        },
+                        "id": 6085927965988954,
+                        "layout": {
+                            "height": 1,
+                            "width": 12,
+                            "x": 0,
+                            "y": 0
+                        }
+                    },
+                    {
+                        "definition": {
+                            "hide_total": false,
+                            "legend": {
+                                "type": "table"
+                            },
+                            "requests": [
+                                {
+                                    "formulas": [
+                                        {
+                                            "formula": "query1",
+                                            "limit": {
+                                                "order": "desc"
+                                            }
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "compute": {
+                                                "aggregation": "count"
+                                            },
+                                            "data_source": "logs",
+                                            "group_by": [
+                                                {
+                                                    "facet": "status",
+                                                    "limit": 10,
+                                                    "sort": {
+                                                        "aggregation": "count",
+                                                        "order": "desc"
+                                                    }
+                                                }
+                                            ],
+                                            "indexes": [
+                                                "*"
+                                            ],
+                                            "name": "query1",
+                                            "search": {
+                                                "query": "source:torchserve"
+                                            },
+                                            "storage": "hot"
+                                        }
+                                    ],
+                                    "response_format": "scalar",
+                                    "style": {
+                                        "palette": "semantic"
+                                    }
+                                }
+                            ],
+                            "title": "Volume by Status",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "sunburst"
+                        },
+                        "id": 972406572464752,
+                        "layout": {
+                            "height": 3,
+                            "width": 12,
+                            "x": 0,
+                            "y": 1
+                        }
+                    },
+                    {
+                        "definition": {
+                            "legend_columns": [
+                                "avg",
+                                "max",
+                                "value"
+                            ],
+                            "legend_layout": "horizontal",
+                            "markers": [],
+                            "requests": [
+                                {
+                                    "display_type": "bars",
+                                    "formulas": [
+                                        {
+                                            "formula": "query2"
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "compute": {
+                                                "aggregation": "count"
+                                            },
+                                            "data_source": "logs",
+                                            "group_by": [
+                                                {
+                                                    "facet": "status",
+                                                    "limit": 10,
+                                                    "sort": {
+                                                        "aggregation": "count",
+                                                        "order": "desc"
+                                                    }
+                                                }
+                                            ],
+                                            "indexes": [
+                                                "*"
+                                            ],
+                                            "name": "query2",
+                                            "search": {
+                                                "query": "source:torchserve"
+                                            },
+                                            "storage": "hot"
+                                        }
+                                    ],
+                                    "response_format": "timeseries",
+                                    "style": {
+                                        "line_type": "solid",
+                                        "line_width": "normal",
+                                        "palette": "semantic"
+                                    }
+                                }
+                            ],
+                            "show_legend": true,
+                            "title": "Volume by Status over Time",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "timeseries",
+                            "yaxis": {
+                                "include_zero": true,
+                                "label": "",
+                                "max": "auto",
+                                "min": "auto",
+                                "scale": "linear"
+                            }
+                        },
+                        "id": 2882736407867586,
+                        "layout": {
+                            "height": 3,
+                            "width": 12,
+                            "x": 0,
+                            "y": 4
+                        }
+                    },
+                    {
+                        "definition": {
+                            "requests": [
+                                {
+                                    "formulas": [
+                                        {
+                                            "alias": "Logs",
+                                            "cell_display_mode": "bar",
+                                            "formula": "query2",
+                                            "limit": {
+                                                "count": 100,
+                                                "order": "desc"
+                                            }
+                                        }
+                                    ],
+                                    "queries": [
+                                        {
+                                            "compute": {
+                                                "aggregation": "count"
+                                            },
+                                            "data_source": "logs",
+                                            "group_by": [
+                                                {
+                                                    "facet": "host",
+                                                    "limit": 10,
+                                                    "sort": {
+                                                        "aggregation": "count",
+                                                        "order": "desc"
+                                                    }
+                                                },
+                                                {
+                                                    "facet": "service",
+                                                    "limit": 10,
+                                                    "sort": {
+                                                        "aggregation": "count",
+                                                        "order": "desc"
+                                                    }
+                                                }
+                                            ],
+                                            "indexes": [
+                                                "*"
+                                            ],
+                                            "name": "query2",
+                                            "search": {
+                                                "query": "source:torchserve"
+                                            },
+                                            "storage": "hot"
+                                        }
+                                    ],
+                                    "response_format": "scalar"
+                                }
+                            ],
+                            "title": "Logs by Host and Service",
+                            "title_align": "left",
+                            "title_size": "16",
+                            "type": "query_table"
+                        },
+                        "id": 3297077839160356,
+                        "layout": {
+                            "height": 2,
+                            "width": 12,
+                            "x": 0,
+                            "y": 7
+                        }
+                    },
+                    {
+                        "definition": {
+                            "requests": [
+                                {
+                                    "columns": [
+                                        {
+                                            "field": "status_line",
+                                            "width": "auto"
+                                        },
+                                        {
+                                            "field": "timestamp",
+                                            "width": "auto"
+                                        },
+                                        {
+                                            "field": "host",
+                                            "width": "auto"
+                                        },
+                                        {
+                                            "field": "service_type",
+                                            "width": "auto"
+                                        },
+                                        {
+                                            "field": "content",
+                                            "width": "auto"
+                                        }
+                                    ],
+                                    "query": {
+                                        "data_source": "logs_stream",
+                                        "indexes": [],
+                                        "query_string": "status:(error OR critical) source:torchserve",
+                                        "sort": {
+                                            "column": "timestamp",
+                                            "order": "desc"
+                                        },
+                                        "storage": "hot"
+                                    },
+                                    "response_format": "event_list"
+                                }
+                            ],
+                            "title": "Error Logs",
+                            "title_size": "16",
+                            "type": "list_stream"
+                        },
+                        "id": 6999445441381676,
+                        "layout": {
+                            "height": 4,
+                            "width": 6,
+                            "x": 0,
+                            "y": 9
+                        }
+                    },
+                    {
+                        "definition": {
+                            "requests": [
+                                {
+                                    "columns": [
+                                        {
+                                            "field": "status_line",
+                                            "width": "auto"
+                                        },
+                                        {
+                                            "field": "timestamp",
+                                            "width": "auto"
+                                        },
+                                        {
+                                            "field": "host",
+                                            "width": "auto"
+                                        },
+                                        {
+                                            "field": "service_type",
+                                            "width": "auto"
+                                        },
+                                        {
+                                            "field": "content",
+                                            "width": "auto"
+                                        }
+                                    ],
+                                    "query": {
+                                        "data_source": "logs_stream",
+                                        "indexes": [],
+                                        "query_string": "source:torchserve",
+                                        "sort": {
+                                            "column": "timestamp",
+                                            "order": "desc"
+                                        },
+                                        "storage": "hot"
+                                    },
+                                    "response_format": "event_list"
+                                }
+                            ],
+                            "title": "All Logs",
+                            "title_size": "16",
+                            "type": "list_stream"
+                        },
+                        "id": 2613469200354810,
+                        "layout": {
+                            "height": 4,
+                            "width": 6,
+                            "x": 6,
+                            "y": 9
+                        }
+                    }
+                ]
             },
+            "id": 5719118412081720,
             "layout": {
-              "x": 0,
-              "y": 0,
-              "width": 12,
-              "height": 1
+                "height": 14,
+                "width": 12,
+                "x": 0,
+                "y": 54
             }
-          },
-          {
-            "id": 1223374758670872,
-            "definition": {
-              "title": "Memory usage",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "query": "sum:torchserve.openmetrics.gpu.memory.used{$service,$host}",
-                      "data_source": "metrics",
-                      "name": "query1"
-                    }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "line"
-                }
-              ]
-            },
-            "layout": {
-              "x": 0,
-              "y": 1,
-              "width": 9,
-              "height": 3
-            }
-          },
-          {
-            "id": 3943683997022512,
-            "definition": {
-              "title": "Memory utilization",
-              "title_size": "16",
-              "title_align": "left",
-              "type": "query_value",
-              "requests": [
-                {
-                  "response_format": "scalar",
-                  "queries": [
-                    {
-                      "name": "query1",
-                      "data_source": "metrics",
-                      "query": "avg:torchserve.gpu.memory.utilization{$service,$host}",
-                      "aggregator": "avg"
-                    }
-                  ],
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ]
-                }
-              ],
-              "autoscale": true,
-              "precision": 2,
-              "timeseries_background": {
-                "type": "area"
-              }
-            },
-            "layout": {
-              "x": 9,
-              "y": 1,
-              "width": 3,
-              "height": 3
-            }
-          },
-          {
-            "id": 383800795128260,
-            "definition": {
-              "title": "GPU utilization",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "query": "sum:torchserve.openmetrics.gpu.memory.utilization{$service,$host}",
-                      "data_source": "metrics",
-                      "name": "query1"
-                    }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "line"
-                }
-              ]
-            },
-            "layout": {
-              "x": 0,
-              "y": 4,
-              "width": 6,
-              "height": 3
-            }
-          },
-          {
-            "id": 6462277535549286,
-            "definition": {
-              "title": "GPU workers",
-              "title_size": "16",
-              "title_align": "left",
-              "show_legend": true,
-              "legend_layout": "horizontal",
-              "legend_columns": [
-                "avg",
-                "min",
-                "max",
-                "value",
-                "sum"
-              ],
-              "type": "timeseries",
-              "requests": [
-                {
-                  "formulas": [
-                    {
-                      "formula": "query1"
-                    }
-                  ],
-                  "queries": [
-                    {
-                      "query": "sum:torchserve.management_api.model.worker.is_gpu{$service,$host}",
-                      "data_source": "metrics",
-                      "name": "query1"
-                    }
-                  ],
-                  "response_format": "timeseries",
-                  "style": {
-                    "palette": "classic"
-                  },
-                  "display_type": "line"
-                }
-              ]
-            },
-            "layout": {
-              "x": 6,
-              "y": 4,
-              "width": 6,
-              "height": 3
-            }
-          }
-        ]
-      },
-      "layout": {
-        "x": 0,
-        "y": 28,
-        "width": 12,
-        "height": 8
-      }
-    }
-  ],
-  "template_variables": [
-    {
-      "name": "service",
-      "available_values": [],
-      "default": "*"
-    },
-    {
-      "name": "host",
-      "available_values": [],
-      "default": "*"
-    },
-    {
-      "name": "model_name",
-      "prefix": "model_name",
-      "available_values": [],
-      "default": "*"
-    },
-    {
-      "name": "model_version",
-      "prefix": "model_version",
-      "available_values": [],
-      "default": "*"
-    }
-  ],
-  "layout_type": "ordered",
-  "notify_list": [],
-  "reflow_type": "fixed"
+        }
+    ]
 }


### PR DESCRIPTION
### What does this PR do?
Small nit as requested from PMs

Updates to order of widget groups. The dashboard is identical to the old one, but has widget groups rearranged to fit the desired order for better visibility when viewing in laptop mode