### PR TITLE
Include distribution as valid metric type for  metadata.csv validation

### DIFF
--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/metadata.py
@@ -27,7 +27,7 @@ OPTIONAL_HEADERS = {'description', 'interval', 'unit_name', 'per_unit_name', 'sh
 
 ALL_HEADERS = REQUIRED_HEADERS | OPTIONAL_HEADERS
 
-VALID_METRIC_TYPE = {'count', 'gauge', 'rate'}
+VALID_METRIC_TYPE = {'count', 'gauge', 'rate', 'distribution'}
 
 VALID_ORIENTATION = {'0', '1', '-1'}
 


### PR DESCRIPTION
### What does this PR do?
Allows metadata.csv to accept distribution as a metric type

### Motivation
Airbyte integration sends distribution type metric via dogstatsd but our metadata.csv validation does not allow specifying distribution metric type.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.