### PR TITLE
Close and recreate a connection instead of using the `reset_connection` method

### DIFF
--- a/vertica/datadog_checks/vertica/vertica.py
+++ b/vertica/datadog_checks/vertica/vertica.py
@@ -173,7 +173,9 @@ class VerticaClient(object):
         """
         if self.connection:
             if self.connection_load_balance or self.connection.closed():
-                self.connection.reset_connection()
+                self.log.debug("Recreate the connection")
+                self.connection.close()
+                self.connection = vertica.connect(**exclude_undefined_keys(self.options))
         else:
             self.connection = vertica.connect(**exclude_undefined_keys(self.options))
 

--- a/vertica/tests/conftest.py
+++ b/vertica/tests/conftest.py
@@ -29,6 +29,10 @@ class InitializeDB(LazyFunction):
             # Trigger an audit
             cur.execute('SELECT AUDIT_LICENSE_SIZE()')
 
+            # Enable load balance policy
+            # https://docs.vertica.com/12.0.x/en/admin/managing-client-connections/connection-load-balancing/
+            cur.execute("SELECT SET_LOAD_BALANCE_POLICY('ROUNDROBIN')")
+
 
 @pytest.fixture(scope='session')
 def dd_environment():


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Close and recreate a connection instead of using the `reset_connection` method

### Motivation
<!-- What inspired you to submit this pull request? -->

Support case

- When the check runs for the first time, we initiate a new connection using `vertica.connect` which works fine for the current check run.
- If the connection is closed or the `connection_load_balance` option is used (which was the case in our support case), we reset the connection using the `reset_connection` method (code [here](https://github.com/vertica/vertica-python/blob/master/vertica_python/vertica/connection.py#L636-L638)).
- This method does not work as expected because the next check runs are all failing with the following timeout error: 

```
E   Exception: Message: timed out
E   Traceback (most recent call last):
E     File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/vertica_python/vertica/connection.py", line 668, in read_message
E       type_ = self.read_bytes(1)
E     File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/vertica_python/vertica/connection.py", line 731, in read_bytes
E       result = self._socket_as_file().read(1)
E     File "/opt/datadog-agent/embedded/lib/python3.9/socket.py", line 704, in readinto
E       return self._sock.recv_into(b)
E   socket.timeout: timed out
E   
E   During handling of the above exception, another exception occurred:
E   
E   Traceback (most recent call last):
E     File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/datadog_checks/base/checks/base.py", line 1129, in run
E       self.check(instance)
E     File "/home/vertica/datadog_checks/vertica/vertica.py", line 116, in check
E       self.setup_query_manager()
E     File "/home/vertica/datadog_checks/vertica/vertica.py", line 100, in setup_query_manager
E       query_builder = QueryBuilder(self._major_version())
E     File "/home/vertica/datadog_checks/vertica/vertica.py", line 133, in _major_version
E       return parse_major_version(self._version())
E     File "/home/vertica/datadog_checks/vertica/vertica.py", line 136, in _version
E       return self.parse_db_version(self._client.query_version())
E     File "/home/vertica/datadog_checks/vertica/vertica.py", line 193, in query_version
E       return self.connection.cursor().execute('SELECT version()').fetchone()[0]
E     File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/vertica_python/vertica/cursor.py", line 183, in wrap
E       return func(self, *args, **kwargs)
E     File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/vertica_python/vertica/cursor.py", line 210, in execute
E       self.flush_to_query_ready()
E     File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/vertica_python/vertica/cursor.py", line 546, in flush_to_query_ready
E       message = self.connection.read_message()
E     File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/vertica_python/vertica/connection.py", line 704, in read_message
E       raise errors.ConnectionError(str(e))
E   vertica_python.errors.ConnectionError: timed out
```

- I tried to track the problem in the Vertica client but got lost somewhere around [here](https://github.com/vertica/vertica-python/blob/master/vertica_python/vertica/connection.py#L483) after the `reset_connection` method is called and before the next cursor is called. 
- Closing and re-creating the connection works fine in that case

### Additional Notes
<!-- Anything else we should know when reviewing? -->

You can easily reproduce the error with this code: 

```python
import vertica_python

options = {'database': 'datadog', 'host': 'localhost', 'port': 5433, 'user': 'dbadmin', 'password': 'monitor',
 'backup_server_node': [], 'connection_timeout': 10.0}

c = vertica_python.connect(**options)

c.cursor().execute('SELECT version()').fetchone()[0]

c.reset_connection()

c.cursor().execute('SELECT version()').fetchone()[0]
```

Here I have a Vertica service up and running locally on port 5433. 

I'll open an issue on the Vertica repository once that is fixed for our customer.

In the official documentation they do not call this function and create a new connection: https://github.com/vertica/vertica-python/tree/master#connection-load-balancing

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.