### PR TITLE
Mark  the `calico.felix.ipset.errors.count` as optional in the e2e tests

### DIFF
--- a/calico/tests/common.py
+++ b/calico/tests/common.py
@@ -49,4 +49,7 @@ MOCK_CALICO_INSTANCE = {
     "extra_metrics": EXTRA_METRICS,
 }
 
-OPTIONAL_METRICS = {'calico.felix.ipset.calls.count'}
+OPTIONAL_METRICS = {
+    'calico.felix.ipset.calls.count',
+    'calico.felix.ipset.errors.count',
+}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Mark the calico.felix.ipset.errors.count as optional in the e2e tests

### Motivation
<!-- What inspired you to submit this pull request? -->

- Follow-up PR: https://github.com/DataDog/integrations-core/pull/15440
- https://github.com/DataDog/integrations-core/actions/runs/5728498990/job/15523284954

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.