### PR TITLE
Pin the 3.3.2 docker image

### DIFF
--- a/kafka_consumer/hatch.toml
+++ b/kafka_consumer/hatch.toml
@@ -23,7 +23,7 @@ auth = ["ssl", "kerberos"]
 [envs.default.overrides]
 matrix.version.env-vars = [
   { key = "KAFKA_VERSION", value = "2.6.0", if = ["2.6"] },
-  { key = "KAFKA_VERSION", value = "3.3.2", if = ["3.3"] },
+  { key = "KAFKA_VERSION", value = "3.3.2-debian-11-r175", if = ["3.3"] },
 ]
 matrix.auth.env-vars = "AUTHENTICATION"
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

"Pin" the 3.3.2 docker image

### Motivation
<!-- What inspired you to submit this pull request? -->

Even if our version is pinned already, Bitnami overrides the tag to push security/os fixes to their image. They also provide a tag that they do not override. Two days ago they pushed something that makes our ssl tests fail (see [this example](https://github.com/DataDog/integrations-core/actions/runs/5736291708/job/15545679445)). I pinned the docker image to the previous one.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

We already had this kind of issues with the kafka images that are overriden: https://github.com/DataDog/integrations-core/pull/14481, not sure I'll "unpin" it this time

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.