### PR TITLE
Rename to assert_extend_generic_entity_sensor to match profile name

### DIFF
--- a/snmp/tests/test_e2e_core_profiles/test_profile__generic_entity_sensor.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile__generic_entity_sensor.py
@@ -10,7 +10,7 @@ from .. import common
 from ..test_e2e_core_metadata import assert_device_metadata
 from .utils import (
     assert_common_metrics,
-    assert_extend_entity_sensor,
+    assert_extend_generic_entity_sensor,
     create_e2e_core_test_config,
     get_device_ip_from_config,
 )
@@ -32,7 +32,7 @@ def test_e2e_profile__generic_entity_sensor(dd_agent_check):
 
     # --- TEST METRICS ---
     assert_common_metrics(aggregator, common_tags)
-    assert_extend_entity_sensor(aggregator, common_tags)
+    assert_extend_generic_entity_sensor(aggregator, common_tags)
 
     aggregator.assert_all_metrics_covered()
 

--- a/snmp/tests/test_e2e_core_profiles/test_profile_extreme_switching.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_extreme_switching.py
@@ -10,7 +10,7 @@ from .. import common
 from ..test_e2e_core_metadata import assert_device_metadata
 from .utils import (
     assert_common_metrics,
-    assert_extend_entity_sensor,
+    assert_extend_generic_entity_sensor,
     assert_extend_generic_if,
     create_e2e_core_test_config,
     get_device_ip_from_config,
@@ -33,7 +33,7 @@ def test_e2e_profile_extreme_switching(dd_agent_check):
 
     # --- TEST EXTENDED METRICS ---
     assert_extend_generic_if(aggregator, common_tags)
-    assert_extend_entity_sensor(aggregator, common_tags)
+    assert_extend_generic_entity_sensor(aggregator, common_tags)
 
     # --- TEST METRICS ---
     assert_common_metrics(aggregator, common_tags)

--- a/snmp/tests/test_e2e_core_profiles/test_profile_nvidia_cumulus_linux_switch.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_nvidia_cumulus_linux_switch.py
@@ -10,7 +10,7 @@ from .. import common
 from ..test_e2e_core_metadata import assert_device_metadata
 from .utils import (
     assert_common_metrics,
-    assert_extend_entity_sensor,
+    assert_extend_generic_entity_sensor,
     assert_extend_generic_if,
     assert_extend_generic_ucd,
     create_e2e_core_test_config,
@@ -35,7 +35,7 @@ def test_e2e_profile_nvidia_cumulus_linux_switch(dd_agent_check):
     # --- TEST EXTENDED METRICS ---
     assert_extend_generic_if(aggregator, common_tags)
     assert_extend_generic_ucd(aggregator, common_tags)
-    assert_extend_entity_sensor(aggregator, common_tags)
+    assert_extend_generic_entity_sensor(aggregator, common_tags)
 
     # --- TEST METRICS ---
     assert_common_metrics(aggregator, common_tags)

--- a/snmp/tests/test_e2e_core_profiles/test_profile_nvidia_mellanox_switchx.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_nvidia_mellanox_switchx.py
@@ -10,7 +10,7 @@ from .. import common
 from ..test_e2e_core_metadata import assert_device_metadata
 from .utils import (
     assert_common_metrics,
-    assert_extend_entity_sensor,
+    assert_extend_generic_entity_sensor,
     assert_extend_generic_host_resources,
     assert_extend_generic_if,
     create_e2e_core_test_config,
@@ -35,7 +35,7 @@ def test_e2e_profile_nvidia_mellanox_switchx(dd_agent_check):
     # --- TEST METRICS ---
     assert_common_metrics(aggregator, common_tags)
     assert_extend_generic_if(aggregator, common_tags)
-    assert_extend_entity_sensor(aggregator, common_tags)
+    assert_extend_generic_entity_sensor(aggregator, common_tags)
     assert_extend_generic_host_resources(aggregator, common_tags)
     aggregator.assert_all_metrics_covered()
 

--- a/snmp/tests/test_e2e_core_profiles/utils.py
+++ b/snmp/tests/test_e2e_core_profiles/utils.py
@@ -191,7 +191,7 @@ def assert_extend_generic_host_resources(aggregator, common_tags):
     assert_extend_generic_host_resources_base(aggregator, common_tags)
 
 
-def assert_extend_entity_sensor(aggregator, common_tags):
+def assert_extend_generic_entity_sensor(aggregator, common_tags):
     # fmt: off
     """Add the following to the snmprec
 1.3.6.1.2.1.99.1.1.1.1.8|2|9


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Rename to assert_extend_generic_entity_sensor to match profile name

### Motivation
<!-- What inspired you to submit this pull request? -->

`assert_extend_*` should match the profile name `_generic-entity-sensor.yaml`

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.