### PR TITLE
Remove deprecated service check group

### DIFF
--- a/vsphere/assets/service_checks.json
+++ b/vsphere/assets/service_checks.json
@@ -9,8 +9,7 @@
         ],
         "groups": [
             "host",
-            "vcenter_server",
-            "vcenter_host"
+            "vcenter_server"
         ],
         "name": "Can Connect",
         "description": "Returns status after pinging your vCenter instance. Additional information about response status at the time of collection is included in the check message."


### PR DESCRIPTION
### What does this PR do?
Removes `vcenter_host` group from the service checks definition
### Motivation
This tag is only sent on service checks from the legacy implementation of the check
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.