### PR TITLE
Add more metrics that we check to autoenable integration tile.

### DIFF
--- a/airbyte/manifest.json
+++ b/airbyte/manifest.json
@@ -22,7 +22,11 @@
       "source_type_name": "Airbyte",
       "metrics": {
         "prefix": "airbyte.",
-        "check": "airbyte.metrics_reporter.est_num_metrics_emitted_by_reporter",
+        "check": [
+            "airbyte.metrics_reporter.est_num_metrics_emitted_by_reporter",
+            "airbyte.worker.attempt.created",
+            "airbyte.cron.jobs_run"
+        ],
         "metadata_path": "metadata.csv"
       },
       "service_checks": {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add 2 more metrics to check for when deciding to autoenable the integration tile.
### Motivation
<!-- What inspired you to submit this pull request? -->
Airbyte may not submit the metric we initially added, but it will definitely submit at least one of the 3 metrics we will have after this PR is merged.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.