### PR TITLE
Add a diagnostic for TLS certificate files

### DIFF
--- a/mongo/tests/test_diagnose.py
+++ b/mongo/tests/test_diagnose.py
@@ -1,0 +1,51 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+from operator import itemgetter
+
+from datadog_checks.base.utils.diagnose import Diagnosis
+
+
+def test_no_diagnosis_when_no_certificates_are_specified(instance, check):
+    mongo_check = check(instance)
+    diagnoses = json.loads(mongo_check.get_diagnoses())
+    assert len(diagnoses) == 0
+
+
+def test_certificate_files_success(instance, check, tmp_path):
+    certificate_key_path = tmp_path / 'client.pem'
+    ca_path = tmp_path / 'ca.pem'
+
+    # Create dummy certificate files
+    certificate_key_path.touch()
+    ca_path.touch()
+
+    instance['tls_certificate_key_file'] = str(certificate_key_path)
+    instance['tls_ca_file'] = str(ca_path)
+
+    mongo_check = check(instance)
+    diagnoses = sorted(json.loads(mongo_check.get_diagnoses()), key=itemgetter('diagnosis'))
+    assert len(diagnoses) == 2
+    assert diagnoses[0]['result'] == Diagnosis.DIAGNOSIS_SUCCESS
+    assert str(ca_path) in diagnoses[0]['diagnosis']
+    assert diagnoses[1]['result'] == Diagnosis.DIAGNOSIS_SUCCESS
+    assert str(certificate_key_path) in diagnoses[1]['diagnosis']
+
+
+def test_certificate_files_failure_not_exist(instance, check, tmp_path):
+    certificate_key_path = tmp_path / 'client.pem'
+    ca_path = tmp_path / 'ca.pem'
+
+    instance['tls_certificate_key_file'] = str(certificate_key_path)
+    instance['tls_ca_file'] = str(ca_path)
+
+    mongo_check = check(instance)
+    diagnoses = sorted(json.loads(mongo_check.get_diagnoses()), key=itemgetter('diagnosis'))
+    assert len(diagnoses) == 2
+    assert diagnoses[0]['result'] == Diagnosis.DIAGNOSIS_FAIL
+    assert str(ca_path) in diagnoses[0]['diagnosis']
+    assert "does not exist" in diagnoses[0]['diagnosis']
+    assert diagnoses[1]['result'] == Diagnosis.DIAGNOSIS_FAIL
+    assert str(certificate_key_path) in diagnoses[1]['diagnosis']
+    assert "does not exist" in diagnoses[1]['diagnosis']


### PR DESCRIPTION
### What does this PR do?

Implements a diagnostic to help users detect if the certificates they specify in their config exist and are readable.

### Motivation

Proof of concept for the use of diagnostics as introduced by https://github.com/DataDog/integrations-core/pull/14394.
[ASUP-14](https://datadoghq.atlassian.net/browse/ASUP-14)

### Additional Notes

This still needs a new release of the base check to include #14394 and a bump to the minimum base version before actually getting merged.

I struggled to come up with good pragmatic ideas for diagnostics for this integration. Other than the one I actually implemented, I considered trying to check that the configured users had the necessary permissions on the Mongo database as required by our integration, but that proved difficult to do (partly because it's not even clear to me what permissions our integration _actually_ needs.

The diagnostic that I actually implemented is based on what `pymongo` actually already does under the hood. In fact, the client would normally raise a somewhat clear exception when you try to instantiate the client with a non-existing certificate file:

```
cl = MongoClient(tlsCertificateKeyFile='nonexisting')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/pymongo/mongo_client.py", line 771, in __init__
    dict(common.validate(keyword_opts.cased_key(k), v) for k, v in keyword_opts.items())
  File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/pymongo/mongo_client.py", line 771, in <genexpr>
    dict(common.validate(keyword_opts.cased_key(k), v) for k, v in keyword_opts.items())
  File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/pymongo/common.py", line 780, in validate
    value = validator(option, value)
  File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/pymongo/common.py", line 223, in validate_readable
    open(value, "r").close()
FileNotFoundError: [Errno 2] No such file or directory: 'nonexisting'
```

However, this is mostly swallowed by our current implementation of the integration (transformed into a `CRITICAL` service check with no further information), and only visible in the logs. In this sense, such a diagnostic as this one could make some sense.

At the same time, it's unclear to me that such a diagnostic would be preferable to simply raising an exception during the normal check run so that a message would be shown on `agent status`. I'm not sure the value added by this diagnostic offsets the potential increase in maintenance costs (especially if we want to have all of this reasonably well tested) for a diagnostic such as this one.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.

[ASUP-14]: https://datadoghq.atlassian.net/browse/ASUP-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ