### PR TITLE
Mark the `calico.felix.iptables.restore_calls.count` metric optional in the e2e tests

### DIFF
--- a/calico/tests/common.py
+++ b/calico/tests/common.py
@@ -52,4 +52,5 @@ MOCK_CALICO_INSTANCE = {
 OPTIONAL_METRICS = {
     'calico.felix.ipset.calls.count',
     'calico.felix.ipset.errors.count',
+    'calico.felix.iptables.restore_calls.count',
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Mark the `calico.felix.iptables.restore_calls.count` metric optional in the e2e tests

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/actions/runs/5758934015/job/15612228195

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.