### PR TITLE
Remove disable_generic_tags from the example yaml

### DIFF
--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -683,6 +683,10 @@ files:
         example: false
         display_default: false
     - template: instances/default
+      overrides:
+        disable_generic_tags.hidden: False
+        disable_generic_tags.enabled: True
+        disable_generic_tags.description: The integration will stop sending server tag as is reduntant with host tag
   - template: logs
     example:
     - type: file

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -683,10 +683,6 @@ files:
         example: false
         display_default: false
     - template: instances/default
-      overrides:
-        disable_generic_tags.hidden: False
-        disable_generic_tags.enabled: True
-        disable_generic_tags.description: The integration will stop sending server tag as is reduntant with host tag
   - template: logs
     example:
     - type: file

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -1,519 +1,513 @@
 name: SQL Server
 files:
-- name: sqlserver.yaml
-  options:
-  - template: init_config
+  - name: sqlserver.yaml
     options:
-    - name: custom_metrics
-      description: |
-        Collect custom metrics and send them to Datadog based on
-        your SQL server counters.
+      - template: init_config
+        options:
+          - name: custom_metrics
+            description: |
+              Collect custom metrics and send them to Datadog based on
+              your SQL server counters.
 
-        See https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/
-      value:
-        type: array
-        items:
-          type: object
+              See https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/
+            value:
+              type: array
+              items:
+                type: object
+              example:
+                - name: sqlserver.clr.execution
+                  counter_name: CLR Execution
+          - template: init_config/db
+          - template: init_config/default
+      - template: instances
+        description: |
+          Every instance is scheduled independent of the others.
+
+          Note: All '%' characters must be escaped as '%%'.
+        options:
+          - name: host
+            description: |
+              Host and port of your SQL server. If a port is ommitted, a default port of 1433 will be used. 
+              If you use Sql Server Browser Service or a similar port autodiscovery service, pass in a port
+              of 0 to omit port from your connection string. This should allow SSBS to autodiscover the 
+              correct database port.
+            required: true
+            value:
+              type: string
+              example: <HOST>,<PORT>
+          - name: username
+            description: Username for the Datadog-SQL server check user. It will be ignored if using Windows authentication.
+            value:
+              type: string
+          - name: password
+            description: Password for the Datadog-SQL server check user. It will be ignored if using Windows authentication.
+            value:
+              type: string
+          - name: server_version
+            description: |
+              Server version year of sqlserver the agent will connect to. 
+              Important for validating connection string attributes for older sqlserver versions.
+
+              This is required if connecting to a SQLServer instance older than 2014.
+            value:
+              type: string
+              example: "2014"
+          - name: database
+            description: |
+              Database name to query.  Not compatible with `database_autodiscovery`.
+            value:
+              type: string
+              example: master
+          - name: reported_hostname
+            description: |
+              Set the reported hostname for this instance. This value overrides the hostname detected by the Agent
+              and can be useful to set a custom hostname when connecting to a remote database through a proxy.
+            value:
+              type: string
+          - name: database_autodiscovery
+            description: |
+              Auto-discover and monitor databases. Supported for the metrics check. 
+              If `true`, overrides `database` option.
+              Can be combined with `autodiscovery_include` and `autodiscovery_exclude` options.
+            value:
+              type: boolean
+              example: false
+          - name: autodiscovery_include
+            description: |
+              Regular expression for database names to include as part of `database_autodiscovery`.
+              Will report metrics for databases that are found in this instance, ignores databases listed but not found.
+
+              Character casing is ignored. The regular expressions start matching from the beginning, so
+              to match anywhere, prepend `.*`. For exact matches append `$`.
+
+              Defaults to `.*` to include everything.
+            value:
+              type: array
+              items:
+                type: string
+              example:
+                - master$
+                - AdventureWorks.*
+          - name: autodiscovery_exclude
+            description: |
+              Regular expression for database names to exclude as part of `database_autodiscovery`.
+
+              Character casing is ignored. The regular expressions start matching from the beginning, so
+              to match anywhere, prepend `.*`. For exact matches append `$`.
+
+              In case of conflicts, database exclusion via `autodiscovery_exclude` takes precedence over
+              those found via `autodiscovery_include`.
+            value:
+              type: array
+              items:
+                type: string
+              example:
+                - model
+                - msdb
+          - name: database_autodiscovery_interval
+            description: |
+              Frequency in seconds of scans for new databases.  Defaults to `3600`.
+            value:
+              type: integer
+              example: 3600
+          - name: autodiscovery_db_service_check
+            description: |
+              When enabled with database autodiscovery, attempts to connect to the list of
+              autodiscovered databases and submits a service check that signifies whether
+              the agent can connect to that database or not.
+            enabled: true
+            value:
+              type: boolean
+              example: false
+              display_default: true
+          - name: include_ao_metrics
+            description: |
+              Include AlwaysOn availability group metrics.
+            value:
+              type: boolean
+              example: false
+          - name: availability_group
+            description: |
+              You can specify an availability group when `include_ao_metrics`
+              is enabled to monitor a specific availability group.
+              If no availability group is specified, then all availability
+              groups on the current replica will output metrics.
+            value:
+              type: string
+          - name: only_emit_local
+            description: |
+              Primary replicas may emit metrics for remote secondary replicas
+              in the same availability group. If this option is set to true,
+              the primary replica will only emit information local to itself.
+            value:
+              type: boolean
+              example: false
+          - name: ao_database
+            description: |
+              AlwaysOn metrics are only emitted for the selected `ao_database` if not empty.
+            value:
+              type: string
+          - name: include_master_files_metrics
+            description: |
+              Include database file size and state from `sys.master_files`.
+            value:
+              type: boolean
+              example: false
+          - name: include_fci_metrics
+            description: |
+              Include Failover Cluster Instance metrics. Note that these metrics
+              requires a SQLServer set up with Failover Clustering enabled.
+            value:
+              type: boolean
+              example: false
+          - name: include_instance_metrics
+            description: |
+              Include server-level instance metrics.  When setting up multiple instances for
+              different databases on the same host these metrics will be duplicated unless this option is turned off.
+            value:
+              type: boolean
+              example: true
+          - name: include_task_scheduler_metrics
+            description: Include additional Task and Scheduler metrics.
+            value:
+              type: boolean
+              example: false
+          - name: include_db_fragmentation_metrics
+            description: |
+              Include database fragmentation metrics. Note these queries can be resource intensive on large datasets.
+              Recommend to limit these via autodiscovery or specific database instances.
+            value:
+              type: boolean
+              example: false
+          - name: db_fragmentation_object_names
+            description: |
+              Fragmentation metrics normally emit metrics for all objects within a database.
+              This option allows you to specify database object names to query for fragmentation metrics.
+              Note: Each object name is unique to each database.
+            value:
+              type: array
+              items:
+                type: string
+          - name: adoprovider
+            description: |
+              Choose the ADO provider.  Note that the (default) provider
+              SQLOLEDB is being deprecated.  To use the newer MSOLEDBSQL
+              provider, set the adoprovider to "MSOLEDBSQL" below or "MSOLEDBSQL19" for version 19 of the driver.
+              You will also need to download the new provider from
+              https://docs.microsoft.com/en-us/sql/connect/oledb/oledb-driver-for-sql-server?view=sql-server-2017
+            value:
+              type: string
+              example: SQLOLEDB
+          - name: connector
+            description: |
+              Change the connection method from adodbapi (the default) to
+              odbc (valid connector names are 'odbc' and 'adodbapi')
+              Note: 'adodbapi` is only available on Windows
+            value:
+              type: string
+              example: adodbapi
+          - name: driver
+            description: If using odbc, use the named driver.
+            value:
+              type: string
+              example: SQL Server
+          - name: dsn
+            description: If using odbc, configure a connection using a DSN.
+            value:
+              type: string
+          - name: connection_string
+            description: |
+              Specify a custom connection string to be used
+              Ex: "ApplicationIntent=ReadWrite" or "Trusted_Connection=Yes" to use Windows Authentication
+              (note that in this case the connection will be performed with the `ddagentuser` user, you can
+              find more information about this user in https://docs.datadoghq.com/agent/faq/windows-agent-ddagent-user/)
+
+              Please note that certain connection string values will vary depending on the connection Provider used,
+              for example:
+              * "OLE DB" provider uses "MultiSubnetFailover=Yes"
+              * "ADO" provider uses "MultiSubnetFailover=True"
+            value:
+              type: string
+              example: "<CONNECTION_STRING>"
+          - name: dbm
+            description: |
+              Set to `true` to enable Database Monitoring.
+            value:
+              type: boolean
+              example: false
+              display_default: false
+          - name: query_metrics
+            description: Configure collection of query metrics
+            options:
+              - name: enabled
+                description: |
+                  Enable collection of query metrics. Requires `dbm: true`.
+                value:
+                  type: boolean
+                  example: true
+              - name: disable_secondary_tags
+                description: |
+                  Disable the secondary tags on query aggregate metrics, such as `user` and `database`. This is an optimization 
+                  for certain database workloads which result in long metric collection times.
+                value:
+                  type: boolean
+                  example: false
+                hidden: true
+              - name: collection_interval
+                description: |
+                  Set the query metric collection interval (in seconds). Each collection involves one or more queries to
+                  the SQL Server Query Plan Cache. If a non-default value is chosen then that exact same value must be used
+                  for *every* check instance. Running different instances with different collection intervals is not supported.
+                value:
+                  type: number
+                  example: 60
+              - name: dm_exec_query_stats_row_limit
+                description: |
+                  Set the maximum number of query stats rows that can be retrieved in a single check run.
+                value:
+                  type: integer
+                  example: 10000
+              - name: samples_per_hour_per_query
+                description: |
+                  Set the rate limit for the number of query sample events that are ingested per hour and per normalized
+                  execution plan.
+                value:
+                  type: integer
+                  example: 4
+              - name: enforce_collection_interval_deadline
+                description: |
+                  By default, plan collection stops if it is time for the next run of the query metrics & plans loop. This
+                  means that some plans may not be collected. If it is necessary to collect all of the plans and in doing so
+                  cause delays in collecting query metrics, then this deadline can be disabled by setting this option to
+                  false.
+                value:
+                  type: boolean
+                  example: True
+                hidden: true
+              - name: max_queries
+                description: |
+                  Limit the number of queries sent to the backend. 
+                  Note: The only time this value would need to be set is in special cases where the query limit
+                  applied on the backend is being modified.
+                value:
+                  type: integer
+                  example: 250
+                  display_default: 250
+                hidden: true
+          - name: query_activity
+            description: Configure collection of active sessions monitoring
+            options:
+              - name: enabled
+                description: |
+                  Enable collection of active sessions. Requires `dbm: true`.
+                value:
+                  type: boolean
+                  example: true
+              - name: collection_interval
+                description: |
+                  Set the activity collection interval in seconds. Each collection involves querying several
+                  different DMV tables such as `dm_exec_requests`, `dm_exec_sessions`, and `dm_exec_sql_text`.
+                  If a non-default value is chosen, then that exact same value must be used for *every* check instance.
+                  Running different instances with different collection intervals is not supported.
+                value:
+                  type: number
+                  example: 10
+
+          - name: aws
+            description: |
+              This block defines the configuration for AWS RDS and Aurora instances. 
+
+              Complete this section if you have installed the Datadog AWS Integration 
+              (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+              with SQL Server integration telemetry.
+
+              These values are only applied when `dbm: true` option is set.
+            options:
+              - name: instance_endpoint
+                description: |
+                  Equal to the Endpoint.Address of the instance the agent is connecting to. 
+                  This value is optional if the value of `host` is already configured to the instance endpoint.
+
+                  For more information on instance endpoints, 
+                  see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
+                value:
+                  type: string
+                  example: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+
+          - name: gcp
+            description: |
+              This block defines the configuration for Google Cloud SQL instances.
+
+              Complete this section if you have installed the Datadog GCP Integration 
+              (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+              with SQL Server integration telemetry.
+
+              These values are only applied when `dbm: true` option is set.
+            options:
+              - name: project_id
+                description: |
+                  Equal to the GCP resource's project ID.
+
+                  For more information on project IDs,
+                  See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
+                value:
+                  type: string
+                  example: foo-project
+              - name: instance_id
+                description: |
+                  Equal to the GCP resource's instance ID.
+
+                  For more information on instance IDs,
+                  See the GCP docs https://cloud.google.com/sql/docs/sqlserver/instance-settings#instance-id-2ndgen
+                value:
+                  type: string
+                  example: foo-database
+
+          - name: azure
+            description: |
+              This block defines the configuration for Azure Managed Instance, Azure SQL Database or 
+              SQLServer on Virtual Machines.
+
+              Complete this section if you have installed the Datadog Azure Integration 
+              (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+              with SQL Server integration telemetry.
+
+              These values are only applied when `dbm: true` option is set.
+            options:
+              - name: deployment_type
+                description: |
+                  Equal to the deployment type for the managed database. 
+
+                  Acceptable values are:
+                    - `sql_database` 
+                    - `managed_instance`
+                    - `virtual_machine`
+
+                  For more information on deployment types, see the Azure
+                  docs https://docs.microsoft.com/en-us/azure/azure-sql/azure-sql-iaas-vs-paas-what-is-overview?view=azuresql
+                value:
+                  type: string
+                  example: sql_database
+              - name: fully_qualified_domain_name
+                description: |
+                  Equal to the name of the SQL Database, Managed Instance (SQL MI) or virtual machine.
+
+                  This value is optional if the value of `host` is already configured to the fully qualified domain name.
+                value:
+                  type: string
+                  example: my-sqlserver-database.database.windows.net
+
+          - name: obfuscator_options
+            description: |
+              Configure how the SQL obfuscator behaves.
+              Note: This option only applies when `dbm` is enabled.
+            options:
+              - name: replace_digits
+                description: |
+                  Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
+                  Note: This option also applies to extracted tables using `collect_tables`.
+                value:
+                  type: boolean
+                  example: false
+              - name: collect_metadata
+                description: |
+                  Set to `false` to disable the collection of metadata in your SQL statements.
+                  Metadata includes things such as tables, commands, and comments.
+                value:
+                  type: boolean
+                  example: true
+              - name: collect_tables
+                description: |
+                  Set to `false` to disable the collection of tables in your SQL statements.
+                  Requires `collect_metadata: true`.
+                value:
+                  type: boolean
+                  example: true
+              - name: collect_commands
+                description: |
+                  Set to `false` to disable the collection of commands in your SQL statements.
+                  Requires `collect_metadata: true`.
+
+                  Examples: SELECT, UPDATE, DELETE, etc.
+                value:
+                  type: boolean
+                  example: true
+              - name: collect_comments
+                description: |
+                  Set to `false` to disable the collection of comments in your SQL statements.
+                  Requires `collect_metadata: true`.
+                value:
+                  type: boolean
+                  example: true
+              - name: keep_sql_alias
+                description: |
+                  Set to `true` to keep sql aliases in obfuscated SQL statements. Examples of aliases are
+                  `with select 1 as alias`, `select column as other_name`, or `select * from table t`.
+                  When `true` these aliases will not be removed.
+                value:
+                  type: boolean
+                  example: true
+                  display_default: true
+          - name: log_unobfuscated_queries
+            hidden: true
+            description: |
+              Set to `true` to enable logging of original unobfuscated SQL queries when obfuscation errors occur.
+              For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
+              Note: This option only applies when `dbm` is enabled.
+            value:
+              type: boolean
+              example: false
+              display_default: false
+          - name: log_unobfuscated_plans
+            hidden: true
+            description: |
+              Set to `true` to enable logging of original unobfuscated SQL plans when obfuscation errors occur.
+              For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
+              Note: This option only applies when `dbm` is enabled.
+            value:
+              type: boolean
+              example: false
+              display_default: false
+          - name: command_timeout
+            description: Timeout in seconds for the connection and each command run
+            value:
+              type: integer
+              example: 10
+          - template: instances/db
+          - name: stored_procedure
+            description: |
+              DEPRECATED - use `custom_queries` instead. For guidance, see:
+              https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/
+              Get metrics from custom proc in MyDB but only if the database is writable
+              (i.e. it's the master in an availability group) Note: Custom proc must be defined in its own instance
+            value:
+              type: string
+              example: <PROCEDURE_NAME>
+          - name: proc_only_if
+            description: Run this SQL before each call to `stored_procedure`. Only if it returns 1 then call the proc.
+            value:
+              type: string
+              example: <SQL_QUERY>
+          - name: proc_only_if_database
+            description: The database to run the `proc_only_if` SQL in.
+            value:
+              type: string
+              example: master
+          - name: ignore_missing_database
+            description: If the DB specified doesn't exist on the server then don't do the check
+            value:
+              type: boolean
+              example: false
+          - template: instances/default
+
+      - template: logs
         example:
-          - name: sqlserver.clr.execution
-            counter_name: CLR Execution
-    - template: init_config/db
-    - template: init_config/default
-  - template: instances
-    description: |
-      Every instance is scheduled independent of the others.
-
-      Note: All '%' characters must be escaped as '%%'.
-    options:
-    - name: host
-      description: | 
-        Host and port of your SQL server. If a port is ommitted, a default port of 1433 will be used. 
-        If you use Sql Server Browser Service or a similar port autodiscovery service, pass in a port
-        of 0 to omit port from your connection string. This should allow SSBS to autodiscover the 
-        correct database port. 
-      required: true
-      value:
-        type: string
-        example: <HOST>,<PORT>
-    - name: username
-      description: Username for the Datadog-SQL server check user. It will be ignored if using Windows authentication.
-      value:
-        type: string
-    - name: password
-      description: Password for the Datadog-SQL server check user. It will be ignored if using Windows authentication.
-      value:
-        type: string
-    - name: server_version
-      description: |
-        Server version year of sqlserver the agent will connect to. 
-        Important for validating connection string attributes for older sqlserver versions.
-        
-        This is required if connecting to a SQLServer instance older than 2014.
-      value:
-        type: string
-        example: "2014"
-    - name: database
-      description: |
-        Database name to query.  Not compatible with `database_autodiscovery`.
-      value:
-        type: string
-        example: master
-    - name: reported_hostname
-      description: |
-        Set the reported hostname for this instance. This value overrides the hostname detected by the Agent
-        and can be useful to set a custom hostname when connecting to a remote database through a proxy.
-      value:
-        type: string
-    - name: database_autodiscovery
-      description: |
-        Auto-discover and monitor databases. Supported for the metrics check. 
-        If `true`, overrides `database` option.
-        Can be combined with `autodiscovery_include` and `autodiscovery_exclude` options.
-      value:
-        type: boolean
-        example: false
-    - name: autodiscovery_include
-      description: |
-        Regular expression for database names to include as part of `database_autodiscovery`.
-        Will report metrics for databases that are found in this instance, ignores databases listed but not found.
-
-        Character casing is ignored. The regular expressions start matching from the beginning, so
-        to match anywhere, prepend `.*`. For exact matches append `$`.
-
-        Defaults to `.*` to include everything.
-      value:
-        type: array
-        items:
-          type: string
-        example:
-          - master$
-          - AdventureWorks.*
-    - name: autodiscovery_exclude
-      description: |
-        Regular expression for database names to exclude as part of `database_autodiscovery`.
-
-        Character casing is ignored. The regular expressions start matching from the beginning, so
-        to match anywhere, prepend `.*`. For exact matches append `$`.
-
-        In case of conflicts, database exclusion via `autodiscovery_exclude` takes precedence over
-        those found via `autodiscovery_include`.
-      value:
-        type: array
-        items:
-          type: string
-        example:
-          - model
-          - msdb
-    - name: database_autodiscovery_interval
-      description: |
-        Frequency in seconds of scans for new databases.  Defaults to `3600`.
-      value:
-        type: integer
-        example: 3600
-    - name: autodiscovery_db_service_check
-      description: |
-        When enabled with database autodiscovery, attempts to connect to the list of
-        autodiscovered databases and submits a service check that signifies whether
-        the agent can connect to that database or not.
-      enabled: true
-      value:
-        type: boolean
-        example: false
-        display_default: true
-    - name: include_ao_metrics
-      description: |
-        Include AlwaysOn availability group metrics.
-      value:
-        type: boolean
-        example: false
-    - name: availability_group
-      description: |
-        You can specify an availability group when `include_ao_metrics`
-        is enabled to monitor a specific availability group.
-        If no availability group is specified, then all availability
-        groups on the current replica will output metrics.
-      value:
-        type: string
-    - name: only_emit_local
-      description: |
-        Primary replicas may emit metrics for remote secondary replicas
-        in the same availability group. If this option is set to true,
-        the primary replica will only emit information local to itself.
-      value:
-        type: boolean
-        example: false
-    - name: ao_database
-      description: |
-        AlwaysOn metrics are only emitted for the selected `ao_database` if not empty.
-      value:
-        type: string
-    - name: include_master_files_metrics
-      description: |
-        Include database file size and state from `sys.master_files`.
-      value:
-        type: boolean
-        example: false
-    - name: include_fci_metrics
-      description: |
-        Include Failover Cluster Instance metrics. Note that these metrics
-        requires a SQLServer set up with Failover Clustering enabled.
-      value:
-        type: boolean
-        example: false
-    - name: include_instance_metrics
-      description: |
-        Include server-level instance metrics.  When setting up multiple instances for
-        different databases on the same host these metrics will be duplicated unless this option is turned off.
-      value:
-        type: boolean
-        example: true
-    - name: include_task_scheduler_metrics
-      description: Include additional Task and Scheduler metrics.
-      value:
-        type: boolean
-        example: false
-    - name: include_db_fragmentation_metrics
-      description: |
-        Include database fragmentation metrics. Note these queries can be resource intensive on large datasets.
-        Recommend to limit these via autodiscovery or specific database instances.
-      value:
-        type: boolean
-        example: false
-    - name: db_fragmentation_object_names
-      description: |
-        Fragmentation metrics normally emit metrics for all objects within a database.
-        This option allows you to specify database object names to query for fragmentation metrics.
-        Note: Each object name is unique to each database.
-      value:
-        type: array
-        items:
-          type: string
-    - name: adoprovider
-      description: |
-        Choose the ADO provider.  Note that the (default) provider
-        SQLOLEDB is being deprecated.  To use the newer MSOLEDBSQL
-        provider, set the adoprovider to "MSOLEDBSQL" below or "MSOLEDBSQL19" for version 19 of the driver.
-        You will also need to download the new provider from
-        https://docs.microsoft.com/en-us/sql/connect/oledb/oledb-driver-for-sql-server?view=sql-server-2017
-      value:
-        type: string
-        example: SQLOLEDB
-    - name: connector
-      description: |
-        Change the connection method from adodbapi (the default) to
-        odbc (valid connector names are 'odbc' and 'adodbapi')
-        Note: 'adodbapi` is only available on Windows
-      value:
-        type: string
-        example: adodbapi
-    - name: driver
-      description: If using odbc, use the named driver.
-      value:
-        type: string
-        example: SQL Server
-    - name: dsn
-      description: If using odbc, configure a connection using a DSN.
-      value:
-        type: string
-    - name: connection_string
-      description: |
-        Specify a custom connection string to be used
-        Ex: "ApplicationIntent=ReadWrite" or "Trusted_Connection=Yes" to use Windows Authentication
-        (note that in this case the connection will be performed with the `ddagentuser` user, you can
-        find more information about this user in https://docs.datadoghq.com/agent/faq/windows-agent-ddagent-user/)
-
-        Please note that certain connection string values will vary depending on the connection Provider used,
-        for example:
-        * "OLE DB" provider uses "MultiSubnetFailover=Yes"
-        * "ADO" provider uses "MultiSubnetFailover=True"
-      value:
-        type: string
-        example: "<CONNECTION_STRING>"
-    - name: dbm
-      description: |
-        Set to `true` to enable Database Monitoring.
-      value:
-        type: boolean
-        example: false
-        display_default: false
-    - name: query_metrics
-      description: Configure collection of query metrics
-      options:
-        - name: enabled
-          description: |
-            Enable collection of query metrics. Requires `dbm: true`.
-          value:
-            type: boolean
-            example: true
-        - name: disable_secondary_tags
-          description: |
-            Disable the secondary tags on query aggregate metrics, such as `user` and `database`. This is an optimization 
-            for certain database workloads which result in long metric collection times.
-          value:
-            type: boolean
-            example: false
-          hidden: true
-        - name: collection_interval
-          description: |
-            Set the query metric collection interval (in seconds). Each collection involves one or more queries to
-            the SQL Server Query Plan Cache. If a non-default value is chosen then that exact same value must be used
-            for *every* check instance. Running different instances with different collection intervals is not supported.
-          value:
-            type: number
-            example: 60
-        - name: dm_exec_query_stats_row_limit
-          description: |
-            Set the maximum number of query stats rows that can be retrieved in a single check run.
-          value:
-            type: integer
-            example: 10000
-        - name: samples_per_hour_per_query
-          description: |
-            Set the rate limit for the number of query sample events that are ingested per hour and per normalized
-            execution plan.
-          value:
-            type: integer
-            example: 4
-        - name: enforce_collection_interval_deadline
-          description: |
-            By default, plan collection stops if it is time for the next run of the query metrics & plans loop. This
-            means that some plans may not be collected. If it is necessary to collect all of the plans and in doing so
-            cause delays in collecting query metrics, then this deadline can be disabled by setting this option to
-            false.
-          value:
-            type: boolean
-            example: True
-          hidden: true
-        - name: max_queries
-          description: |
-            Limit the number of queries sent to the backend. 
-            Note: The only time this value would need to be set is in special cases where the query limit
-            applied on the backend is being modified.
-          value:
-            type: integer
-            example: 250
-            display_default: 250
-          hidden: true
-    - name: query_activity
-      description: Configure collection of active sessions monitoring
-      options:
-        - name: enabled
-          description: |
-            Enable collection of active sessions. Requires `dbm: true`.
-          value:
-            type: boolean
-            example: true
-        - name: collection_interval
-          description: |
-            Set the activity collection interval in seconds. Each collection involves querying several
-            different DMV tables such as `dm_exec_requests`, `dm_exec_sessions`, and `dm_exec_sql_text`.
-            If a non-default value is chosen, then that exact same value must be used for *every* check instance.
-            Running different instances with different collection intervals is not supported.
-          value:
-            type: number
-            example: 10
-
-    - name: aws
-      description: |
-        This block defines the configuration for AWS RDS and Aurora instances. 
-        
-        Complete this section if you have installed the Datadog AWS Integration 
-        (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
-        with SQL Server integration telemetry.
-        
-        These values are only applied when `dbm: true` option is set.
-      options:
-        - name: instance_endpoint
-          description: |
-            Equal to the Endpoint.Address of the instance the agent is connecting to. 
-            This value is optional if the value of `host` is already configured to the instance endpoint.
-            
-            For more information on instance endpoints, 
-            see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
-          value:
-            type: string
-            example: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
-
-    - name: gcp
-      description: |
-        This block defines the configuration for Google Cloud SQL instances.
-        
-        Complete this section if you have installed the Datadog GCP Integration 
-        (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
-        with SQL Server integration telemetry.
-
-        These values are only applied when `dbm: true` option is set.
-      options:
-        - name: project_id
-          description: |
-            Equal to the GCP resource's project ID.
-            
-            For more information on project IDs,
-            See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
-          value:
-            type: string
-            example: foo-project
-        - name: instance_id
-          description: |
-            Equal to the GCP resource's instance ID.
-            
-            For more information on instance IDs,
-            See the GCP docs https://cloud.google.com/sql/docs/sqlserver/instance-settings#instance-id-2ndgen
-          value:
-            type: string
-            example: foo-database
-
-    - name: azure
-      description: |
-        This block defines the configuration for Azure Managed Instance, Azure SQL Database or 
-        SQLServer on Virtual Machines.
-        
-        Complete this section if you have installed the Datadog Azure Integration 
-        (https://docs.datadoghq.com/integrations/azure) to enrich instances 
-        with SQL Server integration telemetry.
-
-        These values are only applied when `dbm: true` option is set.
-      options:
-        - name: deployment_type
-          description: |
-            Equal to the deployment type for the managed database. 
-            
-            Acceptable values are:
-              - `sql_database` 
-              - `managed_instance`
-              - `virtual_machine`
-            
-            For more information on deployment types, see the Azure
-            docs https://docs.microsoft.com/en-us/azure/azure-sql/azure-sql-iaas-vs-paas-what-is-overview?view=azuresql
-          value:
-            type: string
-            example: sql_database
-        - name: fully_qualified_domain_name
-          description: |
-            Equal to the name of the SQL Database, Managed Instance (SQL MI) or virtual machine.
-            
-            This value is optional if the value of `host` is already configured to the fully qualified domain name.
-          value:
-            type: string
-            example: my-sqlserver-database.database.windows.net
-
-    - name: obfuscator_options
-      description: |
-        Configure how the SQL obfuscator behaves.
-        Note: This option only applies when `dbm` is enabled.
-      options:
-        - name: replace_digits
-          description: |
-            Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
-            Note: This option also applies to extracted tables using `collect_tables`.
-          value:
-            type: boolean
-            example: false
-        - name: collect_metadata
-          description: |
-            Set to `false` to disable the collection of metadata in your SQL statements.
-            Metadata includes things such as tables, commands, and comments.
-          value:
-            type: boolean
-            example: true
-        - name: collect_tables
-          description: |
-            Set to `false` to disable the collection of tables in your SQL statements.
-            Requires `collect_metadata: true`.
-          value:
-            type: boolean
-            example: true
-        - name: collect_commands
-          description: |
-            Set to `false` to disable the collection of commands in your SQL statements.
-            Requires `collect_metadata: true`.
-
-            Examples: SELECT, UPDATE, DELETE, etc.
-          value:
-            type: boolean
-            example: true
-        - name: collect_comments
-          description: |
-            Set to `false` to disable the collection of comments in your SQL statements.
-            Requires `collect_metadata: true`.
-          value:
-            type: boolean
-            example: true
-        - name: keep_sql_alias
-          description: |
-            Set to `true` to keep sql aliases in obfuscated SQL statements. Examples of aliases are
-            `with select 1 as alias`, `select column as other_name`, or `select * from table t`.
-            When `true` these aliases will not be removed.
-          value:
-            type: boolean
-            example: true
-            display_default: true
-    - name: log_unobfuscated_queries
-      hidden: true
-      description: |
-        Set to `true` to enable logging of original unobfuscated SQL queries when obfuscation errors occur.
-        For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
-        Note: This option only applies when `dbm` is enabled.
-      value:
-        type: boolean
-        example: false
-        display_default: false
-    - name: log_unobfuscated_plans
-      hidden: true
-      description: |
-        Set to `true` to enable logging of original unobfuscated SQL plans when obfuscation errors occur.
-        For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
-        Note: This option only applies when `dbm` is enabled.
-      value:
-        type: boolean
-        example: false
-        display_default: false
-    - name: command_timeout
-      description: Timeout in seconds for the connection and each command run
-      value:
-        type: integer
-        example: 10
-    - template: instances/db
-    - name: stored_procedure
-      description: |
-        DEPRECATED - use `custom_queries` instead. For guidance, see:
-        https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/
-        Get metrics from custom proc in MyDB but only if the database is writable
-        (i.e. it's the master in an availability group) Note: Custom proc must be defined in its own instance
-      value:
-        type: string
-        example: <PROCEDURE_NAME>
-    - name: proc_only_if
-      description: Run this SQL before each call to `stored_procedure`. Only if it returns 1 then call the proc.
-      value:
-        type: string
-        example: <SQL_QUERY>
-    - name: proc_only_if_database
-      description: The database to run the `proc_only_if` SQL in.
-      value:
-        type: string
-        example: master
-    - name: ignore_missing_database
-      description: If the DB specified doesn't exist on the server then don't do the check
-      value:
-        type: boolean
-        example: false
-    - template: instances/default
-      overrides:
-        disable_generic_tags.hidden: False
-        disable_generic_tags.enabled: True
-        disable_generic_tags.description: |
-            Generic tags such as `host` are replaced by `sqlserver_host` to avoid
-            getting mixed with other integration tags.
-
-  - template: logs
-    example:
-    - type: file
-      path: /var/opt/mssql/log/errorlog
-      source: sqlserver
-      encoding: utf-16-le
-      service: <SERVICE_NAME>
-      log_processing_rules:
-      - type: multi_line
-        name: new_log_start_with_date
-        pattern: \d{4}\-\d{2}\-\d{2}
+          - type: file
+            path: /var/opt/mssql/log/errorlog
+            source: sqlserver
+            encoding: utf-16-le
+            service: <SERVICE_NAME>
+            log_processing_rules:
+              - type: multi_line
+                name: new_log_start_with_date
+                pattern: \d{4}\-\d{2}\-\d{2}

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -1,513 +1,519 @@
 name: SQL Server
 files:
-  - name: sqlserver.yaml
+- name: sqlserver.yaml
+  options:
+  - template: init_config
     options:
-      - template: init_config
-        options:
-          - name: custom_metrics
-            description: |
-              Collect custom metrics and send them to Datadog based on
-              your SQL server counters.
+    - name: custom_metrics
+      description: |
+        Collect custom metrics and send them to Datadog based on
+        your SQL server counters.
 
-              See https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/
-            value:
-              type: array
-              items:
-                type: object
-              example:
-                - name: sqlserver.clr.execution
-                  counter_name: CLR Execution
-          - template: init_config/db
-          - template: init_config/default
-      - template: instances
-        description: |
-          Every instance is scheduled independent of the others.
-
-          Note: All '%' characters must be escaped as '%%'.
-        options:
-          - name: host
-            description: |
-              Host and port of your SQL server. If a port is ommitted, a default port of 1433 will be used. 
-              If you use Sql Server Browser Service or a similar port autodiscovery service, pass in a port
-              of 0 to omit port from your connection string. This should allow SSBS to autodiscover the 
-              correct database port.
-            required: true
-            value:
-              type: string
-              example: <HOST>,<PORT>
-          - name: username
-            description: Username for the Datadog-SQL server check user. It will be ignored if using Windows authentication.
-            value:
-              type: string
-          - name: password
-            description: Password for the Datadog-SQL server check user. It will be ignored if using Windows authentication.
-            value:
-              type: string
-          - name: server_version
-            description: |
-              Server version year of sqlserver the agent will connect to. 
-              Important for validating connection string attributes for older sqlserver versions.
-
-              This is required if connecting to a SQLServer instance older than 2014.
-            value:
-              type: string
-              example: "2014"
-          - name: database
-            description: |
-              Database name to query.  Not compatible with `database_autodiscovery`.
-            value:
-              type: string
-              example: master
-          - name: reported_hostname
-            description: |
-              Set the reported hostname for this instance. This value overrides the hostname detected by the Agent
-              and can be useful to set a custom hostname when connecting to a remote database through a proxy.
-            value:
-              type: string
-          - name: database_autodiscovery
-            description: |
-              Auto-discover and monitor databases. Supported for the metrics check. 
-              If `true`, overrides `database` option.
-              Can be combined with `autodiscovery_include` and `autodiscovery_exclude` options.
-            value:
-              type: boolean
-              example: false
-          - name: autodiscovery_include
-            description: |
-              Regular expression for database names to include as part of `database_autodiscovery`.
-              Will report metrics for databases that are found in this instance, ignores databases listed but not found.
-
-              Character casing is ignored. The regular expressions start matching from the beginning, so
-              to match anywhere, prepend `.*`. For exact matches append `$`.
-
-              Defaults to `.*` to include everything.
-            value:
-              type: array
-              items:
-                type: string
-              example:
-                - master$
-                - AdventureWorks.*
-          - name: autodiscovery_exclude
-            description: |
-              Regular expression for database names to exclude as part of `database_autodiscovery`.
-
-              Character casing is ignored. The regular expressions start matching from the beginning, so
-              to match anywhere, prepend `.*`. For exact matches append `$`.
-
-              In case of conflicts, database exclusion via `autodiscovery_exclude` takes precedence over
-              those found via `autodiscovery_include`.
-            value:
-              type: array
-              items:
-                type: string
-              example:
-                - model
-                - msdb
-          - name: database_autodiscovery_interval
-            description: |
-              Frequency in seconds of scans for new databases.  Defaults to `3600`.
-            value:
-              type: integer
-              example: 3600
-          - name: autodiscovery_db_service_check
-            description: |
-              When enabled with database autodiscovery, attempts to connect to the list of
-              autodiscovered databases and submits a service check that signifies whether
-              the agent can connect to that database or not.
-            enabled: true
-            value:
-              type: boolean
-              example: false
-              display_default: true
-          - name: include_ao_metrics
-            description: |
-              Include AlwaysOn availability group metrics.
-            value:
-              type: boolean
-              example: false
-          - name: availability_group
-            description: |
-              You can specify an availability group when `include_ao_metrics`
-              is enabled to monitor a specific availability group.
-              If no availability group is specified, then all availability
-              groups on the current replica will output metrics.
-            value:
-              type: string
-          - name: only_emit_local
-            description: |
-              Primary replicas may emit metrics for remote secondary replicas
-              in the same availability group. If this option is set to true,
-              the primary replica will only emit information local to itself.
-            value:
-              type: boolean
-              example: false
-          - name: ao_database
-            description: |
-              AlwaysOn metrics are only emitted for the selected `ao_database` if not empty.
-            value:
-              type: string
-          - name: include_master_files_metrics
-            description: |
-              Include database file size and state from `sys.master_files`.
-            value:
-              type: boolean
-              example: false
-          - name: include_fci_metrics
-            description: |
-              Include Failover Cluster Instance metrics. Note that these metrics
-              requires a SQLServer set up with Failover Clustering enabled.
-            value:
-              type: boolean
-              example: false
-          - name: include_instance_metrics
-            description: |
-              Include server-level instance metrics.  When setting up multiple instances for
-              different databases on the same host these metrics will be duplicated unless this option is turned off.
-            value:
-              type: boolean
-              example: true
-          - name: include_task_scheduler_metrics
-            description: Include additional Task and Scheduler metrics.
-            value:
-              type: boolean
-              example: false
-          - name: include_db_fragmentation_metrics
-            description: |
-              Include database fragmentation metrics. Note these queries can be resource intensive on large datasets.
-              Recommend to limit these via autodiscovery or specific database instances.
-            value:
-              type: boolean
-              example: false
-          - name: db_fragmentation_object_names
-            description: |
-              Fragmentation metrics normally emit metrics for all objects within a database.
-              This option allows you to specify database object names to query for fragmentation metrics.
-              Note: Each object name is unique to each database.
-            value:
-              type: array
-              items:
-                type: string
-          - name: adoprovider
-            description: |
-              Choose the ADO provider.  Note that the (default) provider
-              SQLOLEDB is being deprecated.  To use the newer MSOLEDBSQL
-              provider, set the adoprovider to "MSOLEDBSQL" below or "MSOLEDBSQL19" for version 19 of the driver.
-              You will also need to download the new provider from
-              https://docs.microsoft.com/en-us/sql/connect/oledb/oledb-driver-for-sql-server?view=sql-server-2017
-            value:
-              type: string
-              example: SQLOLEDB
-          - name: connector
-            description: |
-              Change the connection method from adodbapi (the default) to
-              odbc (valid connector names are 'odbc' and 'adodbapi')
-              Note: 'adodbapi` is only available on Windows
-            value:
-              type: string
-              example: adodbapi
-          - name: driver
-            description: If using odbc, use the named driver.
-            value:
-              type: string
-              example: SQL Server
-          - name: dsn
-            description: If using odbc, configure a connection using a DSN.
-            value:
-              type: string
-          - name: connection_string
-            description: |
-              Specify a custom connection string to be used
-              Ex: "ApplicationIntent=ReadWrite" or "Trusted_Connection=Yes" to use Windows Authentication
-              (note that in this case the connection will be performed with the `ddagentuser` user, you can
-              find more information about this user in https://docs.datadoghq.com/agent/faq/windows-agent-ddagent-user/)
-
-              Please note that certain connection string values will vary depending on the connection Provider used,
-              for example:
-              * "OLE DB" provider uses "MultiSubnetFailover=Yes"
-              * "ADO" provider uses "MultiSubnetFailover=True"
-            value:
-              type: string
-              example: "<CONNECTION_STRING>"
-          - name: dbm
-            description: |
-              Set to `true` to enable Database Monitoring.
-            value:
-              type: boolean
-              example: false
-              display_default: false
-          - name: query_metrics
-            description: Configure collection of query metrics
-            options:
-              - name: enabled
-                description: |
-                  Enable collection of query metrics. Requires `dbm: true`.
-                value:
-                  type: boolean
-                  example: true
-              - name: disable_secondary_tags
-                description: |
-                  Disable the secondary tags on query aggregate metrics, such as `user` and `database`. This is an optimization 
-                  for certain database workloads which result in long metric collection times.
-                value:
-                  type: boolean
-                  example: false
-                hidden: true
-              - name: collection_interval
-                description: |
-                  Set the query metric collection interval (in seconds). Each collection involves one or more queries to
-                  the SQL Server Query Plan Cache. If a non-default value is chosen then that exact same value must be used
-                  for *every* check instance. Running different instances with different collection intervals is not supported.
-                value:
-                  type: number
-                  example: 60
-              - name: dm_exec_query_stats_row_limit
-                description: |
-                  Set the maximum number of query stats rows that can be retrieved in a single check run.
-                value:
-                  type: integer
-                  example: 10000
-              - name: samples_per_hour_per_query
-                description: |
-                  Set the rate limit for the number of query sample events that are ingested per hour and per normalized
-                  execution plan.
-                value:
-                  type: integer
-                  example: 4
-              - name: enforce_collection_interval_deadline
-                description: |
-                  By default, plan collection stops if it is time for the next run of the query metrics & plans loop. This
-                  means that some plans may not be collected. If it is necessary to collect all of the plans and in doing so
-                  cause delays in collecting query metrics, then this deadline can be disabled by setting this option to
-                  false.
-                value:
-                  type: boolean
-                  example: True
-                hidden: true
-              - name: max_queries
-                description: |
-                  Limit the number of queries sent to the backend. 
-                  Note: The only time this value would need to be set is in special cases where the query limit
-                  applied on the backend is being modified.
-                value:
-                  type: integer
-                  example: 250
-                  display_default: 250
-                hidden: true
-          - name: query_activity
-            description: Configure collection of active sessions monitoring
-            options:
-              - name: enabled
-                description: |
-                  Enable collection of active sessions. Requires `dbm: true`.
-                value:
-                  type: boolean
-                  example: true
-              - name: collection_interval
-                description: |
-                  Set the activity collection interval in seconds. Each collection involves querying several
-                  different DMV tables such as `dm_exec_requests`, `dm_exec_sessions`, and `dm_exec_sql_text`.
-                  If a non-default value is chosen, then that exact same value must be used for *every* check instance.
-                  Running different instances with different collection intervals is not supported.
-                value:
-                  type: number
-                  example: 10
-
-          - name: aws
-            description: |
-              This block defines the configuration for AWS RDS and Aurora instances. 
-
-              Complete this section if you have installed the Datadog AWS Integration 
-              (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
-              with SQL Server integration telemetry.
-
-              These values are only applied when `dbm: true` option is set.
-            options:
-              - name: instance_endpoint
-                description: |
-                  Equal to the Endpoint.Address of the instance the agent is connecting to. 
-                  This value is optional if the value of `host` is already configured to the instance endpoint.
-
-                  For more information on instance endpoints, 
-                  see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
-                value:
-                  type: string
-                  example: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
-
-          - name: gcp
-            description: |
-              This block defines the configuration for Google Cloud SQL instances.
-
-              Complete this section if you have installed the Datadog GCP Integration 
-              (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
-              with SQL Server integration telemetry.
-
-              These values are only applied when `dbm: true` option is set.
-            options:
-              - name: project_id
-                description: |
-                  Equal to the GCP resource's project ID.
-
-                  For more information on project IDs,
-                  See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
-                value:
-                  type: string
-                  example: foo-project
-              - name: instance_id
-                description: |
-                  Equal to the GCP resource's instance ID.
-
-                  For more information on instance IDs,
-                  See the GCP docs https://cloud.google.com/sql/docs/sqlserver/instance-settings#instance-id-2ndgen
-                value:
-                  type: string
-                  example: foo-database
-
-          - name: azure
-            description: |
-              This block defines the configuration for Azure Managed Instance, Azure SQL Database or 
-              SQLServer on Virtual Machines.
-
-              Complete this section if you have installed the Datadog Azure Integration 
-              (https://docs.datadoghq.com/integrations/azure) to enrich instances 
-              with SQL Server integration telemetry.
-
-              These values are only applied when `dbm: true` option is set.
-            options:
-              - name: deployment_type
-                description: |
-                  Equal to the deployment type for the managed database. 
-
-                  Acceptable values are:
-                    - `sql_database` 
-                    - `managed_instance`
-                    - `virtual_machine`
-
-                  For more information on deployment types, see the Azure
-                  docs https://docs.microsoft.com/en-us/azure/azure-sql/azure-sql-iaas-vs-paas-what-is-overview?view=azuresql
-                value:
-                  type: string
-                  example: sql_database
-              - name: fully_qualified_domain_name
-                description: |
-                  Equal to the name of the SQL Database, Managed Instance (SQL MI) or virtual machine.
-
-                  This value is optional if the value of `host` is already configured to the fully qualified domain name.
-                value:
-                  type: string
-                  example: my-sqlserver-database.database.windows.net
-
-          - name: obfuscator_options
-            description: |
-              Configure how the SQL obfuscator behaves.
-              Note: This option only applies when `dbm` is enabled.
-            options:
-              - name: replace_digits
-                description: |
-                  Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
-                  Note: This option also applies to extracted tables using `collect_tables`.
-                value:
-                  type: boolean
-                  example: false
-              - name: collect_metadata
-                description: |
-                  Set to `false` to disable the collection of metadata in your SQL statements.
-                  Metadata includes things such as tables, commands, and comments.
-                value:
-                  type: boolean
-                  example: true
-              - name: collect_tables
-                description: |
-                  Set to `false` to disable the collection of tables in your SQL statements.
-                  Requires `collect_metadata: true`.
-                value:
-                  type: boolean
-                  example: true
-              - name: collect_commands
-                description: |
-                  Set to `false` to disable the collection of commands in your SQL statements.
-                  Requires `collect_metadata: true`.
-
-                  Examples: SELECT, UPDATE, DELETE, etc.
-                value:
-                  type: boolean
-                  example: true
-              - name: collect_comments
-                description: |
-                  Set to `false` to disable the collection of comments in your SQL statements.
-                  Requires `collect_metadata: true`.
-                value:
-                  type: boolean
-                  example: true
-              - name: keep_sql_alias
-                description: |
-                  Set to `true` to keep sql aliases in obfuscated SQL statements. Examples of aliases are
-                  `with select 1 as alias`, `select column as other_name`, or `select * from table t`.
-                  When `true` these aliases will not be removed.
-                value:
-                  type: boolean
-                  example: true
-                  display_default: true
-          - name: log_unobfuscated_queries
-            hidden: true
-            description: |
-              Set to `true` to enable logging of original unobfuscated SQL queries when obfuscation errors occur.
-              For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
-              Note: This option only applies when `dbm` is enabled.
-            value:
-              type: boolean
-              example: false
-              display_default: false
-          - name: log_unobfuscated_plans
-            hidden: true
-            description: |
-              Set to `true` to enable logging of original unobfuscated SQL plans when obfuscation errors occur.
-              For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
-              Note: This option only applies when `dbm` is enabled.
-            value:
-              type: boolean
-              example: false
-              display_default: false
-          - name: command_timeout
-            description: Timeout in seconds for the connection and each command run
-            value:
-              type: integer
-              example: 10
-          - template: instances/db
-          - name: stored_procedure
-            description: |
-              DEPRECATED - use `custom_queries` instead. For guidance, see:
-              https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/
-              Get metrics from custom proc in MyDB but only if the database is writable
-              (i.e. it's the master in an availability group) Note: Custom proc must be defined in its own instance
-            value:
-              type: string
-              example: <PROCEDURE_NAME>
-          - name: proc_only_if
-            description: Run this SQL before each call to `stored_procedure`. Only if it returns 1 then call the proc.
-            value:
-              type: string
-              example: <SQL_QUERY>
-          - name: proc_only_if_database
-            description: The database to run the `proc_only_if` SQL in.
-            value:
-              type: string
-              example: master
-          - name: ignore_missing_database
-            description: If the DB specified doesn't exist on the server then don't do the check
-            value:
-              type: boolean
-              example: false
-          - template: instances/default
-
-      - template: logs
+        See https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/
+      value:
+        type: array
+        items:
+          type: object
         example:
-          - type: file
-            path: /var/opt/mssql/log/errorlog
-            source: sqlserver
-            encoding: utf-16-le
-            service: <SERVICE_NAME>
-            log_processing_rules:
-              - type: multi_line
-                name: new_log_start_with_date
-                pattern: \d{4}\-\d{2}\-\d{2}
+          - name: sqlserver.clr.execution
+            counter_name: CLR Execution
+    - template: init_config/db
+    - template: init_config/default
+  - template: instances
+    description: |
+      Every instance is scheduled independent of the others.
+
+      Note: All '%' characters must be escaped as '%%'.
+    options:
+    - name: host
+      description: | 
+        Host and port of your SQL server. If a port is ommitted, a default port of 1433 will be used. 
+        If you use Sql Server Browser Service or a similar port autodiscovery service, pass in a port
+        of 0 to omit port from your connection string. This should allow SSBS to autodiscover the 
+        correct database port. 
+      required: true
+      value:
+        type: string
+        example: <HOST>,<PORT>
+    - name: username
+      description: Username for the Datadog-SQL server check user. It will be ignored if using Windows authentication.
+      value:
+        type: string
+    - name: password
+      description: Password for the Datadog-SQL server check user. It will be ignored if using Windows authentication.
+      value:
+        type: string
+    - name: server_version
+      description: |
+        Server version year of sqlserver the agent will connect to. 
+        Important for validating connection string attributes for older sqlserver versions.
+        
+        This is required if connecting to a SQLServer instance older than 2014.
+      value:
+        type: string
+        example: "2014"
+    - name: database
+      description: |
+        Database name to query.  Not compatible with `database_autodiscovery`.
+      value:
+        type: string
+        example: master
+    - name: reported_hostname
+      description: |
+        Set the reported hostname for this instance. This value overrides the hostname detected by the Agent
+        and can be useful to set a custom hostname when connecting to a remote database through a proxy.
+      value:
+        type: string
+    - name: database_autodiscovery
+      description: |
+        Auto-discover and monitor databases. Supported for the metrics check. 
+        If `true`, overrides `database` option.
+        Can be combined with `autodiscovery_include` and `autodiscovery_exclude` options.
+      value:
+        type: boolean
+        example: false
+    - name: autodiscovery_include
+      description: |
+        Regular expression for database names to include as part of `database_autodiscovery`.
+        Will report metrics for databases that are found in this instance, ignores databases listed but not found.
+
+        Character casing is ignored. The regular expressions start matching from the beginning, so
+        to match anywhere, prepend `.*`. For exact matches append `$`.
+
+        Defaults to `.*` to include everything.
+      value:
+        type: array
+        items:
+          type: string
+        example:
+          - master$
+          - AdventureWorks.*
+    - name: autodiscovery_exclude
+      description: |
+        Regular expression for database names to exclude as part of `database_autodiscovery`.
+
+        Character casing is ignored. The regular expressions start matching from the beginning, so
+        to match anywhere, prepend `.*`. For exact matches append `$`.
+
+        In case of conflicts, database exclusion via `autodiscovery_exclude` takes precedence over
+        those found via `autodiscovery_include`.
+      value:
+        type: array
+        items:
+          type: string
+        example:
+          - model
+          - msdb
+    - name: database_autodiscovery_interval
+      description: |
+        Frequency in seconds of scans for new databases.  Defaults to `3600`.
+      value:
+        type: integer
+        example: 3600
+    - name: autodiscovery_db_service_check
+      description: |
+        When enabled with database autodiscovery, attempts to connect to the list of
+        autodiscovered databases and submits a service check that signifies whether
+        the agent can connect to that database or not.
+      enabled: true
+      value:
+        type: boolean
+        example: false
+        display_default: true
+    - name: include_ao_metrics
+      description: |
+        Include AlwaysOn availability group metrics.
+      value:
+        type: boolean
+        example: false
+    - name: availability_group
+      description: |
+        You can specify an availability group when `include_ao_metrics`
+        is enabled to monitor a specific availability group.
+        If no availability group is specified, then all availability
+        groups on the current replica will output metrics.
+      value:
+        type: string
+    - name: only_emit_local
+      description: |
+        Primary replicas may emit metrics for remote secondary replicas
+        in the same availability group. If this option is set to true,
+        the primary replica will only emit information local to itself.
+      value:
+        type: boolean
+        example: false
+    - name: ao_database
+      description: |
+        AlwaysOn metrics are only emitted for the selected `ao_database` if not empty.
+      value:
+        type: string
+    - name: include_master_files_metrics
+      description: |
+        Include database file size and state from `sys.master_files`.
+      value:
+        type: boolean
+        example: false
+    - name: include_fci_metrics
+      description: |
+        Include Failover Cluster Instance metrics. Note that these metrics
+        requires a SQLServer set up with Failover Clustering enabled.
+      value:
+        type: boolean
+        example: false
+    - name: include_instance_metrics
+      description: |
+        Include server-level instance metrics.  When setting up multiple instances for
+        different databases on the same host these metrics will be duplicated unless this option is turned off.
+      value:
+        type: boolean
+        example: true
+    - name: include_task_scheduler_metrics
+      description: Include additional Task and Scheduler metrics.
+      value:
+        type: boolean
+        example: false
+    - name: include_db_fragmentation_metrics
+      description: |
+        Include database fragmentation metrics. Note these queries can be resource intensive on large datasets.
+        Recommend to limit these via autodiscovery or specific database instances.
+      value:
+        type: boolean
+        example: false
+    - name: db_fragmentation_object_names
+      description: |
+        Fragmentation metrics normally emit metrics for all objects within a database.
+        This option allows you to specify database object names to query for fragmentation metrics.
+        Note: Each object name is unique to each database.
+      value:
+        type: array
+        items:
+          type: string
+    - name: adoprovider
+      description: |
+        Choose the ADO provider.  Note that the (default) provider
+        SQLOLEDB is being deprecated.  To use the newer MSOLEDBSQL
+        provider, set the adoprovider to "MSOLEDBSQL" below or "MSOLEDBSQL19" for version 19 of the driver.
+        You will also need to download the new provider from
+        https://docs.microsoft.com/en-us/sql/connect/oledb/oledb-driver-for-sql-server?view=sql-server-2017
+      value:
+        type: string
+        example: SQLOLEDB
+    - name: connector
+      description: |
+        Change the connection method from adodbapi (the default) to
+        odbc (valid connector names are 'odbc' and 'adodbapi')
+        Note: 'adodbapi` is only available on Windows
+      value:
+        type: string
+        example: adodbapi
+    - name: driver
+      description: If using odbc, use the named driver.
+      value:
+        type: string
+        example: SQL Server
+    - name: dsn
+      description: If using odbc, configure a connection using a DSN.
+      value:
+        type: string
+    - name: connection_string
+      description: |
+        Specify a custom connection string to be used
+        Ex: "ApplicationIntent=ReadWrite" or "Trusted_Connection=Yes" to use Windows Authentication
+        (note that in this case the connection will be performed with the `ddagentuser` user, you can
+        find more information about this user in https://docs.datadoghq.com/agent/faq/windows-agent-ddagent-user/)
+
+        Please note that certain connection string values will vary depending on the connection Provider used,
+        for example:
+        * "OLE DB" provider uses "MultiSubnetFailover=Yes"
+        * "ADO" provider uses "MultiSubnetFailover=True"
+      value:
+        type: string
+        example: "<CONNECTION_STRING>"
+    - name: dbm
+      description: |
+        Set to `true` to enable Database Monitoring.
+      value:
+        type: boolean
+        example: false
+        display_default: false
+    - name: query_metrics
+      description: Configure collection of query metrics
+      options:
+        - name: enabled
+          description: |
+            Enable collection of query metrics. Requires `dbm: true`.
+          value:
+            type: boolean
+            example: true
+        - name: disable_secondary_tags
+          description: |
+            Disable the secondary tags on query aggregate metrics, such as `user` and `database`. This is an optimization 
+            for certain database workloads which result in long metric collection times.
+          value:
+            type: boolean
+            example: false
+          hidden: true
+        - name: collection_interval
+          description: |
+            Set the query metric collection interval (in seconds). Each collection involves one or more queries to
+            the SQL Server Query Plan Cache. If a non-default value is chosen then that exact same value must be used
+            for *every* check instance. Running different instances with different collection intervals is not supported.
+          value:
+            type: number
+            example: 60
+        - name: dm_exec_query_stats_row_limit
+          description: |
+            Set the maximum number of query stats rows that can be retrieved in a single check run.
+          value:
+            type: integer
+            example: 10000
+        - name: samples_per_hour_per_query
+          description: |
+            Set the rate limit for the number of query sample events that are ingested per hour and per normalized
+            execution plan.
+          value:
+            type: integer
+            example: 4
+        - name: enforce_collection_interval_deadline
+          description: |
+            By default, plan collection stops if it is time for the next run of the query metrics & plans loop. This
+            means that some plans may not be collected. If it is necessary to collect all of the plans and in doing so
+            cause delays in collecting query metrics, then this deadline can be disabled by setting this option to
+            false.
+          value:
+            type: boolean
+            example: True
+          hidden: true
+        - name: max_queries
+          description: |
+            Limit the number of queries sent to the backend. 
+            Note: The only time this value would need to be set is in special cases where the query limit
+            applied on the backend is being modified.
+          value:
+            type: integer
+            example: 250
+            display_default: 250
+          hidden: true
+    - name: query_activity
+      description: Configure collection of active sessions monitoring
+      options:
+        - name: enabled
+          description: |
+            Enable collection of active sessions. Requires `dbm: true`.
+          value:
+            type: boolean
+            example: true
+        - name: collection_interval
+          description: |
+            Set the activity collection interval in seconds. Each collection involves querying several
+            different DMV tables such as `dm_exec_requests`, `dm_exec_sessions`, and `dm_exec_sql_text`.
+            If a non-default value is chosen, then that exact same value must be used for *every* check instance.
+            Running different instances with different collection intervals is not supported.
+          value:
+            type: number
+            example: 10
+
+    - name: aws
+      description: |
+        This block defines the configuration for AWS RDS and Aurora instances. 
+        
+        Complete this section if you have installed the Datadog AWS Integration 
+        (https://docs.datadoghq.com/integrations/amazon_web_services) to enrich instances 
+        with SQL Server integration telemetry.
+        
+        These values are only applied when `dbm: true` option is set.
+      options:
+        - name: instance_endpoint
+          description: |
+            Equal to the Endpoint.Address of the instance the agent is connecting to. 
+            This value is optional if the value of `host` is already configured to the instance endpoint.
+            
+            For more information on instance endpoints, 
+            see the AWS docs https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_Endpoint.html
+          value:
+            type: string
+            example: mydb.cfxgae8cilcf.us-east-1.rds.amazonaws.com
+
+    - name: gcp
+      description: |
+        This block defines the configuration for Google Cloud SQL instances.
+        
+        Complete this section if you have installed the Datadog GCP Integration 
+        (https://docs.datadoghq.com/integrations/google_cloud_platform) to enrich instances 
+        with SQL Server integration telemetry.
+
+        These values are only applied when `dbm: true` option is set.
+      options:
+        - name: project_id
+          description: |
+            Equal to the GCP resource's project ID.
+            
+            For more information on project IDs,
+            See the GCP docs https://cloud.google.com/resource-manager/docs/creating-managing-projects
+          value:
+            type: string
+            example: foo-project
+        - name: instance_id
+          description: |
+            Equal to the GCP resource's instance ID.
+            
+            For more information on instance IDs,
+            See the GCP docs https://cloud.google.com/sql/docs/sqlserver/instance-settings#instance-id-2ndgen
+          value:
+            type: string
+            example: foo-database
+
+    - name: azure
+      description: |
+        This block defines the configuration for Azure Managed Instance, Azure SQL Database or 
+        SQLServer on Virtual Machines.
+        
+        Complete this section if you have installed the Datadog Azure Integration 
+        (https://docs.datadoghq.com/integrations/azure) to enrich instances 
+        with SQL Server integration telemetry.
+
+        These values are only applied when `dbm: true` option is set.
+      options:
+        - name: deployment_type
+          description: |
+            Equal to the deployment type for the managed database. 
+            
+            Acceptable values are:
+              - `sql_database` 
+              - `managed_instance`
+              - `virtual_machine`
+            
+            For more information on deployment types, see the Azure
+            docs https://docs.microsoft.com/en-us/azure/azure-sql/azure-sql-iaas-vs-paas-what-is-overview?view=azuresql
+          value:
+            type: string
+            example: sql_database
+        - name: fully_qualified_domain_name
+          description: |
+            Equal to the name of the SQL Database, Managed Instance (SQL MI) or virtual machine.
+            
+            This value is optional if the value of `host` is already configured to the fully qualified domain name.
+          value:
+            type: string
+            example: my-sqlserver-database.database.windows.net
+
+    - name: obfuscator_options
+      description: |
+        Configure how the SQL obfuscator behaves.
+        Note: This option only applies when `dbm` is enabled.
+      options:
+        - name: replace_digits
+          description: |
+            Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
+            Note: This option also applies to extracted tables using `collect_tables`.
+          value:
+            type: boolean
+            example: false
+        - name: collect_metadata
+          description: |
+            Set to `false` to disable the collection of metadata in your SQL statements.
+            Metadata includes things such as tables, commands, and comments.
+          value:
+            type: boolean
+            example: true
+        - name: collect_tables
+          description: |
+            Set to `false` to disable the collection of tables in your SQL statements.
+            Requires `collect_metadata: true`.
+          value:
+            type: boolean
+            example: true
+        - name: collect_commands
+          description: |
+            Set to `false` to disable the collection of commands in your SQL statements.
+            Requires `collect_metadata: true`.
+
+            Examples: SELECT, UPDATE, DELETE, etc.
+          value:
+            type: boolean
+            example: true
+        - name: collect_comments
+          description: |
+            Set to `false` to disable the collection of comments in your SQL statements.
+            Requires `collect_metadata: true`.
+          value:
+            type: boolean
+            example: true
+        - name: keep_sql_alias
+          description: |
+            Set to `true` to keep sql aliases in obfuscated SQL statements. Examples of aliases are
+            `with select 1 as alias`, `select column as other_name`, or `select * from table t`.
+            When `true` these aliases will not be removed.
+          value:
+            type: boolean
+            example: true
+            display_default: true
+    - name: log_unobfuscated_queries
+      hidden: true
+      description: |
+        Set to `true` to enable logging of original unobfuscated SQL queries when obfuscation errors occur.
+        For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
+        Note: This option only applies when `dbm` is enabled.
+      value:
+        type: boolean
+        example: false
+        display_default: false
+    - name: log_unobfuscated_plans
+      hidden: true
+      description: |
+        Set to `true` to enable logging of original unobfuscated SQL plans when obfuscation errors occur.
+        For security purposes, it is recommended to use this option for debugging only when requested by Datadog Support.
+        Note: This option only applies when `dbm` is enabled.
+      value:
+        type: boolean
+        example: false
+        display_default: false
+    - name: command_timeout
+      description: Timeout in seconds for the connection and each command run
+      value:
+        type: integer
+        example: 10
+    - template: instances/db
+    - name: stored_procedure
+      description: |
+        DEPRECATED - use `custom_queries` instead. For guidance, see:
+        https://docs.datadoghq.com/integrations/guide/collect-sql-server-custom-metrics/
+        Get metrics from custom proc in MyDB but only if the database is writable
+        (i.e. it's the master in an availability group) Note: Custom proc must be defined in its own instance
+      value:
+        type: string
+        example: <PROCEDURE_NAME>
+    - name: proc_only_if
+      description: Run this SQL before each call to `stored_procedure`. Only if it returns 1 then call the proc.
+      value:
+        type: string
+        example: <SQL_QUERY>
+    - name: proc_only_if_database
+      description: The database to run the `proc_only_if` SQL in.
+      value:
+        type: string
+        example: master
+    - name: ignore_missing_database
+      description: If the DB specified doesn't exist on the server then don't do the check
+      value:
+        type: boolean
+        example: false
+    - template: instances/default
+      overrides:
+        disable_generic_tags.hidden: False
+        disable_generic_tags.enabled: True
+        disable_generic_tags.description: |
+            Generic tags such as `host` are replaced by `sqlserver_host` to avoid
+            getting mixed with other integration tags.
+
+  - template: logs
+    example:
+    - type: file
+      path: /var/opt/mssql/log/errorlog
+      source: sqlserver
+      encoding: utf-16-le
+      service: <SERVICE_NAME>
+      log_processing_rules:
+      - type: multi_line
+        name: new_log_start_with_date
+        pattern: \d{4}\-\d{2}\-\d{2}

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -499,13 +499,6 @@ files:
         type: boolean
         example: false
     - template: instances/default
-      overrides:
-        disable_generic_tags.hidden: False
-        disable_generic_tags.enabled: True
-        disable_generic_tags.description: |
-            Generic tags such as `host` are replaced by `sqlserver_host` to avoid
-            getting mixed with other integration tags.
-
   - template: logs
     example:
     - type: file

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -40,7 +40,7 @@ instances:
     ## Host and port of your SQL server. If a port is ommitted, a default port of 1433 will be used. 
     ## If you use Sql Server Browser Service or a similar port autodiscovery service, pass in a port
     ## of 0 to omit port from your connection string. This should allow SSBS to autodiscover the 
-    ## correct database port. 
+    ## correct database port.
     #
   - host: <HOST>,<PORT>
 
@@ -511,12 +511,6 @@ instances:
     ## This is useful for cluster-level checks.
     #
     # empty_default_hostname: false
-
-    ## @param disable_generic_tags - boolean - optional - default: false
-    ## Generic tags such as `host` are replaced by `sqlserver_host` to avoid
-    ## getting mixed with other integration tags.
-    #
-    disable_generic_tags: true
 
     ## @param metric_patterns - mapping - optional
     ## A mapping of metrics to include or exclude, with each entry being a regular expression.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -40,7 +40,7 @@ instances:
     ## Host and port of your SQL server. If a port is ommitted, a default port of 1433 will be used. 
     ## If you use Sql Server Browser Service or a similar port autodiscovery service, pass in a port
     ## of 0 to omit port from your connection string. This should allow SSBS to autodiscover the 
-    ## correct database port.
+    ## correct database port. 
     #
   - host: <HOST>,<PORT>
 


### PR DESCRIPTION
### What does this PR do?

The `disable_generic_tags` option namespaces tags like `host` to instead use `sqlserver_host` as the tag key. The original intention for this was described [here](https://datadoghq.atlassian.net/wiki/spaces/AI/pages/2205975610/RFC+-+Generic+tags) (for Datadog employees).

The config is used in the Service Check tags here: https://github.com/DataDog/integrations-core/blob/53daf26263a660685e4fefe8821d8d1fd61e4ee7/sqlserver/datadog_checks/sqlserver/sqlserver.py#L377-L383

However, this namespacing interferes with the Recommended Monitor feature, DBM, and Unified host linking features which rely on the `host` tag being set. It also makes it hard to document expected behaviors and train solutions engineers to assist customers because this option forks the expected behavior of the output tag names and all comms around tag names must have an asterisk with a footnote ("except when using disable_generic_tags"). Prefixing also creates an inconsistent experience for users where the Service Check is tagged with one set of tags, but metrics use another not-namespaced set. 

Removing this option from the example yaml will not affect any existing users (the default behavior is `false` and existing configs will not be affected). However users who clone the example config will no longer have `disable_generic_tags: true` in their config.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.