### PR TITLE
Fix error handling for psycopg3 err messages

### DIFF
--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -298,7 +298,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
 
             if (
                 isinstance(e, psycopg.errors.ObjectNotInPrerequisiteState)
-            ) and 'pg_stat_statements must be loaded' in str(e.sqlstate):
+            ) and 'pg_stat_statements must be loaded' in str(e.diag.message_primary):
                 error_tag = "error:database-{}-pg_stat_statements_not_loaded".format(type(e).__name__)
                 self._check.record_warning(
                     DatabaseConfigurationError.pg_stat_statements_not_loaded,
@@ -314,7 +314,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                         code=DatabaseConfigurationError.pg_stat_statements_not_loaded.value,
                     ),
                 )
-            elif isinstance(e, psycopg.errors.UndefinedTable) and 'pg_stat_statements' in str(e.sqlstate):
+            elif isinstance(e, psycopg.errors.UndefinedTable) and 'pg_stat_statements' in str(e.diag.message_primary):
                 error_tag = "error:database-{}-pg_stat_statements_not_created".format(type(e).__name__)
                 self._check.record_warning(
                     DatabaseConfigurationError.pg_stat_statements_not_created,

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1610,6 +1610,24 @@ def test_statement_samples_config_invalid_number(integration_check, pg_instance,
         integration_check(pg_instance)
 
 
+class Diagnostic(psycopg.errors.Diagnostic):
+    """
+    A fake Diagnostic that allows returning the expected err msg
+    """
+
+    def __init__(self, message):
+        self._message = message
+
+    def __getattribute__(self, attr):
+        if attr == 'message_primary':
+            return self._message
+        else:
+            return super(Diagnostic, self).__getattribute__(attr)
+
+    def __str__(self):
+        return self._message
+
+
 class ObjectNotInPrerequisiteState(psycopg.errors.ObjectNotInPrerequisiteState):
     """
     A fake ObjectNotInPrerequisiteState that allows setting pg_error on construction since ObjectNotInPrerequisiteState
@@ -1620,8 +1638,8 @@ class ObjectNotInPrerequisiteState(psycopg.errors.ObjectNotInPrerequisiteState):
         self.pg_error = pg_error
 
     def __getattribute__(self, attr):
-        if attr == 'sqlstate':
-            return self.pg_error
+        if attr == 'diag':
+            return Diagnostic(message=self.pg_error)
         else:
             return super(ObjectNotInPrerequisiteState, self).__getattribute__(attr)
 
@@ -1639,8 +1657,8 @@ class UndefinedTable(psycopg.errors.UndefinedTable):
         self.pg_error = pg_error
 
     def __getattribute__(self, attr):
-        if attr == 'sqlstate':
-            return self.pg_error
+        if attr == 'diag':
+            return Diagnostic(message=self.pg_error)
         else:
             return super(UndefinedTable, self).__getattribute__(attr)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This fixes a bug introduced in https://github.com/DataDog/integrations-core/pull/15411 where we were erroneously checking the `sqlstate` field in order to properly format our error messages, when the `Diagnostic` [object](https://www.psycopg.org/psycopg3/docs/api/errors.html#db-api-exceptions) contains the message that was relevant.  

### Additional Notes
<!-- Anything else we should know when reviewing? -->

To test, just run a simple script 
```python
import psycopg

try:
    conn = psycopg.connect(host="localhost", dbname="datadog_test", user="bob", password="bob")
    cursor = conn.cursor()
    cursor.execute("SELECT * FROM fake")
except psycopg.Error as e:
    print(e.diag.message_primary)
```

-> which produces `relation "fake" does not exist`, which would then be caught [here](https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/statements.py#L317) 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.