### PR TITLE
Prevent `command already in progress` errors in the Postgres integration

### DIFF
--- a/.ddev/config.toml
+++ b/.ddev/config.toml
@@ -88,6 +88,8 @@ paramiko = ['LGPL-2.1-only']
 oracledb = ['Apache-2.0']
 # https://github.com/psycopg/psycopg/blob/master/LICENSE.txt
 psycopg = ['LGPL-3.0-only']
+# https://github.com/psycopg/psycopg/blob/master/psycopg_pool/LICENSE.txt
+psycopg-pool = ['LGPL-3.0-only']
 # https://github.com/psycopg/psycopg2/blob/master/LICENSE
 # https://github.com/psycopg/psycopg2/blob/master/doc/COPYING.LESSER
 psycopg2-binary = ['LGPL-3.0-only', 'BSD-3-Clause']

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -64,6 +64,7 @@ protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.
 protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.  All rights reserved.
 psutil,PyPI,BSD-3-Clause,"Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola'"
 psycopg,PyPI,LGPL-3.0-only,Copyright (C) 2020 The Psycopg Team
+psycopg-pool,PyPI,LGPL-3.0-only,Copyright (C) 2020 The Psycopg Team
 psycopg2-binary,PyPI,BSD-3-Clause,Copyright 2013 Federico Di Gregorio
 psycopg2-binary,PyPI,LGPL-3.0-only,Copyright (C) 2013 Federico Di Gregorio
 pyasn1,PyPI,BSD-3-Clause,"Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -64,22 +64,21 @@ protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.
 protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.  All rights reserved.
 psutil,PyPI,BSD-3-Clause,"Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola'"
 psycopg,PyPI,LGPL-3.0-only,Copyright (C) 2020 The Psycopg Team
-psycopg-pool,PyPI,LGPL-3.0-only,Copyright (C) 2020 The Psycopg Team
 psycopg2-binary,PyPI,BSD-3-Clause,Copyright 2013 Federico Di Gregorio
-psycopg2-binary,PyPI,LGPL-3.0-only,Copyright (C) Federico Di Gregorio
+psycopg2-binary,PyPI,LGPL-3.0-only,Copyright (C) 2013 Federico Di Gregorio
 pyasn1,PyPI,BSD-3-Clause,"Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>"
-pycryptodomex,PyPI,BSD-2-Clause,Copyright Helder Eijs
+pycryptodomex,PyPI,BSD-2-Clause,Copyright 2014 Helder Eijs
 pycryptodomex,PyPI,Unlicense,Helder Eijs. pycryptodomex is dedicated to the public domain under Unlicense.
 pydantic,PyPI,MIT,Copyright (c) 2017 to present Pydantic Services Inc. and individual contributors.
-pymongo,PyPI,Apache-2.0,Copyright The MongoDB Python Team
+pymongo,PyPI,Apache-2.0,Copyright 2009 The MongoDB Python Team
 pymqi,PyPI,PSF,Copyright (c) Zato Source s.r.o.
 pymysql,PyPI,MIT,"Copyright (c) 2010, 2013 PyMySQL contributors"
-pyodbc,PyPI,MIT,Copyright (c) Michael Kleehammer
+pyodbc,PyPI,MIT,Copyright (c) 2008 Michael Kleehammer
 pysmi,PyPI,BSD-3-Clause,Copyright (c) 2015-2019 Ilya Etingof <etingof@gmail.com>
 pysnmp,PyPI,BSD-3-Clause,"Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>"
 pysnmp-mibs,PyPI,BSD-3-Clause,"Copyright (c) 2005-2016, Ilya Etingof <ilya@glas.net>"
+python-binary-memcached,PyPI,MIT,Copyright (c) 2011 Jayson Reis
 python-binary-memcached,PyPI,MIT,Copyright (c) 2011 Jayson Reis <santosdosreis@gmail.com>
-python-binary-memcached,PyPI,MIT,Copyright (c) Jayson Reis
 python-dateutil,PyPI,Apache-2.0,Copyright 2017- Paul Ganssle <paul@ganssle.io>
 python-dateutil,PyPI,BSD-3-Clause,Copyright 2017- Paul Ganssle <paul@ganssle.io>
 python3-gearman,PyPI,Apache-2.0,
@@ -93,8 +92,8 @@ requests-ntlm,PyPI,ISC,Copyright (c) 2013 Ben Toews
 requests-oauthlib,PyPI,BSD-3-Clause,Copyright (c) 2014 Kenneth Reitz.
 requests-oauthlib,PyPI,ISC,Copyright (c) 2014 Kenneth Reitz.
 requests-toolbelt,PyPI,Apache-2.0,"Copyright 2014 Ian Cordasco, Cory Benfield"
-requests-unixsocket,PyPI,Apache-2.0,Copyright Marc Abramowitz
-rethinkdb,PyPI,Apache-2.0,Copyright RethinkDB.
+requests-unixsocket,PyPI,Apache-2.0,Copyright 2014 Marc Abramowitz
+rethinkdb,PyPI,Apache-2.0,Copyright 2018 RethinkDB.
 scandir,PyPI,BSD-3-Clause,"Copyright (c) 2012, Ben Hoyt"
 securesystemslib,PyPI,MIT,Copyright (c) 2016 Santiago Torres
 semver,PyPI,BSD-3-Clause,"Copyright (c) 2013, Konstantine Rybnikov"
@@ -108,6 +107,6 @@ tuf,PyPI,Apache-2.0,Copyright (c) 2010 New York University
 tuf,PyPI,MIT,Copyright (c) 2010 New York University
 typing,PyPI,PSF,"Copyright (c) 1991 - 1995, Stichting Mathematisch Centrum Amsterdam"
 uptime,PyPI,BSD-2-Clause,"Copyright (c) 2012, Koen Crolla"
-vertica-python,PyPI,Apache-2.0,"Copyright Justin Berka, Alex Kim, Siting Ren"
+vertica-python,PyPI,Apache-2.0,"Copyright 2013 Justin Berka, Alex Kim, Siting Ren"
 win-inet-pton,PyPI,Unlicense,Ryan Vennell. win-inet-pton is dedicated to the public domain under Unlicense.
 wrapt,PyPI,BSD-3-Clause,"Copyright (c) 2013-2023, Graham Dumpleton"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -64,21 +64,22 @@ protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.
 protobuf,PyPI,BSD-3-Clause,Copyright 2008 Google Inc.  All rights reserved.
 psutil,PyPI,BSD-3-Clause,"Copyright (c) 2009, Jay Loden, Dave Daeschler, Giampaolo Rodola'"
 psycopg,PyPI,LGPL-3.0-only,Copyright (C) 2020 The Psycopg Team
+psycopg-pool,PyPI,LGPL-3.0-only,Copyright (C) 2020 The Psycopg Team
 psycopg2-binary,PyPI,BSD-3-Clause,Copyright 2013 Federico Di Gregorio
-psycopg2-binary,PyPI,LGPL-3.0-only,Copyright (C) 2013 Federico Di Gregorio
+psycopg2-binary,PyPI,LGPL-3.0-only,Copyright (C) Federico Di Gregorio
 pyasn1,PyPI,BSD-3-Clause,"Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>"
-pycryptodomex,PyPI,BSD-2-Clause,Copyright 2014 Helder Eijs
+pycryptodomex,PyPI,BSD-2-Clause,Copyright Helder Eijs
 pycryptodomex,PyPI,Unlicense,Helder Eijs. pycryptodomex is dedicated to the public domain under Unlicense.
 pydantic,PyPI,MIT,Copyright (c) 2017 to present Pydantic Services Inc. and individual contributors.
-pymongo,PyPI,Apache-2.0,Copyright 2009 The MongoDB Python Team
+pymongo,PyPI,Apache-2.0,Copyright The MongoDB Python Team
 pymqi,PyPI,PSF,Copyright (c) Zato Source s.r.o.
 pymysql,PyPI,MIT,"Copyright (c) 2010, 2013 PyMySQL contributors"
-pyodbc,PyPI,MIT,Copyright (c) 2008 Michael Kleehammer
+pyodbc,PyPI,MIT,Copyright (c) Michael Kleehammer
 pysmi,PyPI,BSD-3-Clause,Copyright (c) 2015-2019 Ilya Etingof <etingof@gmail.com>
 pysnmp,PyPI,BSD-3-Clause,"Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>"
 pysnmp-mibs,PyPI,BSD-3-Clause,"Copyright (c) 2005-2016, Ilya Etingof <ilya@glas.net>"
-python-binary-memcached,PyPI,MIT,Copyright (c) 2011 Jayson Reis
 python-binary-memcached,PyPI,MIT,Copyright (c) 2011 Jayson Reis <santosdosreis@gmail.com>
+python-binary-memcached,PyPI,MIT,Copyright (c) Jayson Reis
 python-dateutil,PyPI,Apache-2.0,Copyright 2017- Paul Ganssle <paul@ganssle.io>
 python-dateutil,PyPI,BSD-3-Clause,Copyright 2017- Paul Ganssle <paul@ganssle.io>
 python3-gearman,PyPI,Apache-2.0,
@@ -92,8 +93,8 @@ requests-ntlm,PyPI,ISC,Copyright (c) 2013 Ben Toews
 requests-oauthlib,PyPI,BSD-3-Clause,Copyright (c) 2014 Kenneth Reitz.
 requests-oauthlib,PyPI,ISC,Copyright (c) 2014 Kenneth Reitz.
 requests-toolbelt,PyPI,Apache-2.0,"Copyright 2014 Ian Cordasco, Cory Benfield"
-requests-unixsocket,PyPI,Apache-2.0,Copyright 2014 Marc Abramowitz
-rethinkdb,PyPI,Apache-2.0,Copyright 2018 RethinkDB.
+requests-unixsocket,PyPI,Apache-2.0,Copyright Marc Abramowitz
+rethinkdb,PyPI,Apache-2.0,Copyright RethinkDB.
 scandir,PyPI,BSD-3-Clause,"Copyright (c) 2012, Ben Hoyt"
 securesystemslib,PyPI,MIT,Copyright (c) 2016 Santiago Torres
 semver,PyPI,BSD-3-Clause,"Copyright (c) 2013, Konstantine Rybnikov"
@@ -107,6 +108,6 @@ tuf,PyPI,Apache-2.0,Copyright (c) 2010 New York University
 tuf,PyPI,MIT,Copyright (c) 2010 New York University
 typing,PyPI,PSF,"Copyright (c) 1991 - 1995, Stichting Mathematisch Centrum Amsterdam"
 uptime,PyPI,BSD-2-Clause,"Copyright (c) 2012, Koen Crolla"
-vertica-python,PyPI,Apache-2.0,"Copyright 2013 Justin Berka, Alex Kim, Siting Ren"
+vertica-python,PyPI,Apache-2.0,"Copyright Justin Berka, Alex Kim, Siting Ren"
 win-inet-pton,PyPI,Unlicense,Ryan Vennell. win-inet-pton is dedicated to the public domain under Unlicense.
 wrapt,PyPI,BSD-3-Clause,"Copyright (c) 2013-2023, Graham Dumpleton"

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -17,9 +17,9 @@
 
 ***Fixed***:
 
-* Prevent `command already in progress` errors for pg integration ([#15489](https://github.com/DataDog/integrations-core/pull/15489))
 * Downgrade pydantic to 2.0.2 ([#15596](https://github.com/DataDog/integrations-core/pull/15596))
 * Bump cryptography to 41.0.3 ([#15517](https://github.com/DataDog/integrations-core/pull/15517))
+* Prevent `command already in progress` errors in the Postgres integration ([#15489](https://github.com/DataDog/integrations-core/pull/15489))
 
 ## 32.7.0 / 2023-08-10
 

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ***Fixed***:
 
+* Prevent `command already in progress` errors for pg integration ([#15489](https://github.com/DataDog/integrations-core/pull/15489))
 * Downgrade pydantic to 2.0.2 ([#15596](https://github.com/DataDog/integrations-core/pull/15596))
 * Bump cryptography to 41.0.3 ([#15517](https://github.com/DataDog/integrations-core/pull/15517))
 

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -59,7 +59,7 @@ protobuf==3.20.2; python_version > '3.0'
 psutil==5.9.0
 psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'
 psycopg[binary]==3.1.10; python_version > '3.0'
-psycopg[pool]==3.1.7; python_version > '3.0'
+psycopg_pool==3.1.7; python_version > '3.0'
 pyasn1==0.4.6
 pycryptodomex==3.10.1
 pydantic==2.0.2; python_version > '3.0'

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -59,6 +59,7 @@ protobuf==3.20.2; python_version > '3.0'
 psutil==5.9.0
 psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'
 psycopg[binary]==3.1.10; python_version > '3.0'
+psycopg[pool]==3.1.7; python_version > '3.0'
 pyasn1==0.4.6
 pycryptodomex==3.10.1
 pydantic==2.0.2; python_version > '3.0'

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -59,7 +59,7 @@ protobuf==3.20.2; python_version > '3.0'
 psutil==5.9.0
 psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'
 psycopg[binary]==3.1.10; python_version > '3.0'
-psycopg_pool==3.1.7; python_version > '3.0'
+psycopg-pool==3.1.7; python_version > '3.0'
 pyasn1==0.4.6
 pycryptodomex==3.10.1
 pydantic==2.0.2; python_version > '3.0'

--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 * Ignore `pydantic` when bumping the dependencies ([#15597](https://github.com/DataDog/integrations-core/pull/15597))
 * Stop using the TOX_ENV_NAME variable ([#15528](https://github.com/DataDog/integrations-core/pull/15528))
+* Prevent `command already in progress` errors in the Postgres integration ([#15489](https://github.com/DataDog/integrations-core/pull/15489))
 
 ## 23.0.0 / 2023-08-10
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/licenses.py
@@ -54,6 +54,8 @@ EXPLICIT_LICENSES = {
     'psycopg2-binary': ['LGPL-3.0-only', 'BSD-3-Clause'],
     # https://github.com/psycopg/psycopg/blob/master/LICENSE.txt
     'psycopg': ['LGPL-3.0-only'],
+    # https://github.com/psycopg/psycopg/blob/master/psycopg_pool/LICENSE.txt
+    'psycopg-pool': ['LGPL-3.0-only'],
     # https://github.com/Legrandin/pycryptodome/blob/master/LICENSE.rst
     'pycryptodomex': ['Unlicense', 'BSD-2-Clause'],
     # https://github.com/requests/requests-kerberos/pull/123

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -12,6 +12,7 @@
 ***Fixed***:
 
 * Update datadog-checks-base dependency version to 32.6.0 ([#15604](https://github.com/DataDog/integrations-core/pull/15604))
+* Prevent `command already in progress` errors for pg integration ([#15489](https://github.com/DataDog/integrations-core/pull/15489))
 
 ## 14.1.0 / 2023-08-10
 

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -12,7 +12,7 @@
 ***Fixed***:
 
 * Update datadog-checks-base dependency version to 32.6.0 ([#15604](https://github.com/DataDog/integrations-core/pull/15604))
-* Prevent `command already in progress` errors for pg integration ([#15489](https://github.com/DataDog/integrations-core/pull/15489))
+* Prevent `command already in progress` errors in the Postgres integration ([#15489](https://github.com/DataDog/integrations-core/pull/15489))
 
 ## 14.1.0 / 2023-08-10
 

--- a/postgres/datadog_checks/postgres/connections.py
+++ b/postgres/datadog_checks/postgres/connections.py
@@ -217,7 +217,7 @@ class MultiDatabaseConnectionPool(object):
                 return False
         return True
 
-    def get_main_db(self):
+    def _get_main_db(self):
         """
         Returns a memoized, persistent psycopg connection to `self.dbname`.
         Utilizes the db connection pool, and is meant to be shared across multiple threads.
@@ -241,18 +241,17 @@ class MultiDatabaseConnectionPool(object):
         with self._query_lock:
             self._log.debug("Running query [{}] {}".format(query, params))
             if row_format:
-                with self.get_main_db().cursor(row_factory=row_format) as cursor:
+                with self._get_main_db().cursor(row_factory=row_format) as cursor:
                     cursor.execute(query, params)
                     return cursor.fetchall()
             else:
-                with self.get_main_db().cursor() as cursor:
+                with self._get_main_db().cursor() as cursor:
                     cursor.execute(query, params)
                     return cursor.fetchall()
 
     def get_main_db_columns_safe(self, query, params):
         with self._query_lock:
-            with self.get_main_db().cursor() as cursor:
+            with self._get_main_db().cursor() as cursor:
                 self._log.debug("Running query [%s] %s", query, params)
                 cursor.execute(query, params)
                 return [desc[0] for desc in cursor.description] if cursor.description else []
-

--- a/postgres/datadog_checks/postgres/connections.py
+++ b/postgres/datadog_checks/postgres/connections.py
@@ -9,6 +9,7 @@ import time
 from typing import Callable, Dict
 
 import psycopg
+from psycopg_pool import ConnectionPool
 
 from datadog_checks.base import AgentCheck
 

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -110,9 +110,7 @@ class ExplainParameterizedQueries:
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _get_number_of_parameters_for_prepared_statement(self, conn, query_signature):
-        rows = self._execute_query_and_fetch_rows(
-            conn, PARAM_TYPES_COUNT_QUERY.format(query_signature=query_signature)
-        )
+        rows = self._execute_query_and_fetch_rows(conn, PARAM_TYPES_COUNT_QUERY.format(query_signature=query_signature))
         count = 0
         if rows and 'count' in rows[0]:
             count = rows[0]['count']
@@ -150,9 +148,7 @@ class ExplainParameterizedQueries:
 
     def _deallocate_prepared_statement(self, conn, query_signature):
         try:
-            self._execute_query(
-                conn, "DEALLOCATE PREPARE dd_{query_signature}".format(query_signature=query_signature)
-            )
+            self._execute_query(conn, "DEALLOCATE PREPARE dd_{query_signature}".format(query_signature=query_signature))
         except Exception as e:
             logger.warning(
                 'Failed to deallocate prepared statement query_signature=[%s] | err=[%s]',

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -64,35 +64,36 @@ class ExplainParameterizedQueries:
                 Returns: (plan)
     '''
 
-    def __init__(self, check, config, thread_id):
+    def __init__(self, check, config):
         self._check = check
         self._config = config
-        self._thread_id = thread_id
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def explain_statement(self, dbname, statement, obfuscated_statement):
         if self._check.version < V12:
             return None
-        self._set_plan_cache_mode(dbname)
 
         query_signature = compute_sql_signature(obfuscated_statement)
-        if not self._create_prepared_statement(dbname, statement, obfuscated_statement, query_signature):
-            return None
+        with self._check.db_pool.get_connection(dbname, self._check._config.idle_connection_timeout) as conn:
+            self._set_plan_cache_mode(conn)
 
-        result = self._explain_prepared_statement(dbname, statement, obfuscated_statement, query_signature)
-        self._deallocate_prepared_statement(dbname, query_signature)
-        if result:
-            return result[0]['explain_statement'][0]
+            if not self._create_prepared_statement(conn, statement, obfuscated_statement, query_signature):
+                return None
+
+            result = self._explain_prepared_statement(conn, statement, obfuscated_statement, query_signature)
+            self._deallocate_prepared_statement(conn, query_signature)
+            if result:
+                return result[0]['explain_statement'][0]
         return None
 
-    def _set_plan_cache_mode(self, dbname):
-        self._execute_query(dbname, "SET plan_cache_mode = force_generic_plan")
+    def _set_plan_cache_mode(self, conn):
+        self._execute_query(conn, "SET plan_cache_mode = force_generic_plan")
 
     @tracked_method(agent_check_getter=agent_check_getter)
-    def _create_prepared_statement(self, dbname, statement, obfuscated_statement, query_signature):
+    def _create_prepared_statement(self, conn, statement, obfuscated_statement, query_signature):
         try:
             self._execute_query(
-                dbname, PREPARE_STATEMENT_QUERY.format(query_signature=query_signature, statement=statement)
+                conn, PREPARE_STATEMENT_QUERY.format(query_signature=query_signature, statement=statement)
             )
             return True
         except Exception as e:
@@ -108,9 +109,9 @@ class ExplainParameterizedQueries:
         return False
 
     @tracked_method(agent_check_getter=agent_check_getter)
-    def _get_number_of_parameters_for_prepared_statement(self, dbname, query_signature):
+    def _get_number_of_parameters_for_prepared_statement(self, conn, query_signature):
         rows = self._execute_query_and_fetch_rows(
-            dbname, PARAM_TYPES_COUNT_QUERY.format(query_signature=query_signature)
+            conn, PARAM_TYPES_COUNT_QUERY.format(query_signature=query_signature)
         )
         count = 0
         if rows and 'count' in rows[0]:
@@ -118,16 +119,16 @@ class ExplainParameterizedQueries:
         return count
 
     @tracked_method(agent_check_getter=agent_check_getter)
-    def _explain_prepared_statement(self, dbname, statement, obfuscated_statement, query_signature):
+    def _explain_prepared_statement(self, conn, statement, obfuscated_statement, query_signature):
         null_parameter = ','.join(
-            'null' for _ in range(self._get_number_of_parameters_for_prepared_statement(dbname, query_signature))
+            'null' for _ in range(self._get_number_of_parameters_for_prepared_statement(conn, query_signature))
         )
         execute_prepared_statement_query = EXECUTE_PREPARED_STATEMENT_QUERY.format(
             prepared_statement=query_signature, generic_values=null_parameter
         )
         try:
             return self._execute_query_and_fetch_rows(
-                dbname,
+                conn,
                 EXPLAIN_QUERY.format(
                     explain_function=self._config.statement_samples_config.get(
                         'explain_function', 'datadog.explain_statement'
@@ -147,10 +148,10 @@ class ExplainParameterizedQueries:
             )
         return None
 
-    def _deallocate_prepared_statement(self, dbname, query_signature):
+    def _deallocate_prepared_statement(self, conn, query_signature):
         try:
             self._execute_query(
-                dbname, "DEALLOCATE PREPARE dd_{query_signature}".format(query_signature=query_signature)
+                conn, "DEALLOCATE PREPARE dd_{query_signature}".format(query_signature=query_signature)
             )
         except Exception as e:
             logger.warning(
@@ -159,19 +160,13 @@ class ExplainParameterizedQueries:
                 e,
             )
 
-    def _execute_query(self, dbname, query):
-        with self._check.db_pool.get_connection(
-            dbname, self._check._config.idle_connection_timeout, conn_prefix=self._thread_id
-        ) as conn:
-            with conn.cursor(row_factory=dict_row) as cursor:
-                logger.debug('Executing query=[%s]', query)
-                cursor.execute(query)
+    def _execute_query(self, conn, query):
+        with conn.cursor(row_factory=dict_row) as cursor:
+            logger.debug('Executing query=[%s]', query)
+            cursor.execute(query)
 
-    def _execute_query_and_fetch_rows(self, dbname, query):
-        with self._check.db_pool.get_connection(
-            dbname, self._check._config.idle_connection_timeout, conn_prefix=self._thread_id
-        ) as conn:
-            with conn.cursor(row_factory=dict_row) as cursor:
-                logger.debug('Executing query=[%s]', query)
-                cursor.execute(query)
-                return cursor.fetchall()
+    def _execute_query_and_fetch_rows(self, conn, query):
+        with conn.cursor(row_factory=dict_row) as cursor:
+            logger.debug('Executing query=[%s]', query)
+            cursor.execute(query)
+            return cursor.fetchall()

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -214,7 +214,6 @@ class PostgresMetadata(DBMAsyncJob):
         self.tags = [t for t in self._tags if not t.startswith('dd.internal')]
         self._tags_no_db = [t for t in self.tags if not t.startswith('db:')]
         self.report_postgres_metadata()
-        self._check.db_pool.prune_connections()
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def report_postgres_metadata(self):

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -463,10 +463,11 @@ class PostgresMetadata(DBMAsyncJob):
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_postgres_settings(self):
-        with self._check.get_main_db().cursor(row_factory=dict_row) as cursor:
-            self._log.debug("Running query [%s]", PG_SETTINGS_QUERY)
-            self._time_since_last_settings_query = time.time()
-            cursor.execute(PG_SETTINGS_QUERY)
-            rows = cursor.fetchall()
-            self._log.debug("Loaded %s rows from pg_settings", len(rows))
-            return [dict(row) for row in rows]
+        with self.db_pool.get_main_db_pool().connection() as conn:
+            with conn.cursor(row_factory=dict_row) as cursor:
+                self._log.debug("Running query [%s]", PG_SETTINGS_QUERY)
+                self._time_since_last_settings_query = time.time()
+                cursor.execute(PG_SETTINGS_QUERY)
+                rows = cursor.fetchall()
+                self._log.debug("Loaded %s rows from pg_settings", len(rows))
+                return [dict(row) for row in rows]

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -222,19 +222,19 @@ class PostgresMetadata(DBMAsyncJob):
         elapsed_s = time.time() - self._time_since_last_settings_query
         if elapsed_s >= self.pg_settings_collection_interval and self._collect_pg_settings_enabled:
             self._pg_settings_cached = self._collect_postgres_settings()
-        event = {
-            "host": self._check.resolved_hostname,
-            "agent_version": datadog_agent.get_version(),
-            "dbms": "postgres",
-            "kind": "pg_settings",
-            "collection_interval": self.collection_interval,
-            'dbms_version': payload_pg_version(self._check.version),
-            "tags": self._tags_no_db,
-            "timestamp": time.time() * 1000,
-            "cloud_metadata": self._config.cloud_metadata,
-            "metadata": self._pg_settings_cached,
-        }
-        self._check.database_monitoring_metadata(json.dumps(event, default=default_json_event_encoding))
+            event = {
+                "host": self._check.resolved_hostname,
+                "agent_version": datadog_agent.get_version(),
+                "dbms": "postgres",
+                "kind": "pg_settings",
+                "collection_interval": self.collection_interval,
+                'dbms_version': payload_pg_version(self._check.version),
+                "tags": self._tags_no_db,
+                "timestamp": time.time() * 1000,
+                "cloud_metadata": self._config.cloud_metadata,
+                "metadata": self._pg_settings_cached,
+            }
+            self._check.database_monitoring_metadata(json.dumps(event, default=default_json_event_encoding))
 
         elapsed_s_schemas = time.time() - self._time_since_last_schemas_query
         if elapsed_s_schemas >= self.schemas_collection_interval and self._collect_schemas_enabled:
@@ -312,7 +312,7 @@ class PostgresMetadata(DBMAsyncJob):
         """
         limit = self._config.schemas_metadata_config.get('max_tables', 1000)
         if self._config.relations:
-            if VersionUtils.transform_version(str(self._check._version))['version.major'] == "9":
+            if VersionUtils.transform_version(str(self._check.version))['version.major'] == "9":
                 cursor.execute(PG_TABLES_QUERY_V9.format(schema_oid=schema_id))
             else:
                 cursor.execute(PG_TABLES_QUERY_V10_PLUS.format(schema_oid=schema_id))
@@ -349,7 +349,7 @@ class PostgresMetadata(DBMAsyncJob):
             # so we have to grab the total partition activity
             # note: partitions don't exist in V9, so we have to check this first
             if (
-                VersionUtils.transform_version(str(self._check._version))['version.major'] == "9"
+                VersionUtils.transform_version(str(self._check.version))['version.major'] == "9"
                 or not info["has_partitions"]
             ):
                 return (
@@ -404,7 +404,7 @@ class PostgresMetadata(DBMAsyncJob):
                 idxs = [dict(row) for row in rows]
                 this_payload.update({'indexes': idxs})
 
-            if VersionUtils.transform_version(str(self._check._version))['version.major'] != "9":
+            if VersionUtils.transform_version(str(self._check.version))['version.major'] != "9":
                 if table['has_partitions']:
                     cursor.execute(PARTITION_KEY_QUERY.format(parent=name))
                     row = cursor.fetchone()

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -182,7 +182,10 @@ class PostgreSql(AgentCheck):
         )
 
     def execute_query_raw(self, query):
-        return self.db_pool.execute_main_db_safe(query)
+        with self.db.cursor() as cursor:
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            return rows
 
     @property
     def dynamic_queries(self):

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -229,7 +229,6 @@ class PostgreSql(AgentCheck):
             # Wal receiver is not supported on aurora
             # select * from pg_stat_wal_receiver;
             # ERROR:  Function pg_stat_get_wal_receiver() is currently not supported in Aurora
-            print(self.is_aurora)
             if self.is_aurora is False:
                 queries.append(QUERY_PG_STAT_WAL_RECEIVER)
             queries.append(QUERY_PG_REPLICATION_SLOTS)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -8,7 +8,6 @@ from time import time
 
 import psycopg
 from cachetools import TTLCache
-from psycopg import ClientCursor
 from psycopg.rows import dict_row
 from psycopg_pool import ConnectionPool
 from six import iteritems

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -112,6 +112,7 @@ class PostgreSql(AgentCheck):
         self._clean_state()
         self.check_initializations.append(lambda: RelationsManager.validate_relations_config(self._config.relations))
         self.check_initializations.append(self.set_resolved_hostname_metadata)
+        self.check_initializations.append(self._connect)
         self.check_initializations.append(self.load_version)
         self.check_initializations.append(self.initialize_is_aurora)
         self.tags_without_db = [t for t in copy.copy(self.tags) if not t.startswith("db:")]

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -85,8 +85,8 @@ class PostgreSql(AgentCheck):
         self.persistent_conn = None
         self._resolved_hostname = None
         self._agent_hostname = None
-        self._version = None
-        self._is_aurora = None
+        self.version = None
+        self.is_aurora = None
         self._version_utils = VersionUtils()
         # Deprecate custom_metrics in favor of custom_queries
         if 'custom_metrics' in self.instance:
@@ -113,6 +113,8 @@ class PostgreSql(AgentCheck):
         self._clean_state()
         self.check_initializations.append(lambda: RelationsManager.validate_relations_config(self._config.relations))
         self.check_initializations.append(self.set_resolved_hostname_metadata)
+        self.check_initializations.append(self.load_version)
+        self.check_initializations.append(self.initialize_is_aurora)
         self.tags_without_db = [t for t in copy.copy(self.tags) if not t.startswith("db:")]
         self.autodiscovery = self._build_autodiscovery()
         self._dynamic_queries = None
@@ -183,17 +185,18 @@ class PostgreSql(AgentCheck):
         )
 
     def execute_query_raw(self, query):
-        with self.db.cursor() as cursor:
-            cursor.execute(query)
-            rows = cursor.fetchall()
-            return rows
+        with self.db.connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute(query)
+                rows = cursor.fetchall()
+                return rows
 
     @property
     def dynamic_queries(self):
         if self._dynamic_queries:
             return self._dynamic_queries
 
-        if self._version is None:
+        if self.version is None:
             self.log.debug("Version set to None due to incorrect identified version, aborting dynamic queries")
             return None
 
@@ -281,8 +284,6 @@ class PostgreSql(AgentCheck):
 
     def _clean_state(self):
         self.log.debug("Cleaning state")
-        self._version = None
-        self._is_aurora = None
         self.metrics_cache.clean_state()
         self._dynamic_queries = None
 
@@ -295,11 +296,12 @@ class PostgreSql(AgentCheck):
         return list(service_check_tags)
 
     def _get_replication_role(self):
-        with self.db.cursor() as cursor:
-            cursor.execute('SELECT pg_is_in_recovery();')
-            role = cursor.fetchone()[0]
-            # value fetched for role is of <type 'bool'>
-            return "standby" if role else "master"
+        with self.db.connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute('SELECT pg_is_in_recovery();')
+                role = cursor.fetchone()[0]
+                # value fetched for role is of <type 'bool'>
+                return "standby" if role else "master"
 
     def _collect_wal_metrics(self, instance_tags):
         if self.version >= V10:
@@ -344,19 +346,16 @@ class PostgreSql(AgentCheck):
         oldest_file_age = now - os.path.getctime(oldest_file)
         return oldest_file_age
 
-    @property
-    def version(self):
-        if self._version is None:
-            raw_version = self._version_utils.get_raw_version(self.db)
-            self._version = self._version_utils.parse_version(raw_version)
-            self.set_metadata('version', raw_version)
-        return self._version
+    def load_version(self):
+        raw_version = self._version_utils.get_raw_version(self.db)
+        self.version = self._version_utils.parse_version(raw_version)
+        self.set_metadata('version', raw_version)
+        return self.version
 
-    @property
-    def is_aurora(self):
-        if self._is_aurora is None:
-            self._is_aurora = self._version_utils.is_aurora(self.db)
-        return self._is_aurora
+    def initialize_is_aurora(self):
+        if self.is_aurora is None:
+            self.is_aurora = self._version_utils.is_aurora(self.db)
+        return self.is_aurora
 
     @property
     def resolved_hostname(self):
@@ -414,7 +413,6 @@ class PostgreSql(AgentCheck):
         except psycopg.errors.FeatureNotSupported as e:
             # This happens for example when trying to get replication metrics from readers in Aurora. Let's ignore it.
             log_func(e)
-            self.db.rollback()
             self.log.debug("Disabling replication metrics")
             self._is_aurora = False
             self.metrics_cache.replication_metrics = {}
@@ -422,13 +420,11 @@ class PostgreSql(AgentCheck):
             log_func(e)
             log_func(
                 "It seems the PG version has been incorrectly identified as %s. "
-                "A reattempt to identify the right version will happen on next agent run." % self._version
+                "A reattempt to identify the right version will happen on next agent run." % self.version
             )
             self._clean_state()
-            self.db.rollback()
         except (psycopg.ProgrammingError, psycopg.errors.QueryCanceled) as e:
             log_func("Not all metrics may be available: %s" % str(e))
-            self.db.rollback()
 
         if not results:
             return None
@@ -592,7 +588,6 @@ class PostgreSql(AgentCheck):
         # Do we need relation-specific metrics?
         if self._config.relations:
             relations_scopes = list(RELATION_METRICS)
-
             if self._config.collect_bloat_metrics:
                 relations_scopes.extend([INDEX_BLOAT, TABLE_BLOAT])
 
@@ -613,30 +608,33 @@ class PostgreSql(AgentCheck):
         if replication_stats_metrics:
             metric_scope.append(replication_stats_metrics)
 
-        with self.db.cursor() as cursor:
-            results_len = self._query_scope(cursor, db_instance_metrics, instance_tags, False)
-            if results_len is not None:
-                self.gauge(
-                    "postgresql.db.count",
-                    results_len,
-                    tags=copy.copy(self.tags_without_db),
-                    hostname=self.resolved_hostname,
-                )
+        with self.db.connection() as conn:
+            with conn.cursor() as cursor:
+                results_len = self._query_scope(cursor, db_instance_metrics, instance_tags, False)
+                if results_len is not None:
+                    self.gauge(
+                        "postgresql.db.count",
+                        results_len,
+                        tags=copy.copy(self.tags_without_db),
+                        hostname=self.resolved_hostname,
+                    )
 
-            self._query_scope(cursor, bgw_instance_metrics, instance_tags, False)
-            self._query_scope(cursor, archiver_instance_metrics, instance_tags, False)
+                self._query_scope(cursor, bgw_instance_metrics, instance_tags, False)
+                self._query_scope(cursor, archiver_instance_metrics, instance_tags, False)
 
-            if self._config.collect_activity_metrics:
-                activity_metrics = self.metrics_cache.get_activity_metrics(self.version)
-                self._query_scope(cursor, activity_metrics, instance_tags, False)
+                if self._config.collect_activity_metrics:
+                    activity_metrics = self.metrics_cache.get_activity_metrics(self.version)
+                    self._query_scope(cursor, activity_metrics, instance_tags, False)
 
-            for scope in list(metric_scope) + self._config.custom_metrics:
-                self._query_scope(cursor, scope, instance_tags, scope in self._config.custom_metrics)
+                for scope in list(metric_scope) + self._config.custom_metrics:
+                    self._query_scope(cursor, scope, instance_tags, scope in self._config.custom_metrics)
 
-            if self.dynamic_queries:
-                self.dynamic_queries.execute()
+        if self.dynamic_queries:
+            self.dynamic_queries.execute()
 
-    def _new_connection(self, dbname):
+    def _new_connection(self, dbname: str, min_pool_size: int = 1, max_pool_size: int = None):
+        # required for autocommit as well as using params in queries
+        args = {"autocommit": True, "cursor_factory": psycopg.ClientCursor}
         if self._config.host == 'localhost' and self._config.password == '':
             # Use ident method
             connection_string = "user=%s dbname=%s application_name=%s" % (
@@ -646,7 +644,14 @@ class PostgreSql(AgentCheck):
             )
             if self._config.query_timeout:
                 connection_string += " options='-c statement_timeout=%s'" % self._config.query_timeout
-            conn = psycopg.connect(conninfo=connection_string, autocommit=True, cursor_factory=ClientCursor)
+            pool = ConnectionPool(
+                conninfo=connection_string,
+                min_size=min_pool_size,
+                max_size=max_pool_size,
+                kwargs=args,
+                open=True,
+                name=dbname,
+            )
         else:
             password = self._config.password
             region = self._config.cloud_metadata.get('aws', {}).get('region', None)
@@ -662,7 +667,7 @@ class PostgreSql(AgentCheck):
             if client_id is not None:
                 password = azure.generate_managed_identity_token(client_id=client_id, scope=scope)
 
-            args = {
+            conn_args = {
                 'host': self._config.host,
                 'user': self._config.user,
                 'password': password,
@@ -671,20 +676,20 @@ class PostgreSql(AgentCheck):
                 'application_name': self._config.application_name,
             }
             if self._config.port:
-                args['port'] = self._config.port
+                conn_args['port'] = self._config.port
             if self._config.query_timeout:
-                args['options'] = '-c statement_timeout=%s' % self._config.query_timeout
+                conn_args['options'] = '-c statement_timeout=%s' % self._config.query_timeout
             if self._config.ssl_cert:
-                args['sslcert'] = self._config.ssl_cert
+                conn_args['sslcert'] = self._config.ssl_cert
             if self._config.ssl_root_cert:
-                args['sslrootcert'] = self._config.ssl_root_cert
+                conn_args['sslrootcert'] = self._config.ssl_root_cert
             if self._config.ssl_key:
-                args['sslkey'] = self._config.ssl_key
+                conn_args['sslkey'] = self._config.ssl_key
             if self._config.ssl_password:
-                args['sslpassword'] = self._config.ssl_password
-
-            conn = psycopg.connect(**args, autocommit=True, cursor_factory=ClientCursor)
-        return conn
+                conn_args['sslpassword'] = self._config.ssl_password
+            args.update(conn_args)
+            pool = ConnectionPool(min_size=min_pool_size, max_size=max_pool_size, kwargs=args, open=True, name=dbname)
+        return pool
 
     def _connect(self):
         """
@@ -696,28 +701,26 @@ class PostgreSql(AgentCheck):
         if self.db and self.db.closed:
             # Reset the connection object to retry to connect
             self.db = None
-        if self.db:
-            if self.db.info.status != psycopg.pq.ConnStatus.OK:
-                # Some transaction went wrong and the connection is in an unhealthy state. Let's fix that
-                self.db.rollback()
-        else:
-            self.db = self._new_connection(self._config.dbname)
+
+        if not self.db:
+            self.db = self._new_connection(self._config.dbname, max_pool_size=1)
 
     # Reload pg_settings on a new connection to the main db
     def load_pg_settings(self, db):
         try:
-            with db.cursor(row_factory=dict_row) as cursor:
-                self.log.debug("Running query [%s]", PG_SETTINGS_QUERY)
-                cursor.execute(
-                    PG_SETTINGS_QUERY,
-                    ("pg_stat_statements.max", "track_activity_query_size", "track_io_timing"),
-                )
-                rows = cursor.fetchall()
-                self.pg_settings.clear()
-                for setting in rows:
-                    name = setting['name']
-                    val = setting['setting']
-                    self.pg_settings[name] = val
+            with db.connection() as conn:
+                with conn.cursor(row_factory=dict_row) as cursor:
+                    self.log.debug("Running query [%s]", PG_SETTINGS_QUERY)
+                    cursor.execute(
+                        PG_SETTINGS_QUERY,
+                        ("pg_stat_statements.max", "track_activity_query_size", "track_io_timing"),
+                    )
+                    rows = cursor.fetchall()
+                    self.pg_settings.clear()
+                    for setting in rows:
+                        name = setting['name']
+                        val = setting['setting']
+                        self.pg_settings[name] = val
         except (psycopg.DatabaseError, psycopg.OperationalError) as err:
             self.log.warning("Failed to query for pg_settings: %s", repr(err))
             self.count(
@@ -754,79 +757,81 @@ class PostgreSql(AgentCheck):
                 self.log.error("custom query field `columns` is required for metric_prefix `%s`", metric_prefix)
                 continue
 
-            with self.db.cursor() as cursor:
-                try:
-                    self.log.debug("Running query: %s", query)
-                    cursor.execute(query)
-                except (psycopg.ProgrammingError, psycopg.errors.QueryCanceled) as e:
-                    self.log.error("Error executing query for metric_prefix %s: %s", metric_prefix, str(e))
-                    self.db.rollback()
-                    continue
-
-                for row in cursor:
-                    if not row:
-                        self.log.debug("query result for metric_prefix %s: returned an empty result", metric_prefix)
+            with self.db.connection() as conn:
+                with conn.cursor() as cursor:
+                    try:
+                        self.log.debug("Running query: %s", query)
+                        cursor.execute(query)
+                    except (psycopg.ProgrammingError, psycopg.errors.QueryCanceled) as e:
+                        self.log.error("Error executing query for metric_prefix %s: %s", metric_prefix, str(e))
                         continue
 
-                    if len(columns) != len(row):
-                        self.log.error(
-                            "query result for metric_prefix %s: expected %s columns, got %s",
-                            metric_prefix,
-                            len(columns),
-                            len(row),
-                        )
-                        continue
-
-                    metric_info = []
-                    query_tags = list(custom_query.get('tags', []))
-                    query_tags.extend(tags)
-
-                    for column, value in zip(columns, row):
-                        # Columns can be ignored via configuration.
-                        if not column:
+                    for row in cursor:
+                        if not row:
+                            self.log.debug("query result for metric_prefix %s: returned an empty result", metric_prefix)
                             continue
 
-                        name = column.get('name')
-                        if not name:
-                            self.log.error("column field `name` is required for metric_prefix `%s`", metric_prefix)
-                            break
-
-                        column_type = column.get('type')
-                        if not column_type:
+                        if len(columns) != len(row):
                             self.log.error(
-                                "column field `type` is required for column `%s` of metric_prefix `%s`",
-                                name,
+                                "query result for metric_prefix %s: expected %s columns, got %s",
                                 metric_prefix,
+                                len(columns),
+                                len(row),
                             )
-                            break
+                            continue
 
-                        if column_type == 'tag':
-                            query_tags.append('{}:{}'.format(name, value))
+                        metric_info = []
+                        query_tags = list(custom_query.get('tags', []))
+                        query_tags.extend(tags)
+
+                        for column, value in zip(columns, row):
+                            # Columns can be ignored via configuration.
+                            if not column:
+                                continue
+
+                            name = column.get('name')
+                            if not name:
+                                self.log.error("column field `name` is required for metric_prefix `%s`", metric_prefix)
+                                break
+
+                            column_type = column.get('type')
+                            if not column_type:
+                                self.log.error(
+                                    "column field `type` is required for column `%s` of metric_prefix `%s`",
+                                    name,
+                                    metric_prefix,
+                                )
+                                break
+
+                            if column_type == 'tag':
+                                query_tags.append('{}:{}'.format(name, value))
+                            else:
+                                if not hasattr(self, column_type):
+                                    self.log.error(
+                                        "invalid submission method `%s` for column `%s` of metric_prefix `%s`",
+                                        column_type,
+                                        name,
+                                        metric_prefix,
+                                    )
+                                    break
+                                try:
+                                    metric_info.append(('{}.{}'.format(metric_prefix, name), float(value), column_type))
+                                except (ValueError, TypeError):
+                                    self.log.error(
+                                        "non-numeric value `%s` for metric column `%s` of metric_prefix `%s`",
+                                        value,
+                                        name,
+                                        metric_prefix,
+                                    )
+                                    break
+
+                        # Only submit metrics if there were absolutely no errors - all or nothing.
                         else:
-                            if not hasattr(self, column_type):
-                                self.log.error(
-                                    "invalid submission method `%s` for column `%s` of metric_prefix `%s`",
-                                    column_type,
-                                    name,
-                                    metric_prefix,
+                            for info in metric_info:
+                                metric, value, method = info
+                                getattr(self, method)(
+                                    metric, value, tags=set(query_tags), hostname=self.resolved_hostname
                                 )
-                                break
-                            try:
-                                metric_info.append(('{}.{}'.format(metric_prefix, name), float(value), column_type))
-                            except (ValueError, TypeError):
-                                self.log.error(
-                                    "non-numeric value `%s` for metric column `%s` of metric_prefix `%s`",
-                                    value,
-                                    name,
-                                    metric_prefix,
-                                )
-                                break
-
-                    # Only submit metrics if there were absolutely no errors - all or nothing.
-                    else:
-                        for info in metric_info:
-                            metric, value, method = info
-                            getattr(self, method)(metric, value, tags=set(query_tags), hostname=self.resolved_hostname)
 
     def record_warning(self, code, message):
         # type: (DatabaseConfigurationError, str) -> None
@@ -867,6 +872,7 @@ class PostgreSql(AgentCheck):
         try:
             # Check version
             self._connect()
+            self.load_version()  # We don't want to cache versions between runs to capture minor updates for metadata
             if self._config.tag_replication_role:
                 replication_role_tag = "replication_role:{}".format(self._get_replication_role())
                 tags.append(replication_role_tag)
@@ -907,12 +913,6 @@ class PostgreSql(AgentCheck):
                 tags=self._get_service_check_tags(),
                 hostname=self.resolved_hostname,
             )
-            try:
-                # commit to close the current query transaction
-                self.db.commit()
-            except Exception as e:
-                self.log.warning("Unable to commit: %s", e)
-            self._version = None  # We don't want to cache versions between runs to capture minor updates for metadata
         finally:
             # Add the warnings saved during the execution of the check
             self._report_warnings()

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -10,6 +10,7 @@ import psycopg
 from cachetools import TTLCache
 from psycopg import ClientCursor
 from psycopg.rows import dict_row
+from psycopg_pool import ConnectionPool
 from six import iteritems
 
 from datadog_checks.base import AgentCheck

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -229,6 +229,7 @@ class PostgreSql(AgentCheck):
             # Wal receiver is not supported on aurora
             # select * from pg_stat_wal_receiver;
             # ERROR:  Function pg_stat_get_wal_receiver() is currently not supported in Aurora
+            print(self.is_aurora)
             if self.is_aurora is False:
                 queries.append(QUERY_PG_STAT_WAL_RECEIVER)
             queries.append(QUERY_PG_REPLICATION_SLOTS)

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -269,11 +269,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         query = PG_ACTIVE_CONNECTIONS_QUERY.format(
             pg_stat_activity_view=self._config.pg_stat_activity_view, extra_filters=extra_filters
         )
-        with self._check.get_main_db().cursor(row_factory=dict_row) as cursor:
-            self._log.debug("Running query [%s] %s", query, params)
-            cursor.execute(query, params)
-            rows = cursor.fetchall()
-
+        rows = self.db_pool.execute_main_db_safe(query, params, row_format=dict_row)
         self._report_check_hist_metrics(start_time, len(rows), "get_active_connections")
         self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)
         return [dict(row) for row in rows]
@@ -302,11 +298,7 @@ class PostgresStatementSamples(DBMAsyncJob):
             pg_stat_activity_view=self._config.pg_stat_activity_view,
             extra_filters=extra_filters,
         )
-        with self._check.get_main_db().cursor(row_factory=dict_row) as cursor:
-            self._log.debug("Running query [%s] %s", query, params)
-            cursor.execute(query, params)
-            rows = cursor.fetchall()
-
+        rows = self.db_pool.execute_main_db_safe(query, params, row_format=dict_row)
         self._report_check_hist_metrics(start_time, len(rows), "get_new_pg_stat_activity")
         self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)
         return rows
@@ -320,18 +312,15 @@ class PostgresStatementSamples(DBMAsyncJob):
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _get_available_activity_columns(self, all_expected_columns):
-        with self._check.get_main_db().cursor(row_factory=dict_row) as cursor:
-            cursor.execute(
-                "select * from {pg_stat_activity_view} LIMIT 0".format(
-                    pg_stat_activity_view=self._config.pg_stat_activity_view
-                )
-            )
-            all_columns = {i[0] for i in cursor.description}
-            available_columns = [c for c in all_expected_columns if c in all_columns]
-            missing_columns = set(all_expected_columns) - set(available_columns)
-            if missing_columns:
-                self._log.debug("missing the following expected columns from pg_stat_activity: %s", missing_columns)
-            self._log.debug("found available pg_stat_activity columns: %s", available_columns)
+        query = "select * from {pg_stat_activity_view} LIMIT 0".format(
+            pg_stat_activity_view=self._config.pg_stat_activity_view
+        )
+        all_columns = self.db_pool.get_main_db_columns_safe(query, params=())
+        available_columns = [c for c in all_expected_columns if c in all_columns]
+        missing_columns = set(all_expected_columns) - set(available_columns)
+        if missing_columns:
+            self._log.debug("missing the following expected columns from pg_stat_activity: %s", missing_columns)
+        self._log.debug("found available pg_stat_activity columns: %s", available_columns)
         return available_columns
 
     def _filter_and_normalize_statement_rows(self, rows):

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -210,8 +210,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         self._activity_last_query_start = None
         # The value is loaded when connecting to the main database
         self._explain_function = config.statement_samples_config.get('explain_function', 'datadog.explain_statement')
-        self._thread_id = "query-samples"
-        self._explain_parameterized_queries = ExplainParameterizedQueries(check, config, self._thread_id)
+        self._explain_parameterized_queries = ExplainParameterizedQueries(check, config)
         self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
 
         self._collection_strategy_cache = TTLCache(
@@ -270,10 +269,11 @@ class PostgresStatementSamples(DBMAsyncJob):
         query = PG_ACTIVE_CONNECTIONS_QUERY.format(
             pg_stat_activity_view=self._config.pg_stat_activity_view, extra_filters=extra_filters
         )
-        with self.db_pool.get_main_db(conn_prefix=self._thread_id).cursor(row_factory=dict_row) as cursor:
-            self._log.debug("Running query [%s] %s", query, params)
-            cursor.execute(query, params)
-            rows = cursor.fetchall()
+        with self.db_pool.get_main_db_pool().connection() as conn:
+            with conn.cursor(row_factory=dict_row) as cursor:
+                self._log.debug("Running query [%s] %s", query, params)
+                cursor.execute(query, params)
+                rows = cursor.fetchall()
         self._report_check_hist_metrics(start_time, len(rows), "get_active_connections")
         self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)
         return [dict(row) for row in rows]
@@ -302,10 +302,11 @@ class PostgresStatementSamples(DBMAsyncJob):
             pg_stat_activity_view=self._config.pg_stat_activity_view,
             extra_filters=extra_filters,
         )
-        with self.db_pool.get_main_db(conn_prefix=self._thread_id).cursor(row_factory=dict_row) as cursor:
-            self._log.debug("Running query [%s] %s", query, params)
-            cursor.execute(query, params)
-            rows = cursor.fetchall()
+        with self.db_pool.get_main_db_pool().connection() as conn:
+            with conn.cursor(row_factory=dict_row) as cursor:
+                self._log.debug("Running query [%s] %s", query, params)
+                cursor.execute(query, params)
+                rows = cursor.fetchall()
         self._report_check_hist_metrics(start_time, len(rows), "get_new_pg_stat_activity")
         self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)
         return rows
@@ -319,18 +320,19 @@ class PostgresStatementSamples(DBMAsyncJob):
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _get_available_activity_columns(self, all_expected_columns):
-        with self.db_pool.get_main_db(conn_prefix=self._thread_id).cursor(row_factory=dict_row) as cursor:
-            cursor.execute(
-                "select * from {pg_stat_activity_view} LIMIT 0".format(
-                    pg_stat_activity_view=self._config.pg_stat_activity_view
+        with self.db_pool.get_main_db_pool().connection() as conn:
+            with conn.cursor(row_factory=dict_row) as cursor:
+                cursor.execute(
+                    "select * from {pg_stat_activity_view} LIMIT 0".format(
+                        pg_stat_activity_view=self._config.pg_stat_activity_view
+                    )
                 )
-            )
-            all_columns = {i[0] for i in cursor.description}
-            available_columns = [c for c in all_expected_columns if c in all_columns]
-            missing_columns = set(all_expected_columns) - set(available_columns)
-            if missing_columns:
-                self._log.debug("missing the following expected columns from pg_stat_activity: %s", missing_columns)
-            self._log.debug("found available pg_stat_activity columns: %s", available_columns)
+                all_columns = {i[0] for i in cursor.description}
+                available_columns = [c for c in all_expected_columns if c in all_columns]
+                missing_columns = set(all_expected_columns) - set(available_columns)
+                if missing_columns:
+                    self._log.debug("missing the following expected columns from pg_stat_activity: %s", missing_columns)
+                self._log.debug("found available pg_stat_activity columns: %s", available_columns)
         return available_columns
 
     def _filter_and_normalize_statement_rows(self, rows):
@@ -518,7 +520,7 @@ class PostgresStatementSamples(DBMAsyncJob):
     def _get_db_explain_setup_state(self, dbname):
         # type: (str) -> Tuple[Optional[DBExplainError], Optional[Exception]]
         try:
-            with self.db_pool.get_connection(dbname, self._conn_ttl_ms, conn_prefix=self._thread_id):
+            with self.db_pool.get_connection(dbname, self._conn_ttl_ms):
                 pass
         except psycopg.OperationalError as e:
             self._log.warning(
@@ -583,7 +585,7 @@ class PostgresStatementSamples(DBMAsyncJob):
 
     def _run_explain(self, dbname, statement, obfuscated_statement):
         start_time = time.time()
-        with self.db_pool.get_connection(dbname, ttl_ms=self._conn_ttl_ms, conn_prefix=self._thread_id) as conn:
+        with self.db_pool.get_connection(dbname, ttl_ms=self._conn_ttl_ms) as conn:
             with conn.cursor() as cursor:
                 self._log.debug(
                     "Running query on dbname=%s: %s(%s)", dbname, self._explain_function, obfuscated_statement

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -144,10 +144,13 @@ class PostgresStatementMetrics(DBMAsyncJob):
             maxsize=config.full_statement_text_cache_max_size,
             ttl=60 * 60 / config.full_statement_text_samples_per_hour_per_query,
         )
+        self._thread_id = "query-metrics"
 
-    def _execute_query(self, query, params=(), row_format=None):
+    def _execute_query(self, cursor, query, params=()):
         try:
-            return self.db_pool.execute_main_db_safe(query, params, row_format)
+            self._log.debug("Running query [%s] %s", query, params)
+            cursor.execute(query, params)
+            return cursor.fetchall()
         except (psycopg.ProgrammingError, psycopg.errors.QueryCanceled) as e:
             # A failed query could've derived from incorrect columns within the cache. It's a rare edge case,
             # but the next time the query is run, it will retrieve the correct columns.
@@ -168,9 +171,11 @@ class PostgresStatementMetrics(DBMAsyncJob):
         query = STATEMENTS_QUERY.format(
             cols='*', pg_stat_statements_view=self._config.pg_stat_statements_view, extra_clauses="LIMIT 0", filters=""
         )
-        col_names = self.db_pool.get_main_db_columns_safe(query, params=())
-        self._stat_column_cache = col_names
-        return col_names
+        with self.db_pool.get_main_db(conn_prefix=self._thread_id).cursor() as cursor:
+            self._execute_query(cursor, query, params=())
+            col_names = [desc[0] for desc in cursor.description] if cursor.description else []
+            self._stat_column_cache = col_names
+            return col_names
 
     def run_job(self):
         # do not emit any dd.internal metrics for DBM specific check code
@@ -272,16 +277,17 @@ class PostgresStatementMetrics(DBMAsyncJob):
                     "pg_database.datname NOT ILIKE %s" for _ in self._config.ignore_databases
                 )
                 params = params + tuple(self._config.ignore_databases)
-            return self._execute_query(
-                STATEMENTS_QUERY.format(
-                    cols=', '.join(query_columns),
-                    pg_stat_statements_view=self._config.pg_stat_statements_view,
-                    filters=filters,
-                    extra_clauses="",
-                ),
-                params=params,
-                row_format=dict_row,
-            )
+            with self.db_pool.get_main_db(conn_prefix=self._thread_id).cursor(row_factory=dict_row) as cursor:
+                return self._execute_query(
+                    cursor,
+                    STATEMENTS_QUERY.format(
+                        cols=', '.join(query_columns),
+                        pg_stat_statements_view=self._config.pg_stat_statements_view,
+                        filters=filters,
+                        extra_clauses="",
+                    ),
+                    params=params,
+                )
         except psycopg.Error as e:
             error_tag = "error:database-{}".format(type(e).__name__)
 
@@ -344,7 +350,11 @@ class PostgresStatementMetrics(DBMAsyncJob):
         if self._check.version < V14:
             return
         try:
-            rows = self.db_pool.execute_main_db_safe(PG_STAT_STATEMENTS_DEALLOC, row_format=dict_row)
+            with self.db_pool.get_main_db(conn_prefix=self._thread_id).cursor(row_factory=dict_row) as cursor:
+                rows = self._execute_query(
+                    cursor,
+                    PG_STAT_STATEMENTS_DEALLOC,
+                )
             if rows:
                 dealloc = list(rows[0].values())[0]
                 self._check.monotonic_count(
@@ -360,7 +370,11 @@ class PostgresStatementMetrics(DBMAsyncJob):
     def _emit_pg_stat_statements_metrics(self):
         query = PG_STAT_STATEMENTS_COUNT_QUERY_LT_9_4 if self._check.version < V9_4 else PG_STAT_STATEMENTS_COUNT_QUERY
         try:
-            rows = self.db_pool.execute_main_db_safe(query, row_format=dict_row)
+            with self.db_pool.get_main_db(conn_prefix=self._thread_id).cursor(row_factory=dict_row) as cursor:
+                rows = self._execute_query(
+                    cursor,
+                    query,
+                )
             count = 0
             if rows and 'count' in rows[0]:
                 count = rows[0]['count']

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -171,11 +171,12 @@ class PostgresStatementMetrics(DBMAsyncJob):
         query = STATEMENTS_QUERY.format(
             cols='*', pg_stat_statements_view=self._config.pg_stat_statements_view, extra_clauses="LIMIT 0", filters=""
         )
-        with self.db_pool.get_main_db(conn_prefix=self._thread_id).cursor() as cursor:
-            self._execute_query(cursor, query, params=())
-            col_names = [desc[0] for desc in cursor.description] if cursor.description else []
-            self._stat_column_cache = col_names
-            return col_names
+        with self.db_pool.get_main_db_pool().connection() as conn:
+            with conn.cursor() as cursor:
+                self._execute_query(cursor, query, params=())
+                col_names = [desc[0] for desc in cursor.description] if cursor.description else []
+                self._stat_column_cache = col_names
+                return col_names
 
     def run_job(self):
         # do not emit any dd.internal metrics for DBM specific check code
@@ -277,17 +278,18 @@ class PostgresStatementMetrics(DBMAsyncJob):
                     "pg_database.datname NOT ILIKE %s" for _ in self._config.ignore_databases
                 )
                 params = params + tuple(self._config.ignore_databases)
-            with self.db_pool.get_main_db(conn_prefix=self._thread_id).cursor(row_factory=dict_row) as cursor:
-                return self._execute_query(
-                    cursor,
-                    STATEMENTS_QUERY.format(
-                        cols=', '.join(query_columns),
-                        pg_stat_statements_view=self._config.pg_stat_statements_view,
-                        filters=filters,
-                        extra_clauses="",
-                    ),
-                    params=params,
-                )
+            with self.db_pool.get_main_db_pool().connection() as conn:
+                with conn.cursor(row_factory=dict_row) as cursor:
+                    return self._execute_query(
+                        cursor,
+                        STATEMENTS_QUERY.format(
+                            cols=', '.join(query_columns),
+                            pg_stat_statements_view=self._config.pg_stat_statements_view,
+                            filters=filters,
+                            extra_clauses="",
+                        ),
+                        params=params,
+                    )
         except psycopg.Error as e:
             error_tag = "error:database-{}".format(type(e).__name__)
 
@@ -350,11 +352,12 @@ class PostgresStatementMetrics(DBMAsyncJob):
         if self._check.version < V14:
             return
         try:
-            with self.db_pool.get_main_db(conn_prefix=self._thread_id).cursor(row_factory=dict_row) as cursor:
-                rows = self._execute_query(
-                    cursor,
-                    PG_STAT_STATEMENTS_DEALLOC,
-                )
+            with self.db_pool.get_main_db_pool().connection() as conn:
+                with conn.cursor(row_factory=dict_row) as cursor:
+                    rows = self._execute_query(
+                        cursor,
+                        PG_STAT_STATEMENTS_DEALLOC,
+                    )
             if rows:
                 dealloc = list(rows[0].values())[0]
                 self._check.monotonic_count(
@@ -370,11 +373,12 @@ class PostgresStatementMetrics(DBMAsyncJob):
     def _emit_pg_stat_statements_metrics(self):
         query = PG_STAT_STATEMENTS_COUNT_QUERY_LT_9_4 if self._check.version < V9_4 else PG_STAT_STATEMENTS_COUNT_QUERY
         try:
-            with self.db_pool.get_main_db(conn_prefix=self._thread_id).cursor(row_factory=dict_row) as cursor:
-                rows = self._execute_query(
-                    cursor,
-                    query,
-                )
+            with self.db_pool.get_main_db_pool().connection() as conn:
+                with conn.cursor(row_factory=dict_row) as cursor:
+                    rows = self._execute_query(
+                        cursor,
+                        query,
+                    )
             count = 0
             if rows and 'count' in rows[0]:
                 count = rows[0]['count']

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -145,11 +145,9 @@ class PostgresStatementMetrics(DBMAsyncJob):
             ttl=60 * 60 / config.full_statement_text_samples_per_hour_per_query,
         )
 
-    def _execute_query(self, cursor, query, params=()):
+    def _execute_query(self, query, params=(), row_format=None):
         try:
-            self._log.debug("Running query [%s] %s", query, params)
-            cursor.execute(query, params)
-            return cursor.fetchall()
+            return self.db_pool.execute_main_db_safe(query, params, row_format)
         except (psycopg.ProgrammingError, psycopg.errors.QueryCanceled) as e:
             # A failed query could've derived from incorrect columns within the cache. It's a rare edge case,
             # but the next time the query is run, it will retrieve the correct columns.
@@ -170,11 +168,9 @@ class PostgresStatementMetrics(DBMAsyncJob):
         query = STATEMENTS_QUERY.format(
             cols='*', pg_stat_statements_view=self._config.pg_stat_statements_view, extra_clauses="LIMIT 0", filters=""
         )
-        with self._check.get_main_db().cursor() as cursor:
-            self._execute_query(cursor, query, params=())
-            col_names = [desc[0] for desc in cursor.description] if cursor.description else []
-            self._stat_column_cache = col_names
-            return col_names
+        col_names = self.db_pool.get_main_db_columns_safe(query, params=())
+        self._stat_column_cache = col_names
+        return col_names
 
     def run_job(self):
         # do not emit any dd.internal metrics for DBM specific check code
@@ -276,17 +272,16 @@ class PostgresStatementMetrics(DBMAsyncJob):
                     "pg_database.datname NOT ILIKE %s" for _ in self._config.ignore_databases
                 )
                 params = params + tuple(self._config.ignore_databases)
-            with self._check.get_main_db().cursor(row_factory=dict_row) as cursor:
-                return self._execute_query(
-                    cursor,
-                    STATEMENTS_QUERY.format(
-                        cols=', '.join(query_columns),
-                        pg_stat_statements_view=self._config.pg_stat_statements_view,
-                        filters=filters,
-                        extra_clauses="",
-                    ),
-                    params=params,
-                )
+            return self._execute_query(
+                STATEMENTS_QUERY.format(
+                    cols=', '.join(query_columns),
+                    pg_stat_statements_view=self._config.pg_stat_statements_view,
+                    filters=filters,
+                    extra_clauses="",
+                ),
+                params=params,
+                row_format=dict_row,
+            )
         except psycopg.Error as e:
             error_tag = "error:database-{}".format(type(e).__name__)
 
@@ -349,11 +344,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
         if self._check.version < V14:
             return
         try:
-            with self._check.get_main_db().cursor(row_factory=dict_row) as cursor:
-                rows = self._execute_query(
-                    cursor,
-                    PG_STAT_STATEMENTS_DEALLOC,
-                )
+            rows = self.db_pool.execute_main_db_safe(PG_STAT_STATEMENTS_DEALLOC, row_format=dict_row)
             if rows:
                 dealloc = list(rows[0].values())[0]
                 self._check.monotonic_count(
@@ -369,11 +360,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
     def _emit_pg_stat_statements_metrics(self):
         query = PG_STAT_STATEMENTS_COUNT_QUERY_LT_9_4 if self._check.version < V9_4 else PG_STAT_STATEMENTS_COUNT_QUERY
         try:
-            with self._check.get_main_db().cursor(row_factory=dict_row) as cursor:
-                rows = self._execute_query(
-                    cursor,
-                    query,
-                )
+            rows = self.db_pool.execute_main_db_safe(query, row_format=dict_row)
             count = 0
             if rows and 'count' in rows[0]:
                 count = rows[0]['count']

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -41,6 +41,7 @@ deps = [
     "azure-identity==1.14.0; python_version > '3.0'",
     "cachetools==5.3.1; python_version > '3.0'",
     "psycopg[binary]==3.1.10; python_version > '3.0'",
+    "psycopg[pool]==3.1.7; python_version > '3.0'",
     "semver==3.0.1; python_version > '3.0'",
 ]
 

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -41,7 +41,7 @@ deps = [
     "azure-identity==1.14.0; python_version > '3.0'",
     "cachetools==5.3.1; python_version > '3.0'",
     "psycopg[binary]==3.1.10; python_version > '3.0'",
-    "psycopg[pool]==3.1.7; python_version > '3.0'",
+    "psycopg_pool==3.1.7; python_version > '3.0'",
     "semver==3.0.1; python_version > '3.0'",
 ]
 

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -41,7 +41,7 @@ deps = [
     "azure-identity==1.14.0; python_version > '3.0'",
     "cachetools==5.3.1; python_version > '3.0'",
     "psycopg[binary]==3.1.10; python_version > '3.0'",
-    "psycopg_pool==3.1.7; python_version > '3.0'",
+    "psycopg-pool==3.1.7; python_version > '3.0'",
     "semver==3.0.1; python_version > '3.0'",
 ]
 

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -173,7 +173,7 @@ def check_connection_metrics(aggregator, expected_tags, count=1):
             aggregator.assert_metric(name, count=count, tags=db_tags)
 
 
-def check_activity_metrics(aggregator, tags, hostname=None, count=1):
+def check_activity_metrics(aggregator, tags):
     activity_metrics = [
         'postgresql.transactions.open',
         'postgresql.transactions.idle_in_transaction',
@@ -186,7 +186,7 @@ def check_activity_metrics(aggregator, tags, hostname=None, count=1):
         # Query won't have xid assigned so postgresql.activity.backend_xid_age won't be emitted
         activity_metrics.append('postgresql.activity.backend_xmin_age')
     for name in activity_metrics:
-        aggregator.assert_metric(name, count=1, tags=tags, hostname=hostname)
+        assert_metric_at_least(aggregator, name, count=1, tags=tags)
 
 
 def check_stat_replication(aggregator, expected_tags, count=1):

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -186,7 +186,7 @@ def check_activity_metrics(aggregator, tags):
         # Query won't have xid assigned so postgresql.activity.backend_xid_age won't be emitted
         activity_metrics.append('postgresql.activity.backend_xmin_age')
     for name in activity_metrics:
-        assert_metric_at_least(aggregator, name, count=1, tags=tags)
+        assert_metric_at_least(aggregator, name, tags=tags)
 
 
 def check_stat_replication(aggregator, expected_tags, count=1):

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -26,6 +26,7 @@ INSTANCE = {
     'dbname': DB_NAME,
     'tags': ['foo:bar'],
     'disable_generic_tags': True,
+    'dbm': False,
 }
 
 

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -110,16 +110,21 @@ def e2e_instance():
 
 @pytest.fixture()
 def mock_cursor_for_replica_stats():
-    with mock.patch('psycopg.connect') as connect:
-        cursor = mock.MagicMock()
+    with mock.patch('psycopg_pool.ConnectionPool.connection') as pooled_conn:
         data = deque()
-        connect.return_value = mock.MagicMock(cursor=mock.MagicMock(return_value=cursor))
+        mocked_cursor = mock.MagicMock()
+        mocked_conn = mock.MagicMock()
+        mocked_conn.cursor.return_value = mocked_cursor
+
+        pooled_conn.return_value.__enter__.return_value = mocked_conn
 
         def cursor_execute(query, second_arg=""):
+            print(query)
             if "FROM pg_stat_replication" in query:
                 data.appendleft(['app1', 'streaming', 'async', '1.1.1.1', 12, 12, 12, 12])
                 data.appendleft(['app2', 'backup', 'sync', '1.1.1.1', 13, 13, 13, 13])
             elif query == 'SHOW SERVER_VERSION;':
+                print("SHOW SERVER_VERSION")
                 data.appendleft(['10.15'])
 
         def cursor_fetchall():
@@ -127,10 +132,11 @@ def mock_cursor_for_replica_stats():
                 yield data.pop()
 
         def cursor_fetchone():
+            print("fetchone")
             return data.pop()
 
-        cursor.__enter__().execute = cursor_execute
-        cursor.__enter__().fetchall = cursor_fetchall
-        cursor.__enter__().fetchone = cursor_fetchone
+        mocked_cursor.__enter__().execute = cursor_execute
+        mocked_cursor.__enter__().fetchall = cursor_fetchall
+        mocked_cursor.__enter__().fetchone = cursor_fetchone
 
         yield

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -7,10 +7,9 @@ import threading
 import time
 import uuid
 
-import psycopg
-from psycopg_pool import ConnectionPool
 import pytest
 from psycopg.rows import dict_row
+from psycopg_pool import ConnectionPool
 
 from datadog_checks.postgres import PostgreSql
 from datadog_checks.postgres.connections import ConnectionPoolFullError, MultiDatabaseConnectionPool

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -295,7 +295,7 @@ def test_conn_pool_manages_connections(pg_instance):
 
     # ask for one more connection
     with pytest.raises(ConnectionPoolFullError):
-        with pool.get_connection('dogs_{}'.format(limit + 1), 1, 1):
+        with pool.get_connection(dbname='dogs_{}'.format(limit + 1), ttl_ms=1, timeout=1):
             pass
 
     # join threads

--- a/postgres/tests/test_deadlock.py
+++ b/postgres/tests/test_deadlock.py
@@ -15,7 +15,7 @@ from .common import DB_NAME, HOST, PORT, POSTGRES_VERSION
 def wait_on_result(sql=None, binds=None, expected_value=None):
     for _i in range(5):
         with psycopg.connect(
-                host=HOST, dbname=DB_NAME, user="bob", password="bob", cursor_factory=ClientCursor
+            host=HOST, dbname=DB_NAME, user="bob", password="bob", cursor_factory=ClientCursor
         ) as tconn:
             with tconn.cursor() as cursor:
                 cursor.execute(sql, binds)

--- a/postgres/tests/test_deadlock.py
+++ b/postgres/tests/test_deadlock.py
@@ -12,14 +12,17 @@ from psycopg import ClientCursor
 from .common import DB_NAME, HOST, PORT, POSTGRES_VERSION
 
 
-def wait_on_result(cursor=None, sql=None, binds=None, expected_value=None):
-    for _i in range(300):
-        cursor.execute(sql, binds)
-        result = cursor.fetchone()[0]
-        if result == expected_value:
-            break
-
-        time.sleep(0.1)
+def wait_on_result(sql=None, binds=None, expected_value=None):
+    for _i in range(5):
+        with psycopg.connect(
+                host=HOST, dbname=DB_NAME, user="bob", password="bob", cursor_factory=ClientCursor
+        ) as tconn:
+            with tconn.cursor() as cursor:
+                cursor.execute(sql, binds)
+                result = cursor.fetchone()[0]
+                if result == expected_value:
+                    break
+                time.sleep(0.1)
     else:
         return False
 
@@ -33,8 +36,6 @@ def wait_on_result(cursor=None, sql=None, binds=None, expected_value=None):
 def test_deadlock(aggregator, dd_run_check, integration_check, pg_instance):
     check = integration_check(pg_instance)
     check._connect()
-    conn = check._new_connection(pg_instance['dbname'])
-    cursor = conn.cursor()
 
     def execute_in_thread(q, args):
         with psycopg.connect(
@@ -55,8 +56,10 @@ def test_deadlock(aggregator, dd_run_check, integration_check, pg_instance):
     update_sql = "update personsdup1 set address = 'changed' where personid = %s"
 
     deadlock_count_sql = "select deadlocks from pg_stat_database where datname = %s"
-    cursor.execute(deadlock_count_sql, (DB_NAME,))
-    deadlocks_before = cursor.fetchone()[0]
+    with check._new_connection(pg_instance['dbname']).connection() as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(deadlock_count_sql, (DB_NAME,))
+            deadlocks_before = cursor.fetchone()[0]
 
     conn_args = {'host': HOST, 'dbname': DB_NAME, 'user': "bob", 'password': "bob"}
     conn1 = psycopg.connect(**conn_args, autocommit=False, cursor_factory=ClientCursor)
@@ -98,7 +101,7 @@ commit;
     AND blocking_activity.application_name = %s
     AND blocked_activity.application_name = %s """
 
-    is_locked = wait_on_result(cursor=cursor, sql=lock_count_sql, binds=(appname1, appname2), expected_value=1)
+    is_locked = wait_on_result(sql=lock_count_sql, binds=(appname1, appname2), expected_value=1)
 
     if not is_locked:
         raise Exception("ERROR: Couldn't reproduce a deadlock. That can happen on an extremely overloaded system.")
@@ -111,7 +114,7 @@ commit;
 
     dd_run_check(check)
 
-    wait_on_result(cursor=cursor, sql=deadlock_count_sql, binds=(DB_NAME,), expected_value=deadlocks_before + 1)
+    wait_on_result(sql=deadlock_count_sql, binds=(DB_NAME,), expected_value=deadlocks_before + 1)
 
     aggregator.assert_metric(
         'postgresql.deadlocks.count',

--- a/postgres/tests/test_explain_parameterized_queries.py
+++ b/postgres/tests/test_explain_parameterized_queries.py
@@ -52,16 +52,6 @@ def test_explain_parameterized_queries(integration_check, dbm_instance, query, e
     assert explain_err_code == expected_explain_err_code
     assert err is None
 
-    explain_param_queries = check.statement_samples._explain_parameterized_queries
-    # check that we deallocated the prepared statement after explaining
-    rows = explain_param_queries._execute_query_and_fetch_rows(
-        DB_NAME,
-        "SELECT * FROM pg_prepared_statements WHERE name = 'dd_{query_signature}'".format(
-            query_signature=compute_sql_signature(query)
-        ),
-    )
-    assert len(rows) == 0
-
 
 @pytest.mark.parametrize(
     "query,expected_generic_values",
@@ -85,7 +75,8 @@ def test_explain_parameterized_queries_generic_params(integration_check, dbm_ins
     query_signature = compute_sql_signature(query)
 
     explain_param_queries = check.statement_samples._explain_parameterized_queries
-    assert explain_param_queries._create_prepared_statement(DB_NAME, query, query, query_signature) is True
-    assert expected_generic_values == explain_param_queries._get_number_of_parameters_for_prepared_statement(
-        DB_NAME, query_signature
-    )
+    with check._new_connection(DB_NAME).connection() as conn:
+        assert explain_param_queries._create_prepared_statement(conn, query, query, query_signature) is True
+        assert expected_generic_values == explain_param_queries._get_number_of_parameters_for_prepared_statement(
+            conn, query_signature
+        )

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -7,7 +7,6 @@ import time
 import mock
 import psycopg
 import pytest
-from semver import VersionInfo
 
 from datadog_checks.postgres import PostgreSql
 from datadog_checks.postgres.__about__ import __version__
@@ -602,7 +601,7 @@ def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, agg
         c_metrics = c_metrics + DBM_MIGRATED_METRICS
     for name in c_metrics:
         aggregator.assert_metric(name, count=1, tags=expected_tags_with_db, hostname=expected_hostname)
-    check_activity_metrics(aggregator, tags=expected_activity_tags, hostname=expected_hostname)
+    check_activity_metrics(aggregator, tags=expected_activity_tags)
 
     for name in CONNECTION_METRICS:
         aggregator.assert_metric(name, count=1, tags=expected_tags_no_db, hostname=expected_hostname)

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -629,6 +629,9 @@ def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, agg
 @pytest.mark.usefixtures('dd_environment')
 def test_database_instance_metadata(aggregator, pg_instance, dbm_enabled, reported_hostname):
     pg_instance['dbm'] = dbm_enabled
+    # this will block on cancel and wait for the coll interval of 600 seconds,
+    # unless the collection_interval is set to a short amount of time
+    pg_instance['collect_resources'] = {'collection_interval': 0.1}
     if reported_hostname:
         pg_instance['reported_hostname'] = reported_hostname
     expected_host = reported_hostname if reported_hostname else 'stubbed.hostname'

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -52,7 +52,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')
 )
 def test_common_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check = integration_check(pg_instance)
-    check._is_aurora = is_aurora
+    check.is_aurora = is_aurora
     check.check(pg_instance)
 
     expected_tags = _get_expected_tags(check, pg_instance)
@@ -404,12 +404,14 @@ def test_backend_transaction_age(aggregator, integration_check, pg_instance):
 @requires_over_10
 def test_wrong_version(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
-    # Enforce to cache wrong version
-    check._version = VersionInfo(*[9, 6, 0])
 
+    # Enforce the wrong version
+    check._version_utils.get_raw_version = mock.MagicMock(return_value="9.6.0")
     check.check(pg_instance)
     assert_state_clean(check)
 
+    # Reset the mock to a good version
+    check._version_utils.get_raw_version = mock.MagicMock(return_value="13.0.0")
     check.check(pg_instance)
     assert_state_set(check)
 
@@ -491,9 +493,10 @@ def test_query_timeout(integration_check, pg_instance):
     pg_instance['query_timeout'] = 1000
     check = integration_check(pg_instance)
     check._connect()
-    cursor = check.db.cursor()
     with pytest.raises(psycopg.errors.QueryCanceled):
-        cursor.execute("select pg_sleep(2000)")
+        with check.db.connection() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute("select pg_sleep(2000)")
 
 
 @requires_over_10
@@ -661,7 +664,6 @@ def assert_state_clean(check):
     assert check.metrics_cache.archiver_metrics is None
     assert check.metrics_cache.replication_metrics is None
     assert check.metrics_cache.activity_metrics is None
-    assert check._is_aurora is None
 
 
 def assert_state_set(check):
@@ -670,4 +672,3 @@ def assert_state_set(check):
     if POSTGRES_VERSION != '9.3':
         assert check.metrics_cache.archiver_metrics
     assert check.metrics_cache.replication_metrics
-    assert check._is_aurora is False

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -31,6 +31,7 @@ pytestmark = [pytest.mark.integration, pytest.mark.usefixtures('dd_environment')
 @requires_over_10
 def test_common_replica_metrics(aggregator, integration_check, metrics_cache_replica, pg_replica_instance):
     check = integration_check(pg_replica_instance)
+    check.initialize_is_aurora()
     check.check(pg_replica_instance)
 
     expected_tags = _get_expected_tags(check, pg_replica_instance)
@@ -54,6 +55,7 @@ def test_common_replica_metrics(aggregator, integration_check, metrics_cache_rep
 @requires_over_10
 def test_wal_receiver_metrics(aggregator, integration_check, pg_instance, pg_replica_instance):
     check = integration_check(pg_replica_instance)
+    check.initialize_is_aurora()
     expected_tags = _get_expected_tags(check, pg_replica_instance, status='streaming')
     with _get_superconn(pg_instance) as conn:
         with conn.cursor() as cur:

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1338,7 +1338,7 @@ def test_load_pg_settings(aggregator, integration_check, dbm_instance, db_user):
     dbm_instance["dbname"] = "postgres"
     check = integration_check(dbm_instance)
     check._connect()
-    check._load_pg_settings(check.db)
+    check.load_pg_settings(check.db)
     if db_user == 'datadog_no_catalog':
         aggregator.assert_metric(
             "dd.postgres.error",
@@ -1360,10 +1360,10 @@ def test_pg_settings_caching(aggregator, integration_check, dbm_instance):
     check = integration_check(dbm_instance)
     assert not check.pg_settings, "pg_settings should not have been initialized yet"
     check._connect()
-    check.get_main_db()
+    check.db_pool.get_main_db()
     assert "track_activity_query_size" in check.pg_settings
     check.pg_settings["test_key"] = True
-    check.get_main_db()
+    check.db_pool.get_main_db()
     assert (
         "test_key" in check.pg_settings
     ), "key should not have been blown away. If it was then pg_settings was not cached correctly"

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1360,10 +1360,10 @@ def test_pg_settings_caching(aggregator, integration_check, dbm_instance):
     check = integration_check(dbm_instance)
     assert not check.pg_settings, "pg_settings should not have been initialized yet"
     check._connect()
-    check.db_pool.get_main_db()
+    check.db_pool._get_main_db()
     assert "track_activity_query_size" in check.pg_settings
     check.pg_settings["test_key"] = True
-    check.db_pool.get_main_db()
+    check.db_pool._get_main_db()
     assert (
         "test_key" in check.pg_settings
     ), "key should not have been blown away. If it was then pg_settings was not cached correctly"

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -93,8 +93,7 @@ def test_malformed_get_custom_queries(check):
     Test early-exit conditions for _get_custom_queries()
     """
     check.log = MagicMock()
-    db = MagicMock()
-    check.db = db
+    check.db = MagicMock()
 
     check._config.custom_queries = [{}]
 
@@ -124,7 +123,7 @@ def test_malformed_get_custom_queries(check):
     # Make sure we gracefully handle an error while performing custom queries
     malformed_custom_query_column = {}
     malformed_custom_query['columns'] = [malformed_custom_query_column]
-    db.cursor().__enter__().execute.side_effect = psycopg.ProgrammingError('FOO')
+    check.db.connection().__enter__().cursor().__enter__().execute.side_effect = psycopg.ProgrammingError('FOO')
     check._collect_custom_queries([])
     check.log.error.assert_called_once_with(
         "Error executing query for metric_prefix %s: %s", malformed_custom_query['metric_prefix'], 'FOO'
@@ -135,8 +134,8 @@ def test_malformed_get_custom_queries(check):
     malformed_custom_query_column = {}
     malformed_custom_query['columns'] = [malformed_custom_query_column]
     query_return = ['num', 1337]
-    db.cursor().__enter__().execute.side_effect = None
-    db.cursor().__enter__().__iter__.return_value = iter([query_return])
+    check.db.connection().__enter__().cursor().__enter__().execute.side_effect = None
+    check.db.connection().__enter__().cursor().__enter__().__iter__.return_value = iter([query_return])
     check._collect_custom_queries([])
     check.log.error.assert_called_once_with(
         "query result for metric_prefix %s: expected %s columns, got %s",
@@ -147,7 +146,7 @@ def test_malformed_get_custom_queries(check):
     check.log.reset_mock()
 
     # Make sure the query does not return an empty result
-    db.cursor().__enter__().__iter__.return_value = iter([[]])
+    check.db.connection().__enter__().cursor().__enter__().__iter__.return_value = iter([[]])
     check._collect_custom_queries([])
     check.log.debug.assert_called_with(
         "query result for metric_prefix %s: returned an empty result", malformed_custom_query['metric_prefix']
@@ -156,7 +155,7 @@ def test_malformed_get_custom_queries(check):
 
     # Make sure 'name' is defined in each column
     malformed_custom_query_column['some_key'] = 'some value'
-    db.cursor().__enter__().__iter__.return_value = iter([[1337]])
+    check.db.connection().__enter__().cursor().__enter__().__iter__.return_value = iter([[1337]])
     check._collect_custom_queries([])
     check.log.error.assert_called_once_with(
         "column field `name` is required for metric_prefix `%s`", malformed_custom_query['metric_prefix']
@@ -165,7 +164,7 @@ def test_malformed_get_custom_queries(check):
 
     # Make sure 'type' is defined in each column
     malformed_custom_query_column['name'] = 'num'
-    db.cursor().__enter__().__iter__.return_value = iter([[1337]])
+    check.db.connection().__enter__().cursor().__enter__().__iter__.return_value = iter([[1337]])
     check._collect_custom_queries([])
     check.log.error.assert_called_once_with(
         "column field `type` is required for column `%s` of metric_prefix `%s`",
@@ -176,7 +175,7 @@ def test_malformed_get_custom_queries(check):
 
     # Make sure 'type' is a valid metric type
     malformed_custom_query_column['type'] = 'invalid_type'
-    db.cursor().__enter__().__iter__.return_value = iter([[1337]])
+    check.db.connection().__enter__().cursor().__enter__().__iter__.return_value = iter([[1337]])
     check._collect_custom_queries([])
     check.log.error.assert_called_once_with(
         "invalid submission method `%s` for column `%s` of metric_prefix `%s`",
@@ -190,7 +189,7 @@ def test_malformed_get_custom_queries(check):
     malformed_custom_query_column['type'] = 'gauge'
     query_return = MagicMock()
     query_return.__float__.side_effect = ValueError('Mocked exception')
-    db.cursor().__enter__().__iter__.return_value = iter([[query_return]])
+    check.db.connection().__enter__().cursor().__enter__().__iter__.return_value = iter([[query_return]])
     check._collect_custom_queries([])
     check.log.error.assert_called_once_with(
         "non-numeric value `%s` for metric column `%s` of metric_prefix `%s`",

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -79,8 +79,8 @@ def test_get_instance_with_default(pg_instance, collect_default_database):
     """
     pg_instance['collect_default_database'] = collect_default_database
     check = PostgreSql('postgres', {}, [pg_instance])
-    check._version = VersionInfo(9, 2, 0)
-    res = check.metrics_cache.get_instance_metrics(check._version)
+    check.version = VersionInfo(9, 2, 0)
+    res = check.metrics_cache.get_instance_metrics(check.version)
     dbfilter = " AND psd.datname not ilike 'postgres'"
     if collect_default_database:
         assert dbfilter not in res['query']


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

We are intermittently seeing the following error, when running the integration on our internal clusters via the cluster check runner:
```
psycopg.OperationalError: sending query failed: another command is already in progress
```

While the `pyscopg3` Connection object is thread safe, we cannot execute a command on that connection when another is in the process of executing. This makes sharing the connection between multiple threads a bit dangerous, since `psycopg` doesn't do a good job of handling that situation under the hood. After this happens, the connection is basically unusable to the client, which breaks the check. 

This leaves us with the following options:

1. Create a connection per thread
2. Make all queries on the same connection object synchronized
3. Catch this exception & close/re-create the connection object when it happens
4. re-implement our solution using a `pyscopg_pool`

Using the [`pyscopg_pool`](https://www.psycopg.org/psycopg3/docs/api/pool.html) module, which implements a per db connection pool is the most robust solution here. This creates a connection pool object with a `max_size` of 1 instead of individual connections. Doing this prevents `command already in progress` errors because only a single thread can use the connection at a time. In order to do this, we utilize the `connection()` context manager, which returns the connection to the pool once the `with` block exits.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.