### PR TITLE
Bump psycopg3 version && add timeouts on blocking functions

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -57,7 +57,7 @@ protobuf==3.17.3; python_version < '3.0'
 protobuf==3.20.2; python_version > '3.0'
 psutil==5.9.0
 psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'
-psycopg[binary]==3.1.9; python_version > '3.0'
+psycopg[binary]==3.1.10; python_version > '3.0'
 pyasn1==0.4.6
 pycryptodomex==3.10.1
 pydantic==2.0.2; python_version > '3.0'

--- a/postgres/datadog_checks/postgres/connections.py
+++ b/postgres/datadog_checks/postgres/connections.py
@@ -171,10 +171,16 @@ class MultiDatabaseConnectionPool(object):
                     self._stats.connection_pruned += 1
                     self._terminate_connection_unsafe(dbname)
 
-    def close_all_connections(self):
+    def close_all_connections(self, timeout=None):
+        """
+        Will block until all connections are terminated, unless the pre-configured timeout is hit
+        :param timeout:
+        :return:
+        """
         success = True
+        start_time = time.time()
         with self._mu:
-            while self._conns:
+            while self._conns and (timeout is None or time.time() - start_time < timeout):
                 dbname = next(iter(self._conns))
                 if not self._terminate_connection_unsafe(dbname):
                     success = False

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -705,7 +705,7 @@ class PostgreSql(AgentCheck):
         return conn
 
     def _close_db_pool(self):
-        self.db_pool.close_all_connections()
+        self.db_pool.close_all_connections(timeout=self._config.min_collection_interval)
 
     def _collect_custom_queries(self, tags):
         """

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -40,7 +40,7 @@ deps = [
     "boto3==1.27.0; python_version > '3.0'",
     "cachetools==3.1.1; python_version < '3.0'",
     "cachetools==5.3.1; python_version > '3.0'",
-    "psycopg[binary]==3.1.9; python_version > '3.0'",
+    "psycopg[binary]==3.1.10; python_version > '3.0'",
     "semver==3.0.1; python_version > '3.0'",
 ]
 

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -49,7 +49,7 @@ def test_conn_pool(pg_instance):
     db = pool._get_connection_raw('postgres', 999 * 1000)
     assert len(pool._conns) == 1
     assert pool._stats.connection_opened == 2
-    success = pool.close_all_connections()
+    success = pool.close_all_connections(timeout=5)
     assert success
     assert len(pool._conns) == 0
     assert pool._stats.connection_closed == 2
@@ -95,11 +95,11 @@ def test_conn_pool_no_leaks_on_close(pg_instance):
             wg.add(1)
             thread.start()
         # wait for all connections to be opened
-        wg.wait()
+        wg.wait(timeout=5)
         assert pool._stats.connection_opened == conn_count
         assert len(get_activity(pool2, unique_id)) == conn_count
 
-        pool.close_all_connections()
+        pool.close_all_connections(timeout=5)
         assert pool._stats.connection_closed == conn_count
         assert pool._stats.connection_closed_failed == 0
 
@@ -149,7 +149,7 @@ def test_conn_pool_no_leaks_on_prune(pg_instance):
                 assert len(rows) == 1
                 assert list(rows[0].values())[0] == dbname
 
-    pool.close_all_connections()
+    pool.close_all_connections(timeout=5)
 
     pool._stats.reset()
 
@@ -290,7 +290,7 @@ def test_conn_pool_manages_connections(pg_instance):
         thread.start()
 
     # wait until all connections are opened and active
-    wg.wait()
+    wg.wait(timeout=5)
     assert pool._stats.connection_opened == limit
 
     # ask for one more connection
@@ -309,7 +309,7 @@ def test_conn_pool_manages_connections(pg_instance):
     assert pool._stats.connection_closed == 1
 
     # close the rest
-    pool.close_all_connections()
+    pool.close_all_connections(timeout=5)
     assert pool._stats.connection_closed == limit + 1
 
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1049,7 +1049,7 @@ def test_activity_snapshot_collection(
 
         # wait for query to complete, but commit has not been called,
         # so it should remain open and idle
-        wg.wait()
+        wg.wait(timeout=5)
 
         # Wait collection interval to make sure dbm events are reported
         time.sleep(dbm_instance['query_activity']['collection_interval'])

--- a/postgres/tests/utils.py
+++ b/postgres/tests/utils.py
@@ -96,8 +96,10 @@ class WaitGroup(object):
             while self.count > 0:
                 self.cv.wait()
         else:
+
             def timeout_callback():
                 self.timeout_event.set()
+
             timer = threading.Timer(timeout, timeout_callback)
             timer.start()
             while self.count > 0 and not self.timeout_event.is_set():


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Updates `psycopg3` to the [latest released version](https://www.psycopg.org/psycopg3/docs/news.html#psycopg-3-1-10), which contains nice fixes like this one:

> Fix [connect()](https://www.psycopg.org/psycopg3/docs/api/module.html#psycopg.connect) to avoid “leaking” an open [PGconn](https://www.psycopg.org/psycopg3/docs/api/pq.html#psycopg.pq.PGconn) attached to the [OperationalError](https://www.psycopg.org/psycopg3/docs/api/errors.html#psycopg.OperationalError) in case of connection failure. [Error.pgconn](https://www.psycopg.org/psycopg3/docs/api/errors.html#psycopg.Error.pgconn) is now a shallow copy of the real libpq connection, and the latter is closed before the exception propagates (ticket [#565](https://github.com/psycopg/psycopg/issues/565)).


Also, adds a `timeout` parameter on blocking functions like `WaitGroup.wait()` and `close_all_connections`. On master we have seen the [tests timeout](https://github.com/DataDog/integrations-core/actions/runs/5782018759/job/15668165861), and it could be due to us blocking forever when we can't close the connection, which happens every time we call `check.cancel()`.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.