### PR TITLE
Add support for ingesting mysql config settings

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -335,6 +335,22 @@ files:
               type: boolean
               example: false
               display_default: false
+          - name: collect_settings
+            description: Configure collection of performance_schema.global_variables. This is an alpha feature.
+            options:
+              - name: enabled
+                description: |
+                  Enable collection of performance_schema.global_variables. Requires `dbm: true`.
+                value:
+                  type: boolean
+                  example: false
+              - name: collection_interval
+                description: |
+                  Set the database settings collection interval (in seconds). Each collection involves a single query to
+                  `performance_schema.global_variables`.
+                value:
+                  type: number
+                  example: 600
           - name: query_metrics
             description: Configure collection of query metrics
             options:

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -39,6 +39,7 @@ class MySQLConfig(object):
         )
         self.statement_samples_config = instance.get('query_samples', instance.get('statement_samples', {})) or {}
         self.statement_metrics_config = instance.get('query_metrics', {}) or {}
+        self.settings_config = instance.get('collect_settings', {}) or {}
         self.activity_config = instance.get('query_activity', {}) or {}
         self.cloud_metadata = {}
         aws = instance.get('aws', {})

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -166,6 +166,7 @@ class InstanceConfig(BaseModel):
     aws: Optional[Aws] = None
     azure: Optional[Azure] = None
     charset: Optional[str] = None
+    collect_settings: Optional[CollectSettings] = None
     connect_timeout: Optional[float] = None
     custom_queries: Optional[tuple[CustomQuery, ...]] = None
     dbm: Optional[bool] = None

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -37,6 +37,15 @@ class Azure(BaseModel):
     fully_qualified_domain_name: Optional[str] = None
 
 
+class CollectSettings(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    collection_interval: Optional[float] = None
+    enabled: Optional[bool] = None
+
+
 class CustomQuery(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -334,6 +334,21 @@ instances:
     #
     # dbm: false
 
+    ## Configure collection of performance_schema.global_variables. This is an alpha feature.
+    #
+    # collect_settings:
+
+        ## @param enabled - boolean - optional - default: false
+        ## Enable collection of performance_schema.global_variables. Requires `dbm: true`.
+        #
+        # enabled: false
+
+        ## @param collection_interval - number - optional - default: 600
+        ## Set the database settings collection interval (in seconds). Each collection involves a single query to
+        ## `performance_schema.global_variables`.
+        #
+        # collection_interval: 600
+
     ## Configure collection of query metrics
     #
     # query_metrics:

--- a/mysql/datadog_checks/mysql/metadata.py
+++ b/mysql/datadog_checks/mysql/metadata.py
@@ -1,0 +1,62 @@
+import time
+import pymysql
+
+try:
+    import datadog_agent
+except ImportError:
+    from ..stubs import datadog_agent
+
+from datadog_checks.base.utils.db.utils import (
+    DBMAsyncJob,
+    default_json_event_encoding,
+)
+
+class MySQLStatementSamples(DBMAsyncJob):
+    """
+        Collects database metadata. Supports:
+        1. collection of performance_schema.global_variables
+    """
+
+    def __init__(self, check, config, connection_args):
+        collection_interval = float(config.statement_metrics_config.get('collection_interval', 1))
+        if collection_interval <= 0:
+            collection_interval = 1
+        super(MySQLStatementSamples, self).__init__(
+            check,
+            rate_limit=1 / collection_interval,
+            run_sync=is_affirmative(config.statement_samples_config.get('run_sync', False)),
+            enabled=is_affirmative(config.statement_samples_config.get('enabled', True)),
+            min_collection_interval=config.min_collection_interval,
+            dbms="mysql",
+            expected_db_exceptions=(pymysql.err.DatabaseError,),
+            job_name="statement-samples",
+            shutdown_callback=self._close_db_conn,
+        )
+        self._config = config
+        self._version_processed = False
+        self._connection_args = connection_args
+        self._last_check_run = 0
+        self._db = None
+        self._check = check
+        self._configured_collection_interval = self._config.statement_samples_config.get('collection_interval', -1)
+        self._events_statements_row_limit = self._config.statement_samples_config.get(
+            'events_statements_row_limit', 5000
+        )
+        self._explain_procedure = self._config.statement_samples_config.get('explain_procedure', 'explain_statement')
+        self._fully_qualified_explain_procedure = self._config.statement_samples_config.get(
+            'fully_qualified_explain_procedure', 'datadog.explain_statement'
+        )
+        self._events_statements_temp_table = self._config.statement_samples_config.get(
+            'events_statements_temp_table_name', 'datadog.temp_events'
+        )
+        self._events_statements_enable_procedure = self._config.statement_samples_config.get(
+            'events_statements_enable_procedure', 'datadog.enable_events_statements_consumers'
+        )
+        self._explain_strategies = {
+            'PROCEDURE': self._run_explain_procedure,
+            'FQ_PROCEDURE': self._run_fully_qualified_explain_procedure,
+            'STATEMENT': self._run_explain,
+        }
+        self._preferred_explain_strategies = ['PROCEDURE', 'FQ_PROCEDURE', 'STATEMENT']
+        self._obfuscate_options = to_native_string(json.dumps(self._config.obfuscator_options))
+        self._init_caches()

--- a/mysql/datadog_checks/mysql/metadata.py
+++ b/mysql/datadog_checks/mysql/metadata.py
@@ -111,7 +111,7 @@ class MySQLMetadata(DBMAsyncJob):
             "host": self._check.resolved_hostname,
             "agent_version": datadog_agent.get_version(),
             "dbms": "mysql",
-            "kind": "mysql_settings",
+            "kind": "mysql_variables",
             "collection_interval": self.collection_interval,
             'dbms_version': self._check.version.version + '+' + self._check.version.build,
             "tags": self._tags,

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -44,6 +44,7 @@ from .const import (
     VARIABLES_VARS,
 )
 from .innodb_metrics import InnoDBMetrics
+from .metadata import MySQLMetadata
 from .queries import (
     QUERY_USER_CONNECTIONS,
     SQL_95TH_PERCENTILE,
@@ -116,6 +117,7 @@ class MySql(AgentCheck):
         self._warnings_by_code = {}
         self._statement_metrics = MySQLStatementMetrics(self, self._config, self._get_connection_args())
         self._statement_samples = MySQLStatementSamples(self, self._config, self._get_connection_args())
+        self._mysql_metadata = MySQLMetadata(self, self._config, self._get_connection_args())
         self._query_activity = MySQLActivity(self, self._config, self._get_connection_args())
 
         self._runtime_queries = None
@@ -274,6 +276,7 @@ class MySql(AgentCheck):
                     self._statement_metrics.run_job_loop(dbm_tags)
                     self._statement_samples.run_job_loop(dbm_tags)
                     self._query_activity.run_job_loop(dbm_tags)
+                    self._mysql_metadata.run_job_loop(dbm_tags)
 
                 # keeping track of these:
                 self._put_qcache_stats()
@@ -292,6 +295,7 @@ class MySql(AgentCheck):
         self._statement_samples.cancel()
         self._statement_metrics.cancel()
         self._query_activity.cancel()
+        self._mysql_metadata.cancel()
 
     def _new_query_executor(self, queries):
         return QueryExecutor(

--- a/mysql/tests/test_metadata.py
+++ b/mysql/tests/test_metadata.py
@@ -18,6 +18,8 @@ def dbm_instance(instance_complex):
     return instance_complex
 
 
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 def test_collect_mysql_settings(aggregator, dbm_instance, dd_run_check):
     # test to make sure we continue to support the old key
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])

--- a/mysql/tests/test_metadata.py
+++ b/mysql/tests/test_metadata.py
@@ -1,0 +1,30 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from datadog_checks.mysql import MySql
+
+from . import common
+
+
+@pytest.fixture
+def dbm_instance(instance_complex):
+    instance_complex['dbm'] = True
+    instance_complex['query_samples'] = {'enabled': False}
+    instance_complex['query_metrics'] = {'enabled': False}
+    instance_complex['query_activity'] = {'enabled': False}
+    instance_complex['collect_settings'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    return instance_complex
+
+
+def test_collect_mysql_settings(aggregator, dbm_instance):
+    # test to make sure we continue to support the old key
+    mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
+    mysql_check.check(dbm_instance)
+    dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
+    event = dbm_metadata[0]
+    assert event['host'] == "stubbed.hostname"
+    assert event['dbms'] == "mysql"
+    assert event['kind'] == "mysql_settings"
+    assert len(event["metadata"]) > 0

--- a/mysql/tests/test_metadata.py
+++ b/mysql/tests/test_metadata.py
@@ -18,13 +18,13 @@ def dbm_instance(instance_complex):
     return instance_complex
 
 
-def test_collect_mysql_settings(aggregator, dbm_instance):
+def test_collect_mysql_settings(aggregator, dbm_instance, dd_run_check):
     # test to make sure we continue to support the old key
     mysql_check = MySql(common.CHECK_NAME, {}, instances=[dbm_instance])
-    mysql_check.check(dbm_instance)
+    dd_run_check(mysql_check)
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
     event = dbm_metadata[0]
     assert event['host'] == "stubbed.hostname"
     assert event['dbms'] == "mysql"
-    assert event['kind'] == "mysql_settings"
+    assert event['kind'] == "mysql_variables"
     assert len(event["metadata"]) > 0


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Follow on PR to https://github.com/DataDog/integrations-core/pull/15496

Adds support to ingest mysql [global settings](https://dev.mysql.com/doc/refman/8.0/en/performance-schema-system-variable-tables.html), and forward them to the DBM backend

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.