### PR TITLE
Bump snowflake connector to 3.1.0

### DIFF
--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -103,7 +103,7 @@ serpent==1.41; sys_platform == 'win32' and python_version > '3.0'
 service-identity[idna]==21.1.0
 simplejson==3.19.1
 six==1.16.0
-snowflake-connector-python==3.0.4; python_version > '3.0'
+snowflake-connector-python==3.1.0; python_version > '3.0'
 supervisor==4.2.5
 tuf==2.0.0; python_version > '3.0'
 typing==3.10.0.0; python_version < '3.0'

--- a/snowflake/pyproject.toml
+++ b/snowflake/pyproject.toml
@@ -38,7 +38,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "snowflake-connector-python==3.0.4; python_version > '3.0'",
+    "snowflake-connector-python==3.1.0; python_version > '3.0'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump snowflake connector to 3.1.0

### Motivation
<!-- What inspired you to submit this pull request? -->

- We need to bump snowflake to bump cryptography to fix https://github.com/DataDog/image-vuln-scans/issues/1077

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Should be merged at the same time as https://github.com/DataDog/datadog-agent/pull/18679

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.