### PR TITLE
Run full dependency validation on PR as well as master

### DIFF
--- a/.github/workflows/run-validations.yml
+++ b/.github/workflows/run-validations.yml
@@ -165,7 +165,9 @@ jobs:
 
     - name: Validate dependencies
       if: inputs.dep
-      run: ddev validate dep $TARGET
+      # Running this validation without specifying a check will validate all dependency
+      # changes against the agent_requirements.in
+      run: ddev validate dep
 
     - name: Validate EULA files
       if: inputs.eula


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
#### Before
We would pass the changed integration eg `ddev validate dep rabbitmq` when running on PR.

#### After
Both for PRs and for master we run `ddev validate dep`.


### Motivation
<!-- What inspired you to submit this pull request? -->

- [this PR](https://github.com/DataDog/integrations-core/pull/8461) disables validating changes in deps for an individual check against `agent_requirements.in`. The logic is that these errors will be caught soon enough by the `master` CI. Unfortunately this can result in a problem: we break the agent build and there's a lot of pressure to fix our master CI.
- Case: [this PR](https://github.com/DataDog/integrations-core/pull/15212) changed an important dependency. The CI on the PR passed, then failed on master and as soon as we updated `agent_requirements.in` we discovered that we broke the agent build. It would have been useful to check `agent_requirements.in` in the first PR and deal with agent build problems earlier.
- When running locally I didn't observe a noticeable slowdown for running the validation on all integrations vs only a single one. I thought the tradeoff is good between simplicity and performance if I just switch the CI to check agent requirements on every PR.

#### Alternative

We could try to address the original problem, by considering only a subset of `agent_requirements.in` deps that's relevant to a given integration. This is the **proper** solution, but it looks like more work. In my opinion for insufficient performance gain. We could potentially keep the current fix while creating a card for the tools squad to implement the proper fix.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.