### PR TITLE
Allow for collection of AO metrics for azure sql db

### DIFF
--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -761,7 +761,7 @@ class SQLServer(AgentCheck):
         queries = [get_query_file_stats(major_version, engine_edition)]
 
         if is_affirmative(self.instance.get('include_ao_metrics', False)):
-            if major_version > 2012 or engine_edition == ENGINE_EDITION_AZURE_MANAGED_INSTANCE:
+            if major_version > 2012 or is_azure_database(engine_edition):
                 queries.extend(
                     [
                         get_query_ao_availability_groups(major_version),
@@ -770,17 +770,23 @@ class SQLServer(AgentCheck):
                     ]
                 )
             else:
-                self.log.warning('AlwaysOn metrics are not supported on version 2012')
+                self.log_missing_metric("AlwaysOn", major_version, engine_edition)
         if is_affirmative(self.instance.get('include_fci_metrics', False)):
             if major_version > 2012 or engine_edition == ENGINE_EDITION_AZURE_MANAGED_INSTANCE:
                 queries.extend([QUERY_FAILOVER_CLUSTER_INSTANCE])
             else:
-                self.log.warning('Failover Cluster Instance metrics are not supported on version 2012')
+                self.log_missing_metric("Failover Cluster Instance", major_version, engine_edition)
 
         self._dynamic_queries = self._new_query_executor(queries)
         self._dynamic_queries.compile_queries()
         self.log.debug("initialized dynamic queries")
         return self._dynamic_queries
+
+    def log_missing_metric(self, metric_name, major_version, engine_version):
+        if major_version <= 2012:
+            self.log.warning('%s metrics are not supported on version 2012', metric_name)
+        else:
+            self.log.warning('%s metrics are not supported on Azure engine version: %s', metric_name, engine_version)
 
     def collect_metrics(self):
         """Fetch the metrics from all the associated database tables."""


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This fixes a bug, which was introduced in https://github.com/DataDog/integrations-core/pull/14679 where we dropped support for collecting AO metrics for Azure SQL DB hosts. Azure SQL DB uses its own special flavor of high availability, which uses [AO under the hood](https://learn.microsoft.com/en-us/azure/azure-sql/database/high-availability-sla?view=azuresql-db&tabs=azure-powershell#conclusion), so it makes sense to collect these metrics. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.