### PR TITLE
Update `ddev validate ci` testing

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -823,7 +823,7 @@ flags:
   ddev:
     carryforward: true
     paths:
-    - ddev/datadog_checks/ddev
+    - ddev/src/ddev
     - ddev/tests
   directory:
     carryforward: true

--- a/ddev/src/ddev/cli/validate/ci.py
+++ b/ddev/src/ddev/cli/validate/ci.py
@@ -30,11 +30,14 @@ def code_coverage_enabled(check_name, app):
 
 
 def get_coverage_sources(check_name, app):
+    import os
+
+    test_dir = os.path.join(check_name, 'tests')
     package_path = app.repo.integrations.get(check_name).package_directory
-    package_dir = package_path.relative_to(app.repo.path / check_name)
+    package_dir = package_path.relative_to(app.repo.path)
     if check_name == 'ddev':
-        package_dir = 'datadog_checks/ddev'
-    return sorted([f'{check_name}/{package_dir}', f'{check_name}/tests'])
+        package_dir = 'ddev/datadog_checks/ddev'
+    return sorted([f'{package_dir}', f'{test_dir}'])
 
 
 def sort_projects(projects):

--- a/ddev/src/ddev/cli/validate/ci.py
+++ b/ddev/src/ddev/cli/validate/ci.py
@@ -30,14 +30,9 @@ def code_coverage_enabled(check_name, app):
 
 
 def get_coverage_sources(check_name, app):
-    import os
-
-    test_dir = os.path.join(check_name, 'tests')
     package_path = app.repo.integrations.get(check_name).package_directory
     package_dir = package_path.relative_to(app.repo.path)
-    if check_name == 'ddev':
-        package_dir = 'ddev/datadog_checks/ddev'
-    return sorted([f'{package_dir}', f'{test_dir}'])
+    return sorted([str(package_dir.as_posix()), f'{check_name}/tests'])
 
 
 def sort_projects(projects):

--- a/ddev/tests/cli/validate/test_ci.py
+++ b/ddev/tests/cli/validate/test_ci.py
@@ -145,7 +145,7 @@ def test_codecov_missing_flag(ddev, repository, helpers):
     assert error in helpers.remove_trailing_spaces(result.output)
 
 
-def test_valdiate_ci_success(ddev, repository, helpers):
+def test_validate_ci_success(ddev, repository, helpers):
     result = ddev('validate', 'ci')
     assert result.exit_code == 0, result.output
     assert helpers.remove_trailing_spaces(result.output) == helpers.dedent(

--- a/ddev/tests/cli/validate/test_ci.py
+++ b/ddev/tests/cli/validate/test_ci.py
@@ -145,13 +145,13 @@ def test_codecov_missing_flag(ddev, repository, helpers):
     assert error in helpers.remove_trailing_spaces(result.output)
 
 
-# def test_valdiate_ci_success(ddev, repository, helpers):
-#     result = ddev('validate', 'ci')
-#     assert result.exit_code == 0, result.output
-#     assert helpers.remove_trailing_spaces(result.output) == helpers.dedent(
-#         """
-#         CI configuration validation
+def test_valdiate_ci_success(ddev, repository, helpers):
+    result = ddev('validate', 'ci')
+    assert result.exit_code == 0, result.output
+    assert helpers.remove_trailing_spaces(result.output) == helpers.dedent(
+        """
+        CI configuration validation
 
-#         Passed: 1
-#         """
-#     )
+        Passed: 1
+        """
+    )


### PR DESCRIPTION
### What does this PR do?
Uncommented a test case from migration of `ddev validate ci` from `datadog_checks_dev` to `ddev`. It was previously failing because I changed some project names in `.codecov.yml` 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.