### PR TITLE
Migrate `release agent changelog` to ddev

### DIFF
--- a/ddev/src/ddev/cli/release/agent/__init__.py
+++ b/ddev/src/ddev/cli/release/agent/__init__.py
@@ -2,10 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import click
-from datadog_checks.dev.tooling.commands.agent.changelog import changelog
 from datadog_checks.dev.tooling.commands.agent.integrations import integrations
 from datadog_checks.dev.tooling.commands.agent.integrations_changelog import integrations_changelog
 from datadog_checks.dev.tooling.commands.agent.requirements import requirements
+
+from ddev.cli.release.agent.changelog import changelog
 
 
 @click.group(short_help='A collection of tasks related to the Datadog Agent')

--- a/ddev/src/ddev/cli/release/agent/changelog.py
+++ b/ddev/src/ddev/cli/release/agent/changelog.py
@@ -8,8 +8,6 @@ from typing import TYPE_CHECKING
 
 import click
 
-from ddev.cli.release.agent.common import get_changes_per_agent
-
 if TYPE_CHECKING:
     from ddev.cli.application import Application
 
@@ -47,6 +45,8 @@ def changelog(app: Application, since: str, to: str, write: bool, force: bool):
     tool will generate the whole changelog since Agent version 6.3.0
     (before that point we don't have enough information to build the log).
     """
+    from ddev.cli.release.agent.common import get_changes_per_agent
+
     changes_per_agent = get_changes_per_agent(app.repo, since, to)
 
     # store the changelog in memory

--- a/ddev/src/ddev/cli/release/agent/changelog.py
+++ b/ddev/src/ddev/cli/release/agent/changelog.py
@@ -2,13 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-import os
 from io import StringIO
 
 import click
 
 from ddev.cli.release.agent.common import get_changes_per_agent
-from ddev.utils.fs import Path
 
 # Extra entries in the agent changelog
 CHANGELOG_MANUAL_ENTRIES = {
@@ -75,12 +73,12 @@ def changelog(app, since, to, write, force):
 
     # save the changelog on disk if --write was passed
     if write:
-        dest = str(app.repo.agent_changelog)
+        dest = app.repo.agent_changelog
         # don't overwrite an existing file
-        if os.path.exists(dest) and not force:
+        if dest.exists() and not force:
             msg = "Output file {} already exists, run the command again with --force to overwrite"
             app.abort(msg.format(dest))
 
-        Path(dest).write_text(changelog_contents.getvalue())
+        dest.write_text(changelog_contents.getvalue())
     else:
         app.display_info(changelog_contents.getvalue())

--- a/ddev/src/ddev/cli/release/agent/changelog.py
+++ b/ddev/src/ddev/cli/release/agent/changelog.py
@@ -42,7 +42,7 @@ def changelog(app, since, to, write, force):
     tool will generate the whole changelog since Agent version 6.3.0
     (before that point we don't have enough information to build the log).
     """
-    changes_per_agent = get_changes_per_agent(since, to)
+    changes_per_agent = get_changes_per_agent(app.repo, since, to)
 
     # store the changelog in memory
     changelog_contents = StringIO()

--- a/ddev/src/ddev/cli/release/agent/changelog.py
+++ b/ddev/src/ddev/cli/release/agent/changelog.py
@@ -1,0 +1,95 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+# (C) Datadog, Inc. 2018-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+from io import StringIO
+
+import click
+from datadog_checks.dev.fs import write_file
+from datadog_checks.dev.tooling.commands.agent.common import get_changes_per_agent
+from datadog_checks.dev.tooling.commands.console import CONTEXT_SETTINGS, abort, echo_info
+from datadog_checks.dev.tooling.constants import get_agent_changelog
+from datadog_checks.dev.tooling.manifest_utils import Manifest
+
+# Extra entries in the agent changelog
+CHANGELOG_MANUAL_ENTRIES = {
+    '7.30.1': [
+        '* Revert requests bump back to 2.22.0 [#9912](https://github.com/DataDog/integrations-core/pull/9912)',
+    ]
+}
+
+DISPLAY_NAME_MAPPING = {
+    # `Mesos` tile was migrated into `Mesos Slave`, so the display name must be manually changed
+    'Mesos': 'Mesos Slave'
+}
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+    short_help="Provide a list of updated checks on a given Datadog Agent version, in changelog form",
+)
+@click.option('--since', help="Initial Agent version", default='6.3.0')
+@click.option('--to', help="Final Agent version")
+@click.option(
+    '--write', '-w', is_flag=True, help="Write to the changelog file, if omitted contents will be printed to stdout"
+)
+@click.option('--force', '-f', is_flag=True, default=False, help="Replace an existing file")
+def changelog(since, to, write, force):
+    """
+    Generates a markdown file containing the list of checks that changed for a
+    given Agent release. Agent version numbers are derived inspecting tags on
+    `integrations-core` so running this tool might provide unexpected results
+    if the repo is not up to date with the Agent release process.
+
+    If neither `--since` or `--to` are passed (the most common use case), the
+    tool will generate the whole changelog since Agent version 6.3.0
+    (before that point we don't have enough information to build the log).
+    """
+    changes_per_agent = get_changes_per_agent(since, to)
+
+    # store the changelog in memory
+    changelog_contents = StringIO()
+
+    # prepare the links
+    agent_changelog_url = 'https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#{}'
+    check_changelog_url = 'https://github.com/DataDog/integrations-core/blob/master/{}/CHANGELOG.md'
+
+    # go through all the agent releases
+    for agent, version_changes in changes_per_agent.items():
+        url = agent_changelog_url.format(agent.replace('.', ''))  # Github removes dots from the anchor
+        changelog_contents.write(f'## Datadog Agent version [{agent}]({url})\n\n')
+
+        if not version_changes and not CHANGELOG_MANUAL_ENTRIES.get(agent):
+            changelog_contents.write('* There were no integration updates for this version of the Agent.\n\n')
+        else:
+            for entry in CHANGELOG_MANUAL_ENTRIES.get(agent, []):
+                changelog_contents.write(f'{entry}\n')
+            for name, ver in version_changes.items():
+                manifest = Manifest.load_manifest(name)
+                if manifest is None:
+                    display_name = name
+                else:
+                    display_name = manifest.get_display_name()
+                display_name = DISPLAY_NAME_MAPPING.get(display_name, display_name)
+
+                breaking_notice = " **BREAKING CHANGE**" if ver[1] else ""
+                changelog_url = check_changelog_url.format(name)
+                changelog_contents.write(f'* {display_name} [{ver[0]}]({changelog_url}){breaking_notice}\n')
+            # add an extra line to separate the release block
+            changelog_contents.write('\n')
+
+    # save the changelog on disk if --write was passed
+    if write:
+        dest = get_agent_changelog()
+        # don't overwrite an existing file
+        if os.path.exists(dest) and not force:
+            msg = "Output file {} already exists, run the command again with --force to overwrite"
+            abort(msg.format(dest))
+
+        write_file(dest, changelog_contents.getvalue())
+    else:
+        echo_info(changelog_contents.getvalue())

--- a/ddev/src/ddev/cli/release/agent/changelog.py
+++ b/ddev/src/ddev/cli/release/agent/changelog.py
@@ -2,16 +2,12 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-# (C) Datadog, Inc. 2018-present
-# All rights reserved
-# Licensed under a 3-clause BSD style license (see LICENSE)
 import os
 from io import StringIO
 
 import click
 from datadog_checks.dev.fs import write_file
 from datadog_checks.dev.tooling.commands.agent.common import get_changes_per_agent
-from datadog_checks.dev.tooling.commands.console import CONTEXT_SETTINGS, abort, echo_info
 from datadog_checks.dev.tooling.constants import get_agent_changelog
 from datadog_checks.dev.tooling.manifest_utils import Manifest
 
@@ -29,7 +25,6 @@ DISPLAY_NAME_MAPPING = {
 
 
 @click.command(
-    context_settings=CONTEXT_SETTINGS,
     short_help="Provide a list of updated checks on a given Datadog Agent version, in changelog form",
 )
 @click.option('--since', help="Initial Agent version", default='6.3.0')
@@ -38,7 +33,8 @@ DISPLAY_NAME_MAPPING = {
     '--write', '-w', is_flag=True, help="Write to the changelog file, if omitted contents will be printed to stdout"
 )
 @click.option('--force', '-f', is_flag=True, default=False, help="Replace an existing file")
-def changelog(since, to, write, force):
+@click.pass_obj
+def changelog(app, since, to, write, force):
     """
     Generates a markdown file containing the list of checks that changed for a
     given Agent release. Agent version numbers are derived inspecting tags on
@@ -88,8 +84,8 @@ def changelog(since, to, write, force):
         # don't overwrite an existing file
         if os.path.exists(dest) and not force:
             msg = "Output file {} already exists, run the command again with --force to overwrite"
-            abort(msg.format(dest))
+            app.abort(msg.format(dest))
 
         write_file(dest, changelog_contents.getvalue())
     else:
-        echo_info(changelog_contents.getvalue())
+        app.display_info(changelog_contents.getvalue())

--- a/ddev/src/ddev/cli/release/agent/changelog.py
+++ b/ddev/src/ddev/cli/release/agent/changelog.py
@@ -1,12 +1,17 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
 
 from io import StringIO
+from typing import TYPE_CHECKING
 
 import click
 
 from ddev.cli.release.agent.common import get_changes_per_agent
+
+if TYPE_CHECKING:
+    from ddev.cli.application import Application
 
 # Extra entries in the agent changelog
 CHANGELOG_MANUAL_ENTRIES = {
@@ -31,7 +36,7 @@ DISPLAY_NAME_MAPPING = {
 )
 @click.option('--force', '-f', is_flag=True, default=False, help="Replace an existing file")
 @click.pass_obj
-def changelog(app, since, to, write, force):
+def changelog(app: Application, since: str, to: str, write: bool, force: bool):
     """
     Generates a markdown file containing the list of checks that changed for a
     given Agent release. Agent version numbers are derived inspecting tags on

--- a/ddev/src/ddev/cli/release/agent/common.py
+++ b/ddev/src/ddev/cli/release/agent/common.py
@@ -1,0 +1,97 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import os
+
+from datadog_checks.dev.tooling.constants import get_agent_release_requirements
+from datadog_checks.dev.tooling.git import git_show_file, git_tag_list
+from datadog_checks.dev.tooling.release import DATADOG_PACKAGE_PREFIX, get_folder_name, get_package_name
+from datadog_checks.dev.tooling.utils import parse_agent_req_file
+from semver import VersionInfo
+
+
+def get_agent_tags(since, to):
+    """
+    Return a list of tags from integrations-core representing an Agent release,
+    sorted by more recent first.
+    """
+    agent_tags = sorted(VersionInfo.parse(t) for t in git_tag_list(r'^\d+\.\d+\.\d+$'))
+
+    # default value for `to` is the latest tag
+    if to:
+        to = VersionInfo.parse(to)
+    else:
+        to = agent_tags[-1]
+
+    since = VersionInfo.parse(since)
+
+    # filter out versions according to the interval [since, to]
+    agent_tags = [t for t in agent_tags if since <= t <= to]
+
+    # reverse so we have descendant order
+    return [str(t) for t in reversed(agent_tags)]
+
+
+def get_changes_per_agent(since, to):
+    """
+    Return integration versions groups by Agent versions.
+    For each version, we also get a boolean indicating if the version has breaking changes.
+
+    Structure:
+
+    ```
+    {
+        '<AGENT_VERSION>': {
+            '<INTEGRATION_NAME>': ('<INTEGRATION_VERSION>', <IS_BREAKING_CHANGE>)
+        }
+    }
+    ```
+
+    Example output:
+
+    ```python
+    {
+        '7.20.0': {
+            'snmp': ('1.9.1', False)
+        }
+    }
+    ```
+    """
+    agent_tags = get_agent_tags(since, to)
+    # store the changes in a mapping {agent_version --> {check_name --> current_version}}
+    changes_per_agent = {}
+    # to keep indexing easy, we run the loop off-by-one
+    for i in range(1, len(agent_tags)):
+        req_file_name = os.path.basename(get_agent_release_requirements())
+        current_tag = agent_tags[i - 1]
+        # Requirements for current tag
+        file_contents = git_show_file(req_file_name, current_tag)
+        catalog_now = parse_agent_req_file(file_contents)
+        # Requirements for previous tag
+        file_contents = git_show_file(req_file_name, agent_tags[i])
+        catalog_prev = parse_agent_req_file(file_contents)
+
+        changes_per_agent[current_tag] = {}
+
+        for name, ver in catalog_now.items():
+            # at some point in the git history, the requirements file erroneously
+            # contained the folder name instead of the package name for each check,
+            # let's be resilient
+            old_ver = (
+                catalog_prev.get(name)
+                or catalog_prev.get(get_folder_name(name))
+                or catalog_prev.get(get_package_name(name))
+            )
+
+            # normalize the package name to the check_name
+            if name.startswith(DATADOG_PACKAGE_PREFIX):
+                name = get_folder_name(name)
+
+            if old_ver and old_ver != ver:
+                # determine whether major version changed
+                breaking = old_ver.split('.')[0] < ver.split('.')[0]
+                changes_per_agent[current_tag][name] = (ver, breaking)
+            elif not old_ver:
+                # New integration
+                changes_per_agent[current_tag][name] = (ver, False)
+    return changes_per_agent

--- a/ddev/src/ddev/cli/release/agent/common.py
+++ b/ddev/src/ddev/cli/release/agent/common.py
@@ -18,17 +18,17 @@ def get_agent_tags(repo: Repository, since: str, to: str) -> list[str]:
     Return a list of tags from integrations-core representing an Agent release,
     sorted by more recent first.
     """
-    from semver import VersionInfo
+    from packaging.version import parse as parse_version
 
-    agent_tags = sorted(VersionInfo.parse(t) for t in repo.git.filter_tags(r'^\d+\.\d+\.\d+$'))
+    agent_tags = sorted(parse_version(t) for t in repo.git.filter_tags(r'^\d+\.\d+\.\d+$'))
 
     # default value for `to` is the latest tag
     if to:
-        to = VersionInfo.parse(to)
+        to = parse_version(to)
     else:
         to = agent_tags[-1]
 
-    since = VersionInfo.parse(since)
+    since = parse_version(since)
 
     # filter out versions according to the interval [since, to]
     agent_tags = [t for t in agent_tags if since <= t <= to]

--- a/ddev/src/ddev/cli/release/agent/common.py
+++ b/ddev/src/ddev/cli/release/agent/common.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from semver import VersionInfo
-
 if TYPE_CHECKING:
     from ddev.repo.core import Repository
 
@@ -20,6 +18,8 @@ def get_agent_tags(repo: Repository, since: str, to: str) -> list[str]:
     Return a list of tags from integrations-core representing an Agent release,
     sorted by more recent first.
     """
+    from semver import VersionInfo
+
     agent_tags = sorted(VersionInfo.parse(t) for t in repo.git.filter_tags(r'^\d+\.\d+\.\d+$'))
 
     # default value for `to` is the latest tag

--- a/ddev/src/ddev/cli/release/agent/common.py
+++ b/ddev/src/ddev/cli/release/agent/common.py
@@ -1,12 +1,21 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from semver import VersionInfo
+
+if TYPE_CHECKING:
+    from ddev.repo.core import Repository
+
+    AgentChangelog = dict[str, dict[str, tuple[str, bool]]]
 
 DATADOG_PACKAGE_PREFIX = 'datadog-'
 
 
-def get_agent_tags(repo, since, to):
+def get_agent_tags(repo: Repository, since: str, to: str) -> list[str]:
     """
     Return a list of tags from integrations-core representing an Agent release,
     sorted by more recent first.
@@ -28,7 +37,7 @@ def get_agent_tags(repo, since, to):
     return [str(t) for t in reversed(agent_tags)]
 
 
-def get_changes_per_agent(repo, since, to):
+def get_changes_per_agent(repo: Repository, since: str, to: str) -> AgentChangelog:
     """
     Return integration versions groups by Agent versions.
     For each version, we also get a boolean indicating if the version has breaking changes.
@@ -54,8 +63,8 @@ def get_changes_per_agent(repo, since, to):
     ```
     """
     agent_tags = get_agent_tags(repo, since, to)
-    # store the changes in a mapping {agent_version --> {check_name --> current_version}}
-    changes_per_agent = {}
+    # store the changes in a mapping {agent_version --> {check_name --> (current_version, is_breaking_change)}}
+    changes_per_agent: AgentChangelog = {}
     # to keep indexing easy, we run the loop off-by-one
     for i in range(1, len(agent_tags)):
         req_file_name = repo.agent_release_requirements.name
@@ -93,7 +102,7 @@ def get_changes_per_agent(repo, since, to):
     return changes_per_agent
 
 
-def get_package_name(folder_name):
+def get_package_name(folder_name: str) -> str:
     """
     Given a folder name for a check, return the name of the
     corresponding Python package
@@ -110,7 +119,7 @@ def get_package_name(folder_name):
     return f"{DATADOG_PACKAGE_PREFIX}{folder_name.replace('_', '-')}"
 
 
-def get_folder_name(package_name):
+def get_folder_name(package_name: str) -> str:
     """
     Given a Python package name for a check, return the corresponding folder
     name in the git repo
@@ -127,7 +136,7 @@ def get_folder_name(package_name):
     return package_name.replace('-', '_')[len(DATADOG_PACKAGE_PREFIX) :]
 
 
-def parse_agent_req_file(contents):
+def parse_agent_req_file(contents: str) -> dict[str, str]:
     """
     Returns a dictionary mapping {check-package-name --> pinned_version} from the
     given file contents. We can assume lines are in the form:

--- a/ddev/src/ddev/repo/core.py
+++ b/ddev/src/ddev/repo/core.py
@@ -53,6 +53,10 @@ class Repository:
     def agent_requirements(self) -> Path:
         return self.path / 'datadog_checks_base' / 'datadog_checks' / 'base' / 'data' / 'agent_requirements.in'
 
+    @cached_property
+    def agent_changelog(self) -> Path:
+        return self.path / 'AGENT_CHANGELOG.md'
+
 
 class IntegrationRegistry:
     def __init__(self, repo: Repository):

--- a/ddev/src/ddev/repo/core.py
+++ b/ddev/src/ddev/repo/core.py
@@ -54,6 +54,10 @@ class Repository:
         return self.path / 'datadog_checks_base' / 'datadog_checks' / 'base' / 'data' / 'agent_requirements.in'
 
     @cached_property
+    def agent_release_requirements(self) -> Path:
+        return self.path / 'requirements-agent-release.txt'
+
+    @cached_property
     def agent_changelog(self) -> Path:
         return self.path / 'AGENT_CHANGELOG.md'
 

--- a/ddev/src/ddev/utils/git.py
+++ b/ddev/src/ddev/utils/git.py
@@ -101,6 +101,9 @@ class GitManager:
         tags = self.__filtered_tags[pattern] = [tag for tag in self.tags if re.search(pattern, tag)]
         return tags
 
+    def show_file(self, path: str, ref: str) -> str:
+        return self.capture('show', f'{ref}:{path}')
+
     def run(self, *args):
         import subprocess
 

--- a/ddev/tests/cli/release/agent/test_changelog.py
+++ b/ddev/tests/cli/release/agent/test_changelog.py
@@ -1,0 +1,127 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import re
+from contextlib import contextmanager
+
+import pytest
+from datadog_checks.dev.tooling.constants import get_root, set_root
+from ddev.repo.core import Repository
+
+
+def test_changelog_without_arguments(fake_changelog, ddev):
+
+    result = ddev('release', 'agent', 'changelog')
+
+    assert result.exit_code == 0
+    assert result.output.rstrip('\n') == fake_changelog
+
+
+def test_changelog_write_without_force_aborts(fake_changelog, ddev):
+    # Note, this test has the implicit assumption coming from the `repository` fixture
+    # that the changelog file 'AGENT_CHANGELOG.md' already exists, and that's why it must fail.
+    result = ddev('release', 'agent', 'changelog', '--write')
+    assert result.exit_code == 1
+    assert re.match(
+        'Output file (.*?)AGENT_CHANGELOG.md already exists, run the command again with --force to overwrite',
+        result.output,
+    )
+
+
+def test_changelog_write_force(repository, fake_changelog, ddev):
+    result = ddev('release', 'agent', 'changelog', '--write', '--force')
+    assert result.exit_code == 0
+    with open(repository.path / 'AGENT_CHANGELOG.md') as f:
+        assert f.read().rstrip('\n') == fake_changelog
+
+
+def test_changelog_since_to(repository, fake_changelog, ddev):
+    result = ddev('release', 'agent', 'changelog', '--since', '7.38.0', '--to', '7.39.0')
+    assert result.exit_code == 0
+    assert (
+        result.output.rstrip('\n')
+        == """
+## Datadog Agent version [7.39.0](https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7390)
+
+* bar [2.0.0](https://github.com/DataDog/integrations-core/blob/master/bar/CHANGELOG.md) **BREAKING CHANGE**
+""".strip(
+            '\n'
+        )
+    )
+
+
+@pytest.fixture
+def fake_changelog(repository):
+    """Sets up a repo with a fake sequence of agent releases, yielding the expected changelog."""
+
+    repo = Repository(repository.path.name, str(repository.path))
+    # Initial version with a single integration
+    write_agent_requirements(repo.path, ['datadog-foo==1.0.0'])
+    repo.git.run('commit', '-a', '-m', 'first')
+    repo.git.run('tag', '7.37.0')
+    # An update and a new integration
+    write_agent_requirements(repo.path, ['datadog-foo==1.5.0', 'datadog-bar==1.0.0'])
+    repo.git.run('commit', '-a', '-m', 'second')
+    repo.git.run('tag', '7.38.0')
+    # A breaking update
+    write_agent_requirements(repo.path, ['datadog-bar==2.0.0'])
+    repo.git.run('commit', '-a', '-m', 'third')
+    repo.git.run('tag', '7.39.0')
+    # An update with an environment marker
+    write_agent_requirements(repo.path, ["datadog-onlywin==1.0.0; sys_platform == 'win32'"])
+    repo.git.run('commit', '-a', '-m', 'fourth')
+    repo.git.run('tag', '7.40.0')
+
+    # Satisfy manifest requirements
+    write_dummy_manifest(repo.path, 'foo')
+    write_dummy_manifest(repo.path, 'bar')
+    write_dummy_manifest(repo.path, 'onlywin')
+
+    with temporary_root(repository.path):
+        yield """
+## Datadog Agent version [7.40.0](https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7400)
+
+* onlywin [1.0.0](https://github.com/DataDog/integrations-core/blob/master/onlywin/CHANGELOG.md)
+
+## Datadog Agent version [7.39.0](https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7390)
+
+* bar [2.0.0](https://github.com/DataDog/integrations-core/blob/master/bar/CHANGELOG.md) **BREAKING CHANGE**
+
+## Datadog Agent version [7.38.0](https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7380)
+
+* foo [1.5.0](https://github.com/DataDog/integrations-core/blob/master/foo/CHANGELOG.md)
+* bar [1.0.0](https://github.com/DataDog/integrations-core/blob/master/bar/CHANGELOG.md)
+""".strip(
+            '\n'
+        )
+
+
+@contextmanager
+def temporary_root(root):
+    """A temporary way to set the root while migrating the command to get the root
+    through ddev's config. Not thread-safe.
+    """
+    old_root = get_root()
+    set_root(root)
+    yield
+    set_root(old_root)
+
+
+def write_agent_requirements(repo_path, requirements):
+    with open(repo_path / 'requirements-agent-release.txt', 'w') as req_file:
+        req_file.write('\n'.join(requirements))
+
+
+def write_dummy_manifest(repo_path, integration):
+    """Write a manifest to satisfy the initial requirement of having to go through `Manifest.load_manifest()`."""
+    (repo_path / integration).mkdir(exist_ok=True)
+    import json
+
+    with open(repo_path / integration / 'manifest.json', 'w') as f:
+        json.dump(
+            {
+                'manifest_version': '2.0.0',
+                'assets': {'integration': {'source_type_name': integration}},
+            },
+            f,
+        )


### PR DESCRIPTION
### What does this PR do?

Migrates `release agent changelog` from `datadog_checks_dev`.

### Motivation

[AITOOLS-161](https://datadoghq.atlassian.net/browse/AITOOLS-161)

### Additional Notes

For reviewers: I tried to organize commits into meaningful units for ease of review.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.

[AITOOLS-161]: https://datadoghq.atlassian.net/browse/AITOOLS-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ