### PR TITLE
Ignore ddev repo envvar when testing

### DIFF
--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -100,6 +100,7 @@ def config_file(tmp_path, monkeypatch) -> ConfigFile:
         'DD_DD_URL',
         'DD_API_KEY',
         'DD_APP_KEY',
+        'DDEV_REPO',
     ):
         monkeypatch.delenv(env_var, raising=False)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

This was causing one test to fail for me because I have that envvar set.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.