### PR TITLE
Convert `datadog_checks_dependency_provider` to hatch

### DIFF
--- a/datadog_checks_dependency_provider/MANIFEST.in
+++ b/datadog_checks_dependency_provider/MANIFEST.in
@@ -1,7 +1,0 @@
-graft datadog_checks
-
-include MANIFEST.in
-include README.md
-include requirements.in
-
-global-exclude *.py[cod] __pycache__

--- a/datadog_checks_dependency_provider/pyproject.toml
+++ b/datadog_checks_dependency_provider/pyproject.toml
@@ -1,0 +1,60 @@
+[build-system]
+requires = [
+    "hatchling>=0.11.2",
+    "setuptools>=66; python_version > '3.0'",
+    "setuptools; python_version < '3.0'",
+]
+build-backend = "hatchling.build"
+
+[project]
+name = "datadog-datadog_checks_dependency_provider"
+description = "The datadog_checks_dependency_provider check"
+readme = "README.md"
+license = "BSD-3-Clause"
+keywords = [
+    "datadog",
+    "datadog agent",
+    "datadog check",
+]
+authors = [
+    { name = "Datadog", email = "packages@datadoghq.com" },
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Topic :: System :: Monitoring",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.9",
+]
+dependencies = [
+    "datadog-checks-base>=11.2.0",
+]
+dynamic = [
+    "version",
+]
+
+[project.optional-dependencies]
+deps = []
+
+[project.urls]
+Source = "https://github.com/DataDog/integrations-core"
+
+[tool.hatch.version]
+path = "datadog_checks/datadog_checks_dependency_provider/__about__.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/datadog_checks",
+    "/tests",
+    "/manifest.json",
+]
+
+[tool.hatch.build.targets.wheel]
+include = [
+    "/datadog_checks/datadog_checks_dependency_provider",
+]
+dev-mode-dirs = [
+    ".",
+]

--- a/datadog_checks_dependency_provider/setup.py
+++ b/datadog_checks_dependency_provider/setup.py
@@ -27,7 +27,22 @@ def get_dependencies():
         return f.readlines()
 
 
-CHECKS_BASE_REQ = 'datadog-checks-base>=11.2.0'
+def parse_pyproject_array(name):
+    import os
+    import re
+    from ast import literal_eval
+
+    pattern = r'^{} = (\[.*?\])$'.format(name)
+
+    with open(os.path.join(HERE, 'pyproject.toml'), 'r', encoding='utf-8') as f:
+        # Windows \r\n prevents match
+        contents = '\n'.join(line.rstrip() for line in f.readlines())
+
+    array = re.search(pattern, contents, flags=re.MULTILINE | re.DOTALL).group(1)
+    return literal_eval(array)
+
+
+CHECKS_BASE_REQ = parse_pyproject_array('dependencies')[0]
 
 
 setup(
@@ -58,7 +73,7 @@ setup(
     packages=['datadog_checks.datadog_checks_dependency_provider'],
     # Run-time dependencies
     install_requires=[CHECKS_BASE_REQ],
-    extras_require={'deps': get_dependencies()},
+    extras_require={'deps': parse_pyproject_array('deps')},
     # Extra files to ship with the wheel package
     include_package_data=True,
 )


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation

The `ddev release agent changelog` command started to fail after #15513 because it expects all projects to have a pyproject.toml file.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] PR title must be written as a CHANGELOG entry [(see why)](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have `changelog/` and `integration/` labels attached
- [ ] If the PR doesn't need to be tested during QA, please add a `qa/skip-qa` label.