### PR TITLE
Output changelog to stdout instead of stderr on `ddev release agent changelog`

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Output changelog to stdout instead of stderr on `ddev release agent changelog` ([#15548](https://github.com/DataDog/integrations-core/pull/15548))
+
 ## 3.4.0 / 2023-08-10
 
 ***Added***:

--- a/ddev/src/ddev/cli/release/agent/changelog.py
+++ b/ddev/src/ddev/cli/release/agent/changelog.py
@@ -86,4 +86,4 @@ def changelog(app: Application, since: str, to: str, write: bool, force: bool):
 
         dest.write_text(changelog_contents.getvalue())
     else:
-        app.display_info(changelog_contents.getvalue())
+        app.display(changelog_contents.getvalue())


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation

More manual testing after the migration, I was trying to redirect the output to a file and found that it didn't, and it was because I wasn't aware of the distinction between the different new output functions.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
