### PR TITLE
Add "container.memory.usage.peak" metric

### DIFF
--- a/container/metadata.csv
+++ b/container/metadata.csv
@@ -7,6 +7,7 @@ container.cpu.throttled,rate,,nanosecond,,The total cpu throttled time,0,contain
 container.cpu.throttled.periods,rate,,,,The number of periods during which the container was throttled,0,container,cpu_throttled_periods,
 container.cpu.limit,gauge,,nanocore,,The maximum CPU time available to the container,0,container,cpu_limit,
 container.memory.usage,gauge,,byte,,The container total memory usage,0,container,mem_usage,
+container.memory.usage.peak,gauge,,byte,,The maximum memory usage recorded since the container started,0,container,mem_usage_peak,
 container.memory.kernel,gauge,,byte,,The container kernel memory usage,0,container,mem_kernel_usage,
 container.memory.limit,gauge,,byte,,The container memory limit,0,container,mem_limit,
 container.memory.soft_limit,gauge,,byte,,The container memory soft limit,0,container,mem_soft_limit,


### PR DESCRIPTION
### What does this PR do?

Documents the new `container.memory.usage.peak` metric.
It was introduced here: https://github.com/DataDog/datadog-agent/pull/18716
https://github.com/DataDog/datadog-agent/pull/19615


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
