### PR TITLE
Add support for sending database_instance metadata

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Added***:
 
-* Add support for sending `database_instance` metadata. [#15559](https://github.com/DataDog/integrations-core/pull/15559)
+* Add support for sending `database_instance` metadata ([#15559](https://github.com/DataDog/integrations-core/pull/15559))
 
 ## 14.1.0 / 2023-08-10
 

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Added***:
+
+* Add support for sending `database_instance` metadata. See ([#15559](https://github.com/DataDog/integrations-core/pull/15559))
+
 ## 14.1.0 / 2023-08-10
 
 ***Added***:

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Added***:
 
-* Add support for sending `database_instance` metadata. See ([#15559](https://github.com/DataDog/integrations-core/pull/15559))
+* Add support for sending `database_instance` metadata. [#15559](https://github.com/DataDog/integrations-core/pull/15559)
 
 ## 14.1.0 / 2023-08-10
 

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -682,6 +682,16 @@ files:
         type: boolean
         example: false
         display_default: false
+    - name: database_instance_collection_interval
+      hidden: true
+      description: |
+        Set the database instance collection interval (in seconds). The database instance collection sends
+        basic information about the database instance along with a signal that it still exists. 
+        This collection does not involve any additional queries to the database.
+      value:
+        type: number
+        example: 1800
+        display_default: false
     - template: instances/default
       overrides:
         disable_generic_tags.hidden: False

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -134,6 +134,7 @@ class PostgresConfig:
         }
         self.log_unobfuscated_queries = is_affirmative(instance.get('log_unobfuscated_queries', False))
         self.log_unobfuscated_plans = is_affirmative(instance.get('log_unobfuscated_plans', False))
+        self.database_instance_collection_interval = instance.get('database_instance_collection_interval', 1800)
 
     def _build_tags(self, custom_tags):
         # Clean up tags in case there was a None entry in the instance

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -48,6 +48,10 @@ def instance_data_directory():
     return '/usr/local/pgsql/data'
 
 
+def instance_database_instance_collection_interval():
+    return False
+
+
 def instance_dbm():
     return False
 

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -159,6 +159,7 @@ class InstanceConfig(BaseModel):
     custom_queries: Optional[tuple[MappingProxyType[str, Any], ...]] = None
     data_directory: Optional[str] = None
     database_autodiscovery: Optional[DatabaseAutodiscovery] = None
+    database_instance_collection_interval: Optional[float] = None
     dbm: Optional[bool] = None
     dbname: Optional[str] = None
     dbstrict: Optional[bool] = None

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -17,6 +17,8 @@ from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_e
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 
+from .util import payload_pg_version
+
 # default pg_settings collection interval in seconds
 DEFAULT_SETTINGS_COLLECTION_INTERVAL = 600
 DEFAULT_RESOURCES_COLLECTION_INTERVAL = 300
@@ -98,19 +100,13 @@ class PostgresMetadata(DBMAsyncJob):
             "dbms": "postgres",
             "kind": "pg_settings",
             "collection_interval": self.collection_interval,
-            'dbms_version': self._payload_pg_version(),
+            'dbms_version': payload_pg_version(self._check.version),
             "tags": self._tags_no_db,
             "timestamp": time.time() * 1000,
             "cloud_metadata": self._config.cloud_metadata,
             "metadata": self._pg_settings_cached,
         }
         self._check.database_monitoring_metadata(json.dumps(event, default=default_json_event_encoding))
-
-    def _payload_pg_version(self):
-        version = self._check.version
-        if not version:
-            return ""
-        return 'v{major}.{minor}.{patch}'.format(major=version.major, minor=version.minor, patch=version.patch)
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_postgres_settings(self):

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -4,7 +4,7 @@
 import concurrent.futures
 import copy
 import os
-import time
+from time import time
 
 import psycopg
 from cachetools import TTLCache
@@ -839,7 +839,7 @@ class PostgreSql(AgentCheck):
                 'dbms_version': payload_pg_version(self.version),
                 'integration_version': __version__,
                 "tags": self._non_internal_tags,
-                "timestamp": time.time() * 1000,
+                "timestamp": time() * 1000,
                 "cloud_metadata": self._config.cloud_metadata,
                 "metadata": {
                     "dbm": self._config.dbm_enabled,

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -872,7 +872,7 @@ class PostgreSql(AgentCheck):
                 self.metadata_samples.run_job_loop(tags)
             if self._config.collect_wal_metrics:
                 self._collect_wal_metrics(tags)
-
+            self._send_database_instance_metadata()
         except Exception as e:
             self.log.exception("Unable to collect postgres metrics.")
             self._clean_state()

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -4,7 +4,7 @@
 import concurrent.futures
 import copy
 import os
-from time import time
+import time
 
 import psycopg
 from cachetools import TTLCache

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -18,7 +18,7 @@ from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_e
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 
-from .util import DatabaseConfigurationError,  payload_pg_version, warning_with_tags
+from .util import DatabaseConfigurationError, payload_pg_version, warning_with_tags
 from .version_utils import V9_4, V14
 
 try:

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -18,7 +18,7 @@ from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_e
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 
-from .util import DatabaseConfigurationError, warning_with_tags
+from .util import DatabaseConfigurationError,  payload_pg_version, warning_with_tags
 from .version_utils import V9_4, V14
 
 try:
@@ -182,12 +182,6 @@ class PostgresStatementMetrics(DBMAsyncJob):
         self._tags_no_db = [t for t in self.tags if not t.startswith('db:')]
         self.collect_per_statement_metrics()
 
-    def _payload_pg_version(self):
-        version = self._check.version
-        if not version:
-            return ""
-        return 'v{major}.{minor}.{patch}'.format(major=version.major, minor=version.minor, patch=version.patch)
-
     @tracked_method(agent_check_getter=agent_check_getter)
     def collect_per_statement_metrics(self):
         # exclude the default "db" tag from statement metrics & FQT events because this data is collected from
@@ -206,7 +200,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 'tags': self._tags_no_db,
                 'cloud_metadata': self._config.cloud_metadata,
                 'postgres_rows': rows,
-                'postgres_version': self._payload_pg_version(),
+                'postgres_version': payload_pg_version(self._check.version),
                 'ddagentversion': datadog_agent.get_version(),
                 "ddagenthostname": self._check.agent_hostname,
             }

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -59,6 +59,12 @@ def get_schema_field(descriptors):
     raise CheckException("The descriptors are missing a schema field")
 
 
+def payload_pg_version(version):
+    if not version:
+        return ""
+    return 'v{major}.{minor}.{patch}'.format(major=version.major, minor=version.minor, patch=version.patch)
+
+
 fmt = PartialFormatter()
 
 AWS_RDS_HOSTNAME_SUFFIX = ".rds.amazonaws.com"

--- a/postgres/tests/test_metadata.py
+++ b/postgres/tests/test_metadata.py
@@ -33,7 +33,8 @@ def test_collect_metadata(integration_check, dbm_instance, aggregator):
     check = integration_check(dbm_instance)
     check.check(dbm_instance)
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
-    event = dbm_metadata[0]
+    event = next((e for e in dbm_metadata if e['kind'] == 'pg_settings'), None)
+    assert event is not None
     assert event['host'] == "stubbed.hostname"
     assert event['dbms'] == "postgres"
     assert event['kind'] == "pg_settings"

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -627,6 +627,7 @@ def test_database_instance_metadata(aggregator, dd_run_check, pg_instance, dbm_e
     if reported_hostname:
         pg_instance['reported_hostname'] = reported_hostname
     expected_host = reported_hostname if reported_hostname else 'stubbed.hostname'
+    expected_tags = pg_instance['tags'] + ['port:{}'.format(pg_instance['port'])]
     check = PostgreSql('test_instance', {}, [pg_instance])
     dd_run_check(check)
 
@@ -635,7 +636,7 @@ def test_database_instance_metadata(aggregator, dd_run_check, pg_instance, dbm_e
     assert event is not None
     assert event['host'] == expected_host
     assert event['dbms'] == "postgres"
-    assert event['tags'].sort() == []
+    assert event['tags'].sort() == expected_tags.sort()
     assert event['integration_version'] == __version__
     assert event['collection_interval'] == 1800
     assert event['metadata'] == {

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -486,7 +486,7 @@ def test_wal_stats(aggregator, integration_check, pg_instance):
 
 
 def test_query_timeout(integration_check, pg_instance):
-    pg_instance['query_timeout'] = 1000
+    pg_instance['query_tsimeout'] = 1000
     check = integration_check(pg_instance)
     check._connect()
     cursor = check.db.cursor()
@@ -622,12 +622,12 @@ def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, agg
 )
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_database_instance_metadata(aggregator, dd_run_check, instance_complex, dbm_enabled, reported_hostname):
-    instance_complex['dbm'] = dbm_enabled
+def test_database_instance_metadata(aggregator, dd_run_check, pg_instance, dbm_enabled, reported_hostname):
+    pg_instance['dbm'] = dbm_enabled
     if reported_hostname:
-        instance_complex['reported_hostname'] = reported_hostname
+        pg_instance['reported_hostname'] = reported_hostname
     expected_host = reported_hostname if reported_hostname else 'stubbed.hostname'
-    check = PostgreSql('test_instance', {}, [instance_complex])
+    check = PostgreSql('test_instance', {}, [pg_instance])
     dd_run_check(check)
 
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
@@ -640,7 +640,7 @@ def test_database_instance_metadata(aggregator, dd_run_check, instance_complex, 
     assert event['collection_interval'] == 1800
     assert event['metadata'] == {
         'dbm': dbm_enabled,
-        'connection_host': instance_complex['host'],
+        'connection_host': pg_instance['host'],
     }
 
     # Run a second time and expect the metadata to not be emitted again because of the cache TTL

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -486,7 +486,7 @@ def test_wal_stats(aggregator, integration_check, pg_instance):
 
 
 def test_query_timeout(integration_check, pg_instance):
-    pg_instance['query_tsimeout'] = 1000
+    pg_instance['query_timeout'] = 1000
     check = integration_check(pg_instance)
     check._connect()
     cursor = check.db.cursor()

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -25,6 +25,7 @@ from datadog_checks.postgres.statement_samples import (
     StatementTruncationState,
 )
 from datadog_checks.postgres.statements import PG_STAT_STATEMENTS_METRICS_COLUMNS, PG_STAT_STATEMENTS_TIMING_COLUMNS
+from datadog_checks.postgres.util import payload_pg_version
 
 from .common import DB_NAME, HOST, PORT, PORT_REPLICA2, POSTGRES_VERSION
 from .utils import WaitGroup, _get_conn, _get_superconn, requires_over_10, run_one_check
@@ -100,7 +101,7 @@ def test_statement_metrics_version(integration_check, dbm_instance, version, exp
         check = integration_check(dbm_instance)
         check._version = version
         check._connect()
-        assert check.statement_metrics.payload_pg_version() == expected_payload_version
+        assert payload_pg_version(check.version) == expected_payload_version
     else:
         with mock.patch(
             'datadog_checks.postgres.postgres.PostgreSql.version', new_callable=mock.PropertyMock
@@ -108,7 +109,7 @@ def test_statement_metrics_version(integration_check, dbm_instance, version, exp
             patched_version.return_value = None
             check = integration_check(dbm_instance)
             check._connect()
-            assert check.statement_metrics.payload_pg_version() == expected_payload_version
+            assert payload_pg_version(check.version) == expected_payload_version
 
 
 @pytest.mark.parametrize("dbstrict,ignore_databases", [(True, []), (False, ['dogs']), (False, [])])

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -100,7 +100,7 @@ def test_statement_metrics_version(integration_check, dbm_instance, version, exp
         check = integration_check(dbm_instance)
         check._version = version
         check._connect()
-        assert check.statement_metrics._payload_pg_version() == expected_payload_version
+        assert check.statement_metrics.payload_pg_version() == expected_payload_version
     else:
         with mock.patch(
             'datadog_checks.postgres.postgres.PostgreSql.version', new_callable=mock.PropertyMock
@@ -108,7 +108,7 @@ def test_statement_metrics_version(integration_check, dbm_instance, version, exp
             patched_version.return_value = None
             check = integration_check(dbm_instance)
             check._connect()
-            assert check.statement_metrics._payload_pg_version() == expected_payload_version
+            assert check.statement_metrics.payload_pg_version() == expected_payload_version
 
 
 @pytest.mark.parametrize("dbstrict,ignore_databases", [(True, []), (False, ['dogs']), (False, [])])


### PR DESCRIPTION
### What does this PR do?
This adds sending of a new metadata kind: `database_instance`. This doesn't require any new queries to collect the data as it's inferred from configuration and things collected during initialization (like version). 

### Motivation
We'd like to keep a better inventory of database instances regardless of whether dbm is enabled or not. We already have a concept of `database_instance` but this makes it a more direct element of collected information rather than something that is inferred / implicit from other data we collect. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
