### PR TITLE
Remove recommended monitors from GH templates

### DIFF
--- a/.github/workflows/run-validations.yml
+++ b/.github/workflows/run-validations.yml
@@ -86,10 +86,6 @@ on:
         required: false
         default: false
         type: boolean
-      recommended-monitors:
-        required: false
-        default: false
-        type: boolean
       saved-views:
         required: false
         default: false
@@ -214,10 +210,6 @@ jobs:
     - name: Validate README files
       if: inputs.readmes
       run: ddev validate readmes $TARGET
-
-    - name: Validate recommended monitors
-      if: inputs.recommended-monitors
-      run: ddev validate recommended-monitors $TARGET
 
     - name: Validate saved views
       if: inputs.saved-views


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Remove the recommended_monitors option from the GH Action Templates

### Motivation
<!-- What inspired you to submit this pull request? -->
All other integrations repos no longer set this option (and the underlying command is removed on the main branch of ddev)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
