### PR TITLE
CoreDNS: Add a further reading section and link to blog posts

### DIFF
--- a/coredns/README.md
+++ b/coredns/README.md
@@ -247,6 +247,14 @@ See [service_checks.json][15] for a list of service checks provided by this inte
 
 Need help? Contact [Datadog support][16].
 
+## Further Reading
+
+Additional helpful documentation, links, and articles:
+
+- [Key metrics for CoreDNS monitoring][21]
+- [Tools for collecting metrics and logs from CoreDNS][22]
+- [How to monitor CoreDNS with Datadog][23]
+
 
 [1]: https://app.datadoghq.com/account/settings/agent/latest
 [2]: http://docs.datadoghq.com/agent/docker/integrations/?tab=docker
@@ -267,4 +275,7 @@ Need help? Contact [Datadog support][16].
 [17]: https://docs.datadoghq.com/integrations/openmetrics
 [18]: https://github.com/DataDog/integrations-core/blob/7.32.x/coredns/datadog_checks/coredns/data/conf.yaml.example
 [19]: https://github.com/DataDog/integrations-core/blob/master/coredns/datadog_checks/coredns/data/auto_conf.yaml
-[20]:https://github.com/DataDog/integrations-core/blob/master/coredns/datadog_checks/coredns/data/conf.yaml.example
+[20]: https://github.com/DataDog/integrations-core/blob/master/coredns/datadog_checks/coredns/data/conf.yaml.example
+[21]: https://www.datadoghq.com/blog/coredns-metrics/
+[22]: https://www.datadoghq.com/blog/coredns-monitoring-tools/
+[23]: https://www.datadoghq.com/blog/monitoring-coredns-with-datadog/


### PR DESCRIPTION
### What does this PR do?
Updates the CoreDNS readme with a Further Reading section linking to the recent series of blog posts

### Motivation
The Docs team does this as a courtesy to drive traffic to the Datadog blog

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
