### PR TITLE
Add `weaviate.requests` metric

### DIFF
--- a/weaviate/datadog_checks/weaviate/metrics.py
+++ b/weaviate/datadog_checks/weaviate/metrics.py
@@ -78,4 +78,6 @@ METRICS = {
     'bucket_pause_durations_ms': 'bucket.pause.durations.ms',
     'backup_restore_data_transferred': 'backup.restore.data.transferred',
     'backup_store_data_transferred': 'backup.store.data.transferred',
+    # Weaviate 1.20.0+ only
+    'requests_total': 'requests',
 }

--- a/weaviate/hatch.toml
+++ b/weaviate/hatch.toml
@@ -5,12 +5,12 @@ DDEV_SKIP_GENERIC_TAGS_CHECK = "true"
 
 [[envs.default.matrix]]
 python = ["3.9"]
-version = ["1.19"]
+version = ["1.20"]
 auth = ["no-auth", "auth"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
-  { key = "WEAVIATE_VERSION", value = "1.19.1", if = ["1.19"] },
+  { key = "WEAVIATE_VERSION", value = "1.20.0", if = ["1.20"] },
 ]
 matrix.auth.env-vars = [
   { key = "USE_AUTH", value = "true", if = ["auth"] },

--- a/weaviate/metadata.csv
+++ b/weaviate/metadata.csv
@@ -77,6 +77,7 @@ weaviate.queries.durations_ms.count,count,,operation,,"The count of operations o
 weaviate.queries.durations_ms.sum,count,,millisecond,,The sum of query durations in milliseconds,0,weaviate,weaviate queries duration sum,
 weaviate.queries.filtered.vector.durations_ms.count,count,,,,The count of the duration of queries summary,0,weaviate,weaviate queries filtered vector duration count,
 weaviate.queries.filtered.vector.durations_ms.sum,count,,millisecond,,The duration of queries in milliseconds,0,weaviate,weaviate queries filtered vector duration sum,
+weaviate.requests,gauge,,request,,"The number of requests of tagged by a given status(ok, user_error, server_error)",0,weaviate,weaviate requests count,
 weaviate.startup.diskio.throughput.bucket,count,,operation,,"The number of operations observed for the the disk I/O throughput duration by `upper_bound` buckets",0,weaviate,weaviate startup diskio throughput bucket,
 weaviate.startup.diskio.throughput.count,count,,operation,,"The count of operations observed in the disk I/O throughput duration histogram",0,weaviate,weaviate startup diskio throughput count,
 weaviate.startup.diskio.throughput.sum,count,,byte,second,"The sum of disk I/O throughput startup operations in bytes/s, such as reading back the HNSW index or recovering LSM segments. The operation itself is defined by the operation label",0,weaviate,weaviate startup diskio throughput sum,

--- a/weaviate/tests/common.py
+++ b/weaviate/tests/common.py
@@ -99,6 +99,7 @@ OM_METRICS = [
     "weaviate.queries.durations_ms.count",
     "weaviate.queries.durations_ms.sum",
     "weaviate.query.dimensions.count",
+    "weaviate.requests",
 ]
 
 API_METRICS = [

--- a/weaviate/tests/fixtures/weaviate_openmetrics.txt
+++ b/weaviate/tests/fixtures/weaviate_openmetrics.txt
@@ -734,3 +734,19 @@ vector_index_tombstone_cleanup_threads{class_name="Movies",shard_name="S4Gq0SGpz
 # HELP vector_index_tombstones Number of active vector index tombstones
 # TYPE vector_index_tombstones gauge
 vector_index_tombstones{class_name="Movies",shard_name="S4Gq0SGpzte6"} 0
+# HELP requests_total Number of all requests made
+# TYPE requests_total gauge
+requests_total{api="graphql",class_name="n/a",query_type="",status="ok"} 839
+requests_total{api="graphql",class_name="n/a",query_type="",status="user_error"} 3
+requests_total{api="graphql",class_name="n/a",query_type="Aggregate",status="user_error"} 8
+requests_total{api="graphql",class_name="n/a",query_type="Explore",status="user_error"} 3
+requests_total{api="graphql",class_name="n/a",query_type="Get",status="user_error"} 28
+requests_total{api="rest",class_name="n/a",query_type="batch",status="ok"} 1143
+requests_total{api="rest",class_name="n/a",query_type="classification",status="ok"} 9
+requests_total{api="rest",class_name="n/a",query_type="misc",status="ok"} 14
+requests_total{api="rest",class_name="n/a",query_type="nodes",status="ok"} 12
+requests_total{api="rest",class_name="n/a",query_type="objects",status="ok"} 839
+requests_total{api="rest",class_name="n/a",query_type="objects",status="server_error"} 4
+requests_total{api="rest",class_name="n/a",query_type="objects",status="user_error"} 56
+requests_total{api="rest",class_name="n/a",query_type="schema",status="ok"} 552
+requests_total{api="rest",class_name="n/a",query_type="schema",status="user_error"} 55

--- a/weaviate/tests/kind/weaviate_auth.yaml
+++ b/weaviate/tests/kind/weaviate_auth.yaml
@@ -95,7 +95,7 @@ spec:
       terminationGracePeriodSeconds: 600
       containers:
       - name: weaviate
-        image: 'docker.io/semitechnologies/weaviate:1.19.1'
+        image: 'docker.io/semitechnologies/weaviate:1.20.0'
         imagePullPolicy: IfNotPresent
         command: 
           - /bin/weaviate

--- a/weaviate/tests/kind/weaviate_install.yaml
+++ b/weaviate/tests/kind/weaviate_install.yaml
@@ -89,7 +89,7 @@ spec:
       terminationGracePeriodSeconds: 600
       containers:
       - name: weaviate
-        image: 'docker.io/semitechnologies/weaviate:1.19.1'
+        image: 'docker.io/semitechnologies/weaviate:1.20.0'
         imagePullPolicy: IfNotPresent
         command: 
           - /bin/weaviate


### PR DESCRIPTION
### What does this PR do?
Bumps test environment to 1.20.
Added a new metric that weaviate team deemed important that was added in version 1.20.0+. This metric comes tagged with a request status. 
