### PR TITLE
Print the metric list when parsing a prometheus endpoint

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ***Added***:
 
-* Print the metric list when parsing a prometheus endpoint ([#15586](https://github.com/DataDog/integrations-core/pull/15586))
+* Print the metric list when parsing a Prometheus endpoint ([#15586](https://github.com/DataDog/integrations-core/pull/15586))
 * Update dependencies for Agent 7.48 ([#15585](https://github.com/DataDog/integrations-core/pull/15585))
 
 ***Fixed***:

--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ***Added***:
 
+* Print the metric list when parsing a prometheus endpoint ([#15586](https://github.com/DataDog/integrations-core/pull/15586))
 * Update dependencies for Agent 7.48 ([#15585](https://github.com/DataDog/integrations-core/pull/15585))
 
 ***Fixed***:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/prometheus.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/meta/prometheus.py
@@ -250,3 +250,9 @@ def parse(ctx, endpoint, fh, check, here):
     )
 
     echo_info(metric_map)
+
+    metric_list = (
+        '\nMETRICS = [\n' '{}\n' ']'.format('\n'.join("    '{}',".format(data['dd_name']) for _, data in metric_items))
+    )
+
+    echo_info(metric_list)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Print the metric list when parsing a prometheus endpoint

### Motivation
<!-- What inspired you to submit this pull request? -->

We use this list in the tests

Before:

```
╰─❯ ddev meta prom parse -f ray_head.txt ray                                                                                                                                                                                                                                                                                                                         ─╯

Globally available options:
    t - Append .total to the available options
    s - Skip
    q - Quit

(1 of 1) python_gc_objects_collected_total
         Type: counter
         Info: Objects collected during gc

1 - python.gc.objects.collected.total
2 - python.gc.objects.collected_total
3 - python.gc.objects_collected.total
4 - python.gc.objects_collected_total
5 - python.gc_objects.collected.total
6 - python.gc_objects.collected_total
7 - python.gc_objects_collected.total
8 - python.gc_objects_collected_total
9 - python_gc.objects.collected.total
10 - python_gc.objects.collected_total
11 - python_gc.objects_collected.total
12 - python_gc.objects_collected_total
13 - python_gc_objects.collected.total
14 - python_gc_objects.collected_total
15 - python_gc_objects_collected.total
16 - python_gc_objects_collected_total
q - Quit
Choose an option (default 16, as-is): 
python_gc_objects_collected_total

Writing `/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/ray/metadata.csv`... success!
METRIC_MAP = {
    'python_gc_objects_collected_total': 'python_gc_objects_collected_total',
}
```

After: 

```
╰─❯ ddev meta prom parse -f ray_head.txt ray                                                                                                                                                                                                                                                                                                                         ─╯

Globally available options:
    t - Append .total to the available options
    s - Skip
    q - Quit

(1 of 1) python_gc_objects_collected_total
         Type: counter
         Info: Objects collected during gc

1 - python.gc.objects.collected.total
2 - python.gc.objects.collected_total
3 - python.gc.objects_collected.total
4 - python.gc.objects_collected_total
5 - python.gc_objects.collected.total
6 - python.gc_objects.collected_total
7 - python.gc_objects_collected.total
8 - python.gc_objects_collected_total
9 - python_gc.objects.collected.total
10 - python_gc.objects.collected_total
11 - python_gc.objects_collected.total
12 - python_gc.objects_collected_total
13 - python_gc_objects.collected.total
14 - python_gc_objects.collected_total
15 - python_gc_objects_collected.total
16 - python_gc_objects_collected_total
q - Quit
Choose an option (default 16, as-is): 
python_gc_objects_collected_total

Writing `/Users/florent.clarret/go/src/github.com/DataDog/integrations-core/ray/metadata.csv`... success!

METRIC_MAP = {
    'python_gc_objects_collected_total': 'python_gc_objects_collected_total',
}

METRICS = [
    'python_gc_objects_collected_total',
]
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
