### PR TITLE
Fix documentation publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,8 +41,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends libkrb5-dev
 
-    - name: Build documentation
+    - name: Validate documentation
       run: ddev -v docs build --check
+
+    - name: Build documentation
+      run: ddev -v docs build
 
     - uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
### Motivation

Missed a step, the link checker requires built pages in a different format so we must do the actual build afterward