### PR TITLE
Support Auth through Azure AD MI / Service Principal

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -8,6 +8,7 @@ PyYAML,PyPI,MIT,Copyright (c) 2017-2021 Ingy döt Net
 Pyro4,PyPI,MIT,Copyright (c) 2016 Irmen de Jong
 aerospike,PyPI,Apache-2.0,"Copyright Aerospike, Inc."
 aws-requests-auth,PyPI,BSD-3-Clause,Copyright (c) David Muller.
+azure-identity,PyPI,MIT,Copyright (c) Microsoft Corporation.
 beautifulsoup4,PyPI,MIT,Copyright (c) 2004-2017 Leonard Richardson
 beautifulsoup4,PyPI,MIT,Copyright (c) Leonard Richardson
 binary,PyPI,Apache-2.0,Copyright 2018 Ofek Lev

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Dependency update for 7.48 ([#15585](https://github.com/DataDog/integrations-core/pull/15585))
 * Improve documentation of APIs ([#15582](https://github.com/DataDog/integrations-core/pull/15582))
 
+***Added***:
+
+* Support Auth via Azure AD MI / Service Principal ([#15591](https://github.com/DataDog/integrations-core/pull/15591))
+
 ***Fixed***:
 
 * Downgrade pydantic to 2.0.2 ([#15596](https://github.com/DataDog/integrations-core/pull/15596))

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ***Added***:
 
-* Support Auth via Azure AD MI / Service Principal ([#15591](https://github.com/DataDog/integrations-core/pull/15591))
+* Support Auth through Azure AD MI / Service Principal ([#15591](https://github.com/DataDog/integrations-core/pull/15591))
 
 ***Fixed***:
 

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -1,6 +1,7 @@
 aerospike==4.0.0; sys_platform != 'win32' and sys_platform != 'darwin' and python_version < '3.0'
 aerospike==7.1.1; sys_platform != 'win32' and sys_platform != 'darwin' and python_version > '3.0'
 aws-requests-auth==0.4.3
+azure-identity==1.14.0; python_version > '3.0'
 beautifulsoup4==4.12.2; python_version > '3.0'
 beautifulsoup4==4.9.3; python_version < '3.0'
 binary==1.0.0

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Add support for sending `database_instance` metadata ([#15562](https://github.com/DataDog/integrations-core/pull/15562))
 * Update dependencies for Agent 7.48 ([#15585](https://github.com/DataDog/integrations-core/pull/15585))
+* Support Auth via Azure AD MI / Service Principal ([#15591](https://github.com/DataDog/integrations-core/pull/15591))
 
 ## 13.0.0 / 2023-08-10
 

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * Add support for sending `database_instance` metadata ([#15562](https://github.com/DataDog/integrations-core/pull/15562))
 * Update dependencies for Agent 7.48 ([#15585](https://github.com/DataDog/integrations-core/pull/15585))
-* Support Auth via Azure AD MI / Service Principal ([#15591](https://github.com/DataDog/integrations-core/pull/15591))
+* Support Auth through Azure AD MI / Service Principal ([#15591](https://github.com/DataDog/integrations-core/pull/15591))
 
 ## 13.0.0 / 2023-08-10
 

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -413,6 +413,44 @@ files:
             type: string
             example: my-sqlserver-database.database.windows.net
 
+    - name: managed_authentication
+      description: |
+        Configuration section used for Azure AD Authentication. 
+        If this section is set, then the `username` and `password` fields will be ignored.
+        
+        Supports two possible ways to authenticate:
+          1. Azure Service Principal 
+          2. Azure Managed Identities
+      options:
+        - name: auth_type
+          description: |
+            Authentication method to use for connecting.
+            
+            Acceptable values are:
+              - `service_principal` 
+              - `managed_identity`
+          value:
+            type: string
+            example: managed_identity
+        - name: client_id
+          description: |
+            Client ID of either the User Managed Identity or the Service Principal. 
+            You do not need to set this option if you are using a System Assigned Managed Identity.
+            
+            For more information on Managed Identities, see the Azure docs
+            https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
+          value:
+            type: string
+        - name: client_secret
+          description: |
+            Client Secret of the Service Principal. 
+            You do not need to set this option if you are using a managed identity.
+            
+            For more information on Service Principals, see the Azure docs
+            https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals
+          value:
+            type: string
+
     - name: obfuscator_options
       description: |
         Configure how the SQL obfuscator behaves.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -413,43 +413,31 @@ files:
             type: string
             example: my-sqlserver-database.database.windows.net
 
-    - name: managed_authentication
+    - name: managed_identity
       description: |
-        Configuration section used for Azure AD Authentication. 
+        Configuration section used for Azure AD Authentication.
+        
+        This supports using System or User assigned managed identities.
         If this section is set, then the `username` and `password` fields will be ignored.
         
-        Supports two possible ways to authenticate:
-          1. Azure Service Principal 
-          2. Azure Managed Identities
+        For more information on Managed Identities, see the Azure docs
+        https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
       options:
-        - name: auth_type
-          description: |
-            Authentication method to use for connecting.
-            
-            Acceptable values are:
-              - `service_principal` 
-              - `managed_identity`
-          value:
-            type: string
-            example: managed_identity
         - name: client_id
           description: |
-            Client ID of either the User Managed Identity or the Service Principal. 
-            You do not need to set this option if you are using a System Assigned Managed Identity.
-            
-            For more information on Managed Identities, see the Azure docs
-            https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
+            Client ID of the Managed Identity.
           value:
             type: string
-        - name: client_secret
+        - name: identity_scope
           description: |
-            Client Secret of the Service Principal. 
-            You do not need to set this option if you are using a managed identity.
+            The permission scope from where to access the identity token. This value is optional if using the default
+            identity scope for Azure managed databases.
             
-            For more information on Service Principals, see the Azure docs
-            https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals
+            For more information on scopes, see the Azure docs
+            https://learn.microsoft.com/en-us/azure/active-directory/develop/scopes-oidc
           value:
             type: string
+            example: https://database.windows.net/.default
 
     - name: obfuscator_options
       description: |

--- a/sqlserver/datadog_checks/sqlserver/azure.py
+++ b/sqlserver/datadog_checks/sqlserver/azure.py
@@ -1,0 +1,18 @@
+import struct
+
+from azure.identity import ManagedIdentityCredential
+
+DEFAULT_PERMISSION_SCOPE = "https://database.windows.net/.default"
+TOKEN_ENCODING = "UTF-16-LE"
+
+
+# Use the azure identity API to generate a token that will be used
+# authenticate with either a system or user assigned managed identity
+def generate_managed_identity_token(client_id: str, identity_scope: str = None):
+    credential = ManagedIdentityCredential(client_id=client_id)
+    if not identity_scope:
+        identity_scope = DEFAULT_PERMISSION_SCOPE
+    token_bytes = credential.get_token(identity_scope).token.encode(TOKEN_ENCODING)
+    token_struct = struct.pack(f'<I{len(token_bytes)}s', len(token_bytes), token_bytes)
+
+    return token_struct

--- a/sqlserver/datadog_checks/sqlserver/azure.py
+++ b/sqlserver/datadog_checks/sqlserver/azure.py
@@ -1,3 +1,6 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
 import struct
 
 from azure.identity import ManagedIdentityCredential

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -58,6 +58,7 @@ class CustomQuery(BaseModel):
 
 class Gcp(BaseModel):
     model_config = ConfigDict(
+        arbitrary_types_allowed=True,
         frozen=True,
     )
     instance_id: Optional[str] = None

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -65,14 +65,13 @@ class Gcp(BaseModel):
     project_id: Optional[str] = None
 
 
-class ManagedAuthentication(BaseModel):
+class ManagedIdentity(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         frozen=True,
     )
-    auth_type: Optional[str] = None
     client_id: Optional[str] = None
-    client_secret: Optional[str] = None
+    identity_scope: Optional[str] = None
 
 
 class MetricPatterns(BaseModel):
@@ -160,7 +159,7 @@ class InstanceConfig(BaseModel):
     include_task_scheduler_metrics: Optional[bool] = None
     log_unobfuscated_plans: Optional[bool] = None
     log_unobfuscated_queries: Optional[bool] = None
-    managed_authentication: Optional[ManagedAuthentication] = None
+    managed_identity: Optional[ManagedIdentity] = None
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None
     obfuscator_options: Optional[ObfuscatorOptions] = None

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -58,11 +58,20 @@ class CustomQuery(BaseModel):
 
 class Gcp(BaseModel):
     model_config = ConfigDict(
-        arbitrary_types_allowed=True,
         frozen=True,
     )
     instance_id: Optional[str] = None
     project_id: Optional[str] = None
+
+
+class ManagedAuthentication(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    auth_type: Optional[str] = None
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
 
 
 class MetricPatterns(BaseModel):
@@ -150,6 +159,7 @@ class InstanceConfig(BaseModel):
     include_task_scheduler_metrics: Optional[bool] = None
     log_unobfuscated_plans: Optional[bool] = None
     log_unobfuscated_queries: Optional[bool] = None
+    managed_authentication: Optional[ManagedAuthentication] = None
     metric_patterns: Optional[MetricPatterns] = None
     min_collection_interval: Optional[float] = None
     obfuscator_options: Optional[ObfuscatorOptions] = None

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -357,6 +357,42 @@ instances:
         #
         # fully_qualified_domain_name: my-sqlserver-database.database.windows.net
 
+    ## Configuration section used for Azure AD Authentication. 
+    ## If this section is set, then the `username` and `password` fields will be ignored.
+    ##
+    ## Supports two possible ways to authenticate:
+    ##   1. Azure Service Principal 
+    ##   2. Azure Managed Identities
+    #
+    # managed_authentication:
+
+        ## @param auth_type - string - optional - default: managed_identity
+        ## Authentication method to use for connecting.
+        ##
+        ## Acceptable values are:
+        ##   - `service_principal` 
+        ##   - `managed_identity`
+        #
+        # auth_type: managed_identity
+
+        ## @param client_id - string - optional
+        ## Client ID of either the User Managed Identity or the Service Principal. 
+        ## You do not need to set this option if you are using a System Assigned Managed Identity.
+        ##
+        ## For more information on Managed Identities, see the Azure docs
+        ## https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
+        #
+        # client_id: <CLIENT_ID>
+
+        ## @param client_secret - string - optional
+        ## Client Secret of the Service Principal. 
+        ## You do not need to set this option if you are using a managed identity.
+        ##
+        ## For more information on Service Principals, see the Azure docs
+        ## https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals
+        #
+        # client_secret: <CLIENT_SECRET>
+
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.
     #

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -357,41 +357,29 @@ instances:
         #
         # fully_qualified_domain_name: my-sqlserver-database.database.windows.net
 
-    ## Configuration section used for Azure AD Authentication. 
+    ## Configuration section used for Azure AD Authentication.
+    ##
+    ## This supports using System or User assigned managed identities.
     ## If this section is set, then the `username` and `password` fields will be ignored.
     ##
-    ## Supports two possible ways to authenticate:
-    ##   1. Azure Service Principal 
-    ##   2. Azure Managed Identities
+    ## For more information on Managed Identities, see the Azure docs
+    ## https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
     #
-    # managed_authentication:
-
-        ## @param auth_type - string - optional - default: managed_identity
-        ## Authentication method to use for connecting.
-        ##
-        ## Acceptable values are:
-        ##   - `service_principal` 
-        ##   - `managed_identity`
-        #
-        # auth_type: managed_identity
+    # managed_identity:
 
         ## @param client_id - string - optional
-        ## Client ID of either the User Managed Identity or the Service Principal. 
-        ## You do not need to set this option if you are using a System Assigned Managed Identity.
-        ##
-        ## For more information on Managed Identities, see the Azure docs
-        ## https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
+        ## Client ID of the Managed Identity.
         #
         # client_id: <CLIENT_ID>
 
-        ## @param client_secret - string - optional
-        ## Client Secret of the Service Principal. 
-        ## You do not need to set this option if you are using a managed identity.
+        ## @param identity_scope - string - optional - default: https://database.windows.net/.default
+        ## The permission scope from where to access the identity token. This value is optional if using the default
+        ## identity scope for Azure managed databases.
         ##
-        ## For more information on Service Principals, see the Azure docs
-        ## https://learn.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals
+        ## For more information on scopes, see the Azure docs
+        ## https://learn.microsoft.com/en-us/azure/active-directory/develop/scopes-oidc
         #
-        # client_secret: <CLIENT_SECRET>
+        # identity_scope: https://database.windows.net/.default
 
     ## Configure how the SQL obfuscator behaves.
     ## Note: This option only applies when `dbm` is enabled.

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -47,6 +47,7 @@ deps = [
     "selectors34==1.2; sys_platform == 'win32' and python_version < '3.0'",
     "serpent==1.28; sys_platform == 'win32' and python_version < '3.0'",
     "serpent==1.41; sys_platform == 'win32' and python_version > '3.0'",
+    "azure-identity==1.14.0; python_version > '3.0'"
 ]
 
 [project.urls]

--- a/sqlserver/tests/odbc/odbcinst.ini
+++ b/sqlserver/tests/odbc/odbcinst.ini
@@ -2,4 +2,4 @@
 FreeTDS=Installed
 
 [FreeTDS]
-Driver=/usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so
+Driver=/usr/lib64/libtdsodbc.so

--- a/sqlserver/tests/odbc/odbcinst.ini
+++ b/sqlserver/tests/odbc/odbcinst.ini
@@ -2,4 +2,4 @@
 FreeTDS=Installed
 
 [FreeTDS]
-Driver=/usr/lib64/libtdsodbc.so
+Driver=/usr/lib/x86_64-linux-gnu/odbc/libtdsodbc.so

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -1,4 +1,4 @@
-﻿# (C) Datadog, Inc. 2020-present
+# (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
@@ -168,6 +168,116 @@ def test_will_fail_for_wrong_parameters_in_the_connection_string(instance_minima
 
     with pytest.raises(ConfigurationError, match=re.escape(match)):
         connection._connection_options_validation('somekey', 'somedb')
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name,managed_auth_config,expected_cs_attr,should_fail,expected_err",
+    [
+        (
+            "valid managed_identity configuration",
+            {
+                'managed_authentication': {
+                    'auth_type': 'managed_identity',
+                    'client_id': "foo",
+                },
+            },
+            "ActiveDirectoryMsi",
+            False,
+            None,
+        ),
+        (
+            "valid service_principal configuration",
+            {
+                'managed_authentication': {
+                    'auth_type': 'service_principal',
+                    'client_id': "foo",
+                    'client_secret': "foo-secret",
+                },
+            },
+            "ActiveDirectoryServicePrincipal",
+            False,
+            None,
+        ),
+        (
+            "invalid auth type raises ConfigurationError",
+            {
+                'managed_authentication': {
+                    'auth_type': 'invalid',
+                },
+            },
+            None,
+            True,
+            (
+                "Azure AD Authentication is configured with unsupported auth_type "
+                "valid options are %s" % ", ".join(['service_principal', 'managed_identity'])
+            ),
+        ),
+        (
+            "valid auth type with username/password set raises ConfigurationError",
+            {
+                'managed_authentication': {
+                    'auth_type': 'service_principal',
+                },
+                "username": "foo",
+                "password": "shame-nun",
+            },
+            None,
+            True,
+            (
+                "Azure AD Authentication is configured, but username and password properties are also set "
+                "please remove `username` and `password` from your instance config to use"
+                "AD Authentication with service_principal"
+            ),
+        ),
+        (
+            "service_principal auth type without client_id set raises ConfigurationError",
+            {
+                'managed_authentication': {
+                    'auth_type': 'service_principal',
+                },
+            },
+            None,
+            True,
+            (
+                "Azure Service Principal Authentication is not properly configured "
+                "missing required property, client_id"
+            ),
+        ),
+        (
+            "service_principal auth type without client_secret set raises ConfigurationError",
+            {
+                'managed_authentication': {
+                    'auth_type': 'service_principal',
+                    'client_id': 'foo',
+                },
+            },
+            None,
+            True,
+            (
+                "Azure Service Principal Authentication is not properly configured "
+                "missing required property, client_secret"
+            ),
+        ),
+    ],
+)
+def test_managed_auth_config_valid(
+    instance_minimal_defaults, name, managed_auth_config, expected_cs_attr, should_fail, expected_err
+):
+    instance_minimal_defaults.pop('username')
+    instance_minimal_defaults.pop('password')
+    if managed_auth_config:
+        for k, v in managed_auth_config.items():
+            instance_minimal_defaults[k] = v
+    instance_minimal_defaults.update({'connector': 'odbc'})
+    check = SQLServer(CHECK_NAME, {}, [instance_minimal_defaults])
+    connection = Connection(check, {}, instance_minimal_defaults, None)
+    if should_fail:
+        with pytest.raises(ConfigurationError, match=re.escape(expected_err)):
+            connection._connection_options_validation('somekey', 'somedb')
+    else:
+        connection._connection_options_validation('somekey', 'somedb')
+        assert 'Authentication={}'.format(expected_cs_attr) in connection._conn_string_odbc('somekey')
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds support for Azure AD managed authentication in the SQL Server integration. Specifically, this implementation works with **[Azure Managed Identity](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview-for-developers?tabs=portal%2Cdotnet)** (both `system` and `user`).

Note: this feature requires using the [ODBC driver (version 18 or above)](https://learn.microsoft.com/en-us/sql/connect/odbc/using-azure-active-directory?view=sql-server-ver16#new-andor-modified-dsn-and-connection-string-keywords) in order to connect.

Azure Managed Identity works very similar to AWS's IAM, in that it allows the customer to avoid managing credentials. There are two main types of managed identities:

1. System-assigned. Some Azure resources, such as virtual machines allow you to enable a managed identity directly on the resource. When you enable a system-assigned managed identity:

    - A service principal of a special type is created in Azure AD for the identity. The service principal is tied to the lifecycle of that Azure resource. When the Azure resource is deleted, Azure automatically deletes the service principal for you.
    - By design, only that Azure resource can use this identity to request tokens from Azure AD.
    - You authorize the managed identity to have access to one or more services.

2. User-assigned. You may also create a managed identity as a standalone Azure resource. You can [create a user-assigned managed identity](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-to-manage-ua-identity-portal) and assign it to one or more Azure Resources. When you enable a user-assigned managed identity:

   - A service principal of a special type is created in Azure AD for the identity. The service principal is managed separately from the resources that use it.
   - User-assigned identities can be used by multiple resources.
   - You authorize the managed identity to have access to one or more services. 
   
  This change allows for customer to use either type of managed identity to authenticate, but the preferred way to do this is to use a **user assigned managed identity that can be shared across many different resources**. This makes configuration very simple for customers who do not want to manage many different users/credentials. 

### Motivation
<!-- What inspired you to submit this pull request? -->

This provides customers with the ability to authenticate to SQLServer in a more secure / automated way. This is especially for users that want to run the agent on linux, where the only auth option current is SQL authentication. 

### Configuration

In order to configure this new feature, complete the following steps:

1. Create your managed identity in the Azure portal
2. Configure your instance config with the following yaml block:

```yaml
    ## Configuration section used for Azure AD Authentication.
    ##
    ## This supports using System or User assigned managed identities.
    ## If this section is set, then the `username` and `password` fields will be ignored.
    ##
    ## For more information on Managed Identities, see the Azure docs
    ## https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview
    #
    managed_identity:

        ## @param client_id - string - optional
        ## Client ID of the Managed Identity.
        #
        client_id: <CLIENT_ID>

        ## @param identity_scope - string - optional - default: https://database.windows.net/.default
        ## The permission scope from where to access the identity token. This value is optional if using the default
        ## identity scope for Azure managed databases.
        ##
        ## For more information on scopes, see the Azure docs
        ## https://learn.microsoft.com/en-us/azure/active-directory/develop/scopes-oidc
        #
        identity_scope: https://database.windows.net/.default
```

3. On the SQL Server side, it is required that your Azure Managed Instance or Azure SQL DB be allowed to read from Azure AD
4. Create a `USER` for your MI on your database with the appropriate permissions, e.g.:
```tsql
CREATE USER [managed-identity-name] FROM EXTERNAL PROVIDER
ALTER ROLE db_datareader ADD MEMBER [managed-identity-name];
GO
``` 
