### PR TITLE
Downgrade pydantic to 2.0.2

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ***Fixed***:
 
+* Downgrade pydantic to 2.0.2 ([#15596](https://github.com/DataDog/integrations-core/pull/15596))
 * Bump cryptography to 41.0.3 ([#15517](https://github.com/DataDog/integrations-core/pull/15517))
 
 ## 32.7.0 / 2023-08-10

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -60,7 +60,7 @@ psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'
 psycopg[binary]==3.1.10; python_version > '3.0'
 pyasn1==0.4.6
 pycryptodomex==3.10.1
-pydantic==2.1.1; python_version > '3.0'
+pydantic==2.0.2; python_version > '3.0'
 pyjwt==1.7.1; python_version < '3.0'
 pyjwt==2.8.0; python_version > '3.0'
 pymongo[srv]==4.3.3; python_version >= '3.9'

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -55,7 +55,7 @@ deps = [
     "prometheus-client==0.17.1; python_version > '3.0'",
     "protobuf==3.17.3; python_version < '3.0'",
     "protobuf==3.20.2; python_version > '3.0'",
-    "pydantic==2.1.1; python_version > '3.0'",
+    "pydantic==2.0.2; python_version > '3.0'",
     "python-dateutil==2.8.2",
     "pywin32==228; sys_platform == 'win32' and python_version < '3.0'",
     "pywin32==306; sys_platform == 'win32' and python_version > '3.0'",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Downgrade pydantic to 2.0.2

### Motivation
<!-- What inspired you to submit this pull request? -->

- We can't use pydantic 2.1.1 because it needs pydantic-core 2.4.0 that we can't build on centos 6 (see https://github.com/DataDog/datadog-agent/pull/18303)
- The CI was already failing on the bump PR https://github.com/DataDog/integrations-core/pull/15585

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I'll open another PR to exclude this dependency from the ddev command until we stop supporting centos 6

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
