### PR TITLE
Ignore `pydantic` when bumping the dependencies

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ***Fixed***:
 
+* Ignore `pydantic` when bumping the dependencies ([#15597](https://github.com/DataDog/integrations-core/pull/15597))
 * Stop using the TOX_ENV_NAME variable ([#15528](https://github.com/DataDog/integrations-core/pull/15528))
 
 ## 23.0.0 / 2023-08-10

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -47,6 +47,8 @@ IGNORED_DEPS = {
     'pyvmomi',  # 7->8 breaks vsphere tests.
     # 4.3->4.4 changes the license field in the package metadata to something our validations cannot handle.
     'pymongo',
+    # We need pydantic 2.0.2 for the rpm x64 agent build (see https://github.com/DataDog/datadog-agent/pull/18303)
+    'pydantic',
 }
 
 # Dependencies for the downloader that are security-related and should be updated separately from the others


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Ignore `pydantic` when bumping the dependencies

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/pull/15596

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
