### PR TITLE
Migrate `ddev release agent integrations` to `ddev`

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -13,6 +13,7 @@
 ***Added***:
 
 * Migrate documentation commands to ddev ([#15582](https://github.com/DataDog/integrations-core/pull/15582))
+* Migrate `ddev release agent integrations` to `ddev` ([#15598](https://github.com/DataDog/integrations-core/pull/15598))
 
 ## 3.5.0 / 2023-08-11
 

--- a/ddev/src/ddev/cli/release/agent/__init__.py
+++ b/ddev/src/ddev/cli/release/agent/__init__.py
@@ -2,11 +2,11 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import click
-from datadog_checks.dev.tooling.commands.agent.integrations_changelog import integrations_changelog
 from datadog_checks.dev.tooling.commands.agent.requirements import requirements
 
 from ddev.cli.release.agent.changelog import changelog
 from ddev.cli.release.agent.integrations import integrations
+from ddev.cli.release.agent.integrations_changelog import integrations_changelog
 
 
 @click.group(short_help='A collection of tasks related to the Datadog Agent')

--- a/ddev/src/ddev/cli/release/agent/integrations_changelog.py
+++ b/ddev/src/ddev/cli/release/agent/integrations_changelog.py
@@ -3,9 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from __future__ import annotations
 
-import re
-from collections import defaultdict
-from io import StringIO
 from typing import TYPE_CHECKING
 
 import click
@@ -32,6 +29,9 @@ def integrations_changelog(app: Application, integrations: tuple[str], since: st
 
     Agent version is only added to the integration versions released with a specific Agent release.
     """
+    import re
+    from collections import defaultdict
+    from io import StringIO
 
     from ddev.cli.release.agent.common import get_changes_per_agent
 

--- a/ddev/src/ddev/cli/release/agent/integrations_changelog.py
+++ b/ddev/src/ddev/cli/release/agent/integrations_changelog.py
@@ -1,15 +1,19 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
 import re
 from collections import defaultdict
 from io import StringIO
+from typing import TYPE_CHECKING
 
 import click
 from datadog_checks.dev.tooling.testing import complete_active_checks
 from six import iteritems
 
-from ddev.cli.release.agent.common import get_changes_per_agent
+if TYPE_CHECKING:
+    from ddev.cli.application import Application
 
 INTEGRATION_CHANGELOG_PATTERN = r'^## (\d+\.\d+\.\d+) / \d{4}-\d{2}-\d{2}$'
 
@@ -24,12 +28,14 @@ INTEGRATION_CHANGELOG_PATTERN = r'^## (\d+\.\d+\.\d+) / \d{4}-\d{2}-\d{2}$'
     '--write', '-w', is_flag=True, help="Write to the changelog file, if omitted contents will be printed to stdout"
 )
 @click.pass_obj
-def integrations_changelog(app, checks, since, to, write):
+def integrations_changelog(app: Application, checks: list[str], since: str, to: str, write: bool):
     """
     Update integration CHANGELOG.md by adding the Agent version.
 
     Agent version is only added to the integration versions released with a specific Agent release.
     """
+
+    from ddev.cli.release.agent.common import get_changes_per_agent
 
     # Process all checks if no check is passed
     if not checks:
@@ -37,7 +43,7 @@ def integrations_changelog(app, checks, since, to, write):
 
     changes_per_agent = get_changes_per_agent(app.repo, since, to)
 
-    integrations_versions = defaultdict(dict)
+    integrations_versions: dict[str, dict[str, str]] = defaultdict(dict)
     for agent_version, version_changes in changes_per_agent.items():
         for name, (ver, _) in version_changes.items():
             if name not in checks:

--- a/ddev/src/ddev/cli/release/agent/integrations_changelog.py
+++ b/ddev/src/ddev/cli/release/agent/integrations_changelog.py
@@ -9,7 +9,6 @@ from io import StringIO
 from typing import TYPE_CHECKING
 
 import click
-from datadog_checks.dev.tooling.testing import complete_active_checks
 
 if TYPE_CHECKING:
     from ddev.cli.application import Application
@@ -20,14 +19,14 @@ INTEGRATION_CHANGELOG_PATTERN = r'^## (\d+\.\d+\.\d+) / \d{4}-\d{2}-\d{2}$'
 @click.command(
     short_help="Update integration CHANGELOG.md by adding the Agent version",
 )
-@click.argument('checks', shell_complete=complete_active_checks, nargs=-1)
+@click.argument('integrations', nargs=-1)
 @click.option('--since', help="Initial Agent version", default='6.3.0')
 @click.option('--to', help="Final Agent version")
 @click.option(
     '--write', '-w', is_flag=True, help="Write to the changelog file, if omitted contents will be printed to stdout"
 )
 @click.pass_obj
-def integrations_changelog(app: Application, checks: list[str], since: str, to: str, write: bool):
+def integrations_changelog(app: Application, integrations: tuple[str], since: str, to: str, write: bool):
     """
     Update integration CHANGELOG.md by adding the Agent version.
 
@@ -37,21 +36,21 @@ def integrations_changelog(app: Application, checks: list[str], since: str, to: 
     from ddev.cli.release.agent.common import get_changes_per_agent
 
     # Process all checks if no check is passed
-    if not checks:
-        checks = [integration.name for integration in app.repo.integrations.iter('all')]
+    if not integrations:
+        integrations = [integration.name for integration in app.repo.integrations.iter('all')]
 
     changes_per_agent = get_changes_per_agent(app.repo, since, to)
 
     integrations_versions: dict[str, dict[str, str]] = defaultdict(dict)
     for agent_version, version_changes in changes_per_agent.items():
         for name, (ver, _) in version_changes.items():
-            if name not in checks:
+            if name not in integrations:
                 continue
             integrations_versions[name][ver] = agent_version
 
-    for check, versions in integrations_versions.items():
+    for integration, versions in integrations_versions.items():
         changelog_contents = StringIO()
-        changelog_file = app.repo.integrations.get(check).path / 'CHANGELOG.md'
+        changelog_file = app.repo.integrations.get(integration).path / 'CHANGELOG.md'
 
         if not changelog_file.exists():
             continue
@@ -64,12 +63,14 @@ def integrations_changelog(app: Application, checks: list[str], since: str, to: 
                     agent_version = versions[version]
                     line = "{} / Agent {}\n".format(line.strip(), agent_version)
                 else:
-                    app.display_debug("Agent version not found for integration {} line {}".format(check, line.strip()))
+                    app.display_debug(
+                        "Agent version not found for integration {} line {}".format(integration, line.strip())
+                    )
             changelog_contents.write(line)
 
         # Save the changelog on disk if --write was passed
         if write:
             app.display_info("Writing to {}".format(changelog_file))
-            (app.repo.integrations.get(check).path / changelog_file).write_text(changelog_contents.getvalue())
+            changelog_file.write_text(changelog_contents.getvalue())
         else:
             print(changelog_contents.getvalue())

--- a/ddev/src/ddev/cli/release/agent/integrations_changelog.py
+++ b/ddev/src/ddev/cli/release/agent/integrations_changelog.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 
 import click
 from datadog_checks.dev.tooling.testing import complete_active_checks
-from six import iteritems
 
 if TYPE_CHECKING:
     from ddev.cli.application import Application
@@ -50,7 +49,7 @@ def integrations_changelog(app: Application, checks: list[str], since: str, to: 
                 continue
             integrations_versions[name][ver] = agent_version
 
-    for check, versions in iteritems(integrations_versions):
+    for check, versions in integrations_versions.items():
         changelog_contents = StringIO()
         changelog_file = app.repo.integrations.get(check).path / 'CHANGELOG.md'
 

--- a/ddev/src/ddev/cli/release/agent/integrations_changelog.py
+++ b/ddev/src/ddev/cli/release/agent/integrations_changelog.py
@@ -7,7 +7,6 @@ from io import StringIO
 
 import click
 from datadog_checks.dev.tooling.testing import complete_active_checks
-from datadog_checks.dev.tooling.utils import get_valid_checks
 from six import iteritems
 
 from ddev.cli.release.agent.common import get_changes_per_agent
@@ -34,7 +33,7 @@ def integrations_changelog(app, checks, since, to, write):
 
     # Process all checks if no check is passed
     if not checks:
-        checks = get_valid_checks()
+        checks = [integration.name for integration in app.repo.integrations.iter('all')]
 
     changes_per_agent = get_changes_per_agent(app.repo, since, to)
 
@@ -48,6 +47,9 @@ def integrations_changelog(app, checks, since, to, write):
     for check, versions in iteritems(integrations_versions):
         changelog_contents = StringIO()
         changelog_file = app.repo.integrations.get(check).path / 'CHANGELOG.md'
+
+        if not changelog_file.exists():
+            continue
 
         for line in changelog_file.read_text().splitlines(keepends=True):
             match = re.search(INTEGRATION_CHANGELOG_PATTERN, line)

--- a/ddev/src/ddev/cli/release/agent/integrations_changelog.py
+++ b/ddev/src/ddev/cli/release/agent/integrations_changelog.py
@@ -1,0 +1,70 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import re
+from collections import defaultdict
+from io import StringIO
+
+import click
+from datadog_checks.dev.fs import read_file_lines, write_file
+from datadog_checks.dev.tooling.commands.agent.common import get_changes_per_agent
+from datadog_checks.dev.tooling.commands.console import CONTEXT_SETTINGS, echo_debug, echo_info
+from datadog_checks.dev.tooling.constants import get_integration_changelog
+from datadog_checks.dev.tooling.testing import complete_active_checks
+from datadog_checks.dev.tooling.utils import get_valid_checks
+from six import iteritems
+
+INTEGRATION_CHANGELOG_PATTERN = r'^## (\d+\.\d+\.\d+) / \d{4}-\d{2}-\d{2}$'
+
+
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+    short_help="Update integration CHANGELOG.md by adding the Agent version",
+)
+@click.argument('checks', shell_complete=complete_active_checks, nargs=-1)
+@click.option('--since', help="Initial Agent version", default='6.3.0')
+@click.option('--to', help="Final Agent version")
+@click.option(
+    '--write', '-w', is_flag=True, help="Write to the changelog file, if omitted contents will be printed to stdout"
+)
+def integrations_changelog(checks, since, to, write):
+    """
+    Update integration CHANGELOG.md by adding the Agent version.
+
+    Agent version is only added to the integration versions released with a specific Agent release.
+    """
+
+    # Process all checks if no check is passed
+    if not checks:
+        checks = get_valid_checks()
+
+    changes_per_agent = get_changes_per_agent(since, to)
+
+    integrations_versions = defaultdict(dict)
+    for agent_version, version_changes in changes_per_agent.items():
+        for name, (ver, _) in version_changes.items():
+            if name not in checks:
+                continue
+            integrations_versions[name][ver] = agent_version
+
+    for check, versions in iteritems(integrations_versions):
+        changelog_contents = StringIO()
+        changelog_file = get_integration_changelog(check)
+
+        for line in read_file_lines(changelog_file):
+            match = re.search(INTEGRATION_CHANGELOG_PATTERN, line)
+            if match:
+                version = match.groups()[0]
+                if version in versions:
+                    agent_version = versions[version]
+                    line = "{} / Agent {}\n".format(line.strip(), agent_version)
+                else:
+                    echo_debug("Agent version not found for integration {} line {}".format(check, line.strip()))
+            changelog_contents.write(line)
+
+        # Save the changelog on disk if --write was passed
+        if write:
+            echo_info("Writing to {}".format(changelog_file))
+            write_file(changelog_file, changelog_contents.getvalue())
+        else:
+            echo_info(changelog_contents.getvalue())

--- a/ddev/src/ddev/cli/terminal.py
+++ b/ddev/src/ddev/cli/terminal.py
@@ -213,6 +213,12 @@ class Terminal:
 
         self.output(text, self._style_level_waiting, stderr=stderr, indent=indent, link=link, **kwargs)
 
+    def display_debug(self, text='', stderr=True, indent=None, link=None, **kwargs):
+        if self.verbosity < VerbosityLevels.DEBUG:
+            return
+
+        self.output(f'DEBUG: {text}', None, stderr=stderr, indent=indent, link=link, **kwargs)
+
     def display_header(self, title=''):
         self.console.rule(Text(title, self._style_level_success))
 

--- a/ddev/tests/cli/release/agent/test_integrations_changelog.py
+++ b/ddev/tests/cli/release/agent/test_integrations_changelog.py
@@ -3,7 +3,6 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 import pytest
-from datadog_checks.dev.tooling.constants import get_root, set_root
 
 
 def test_integrations_changelog_without_arguments(fake_changelogs, ddev):
@@ -36,8 +35,6 @@ def test_integrations_changelog_write(repo_with_fake_changelogs, ddev):
 def repo_with_fake_changelogs(repo_with_history, config_file):
     repo_root = repo_with_history.path
 
-    old_root = get_root()
-    set_root(str(repo_root))
     config_file.model.repos['core'] = str(repo_with_history.path)
     config_file.save()
 
@@ -107,9 +104,7 @@ def repo_with_fake_changelogs(repo_with_history, config_file):
 * Remove unused `metric_prefix` in init_config ([#11464](https://github.com/DataDog/integrations-core/pull/11464))
 """,
     }
-    yield repo_with_history, expected_changelogs
-
-    set_root(old_root)
+    return repo_with_history, expected_changelogs
 
 
 @pytest.fixture

--- a/ddev/tests/cli/release/agent/test_integrations_changelog.py
+++ b/ddev/tests/cli/release/agent/test_integrations_changelog.py
@@ -1,0 +1,116 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+from datadog_checks.dev.tooling.constants import get_root, set_root
+
+
+def test_integrations_changelog_without_arguments(fake_changelogs, ddev):
+    result = ddev('release', 'agent', 'integrations-changelog')
+
+    assert result.exit_code == 0
+    expected_output = '\n'.join([fake_changelogs['bar'], fake_changelogs['foo']])
+    assert result.output.rstrip('\n') == expected_output.rstrip('\n')
+
+
+def test_integrations_changelog_specific_check(fake_changelogs, ddev):
+    result = ddev('release', 'agent', 'integrations-changelog', 'foo')
+    assert result.exit_code == 0
+    assert result.output.rstrip('\n') == fake_changelogs['foo'].rstrip('\n')
+
+
+def test_integrations_changelog_write(repo_with_fake_changelogs, ddev):
+    repo, fake_changelogs = repo_with_fake_changelogs
+
+    result = ddev('release', 'agent', 'integrations-changelog', '--write')
+    assert result.exit_code == 0
+    with open(repo.path / 'foo' / 'CHANGELOG.md') as f:
+        assert f.read().rstrip('\n') == fake_changelogs['foo'].rstrip('\n')
+
+    with open(repo.path / 'bar' / 'CHANGELOG.md') as f:
+        assert f.read().rstrip('\n') == fake_changelogs['bar'].rstrip('\n')
+
+
+@pytest.fixture
+def repo_with_fake_changelogs(repo_with_history):
+    repo_root = repo_with_history.path
+
+    old_root = get_root()
+    set_root(str(repo_root))
+
+    # Write a changelog for a couple of integrations
+    (repo_root / 'foo' / 'CHANGELOG.md').write_text(
+        """# CHANGELOG - foo
+## 1.5.0 / 2022-09-16
+
+***Added***:
+
+* Update HTTP config spec templates ([#12890](https://github.com/DataDog/integrations-core/pull/12890))
+
+## 1.0.0 / 2022-05-18 / Agent 7.37.0
+
+***Fixed***:
+
+* Fix extra metrics description example ([#12043](https://github.com/DataDog/integrations-core/pull/12043))
+"""
+    )
+    (repo_root / 'bar' / 'CHANGELOG.md').write_text(
+        """# CHANGELOG - bar
+## 2.0.0 / 2022-11-16
+
+***Added***:
+
+* Upgrade dependencies ([#11726](https://github.com/DataDog/integrations-core/pull/11726))
+
+## 1.0.0 / 2022-05-18
+
+***Fixed***:
+
+* Remove unused `metric_prefix` in init_config ([#11464](https://github.com/DataDog/integrations-core/pull/11464))
+"""
+    )
+    # Turn 'foo' and 'bar' into *valid checks* by giving them an __about__.py file in the right location
+    (repo_root / 'foo' / 'datadog_checks' / 'foo').mkdir(parents=True)
+    (repo_root / 'foo' / 'datadog_checks' / 'foo' / '__about__.py').touch()
+    (repo_root / 'bar' / 'datadog_checks' / 'bar').mkdir(parents=True)
+    (repo_root / 'bar' / 'datadog_checks' / 'bar' / '__about__.py').touch()
+
+    # The fixture's value is a dictionary with the expected values for each integration
+    expected_changelogs = {
+        'foo': """# CHANGELOG - foo
+## 1.5.0 / 2022-09-16 / Agent 7.38.0
+
+***Added***:
+
+* Update HTTP config spec templates ([#12890](https://github.com/DataDog/integrations-core/pull/12890))
+
+## 1.0.0 / 2022-05-18 / Agent 7.37.0
+
+***Fixed***:
+
+* Fix extra metrics description example ([#12043](https://github.com/DataDog/integrations-core/pull/12043))
+""",
+        'bar': """# CHANGELOG - bar
+## 2.0.0 / 2022-11-16 / Agent 7.39.0
+
+***Added***:
+
+* Upgrade dependencies ([#11726](https://github.com/DataDog/integrations-core/pull/11726))
+
+## 1.0.0 / 2022-05-18 / Agent 7.38.0
+
+***Fixed***:
+
+* Remove unused `metric_prefix` in init_config ([#11464](https://github.com/DataDog/integrations-core/pull/11464))
+""",
+    }
+    yield repo_with_history, expected_changelogs
+
+    set_root(old_root)
+
+
+@pytest.fixture
+def fake_changelogs(repo_with_fake_changelogs):
+    _, fake_changelogs = repo_with_fake_changelogs
+    return fake_changelogs

--- a/ddev/tests/cli/release/agent/test_integrations_changelog.py
+++ b/ddev/tests/cli/release/agent/test_integrations_changelog.py
@@ -33,11 +33,13 @@ def test_integrations_changelog_write(repo_with_fake_changelogs, ddev):
 
 
 @pytest.fixture
-def repo_with_fake_changelogs(repo_with_history):
+def repo_with_fake_changelogs(repo_with_history, config_file):
     repo_root = repo_with_history.path
 
     old_root = get_root()
     set_root(str(repo_root))
+    config_file.model.repos['core'] = str(repo_with_history.path)
+    config_file.save()
 
     # Write a changelog for a couple of integrations
     (repo_root / 'foo' / 'CHANGELOG.md').write_text(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation

[AITOOLS-186](https://datadoghq.atlassian.net/browse/AITOOLS-186)

### Additional Notes

I've left the completion command to still depend on `datadog_checks_dev` because since it's something that will be used from different places and it feels like a separate concern it should probably be dealt with in a separate PR.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[AITOOLS-186]: https://datadoghq.atlassian.net/browse/AITOOLS-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ