### PR TITLE
Remove python 2 references from SQL Server integration

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -96,7 +96,6 @@ requests-unixsocket,PyPI,Apache-2.0,Copyright 2014 Marc Abramowitz
 rethinkdb,PyPI,Apache-2.0,Copyright 2018 RethinkDB.
 scandir,PyPI,BSD-3-Clause,"Copyright (c) 2012, Ben Hoyt"
 securesystemslib,PyPI,MIT,Copyright (c) 2016 Santiago Torres
-selectors34,PyPI,PSF,Copyright (c) 2015 Berker Peksag
 semver,PyPI,BSD-3-Clause,"Copyright (c) 2013, Konstantine Rybnikov"
 serpent,PyPI,MIT,Copyright (c) by Irmen de Jong
 service-identity,PyPI,MIT,Copyright (c) 2014 Hynek Schlawack

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Changed***:
+
+* Remove python 2 references from SQL Server integration ([#15606](https://github.com/DataDog/integrations-core/pull/15606))
+
 ***Added***:
 
 * Dependency update for 7.48 ([#15585](https://github.com/DataDog/integrations-core/pull/15585))

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -96,7 +96,6 @@ requests==2.31.0; python_version > '3.0'
 rethinkdb==2.4.9
 scandir==1.10.0
 securesystemslib[crypto,pynacl]==0.25.0; python_version > '3.0'
-selectors34==1.2; sys_platform == 'win32' and python_version < '3.0'
 semver==2.13.0; python_version < '3.0'
 semver==3.0.1; python_version > '3.0'
 serpent==1.28; sys_platform == 'win32' and python_version < '3.0'

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ***Changed***:
 
+* Remove python 2 references from SQL Server integration ([#15606](https://github.com/DataDog/integrations-core/pull/15606))
+
+***Changed***:
+
 * Collect both DBM active sessions and blocking sessions which are sleeping. See ([#14054](https://github.com/DataDog/integrations-core/pull/14054))
 
 ***Added***:

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -4,11 +4,8 @@
 
 ***Changed***:
 
-* Remove python 2 references from SQL Server integration ([#15606](https://github.com/DataDog/integrations-core/pull/15606))
-
-***Changed***:
-
 * Collect both DBM active sessions and blocking sessions which are sleeping. See ([#14054](https://github.com/DataDog/integrations-core/pull/14054))
+* Remove python 2 references from SQL Server integration ([#15606](https://github.com/DataDog/integrations-core/pull/15606))
 
 ***Added***:
 

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -1,8 +1,6 @@
 [build-system]
 requires = [
     "hatchling>=0.11.2",
-    "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 
@@ -10,6 +8,7 @@ build-backend = "hatchling.build"
 name = "datadog-sqlserver"
 description = "The SQL Server check"
 readme = "README.md"
+requires-python = ">=3.9"
 keywords = [
     "datadog",
     "datadog agent",
@@ -24,7 +23,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.9",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
@@ -42,10 +40,7 @@ deps = [
     "lxml==4.9.3",
     "pyodbc==4.0.32; sys_platform != 'darwin' or platform_machine != 'arm64'",
     "pyro4==4.82; sys_platform == 'win32'",
-    "pywin32==228; sys_platform == 'win32' and python_version < '3.0'",
     "pywin32==306; sys_platform == 'win32' and python_version > '3.0'",
-    "selectors34==1.2; sys_platform == 'win32' and python_version < '3.0'",
-    "serpent==1.28; sys_platform == 'win32' and python_version < '3.0'",
     "serpent==1.41; sys_platform == 'win32' and python_version > '3.0'",
     "azure-identity==1.14.0; python_version > '3.0'"
 ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Removes support for python versions older than 3.9 for the sqlserver integration 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
