### PR TITLE
Update EKS Fargate docs to include DCA env var

### DIFF
--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -184,6 +184,9 @@ agents:
 clusterAgent:
   enabled: true
   replicas: 2
+  env:
+    - name: DD_EKS_FARGATE
+      value: "true"
 ```
 
 


### PR DESCRIPTION
### What does this PR do?
The PR updates the helm values supplied in the `Running the Cluster Agent or the Cluster Checks Runner` section of the EKS Fargate documentation with a necessary environment variable.

### Motivation
This environment variable is how we determine whether we are running on EKS Fargate or not. Without it, any logic we have in place which depends on running in Fargate is not used. This could have unintended consequences, such as the cluster name not being populated properly (as was detailed [here](https://github.com/DataDog/datadog-agent/pull/18859))

[Ticket](https://datadoghq.atlassian.net/browse/CONT-3975)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
