### PR TITLE
Fix InstanceConfig loading error for `ssl` config

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -14,6 +14,10 @@
 * Update datadog-checks-base dependency version to 32.6.0 ([#15604](https://github.com/DataDog/integrations-core/pull/15604))
 * Prevent `command already in progress` errors in the Postgres integration ([#15489](https://github.com/DataDog/integrations-core/pull/15489))
 
+***Fixed***:
+
+* Fix InstanceConfig loading error for `ssl` config ([#15611](https://github.com/DataDog/integrations-core/pull/15611))
+
 ## 14.1.0 / 2023-08-10
 
 ***Added***:

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -88,7 +88,6 @@ files:
         Note: `true` is an alias for `require`, and `false` is an alias for `disable`.
       value:
         type: string
-        display_default: "false"
         example: "false"
     - name: ssl_root_cert
       description: |
@@ -97,8 +96,6 @@ files:
         For a detailed description of how this option works see https://www.postgresql.org/docs/current/libpq-ssl.html
       value:
         type: string
-        display_default: "false"
-        example: "/home/datadog/server-ca.pem"
     - name: ssl_cert
       description: |
         The path to the ssl certificate.
@@ -106,8 +103,6 @@ files:
         For a detailed description of how this option works see https://www.postgresql.org/docs/current/libpq-ssl.html
       value:
         type: string
-        display_default: "false"
-        example: "/home/datadog/client-cert.pem"
     - name: ssl_key
       description: |
         The path to the ssl client key.
@@ -115,8 +110,6 @@ files:
         For a detailed description of how this option works see https://www.postgresql.org/docs/current/libpq-ssl.html
       value:
         type: string
-        display_default: "false"
-        example: "/home/datadog/client-key.pem"
     - name: ssl_password
       description: |
         The password for the secret key specified in ssl_key, allowing client certificate private keys to be stored
@@ -125,8 +118,6 @@ files:
         For a detailed description of how this option works see https://www.postgresql.org/docs/current/libpq-ssl.html
       value:
         type: string
-        display_default: "false"
-        example: "ssl_key_password"
     - name: query_timeout
       description: |
         Adds a statement_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STATEMENT-TIMEOUT

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -84,11 +84,9 @@ files:
                          trusted CA and that the requested server host name matches the one in the certificate.
 
         For a detailed description of how these options work see https://www.postgresql.org/docs/current/libpq-ssl.html
-
-        Note: `true` is an alias for `require`, and `false` is an alias for `disable`.
       value:
         type: string
-        example: "false"
+        example: "disable"
     - name: ssl_root_cert
       description: |
         The path to the ssl root certificate.

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -60,11 +60,9 @@ class PostgresConfig:
         self.max_connections = instance.get('max_connections', 30)
         self.tags = self._build_tags(instance.get('tags', []))
 
-        ssl = instance.get('ssl', "false")
+        ssl = instance.get('ssl', "disable")
         if ssl in SSL_MODES:
             self.ssl_mode = ssl
-        else:
-            self.ssl_mode = 'require' if ssl == "true" else 'disable'
 
         self.ssl_cert = instance.get('ssl_cert', None)
         self.ssl_root_cert = instance.get('ssl_root_cert', None)

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -116,22 +116,6 @@ def instance_ssl():
     return 'false'
 
 
-def instance_ssl_cert():
-    return 'false'
-
-
-def instance_ssl_key():
-    return 'false'
-
-
-def instance_ssl_password():
-    return 'false'
-
-
-def instance_ssl_root_cert():
-    return 'false'
-
-
 def instance_table_count_limit():
     return 200
 

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -113,7 +113,7 @@ def instance_query_timeout():
 
 
 def instance_ssl():
-    return 'false'
+    return 'disable'
 
 
 def instance_table_count_limit():

--- a/postgres/datadog_checks/postgres/config_models/validators.py
+++ b/postgres/datadog_checks/postgres/config_models/validators.py
@@ -8,8 +8,4 @@ def initialize_instance(values, **kwargs):
         if 'data_directory' not in values:
             raise ValueError('Field `data_directory` is required when `collect_wal_metrics` is enabled')
 
-        # `ssl`'s default is `false`, which gets interpreted as a Boolean, but we are expecting a string
-        if 'ssl' in values and isinstance(values['ssl'], bool):
-            values['ssl'] = 'true' if values['ssl'] else 'false'
-
     return values

--- a/postgres/datadog_checks/postgres/config_models/validators.py
+++ b/postgres/datadog_checks/postgres/config_models/validators.py
@@ -8,4 +8,8 @@ def initialize_instance(values, **kwargs):
         if 'data_directory' not in values:
             raise ValueError('Field `data_directory` is required when `collect_wal_metrics` is enabled')
 
+        # `ssl`'s default is `false`, which gets interpreted as a Boolean, but we are expecting a string
+        if 'ssl' in values and isinstance(values['ssl'], bool):
+            values['ssl'] = 'true' if values['ssl'] else 'false'
+
     return values

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -63,7 +63,7 @@ instances:
     #   - rdsadmin
     #   - azure_maintenance
 
-    ## @param ssl - string - optional - default: false
+    ## @param ssl - string - optional - default: disable
     ## This option determines whether or not and with what priority a secure SSL TCP/IP connection
     ## is negotiated with the server. There are six modes:
     ## - `disable`: Only tries a non-SSL connection.
@@ -77,39 +77,37 @@ instances:
     ##                  trusted CA and that the requested server host name matches the one in the certificate.
     ##
     ## For a detailed description of how these options work see https://www.postgresql.org/docs/current/libpq-ssl.html
-    ##
-    ## Note: `true` is an alias for `require`, and `false` is an alias for `disable`.
     #
-    # ssl: 'false'
+    # ssl: disable
 
-    ## @param ssl_root_cert - string - optional - default: false
+    ## @param ssl_root_cert - string - optional
     ## The path to the ssl root certificate.
     ##
     ## For a detailed description of how this option works see https://www.postgresql.org/docs/current/libpq-ssl.html
     #
-    # ssl_root_cert: /home/datadog/server-ca.pem
+    # ssl_root_cert: <SSL_ROOT_CERT>
 
-    ## @param ssl_cert - string - optional - default: false
+    ## @param ssl_cert - string - optional
     ## The path to the ssl certificate.
     ##
     ## For a detailed description of how this option works see https://www.postgresql.org/docs/current/libpq-ssl.html
     #
-    # ssl_cert: /home/datadog/client-cert.pem
+    # ssl_cert: <SSL_CERT>
 
-    ## @param ssl_key - string - optional - default: false
+    ## @param ssl_key - string - optional
     ## The path to the ssl client key.
     ##
     ## For a detailed description of how this option works see https://www.postgresql.org/docs/current/libpq-ssl.html
     #
-    # ssl_key: /home/datadog/client-key.pem
+    # ssl_key: <SSL_KEY>
 
-    ## @param ssl_password - string - optional - default: false
+    ## @param ssl_password - string - optional
     ## The password for the secret key specified in ssl_key, allowing client certificate private keys to be stored
     ## in encrypted form on disk.
     ##
     ## For a detailed description of how this option works see https://www.postgresql.org/docs/current/libpq-ssl.html
     #
-    # ssl_password: ssl_key_password
+    # ssl_password: <SSL_PASSWORD>
 
     ## @param query_timeout - integer - optional - default: 5000
     ## Adds a statement_timeout https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-STATEMENT-TIMEOUT


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Since updating our config validation code, we started seeing issues with setting the default value for `ssl` mode as it was being interpretted as a `boolean` instead of a `str` during the validation process. This would lead to errors like this:

```
2023-08-17 20:16:45 UTC | CORE | ERROR | (pkg/collector/worker/check_logger.go:70 in Error) | check:postgres | Error running check: [{"message": "Detected 1 error while loading configuration model `InstanceConfig`:\nssl\n  Input should be a valid string", "traceback": "Traceback (most recent call last):\n  File \"/usr/src/dbm-integrations-core/datadog_checks_base/datadog_checks/base/checks/base.py\", line 1126, in run\n    initialization()\n  File \"/usr/src/dbm-integrations-core/datadog_checks_base/datadog_checks/base/checks/base.py\", line 512, in load_configuration_models\n    instance_model = self.load_configuration_model(package_path, 'InstanceConfig', instance_config, context)\n  File \"/usr/src/dbm-integrations-core/datadog_checks_base/datadog_checks/base/checks/base.py\", line 556, in load_configuration_model\n    raise_from(ConfigurationError('\\n'.join(message_lines)), None)\n  File \"<string>\", line 3, in raise_from\ndatadog_checks.base.errors.ConfigurationError: Detected 1 error while loading configuration model `InstanceConfig`:\nssl\n  Input should be a valid string\n"}]
```

... for a configuration like this:

```yaml
   instances:
     - port: 5432
       host: localhost
       ssl: false
       user: "datadog"
```

setting the default to `disable`, which was the intention of having a `false` value fixes this. Also, this PR removes unnecessary defaults that we had set for things like ssl cert file paths, which the customer should always be setting themselves. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
