### PR TITLE
Do not install libpython2-dev in the agent container

### DIFF
--- a/cacti/tests/common.py
+++ b/cacti/tests/common.py
@@ -27,7 +27,7 @@ INSTANCE_INTEGRATION = {
 E2E_METADATA = {
     'start_commands': [
         'apt-get update',
-        'apt-get install rrdtool librrd-dev libpython2-dev build-essential -y',
+        'apt-get install rrdtool librrd-dev build-essential -y',
         'pip install rrdtool',
     ]
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not install `libpython2-dev` in the agent container

### Motivation
<!-- What inspired you to submit this pull request? -->

- https://github.com/DataDog/integrations-core/actions/runs/5900811282/job/16005852279#step:14:36
- Seems like it's not needed anyway

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
