### PR TITLE
Rename Jira project PINT -> PLINT in ddqa config

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -23,7 +23,7 @@ exclude_members = [
 ]
 
 [teams."Platform Integrations"]
-jira_project = "PINT"
+jira_project = "PLINT"
 jira_issue_type = "Task"
 jira_statuses = [
   "To Do",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation

ddqa reporting an error from Jira: `The value 'PINT' does not exist for the field 'project'.`. Apparently the Jira project for Platform Integrations has been renamed from PINT to PLINT.

### Additional Notes



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
