### PR TITLE
Reduce postgres test_statement_samples_main_collection_rate_limit test flakyness

### DIFF
--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1395,9 +1395,9 @@ def test_statement_samples_main_collection_rate_limit(aggregator, integration_ch
     # the loop and trigger cancel before another job_loop is triggered
     check_frequency = collection_interval / 5.0
     _check_until_time(check, dbm_instance, sleep_time, check_frequency)
-    max_collections = int(1 / collection_interval * sleep_time) + 1
-    metrics = aggregator.metrics("dd.postgres.collect_statement_samples.time")
+    max_collections = int(1 / collection_interval * sleep_time) + 2
     check.cancel()
+    metrics = aggregator.metrics("dd.postgres.collect_statement_samples.time")
     assert max_collections / 2.0 <= len(metrics) <= max_collections
 
 


### PR DESCRIPTION
### What does this PR do?
`test_statement_samples_main_collection_rate_limit` relies on sleep time and the sleep needs to be low in order to make test run time reasonable. But given this and the time-driven nature of this test, the collection rate value ends up often being off by one (3 instead of 2). We could help with this by increasing the test duration but then we pay the penalty every time we run tests. Instead, this relaxes the tolerance for the collection rate. Now the test would pass if the value is 3. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
