### PR TITLE
Add missing timeout when looking up offsets

### DIFF
--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Fixed***:
 
-* Add missing timeout when looking up offsets ([#15630](https://github.com/DataDog/integrations-core/pull/15630))
+* Use `_request_timeout` config parameter when querying metadata with kafka client ([#15630](https://github.com/DataDog/integrations-core/pull/15630))
 
 ## 4.1.0 / 2023-08-18
 

--- a/kafka_consumer/CHANGELOG.md
+++ b/kafka_consumer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Add missing timeout when looking up offsets ([#15630](https://github.com/DataDog/integrations-core/pull/15630))
+
 ## 4.1.0 / 2023-08-18
 
 ***Added***:

--- a/kafka_consumer/datadog_checks/kafka_consumer/client.py
+++ b/kafka_consumer/datadog_checks/kafka_consumer/client.py
@@ -133,9 +133,10 @@ class KafkaClient:
                     consumer_group,
                 )
                 for topic_partition_with_highwater_offset in consumer.offsets_for_times(
-                    partitions=list(topic_partitions_for_highwater_offsets)
+                    partitions=list(topic_partitions_for_highwater_offsets),
+                    timeout=self.config._request_timeout,
                 ):
-                    self.log.debug('%s', topic_partition_with_highwater_offset)
+                    self.log.debug('Topic partition with highwater offset: %s', topic_partition_with_highwater_offset)
                     topic = topic_partition_with_highwater_offset.topic
                     partition = topic_partition_with_highwater_offset.partition
                     offset = topic_partition_with_highwater_offset.offset
@@ -164,7 +165,7 @@ class KafkaClient:
 
     def request_metadata_update(self):
         # https://github.com/confluentinc/confluent-kafka-python/issues/594
-        self.kafka_client.list_topics(None, timeout=self.config._request_timeout_ms / 1000)
+        self.kafka_client.list_topics(None, timeout=self.config._request_timeout)
 
     def get_consumer_offsets(self):
         # {(consumer_group, topic, partition): offset}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add missing timeout when looking up offsets

### Motivation
<!-- What inspired you to submit this pull request? -->

- QA for https://github.com/DataDog/integrations-core/pull/15285
- https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#id14

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
