### PR TITLE
Update the description of the `status_mapping_override` option

### DIFF
--- a/supervisord/CHANGELOG.md
+++ b/supervisord/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Update the description of the `status_mapping_override` option ([#15631](https://github.com/DataDog/integrations-core/pull/15631))
+
 ## 2.5.1 / 2023-08-18
 
 ***Fixed***:

--- a/supervisord/assets/configuration/spec.yaml
+++ b/supervisord/assets/configuration/spec.yaml
@@ -78,9 +78,9 @@ files:
             example: [<PROCESS_NAME_EXCLUDE_1>, <PROCESS_NAME_EXCLUDE_2>]
         - name: status_mapping_override
           description: |
-            The process status mapping override between Supervisord status and Datadog status.
+            The process status mapping override between supervisord status and Datadog status.
 
-            This setting overrides default mapping (Supervisord => Datadog):
+            This setting overrides default mapping (supervisord => Datadog):
               RUNNING  => up
               BACKOFF  => down
               STOPPING => down

--- a/supervisord/datadog_checks/supervisord/data/conf.yaml.example
+++ b/supervisord/datadog_checks/supervisord/data/conf.yaml.example
@@ -75,9 +75,9 @@ instances:
     #   - <PROCESS_NAME_EXCLUDE_2>
 
     ## @param status_mapping_override - mapping - optional
-    ## The process status mapping override between Supervisord status and Datadog status.
+    ## The process status mapping override between supervisord status and Datadog status.
     ##
-    ## This setting overrides default mapping (Supervisord => Datadog):
+    ## This setting overrides default mapping (supervisord => Datadog):
     ##   RUNNING  => up
     ##   BACKOFF  => down
     ##   STOPPING => down


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the description of the `status_mapping_override` option

### Motivation
<!-- What inspired you to submit this pull request? -->

- This is probably nitpicking, but `Supervisor` is the product, `supervisord` is the process and this is what we use everywhere else in the config file, so switching for consistency.
- This was requested by the docs team: https://github.com/DataDog/integrations-core/pull/14190#discussion_r1142131918 
- It was applied here: https://github.com/DataDog/integrations-core/pull/14190/commits/1975802b245c374e850971e46a9e7891e941b751
- And dropped there: https://github.com/DataDog/integrations-core/pull/14190/commits/4774a316ad8180ccd09523ed444b5d64f913f7d3

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
