### PR TITLE
Stop raising `TypeError`s when `status_mapping_override` contains unknown Datadog statuses

### DIFF
--- a/supervisord/CHANGELOG.md
+++ b/supervisord/CHANGELOG.md
@@ -5,6 +5,7 @@
 ***Fixed***:
 
 * Update the description of the `status_mapping_override` option ([#15631](https://github.com/DataDog/integrations-core/pull/15631))
+* Stop raising `TypeError`s when `status_mapping_override` contains unknown Datadog statuses ([#15632](https://github.com/DataDog/integrations-core/pull/15632))
 
 ## 2.5.1 / 2023-08-18
 

--- a/supervisord/datadog_checks/supervisord/supervisord.py
+++ b/supervisord/datadog_checks/supervisord/supervisord.py
@@ -17,6 +17,7 @@ DEFAULT_PORT = '9001'
 DEFAULT_SOCKET_IP = 'http://127.0.0.1'
 
 PROCESS_STATUS = {AgentCheck.CRITICAL: 'down', AgentCheck.OK: 'up', AgentCheck.UNKNOWN: 'unknown'}
+REVERSED_PROCESS_STATUS = {v: k for k, v in PROCESS_STATUS.items()}
 
 SERVER_TAG = 'supervisord_server'
 
@@ -136,16 +137,15 @@ class SupervisordCheck(AgentCheck):
 
         status_mapping_override = instance.get('status_mapping_override', {})
         if not isinstance(status_mapping_override, dict):
-            raise Exception("'status_mapping_override' should be a dictionary. e.g. %s" % [status_mapping_override])
+            raise Exception("'status_mapping_override' should be a dictionary")
 
         if len(status_mapping_override) != 0:
-            reverse_process_status = {v: k for k, v in PROCESS_STATUS.items()}
             for status, ddstatus in status_mapping_override.items():
                 if ddstatus in PROCESS_STATUS.values():
-                    status_mapping[status] = reverse_process_status[ddstatus]
+                    status_mapping[status] = REVERSED_PROCESS_STATUS[ddstatus]
                 else:
                     raise Exception(
-                        "'status_mapping_override' should be a status mapping e.g. %s => %s" % [status, ddstatus]
+                        "'status_mapping_override' should be a status mapping e.g. %s => %s" % (status, ddstatus)
                     )
 
         # Collect information on each monitored process

--- a/supervisord/tests/common.py
+++ b/supervisord/tests/common.py
@@ -373,4 +373,21 @@ TEST_CASES = [
             ]
         },
     },
+    # Unknown ddstatus in the override, so we do not get any metrics but the server is up.
+    {
+        'instances': [
+            {'name': 'server0', 'host': 'localhost', 'port': 9001, 'status_mapping_override': {'STOPPED': 'unknown'}}
+        ],
+        'expected_metrics': {'server0': []},
+        'expected_service_checks': {
+            'server0': [
+                {'status': ServiceCheck.OK, 'tags': ['supervisord_server:server0'], 'check': 'supervisord.can_connect'},
+                {
+                    'status': ServiceCheck.OK,
+                    'tags': ['supervisord_server:server0', 'supervisord_process:mysql'],
+                    'check': 'supervisord.process.status',
+                },
+            ]
+        },
+    },
 ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Stop raising `TypeError`s when `status_mapping_override` contains unknown Datadog statuses

### Motivation
<!-- What inspired you to submit this pull request? -->

QA for https://github.com/DataDog/integrations-core/pull/14190

```
>>> print("%s - %s" % [1, 2])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: not enough arguments for format string
>>> print("%s - %s" % (1, 2))
1 - 2
```

`[...]` is used in the other exceptions because we need a list there, here we want to print both parameters

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I'll probably refactor this giant test in the future to use `parametrize`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
