### PR TITLE
Revive the 2.3.2 test env

### DIFF
--- a/harbor/hatch.toml
+++ b/harbor/hatch.toml
@@ -2,12 +2,13 @@
 
 [[envs.default.matrix]]
 python = ["2.7", "3.9"]
-version = ["1.10", "2.0"]
+version = ["1.10", "2.0", "2.3"]
 
 [envs.default.overrides]
 matrix.version.env-vars = [
   { key = "HARBOR_VERSION", value = "1.10.0", if = ["1.10"] },
   { key = "HARBOR_VERSION", value = "2.0.5", if = ["2.0"] },
+  { key = "HARBOR_VERSION", value = "2.3.2", if = ["2.3"] },
 ]
 
 [envs.default.env-vars]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Revive the 2.3.2 test env

### Motivation
<!-- What inspired you to submit this pull request? -->

In https://github.com/DataDog/integrations-core/pull/13079, I copied the test matrix which did not include `2.3.2`, but the environment was declared, it was just not used

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
