### PR TITLE
Remove coming soon banner

### DIFF
--- a/dcgm/README.md
+++ b/dcgm/README.md
@@ -2,8 +2,6 @@
 
 ## Overview
 
-**Coming soon**: This integration is included in the upcoming 7.47.0 release of the Datadog Agent.
-
 This check submits metrics exposed by the [NVIDIA DCGM Exporter][16] in Datadog Agent format. For more information on NVIDIA Data Center GPU Manager (DCGM), see [NVIDIA DCGM][15].
 
 ## Setup

--- a/torchserve/README.md
+++ b/torchserve/README.md
@@ -2,8 +2,6 @@
 
 ## Overview
 
-**Coming soon**: This integration is included in the upcoming 7.47.0 release of the Datadog Agent.
-
 This check monitors [TorchServe][1] through the Datadog Agent. 
 
 ## Setup

--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -2,8 +2,6 @@
 
 ## Overview
 
-**Coming soon**: This integration is included in the upcoming 7.47.0 release of the Datadog Agent.
-
 This check monitors [Weaviate][1] through the Datadog Agent. For more information, see [Weaviate monitoring][10].
 
 ## Setup


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR removes the `coming soon` banners for Weaviate, Torchserve, and DCGM once 7.47 is available.

### Motivation
<!-- What inspired you to submit this pull request? -->
Once 7.47 is available the banners are no longer necessary.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
