### PR TITLE
Add missing changelog for ddev

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -22,6 +22,7 @@
 ***Added***:
 
 * Migrate `validate http` to ddev ([#15526](https://github.com/DataDog/integrations-core/pull/15526))
+* Migrate `ddev validate licenses` command to ddev ([#15475](https://github.com/DataDog/integrations-core/pull/15475))
 
 ***Fixed***:
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds a missing changelog entry for https://github.com/DataDog/integrations-core/pull/15475. 
### Motivation
<!-- What inspired you to submit this pull request? -->
The feature is [included in ddev 3.5.0](https://github.com/DataDog/integrations-core/commits/ddev-v3.5.0/ddev).
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
