### PR TITLE
Add E2E testing instructions for marklogic on ARM

### DIFF
--- a/marklogic/tests/README.md
+++ b/marklogic/tests/README.md
@@ -2,7 +2,17 @@
 
 Test this integration using the Docker Compose environment.
 
-To get the MarkLogic Docker image, run `docker login` and download the Docker image here https://hub.docker.com/_/marklogic.
+To get the MarkLogic Docker image, run `docker login` and download the Docker image here https://hub.docker.com/r/marklogicdb/marklogic-db.
+
+## E2E testing on Apple Silicon
+(Starting with MarkLogic 11 and above)[https://docs.marklogic.com/11.0/guide/release-notes/en/new-features-in-marklogic-11/install-on-macos-running-on-apple-m1-processors.html], you can run MarkLogic on ARM with Rosetta 2 emulation.
+
+Docker Desktop 4.16+ supports Rosetta emulation for x86/amd64 on Apple Silicon, although you will need to enable this experimental feature in the settings. 
+1. Under `Settings` -> `General` tab, click on `Use Virtualization framework` to enable [Virtualization](https://developer.apple.com/documentation/virtualization). 
+1. Then go to the `Features in development` tab, and click on `Use Rosetta for x86/amd64 emulation on Apple Silicon` under `Beta features`. 
+1. Apply and restart Docker Desktop for changes to go into effect.
+
+Note: MarkLogic 9 and 10 still do not support ARM.
 
 ## Cluster mode
 

--- a/marklogic/tests/README.md
+++ b/marklogic/tests/README.md
@@ -5,7 +5,7 @@ Test this integration using the Docker Compose environment.
 To get the MarkLogic Docker image, run `docker login` and download the Docker image here https://hub.docker.com/r/marklogicdb/marklogic-db.
 
 ## E2E testing on Apple Silicon
-(Starting with MarkLogic 11 and above)[https://docs.marklogic.com/11.0/guide/release-notes/en/new-features-in-marklogic-11/install-on-macos-running-on-apple-m1-processors.html], you can run MarkLogic on ARM with Rosetta 2 emulation.
+[Starting with MarkLogic 11 and above](https://docs.marklogic.com/11.0/guide/release-notes/en/new-features-in-marklogic-11/install-on-macos-running-on-apple-m1-processors.html), you can run MarkLogic on ARM with Rosetta 2 emulation.
 
 Docker Desktop 4.16+ supports Rosetta emulation for x86/amd64 on Apple Silicon, although you will need to enable this experimental feature in the settings. 
 1. Under `Settings` -> `General` tab, click on `Use Virtualization framework` to enable [Virtualization](https://developer.apple.com/documentation/virtualization). 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds instructions for testing MarkLogic 11 on ARM Macs.

### Motivation
<!-- What inspired you to submit this pull request? -->
Docker Desktop 4.16+ supports running amd64 containers on ARM using Virtualization.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
This could likely also work for other integrations with intel-based containers.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
