### PR TITLE
Delete unnecessary extend for ubiquiti profiles

### DIFF
--- a/snmp/CHANGELOG.md
+++ b/snmp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Changed***:
+
+* Delete unnecessary extend for ubiquiti profiles ([#15643](https://github.com/DataDog/integrations-core/pull/15643))
+
 ## 6.2.0 / 2023-08-18
 
 ***Added***:

--- a/snmp/datadog_checks/snmp/data/default_profiles/ubiquiti-unifi-security-gateway.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/ubiquiti-unifi-security-gateway.yaml
@@ -1,5 +1,4 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _generic-ucd.yaml
   - _ubiquiti.yaml

--- a/snmp/datadog_checks/snmp/data/default_profiles/ubiquiti-unifi.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/ubiquiti-unifi.yaml
@@ -1,5 +1,4 @@
 extends:
-  - _base.yaml
   - _generic-if.yaml
   - _ubiquiti.yaml
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
See title. `_base.yaml` exists in `_ubiquiti.yaml`

### Motivation
<!-- What inspired you to submit this pull request? -->
Relates to https://github.com/DataDog/integrations-core/pull/15399

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
