### PR TITLE
Exclude go-metro from downloader testing

### DIFF
--- a/datadog_checks_downloader/tests/test_downloader.py
+++ b/datadog_checks_downloader/tests/test_downloader.py
@@ -51,6 +51,7 @@ EXCLUDED_INTEGRATIONS = [
     "datadog-docker-daemon",
     "datadog-dd-cluster-agent",  # excluding this since actual integration is called `datadog-cluster-agent`
     "datadog-kubernetes",  # excluding this since `kubernetes` check is Agent v5 only
+    "datadog-go-metro",  # excluding this since `go-metro` check is Agent v5 only
 ]
 
 # Specific integration versions released for the last time by a revoked developer but not shipped anymore.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR removes `datadog-go-metro` from being tested in the datadog-checks-downloader E2E tests.

### Motivation
<!-- What inspired you to submit this pull request? -->
[`go-metro`](https://github.com/DataDog/integrations-core/tree/master/go-metro) is an Agent v5-only integration that was [last signed by a revoked dev](https://github.com/DataDog/integrations-core/pull/8782), so it occasionally [fails CI](https://github.com/DataDog/integrations-core/actions/runs/5937862379/job/16101230312#step:12:638).

### Additional Notes
[AI-3435](https://datadoghq.atlassian.net/browse/AI-3435)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[AI-3435]: https://datadoghq.atlassian.net/browse/AI-3435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ