### PR TITLE
Fix ECS Fargate memory task limit units

### DIFF
--- a/ecs_fargate/CHANGELOG.md
+++ b/ecs_fargate/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Fix ECS Fargate memory task limit units ([#15656](https://github.com/DataDog/integrations-core/pull/15656))
+
 ## 4.0.0 / 2023-08-10
 
 ***Changed***:

--- a/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
@@ -192,7 +192,7 @@ class FargateCheck(AgentCheck):
             self.gauge('ecs.fargate.cpu.task.limit', metadata['Limits']['CPU'] * 10**9, task_tags)
 
         if metadata.get('Limits', {}).get('Memory', 0) > 0:
-            self.gauge('ecs.fargate.mem.task.limit', metadata['Limits']['Memory'], task_tags)
+            self.gauge('ecs.fargate.mem.task.limit', metadata['Limits']['Memory'] * 1024**2, task_tags)
 
         try:
             request = self.http.get(stats_endpoint)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Multiplies the value of memory by 1024*1024 to ensure that the `ecs.fargate.mem.task.limit` metric is reported correctly.
<img width="681" alt="image" src="https://github.com/DataDog/integrations-core/assets/32009013/a150a893-23f5-4dbf-9c58-16850febd411">

### Motivation
<!-- What inspired you to submit this pull request? -->
When testing that the ECS Fargate integration now has a new task memory limit metric (`ecs.fargate.mem.task.limit`), it was noticed that though the metric shows up, the units are in the wrong order of magnitude. This change updates the value so it matches the actual value being sent through. 

Original PR adding this feature: https://github.com/DataDog/integrations-core/pull/15401

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
