### PR TITLE
Mark a broker metric as optional

### DIFF
--- a/confluent_platform/tests/metrics.py
+++ b/confluent_platform/tests/metrics.py
@@ -8,7 +8,6 @@ BROKER_METRICS = [
     'confluent.kafka.controller.active_controller_count',
     'confluent.kafka.controller.leader_election_rate_and_time_ms.avg',
     'confluent.kafka.controller.offline_partitions_count',
-    'confluent.kafka.controller.unclean_leader_elections_per_sec.rate',
     'confluent.kafka.controller.preferred_replica_imbalance_count',
     'confluent.kafka.controller.offline_partitions_count',
     'confluent.kafka.controller.global_topic_count',
@@ -320,6 +319,7 @@ SCHEMA_REGISTRY_JERSEY_METRICS_DEPRECATED = [
 
 BROKER_OPTIONAL_METRICS = [
     'confluent.kafka.controller.leader_election_rate_and_time_ms.rate',
+    'confluent.kafka.controller.unclean_leader_elections_per_sec.rate',
     'confluent.kafka.log.log_flush_rate_and_time_ms.avg',
     'confluent.kafka.log.size',
     'confluent.kafka.server.broker_topic_metrics.bytes_in_per_sec',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Mark a broker metric as optional

### Motivation
<!-- What inspired you to submit this pull request? -->

This metric is a bit flaky: https://github.com/DataDog/integrations-core/actions/runs/5940406795/job/16109082882

```
=================================== FAILURES ===================================
___________________________________ test_e2e ___________________________________
tests/test_e2e.py:35: in test_e2e
    aggregator.assert_metric(metric)
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:368: in assert_metric
    self._assert(condition, msg=msg, expected_stub=expected_metric, submitted_elements=self._metrics)
../datadog_checks_base/datadog_checks/base/stubs/aggregator.py:410: in _assert
    assert condition, new_msg
E   AssertionError: Needed at least 1 candidates for 'confluent.kafka.controller.unclean_leader_elections_per_sec.rate', got 0
E   Expected:
E           MetricStub(name='confluent.kafka.controller.unclean_leader_elections_per_sec.rate', type=None, value=None, tags=None, hostname=None, device=None, flush_first_value=None)
E   Similar submitted:
E   Score   Most similar
E   0.74    MetricStub(name='confluent.kafka.controller.leader_election_rate_and_time_ms.avg', type=0, value=0.0, tags=['instance:confluent_platform-localhost-31001', 'jmx_domain:kafka.controller', 'name:LeaderElectionRateAndTimeMs', 'type:ControllerStats'], hostname='default', device=None, flush_first_value=False)
E   0.69    MetricStub(name='confluent.kafka.controller.global_partition_count', type=0, value=165.0, tags=['instance:confluent_platform-localhost-31001', 'jmx_domain:kafka.controller', 'name:GlobalPartitionCount', 'type:KafkaController'], hostname='default', device=None, flush_first_value=False)
E   0.68    MetricStub(name='confluent.kafka.controller.offline_partitions_count', type=0, value=0.0, tags=['instance:confluent_platform-localhost-31001', 'jmx_domain:kafka.controller', 'name:OfflinePartitionsCount', 'type:KafkaController'], hostname='default', device=None, flush_first_value=False)
E   0.64    MetricStub(name='confluent.kafka.producer.node.response_rate', type=0, value=20.05[56](https://github.com/DataDog/integrations-core/actions/runs/5940406795/job/16109082882#step:14:57)97794547005, tags=['client-id:connector-producer-datagen-pageviews-0', 'instance:confluent_platform-localhost-31002', 'jmx_domain:kafka.producer', 'node-id:node-1', 'type:producer-node-metrics'], hostname='default', device=None, flush_first_value=False)
E   0.64    MetricStub(name='confluent.kafka.producer.node.response_rate', type=0, value=19.96898485029226, tags=['client-id:connector-producer-datagen-pageviews-0', 'instance:confluent_platform-localhost-31002', 'jmx_domain:kafka.producer', 'node-id:node-1', 'type:producer-node-metrics'], hostname='default', device=None, flush_first_value=False)
E   0.64    MetricStub(name='confluent.kafka.producer.node.response_rate', type=0, value=0.36234647951788845, tags=['client-id:confluent-metrics-reporter', 'instance:confluent_platform-localhost-31001', 'jmx_domain:kafka.producer', 'node-id:node-1', 'type:producer-node-metrics'], hostname='default', device=None, flush_first_value=False)
E   0.64    MetricStub(name='confluent.kafka.producer.node.response_rate', type=0, value=0.12106537530266344, tags=['client-id:producer-1', 'instance:confluent_platform-localhost-31002', 'jmx_domain:kafka.producer', 'node-id:node-1', 'type:producer-node-metrics'], hostname='default', device=None, flush_first_value=False)
E   0.64    MetricStub(name='confluent.kafka.producer.node.response_rate', type=0, value=0.11203854125819282, tags=['client-id:producer-1', 'instance:confluent_platform-localhost-31002', 'jmx_domain:kafka.producer', 'node-id:node-1', 'type:producer-node-metrics'], hostname='default', device=None, flush_first_value=False)
E   0.64    MetricStub(name='confluent.kafka.producer.node.response_rate', type=0, value=0.07139924673794691, tags=['client-id:confluent.monitoring.interceptor.connector-consumer-local-file-sink-0', 'instance:confluent_platform-localhost-31002', 'jmx_domain:kafka.producer', 'node-id:node-1', 'type:producer-node-metrics'], hostname='default', device=None, flush_first_value=False)
E   0.64    MetricStub(name='confluent.kafka.producer.node.response_rate', type=0, value=0.07104290991759023, tags=['client-id:confluent.monitoring.interceptor.connector-producer-datagen-pageviews-0', 'instance:confluent_platform-localhost-31002', 'jmx_domain:kafka.producer', 'node-id:node-1', 'type:producer-node-metrics'], hostname='default', device=None, flush_first_value=False)
E   0.64    MetricStub(name='confluent.kafka.producer.node.response_rate', type=0, value=0.0686931135153701, tags=['client-id:confluent.monitoring.interceptor.connector-consumer-local-file-sink-0', 'instance:confluent_platform-localhost-31002', 'jmx_domain:kafka.producer', 'node-id:node-1', 'type:producer-node-metrics'], hostname='default', device=None, flush_first_value=False)
E   0.64    MetricStub(name='confluent.kafka.producer.node.response_rate', type=0, value=0.0676[57](https://github.com/DataDog/integrations-core/actions/runs/5940406795/job/16109082882#step:14:58)85423115306, tags=['client-id:confluent.monitoring.interceptor.connector-producer-datagen-pageviews-0', 'instance:confluent_platform-localhost-31002', 'jmx_domain:kafka.producer', 'node-id:node-1', 'type:producer-node-metrics'], hostname='default', device=None, flush_first_value=False)
E   0.[64](https://github.com/DataDog/integrations-core/actions/runs/5940406795/job/16109082882#step:14:65)    MetricStub(name='confluent.kafka.producer.node.response_rate', type=0, value=0.0, tags=['client-id:producer-3', 'instance:confluent_platform-localhost-31008', 'jmx_domain:kafka.producer', 'node-id:node-1', 'type:producer-node-metrics'], hostname='default', device=None, flush_first_value=False)
E   0.64    MetricStub(name='confluent.kafka.producer.node.response_rate', type=0, value=0.0, tags=['client-id:producer-3', 'instance:confluent_platform-localhost-31008', 'jmx_domain:kafka.producer', 'node-id:node-1', 'type:producer-node-metrics'], hostname='default', device=None, flush_first_value=False)
E   0.64    MetricStub(name='confluent.kafka.producer.node.response_rate', type=0, value=0.0, tags=['client-id:producer-3', 'instance:confluent_platform-localhost-31008', 'jmx_domain:kafka.producer', 'node-id:node--1', 'type:producer-node-metrics'], hostname='default', device=None, flush_first_value=False)
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
