### PR TITLE
Add pytest-repeat plugin as a tool to check flaky tests.

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Added***:
+
+* Add pytest-repeat plugin as a tool to check flaky tests. ([#15665](https://github.com/DataDog/integrations-core/pull/15665))
+
 ## 24.0.0 / 2023-08-18
 
 ***Removed***:

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "pytest-cov>=2.6.1",
     "pytest-memray>=1.4.0; python_version > '3.0' and (platform_system=='Linux' or platform_system=='Darwin')",
     "pytest-mock",
+    "pytest-repeat",
     "pyyaml>=5.4.1",
     "requests>=2.22.0",
     "shutilwhich==1.1.0; python_version < '3.0'",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add a plugin to repeat tests. Should not affect regular runs, but adds capabilities to repeat the whole suite or individual tests several times.

### Motivation
<!-- What inspired you to submit this pull request? -->
Lets us hunt out flaky tests locally and verify our fixes before sending them to CI.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
