### PR TITLE
Bump datadog-checks-dev version to ~=24.0

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Remove `release agent requirements` subcommand ([#15621](https://github.com/DataDog/integrations-core/pull/15621))
 
+***Fixed***:
+
+* Bump datadog-checks-dev version to ~=24.0 ([#15683](https://github.com/DataDog/integrations-core/pull/15683))
+
 ## 4.0.1 / 2023-08-25
 
 ***Fixed***:

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "click~=8.1.6",
-    "datadog-checks-dev[cli]~=23.0",
+    "datadog-checks-dev[cli]~=24.0",
     "hatch>=1.6.3",
     "httpx",
     "jsonpointer",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump datadog-checks-dev version to ~=24.0

### Motivation
<!-- What inspired you to submit this pull request? -->

I needed https://github.com/DataDog/integrations-core/pull/15586 that is shipped in 24.*

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
