### PR TITLE
Add a section to Openmetrics README on how untyped metrics are handled

### DIFF
--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -64,7 +64,7 @@ Datadog recommends that you use specific metric names or partial metric name mat
 
 ### Missing untyped metrics
 
-By default, the integration will skip metrics that come without a type on a Prometheus exposition. If you want to collect untyped metrics, you must explicitly specify their type in the `metrics` mapping, for example:
+By default, the integration skips metrics that come without a type on a Prometheus exposition. If you want to collect untyped metrics, you must explicitly specify their type in the `metrics` mapping, for example:
 
 ```yaml
   metrics:
@@ -72,7 +72,7 @@ By default, the integration will skip metrics that come without a type on a Prom
         "type": "gauge"
 ```
 
-Remember that metric names can be specified as regular expressions, making it possible to easily specify the type for a set of metrics without listing all of them individually.
+Remember that metric names can be specified as regular expressions, making it possible to specify the type for a set of metrics without listing all of them individually.
 
 ### Errors parsing the OpenMetrics payload with Agent 7.46 and above
 

--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -62,6 +62,18 @@ OpenMetrics configurations with generic wildcard values for the `metrics` option
 
 Datadog recommends that you use specific metric names or partial metric name matches for more precise collection.
 
+### Missing untyped metrics
+
+By default, the integration will skip metrics that come without a type on a Prometheus exposition. If you want to collect untyped metrics, you must explicitly specify their type in the `metrics` mapping, for example:
+
+```yaml
+  metrics:
+    - "metric_without_type":
+        "type": "gauge"
+```
+
+Remember that metric names can be specified as regular expressions, making it possible to easily specify the type for a set of metrics without listing all of them individually.
+
 ### Errors parsing the OpenMetrics payload with Agent 7.46 and above
 
 Starting with version 3.0.0 of this integration, which is shipped by default with Agent 7.46 and above, the integration sends by default the `Accept` header set to `application/openmetrics-text;version=1.0.0,application/openmetrics-text;version=0.0.1;q=0.75,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`. Previous versions set the `Accept` header to `text/plain`. The integration then dynamically determines which scraper to use based on the `Content-type` it receives from the server.


### PR DESCRIPTION
### What does this PR do?

Adds an explanation for the default behavior around untyped metrics and how to collect such metrics.

### Motivation

#15431 rightly pointed out that the default behavior around untyped metrics seems to be undocumented.

### Additional Notes

Documentation about our Openmetrics integration is somewhat spread around guides beyond the integration's documentation which I'm updating here. #15431 pointed at https://docs.datadoghq.com/containers/kubernetes/prometheus/, but I feel that this README should be the ultimate and common source of truth when it comes to this integration, hence why I'm putting it there.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
