### PR TITLE
[SNMP] Tripplite-ups : Tag tlUpsOutputCircuitTable by index to avoid metrics collision

### DIFF
--- a/snmp/CHANGELOG.md
+++ b/snmp/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Tag tlUpsOutputCircuitTable in tripplite-ups.yaml by index to avoid metrics collision ([#15692](https://github.com/DataDog/integrations-core/pull/15692))
+
 ## 6.2.0 / 2023-08-18
 
 ***Added***:

--- a/snmp/datadog_checks/snmp/data/default_profiles/tripplite-ups.yaml
+++ b/snmp/datadog_checks/snmp/data/default_profiles/tripplite-ups.yaml
@@ -118,6 +118,8 @@ metrics:
       - OID: 1.3.6.1.4.1.850.100.1.4.7.1.5
         name: tlUpsOutputCircuitPower
     metric_tags:
+      - index: 1
+        tag:  tl_ups_output_circuit_index
       - column:
           OID: 1.3.6.1.4.1.850.100.1.4.7.1.2
           name: tlUpsOutputCircuitStatus

--- a/snmp/tests/test_e2e_core_profiles/test_profile_tripplite_ups.py
+++ b/snmp/tests/test_e2e_core_profiles/test_profile_tripplite_ups.py
@@ -57,8 +57,8 @@ def test_e2e_profile_tripplite_ups(dd_agent_check):
         aggregator.assert_metric('snmp.tlUpsInputVoltage', metric_type=aggregator.GAUGE, tags=common_tags + tag_row)
 
     tag_rows = [
-        ['tl_ups_output_circuit_status:closed'],
-        ['tl_ups_output_circuit_status:open'],
+        ['tl_ups_output_circuit_status:closed', 'tl_ups_output_circuit_index:31'],
+        ['tl_ups_output_circuit_status:open', 'tl_ups_output_circuit_index:12'],
     ]
     for tag_row in tag_rows:
         aggregator.assert_metric(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Tag tlUpsOutputCircuitTable by index to avoid metrics collision

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
