### PR TITLE
Fix sqlserver file stats metrics for Azure SQL DB

### DIFF
--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Fix sqlserver file stats metrics for Azure SQL DB ([#15695](https://github.com/DataDog/integrations-core/pull/15695))
+
 ## 14.0.0 / 2023-08-18
 
 ***Changed***:

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -240,7 +240,7 @@ def get_query_file_stats(sqlserver_major_version, sqlserver_engine_edition):
             df.name,
             df.physical_name,
             {sql_columns}
-        FROM sys.dm_io_virtual_file_stats(NULL, NULL) fs
+        FROM sys.dm_io_virtual_file_stats(DB_ID(), NULL) fs
             LEFT JOIN sys.database_files df
                 ON df.file_id = fs.file_id;
         """


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This change fixes an issue we are seeing where file stats metrics for Azure SQL DB were incorrect. You can see in the screenshot below that the sizes tagged by `logical_name` look wrong since one is tagged as `none`

![Screen Shot 2023-08-25 at 12 49 05 PM](https://github.com/DataDog/integrations-core/assets/14317240/c7e25263-6641-41f0-82d6-620a653b1482)

... this is because, our query calls the `sys.dm_io_virtual_file_stats` function with the `database_id` parameter set to `NULL`, which will show data for all databases on the Azure SQL DB, **despite the fact that the user does not have access to these other databases, and therefore doesn't need this information**.  This returns a strange result that looks like this:

![Screen Shot 2023-08-25 at 12 54 10 PM](https://github.com/DataDog/integrations-core/assets/14317240/b0f46387-fb2d-4495-8318-4f8a59ab9f8a)

... what we should do is use the `database_id` parameter to filter to the database we are connected to (and the only one the customer cares about). This returns correct results:

![Screen Shot 2023-08-25 at 12 53 54 PM](https://github.com/DataDog/integrations-core/assets/14317240/704d3705-b4a1-4475-9d7d-dc54b6942286)
