### PR TITLE
Add test script for debugging

### DIFF
--- a/kafka_consumer/tests/README.md
+++ b/kafka_consumer/tests/README.md
@@ -30,3 +30,7 @@ If you face this issue:
 
 1. Make sure you installed `librdkafka` (see the previous section).
 2. You might need to set the `C_INCLUDE_PATH` and `LIBRARY_PATH` environments variable to load `librdkafka` when building `confluent-kafka`. For instance: `C_INCLUDE_PATH=/opt/homebrew/Cellar/librdkafka/2.1.1/include/ LIBRARY_PATH=/opt/homebrew/Cellar/librdkafka/2.1.1/lib ddev test kafka_consumer`. (be sure to use the same version as declared in the `pyproject.toml` file). Setting these environment variables is only needed when the test environment is built (or rebuilt with the `--force-env-rebuild` option).  
+
+### Barebones connection
+
+If you are unable to connect to your Kafka cluster in your Agent, you can use the script in `tests/python_client/script.py` to run a barebones connection directly to the cluster for debugging. This script will attempt a connection and then fetch all of the consumer groups for that configuration.

--- a/kafka_consumer/tests/python_client/script.py
+++ b/kafka_consumer/tests/python_client/script.py
@@ -1,0 +1,82 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+from confluent_kafka.admin import AdminClient
+
+'''
+This is a simple script that can be used to start a barebones
+AdminClient similar to the integration to test connections.
+
+The client will attempt to connect and then query for consumer groups.
+'''
+
+# EDITME
+kafka_connect_str = ""
+request_timeout_ms = 30000
+tls_ca_cert = ""
+tls_cert = ""
+tls_private_key = ""
+tls_private_key_password = ""
+tls_validate_hostname = ""
+crlfile = ""
+tls_verify = "true"
+sasl_mechanism = ""
+sasl_plain_username = ""
+sasl_plain_password = ""
+sasl_kerberos_keytab = ""
+sasl_kerberos_principal = ""
+sasl_kerberos_service_name = ""
+security_protocol = ""
+
+
+def __get_authentication_config():
+    config = {
+        "security.protocol": security_protocol.lower(),
+    }
+
+    extras_parameters = {
+        "ssl.ca.location": tls_ca_cert,
+        "ssl.certificate.location": tls_cert,
+        "ssl.key.location": tls_private_key,
+        "ssl.key.password": tls_private_key_password,
+        "ssl.endpoint.identification.algorithm": "https" if tls_validate_hostname else "none",
+        "ssl.crl.location": crlfile,
+        "enable.ssl.certificate.verification": tls_verify,
+        "sasl.mechanism": sasl_mechanism,
+        "sasl.username": sasl_plain_username,
+        "sasl.password": sasl_plain_password,
+        "sasl.kerberos.keytab": sasl_kerberos_keytab,
+        "sasl.kerberos.principal": sasl_kerberos_principal,
+        "sasl.kerberos.service.name": sasl_kerberos_service_name,
+    }
+
+    for key, value in extras_parameters.items():
+        if value:
+            config[key] = value
+
+    return config
+
+
+def create_client():
+    config = {
+        "bootstrap.servers": kafka_connect_str,
+        "socket.timeout.ms": request_timeout_ms,
+        "client.id": "dd-agent",
+    }
+    config.update(__get_authentication_config())
+
+    return AdminClient(config)
+
+
+def main():
+    admin_client = create_client()
+    print("Connecting to AdminClient")
+    future = admin_client.list_consumer_groups()
+    results = future.result()
+    for valid_consumer_group in results.valid:
+        print("Found consumer group: %s" % valid_consumer_group.group_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds a test script `script.py` that attempts a connection to Kafka for debugging. The script will connect to the Kafka cluster and output all consumer groups.

### Motivation
<!-- What inspired you to submit this pull request? -->
This is helpful for support cases where connection issues are difficult to determine.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
