### PR TITLE
Add more attempts to the conditions in the e2e environment

### DIFF
--- a/confluent_platform/tests/conftest.py
+++ b/confluent_platform/tests/conftest.py
@@ -53,7 +53,7 @@ def dd_environment():
         compose_file,
         conditions=[
             # Kafka Broker
-            CheckDockerLogs('broker', 'Created log for partition _confluent'),
+            CheckDockerLogs('broker', 'Created log for partition _confluent', wait=2),
             # Kafka Schema Registry
             CheckDockerLogs('schema-registry', 'Server started, listening for requests...', attempts=45, wait=2),
             # Kafka Connect
@@ -61,7 +61,7 @@ def dd_environment():
                 'connect',
                 [' Started KafkaBasedLog', 'INFO REST resources initialized', 'Kafka Connect started'],
                 matches='all',
-                attempts=60,
+                attempts=120,
                 wait=3,
             ),
             # Create connectors


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add more attempts to the conditions in the e2e environment 

### Motivation
<!-- What inspired you to submit this pull request? -->

- https://datadoghq.atlassian.net/browse/AI-3436
- The e2e is a bit flaky, let's give it a bit more time to spin up

```
2023-08-28T15:59:11.5859720Z E           datadog_checks.dev.errors.RetryError: Command: ['docker', 'logs', 'connect']
2023-08-28T15:59:11.5878665Z E           Failed to match `3` of the patterns.
2023-08-28T15:59:11.5899736Z E           Provided patterns: 	- re.compile(' Started KafkaBasedLog', re.MULTILINE)	- re.compile('INFO REST resources initialized', re.MULTILINE)	- re.compile('Kafka Connect started', re.MULTILINE)
2023-08-28T15:59:11.5920885Z E           Missing patterns: 	- re.compile(' Started KafkaBasedLog', re.MULTILINE)	- re.compile('INFO REST resources initialized', re.MULTILINE)	- re.compile('Kafka Connect started', re.MULTILINE)
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
