### PR TITLE
Disable docs appearing + validation for wincrashdetect

### DIFF
--- a/wincrashdetect/manifest.json
+++ b/wincrashdetect/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "2.0.0",
   "app_uuid": "44210c4a-0fe6-4702-88bf-d720e492a806",
   "app_id": "wincrashdetect",
-  "display_on_public_website": true,
+  "display_on_public_website": false,
   "tile": {
     "overview": "README.md#Overview",
     "configuration": "README.md#Setup",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Disable the showing of these docs on the documentation site. 

### Motivation
<!-- What inspired you to submit this pull request? -->
There is no associated logo (which we're actively adding a validation for, and this is failing)
So the tile and docs page show an empty logo until thats resolved. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
