### PR TITLE
[DBM-2797] fix rate limited activity collection test case

### DIFF
--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -364,11 +364,12 @@ def test_activity_collection_rate_limit(aggregator, dd_run_check, dbm_instance):
     dbm_instance['query_activity']['collection_interval'] = collection_interval
     dbm_instance['query_activity']['run_sync'] = False
     check = MySql(CHECK_NAME, {}, [dbm_instance])
-    sleep_time = 1
+    start = time.time()
     dd_run_check(check)
-    time.sleep(sleep_time)
+    time.sleep(1)
     check.cancel()
-    max_collections = int(1 / collection_interval * sleep_time) + 1
+    time_elapsed = time.time() - start
+    max_collections = int(1 / collection_interval * time_elapsed) + 1
     metrics = aggregator.metrics("dd.mysql.activity.collect_activity.payload_size")
     assert max_collections / 2.0 <= len(metrics) <= max_collections
 


### PR DESCRIPTION
### What does this PR do?
This PR fixes the flakey test `test_activity_collection_rate_limit`. 
The test relies on `time.sleep(sleep_time)` to run the activity collection for certain period of time and then uses the `sleep_time` to calculate the maximum possible metrics to be collected during this time period.

The reason why the test sometimes fails is because `check.cancel()` cancels a list of checks one by one. By the time it successfully cancels `_query_activity`, the collection of the metrics might run slightly over the `sleep_time`, causing the number of metrics collected exceed the maximum number we are expecting. 

The change is to calculate the expected `max_collections` based on `time_elapsed`. This way it provides a more accurate view of how much time the check has been running. 

### Motivation
More robust logic in calculating the expected `max_collections` to prevent tests fails intermittently.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
