### PR TITLE
[DBM-2734] fix test_snapshot_xmin for pg > 13

### DIFF
--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -80,7 +80,6 @@ def test_snapshot_xmin(aggregator, integration_check, pg_instance):
     # In the test we are going to first run the check to collect xmin & xmax
     check = integration_check(pg_instance)
     check.check(pg_instance)
-    check.cancel()
 
     # Once we have the metrics, we will run a simple query to collect the xmin
     # The xmin we collect should be the same as the one collected by the check
@@ -110,7 +109,6 @@ def test_snapshot_xmin(aggregator, integration_check, pg_instance):
 
     # Recollect the metrics
     check.check(pg_instance)
-    check.cancel()
     aggregator.assert_metric('postgresql.snapshot.xmin', value=xmin + 2, count=1, tags=expected_tags)
     aggregator.assert_metric('postgresql.snapshot.xmax', value=xmin + 2, count=1, tags=expected_tags)
 


### PR DESCRIPTION
### What does this PR do?
This PR checks PG version in `test_snapshot_xmin`. `txid_current_snapshot` and `txid_current` is deprecated starting PG 13. For PG > 13, use `pg_current_snapshot` and `txid_current`. 
In addition to the PG version check, also reordered the steps in the test to ensure we correctly collect the metrics and compare to the right value.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
