### PR TITLE
Mark one metric as optional

### DIFF
--- a/calico/tests/common.py
+++ b/calico/tests/common.py
@@ -50,6 +50,7 @@ MOCK_CALICO_INSTANCE = {
 }
 
 OPTIONAL_METRICS = {
+    'calico.felix.int_dataplane_failures.count',
     'calico.felix.ipset.calls.count',
     'calico.felix.ipset.errors.count',
     'calico.felix.iptables.restore_calls.count',


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Mark one metric as optional

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/actions/runs/6015629865/job/16317946139:

```
E   AssertionError: Needed at least 1 candidates for 'calico.felix.int_dataplane_failures.count', got 0
E   Expected:
E           MetricStub(name='calico.felix.int_dataplane_failures.count', type=None, value=None, tags=None, hostname=None, device=None, flush_first_value=None)
E   Similar submitted:
E   Score   Most similar
E   0.[64](https://github.com/DataDog/integrations-core/actions/runs/6015629865/job/16317946139#step:14:65)    MetricStub(name='calico.felix.iptables.chains', type=0, value=32, tags=['endpoint:http://10.1.0.230:34737/metrics', 'ip_version:4', 'table:filter'], hostname='fv-az448-717', device=None, flush_first_value=False)
E   0.64    MetricStub(name='calico.felix.iptables.chains', type=0, value=10, tags=['endpoint:http://10.1.0.230:34737/metrics', 'ip_version:4', 'table:nat'], hostname='fv-az448-717', device=None, flush_first_value=False)
E   0.64    MetricStub(name='calico.felix.iptables.chains', type=0, value=9, tags=['endpoint:http://10.1.0.230:34737/metrics', 'ip_version:4', 'table:mangle'], hostname='fv-az448-[71](https://github.com/DataDog/integrations-core/actions/runs/6015629865/job/16317946139#step:14:72)7', device=None, flush_first_value=False)
E   0.64    MetricStub(name='calico.felix.iptables.chains', type=0, value=7, tags=['endpoint:http://10.1.0.230:34737/metrics', 'ip_version:4', 'table:raw'], hostname='fv-az448-717', device=None, flush_first_value=False)
E   0.62    MetricStub(name='calico.felix.iptables.rules', type=0, value=140, tags=['endpoint:http://10.1.0.230:34737/metrics', 'ip_version:4', 'table:filter'], hostname='fv-az448-717', device=None, flush_first_value=False)
E   0.62    MetricStub(name='calico.felix.iptables.rules', type=0, value=52, tags=['endpoint:http://10.1.0.230:34[73](https://github.com/DataDog/integrations-core/actions/runs/6015629865/job/16317946139#step:14:74)7/metrics', 'ip_version:4', 'table:raw'], hostname='fv-az448-717', device=None, flush_first_value=False)
E   0.62    MetricStub(name='calico.felix.iptables.rules', type=0, value=35, tags=['endpoint:http://10.1.0.230:34737/metrics', 'ip_version:4', 'table:mangle'], hostname='fv-az448-717', device=None, flush_first_value=False)
E   0.62    MetricStub(name='calico.felix.iptables.rules', type=0, value=9, tags=['endpoint:http://10.1.0.230:34737/metrics', 'ip_version:4', 'table:nat'], hostname='fv-az448-717', device=None, flush_first_value=False)
E   0.57    MetricStub(name='calico.felix.ipsets.calico', type=0, value=4, tags=['endpoint:http://10.1.0.230:34737/metrics', 'ip_version:inet'], hostname='fv-az448-717', device=None, flush_first_value=False)
E   0.55    MetricStub(name='calico.felix.ipsets.total', type=0, value=4, tags=['endpoint:http://10.1.0.230:34737/metrics'], hostname='fv-az448-717', device=None, flush_first_value=False)
E   0.53    MetricStub(name='calico.felix.active.local_policies', type=0, value=0, tags=['endpoint:http://10.1.0.230:34737/metrics'], hostname='fv-az448-717', device=None, flush_first_value=False)
E   0.51    MetricStub(name='calico.felix.cluster.num_hosts', type=0, value=1, tags=['endpoint:http://10.1.0.230:34737/metrics'], hostname='fv-az448-717', device=None, flush_first_value=False)
E   0.45    MetricStub(name='calico.felix.active.local_selectors', type=0, value=0, tags=['endpoint:http://10.1.0.230:34737/metrics'], hostname='fv-az448-717', device=None, flush_first_value=False)
E   0.45    MetricStub(name='calico.felix.active.local_endpoints', type=0, value=4, tags=['endpoint:http://10.1.0.230:34737/metrics'], hostname='fv-az448-717', device=None, flush_first_value=False)
E   0.42    MetricStub(name='calico.felix.cluster.num_host_endpoints', type=0, value=0, tags=['endpoint:http://10.1.0.230:34737/metrics'], hostname='fv-az448-717', device=None, flush_first_value=False)
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
