### PR TITLE
[SQLServer] - Add index page count metric, and index name to fragmentation metrics

### DIFF
--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ***Added***:
 
-* Add `index_name` tag to `.database.avg_fragmentation_in_percent`, `.database.fragment_count`, `.database.avg_fragment_size_in_pages` metrics. Also add a new metric `sqlserver.database.index_page_count`, tagged by `database_name`, `object_name`, `index_id` and `index_name`. ([#15562](https://github.com/DataDog/integrations-core/pull/15562))
+* Add `index_name` tag to `.database.avg_fragmentation_in_percent`, `.database.fragment_count`, `.database.avg_fragment_size_in_pages` metrics. Also add a new metric `sqlserver.database.index_page_count`, tagged by `database_name`, `object_name`, `index_id` and `index_name`. ([#15721](https://github.com/DataDog/integrations-core/pull/15721))
 
 ***Fixed***:
 

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Cache performance counter type to prevent querying for the same counter multiple times (especially for the per-db counters) ([#15714](https://github.com/DataDog/integrations-core/pull/15714))
 
+***Added***:
+
+* Add `index_name` tag to `.database.avg_fragmentation_in_percent`, `.database.fragment_count`, `.database.avg_fragment_size_in_pages` metrics. Also add a new metric `sqlserver.database.index_page_count`, tagged by `database_name`, `object_name`, `index_id` and `index_name`. ([#15562](https://github.com/DataDog/integrations-core/pull/15562))
+
 ***Fixed***:
 
 * Fix sqlserver file stats metrics for Azure SQL DB ([#15695](https://github.com/DataDog/integrations-core/pull/15695))

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -170,6 +170,11 @@ DATABASE_FRAGMENTATION_METRICS = [
         'sys.dm_db_index_physical_stats',
         'avg_fragment_size_in_pages',
     ),
+    (
+        'sqlserver.database.index_page_count',
+        'sys.dm_db_index_physical_stats',
+        'page_count',
+    ),
 ]
 
 DATABASE_MASTER_FILES = [

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -659,7 +659,7 @@ class SqlDbFragmentation(BaseSqlServerMetric):
         "DDIPS.index_id as index_id, DDIPS.fragment_count as fragment_count, DDIPS.avg_fragment_size_in_pages as avg_fragment_size_in_pages, DDIPS.page_count as page_count, "
         "DDIPS.avg_fragmentation_in_percent as avg_fragmentation_in_percent, I.name as index_name "
         "FROM {table} (DB_ID('{{db}}'),null,null,null,null) as DDIPS INNER JOIN sys.indexes as I ON I.object_id = DDIPS.object_id AND DDIPS.index_id = I.index_id "
-        "WHERE DDIPS.fragment_count is not null and DDIPS.avg_fragmentation_in_percent > 0".format(table=TABLE)
+        "WHERE DDIPS.fragment_count is not null".format(table=TABLE)
     )
 
     def __init__(self, cfg_instance, base_name, report_function, column, logger):

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -657,8 +657,8 @@ class SqlDbFragmentation(BaseSqlServerMetric):
     QUERY_BASE = (
         "SELECT DB_NAME(DDIPS.database_id) as database_name, OBJECT_NAME(DDIPS.object_id, DDIPS.database_id) as object_name, "
         "DDIPS.index_id as index_id, DDIPS.fragment_count as fragment_count, DDIPS.avg_fragment_size_in_pages as avg_fragment_size_in_pages, DDIPS.page_count as page_count, "
-        "DDIPS.avg_fragmentation_in_percent as avg_fragmentation_in_percent, I.name as index_name"
-        "FROM {table} (DB_ID('{{db}}'),null,null,null,null) as DDIPS INNER JOIN sys.indexes as I ON I.object_id = DDIPS.object_id AND DDIPS.index_id = I.index_id"
+        "DDIPS.avg_fragmentation_in_percent as avg_fragmentation_in_percent, I.name as index_name "
+        "FROM {table} (DB_ID('{{db}}'),null,null,null,null) as DDIPS INNER JOIN sys.indexes as I ON I.object_id = DDIPS.object_id AND DDIPS.index_id = I.index_id "
         "WHERE DDIPS.fragment_count is not null and DDIPS.avg_fragmentation_in_percent > 0".format(table=TABLE)
     )
 

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -656,8 +656,8 @@ class SqlDbFragmentation(BaseSqlServerMetric):
 
     QUERY_BASE = (
         "SELECT DB_NAME(DDIPS.database_id) as database_name, OBJECT_NAME(DDIPS.object_id, DDIPS.database_id) as object_name, "
-        "index_id, fragment_count, avg_fragment_size_in_pages, page_count, "
-        "avg_fragmentation_in_percent, I.name as index_name"
+        "DDIPS.index_id as index_id, DDIPS.fragment_count as fragment_count, DDIPS.avg_fragment_size_in_pages as avg_fragment_size_in_pages, DDIPS.page_count as page_count, "
+        "DDIPS.avg_fragmentation_in_percent as avg_fragmentation_in_percent, I.name as index_name"
         "FROM {table} as DDIPS (DB_ID('{{db}}'),null,null,null,null) INNER JOIN sys.indexes as I ON I.object_id = DDIPS.object_id AND DDIPS.index_id = I.index_id"
         "WHERE fragment_count is not null and avg_fragmentation_in_percent > 0".format(table=TABLE)
     )

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -655,10 +655,15 @@ class SqlDbFragmentation(BaseSqlServerMetric):
     DEFAULT_METRIC_TYPE = 'gauge'
 
     QUERY_BASE = (
-        "SELECT DB_NAME(DDIPS.database_id) as database_name, OBJECT_NAME(DDIPS.object_id, DDIPS.database_id) as object_name, "
-        "DDIPS.index_id as index_id, DDIPS.fragment_count as fragment_count, DDIPS.avg_fragment_size_in_pages as avg_fragment_size_in_pages, DDIPS.page_count as page_count, "
+        "SELECT DB_NAME(DDIPS.database_id) as database_name, "
+        "OBJECT_NAME(DDIPS.object_id, DDIPS.database_id) as object_name, "
+        "DDIPS.index_id as index_id, DDIPS.fragment_count as fragment_count, "
+        "DDIPS.avg_fragment_size_in_pages as avg_fragment_size_in_pages, "
+        "DDIPS.page_count as page_count, "
         "DDIPS.avg_fragmentation_in_percent as avg_fragmentation_in_percent, I.name as index_name "
-        "FROM {table} (DB_ID('{{db}}'),null,null,null,null) as DDIPS INNER JOIN sys.indexes as I ON I.object_id = DDIPS.object_id AND DDIPS.index_id = I.index_id "
+        "FROM {table} (DB_ID('{{db}}'),null,null,null,null) as DDIPS "
+        "INNER JOIN sys.indexes as I ON I.object_id = DDIPS.object_id "
+        "AND DDIPS.index_id = I.index_id "
         "WHERE DDIPS.fragment_count is not null".format(table=TABLE)
     )
 

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -676,10 +676,13 @@ class SqlDbFragmentation(BaseSqlServerMetric):
         logger.debug("%s: gathering fragmentation metrics for these databases: %s", cls.__name__, databases)
 
         for db in databases:
+            ctx = construct_use_statement(db)
             query = cls.QUERY_BASE.format(db=db)
-            logger.debug("%s: fetch_all executing query: %s", cls.__name__, query)
             start = get_precise_time()
             try:
+                logger.debug("%s: changing cursor context via use statement: %s", cls.__name__, ctx)
+                cursor.execute(ctx)
+                logger.debug("%s: fetch_all executing query: %s", cls.__name__, query)
                 cursor.execute(query)
                 data = cursor.fetchall()
             except Exception as e:

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -658,7 +658,7 @@ class SqlDbFragmentation(BaseSqlServerMetric):
         "SELECT DB_NAME(DDIPS.database_id) as database_name, OBJECT_NAME(DDIPS.object_id, DDIPS.database_id) as object_name, "
         "index_id, fragment_count, avg_fragment_size_in_pages, page_count, "
         "avg_fragmentation_in_percent, I.name as index_name"
-        "FROM {table} as DDIPS (DB_ID('{{db}}'),null,null,null,null) INNER JOIN sys.indexes I ON I.object_id = DDIPS.object_id AND DDIPS.index_id = I.index_id"
+        "FROM {table} as DDIPS (DB_ID('{{db}}'),null,null,null,null) INNER JOIN sys.indexes as I ON I.object_id = DDIPS.object_id AND DDIPS.index_id = I.index_id"
         "WHERE fragment_count is not null and avg_fragmentation_in_percent > 0".format(table=TABLE)
     )
 

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -658,8 +658,8 @@ class SqlDbFragmentation(BaseSqlServerMetric):
         "SELECT DB_NAME(DDIPS.database_id) as database_name, OBJECT_NAME(DDIPS.object_id, DDIPS.database_id) as object_name, "
         "DDIPS.index_id as index_id, DDIPS.fragment_count as fragment_count, DDIPS.avg_fragment_size_in_pages as avg_fragment_size_in_pages, DDIPS.page_count as page_count, "
         "DDIPS.avg_fragmentation_in_percent as avg_fragmentation_in_percent, I.name as index_name"
-        "FROM {table} as DDIPS (DB_ID('{{db}}'),null,null,null,null) INNER JOIN sys.indexes as I ON I.object_id = DDIPS.object_id AND DDIPS.index_id = I.index_id"
-        "WHERE fragment_count is not null and avg_fragmentation_in_percent > 0".format(table=TABLE)
+        "FROM {table} (DB_ID('{{db}}'),null,null,null,null) as DDIPS INNER JOIN sys.indexes as I ON I.object_id = DDIPS.object_id AND DDIPS.index_id = I.index_id"
+        "WHERE DDIPS.fragment_count is not null and DDIPS.avg_fragmentation_in_percent > 0".format(table=TABLE)
     )
 
     def __init__(self, cfg_instance, base_name, report_function, column, logger):

--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -51,6 +51,7 @@ sqlserver.database.master_files.size,gauge,,kibibyte,,"Current size of the datab
 sqlserver.database.master_files.state,gauge,,,,"Database file state: 0 = Online, 1 = Restoring, 2 = Recovering, 3 = Recovery_Pending, 4 = Suspect, 5 = Unknown, 6 = Offline, 7 = Defunct",0,sql_server,database master file status,
 sqlserver.database.active_transactions,gauge,,transaction,,Number of active transactions across all databases on the SQL Server instance.,0,sql_server,database trans active,
 sqlserver.database.avg_fragment_size_in_pages,gauge,,,,"The average number of pages in one fragment on the leaf level of an IN_ROW_DATA allocation unit.",0,sql_server,avg fragment size in pages,
+sqlserver.database.index_page_count,gauge,,,,"Total number of index or data pages.",0,sql_server,page count per index,
 sqlserver.database.avg_fragmentation_in_percent,gauge,,,,"Logical fragmentation for indexes, or extent fragmentation for heaps in the IN_ROW_DATA allocation unit.",0,sql_server,avg fragmentation percent,
 sqlserver.database.backup_count,gauge,,,,"The total count of successful backups made for a database.",0,sql_server,backup count,
 sqlserver.database.fragment_count,gauge,,,,"The number of fragments in the leaf level of an IN_ROW_DATA allocation unit.",0,sql_server,fragment count,

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -26,6 +26,7 @@ CREATE TABLE datadog_test.dbo.ϑings (id int, name varchar(255));
 INSERT INTO datadog_test.dbo.ϑings VALUES (1, 'foo'), (2, 'bar');
 CREATE USER bob FOR LOGIN bob;
 CREATE USER fred FOR LOGIN fred;
+CREATE INDEX thingsindex ON datadog_test.dbo.ϑings (name);
 GO
 
 EXEC sp_addrolemember 'db_datareader', 'bob'


### PR DESCRIPTION
### What does this PR do?
- Add `index_name` tag to `.database.avg_fragmentation_in_percent`, `.database.fragment_count`, `.database.avg_fragment_size_in_pages` metrics. 
- Also add a new metric `sqlserver.database.index_page_count`, tagged by `database_name`, `object_name`, `index_id` and `index_name`.

### Motivation

Wanted better and cleaner coverage of SQLServer index fragmentation data from sys.dm_db_index_physical_stats.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
