### PR TITLE
Make test_async_job_enabled less flakey

### DIFF
--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1358,15 +1358,17 @@ def test_async_job_enabled(
     run_one_check(check, dbm_instance)
     # check should be cancelled & all db connections should be shutdown
     assert check._check_cancelled
-    assert check.db_pool._conns.get(dbm_instance['dbname']) is None, "db connection should be gone"
     if statement_samples_enabled or statement_activity_enabled:
         assert check.statement_samples._job_loop_future is not None
+        assert not check.statement_samples._job_loop_future.running(), "samples thread should be stopped"
     else:
         assert check.statement_samples._job_loop_future is None
     if statement_metrics_enabled:
         assert check.statement_metrics._job_loop_future is not None
+        assert not check.statement_metrics._job_loop_future.running(), "metrics thread should be stopped"
     else:
         assert check.statement_metrics._job_loop_future is None
+    assert check.db_pool._conns.get(dbm_instance['dbname']) is None, "db connection should be gone"
 
 
 @pytest.mark.parametrize("db_user", ["datadog", "datadog_no_catalog"])

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1349,6 +1349,7 @@ def test_statement_samples_dbstrict(aggregator, integration_check, dbm_instance,
 def test_async_job_enabled(
     integration_check, dbm_instance, statement_activity_enabled, statement_samples_enabled, statement_metrics_enabled
 ):
+    dbm_instance['min_collection_interval'] = 1
     dbm_instance['query_activity'] = {'enabled': statement_activity_enabled, 'run_sync': False}
     dbm_instance['query_samples'] = {'enabled': statement_samples_enabled, 'run_sync': False}
     dbm_instance['query_metrics'] = {'enabled': statement_metrics_enabled, 'run_sync': False}
@@ -1583,6 +1584,7 @@ def test_async_job_inactive_stop(aggregator, integration_check, dbm_instance):
 
 
 def test_async_job_cancel_cancel(aggregator, integration_check, dbm_instance):
+    dbm_instance['min_collection_interval'] = 1
     dbm_instance['query_samples']['run_sync'] = False
     dbm_instance['query_metrics']['run_sync'] = False
     check = integration_check(dbm_instance)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

We are seeing this test fail the night jobs periodically, so this should help make the test less flakey. The failure is caused by a db connection not being closed completely on a call to `cancel` before we assert that all connections are closed. This commit changes the following:

1. Updates the `min_collection_interval` for the test to be 1 second, which is also the [timeout we set on the blocking call to close connections at shutdown](https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/postgres.py#L737). For the regular check, this number is typically much higher, but we set it to `.2` for the tests.
2. Assert that the job loops are no longer running, which could be holding the open connection in the connection pooling logic
3. Move the db connection assertion until after these basic assertions to make it more clear why the test might fail

### Motivation
<!-- What inspired you to submit this pull request? -->

This is failing the nightly job periodically with this error:

```
tests/test_statements.py:1325: in test_async_job_enabled
    assert check.db_pool._conns.get(dbm_instance['dbname']) is None, "db connection should be gone"
E   AssertionError: db connection should be gone
E   assert <datadog_checks.postgres.connections.ConnectionInfo object at 0x7fee20eb2520> is None
E    +  where <datadog_checks.postgres.connections.ConnectionInfo object at 0x7fee20eb2520> = <built-in method get of dict object at 0x7fee20d98840>('datadog_test')
E    +    where <built-in method get of dict object at 0x7fee20d98840> = {'datadog_test': <datadog_checks.postgres.connections.ConnectionInfo object at 0x7fee20eb2520>}.get
E    +      where {'datadog_test': <datadog_checks.postgres.connections.ConnectionInfo object at 0x7fee20eb2520>} = <datadog_checks.postgres.connections.MultiDatabaseConnectionPool object at 0x7fee20ded400>._conns
E    +        where <datadog_checks.postgres.connections.MultiDatabaseConnectionPool object at 0x7fee20ded400> = <datadog_checks.postgres.postgres.PostgreSql object at 0x7fee20ded5b0>.db_pool`
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
