### PR TITLE
Upgrade clickhouse-driver to 0.2.6 on Python 3

### DIFF
--- a/clickhouse/CHANGELOG.md
+++ b/clickhouse/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Added***:
+
+* Upgrade clickhouse-driver to 0.2.6 on Python 3 ([#15726](https://github.com/DataDog/integrations-core/pull/15726))
+
 ## 3.0.0 / 2023-08-10
 
 ***Changed***:

--- a/clickhouse/pyproject.toml
+++ b/clickhouse/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
 dynamic = [
     "version",
 ]
-
 license = "BSD-3-Clause"
 
 [project.optional-dependencies]
@@ -43,7 +42,7 @@ deps = [
     "clickhouse-cityhash==1.0.2.3; python_version < '3.0'",
     "clickhouse-cityhash==1.0.2.4; python_version > '3.0'",
     "clickhouse-driver==0.2.0; python_version < '3.0'",
-    "clickhouse-driver==0.2.3; python_version > '3.0'",
+    "clickhouse-driver==0.2.6; python_version > '3.0'",
     "lz4==2.2.1; python_version < '3.0'",
     "lz4==3.1.3; python_version > '3.0'",
 ]

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Added***:
+
+* Upgrade clickhouse-driver to 0.2.6 on Python 3 ([#15726](https://github.com/DataDog/integrations-core/pull/15726))
+
 ***Fixed***:
 
 * Bump oracledb version ([#15595](https://github.com/DataDog/integrations-core/pull/15595))

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -15,7 +15,7 @@ cachetools==5.3.1; python_version > '3.0'
 clickhouse-cityhash==1.0.2.3; python_version < '3.0'
 clickhouse-cityhash==1.0.2.4; python_version > '3.0'
 clickhouse-driver==0.2.0; python_version < '3.0'
-clickhouse-driver==0.2.3; python_version > '3.0'
+clickhouse-driver==0.2.6; python_version > '3.0'
 cm-client==45.0.4
 confluent-kafka==2.2.0; python_version > '3.0'
 contextlib2==0.6.0.post1; python_version < '3.0'
@@ -57,9 +57,9 @@ prometheus-client==0.17.1; python_version > '3.0'
 protobuf==3.17.3; python_version < '3.0'
 protobuf==3.20.2; python_version > '3.0'
 psutil==5.9.0
+psycopg-pool==3.1.7; python_version > '3.0'
 psycopg2-binary==2.8.6; sys_platform != 'darwin' or platform_machine != 'arm64'
 psycopg[binary]==3.1.10; python_version > '3.0'
-psycopg-pool==3.1.7; python_version > '3.0'
 pyasn1==0.4.6
 pycryptodomex==3.10.1
 pydantic==2.0.2; python_version > '3.0'
@@ -99,7 +99,6 @@ scandir==1.10.0
 securesystemslib[crypto,pynacl]==0.28.0; python_version > '3.0'
 semver==2.13.0; python_version < '3.0'
 semver==3.0.1; python_version > '3.0'
-serpent==1.28; sys_platform == 'win32' and python_version < '3.0'
 serpent==1.41; sys_platform == 'win32' and python_version > '3.0'
 service-identity[idna]==21.1.0
 simplejson==3.19.1


### PR DESCRIPTION
### Motivation

Newer versions of pip cannot understand ranges that erroneously include wildcards:

- https://github.com/mymarilyn/clickhouse-driver/pull/291
- https://github.com/pypa/packaging/issues/673

```
Collecting clickhouse-driver==0.2.3 (from datadog-clickhouse==3.0.0)
  Downloading clickhouse-driver-0.2.3.tar.gz (213 kB)
     -------------------------------------- 213.3/213.3 kB 4.3 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error

  python setup.py egg_info did not run successfully.
  exit code: 1

  [15 lines of output]
  C:\Users\ofek\AppData\Local\hatch\env\virtual\datadog-clickhouse\BSWKISFA\latest\Lib\site-packages\setuptools\config\setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
  !!

          ********************************************************************************
          The license_file parameter is deprecated, use license_files instead.

          By 2023-Oct-30, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.

          See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
          ********************************************************************************

  !!
    parsed = self.parsers.get(option_name, lambda x: x)(value)
  error in clickhouse-driver setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '>=3.4.*'
  [end of output]
```