### PR TITLE
[Openmetrics] Remove dash to use proper headers mapping -> dic, not list

### DIFF
--- a/openmetrics/README.md
+++ b/openmetrics/README.md
@@ -87,9 +87,9 @@ init_config:
   ...
 instances:
   - openmetrics_endpoint: <OPENMETRICS_ENDPOINT>
-  ...
+    ...
     headers:
-      - Accept: text/plain
+      Accept: text/plain
 ```
 
 With this configuration, the endpoint returns the `Content-type` set to `text/plain`, causing the integration to use the previous scraper.


### PR DESCRIPTION
### What does this PR do?
* Changes the headers code snippet to be a dictionary instead of a list as expected by the config : https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example#L537
* Aligns the `...` to emphase it is meant to represent the other options **inside** the instance
### Motivation
* Customer case, using the example, we get an error while the check tries to parse through the configuration : 
<img width="1246" alt="Image 2023-08-31 at 8 56 40 AM" src="https://github.com/DataDog/integrations-core/assets/97530782/9c6670ba-8d00-4ced-8583-5a9fb548946e">

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
