### PR TITLE
update removed gitlab env variables

### DIFF
--- a/.gitlab/tagger/build-packages.sh
+++ b/.gitlab/tagger/build-packages.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 IFS=$'\n\t'
 
 curl --request POST --form "token=$CI_JOB_TOKEN" --form ref=master \
-  --form variables[ORIG_CI_BUILD_REF]=$CI_BUILD_REF \
+  --form variables[ORIG_CI_BUILD_REF]=$CI_COMMIT_SHA \
   --form variables[ROOT_LAYOUT_TYPE]=core \
   --form variables[REPO_NAME]=integrations-core \
   https://gitlab.ddbuild.io/api/v4/projects/138/trigger/pipeline


### PR DESCRIPTION
### What does this PR do?
ci_build env variables are being removed for ci_job equivalents

### Motivation
We are upgrading gitlab to gitlab 16

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
