### PR TITLE
Capture `node_collector_evictions_total` metric in kube controller manager

### DIFF
--- a/kube_controller_manager/CHANGELOG.md
+++ b/kube_controller_manager/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Changed***:
+
+* Capture node_collector_evictions_total metric in kube controller manager ([#15737](https://github.com/DataDog/integrations-core/pull/15737))
+
 ## 4.4.0 / 2023-08-10
 
 ***Added***:

--- a/kube_controller_manager/CHANGELOG.md
+++ b/kube_controller_manager/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-***Changed***:
+***Added***:
 
 * Capture node_collector_evictions_total metric in kube controller manager ([#15737](https://github.com/DataDog/integrations-core/pull/15737))
 

--- a/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
+++ b/kube_controller_manager/datadog_checks/kube_controller_manager/kube_controller_manager.py
@@ -13,6 +13,11 @@ from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.utils.http import RequestsWrapper
 
+NEW_1_24_COUNTERS = {
+    # This metric replaces the deprecated node_collector_evictions_number metric as of k8s v1.24+
+    'node_collector_evictions_total': 'nodes.evictions',
+}
+
 
 class KubeControllerManagerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
     DEFAULT_METRIC_LIMIT = 0
@@ -127,6 +132,7 @@ class KubeControllerManagerCheck(KubeLeaderElectionMixin, OpenMetricsBaseCheck):
                             "tracking_finalizer_total": "job_controller.terminated"
                             "_pods_tracking_finalizer"
                         },
+                        NEW_1_24_COUNTERS,
                     ],
                 }
             },

--- a/kube_controller_manager/tests/fixtures/metrics.txt
+++ b/kube_controller_manager/tests/fixtures/metrics.txt
@@ -658,6 +658,9 @@ namespace_work_duration_count 0
 # HELP node_collector_evictions_number Number of Node evictions that happened since current instance of NodeController started.
 # TYPE node_collector_evictions_number counter
 node_collector_evictions_number{zone="test"} 1
+# HELP node_collector_evictions_total [STABLE] Number of Node evictions that happened since current instance of NodeController started.
+# TYPE node_collector_evictions_total counter
+node_collector_evictions_total{zone="test-total"} 3
 # HELP node_collector_unhealthy_nodes_in_zone Gauge measuring number of not Ready Nodes per zones.
 # TYPE node_collector_unhealthy_nodes_in_zone gauge
 node_collector_unhealthy_nodes_in_zone{zone="test"} 1

--- a/kube_controller_manager/tests/test_kube_controller_manager.py
+++ b/kube_controller_manager/tests/test_kube_controller_manager.py
@@ -85,6 +85,7 @@ def generic_check_metrics(aggregator, check_deprecated):
     assert_metric('.max_fds')
 
     assert_metric('.nodes.evictions', metric_type=aggregator.MONOTONIC_COUNT, value=1, tags=["zone:test"])
+    assert_metric('.nodes.evictions', metric_type=aggregator.MONOTONIC_COUNT, value=3, tags=["zone:test-total"])
     assert_metric('.nodes.count', value=5, tags=["zone:test"])
     assert_metric('.nodes.unhealthy', value=1, tags=["zone:test"])
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Capture the `node_collector_evictions_total` metric emitted by the kube controller manager, and map it to `kube_controller_manager.nodes.evictions` in Datadog.

### Motivation
<!-- What inspired you to submit this pull request? -->
In Kubernetes v1.24, the `node_collector_evictions_number` metric, which we currently map to `kube_controller_manager.nodes.evictions`, was deprecated and replaced with the `node_collector_evictions_total` metric. This change updates the check logic so we can continue to capture this data for users using Kubernetes v1.24+.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
* Does this PR fall under `Changed` or `Added` ?
* Would separating out the test into a new file make more sense?

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
