### PR TITLE
OpenAI update correct model tag name in cost calculation, update pricing doc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,8 +166,8 @@ datadog_checks_base/tests/**/test_db_statements.py  @DataDog/database-monitoring
 /oracle/manifest.json                               @DataDog/agent-integrations @DataDog/database-monitoring @DataDog/documentation
 
 # APM Integrations
-/langchain/         @DataDog/apm-core-python @DataDog/llm-obs @DataDog/agent-integrations @DataDog/documentation
-/openai/            @DataDog/apm-core-python @DataDog/llm-obs @DataDog/agent-integrations @DataDog/documentation
+/langchain/         @DataDog/llm-obs @DataDog/agent-integrations @DataDog/documentation
+/openai/            @DataDog/llm-obs @DataDog/agent-integrations @DataDog/documentation
 
 
 # Windows agent

--- a/openai/assets/dashboards/overview_dashboard.json
+++ b/openai/assets/dashboards/overview_dashboard.json
@@ -807,85 +807,85 @@
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query1",
-                      "query": "sum:openai.tokens.total{openai.model:ada*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.total{openai.request.model:ada*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:openai.tokens.total{openai.model:gpt-3.5*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.total{openai.request.model:gpt-3.5*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query3",
-                      "query": "sum:openai.tokens.total{openai.model:curie*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.total{openai.request.model:curie*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query4",
-                      "query": "sum:openai.tokens.total{openai.model:babbage*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.total{openai.request.model:babbage*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query5",
-                      "query": "sum:openai.tokens.total{openai.model:davinci*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.total{openai.request.model:davinci*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query6",
-                      "query": "sum:openai.tokens.prompt{openai.model:gpt-4,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-4,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query7",
-                      "query": "sum:openai.tokens.completion{openai.model:gpt-4,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-4,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query8",
-                      "query": "sum:openai.tokens.prompt{openai.model:gpt-4-32k*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-4-32k*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query9",
-                      "query": "sum:openai.tokens.completion{openai.model:gpt-4-32k*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-4-32k*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query10",
-                      "query": "sum:openai.tokens.total{openai.model:text-embedding-ada*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.total{openai.request.model:text-embedding-ada*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query11",
-                      "query": "sum:openai.tokens.total{openai.model:text-davinci*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.total{openai.request.model:text-davinci*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query12",
-                      "query": "sum:openai.tokens.total{openai.model:text-curie*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.total{openai.request.model:text-curie*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query13",
-                      "query": "sum:openai.tokens.total{openai.model:text-babbage*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.total{openai.request.model:text-babbage*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "query14",
-                      "query": "sum:openai.tokens.total{openai.model:text-ada*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.total{openai.request.model:text-ada*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     }
                   ],
                   "response_format": "scalar"
@@ -907,7 +907,7 @@
             "id": 3868770172430520,
             "definition": {
               "type": "note",
-              "content": "OpenAI model pricing (per 1K tokens)\n- **ada**: $0.0004\n- **babbage**: $0.0005\n- **curie**: $0.002\n- **davinci**: $0.02\n- **gpt-3.5-turbo**: $0.002\n- **gpt-4-8k**: $0.03 prompt, $0.06 completion\n- **gpt-4-32k**: $0.06 prompt, $0.12 completion\n\n\n\nhttps://openai.com/pricing (2023-04-12)",
+              "content": "OpenAI base model pricing (per 1K tokens)\n- **ada**: $0.0001\n- **babbage**: $0.0004\n- **curie**: $0.002\n- **davinci**: $0.002\n- **gpt-3.5-turbo-4k**: $0.0015 prompt, $0.002 completion\n- **gpt-3.5-turbo-16k**: $0.003 prompt, $0.004 completion\n- **gpt-4-8k**: $0.03 prompt, $0.06 completion\n- **gpt-4-32k**: $0.06 prompt, $0.12 completion\n\n\n\nhttps://openai.com/pricing (2023-09-01)",
               "background_color": "orange",
               "font_size": "14",
               "text_align": "left",

--- a/openai/assets/dashboards/overview_dashboard.json
+++ b/openai/assets/dashboards/overview_dashboard.json
@@ -799,92 +799,98 @@
                 {
                   "formulas": [
                     {
-                      "formula": "((query1 / 1000) * 0.0004) + ((query2 / 1000) * 0.002) + ((query3 / 1000) * 0.002) + ((query4 / 1000) * 0.0005) + ((query5 / 1000) * 0.02) + ((query6 / 1000) * 0.03) + ((query7 / 1000) * 0.06) + ((query8 / 1000) * 0.06) + ((query9 / 1000) * 0.12) + ((query10 / 1000) * 0.0004) + ((query11 / 1000) * 0.02) + ((query12 / 1000) * 0.002) + ((query13 / 1000) * 0.0005) + ((query14 / 1000) * 0.0004)"
+                      "formula": "((ada / 1000) * 0.0004) + ((gpt_3_5_4k_prompt / 1000) * 0.0015) + ((gpt_3_5_4k_completion / 1000) * 0.002) + ((gpt_3_5_16k_prompt / 1000) * 0.003) + ((gpt_3_5_16k_completion / 1000) * 0.004) + ((curie / 1000) * 0.002) + ((babbage / 1000) * 0.0004) + ((davinci / 1000) * 0.002) + ((gpt_4_8k_prompt / 1000) * 0.03) + ((gpt_4_8k_completion / 1000) * 0.06) + ((gpt_4_32k_prompt / 1000) * 0.06) + ((gpt_4_32k_completion / 1000) * 0.12) + ((text_ada_embedding / 1000) * 0.0001) + ((text_babbage / 1000) * 0.0005) + ((text_ada / 1000) * 0.0004)"
                     }
                   ],
                   "queries": [
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query1",
+                      "name": "ada",
                       "query": "sum:openai.tokens.total{openai.request.model:ada*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query2",
-                      "query": "sum:openai.tokens.total{openai.request.model:gpt-3.5*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_3_5_4k_prompt",
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-3.5-turbo,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query3",
-                      "query": "sum:openai.tokens.total{openai.request.model:curie*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_3_5_4k_completion",
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-3.5-turbo,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
+                    },
+                                        {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "gpt_3_5_16k_prompt",
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-3.5-turbo-16k*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query4",
+                      "name": "gpt_3_5_16k_completion",
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-3.5-turbo-16k*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "curie",
+                      "query": "sum:openai.tokens.total{openai.request.model:*curie*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "babbage",
                       "query": "sum:openai.tokens.total{openai.request.model:babbage*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query5",
-                      "query": "sum:openai.tokens.total{openai.request.model:davinci*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "name": "davinci",
+                      "query": "sum:openai.tokens.total{openai.request.model:*davinci*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query6",
+                      "name": "gpt_4_8k_prompt",
                       "query": "sum:openai.tokens.prompt{openai.request.model:gpt-4,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query7",
+                      "name": "gpt_4_8k_completion",
                       "query": "sum:openai.tokens.completion{openai.request.model:gpt-4,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query8",
+                      "name": "gpt_4_32k_prompt",
                       "query": "sum:openai.tokens.prompt{openai.request.model:gpt-4-32k*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query9",
+                      "name": "gpt_4_32k_completion",
                       "query": "sum:openai.tokens.completion{openai.request.model:gpt-4-32k*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query10",
+                      "name": "text_ada_embedding",
                       "query": "sum:openai.tokens.total{openai.request.model:text-embedding-ada*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query11",
-                      "query": "sum:openai.tokens.total{openai.request.model:text-davinci*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
-                    },
-                    {
-                      "aggregator": "sum",
-                      "data_source": "metrics",
-                      "name": "query12",
-                      "query": "sum:openai.tokens.total{openai.request.model:text-curie*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
-                    },
-                    {
-                      "aggregator": "sum",
-                      "data_source": "metrics",
-                      "name": "query13",
+                      "name": "text_babbage",
                       "query": "sum:openai.tokens.total{openai.request.model:text-babbage*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query14",
+                      "name": "text_ada",
                       "query": "sum:openai.tokens.total{openai.request.model:text-ada*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     }
                   ],


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR updates the estimated cost calculation query in the OpenAI integration dashboard to use the OpenAI V2 integration's `openai.request.model` instead of `openai.model`. This was missed in the V2 integration PR.

This PR also updates the pricing doc the dashboard provides to reflect correct model prices as of September 1, 2023.

This PR also removes the apm-python-core team as a codeowner for the integrations, as this will be owned by the llm-observability team moving forward.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
