### PR TITLE
Speed up test suite

### DIFF
--- a/ddev/src/ddev/config/file.py
+++ b/ddev/src/ddev/config/file.py
@@ -50,16 +50,17 @@ class ConfigFile:
 
         return tomli_w.dumps(config.raw_data)
 
+    def reset(self):
+        config = RootConfig({})
+        config.parse_fields()
+        self.model = config
+
     def restore(self):
         import tomli_w
 
-        config = RootConfig({})
-        config.parse_fields()
-
-        content = tomli_w.dumps(config.raw_data)
+        self.reset()
+        content = tomli_w.dumps(self.model.raw_data)
         self.save(content)
-
-        self.model = config
 
     def update(self):  # no cov
         self.model.parse_fields()

--- a/ddev/tests/cli/config/test_show.py
+++ b/ddev/tests/cli/config/test_show.py
@@ -5,6 +5,7 @@ import os
 
 
 def test_default_scrubbed(ddev, config_file, helpers):
+    config_file.restore()
     config_file.model.orgs['default']['api_key'] = 'foo'
     config_file.model.orgs['default']['app_key'] = 'bar'
     config_file.model.github = {'user': '', 'token': ''}
@@ -67,6 +68,7 @@ def test_default_scrubbed(ddev, config_file, helpers):
 
 
 def test_reveal(ddev, config_file, helpers):
+    config_file.restore()
     config_file.model.orgs['default']['api_key'] = 'foo'
     config_file.model.orgs['default']['app_key'] = 'bar'
     config_file.model.github = {'user': '', 'token': ''}

--- a/ddev/tests/cli/release/test_list_versions.py
+++ b/ddev/tests/cli/release/test_list_versions.py
@@ -3,7 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
 
-def test_list_versions(ddev, repository, helpers, network_replay):
+def test_list_versions(ddev, helpers, network_replay):
     network_replay('list_versions/success_disk.yaml', record_mode='none')
 
     result = ddev('release', 'list', 'disk')
@@ -48,7 +48,7 @@ def test_list_versions(ddev, repository, helpers, network_replay):
     )
 
 
-def test_list_versions_header(ddev, repository, helpers, network_replay):
+def test_list_versions_header(ddev, helpers, network_replay):
     network_replay('list_versions/success_datadog_checks_base.yaml', record_mode='none')
 
     result = ddev('release', 'list', 'datadog_checks_base')

--- a/ddev/tests/cli/validate/test_ci.py
+++ b/ddev/tests/cli/validate/test_ci.py
@@ -145,7 +145,7 @@ def test_codecov_missing_flag(ddev, repository, helpers):
     assert error in helpers.remove_trailing_spaces(result.output)
 
 
-def test_validate_ci_success(ddev, repository, helpers):
+def test_validate_ci_success(ddev, helpers):
     result = ddev('validate', 'ci')
     assert result.exit_code == 0, result.output
     assert helpers.remove_trailing_spaces(result.output) == helpers.dedent(

--- a/ddev/tests/cli/validate/test_http.py
+++ b/ddev/tests/cli/validate/test_http.py
@@ -127,7 +127,7 @@ def test_spec_missing_instance(ddev, repository, helpers):
     )
 
 
-def test_validate_http_success(ddev, repository, helpers):
+def test_validate_http_success(ddev, helpers):
     result = ddev('validate', 'http', 'apache', 'arangodb', 'zk')
     assert result.exit_code == 0, result.output
     assert helpers.remove_trailing_spaces(result.output) == helpers.dedent(

--- a/ddev/tests/cli/validate/test_licenses.py
+++ b/ddev/tests/cli/validate/test_licenses.py
@@ -56,7 +56,7 @@ def test_error_extra_dependency(name, contents, expected_error_output, ddev, rep
     ],
 )
 @pytest.mark.requires_ci
-def test_validate_repo(repo, repository, expected_message, ddev, helpers, config_file):
+def test_validate_repo(repo, expected_message, ddev, helpers, config_file):
     config_file.model.repo = repo
     config_file.save()
 
@@ -65,33 +65,19 @@ def test_validate_repo(repo, repository, expected_message, ddev, helpers, config
     assert expected_message in helpers.remove_trailing_spaces(result.output)
 
 
-@pytest.mark.parametrize(
-    "repo, expected_error_output",
-    [
-        pytest.param("core", "Requirements file is not found. Out of sync, run", id="Core integrations"),
-    ],
-)
-def test_error_no_requirements_file(repo, repository, expected_error_output, ddev, helpers):
+def test_error_no_requirements_file(repository, ddev, helpers):
     agent_requirements_path = (
         repository.path / 'datadog_checks_base' / 'datadog_checks' / 'base' / 'data' / 'agent_requirements.in'
     )
     os.remove(agent_requirements_path)
 
     result = ddev("validate", "licenses")
+
+    expected_error_output = 'Requirements file is not found. Out of sync, run'
     assert expected_error_output in helpers.remove_trailing_spaces(result.output)
 
 
-@pytest.mark.parametrize(
-    "repo, expected_error_output",
-    [
-        pytest.param(
-            "core",
-            "Detected InvalidRequirement error in agent_requirements.in:1 Expected end",
-            id="Core integrations",
-        ),
-    ],
-)
-def test_invalid_requirement(repo, repository, expected_error_output, ddev, helpers):
+def test_invalid_requirement(repository, ddev, helpers):
     agent_requirements_path = (
         repository.path / 'datadog_checks_base' / 'datadog_checks' / 'base' / 'data' / 'agent_requirements.in'
     )
@@ -106,5 +92,6 @@ def test_invalid_requirement(repo, repository, expected_error_output, ddev, help
 
     result = ddev("validate", "licenses")
 
+    expected_error_output = 'Detected InvalidRequirement error in agent_requirements.in:1 Expected end'
     assert expected_error_output in helpers.remove_trailing_spaces(result.output)
     assert 'aerospike==^4.0.0' in helpers.remove_trailing_spaces(result.output)

--- a/ddev/tests/cli/validate/test_manifest.py
+++ b/ddev/tests/cli/validate/test_manifest.py
@@ -14,7 +14,7 @@ def terminal_width():
         yield
 
 
-def test_no_dd_url(ddev, repository, helpers, config_file):
+def test_no_dd_url(ddev, helpers, config_file):
     config_file.model.orgs['default']['dd_url'] = ''
     config_file.save()
 
@@ -82,7 +82,7 @@ def test_error_multiple_integrations(ddev, repository, helpers, network_replay):
     )
 
 
-def test_passing(ddev, repository, helpers, network_replay):
+def test_passing(ddev, helpers, network_replay):
     network_replay('manifest/success.yaml', record_mode='none')
 
     result = ddev('validate', 'manifest', 'postgres')

--- a/ddev/tests/cli/validate/test_metrics.py
+++ b/ddev/tests/cli/validate/test_metrics.py
@@ -610,7 +610,7 @@ def test_warnings(ddev, repository, helpers):
     )
 
 
-def test_metrics_passing(ddev, repository, helpers):
+def test_metrics_passing(ddev, helpers):
     result = ddev('validate', 'metadata', 'postgres')
 
     assert result.exit_code == 0, result.output

--- a/ddev/tests/cli/validate/test_openmetrics.py
+++ b/ddev/tests/cli/validate/test_openmetrics.py
@@ -1,7 +1,6 @@
 import pytest
 
 
-@pytest.mark.usefixtures('repository')
 @pytest.mark.parametrize(
     "check_name, classes",
     [
@@ -45,7 +44,6 @@ def test_openmetrics_fail_single_parameter(ddev, helpers, repository):
     assert "Errors: 1" in helpers.remove_trailing_spaces(result.output)
 
 
-@pytest.mark.usefixtures('repository')
 def test_openmetrics_skip_openmetrics(ddev, helpers):
     result = ddev("validate", "openmetrics", "openmetrics")
 
@@ -55,7 +53,6 @@ def test_openmetrics_skip_openmetrics(ddev, helpers):
     assert "Errors" not in helpers.remove_trailing_spaces(result.output)
 
 
-@pytest.mark.usefixtures('repository')
 @pytest.mark.parametrize(
     "repo, expected_message",
     [

--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -94,7 +94,7 @@ def valid_integration(valid_integrations) -> str:
 
 
 @pytest.fixture(autouse=True)
-def config_file(tmp_path, monkeypatch) -> ConfigFile:
+def config_file(tmp_path, monkeypatch, local_repo) -> ConfigFile:
     for env_var in (
         'DD_SITE',
         'DD_LOGS_CONFIG_DD_URL',
@@ -107,8 +107,14 @@ def config_file(tmp_path, monkeypatch) -> ConfigFile:
 
     path = Path(tmp_path, 'config.toml')
     monkeypatch.setenv(ConfigEnvVars.CONFIG, str(path))
+
     config = ConfigFile(path)
-    config.restore()
+    config.reset()
+
+    # Provide a real default for times when tests have no need to modify the repo
+    config.model.repos['core'] = str(local_repo)
+    config.save()
+
     return config
 
 

--- a/ddev/tests/utils/test_github.py
+++ b/ddev/tests/utils/test_github.py
@@ -6,11 +6,11 @@ from ddev.utils.github import GitHubManager
 
 
 class TestGetPullRequest:
-    def test_no_match(self, repository, config_file, network_replay, terminal):
+    def test_no_match(self, local_repo, config_file, network_replay, terminal):
         network_replay('github/get_pr_no_match.yaml')
 
         github = GitHubManager(
-            Repository(repository.path.name, str(repository.path)),
+            Repository(local_repo.name, str(local_repo)),
             user=config_file.model.github.user,
             token=config_file.model.github.token,
             status=terminal.status,
@@ -18,11 +18,11 @@ class TestGetPullRequest:
 
         assert github.get_pull_request('fcd9c178cb01bcb349c694d34fe6ae237e3c1aa8') is None
 
-    def test_found(self, repository, helpers, config_file, network_replay, terminal):
+    def test_found(self, local_repo, helpers, config_file, network_replay, terminal):
         network_replay('github/get_pr_found.yaml')
 
         github = GitHubManager(
-            Repository(repository.path.name, str(repository.path)),
+            Repository(local_repo.name, str(local_repo)),
             user=config_file.model.github.user,
             token=config_file.model.github.token,
             status=terminal.status,


### PR DESCRIPTION
### Motivation

- Often the tests need a real repository but do not need to make modifications necessitating a cleanup Git reset step
- An upcoming PR requires this to prevent a significant increase in CI time

### Additional Notes

- Linux about the same [2:12](https://github.com/DataDog/integrations-core/actions/runs/6052110731/job/16425053267) to [2:08](https://github.com/DataDog/integrations-core/actions/runs/6065951218/job/16456407905)
- Windows [4:08](https://github.com/DataDog/integrations-core/actions/runs/6052110731/job/16425026443) to [3:06](https://github.com/DataDog/integrations-core/actions/runs/6065951218/job/16456407845)