### PR TITLE
Allow aws-fargate to have a source name without log pipeline in its README

### DIFF
--- a/.gitlab/validate-logs-intgs/validate_log_intgs.py
+++ b/.gitlab/validate-logs-intgs/validate_log_intgs.py
@@ -24,6 +24,9 @@ EXCEPTIONS = {
         ERR_MISSING_LOG_DOC,  # This is a tile only integration, the source is populated by azure directly.
         ERR_NOT_DEFINED_WEB_UI,  # The integration does not have any metrics.
     ],
+    'aws-fargate': [
+        ERR_UNEXPECTED_LOG_DOC,  # Not collecting logs directly, but has example in its readme
+    ],
     'cilium': [
         ERR_UNEXPECTED_LOG_COLLECTION_CAT,  # cilium does not need a pipeline to automatically parse the logs
         ERR_UNEXPECTED_LOG_DOC  # The documentation says to use 'source: cilium'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

We have a script to validate integrations that have a log pipeline are correctly documented. This PR allows aws-fargate to raise the ERR_UNEXPECTED_LOG_DOC error.

### Motivation
<!-- What inspired you to submit this pull request? -->

There's no pipeline for this integration but we have a ton of examples that match the patterns caught by the validation. It's fine for this integration to define these examples and should not raise an error.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
