### PR TITLE
Allow bumping the version of clickhouse-driver

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 * Add short hand for force-env-rebuild ([#15716](https://github.com/DataDog/integrations-core/pull/15716))
 
+***Fixed***:
+
+* Allow bumping the version of clickhouse-driver ([#15745](https://github.com/DataDog/integrations-core/pull/15745))
+
 ## 24.1.0 / 2023-08-25
 
 ***Security***:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -37,7 +37,6 @@ IGNORED_DEPS = {
     'pyasn1',  # Breaking snmp tests
     'pycryptodomex',  # Breaking snmp tests
     'pysnmp',  # Breaking snmp tests
-    'clickhouse-driver',  # Breaking clickhouse tests
     'lz4',  # Breaking clickhouse tests
     'pyodbc',  # Breaking sqlserver tests
     'psutil',  # Breaking disk tests


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Allow bumping the version of clickhouse-driver

### Motivation
<!-- What inspired you to submit this pull request? -->

We can now bump it again https://github.com/DataDog/integrations-core/pull/15726 and we use the [latest version](https://pypi.org/project/clickhouse-driver/) 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
