### PR TITLE
[kubelet] Respect container discovery management rules for `kubernetes.pods.running` and `kubernetes.containers.running`

### DIFF
--- a/kubelet/CHANGELOG.md
+++ b/kubelet/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+**Fixed**:
+* Adhere to container discovery management rules for `kubernetes.pods.running` and `kubernetes.containers.running` metrics ([#15749](https://github.com/DataDog/integrations-core/pull/15749))
+
 ## 7.9.1 / 2023-08-18
 
 ***Fixed***:

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -492,6 +492,12 @@ class KubeletCheck(
             # Containers reporting
             containers = pod.get('status', {}).get('containerStatuses', [])
             has_container_running = False
+
+            # Exclude pods/containers based on namespace filtering
+            namespace = pod.get('metadata', {}).get('namespace')
+            if self.pod_list_utils.is_namespace_excluded(namespace):
+                continue
+
             for container in containers:
                 container_id = container.get('containerID')
                 if not container_id:
@@ -512,6 +518,9 @@ class KubeletCheck(
             pod_id = pod.get('metadata', {}).get('uid')
             if not pod_id:
                 self.log.debug('skipping pod with no uid')
+                continue
+            # Exclude pods/containers based on name/image
+            if self.pod_list_utils.is_excluded(container_id, pod_id):
                 continue
             tags = tagger.tag('kubernetes_pod_uid://%s' % pod_id, tagger.LOW) or None
             if not tags:

--- a/kubelet/tests/test_kubelet.py
+++ b/kubelet/tests/test_kubelet.py
@@ -695,6 +695,8 @@ def test_report_pods_running(monkeypatch, tagger):
     check = KubeletCheck('kubelet', {}, [{}])
     monkeypatch.setattr(check, 'retrieve_pod_list', mock.Mock(return_value=json.loads(mock_from_file('pods.json'))))
     monkeypatch.setattr(check, 'gauge', mock.Mock())
+    attrs = {'is_namespace_excluded.return_value': False, 'is_excluded.return_value': False}
+    check.pod_list_utils = mock.Mock(**attrs)
     pod_list = check.retrieve_pod_list()
 
     check._report_pods_running(pod_list, [])
@@ -734,6 +736,8 @@ def test_report_pods_running_none_ids(monkeypatch, tagger):
     check = KubeletCheck('kubelet', {}, [{}])
     monkeypatch.setattr(check, 'retrieve_pod_list', mock.Mock(return_value=podlist))
     monkeypatch.setattr(check, 'gauge', mock.Mock())
+    attrs = {'is_namespace_excluded.return_value': False, 'is_excluded.return_value': False}
+    check.pod_list_utils = mock.Mock(**attrs)
     pod_list = check.retrieve_pod_list()
 
     check._report_pods_running(pod_list, [])
@@ -947,7 +951,7 @@ def test_pod_expiration(monkeypatch, aggregator, tagger):
         check, 'compute_pod_expiration_datetime', mock.Mock(return_value=parse_rfc3339("2019-02-18T16:00:06Z"))
     )
 
-    attrs = {'is_excluded.return_value': False}
+    attrs = {'is_namespace_excluded.return_value': False, 'is_excluded.return_value': False}
     check.pod_list_utils = mock.Mock(**attrs)
 
     pod_list = check.retrieve_pod_list()


### PR DESCRIPTION
### What does this PR do?
* Updates `_report_pods_running` in the kubelet check to stop reporting `kubernetes.pods/containers.running` from pods/containers excluded by containers discovery management : https://docs.datadoghq.com/containers/guide/autodiscovery-management/?tab=containerizedagent#exclude-containers

### Motivation
* Support case where a customer is confused because they are seeing the number of "monitored" namespaces being the same in the Kubernetes - Overview dashboard despite excluding some of them
    * This is because the widget uses the following query based on `kubernetes.pods.running` : https://github.com/DataDog/integrations-core/blob/9f484b509597f04821969c6b824ad5bd6f46e02e/kubernetes/assets/dashboards/kubernetes_clusters.json#L531
    * This metric along `kubernetes.containers.running` is not respecting the exclusion/inclusion rules


### Q/A
* Test different scenarios of exclusion/inclusion and see the `kubernetes.pods.running` getting updated accordingly : 
    * For instance, using the Helm chart

      ```
      datadog:
        containerExclude: "kube_namespace:.*"
        containerInclude: "kube_namespace:kube-system"
      ```
    * Run `kubectl get pods -n kube-system --no-headers | wc -l` and ensure the metric `kubernetes.pods.running` reported for this cluster corresponds to it

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
