### PR TITLE
[Release] Bumped snmp version to 6.2.1

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -135,7 +135,7 @@ datadog-scylla==2.5.0
 datadog-sidekiq==1.3.1
 datadog-silk==2.0.0
 datadog-singlestore==2.0.0
-datadog-snmp==6.2.0
+datadog-snmp==6.2.1
 datadog-snowflake==5.0.0
 datadog-solr==1.12.1
 datadog-sonarqube==3.0.0

--- a/snmp/CHANGELOG.md
+++ b/snmp/CHANGELOG.md
@@ -8,8 +8,13 @@
 
 ***Fixed***:
 
-* Fix SNMP profiles metric tags mappings using MIBs ([#15668](https://github.com/DataDog/integrations-core/pull/15668))
 * Remove unsupported metric in riverbed-interceptor.yaml ([#15678](https://github.com/DataDog/integrations-core/pull/15678))
+
+## 6.2.1 / 2023-09-05
+
+***Fixed***:
+
+* Fix SNMP profiles metric tags mappings using MIBs ([#15668](https://github.com/DataDog/integrations-core/pull/15668))
 
 ## 6.2.0 / 2023-08-18
 

--- a/snmp/datadog_checks/snmp/__about__.py
+++ b/snmp/datadog_checks/snmp/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '6.2.0'
+__version__ = '6.2.1'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Update changelog for backported 6.2.1 release for 7.48: https://github.com/DataDog/integrations-core/pull/15753
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
