### PR TITLE
Tomcat: Make JMX metrics available on both standalone and embedded Tomcat versions

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ***Changed***:
 
+* Include support for `domain_regex` when validating JMX metric files ([#15761](https://github.com/DataDog/integrations-core/pull/15761))
 * Adjust template and test collection based on new team guidelines ([#15078](https://github.com/DataDog/integrations-core/pull/15078))
     * `ddev create` produces initial test file named `test_unit.py` instead of `test_<integration>.py`.
     * Our pytest collection plugin attaches labels to tests based on their location. E.g. all tests in `test_unit.py` get the `unit` label.

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/jmx_metrics.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/validate/jmx_metrics.py
@@ -88,12 +88,13 @@ def validate_jmx_metrics(check_name, saved_errors, verbose):
             return
 
         domain = include.get('domain')
+        domain_regex = include.get('domain_regex')
         beans = include.get('bean')
-        if (not domain) and (not beans):
-            # Require `domain` or `bean` to be present,
+        if (not domain) and (not domain_regex) and (not beans):
+            # Require `domain`, `domain_regex`, or `bean` to be present,
             # that helps JMXFetch to better scope the beans to retrieve
             saved_errors[(check_name, jmx_metrics_file)].append(
-                f"domain or bean attribute is missing for rule: {include_str}"
+                f"domain, domain_regex or bean attribute is missing for rule: {include_str}"
             )
 
     duplicates = duplicate_bean_check(jmx_metrics_data)

--- a/tomcat/CHANGELOG.md
+++ b/tomcat/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Make JMX metrics available on both standalone and embedded Tomcat versions ([#15761](https://github.com/DataDog/integrations-core/pull/15761))
+
 ## 1.12.1 / 2023-08-18
 
 ***Fixed***:

--- a/tomcat/README.md
+++ b/tomcat/README.md
@@ -224,11 +224,15 @@ See [service_checks.json][14] for a list of service checks provided by this inte
 ## Troubleshooting
 
 ### Missing `tomcat.*` metrics
-The integration collects default Tomcat metrics from the `Catalina` bean domain name. If exposed Tomcat metrics are prefixed with a different bean domain name, such as `Tomcat`, copy the default metrics from the `metrics.yaml` to the `conf` section of the `tomcat.d/conf.yaml` and modify the `domain` filter to use the applicable bean domain name. 
+
+The Datadog agent collects JMX metrics with either `Catalina` or `Tomcat` as bean domain names.
+Standalone Tomcat deployments have metrics under domain `Catalina`, but embedded Tomcat deployments (such as with Spring Boot) have metrics under domain `Tomcat`.
+
+If the Datadog agent is older than **7.47.0**, and if the exposed Tomcat metrics are prefixed with a different bean domain name, such as `Tomcat`, copy the default metrics from the `metrics.yaml` file to the `conf` section of the `tomcat.d/conf.yaml` file and modify the `domain` filter to use the applicable bean domain name.
 
 ```yaml
 - include:
-    domain: Tomcat      # default: Catalina
+    domain: Tomcat
     type: ThreadPool
     attribute:
       maxThreads:

--- a/tomcat/datadog_checks/tomcat/data/metrics.yaml
+++ b/tomcat/datadog_checks/tomcat/data/metrics.yaml
@@ -1,7 +1,7 @@
 # Default metrics collected by this check. You should not have to modify this.
 jmx_metrics:
     - include:
-        domain: Catalina
+        domain_regex: Catalina|Tomcat
         type: ThreadPool
         attribute:
           maxThreads:
@@ -14,7 +14,7 @@ jmx_metrics:
             alias: tomcat.threads.busy
             metric_type: gauge
     - include:
-        domain: Catalina
+        domain_regex: Catalina|Tomcat
         type: GlobalRequestProcessor
         attribute:
           bytesSent:
@@ -36,7 +36,7 @@ jmx_metrics:
             alias: tomcat.processing_time
             metric_type: counter
     - include:
-        domain: Catalina
+        domain_regex: Catalina|Tomcat
         j2eeType: Servlet
         attribute:
           processingTime:
@@ -51,7 +51,7 @@ jmx_metrics:
     - include:
         # Deprecated metric available in Tomcat 7
         # https://github.com/apache/tomcat/blob/7.0.x/java/org/apache/catalina/core/StandardContext.java#L5293-L5297
-        domain: Catalina
+        domain_regex: Catalina|Tomcat
         type: Cache
         attribute:
           accessCount:
@@ -61,7 +61,7 @@ jmx_metrics:
             alias: tomcat.cache.hits_count
             metric_type: counter
     - include:
-        domain: Catalina
+        domain_regex: Catalina|Tomcat
         type: StringCache
         attribute:
           accessCount:
@@ -72,7 +72,7 @@ jmx_metrics:
             metric_type: counter
     - include:
         # Example Bean: `Catalina:type=WebResourceRoot,host=localhost,context=/docs,name=Cache`
-        domain: Catalina
+        domain_regex: Catalina|Tomcat
         type: WebResourceRoot
         name: Cache
         attribute:
@@ -83,7 +83,7 @@ jmx_metrics:
             alias: tomcat.web.cache.lookup_count
             metric_type: counter
     - include:
-        domain: Catalina
+        domain_regex: Catalina|Tomcat
         type: JspMonitor
         attribute:
           jspCount:


### PR DESCRIPTION
### What does this PR do?

This is a follow up to issue https://github.com/DataDog/integrations-core/issues/10233.
It has been suggested we support both `Catalina` and `Tomcat` bean names for JMX. 
This would cover both cases of standalone and embedded Tomcat versions (Spring Boot).

It seems the JMX fetch project supports `domain` and also `domain_regex`.
I am using `domain_regex` here to support both cases.
Regex seems to be supported since 2015: https://github.com/DataDog/jmxfetch/pull/57.

### Motivation

Spring Boot is widely popular and supporting these useful Tomcat metrics out of the box is a great advantage.
It is not as simple to rename the metric if people are using the agent with Kubernetes, as it requires mounting a file and adding a JVM argument to each pod where this is required.

### Additional Notes

The PR build is failing as it seems the CI is checking for the existence of `domain` and not considering `domain_regex`?
I have added support on the Python script to support `domain_regex` on CI checks as well.

I don't know which version this would be released, in the docs I needed to reference, so I used 7.47.0.
I would need to update that in case its released in another version.

Also, once this is released, we need to update the Git submodule in `dd-trace-java` and release a new version for:
https://github.com/DataDog/dd-trace-java/tree/master/dd-java-agent/agent-jmxfetch.



