### PR TITLE
Migrate test command

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -41,7 +41,7 @@ omit =
     ../datadog_checks_dev/datadog_checks/dev/tooling/utils.py
 
 [report]
-show_missing = ${DDEV_COV_MISSING}
+show_missing = True
 ignore_errors = True
 
 exclude_lines =

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -164,6 +164,10 @@ jobs:
         ddev config set repos.${{ inputs.repo }} .
         ddev config set repo ${{ inputs.repo }}
 
+    - name: Lint
+      # TODO: use the more descriptive `--lint` variant when ddev is released
+      run: ddev test -s ${{ inputs.target }}
+
     - name: Prepare for testing
       env: >-
         ${{ fromJson(inputs.setup-env-vars || format(

--- a/.github/workflows/test-target.yml
+++ b/.github/workflows/test-target.yml
@@ -87,6 +87,7 @@ jobs:
 
     env:
       PYTHON_VERSION: "${{ inputs.python-version || '3.9' }}"
+      PYTHON_FILTER: "${{ (inputs.test-py2 && !inputs.test-py3) && '2.7' || (!inputs.test-py2 && inputs.test-py3) && '3.9' || '' }}"
       SKIP_ENV_NAME: "${{ (inputs.test-py2 && !inputs.test-py3) && 'py3.*' || (!inputs.test-py2 && inputs.test-py3) && 'py2.*' || '' }}"
       # Windows E2E requires Windows containers
       DDEV_E2E_AGENT: "${{ inputs.platform == 'windows' && (inputs.agent-image-windows || 'datadog/agent-dev:master-py3-win-servercore') || inputs.agent-image }}"

--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Remove `release agent requirements` subcommand ([#15621](https://github.com/DataDog/integrations-core/pull/15621))
 
+***Added***:
+
+* Migrate test command ([#15762](https://github.com/DataDog/integrations-core/pull/15762))
+
 ***Fixed***:
 
 * Bump datadog-checks-dev version to ~=24.0 ([#15683](https://github.com/DataDog/integrations-core/pull/15683))

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "click~=8.1.6",
+    "coverage",
     "datadog-checks-dev[cli]~=24.0",
     "hatch>=1.6.3",
     "httpx",

--- a/ddev/src/ddev/cli/__init__.py
+++ b/ddev/src/ddev/cli/__init__.py
@@ -8,7 +8,6 @@ import pluggy
 from datadog_checks.dev.tooling.commands.create import create
 from datadog_checks.dev.tooling.commands.dep import dep
 from datadog_checks.dev.tooling.commands.run import run
-from datadog_checks.dev.tooling.commands.test import test
 
 from ddev._version import __version__
 from ddev.cli.application import Application
@@ -20,6 +19,7 @@ from ddev.cli.env import env
 from ddev.cli.meta import meta
 from ddev.cli.release import release
 from ddev.cli.status import status
+from ddev.cli.test import test
 from ddev.cli.validate import validate
 from ddev.config.constants import AppEnvVars, ConfigEnvVars
 from ddev.plugin import specs

--- a/ddev/src/ddev/cli/test/__init__.py
+++ b/ddev/src/ddev/cli/test/__init__.py
@@ -1,0 +1,220 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from ddev.cli.application import Application
+    from ddev.integration.core import Integration
+    from ddev.utils.fs import Path
+
+
+def fix_coverage_report(report_file: Path):
+    target_dir = report_file.parent.name
+    report = report_file.read_bytes()
+
+    # Make every target's `tests` directory path unique so they don't get combined in UI
+    report = report.replace(b'"tests/', f'"{target_dir}/tests/'.encode('utf-8'))
+
+    report_file.write_bytes(report)
+
+
+@click.command(short_help='Run tests')
+@click.argument('target_spec', required=False)
+@click.argument('args', nargs=-1)
+@click.option('--lint', '-s', is_flag=True, help='Run only lint & style checks')
+@click.option('--fmt', '-fs', is_flag=True, help='Run only the code formatter')
+@click.option('--bench', '-b', is_flag=True, help='Run only benchmarks')
+@click.option('--latest', is_flag=True, help='Only verify support of new product versions')
+@click.option('--cov', '-c', 'coverage', is_flag=True, help='Measure code coverage')
+@click.option('--compat', is_flag=True, help='Check compatibility with the minimum allowed Agent version')
+@click.option('--ddtrace', is_flag=True, envvar='DDEV_TEST_ENABLE_TRACING', help='Enable tracing during test execution')
+@click.option('--memray', is_flag=True, help='Measure memory usage during test execution')
+@click.option('--recreate', '-r', is_flag=True, help='Recreate environments from scratch')
+@click.option('--list', '-l', 'list_envs', is_flag=True, help='Show available test environments')
+@click.option('--junit', is_flag=True, hidden=True)
+@click.option('--e2e', is_flag=True, hidden=True)
+@click.pass_obj
+def test(
+    app: Application,
+    target_spec: str | None,
+    args: tuple[str, ...],
+    lint: bool,
+    fmt: bool,
+    bench: bool,
+    latest: bool,
+    coverage: bool,
+    compat: bool,
+    ddtrace: bool,
+    memray: bool,
+    recreate: bool,
+    list_envs: bool,
+    junit: bool,
+    e2e: bool,
+):
+    """
+    Run tests.
+    """
+    import json
+    import os
+    import sys
+
+    from ddev.testing.constants import EndToEndEnvVars, TestEnvVars
+    from ddev.utils.ci import running_in_ci
+
+    if target_spec is None:
+        target_spec = 'changed'
+
+    target_name, _, environments = target_spec.partition(':')
+
+    # target name -> target
+    targets: dict[str, Integration] = {}
+    if target_name == 'changed':
+        for integration in app.repo.integrations.iter_changed():
+            if integration.is_testable:
+                targets[integration.name] = integration
+    else:
+        try:
+            integration = app.repo.integrations.get(target_name)
+        except OSError:
+            app.abort(f'Unknown target: {target_name}')
+
+        if integration.is_testable:
+            targets[integration.name] = integration
+
+    if not targets:
+        app.abort('No testable targets found')
+
+    if list_envs:
+        multiple_targets = len(targets) > 1
+        for target in targets.values():
+            with target.path.as_cwd():
+                if multiple_targets:
+                    app.display_header(target.display_name)
+
+                app.platform.check_command([sys.executable, '-m', 'hatch', 'env', 'show'])
+
+        return
+
+    global_env_vars: dict[str, str] = {}
+
+    hatch_verbosity = app.verbosity + 1
+    if hatch_verbosity > 0:
+        global_env_vars['HATCH_VERBOSE'] = str(hatch_verbosity)
+    elif hatch_verbosity < 0:
+        global_env_vars['HATCH_QUIET'] = str(abs(hatch_verbosity))
+
+    api_key = app.config.org.config.get('api_key')
+    if api_key and not (lint or fmt):
+        global_env_vars['DD_API_KEY'] = api_key
+
+    # Only enable certain functionality when running standard tests
+    standard_tests = not (lint or fmt or bench or latest)
+
+    # Keep track of environments so that they can first be removed if requested
+    chosen_environments = []
+
+    base_command = [sys.executable, '-m', 'hatch', 'env', 'run']
+    if environments and not standard_tests:
+        app.abort('Cannot specify environments when using specific functionality like linting')
+    elif lint:
+        chosen_environments.append('lint')
+        base_command.extend(('--env', 'lint', '--', 'all'))
+    elif fmt:
+        chosen_environments.append('lint')
+        base_command.extend(('--env', 'lint', '--', 'fmt'))
+    elif bench:
+        config_filter = {'benchmark-env': True}
+        base_command.extend(('--filter', json.dumps(config_filter), '--', 'benchmark'))
+    elif latest:
+        config_filter = {'latest-env': True}
+        base_command.extend(('--filter', json.dumps(config_filter), '--', 'test', '--run-latest-metrics'))
+    else:
+        if environments:
+            for env_name in environments.split(','):
+                chosen_environments.append(env_name)
+                base_command.extend(('--env', env_name))
+        else:
+            chosen_environments.append('default')
+            base_command.append('--ignore-compat')
+
+        base_command.extend(('--', 'test-cov' if coverage else 'test'))
+
+        if app.verbosity <= 0:
+            base_command.extend(('--tb', 'short'))
+
+        if memray:
+            if app.platform.windows:
+                app.abort('Memory profiling with `memray` is not supported on Windows')
+
+            base_command.append('--memray')
+
+        if e2e:
+            base_command.extend(('-m', 'e2e'))
+            global_env_vars[EndToEndEnvVars.PARENT_PYTHON] = sys.executable
+
+    app.display_debug(f'Targets: {", ".join(targets)}')
+    for target in targets.values():
+        command = base_command.copy()
+        env_vars = global_env_vars.copy()
+
+        if standard_tests:
+            # TODO: remove the Windows limitation once we drop Python 2
+            if ddtrace and not app.platform.windows and (target.is_integration or target.name == 'datadog_checks_base'):
+                command.append('--ddtrace')
+                env_vars['DDEV_TRACE_ENABLED'] = 'true'
+                env_vars['DD_PROFILING_ENABLED'] = 'true'
+                env_vars['DD_SERVICE'] = os.environ.get('DD_SERVICE', 'ddev-integrations')
+                env_vars['DD_ENV'] = os.environ.get('DD_ENV', 'ddev-integrations')
+
+            if junit:
+                # In order to handle multiple environments the report files must contain the environment name.
+                # Hatch injects the `HATCH_ENV_ACTIVE` environment variable, see:
+                # https://hatch.pypa.io/latest/plugins/environment/reference/#hatch.env.plugin.interface.EnvironmentInterface.get_env_vars
+                command.extend(('--junit-xml', f'.junit/test-{"e2e" if e2e else "unit"}-$HATCH_ENV_ACTIVE.xml'))
+                # Test results class prefix
+                command.extend(('--junit-prefix', target.name))
+
+            if (
+                compat
+                and target.is_package
+                and target.is_integration
+                and target.minimum_base_package_version is not None
+            ):
+                env_vars[TestEnvVars.BASE_PACKAGE_VERSION] = target.minimum_base_package_version
+
+        command.extend(args)
+
+        with target.path.as_cwd(env_vars=env_vars):
+            app.display_header(target.display_name)
+            app.display_debug(f'Command: {command}')
+
+            if recreate:
+                if bench or latest:
+                    variable = 'benchmark-env' if bench else 'latest-env'
+                    env_data = json.loads(
+                        app.platform.check_command_output([sys.executable, '-m', 'hatch', 'env', 'show', '--json'])
+                    )
+                    for env_name, env_config in env_data.items():
+                        if env_config.get(variable, False):
+                            app.platform.check_command([sys.executable, '-m', 'hatch', 'env', 'remove', env_name])
+                else:
+                    for env_name in chosen_environments:
+                        app.platform.check_command([sys.executable, '-m', 'hatch', 'env', 'remove', env_name])
+
+            app.platform.check_command(command)
+            if standard_tests and coverage:
+                app.display_header('Coverage report')
+                app.platform.check_command([sys.executable, '-m', 'coverage', 'report', '--rcfile=../.coveragerc'])
+
+                if running_in_ci():
+                    app.platform.check_command(
+                        [sys.executable, '-m', 'coverage', 'xml', '-i', '--rcfile=../.coveragerc']
+                    )
+                    fix_coverage_report(target.path / 'coverage.xml')
+                else:
+                    (target.path / '.coverage').remove()

--- a/ddev/src/ddev/testing/__init__.py
+++ b/ddev/src/ddev/testing/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/ddev/src/ddev/testing/constants.py
+++ b/ddev/src/ddev/testing/constants.py
@@ -1,0 +1,9 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+class TestEnvVars:
+    BASE_PACKAGE_VERSION = 'DDEV_TEST_BASE_PACKAGE_VERSION'
+
+
+class EndToEndEnvVars:
+    PARENT_PYTHON = 'DDEV_E2E_PARENT_PYTHON'

--- a/ddev/src/ddev/utils/fs.py
+++ b/ddev/src/ddev/utils/fs.py
@@ -52,7 +52,9 @@ class Path(_PathBase):
         return super().write_text(*args, **kwargs)
 
     def open(self, **kwargs):
-        kwargs.setdefault('encoding', 'utf-8')
+        if not kwargs.get('mode', 'r')[1:].startswith('b'):
+            kwargs.setdefault('encoding', 'utf-8')
+
         return super().open(**kwargs)
 
     def remove(self):

--- a/ddev/tests/cli/test/__init__.py
+++ b/ddev/tests/cli/test/__init__.py
@@ -1,0 +1,3 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)

--- a/ddev/tests/cli/test/test_test.py
+++ b/ddev/tests/cli/test/test_test.py
@@ -1,0 +1,840 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+import os
+import sys
+
+import pytest
+
+from ddev.utils.structures import EnvVars
+
+
+class TestInputValidation:
+    @pytest.mark.parametrize('flag', ('--lint', '--fmt', '--bench', '--latest'))
+    def test_specific_environment_and_functionality(self, ddev, helpers, flag):
+        result = ddev('test', 'postgres:foo', flag)
+
+        assert result.exit_code == 1, result.output
+        assert result.output == helpers.dedent(
+            """
+            Cannot specify environments when using specific functionality like linting
+            """
+        )
+
+    def test_unknown_target(self, ddev, helpers):
+        result = ddev('test', 'foo')
+
+        assert result.exit_code == 1, result.output
+        assert result.output == helpers.dedent(
+            """
+            Unknown target: foo
+            """
+        )
+
+    def test_target_not_testable(self, ddev, helpers):
+        result = ddev('test', 'datadog_checks_dependency_provider')
+
+        assert result.exit_code == 1, result.output
+        assert result.output == helpers.dedent(
+            """
+            No testable targets found
+            """
+        )
+
+
+class TestListEnvironments:
+    def test_single_target(self, ddev, mocker):
+        run = mocker.patch('subprocess.run', return_value=mocker.MagicMock(returncode=0))
+
+        result = ddev('test', 'postgres', '--list')
+
+        assert result.exit_code == 0, result.output
+        assert not result.output
+
+        assert run.call_args_list == [
+            mocker.call([sys.executable, '-m', 'hatch', 'env', 'show'], shell=False),
+        ]
+
+    def test_multiple_targets(self, ddev, helpers, mocker):
+        changed_files = ['nginx/pyproject.toml', 'win32_event_log/pyproject.toml']
+        changed_file_processes = helpers.changed_file_processes(changed_files)
+        run = mocker.patch(
+            'subprocess.run',
+            side_effect=[*changed_file_processes, *[mocker.MagicMock(returncode=0)] * len(changed_files)],
+        )
+
+        result = ddev('test', '--list')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ──────────────────────────────────── NGINX ─────────────────────────────────────
+            ────────────────────────────── Windows Event Log ───────────────────────────────
+            """
+        )
+
+        assert run.call_args_list[len(changed_file_processes) :] == [
+            mocker.call([sys.executable, '-m', 'hatch', 'env', 'show'], shell=False),
+            mocker.call([sys.executable, '-m', 'hatch', 'env', 'show'], shell=False),
+        ]
+
+
+class TestStandard:
+    def test_all_environments(self, ddev, helpers, mocker):
+        run = mocker.patch('subprocess.run', return_value=mocker.MagicMock(returncode=0))
+
+        result = ddev('test', 'win32_event_log')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ────────────────────────────── Windows Event Log ───────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'run', '--ignore-compat', '--', 'test', '--tb', 'short'],
+                shell=False,
+            )
+        ]
+
+    def test_specific_environments(self, ddev, helpers, mocker):
+        run = mocker.patch('subprocess.run', return_value=mocker.MagicMock(returncode=0))
+
+        result = ddev('test', 'win32_event_log:foo,bar')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ────────────────────────────── Windows Event Log ───────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [
+                    sys.executable,
+                    '-m',
+                    'hatch',
+                    'env',
+                    'run',
+                    '--env',
+                    'foo',
+                    '--env',
+                    'bar',
+                    '--',
+                    'test',
+                    '--tb',
+                    'short',
+                ],
+                shell=False,
+            )
+        ]
+
+    def test_changed_target_detection(self, ddev, helpers, mocker):
+        changed_files = ['nginx/pyproject.toml', 'win32_event_log/pyproject.toml']
+        changed_file_processes = helpers.changed_file_processes(changed_files)
+        run = mocker.patch(
+            'subprocess.run',
+            side_effect=[*changed_file_processes, *[mocker.MagicMock(returncode=0)] * len(changed_files)],
+        )
+
+        result = ddev('test')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ──────────────────────────────────── NGINX ─────────────────────────────────────
+            ────────────────────────────── Windows Event Log ───────────────────────────────
+            """
+        )
+
+        assert run.call_args_list[len(changed_file_processes) :] == [
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'run', '--ignore-compat', '--', 'test', '--tb', 'short'],
+                shell=False,
+            ),
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'run', '--ignore-compat', '--', 'test', '--tb', 'short'],
+                shell=False,
+            ),
+        ]
+
+    def test_argument_forwarding(self, ddev, helpers, mocker):
+        run = mocker.patch('subprocess.run', return_value=mocker.MagicMock(returncode=0))
+
+        result = ddev('test', 'win32_event_log', 'foo', 'bar')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ────────────────────────────── Windows Event Log ───────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [
+                    sys.executable,
+                    '-m',
+                    'hatch',
+                    'env',
+                    'run',
+                    '--ignore-compat',
+                    '--',
+                    'test',
+                    '--tb',
+                    'short',
+                    'foo',
+                    'bar',
+                ],
+                shell=False,
+            )
+        ]
+
+    @pytest.mark.parametrize(
+        'flag, hatch_verbose, hatch_quiet',
+        [
+            pytest.param('-v', ('HATCH_VERBOSE', '2'), ('HATCH_QUIET', None), id='extra verbose'),
+            pytest.param('-qv', ('HATCH_VERBOSE', '1'), ('HATCH_QUIET', None), id='default verbose'),
+            pytest.param('-q', ('HATCH_VERBOSE', None), ('HATCH_QUIET', None), id='verbosity off'),
+            pytest.param('-qq', ('HATCH_VERBOSE', None), ('HATCH_QUIET', '1'), id='quiet'),
+        ],
+    )
+    def test_verbosity(self, ddev, helpers, mocker, flag, hatch_verbose, hatch_quiet):
+        env_vars = {}
+        run = mocker.patch(
+            'subprocess.run',
+            side_effect=lambda *args, **kwargs: env_vars.update(os.environ) or mocker.MagicMock(returncode=0),
+        )
+
+        result = ddev(flag, 'test', 'win32_event_log')
+
+        expected_command = [sys.executable, '-m', 'hatch', 'env', 'run', '--ignore-compat', '--', 'test']
+
+        assert result.exit_code == 0, result.output
+        if flag.startswith('-v'):
+            assert result.output == helpers.dedent(
+                f"""
+                DEBUG: Targets: win32_event_log
+                ────────────────────────────── Windows Event Log ───────────────────────────────
+                DEBUG: Command: {expected_command!r}
+                """
+            )
+        else:
+            expected_command.extend(('--tb', 'short'))
+            assert result.output == helpers.dedent(
+                """
+                ────────────────────────────── Windows Event Log ───────────────────────────────
+                """
+            )
+
+        assert run.call_args_list == [mocker.call(expected_command, shell=False)]
+
+        verbose_env_var, verbose_value = hatch_verbose
+        if verbose_value is None:
+            assert verbose_env_var not in env_vars
+        else:
+            assert env_vars[verbose_env_var] == verbose_value
+
+        quiet_env_var, quiet_value = hatch_quiet
+        if quiet_value is None:
+            assert quiet_env_var not in env_vars
+        else:
+            assert env_vars[quiet_env_var] == quiet_value
+
+    def test_api_key(self, ddev, config_file, helpers, mocker):
+        config_file.model.orgs['default']['api_key'] = 'foo'
+        config_file.save()
+
+        env_vars = {}
+        run = mocker.patch(
+            'subprocess.run',
+            side_effect=lambda *args, **kwargs: env_vars.update(os.environ) or mocker.MagicMock(returncode=0),
+        )
+
+        with EnvVars({'DD_API_KEY': 'bar'}):
+            result = ddev('test', 'win32_event_log')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ────────────────────────────── Windows Event Log ───────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'run', '--ignore-compat', '--', 'test', '--tb', 'short'],
+                shell=False,
+            )
+        ]
+        assert env_vars['DD_API_KEY'] == 'foo'
+
+
+class TestSpecificFunctionality:
+    @pytest.mark.parametrize('flag', ('--lint', '-s'))
+    def test_lint(self, ddev, config_file, helpers, mocker, flag):
+        config_file.model.orgs['default']['api_key'] = 'foo'
+        config_file.save()
+
+        env_vars = {}
+        run = mocker.patch(
+            'subprocess.run',
+            side_effect=lambda *args, **kwargs: env_vars.update(os.environ) or mocker.MagicMock(returncode=0),
+        )
+
+        with EnvVars({'DD_API_KEY': 'bar'}):
+            result = ddev('test', 'postgres', flag)
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'run', '--env', 'lint', '--', 'all'],
+                shell=False,
+            )
+        ]
+        assert env_vars['DD_API_KEY'] == 'bar'
+
+    @pytest.mark.parametrize('flag', ('--fmt', '-fs'))
+    def test_fmt(self, ddev, config_file, helpers, mocker, flag):
+        config_file.model.orgs['default']['api_key'] = 'foo'
+        config_file.save()
+
+        env_vars = {}
+        run = mocker.patch(
+            'subprocess.run',
+            side_effect=lambda *args, **kwargs: env_vars.update(os.environ) or mocker.MagicMock(returncode=0),
+        )
+
+        with EnvVars({'DD_API_KEY': 'bar'}):
+            result = ddev('test', 'postgres', flag)
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'run', '--env', 'lint', '--', 'fmt'],
+                shell=False,
+            )
+        ]
+        assert env_vars['DD_API_KEY'] == 'bar'
+
+    @pytest.mark.parametrize('flag', ('--bench', '-b'))
+    def test_bench(self, ddev, config_file, helpers, mocker, flag):
+        config_file.model.orgs['default']['api_key'] = 'foo'
+        config_file.save()
+
+        env_vars = {}
+        run = mocker.patch(
+            'subprocess.run',
+            side_effect=lambda *args, **kwargs: env_vars.update(os.environ) or mocker.MagicMock(returncode=0),
+        )
+
+        with EnvVars({'DD_API_KEY': 'bar'}):
+            result = ddev('test', 'postgres', flag)
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'run', '--filter', '{"benchmark-env": true}', '--', 'benchmark'],
+                shell=False,
+            )
+        ]
+        assert env_vars['DD_API_KEY'] == 'foo'
+
+    def test_latest(self, ddev, config_file, helpers, mocker):
+        config_file.model.orgs['default']['api_key'] = 'foo'
+        config_file.save()
+
+        env_vars = {}
+        run = mocker.patch(
+            'subprocess.run',
+            side_effect=lambda *args, **kwargs: env_vars.update(os.environ) or mocker.MagicMock(returncode=0),
+        )
+
+        with EnvVars({'DD_API_KEY': 'bar'}):
+            result = ddev('test', 'clickhouse', '--latest')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ────────────────────────────────── ClickHouse ──────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [
+                    sys.executable,
+                    '-m',
+                    'hatch',
+                    'env',
+                    'run',
+                    '--filter',
+                    '{"latest-env": true}',
+                    '--',
+                    'test',
+                    '--run-latest-metrics',
+                ],
+                shell=False,
+            )
+        ]
+        assert env_vars['DD_API_KEY'] == 'foo'
+
+
+class TestCoverage:
+    def test_local(self, ddev, helpers, mocker, repository):
+        run = mocker.patch('subprocess.run', side_effect=[mocker.MagicMock(returncode=0)] * 2)
+        coverage_file = repository.path / 'postgres' / '.coverage'
+        coverage_file.touch()
+
+        with EnvVars({'GITHUB_ACTIONS': 'false', 'CI': 'false'}):
+            result = ddev('test', 'postgres', '--cov')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            ─────────────────────────────── Coverage report ────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'run', '--ignore-compat', '--', 'test-cov', '--tb', 'short'],
+                shell=False,
+            ),
+            mocker.call([sys.executable, '-m', 'coverage', 'report', '--rcfile=../.coveragerc'], shell=False),
+        ]
+        assert not coverage_file.exists()
+
+    def test_ci(self, ddev, helpers, mocker, repository):
+        run = mocker.patch('subprocess.run', side_effect=[mocker.MagicMock(returncode=0)] * 3)
+        coverage_file = repository.path / 'postgres' / 'coverage.xml'
+        coverage_file.write_text(
+            helpers.dedent(
+                """
+                <?xml version="1.0" ?>
+                <coverage version="6.5.0" ...>
+                    <!-- Generated by coverage.py: https://coverage.readthedocs.io -->
+                    <!-- Based on https://raw.githubusercontent.com/cobertura/web/master/htdocs/xml/coverage-04.dtd -->
+                    <sources>
+                        <source>/</source>
+                    </sources>
+                    <packages>
+                        <package name="tests" ...>
+                            <classes>
+                                <class name="conftest.py" filename="tests/conftest.py" ...>
+                                    <methods/>
+                """
+            )
+        )
+
+        with EnvVars({'GITHUB_ACTIONS': 'true'}):
+            result = ddev('test', 'postgres', '--cov')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            ─────────────────────────────── Coverage report ────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'run', '--ignore-compat', '--', 'test-cov', '--tb', 'short'],
+                shell=False,
+            ),
+            mocker.call([sys.executable, '-m', 'coverage', 'report', '--rcfile=../.coveragerc'], shell=False),
+            mocker.call([sys.executable, '-m', 'coverage', 'xml', '-i', '--rcfile=../.coveragerc'], shell=False),
+        ]
+        assert coverage_file.read_text() == helpers.dedent(
+            """
+            <?xml version="1.0" ?>
+            <coverage version="6.5.0" ...>
+                <!-- Generated by coverage.py: https://coverage.readthedocs.io -->
+                <!-- Based on https://raw.githubusercontent.com/cobertura/web/master/htdocs/xml/coverage-04.dtd -->
+                <sources>
+                    <source>/</source>
+                </sources>
+                <packages>
+                    <package name="tests" ...>
+                        <classes>
+                            <class name="conftest.py" filename="postgres/tests/conftest.py" ...>
+                                <methods/>
+            """
+        )
+
+
+class TestJUnit:
+    def test_unit(self, ddev, helpers, mocker):
+        run = mocker.patch('subprocess.run', return_value=mocker.MagicMock(returncode=0))
+
+        result = ddev('test', 'postgres', '--junit')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [
+                    sys.executable,
+                    '-m',
+                    'hatch',
+                    'env',
+                    'run',
+                    '--ignore-compat',
+                    '--',
+                    'test',
+                    '--tb',
+                    'short',
+                    '--junit-xml',
+                    '.junit/test-unit-$HATCH_ENV_ACTIVE.xml',
+                    '--junit-prefix',
+                    'postgres',
+                ],
+                shell=False,
+            )
+        ]
+
+    def test_e2e(self, ddev, helpers, mocker):
+        run = mocker.patch('subprocess.run', return_value=mocker.MagicMock(returncode=0))
+
+        result = ddev('test', 'postgres', '--junit', '--e2e')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [
+                    sys.executable,
+                    '-m',
+                    'hatch',
+                    'env',
+                    'run',
+                    '--ignore-compat',
+                    '--',
+                    'test',
+                    '--tb',
+                    'short',
+                    '-m',
+                    'e2e',
+                    '--junit-xml',
+                    '.junit/test-e2e-$HATCH_ENV_ACTIVE.xml',
+                    '--junit-prefix',
+                    'postgres',
+                ],
+                shell=False,
+            )
+        ]
+
+
+class TestDDTrace:
+    @pytest.mark.requires_unix
+    def test_default(self, ddev, helpers, mocker):
+        env_vars = {}
+        run = mocker.patch(
+            'subprocess.run',
+            side_effect=lambda *args, **kwargs: env_vars.update(os.environ) or mocker.MagicMock(returncode=0),
+        )
+
+        result = ddev('test', 'postgres', '--ddtrace')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [
+                    sys.executable,
+                    '-m',
+                    'hatch',
+                    'env',
+                    'run',
+                    '--ignore-compat',
+                    '--',
+                    'test',
+                    '--tb',
+                    'short',
+                    '--ddtrace',
+                ],
+                shell=False,
+            )
+        ]
+        assert env_vars['DDEV_TRACE_ENABLED'] == 'true'
+        assert env_vars['DD_PROFILING_ENABLED'] == 'true'
+        assert env_vars['DD_SERVICE'] == 'ddev-integrations'
+        assert env_vars['DD_ENV'] == 'ddev-integrations'
+
+    @pytest.mark.requires_unix
+    def test_specific_tags(self, ddev, helpers, mocker):
+        env_vars = {}
+        run = mocker.patch(
+            'subprocess.run',
+            side_effect=lambda *args, **kwargs: env_vars.update(os.environ) or mocker.MagicMock(returncode=0),
+        )
+
+        with EnvVars({'DD_SERVICE': 'foo', 'DD_ENV': 'bar'}):
+            result = ddev('test', 'postgres', '--ddtrace')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [
+                    sys.executable,
+                    '-m',
+                    'hatch',
+                    'env',
+                    'run',
+                    '--ignore-compat',
+                    '--',
+                    'test',
+                    '--tb',
+                    'short',
+                    '--ddtrace',
+                ],
+                shell=False,
+            )
+        ]
+        assert env_vars['DDEV_TRACE_ENABLED'] == 'true'
+        assert env_vars['DD_PROFILING_ENABLED'] == 'true'
+        assert env_vars['DD_SERVICE'] == 'foo'
+        assert env_vars['DD_ENV'] == 'bar'
+
+
+class TestMemray:
+    @pytest.mark.requires_unix
+    def test_unix(self, ddev, helpers, mocker):
+        run = mocker.patch('subprocess.run', return_value=mocker.MagicMock(returncode=0))
+
+        result = ddev('test', 'postgres', '--memray')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [
+                    sys.executable,
+                    '-m',
+                    'hatch',
+                    'env',
+                    'run',
+                    '--ignore-compat',
+                    '--',
+                    'test',
+                    '--tb',
+                    'short',
+                    '--memray',
+                ],
+                shell=False,
+            )
+        ]
+
+    @pytest.mark.requires_windows
+    def test_windows(self, ddev, helpers, mocker):
+        mocker.patch('subprocess.run', return_value=mocker.MagicMock(returncode=0))
+
+        result = ddev('test', 'postgres', '--memray')
+
+        assert result.exit_code == 1, result.output
+        assert result.output == helpers.dedent(
+            """
+            Memory profiling with `memray` is not supported on Windows
+            """
+        )
+
+
+class TestRecreate:
+    def test_bench(self, ddev, helpers, mocker):
+        mocker.patch(
+            'ddev.utils.platform.Platform.check_command_output',
+            return_value=json.dumps({'foo': {'benchmark-env': True}, 'bar': {}, 'baz': {'benchmark-env': True}}),
+        )
+        run = mocker.patch('subprocess.run', side_effect=[mocker.MagicMock(returncode=0)] * 3)
+
+        result = ddev('test', 'postgres', '--bench', '--recreate')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call([sys.executable, '-m', 'hatch', 'env', 'remove', 'foo'], shell=False),
+            mocker.call([sys.executable, '-m', 'hatch', 'env', 'remove', 'baz'], shell=False),
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'run', '--filter', '{"benchmark-env": true}', '--', 'benchmark'],
+                shell=False,
+            ),
+        ]
+
+    def test_latest(self, ddev, helpers, mocker):
+        mocker.patch(
+            'ddev.utils.platform.Platform.check_command_output',
+            return_value=json.dumps({'foo': {'latest-env': True}, 'bar': {}, 'baz': {'latest-env': True}}),
+        )
+        run = mocker.patch('subprocess.run', side_effect=[mocker.MagicMock(returncode=0)] * 3)
+
+        result = ddev('test', 'postgres', '--latest', '--recreate')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call([sys.executable, '-m', 'hatch', 'env', 'remove', 'foo'], shell=False),
+            mocker.call([sys.executable, '-m', 'hatch', 'env', 'remove', 'baz'], shell=False),
+            mocker.call(
+                [
+                    sys.executable,
+                    '-m',
+                    'hatch',
+                    'env',
+                    'run',
+                    '--filter',
+                    '{"latest-env": true}',
+                    '--',
+                    'test',
+                    '--run-latest-metrics',
+                ],
+                shell=False,
+            ),
+        ]
+
+    def test_specific_environments(self, ddev, helpers, mocker):
+        run = mocker.patch('subprocess.run', side_effect=[mocker.MagicMock(returncode=0)] * 3)
+
+        result = ddev('test', 'postgres:foo,bar', '--recreate')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call([sys.executable, '-m', 'hatch', 'env', 'remove', 'foo'], shell=False),
+            mocker.call([sys.executable, '-m', 'hatch', 'env', 'remove', 'bar'], shell=False),
+            mocker.call(
+                [
+                    sys.executable,
+                    '-m',
+                    'hatch',
+                    'env',
+                    'run',
+                    '--env',
+                    'foo',
+                    '--env',
+                    'bar',
+                    '--',
+                    'test',
+                    '--tb',
+                    'short',
+                ],
+                shell=False,
+            ),
+        ]
+
+    def test_all_environments(self, ddev, helpers, mocker):
+        run = mocker.patch('subprocess.run', side_effect=[mocker.MagicMock(returncode=0)] * 2)
+
+        result = ddev('test', 'postgres', '--recreate')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call([sys.executable, '-m', 'hatch', 'env', 'remove', 'default'], shell=False),
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'run', '--ignore-compat', '--', 'test', '--tb', 'short'],
+                shell=False,
+            ),
+        ]
+
+
+class TestPluginInteraction:
+    def test_minimum_base_package_version(self, ddev, helpers, mocker, repository):
+        import tomlkit
+
+        env_vars = {}
+        run = mocker.patch(
+            'subprocess.run',
+            side_effect=lambda *args, **kwargs: env_vars.update(os.environ) or mocker.MagicMock(returncode=0),
+        )
+
+        project_file = repository.path / 'postgres' / 'pyproject.toml'
+        data = tomlkit.parse(project_file.read_text())
+        data['project']['dependencies'] = ['datadog-checks-base>=9000,<10000']
+        project_file.write_text(tomlkit.dumps(data))
+
+        result = ddev('test', 'postgres', '--compat')
+
+        assert result.exit_code == 0, result.output
+        assert result.output == helpers.dedent(
+            """
+            ─────────────────────────────────── Postgres ───────────────────────────────────
+            """
+        )
+
+        assert run.call_args_list == [
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'run', '--ignore-compat', '--', 'test', '--tb', 'short'],
+                shell=False,
+            ),
+        ]
+        assert env_vars['DDEV_TEST_BASE_PACKAGE_VERSION'] == '9000'

--- a/ddev/tests/conftest.py
+++ b/ddev/tests/conftest.py
@@ -96,12 +96,17 @@ def valid_integration(valid_integrations) -> str:
 @pytest.fixture(autouse=True)
 def config_file(tmp_path, monkeypatch, local_repo) -> ConfigFile:
     for env_var in (
+        'DD_ENV',
+        'DD_SERVICE',
         'DD_SITE',
         'DD_LOGS_CONFIG_DD_URL',
         'DD_DD_URL',
         'DD_API_KEY',
         'DD_APP_KEY',
         'DDEV_REPO',
+        'DDEV_TEST_ENABLE_TRACING',
+        'HATCH_VERBOSE',
+        'HATCH_QUIET',
     ):
         monkeypatch.delenv(env_var, raising=False)
 
@@ -128,7 +133,7 @@ def temp_dir(tmp_path) -> Path:
 @pytest.fixture(scope='session', autouse=True)
 def isolation() -> Generator[Path, None, None]:
     with temp_directory() as d:
-        default_env_vars = {AppEnvVars.NO_COLOR: '1'}
+        default_env_vars = {'DDEV_SELF_TESTING': 'true', AppEnvVars.NO_COLOR: '1', 'COLUMNS': '80', 'LINES': '24'}
         with d.as_cwd(default_env_vars):
             yield d
 

--- a/ddev/tests/helpers/api.py
+++ b/ddev/tests/helpers/api.py
@@ -1,7 +1,10 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
 import re
+from subprocess import CompletedProcess
 from textwrap import dedent as _dedent
 
 import pytest
@@ -20,3 +23,13 @@ def error(exception_class, message='', **kwargs):
         kwargs['match'] = f'^{re.escape(message)}$'
 
     return pytest.raises(exception_class, **kwargs)
+
+
+def changed_file_processes(files: list[str]):
+    # This returns subprocess calls used in `ddev.utils.git.GitManager.get_changed_files`
+    # for tests that have to mock subprocess calls
+    return [
+        CompletedProcess([], 0, stdout='\n'.join(f'M {f}' for f in files)),
+        CompletedProcess([], 0, stdout=''),
+        CompletedProcess([], 0, stdout=''),
+    ]

--- a/docs/developer/testing.md
+++ b/docs/developer/testing.md
@@ -2,7 +2,7 @@
 
 -----
 
-The entrypoint for testing any integration is the command `ddev test`, which accepts an arbitrary number of integrations as arguments.
+The entrypoint for testing any integration is the command [`test`](ddev/cli.md#ddev-test).
 
 Under the hood, we use [hatch][hatch] for environment management and [pytest][pytest-github] as our test framework.
 
@@ -11,35 +11,37 @@ Under the hood, we use [hatch][hatch] for environment management and [pytest][py
 Use the `--list`/`-l` flag to see what environments are available, for example:
 
 ```
-$ ddev test postgres envoy -l
-postgres:
-    py27-10
-    py27-11
-    py27-93
-    py27-94
-    py27-95
-    py27-96
-    py38-10
-    py38-11
-    py38-93
-    py38-94
-    py38-95
-    py38-96
-    format_style
-    style
-envoy:
-    py27
-    py38
-    bench
-    format_style
-    style
+$ ddev test postgres -l
+                                      Standalone
+┏━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Name   ┃ Type    ┃ Features ┃ Dependencies    ┃ Environment variables   ┃ Scripts   ┃
+┡━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ lint   │ virtual │          │ black==22.12.0  │                         │ all       │
+│        │         │          │ pydantic==2.0.2 │                         │ fmt       │
+│        │         │          │ ruff==0.0.257   │                         │ style     │
+├────────┼─────────┼──────────┼─────────────────┼─────────────────────────┼───────────┤
+│ latest │ virtual │ deps     │                 │ POSTGRES_VERSION=latest │ benchmark │
+│        │         │          │                 │                         │ test      │
+│        │         │          │                 │                         │ test-cov  │
+└────────┴─────────┴──────────┴─────────────────┴─────────────────────────┴───────────┘
+                        Matrices
+┏━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Name    ┃ Type    ┃ Envs       ┃ Features ┃ Scripts   ┃
+┡━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━┩
+│ default │ virtual │ py3.9-9.6  │ deps     │ benchmark │
+│         │         │ py3.9-10.0 │          │ test      │
+│         │         │ py3.9-11.0 │          │ test-cov  │
+│         │         │ py3.9-12.1 │          │           │
+│         │         │ py3.9-13.0 │          │           │
+│         │         │ py3.9-14.0 │          │           │
+└─────────┴─────────┴────────────┴──────────┴───────────┘
 ```
 
-You'll notice that all environments for running tests are prefixed with `pyXY`, indicating the Python version to use.
+You'll notice that all environments for running tests are prefixed with `pyX.Y`, indicating the Python version to use.
 If you don't have a particular version installed (for example Python 2.7), such environments will be skipped.
 
-The second part of a test environment's name corresponds to the version of the product. For example, the `11` in `py38-11`
-implies tests will run against version 11.x of PostgreSQL.
+The second part of a test environment's name corresponds to the version of the product. For example, the `14.0` in `py3.9-14.0`
+implies tests will run against version 14.x of PostgreSQL.
 
 If there is no version suffix, it means that either:
 
@@ -50,18 +52,16 @@ If there is no version suffix, it means that either:
 
 ### Explicit
 
-Passing just the integration name will run every test environment e.g. executing `ddev test envoy`
-will run the environments `py27`, `py38`, and `style`.
-
-You may select a subset of environments to run by appending a `:` followed by a comma-separated list of environments.
+Passing just the integration name will run every test environment. You may select a subset of environments
+to run by appending a `:` followed by a comma-separated list of environments.
 
 For example, executing:
 
 ```
-ddev test postgres:py38-11,style envoy:py38
+ddev test postgres:py3.9-13.0,py3.9-11.0
 ```
 
-will run, in order, the environments `py38-11` and `style` for the PostgreSQL check and the environment `py38` for the Envoy check.
+will run tests for the environment `py3.9-13.0` followed by the environment `py3.9-11.0`.
 
 ### Detection
 
@@ -81,31 +81,7 @@ of integrations' tests.
 ```
 $ ddev test tls -c
 ...
----------- Coverage report ----------
-
-Name                              Stmts   Miss Branch BrPart  Cover
--------------------------------------------------------------------
-datadog_checks\tls\__about__.py       1      0      0      0   100%
-datadog_checks\tls\__init__.py        3      0      0      0   100%
-datadog_checks\tls\tls.py           185      4     50      2    97%
-datadog_checks\tls\utils.py          43      0     16      0   100%
-tests\__init__.py                     0      0      0      0   100%
-tests\conftest.py                   105      0      0      0   100%
-tests\test_config.py                 47      0      0      0   100%
-tests\test_local.py                 113      0      0      0   100%
-tests\test_remote.py                189      0      2      0   100%
-tests\test_utils.py                  15      0      0      0   100%
-tests\utils.py                       36      0      2      0   100%
--------------------------------------------------------------------
-TOTAL                               737      4     70      2    99%
-```
-
-To also show any line numbers that were not hit, use the `--cov-missing`/`-cm` flag instead.
-
-```
-$ ddev test tls -cm
-...
----------- Coverage report ----------
+─────────────────────────────── Coverage report ────────────────────────────────
 
 Name                              Stmts   Miss Branch BrPart  Cover   Missing
 -----------------------------------------------------------------------------
@@ -124,23 +100,18 @@ tests\utils.py                       36      0      2      0   100%
 TOTAL                               737      4     70      2    99%
 ```
 
-## Style
+## Linting
 
-To run only the style checking environments, use the `--style`/`-s` shortcut flag.
+To run only the lint checks, use the `--lint`/`-s` shortcut flag.
 
-You may also only run the formatter environment using the `--format-style`/`-fs` shortcut flag. The formatter will
-automatically resolve the most common errors caught by the style checker.
+You may also only run the formatter using the `--fmt`/`-fs` shortcut flag. The formatter will
+automatically resolve the most common errors caught by the lint checks.
 
-## Advanced
+## Argument forwarding
 
-There are a number of shortcut options available that correspond to [pytest options][pytest-usage].
+You may pass arbitrary [arguments](https://docs.pytest.org/en/stable/reference/reference.html#command-line-flags)
+directly to `pytest`, for example:
 
-- `--marker`/`-m` (`pytest`: `-m`) - Only run tests matching a given marker expression e.g. `ddev test elastic:py38-7.2 -m unit`.
-- `--filter`/`-k` (`pytest`: `-k`) - Only run tests matching a given substring expression e.g.`ddev test redisdb -k replication`.
-- `--debug`/`-d` (`pytest`: `--log-level=debug -s`) - Set the log level to debug and stop pytest from capturing stdout.
-- `--pdb` (`pytest`: `--pdb -x`) - Drop to PDB on first failure, then end test session.
-- `--verbose`/`-v` (`pytest`: `-v --tb=auto`) - Increase verbosity (can be used additively) and disables shortened tracebacks.
-- `--ddtrace` (`pytest`: `--ddtrace`) - Submit test traces to a local Datadog Agent using the [`ddtrace`][pytest-ddtrace] Python package. For example:`ddev test --ddtrace consul`. This does not work if you are testing a Python 2 Windows environment.
-
-You may also pass arguments directly to `pytest` using the `--pytest-args`/`-pa` option. For example, you could
-re-write `-d` as `-pa "--log-level=debug -s"`.
+```
+ddev test postgres -- -m unit --pdb -x
+```


### PR DESCRIPTION
### What does this PR do?

This moves the test command to ddev

### Additional Notes

- The command now accepts the name of a single target to test rather than an arbitrary number (not providing this will still test everything that has changed). All arguments after this are passed to the underlying command(s) which is usually just `pytest`, thus removing the need for the `--pytest-args`, `--marker`, `--filter`, `--pdb` and `--debug` options. You may now pass arguments like this:

    ```
    ddev test [TARGET] -- -m unit
    ```

    A benefit of this is that we no longer pass arguments using environment variables and so the full command will be displayed which will ease debugging:

    ```
    cmd [1] | pytest -vv --benchmark-skip --tb short -m unit
    ```

    Since the first argument is the optional name of a target, passing arguments to the underlying commands for everything that has changed requires explicitly setting the target to `changed` like this:

    ```
    ddev test changed -- -m unit
    ```
- The lint checks now do not run as part of the standard test invocation and must be run separately. In CI this is now the first thing that happens to avoid passing tests for a rather large suite and then failing at the end.
- The `--style` flag has been renamed to `--lint` (short flag is still `-s`)
- The `--format-style` flag has been renamed to `--fmt` (short flag is still `-fs`)
- The `--force-env-rebuild`/`-fr` flag has been renamed to `--recreate`/`-r`
- The `--force-base-min` flag has been renamed to `--compat`
- The `--cov-missing` and `--cov-keep` flags have been removed and coverage reports now always show missing line numbers
- The `--passenv` flag has been removed since our new environment manager Hatch passes all environment variables by default
- The `--changed` flag has been removed now that every target runs in its own job since the CI switch to GitHub Actions
- The `--skip-env` flag has been removed to avoid duplicate functionality already made possible by E2E commands
- The `--force-base-unpinned` flag has been removed since it was not used by anything and also it does not have the effect (due to caching) of the original intention which is to test the very latest version
- Flags that are not meaningful to end-users are now hidden such as `--e2e` and `--junit`
- The default verbosity of `pytest` has been changed from `-v` to `-vv`
- We now use Hatch's environment filtering capability to avoid the need to inspect environment config for benchmarks are testing the latest version of products which avoids a subprocess call

### E2E

The E2E commands still use the old test command internally so nothing is changed there and those commands will be migrated next