### PR TITLE
Set lower connection timeout on connection pool, to avoid long running checks

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Set lower connection timeout on connection pool, to avoid long running checks ([#15768](https://github.com/DataDog/integrations-core/pull/15768))
+
 ## 14.2.2 / 2023-09-05
 
 ***Fixed***:

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -125,6 +125,13 @@ files:
       value:
         type: integer
         example: 5000
+    - name: connection_timeout
+      description: |
+        Sets the timeout (in ms) that the agent will wait to receive a connection from the database.
+      hidden: true
+      value:
+        type: integer
+        example: 5000
     - name: idle_connection_timeout
       description: |
         Sets the timeout (in ms) a connection used in the connection pool will be idle until it is closed by the pooler.

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -58,6 +58,9 @@ class PostgresConfig:
                 '"dbname" parameter must be set OR autodiscovery must be enabled when using the "relations" parameter.'
             )
         self.max_connections = instance.get('max_connections', 30)
+        connection_timeout_ms = instance.get('connection_timeout', 5000)
+        # Convert milliseconds to seconds and ensure a minimum of 2 seconds, which is enforced by psycopg
+        self.connection_timeout = max(2, connection_timeout_ms / 1000)
         self.tags = self._build_tags(instance.get('tags', []))
 
         ssl = instance.get('ssl', "disable")

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -44,6 +44,10 @@ def instance_collect_wal_metrics():
     return False
 
 
+def instance_connection_timeout():
+    return 5000
+
+
 def instance_data_directory():
     return '/usr/local/pgsql/data'
 

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -177,6 +177,7 @@ class InstanceConfig(BaseModel):
     collect_schemas: Optional[CollectSchemas] = None
     collect_settings: Optional[CollectSettings] = None
     collect_wal_metrics: Optional[bool] = None
+    connection_timeout: Optional[int] = None
     custom_queries: Optional[tuple[MappingProxyType[str, Any], ...]] = None
     data_directory: Optional[str] = None
     database_autodiscovery: Optional[DatabaseAutodiscovery] = None

--- a/postgres/datadog_checks/postgres/connections.py
+++ b/postgres/datadog_checks/postgres/connections.py
@@ -144,7 +144,7 @@ class MultiDatabaseConnectionPool(object):
         """
         with self._mu:
             pool = self._get_connection_pool(dbname=dbname, ttl_ms=ttl_ms, timeout=timeout, persistent=persistent)
-            db = pool.getconn(timeout=timeout)
+            db = pool.getconn()
         try:
             yield db
         finally:

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -651,6 +651,7 @@ class PostgreSql(AgentCheck):
                 kwargs=args,
                 open=True,
                 name=dbname,
+                timeout=self._config.connection_timeout,
             )
         else:
             password = self._config.password
@@ -688,7 +689,14 @@ class PostgreSql(AgentCheck):
             if self._config.ssl_password:
                 conn_args['sslpassword'] = self._config.ssl_password
             args.update(conn_args)
-            pool = ConnectionPool(min_size=min_pool_size, max_size=max_pool_size, kwargs=args, open=True, name=dbname)
+            pool = ConnectionPool(
+                min_size=min_pool_size,
+                max_size=max_pool_size,
+                kwargs=args,
+                open=True,
+                name=dbname,
+                timeout=self._config.connection_timeout,
+            )
         return pool
 
     def _connect(self):

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -318,7 +318,14 @@ def local_pool(dbname, min_pool_size, max_pool_size):
         'password': PASSWORD_ADMIN,
         'dbname': dbname,
     }
-    return ConnectionPool(min_size=min_pool_size, max_size=max_pool_size, kwargs=args, open=True, name=dbname)
+    return ConnectionPool(
+        min_size=min_pool_size,
+        max_size=max_pool_size,
+        kwargs=args,
+        open=True,
+        name=dbname,
+        timeout=2,
+    )
 
 
 def get_activity(db_pool, unique_id):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This updates the default `timeout` parameter used when grabbing a connection from the [psycopg_pool](https://www.psycopg.org/psycopg3/docs/api/pool.html), which was previously 30 seconds. When databases are misconfigured, this timeout will be hit & can cause issues for the CLC, which is running more checks than just postgres. 

For example, a `PoolTimeout` exception was hit on initialization for this misconfigured databas:
```
Error running check: [{"message": "couldn't get a connection after 30.0 sec", "traceback": "Traceback (most recent call last):
  File \"/opt/datadog-agent/embedded/lib/python3.9/site-packages/datadog_checks/base/checks/base.py\", line 1210, in run
    initialization()
  File \"/opt/datadog-agent/embedded/lib/python3.9/site-packages/datadog_checks/postgres/postgres.py\", line 350, in load_version
    raw_version = self._version_utils.get_raw_version(self.db)
  File \"/opt/datadog-agent/embedded/lib/python3.9/site-packages/datadog_checks/postgres/version_utils.py\", line 29, in get_raw_version
    with db.connection() as conn:
  File \"/opt/datadog-agent/embedded/lib/python3.9/contextlib.py\", line 119, in __enter__
    return next(self.gen)
  File \"/opt/datadog-agent/embedded/lib/python3.9/site-packages/psycopg_pool/pool.py\", line 138, in connection
    conn = self.getconn(timeout=timeout)
  File \"/opt/datadog-agent/embedded/lib/python3.9/site-packages/psycopg_pool/pool.py\", line 182, in getconn
    conn = pos.wait(timeout=timeout)
  File \"/opt/datadog-agent/embedded/lib/python3.9/site-packages/psycopg_pool/pool.py\", line 745, in wait
    raise self.error
psycopg_pool.PoolTimeout: couldn't get a connection after 30.0 sec
```

... which caused the CLC total check run time to jump to 30 seconds for the postgres check 

![Screen Shot 2023-09-06 at 9 33 33 AM](https://github.com/DataDog/integrations-core/assets/14317240/f2425f69-f8d2-4a87-9890-1c47c70276f9)

In order to prevent the check from taking too long on timeouts, we can lower the default `timeout` setting to something more reasonable like 5 seconds. This also will allow customers to configure it themselves. 
