### PR TITLE
[Release] Bumped postgres version to 14.2.3 (#15771)

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+## 14.2.3 / 2023-09-06
+
 ***Fixed***:
 
-* Set lower connection timeout on connection pool, to avoid long running checks ([#15768](https://github.com/DataDog/integrations-core/pull/15768))
+* Set lower connection timeout on connection pool to avoid long running checks ([#15768](https://github.com/DataDog/integrations-core/pull/15768))
 
 ## 14.2.2 / 2023-09-05
 

--- a/postgres/datadog_checks/postgres/__about__.py
+++ b/postgres/datadog_checks/postgres/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "14.2.2"
+__version__ = "14.2.3"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -118,7 +118,7 @@ datadog-pdh-check==2.0.0; sys_platform == 'win32'
 datadog-pgbouncer==5.0.0; sys_platform != 'win32'
 datadog-php-fpm==3.0.0
 datadog-postfix==1.13.1; sys_platform != 'win32'
-datadog-postgres==14.2.2
+datadog-postgres==14.2.3
 datadog-powerdns-recursor==2.3.1
 datadog-presto==2.7.1
 datadog-process==3.0.0


### PR DESCRIPTION
### What does this PR do?
Port postgres 14.2.3 [release](https://github.com/DataDog/integrations-core/pull/15771) changes from 7.48 to master

### Motivation
https://github.com/DataDog/integrations-core/pull/15768

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
