### PR TITLE
Initialize pg_settings on postgres check start and lazy load pg_settings if not set

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ***Fixed***:
 
+* Default `pg_stat_statements.max to 5000` if not set in pg_settings ([#15773](https://github.com/DataDog/integrations-core/pull/15773))
 * Set lower connection timeout on connection pool to avoid long running checks ([#15768](https://github.com/DataDog/integrations-core/pull/15768))
 
 ## 14.2.2 / 2023-09-05

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ***Fixed***:
 
-* Default `pg_stat_statements.max to 5000` if not set in pg_settings ([#15773](https://github.com/DataDog/integrations-core/pull/15773))
+* Initialize pg_settings on postgres check start and lazy load pg_settings if it's not set ([#15773](https://github.com/DataDog/integrations-core/pull/15773))
 * Set lower connection timeout on connection pool to avoid long running checks ([#15768](https://github.com/DataDog/integrations-core/pull/15768))
 
 ## 14.2.2 / 2023-09-05

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ***Fixed***:
 
-* Initialize pg_settings on postgres check start and lazy load pg_settings if it's not set ([#15773](https://github.com/DataDog/integrations-core/pull/15773))
+* Initialize pg_settings on Postgres check start and lazy load pg_settings if it's not set ([#15773](https://github.com/DataDog/integrations-core/pull/15773))
 * Set lower connection timeout on connection pool to avoid long running checks ([#15768](https://github.com/DataDog/integrations-core/pull/15768))
 
 ## 14.2.2 / 2023-09-05

--- a/postgres/datadog_checks/postgres/connections.py
+++ b/postgres/datadog_checks/postgres/connections.py
@@ -228,7 +228,6 @@ class MultiDatabaseConnectionPool(object):
             dbname=self._config.dbname,
             ttl_ms=self._config.idle_connection_timeout,
             max_pool_size=max_pool_conn_size,
-            startup_fn=self._check.load_pg_settings,
             persistent=True,
         )
         return conn

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -749,6 +749,9 @@ class PostgreSql(AgentCheck):
             )
 
     def get_pg_settings(self):
+        if not bool(self.pg_settings):
+            # reload pg_settings if it's empty
+            self.load_pg_settings(self.db)
         return self.pg_settings
 
     def _close_db_pool(self):

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -114,6 +114,7 @@ class PostgreSql(AgentCheck):
         self.check_initializations.append(self.set_resolved_hostname_metadata)
         self.check_initializations.append(self._connect)
         self.check_initializations.append(self.load_version)
+        self.check_initializations.append(self.load_pg_settings)
         self.check_initializations.append(self.initialize_is_aurora)
         self.tags_without_db = [t for t in copy.copy(self.tags) if not t.startswith("db:")]
         self.autodiscovery = self._build_autodiscovery()
@@ -724,9 +725,9 @@ class PostgreSql(AgentCheck):
             self.db = self._new_connection(self._config.dbname, max_pool_size=1)
 
     # Reload pg_settings on a new connection to the main db
-    def load_pg_settings(self, db):
+    def load_pg_settings(self):
         try:
-            with db.connection() as conn:
+            with self.db.connection() as conn:
                 with conn.cursor(row_factory=dict_row) as cursor:
                     self.log.debug("Running query [%s]", PG_SETTINGS_QUERY)
                     cursor.execute(
@@ -751,7 +752,7 @@ class PostgreSql(AgentCheck):
     def get_pg_settings(self):
         if not bool(self.pg_settings):
             # reload pg_settings if it's empty
-            self.load_pg_settings(self.db)
+            self.load_pg_settings()
         return self.pg_settings
 
     def _close_db_pool(self):

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -852,7 +852,9 @@ class PostgresStatementSamples(DBMAsyncJob):
         return True
 
     def _get_track_activity_query_size(self):
-        return int(self._check.get_pg_settings().get("track_activity_query_size", TRACK_ACTIVITY_QUERY_SIZE_UNKNOWN_VALUE))
+        return int(
+            self._check.get_pg_settings().get("track_activity_query_size", TRACK_ACTIVITY_QUERY_SIZE_UNKNOWN_VALUE)
+        )
 
     @staticmethod
     def _get_truncation_state(track_activity_query_size, statement):

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -852,7 +852,7 @@ class PostgresStatementSamples(DBMAsyncJob):
         return True
 
     def _get_track_activity_query_size(self):
-        return int(self._check.pg_settings.get("track_activity_query_size", TRACK_ACTIVITY_QUERY_SIZE_UNKNOWN_VALUE))
+        return int(self._check.get_pg_settings().get("track_activity_query_size", TRACK_ACTIVITY_QUERY_SIZE_UNKNOWN_VALUE))
 
     @staticmethod
     def _get_truncation_state(track_activity_query_size, statement):

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -43,7 +43,7 @@ SELECT {cols}
 PG_STAT_STATEMENTS_COUNT_QUERY = "SELECT COUNT(*) FROM pg_stat_statements(false)"
 PG_STAT_STATEMENTS_COUNT_QUERY_LT_9_4 = "SELECT COUNT(*) FROM pg_stat_statements"
 PG_STAT_STATEMENTS_DEALLOC = "SELECT dealloc FROM pg_stat_statements_info"
-
+DEFAULT_PG_STAT_STATEMENTS = 5000
 
 # Required columns for the check to run
 PG_STAT_STATEMENTS_REQUIRED_COLUMNS = frozenset({'calls', 'query', 'rows'})
@@ -241,7 +241,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             if self._check.get_pg_settings().get("track_io_timing") != "on":
                 desired_columns -= PG_STAT_STATEMENTS_TIMING_COLUMNS
 
-            pg_stat_statements_max = int(self._check.pg_settings.get("pg_stat_statements.max", 5000))
+            pg_stat_statements_max = int(self._check.get_pg_settings().get("pg_stat_statements.max", DEFAULT_PG_STAT_STATEMENTS))
             if pg_stat_statements_max > self._pg_stat_statements_max_warning_threshold:
                 self._check.record_warning(
                     DatabaseConfigurationError.high_pg_stat_statements_max,
@@ -384,7 +384,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 count = rows[0]['count']
             self._check.gauge(
                 "postgresql.pg_stat_statements.max",
-                self._check.pg_settings.get("pg_stat_statements.max", 5000),
+                self._check.get_pg_settings().get("pg_stat_statements.max", DEFAULT_PG_STAT_STATEMENTS),
                 tags=self.tags,
                 hostname=self._check.resolved_hostname,
             )

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -241,7 +241,9 @@ class PostgresStatementMetrics(DBMAsyncJob):
             if self._check.get_pg_settings().get("track_io_timing") != "on":
                 desired_columns -= PG_STAT_STATEMENTS_TIMING_COLUMNS
 
-            pg_stat_statements_max = int(self._check.get_pg_settings().get("pg_stat_statements.max", DEFAULT_PG_STAT_STATEMENTS))
+            pg_stat_statements_max = int(
+                self._check.get_pg_settings().get("pg_stat_statements.max", DEFAULT_PG_STAT_STATEMENTS)
+            )
             if pg_stat_statements_max > self._pg_stat_statements_max_warning_threshold:
                 self._check.record_warning(
                     DatabaseConfigurationError.high_pg_stat_statements_max,

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -241,7 +241,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
             if self._check.get_pg_settings().get("track_io_timing") != "on":
                 desired_columns -= PG_STAT_STATEMENTS_TIMING_COLUMNS
 
-            pg_stat_statements_max = int(self._check.pg_settings.get("pg_stat_statements.max"))
+            pg_stat_statements_max = int(self._check.pg_settings.get("pg_stat_statements.max", 5000))
             if pg_stat_statements_max > self._pg_stat_statements_max_warning_threshold:
                 self._check.record_warning(
                     DatabaseConfigurationError.high_pg_stat_statements_max,
@@ -384,7 +384,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 count = rows[0]['count']
             self._check.gauge(
                 "postgresql.pg_stat_statements.max",
-                self._check.pg_settings.get("pg_stat_statements.max", 0),
+                self._check.pg_settings.get("pg_stat_statements.max", 5000),
                 tags=self.tags,
                 hostname=self._check.resolved_hostname,
             )

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1377,7 +1377,7 @@ def test_load_pg_settings(aggregator, integration_check, dbm_instance, db_user):
     dbm_instance["dbname"] = "postgres"
     check = integration_check(dbm_instance)
     check._connect()
-    check.load_pg_settings(check.db)
+    check.load_pg_settings()
     if db_user == 'datadog_no_catalog':
         aggregator.assert_metric(
             "dd.postgres.error",
@@ -1400,9 +1400,14 @@ def test_pg_settings_caching(integration_check, dbm_instance):
     assert not check.pg_settings, "pg_settings should not have been initialized yet"
     check._connect()
     check.db_pool.get_main_db_pool()
+    # pg_settings is not loaded on connect
+    assert not check.pg_settings, "pg_settings should not have been initialized yet"
+    # pg_settings should now be lazy loaded
+    check.get_pg_settings()
+    assert check.pg_settings, "pg_settings should have been initialized"
     assert "track_activity_query_size" in check.pg_settings
     check.pg_settings["test_key"] = True
-    check.db_pool.get_main_db_pool()
+    check.get_pg_settings()
     assert (
         "test_key" in check.pg_settings
     ), "key should not have been blown away. If it was then pg_settings was not cached correctly"

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1869,20 +1869,21 @@ def test_pg_stat_statements_dealloc(aggregator, integration_check, dbm_instance_
         aggregator.assert_metric("postgresql.pg_stat_statements.dealloc", value=1, tags=expected_tags)
     aggregator.assert_metric("postgresql.pg_stat_statements.count", tags=expected_tags)
 
+
 def test_statement_metrics_pg_settings_not_loaded(integration_check, dbm_instance):
     # don't need samples for this test
     dbm_instance['query_samples']['enabled'] = False
     dbm_instance['query_activity']['enabled'] = False
 
     with mock.patch(
-            'datadog_checks.postgres.PostgreSql.load_pg_settings',
-            return_value={},
-        ):
-            check = integration_check(dbm_instance)
-            check._connect()
-            run_one_check(check, dbm_instance)
-            assert check.pg_settings == {}
-    
+        'datadog_checks.postgres.PostgreSql.load_pg_settings',
+        return_value={},
+    ):
+        check = integration_check(dbm_instance)
+        check._connect()
+        run_one_check(check, dbm_instance)
+        assert check.pg_settings == {}
+
     assert check.pg_settings == {}
     assert check.get_pg_settings() != {}
     assert 'pg_stat_statements.max' in check.pg_settings

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -1868,3 +1868,23 @@ def test_pg_stat_statements_dealloc(aggregator, integration_check, dbm_instance_
     if float(POSTGRES_VERSION) >= 14.0:
         aggregator.assert_metric("postgresql.pg_stat_statements.dealloc", value=1, tags=expected_tags)
     aggregator.assert_metric("postgresql.pg_stat_statements.count", tags=expected_tags)
+
+def test_statement_metrics_pg_settings_not_loaded(integration_check, dbm_instance):
+    # don't need samples for this test
+    dbm_instance['query_samples']['enabled'] = False
+    dbm_instance['query_activity']['enabled'] = False
+
+    with mock.patch(
+            'datadog_checks.postgres.PostgreSql.load_pg_settings',
+            return_value={},
+        ):
+            check = integration_check(dbm_instance)
+            check._connect()
+            run_one_check(check, dbm_instance)
+            assert check.pg_settings == {}
+    
+    assert check.pg_settings == {}
+    assert check.get_pg_settings() != {}
+    assert 'pg_stat_statements.max' in check.pg_settings
+    assert 'track_activity_query_size' in check.pg_settings
+    assert 'track_io_timing' in check.pg_settings


### PR DESCRIPTION
### What does this PR do?
This PR initialize `pg_settings` on Postgres check starts. When retrieving `pg_settings`, it will lazy load from database if it's not set. As part of the PR, we also default `pg_stat_statements.max` to `5000` if it's not been explicitly set. `5000` is the [default](https://www.postgresql.org/docs/current/pgstatstatements.html)) `pg_stat_statements.max` from Postgres.

### Motivation
Fixes uncaught exception
```
Unable to collect statement metrics due to an error
Traceback (most recent call last):
  File "/usr/src/dbm-integrations-core/postgres/datadog_checks/postgres/statements.py", line 193, in collect_per_statement_metrics
    rows = self._collect_metrics_rows()
  File "/usr/src/dbm-integrations-core/datadog_checks_base/datadog_checks/base/utils/tracking.py", line 71, in wrapper
    result = function(self, *args, **kwargs)
  File "/usr/src/dbm-integrations-core/postgres/datadog_checks/postgres/statements.py", line 404, in _collect_metrics_rows
    rows = self._load_pg_stat_statements()
  File "/usr/src/dbm-integrations-core/datadog_checks_base/datadog_checks/base/utils/tracking.py", line 71, in wrapper
    result = function(self, *args, **kwargs)
  File "/usr/src/dbm-integrations-core/postgres/datadog_checks/postgres/statements.py", line 244, in _load_pg_stat_statements
    pg_stat_statements_max = int(self._check.pg_settings.get("pg_stat_statements.max"))
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

**This exception only happens when autodiscovery is enabled BUT it causes the query metrics collection to completely break. The urgency to fix the bug ensures query metrics collection runs properly.**

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
