### PR TITLE
Stop using the old GPG_COMMAND constant from securesystemslib

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Allow bumping the version of lz4 ([#15747](https://github.com/DataDog/integrations-core/pull/15747))
 * Remove flup from the dependency bump exclusion list ([#15748](https://github.com/DataDog/integrations-core/pull/15748))
 * Remove setuptools from the build-system for new integrations ([#15766](https://github.com/DataDog/integrations-core/pull/15766))
+* Stop using the old GPG_COMMAND constant from securesystemslib ([#15776](https://github.com/DataDog/integrations-core/pull/15776))
 
 ## 24.1.0 / 2023-08-25
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/signing.py
@@ -10,7 +10,7 @@ import shutil
 import securesystemslib.settings
 securesystemslib.settings.SUBPROCESS_TIMEOUT = 60
 
-from securesystemslib.gpg.constants import GPG_COMMAND
+from securesystemslib.gpg.constants import gpg_command
 
 from in_toto import runlib
 from securesystemslib.interface import import_rsa_privatekey_from_file
@@ -110,7 +110,7 @@ def update_link_metadata(checks, core_workflow=True):
             products.append(dep_file)
 
     if core_workflow:
-        key_id = get_key_id(GPG_COMMAND)
+        key_id = get_key_id(gpg_command())
 
         # Find this latest signed link metadata file on disk.
         # NOTE: in-toto currently uses the first 8 characters of the signing keyId.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Stop using the old GPG_COMMAND constant from securesystemslib

### Motivation
<!-- What inspired you to submit this pull request? -->

They created a new `gpg_command` function instead [here](https://github.com/secure-systems-lab/securesystemslib/commit/56697adf9803a7bcecadc737d8b160a9ab22392e) and dropped the constant after.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

We should have caught that with the tests. We will add more when moving this command to ddev

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
