### PR TITLE
Override the default test options for some integrations

### DIFF
--- a/.github/workflows/pr-all.yml
+++ b/.github/workflows/pr-all.yml
@@ -7,6 +7,7 @@ on:
     paths:
     - datadog_checks_base/datadog_checks/**
     - datadog_checks_dev/datadog_checks/dev/*.py
+    - ddev/src/**
     - "!datadog_checks_base/datadog_checks/base/data/agent_requirements.in"
 
 concurrency:

--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Remove flup from the dependency bump exclusion list ([#15748](https://github.com/DataDog/integrations-core/pull/15748))
 * Remove setuptools from the build-system for new integrations ([#15766](https://github.com/DataDog/integrations-core/pull/15766))
 * Stop using the old GPG_COMMAND constant from securesystemslib ([#15776](https://github.com/DataDog/integrations-core/pull/15776))
+* Override the default test options for some integrations ([#15779](https://github.com/DataDog/integrations-core/pull/15779))
 
 ## 24.1.0 / 2023-08-25
 

--- a/datadog_checks_dev/hatch.toml
+++ b/datadog_checks_dev/hatch.toml
@@ -21,9 +21,6 @@ python = ["2.7", "3.9"]
 matrix.python.features = [
   { value = "cli", if = ["3.9"] },
 ]
-matrix.python.scripts = [
-  { key = "test", value = "_dd-test --ignore tests/tooling", if = ["2.7"] },
-]
 # TODO: remove this when the old CLI is gone
 matrix.python.pre-install-commands = [
   { value = "python -m pip install --no-deps --disable-pip-version-check {verbosity:flag:-1} -e ../ddev", if = ["3.9"] },

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -118,3 +118,6 @@ include = [
 dev-mode-dirs = [
     ".",
 ]
+
+[tool.pytest.ini_options]
+testpaths = "tests"

--- a/datadog_checks_dev/setup.cfg
+++ b/datadog_checks_dev/setup.cfg
@@ -1,0 +1,6 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+[tool:pytest]
+addopts = "--ignore=tests/tooling"
+testpaths = tests

--- a/datadog_checks_downloader/CHANGELOG.md
+++ b/datadog_checks_downloader/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Override the default test options for some integrations ([#15779](https://github.com/DataDog/integrations-core/pull/15779))
+
 ## 4.3.0 / 2023-08-25
 
 ***Security***:

--- a/datadog_checks_downloader/hatch.toml
+++ b/datadog_checks_downloader/hatch.toml
@@ -3,11 +3,6 @@
 [[envs.default.matrix]]
 python = ["3.9"]
 
-[envs.default.overrides]
-matrix.python.scripts = [
-  { key = "test", value = "_dd-test --capture=no --log-cli-level=debug" },
-]
-
 [envs.default]
 e2e-env = false
 dependencies = [

--- a/datadog_checks_downloader/pyproject.toml
+++ b/datadog_checks_downloader/pyproject.toml
@@ -61,3 +61,6 @@ include = [
 dev-mode-dirs = [
     ".",
 ]
+
+[tool.pytest.ini_options]
+addopts = "--capture=no --log-cli-level=debug"

--- a/teamcity/CHANGELOG.md
+++ b/teamcity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Override the default test options for some integrations ([#15779](https://github.com/DataDog/integrations-core/pull/15779))
+
 ## 4.0.0 / 2023-08-10
 
 ***Changed***:

--- a/teamcity/hatch.toml
+++ b/teamcity/hatch.toml
@@ -12,9 +12,6 @@ impl = ["legacy", "openmetrics"]
 matrix.impl.env-vars = [
   { key = "USE_OPENMETRICS", value = "true", if = ["openmetrics"] },
 ]
-matrix.python.scripts = [
-  { key = "test", value = "_dd-test --ignore=tests/docker" },
-]
 
 [envs.default.env-vars]
 DDEV_SKIP_GENERIC_TAGS_CHECK = "true"

--- a/teamcity/pyproject.toml
+++ b/teamcity/pyproject.toml
@@ -60,3 +60,6 @@ include = [
 dev-mode-dirs = [
     ".",
 ]
+
+[tool.pytest.ini_options]
+addopts = "--ignore=tests/docker"

--- a/teamcity/setup.cfg
+++ b/teamcity/setup.cfg
@@ -1,0 +1,5 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+[tool:pytest]
+addopts = "--ignore=tests/docker"

--- a/win32_event_log/hatch.toml
+++ b/win32_event_log/hatch.toml
@@ -8,8 +8,3 @@ e2e-env = false
 platforms = [
   "windows",
 ]
-
-[envs.default.overrides]
-matrix.python.scripts = [
-  { key = "test", value = "pytest -v --benchmark-skip tests/legacy", if = ["2.7"] },
-]

--- a/win32_event_log/setup.cfg
+++ b/win32_event_log/setup.cfg
@@ -1,0 +1,5 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+[tool:pytest]
+testpaths = "tests/legacy"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix stuff coming from https://github.com/DataDog/integrations-core/pull/15762

- Add more pytest options to some integrations that require it
- Run all tests when ddev is modified
- Move most of the command overrides to either `pyproject.toml` (for python3) or `setup.cfg` (for py2)

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/actions/runs/6105895055/job/16570096990

When we add parameters after 

https://github.com/DataDog/integrations-core/blob/c758504930a54f90c4d35d2d4b5e6868415b6106/ddev/src/ddev/cli/test/__init__.py#L154

, they will be forward to 

https://github.com/DataDog/integrations-core/blob/master/ddev/src/ddev/plugin/external/hatch/environment_collector.py#L114-L119 as `args` and we loose the `tests` part of the command, which make us load everything. 

Trigger all the tests when ddev is modified, similar to what we do with `datadog_checks_dev`. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Adding a default `setup.cfg` file at the root does not work (I might have a look at that a bit later, my priority is to have our CI green)

I'll open follow-up PRs to configure this by default for most of the integrations.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
