### PR TITLE
Make sure repo override in envvar makes it into config

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add color output to tests in CI ([#15774](https://github.com/DataDog/integrations-core/pull/15774))
 
+***Fixed***:
+
+* Make sure repo override in envvar makes it into config ([#15782](https://github.com/DataDog/integrations-core/pull/15782))
+
 ## 5.0.0 / 2023-09-06
 
 ***Removed***:

--- a/ddev/src/ddev/cli/application.py
+++ b/ddev/src/ddev/cli/application.py
@@ -89,6 +89,8 @@ class Application(Terminal):
         self.__config['dd_app_key'] = self.config.orgs.get('default', {}).get('app_key', '')
         # Make sure that envvar overrides of repo make it into config.
         self.__config['repo'] = self.repo.name
+        # Transfer the -x/--here flag to the old CLI.
+        # In the new CLI that flag turns into a repo named "local" but the old CLI expects a bool kwarg "here".
         kwargs = {}
         if self.repo.name == 'local':
             kwargs['here'] = True

--- a/ddev/src/ddev/cli/application.py
+++ b/ddev/src/ddev/cli/application.py
@@ -87,8 +87,11 @@ class Application(Terminal):
         self.__config['color'] = not self.console.no_color
         self.__config['dd_api_key'] = self.config.orgs.get('default', {}).get('api_key', '')
         self.__config['dd_app_key'] = self.config.orgs.get('default', {}).get('app_key', '')
-
-        kwargs = {'here' if self.repo.name == 'local' else self.repo.name: True}
+        # Make sure that envvar overrides of repo make it into config.
+        self.__config['repo'] = self.repo.name
+        kwargs = {}
+        if self.repo.name == 'local':
+            kwargs['here'] = True
         initialize_root(self.__config, **kwargs)
 
     def copy(self):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

#### Before
setting `DDEV_REPO`  environment would not change which tests `ddev test` ran, it would always run the tests for the `core` repo.

#### After
`ddev test` respects fully `DDEV_REPO` envvar.

### Motivation
<!-- What inspired you to submit this pull request? -->
I work with [git worktrees](https://git-scm.com/docs/git-worktree), this helps me maintain multiple unfinished contexts in parallel. I don't want to run ddev tests with the `-x` flag all the time so I set the envvar for REPO to the worktree directory. Unfortunately `ddev test` would ignore this setting.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Any suggestions for **how exactly** to test this would be welcome.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
