### PR TITLE
Grant usage to default warehouse to the role DATADOG

### DIFF
--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -53,6 +53,9 @@ datadog-agent integration install datadog-snowflake==2.0.1
     -- Grant privileges on the SNOWFLAKE database to the new role.
     grant imported privileges on database SNOWFLAKE to role DATADOG;
 
+    -- Grant usage to your default warehouse to the role DATADOG.
+   grant usage to warehouse <WAREHOUSE> to role DATADOG;
+
     -- Create a user, skip this step if you are using an existing user.
     create user DATADOG_USER
     LOGIN_NAME = DATADOG_USER


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add instructions to grant usage to your default warehouse to the role DATADOG

### Motivation
<!-- What inspired you to submit this pull request? -->
[DOCS-6150](https://datadoghq.atlassian.net/browse/DOCS-6150)
- https://datadog.zendesk.com/agent/tickets/1326287
- https://datadog.zendesk.com/agent/tickets/548919
- https://datadog.zendesk.com/agent/tickets/477220

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[DOCS-6150]: https://datadoghq.atlassian.net/browse/DOCS-6150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ