### PR TITLE
[SQLServer] - Standardize on db tag for database name

### DIFF
--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -5,6 +5,7 @@
 ***Changed***:
 
 * Cache performance counter type to prevent querying for the same counter multiple times (especially for the per-db counters) ([#15714](https://github.com/DataDog/integrations-core/pull/15714))
+* Add the `db` tag to every metric also using `database` or `database_name` for consistency ([#15792](https://github.com/DataDog/integrations-core/pull/15792))
 
 ***Added***:
 

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -317,6 +317,7 @@ class SqlIoVirtualFileStat(BaseSqlServerMetric):
             self.pvs_vals[dbid, fid] = value
             metric_tags = [
                 'database:{}'.format(str(dbname).strip()),
+                'db:{}'.format(str(dbname).strip()),
                 'database_id:{}'.format(str(dbid).strip()),
                 'file_id:{}'.format(str(fid).strip()),
             ]
@@ -457,6 +458,7 @@ class SqlMasterDatabaseFileStats(BaseSqlServerMetric):
 
             metric_tags = [
                 'database:{}'.format(str(dbname)),
+                'db:{}'.format(str(dbname)),
                 'file_id:{}'.format(str(fileid)),
                 'file_type:{}'.format(str(filetype)),
                 'file_location:{}'.format(str(location)),
@@ -557,6 +559,7 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
 
             metric_tags = [
                 'database:{}'.format(str(self.instance)),
+                'db:{}'.format(str(self.instance)),
                 'file_id:{}'.format(str(fileid)),
                 'file_type:{}'.format(str(filetype)),
                 'file_location:{}'.format(str(location)),
@@ -593,6 +596,7 @@ class SqlDatabaseStats(BaseSqlServerMetric):
             db_recovery_model_desc = row[db_recovery_model_desc_index]
             metric_tags = [
                 'database:{}'.format(str(self.instance)),
+                'db:{}'.format(str(self.instance)),
                 'database_state_desc:{}'.format(str(db_state_desc)),
                 'database_recovery_model_desc:{}'.format(str(db_recovery_model_desc)),
             ]
@@ -633,6 +637,7 @@ class SqlDatabaseBackup(BaseSqlServerMetric):
             column_val = row[value_column_index]
             metric_tags = [
                 'database:{}'.format(str(self.instance)),
+                'db:{}'.format(str(self.instance)),
             ]
             metric_tags.extend(self.tags)
             metric_name = '{}'.format(self.datadog_name)
@@ -730,6 +735,7 @@ class SqlDbFragmentation(BaseSqlServerMetric):
 
             metric_tags = [
                 u'database_name:{}'.format(ensure_unicode(self.instance)),
+                u'db:{}'.format(ensure_unicode(self.instance)),
                 u'object_name:{}'.format(ensure_unicode(object_name)),
                 u'index_id:{}'.format(ensure_unicode(index_id)),
                 u'index_name:{}'.format(ensure_unicode(index_name)),
@@ -903,6 +909,7 @@ class SqlAvailabilityReplicas(BaseSqlServerMetric):
                 'availability_group:{}'.format(str(resource_group_id)),
                 'availability_group_name:{}'.format(str(resource_group_name)),
                 'failover_mode_desc:{}'.format(str(failover_mode_desc)),
+                'db:{}'.format(str(database_name)),
             ]
             if is_primary_replica_index is not None:
                 is_primary_replica = row[is_primary_replica_index]

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -161,6 +161,7 @@ def test_autodiscovery_database_metrics(aggregator, dd_run_check, instance_autod
 
     master_tags = [
         'database:master',
+        'db:master',
         'database_files_state_desc:ONLINE',
         'file_id:1',
         'file_location:/var/opt/mssql/data/master.mdf',
@@ -168,6 +169,7 @@ def test_autodiscovery_database_metrics(aggregator, dd_run_check, instance_autod
     ] + instance_tags
     msdb_tags = [
         'database:msdb',
+        'db:msdb',
         'database_files_state_desc:ONLINE',
         'file_id:1',
         'file_location:/var/opt/mssql/data/MSDBData.mdf',

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -356,6 +356,6 @@ def test_database_state(aggregator, dd_run_check, init_config, instance_docker):
         'database_recovery_model_desc:SIMPLE',
         'database_state_desc:ONLINE',
         'database:{}'.format(instance_docker['database']),
-        'db:{}'.format(instance_docker['database'])
+        'db:{}'.format(instance_docker['database']),
     ]
     aggregator.assert_metric('sqlserver.database.state', tags=expected_tags, hostname=sqlserver_check.resolved_hostname)

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -356,5 +356,6 @@ def test_database_state(aggregator, dd_run_check, init_config, instance_docker):
         'database_recovery_model_desc:SIMPLE',
         'database_state_desc:ONLINE',
         'database:{}'.format(instance_docker['database']),
+        'db:{}'.format(instance_docker['database'])
     ]
     aggregator.assert_metric('sqlserver.database.state', tags=expected_tags, hostname=sqlserver_check.resolved_hostname)


### PR DESCRIPTION
### What does this PR do?

- Adds the `db:` tag to every metric that bears another key for database name. i.e. `database_name` or `database` for consistency.

### Motivation

We would like to standardize on the `db` tag for logical database name.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
