### PR TITLE
Fix the `--compat` option of the `test` command

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Make sure repo override in envvar makes it into config ([#15782](https://github.com/DataDog/integrations-core/pull/15782))
 * Bump the `target-version` to python 3.9 for ruff and black ([#15824](https://github.com/DataDog/integrations-core/pull/15824))
 * Bump the `datadog-checks-dev` version to ~=25 ([#15823](https://github.com/DataDog/integrations-core/pull/15823))
+* Fix the `--compat` option of the `test` command ([#15815](https://github.com/DataDog/integrations-core/pull/15815))
 
 ## 5.0.0 / 2023-09-06
 

--- a/ddev/src/ddev/cli/test/__init__.py
+++ b/ddev/src/ddev/cli/test/__init__.py
@@ -105,6 +105,11 @@ def test(
 
     in_ci = running_in_ci()
 
+    # Also recreate the environment in the `compat` mode to make sure we are using the right base
+    # check version.
+    if compat:
+        recreate = True
+
     global_env_vars: dict[str, str] = {}
 
     hatch_verbosity = app.verbosity + 1
@@ -234,3 +239,8 @@ def test(
                     fix_coverage_report(target.path / 'coverage.xml')
                 else:
                     (target.path / '.coverage').remove()
+
+            if compat:
+                # We destroy the environment since we edited it
+                for env_name in chosen_environments:
+                    app.platform.check_command([sys.executable, '-m', 'hatch', 'env', 'remove', env_name])

--- a/ddev/tests/cli/test/test_test.py
+++ b/ddev/tests/cli/test/test_test.py
@@ -945,7 +945,15 @@ class TestPluginInteraction:
 
         assert run.call_args_list == [
             mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'remove', 'default'],
+                shell=False,
+            ),
+            mocker.call(
                 [sys.executable, '-m', 'hatch', 'env', 'run', '--ignore-compat', '--', 'test', '--tb', 'short'],
+                shell=False,
+            ),
+            mocker.call(
+                [sys.executable, '-m', 'hatch', 'env', 'remove', 'default'],
                 shell=False,
             ),
         ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix the `--compat` option of the `test` command.

Also allow you to run `ddev test http_check && ddev test --compat http_check && ddev test http_check` since now the `--compat` option will recreate the environment and remove it after running the tests, which was not possible without this fix.

### Motivation
<!-- What inspired you to submit this pull request? -->

It is failing here in some cases: https://github.com/DataDog/integrations-core/actions/runs/6155117614/job/16701562039#step:14:185 

Run `ddev test --compat http_check` if you want to double check the fix is working. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

The bug is coming from [here](https://github.com/DataDog/integrations-core/commit/8ca9fa2242010365f562c23ce9b8c4b4753454cb?diff=split#diff-ecde22fd90da0cd98a6fda7df0f5499102ca47c3724706d612b0cd1c2964513b)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
