### PR TITLE
Add SQL Server 2022 to test matrix

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -104,6 +104,8 @@ files:
         example:
           - model
           - msdb
+          - model_replicatedmaster
+          - model_msdb
     - name: database_autodiscovery_interval
       description: |
         Frequency in seconds of scans for new databases.  Defaults to `3600`.

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -105,6 +105,8 @@ instances:
     # autodiscovery_exclude:
     #   - model
     #   - msdb
+    #   - model_replicatedmaster
+    #   - model_msdb
 
     ## @param database_autodiscovery_interval - integer - optional - default: 3600
     ## Frequency in seconds of scans for new databases.  Defaults to `3600`.

--- a/sqlserver/datadog_checks/sqlserver/queries.py
+++ b/sqlserver/datadog_checks/sqlserver/queries.py
@@ -218,6 +218,10 @@ def get_query_file_stats(sqlserver_major_version, sqlserver_engine_edition):
         sql_columns.append("fs.{}".format(column))
         metric_columns.append(column_definitions[column])
 
+    query_filter = ""
+    if sqlserver_major_version == 2022:
+        query_filter = "WHERE DB_NAME(fs.database_id) not like 'model_%'"
+
     query = """
     SELECT
         DB_NAME(fs.database_id),
@@ -228,7 +232,7 @@ def get_query_file_stats(sqlserver_major_version, sqlserver_engine_edition):
     FROM sys.dm_io_virtual_file_stats(NULL, NULL) fs
         LEFT JOIN sys.master_files mf
             ON mf.database_id = fs.database_id
-            AND mf.file_id = fs.file_id;
+            AND mf.file_id = fs.file_id {filter};
     """
 
     if sqlserver_engine_edition == ENGINE_EDITION_SQL_DATABASE:
@@ -247,7 +251,7 @@ def get_query_file_stats(sqlserver_major_version, sqlserver_engine_edition):
 
     return {
         'name': 'sys.dm_io_virtual_file_stats',
-        'query': query.strip().format(sql_columns=", ".join(sql_columns)),
+        'query': query.strip().format(sql_columns=", ".join(sql_columns), filter=query_filter),
         'columns': [
             {'name': 'db', 'type': 'tag'},
             {'name': 'state', 'type': 'tag'},

--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -60,4 +60,5 @@ matrix.driver.env-vars = [
   { key = "WINDOWS_SQLSERVER_DRIVER", platform = ["windows"] },
 ]
 name.linux-odbc-2019-high-cardinality.env-vars = "COMPOSE_FOLDER=compose-high-cardinality"
+name.linux-odbc-2022-high-cardinality.env-vars = "COMPOSE_FOLDER=compose-high-cardinality"
 name.windows-odbc-2019-high-cardinality.env-vars = "COMPOSE_FOLDER=compose-high-cardinality-windows"

--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -4,7 +4,7 @@ base-package-features = ["deps", "db", "json"]
 [[envs.default.matrix]]
 python = ["3.9"]
 os = ["linux"]
-version = ["2017", "2019"]
+version = ["2017", "2019", "2022"]
 setup = ["single", "ha"]
 
 # test the full combination of python-version/driver against a the latest sql server version
@@ -23,7 +23,7 @@ setup = ["single"]
 python = ["3.9"]
 os = ["linux"]
 driver = ["odbc"]
-version = ["2019"]
+version = ["2019", "2022"]
 case = ["high-cardinality"]
 
 [envs.default.env-vars]
@@ -53,6 +53,7 @@ matrix.version.env-vars = [
   { key = "SQLSERVER_ENGINE_EDITION" },
   { key = "SQLSERVER_IMAGE_TAG", value = "2017-CU24-ubuntu-16.04", if = ["2017"], platform = ["linux"] },
   { key = "SQLSERVER_IMAGE_TAG", value = "2019-CU11-ubuntu-16.04", if = ["2019"], platform = ["linux"] },
+  { key = "SQLSERVER_IMAGE_TAG", value = "2022-preview-ubuntu-22.04", if = ["2022"], platform = ["linux"] },
   { key = "SQLSERVER_BASE_IMAGE", value = "datadog/docker-library:sqlserver_{matrix:version}", platform = ["windows"] },
 ]
 matrix.driver.env-vars = [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Now that we officially support SQL Server 2022, this adds the new linux image & 2022 to our test matrix

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
