### PR TITLE
Commenting out legacy_mode key

### DIFF
--- a/win32_event_log/CHANGELOG.md
+++ b/win32_event_log/CHANGELOG.md
@@ -5,6 +5,7 @@
 ***Fixed***:
 
 * Run all the tests on py3 ([#15798](https://github.com/DataDog/integrations-core/pull/15798))
+* Comment out legacy_mode config ([#15821](https://github.com/DataDog/integrations-core/pull/15821))
 
 ## 3.0.0 / 2023-08-10
 

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -240,7 +240,7 @@ instances:
     ##
     ## Setting this option to `false` is only supported on Agent versions 7 and above.
     #
-    legacy_mode: false
+    # legacy_mode: false
 
     ## @param host - string - optional - default: localhost
     ## By default, the local machine's event logs are captured. To capture a remote


### PR DESCRIPTION
### What does this PR do?
Comment out legacy_mode config

### Motivation
It is very clear that this should be commented out from context because in the comment it says "default: true".  
The reason I am creating this pull request though, is because this integration throws an error and will not run properly if only logs config is added.  
This integration allows win32 events to be sent to events and/or logs, and these config are independent to each other.  
However, if customer configures only for logs, this integration will throw `ERROR_EVT_INVALID_CHANNEL_PATH. 15000`.   
In order to get the integration working, customer has to comment out or remove `legacy_mode: false` from the config file.  
### Additional Notes
Below checks fails because there is change in conf.yaml.example
```
Validate repository / run / Validate (pull_request) Failing after 1m
```
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
