### PR TITLE
Bump the `target-version` to python 3.9 for ruff and black

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -9,6 +9,7 @@
 ***Fixed***:
 
 * Make sure repo override in envvar makes it into config ([#15782](https://github.com/DataDog/integrations-core/pull/15782))
+* Bump the `target-version` to python 3.9 for ruff and black ([#15824](https://github.com/DataDog/integrations-core/pull/15824))
 
 ## 5.0.0 / 2023-09-06
 

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -71,11 +71,11 @@ scripts = ["ddev"]
 include = '\.pyi?$'
 line-length = 120
 skip-string-normalization = true
-target-version = ["py38"]
+target-version = ["py39"]
 
 [tool.ruff]
 exclude = []
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 # Rules were ported over from the legacy flake8 settings for parity
 # All the rules can be found here: https://beta.ruff.rs/docs/rules/


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the `target-version` to python 3.9 for ruff and black

### Motivation
<!-- What inspired you to submit this pull request? -->

We now use py3.9

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
