### PR TITLE
add `_disable_compression` scrapper config to open metrics check

### DIFF
--- a/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
+++ b/datadog_checks_base/datadog_checks/base/checks/openmetrics/mixins.py
@@ -379,6 +379,9 @@ class OpenMetricsScraperMixin(object):
         # on first scrape.
         config['use_process_start_time'] = is_affirmative(_get_setting('use_process_start_time', False))
 
+        # Compression is enabled by default
+        config['_disable_compression'] = False
+
         return config
 
     def get_http_handler(self, scraper_config):
@@ -411,7 +414,8 @@ class OpenMetricsScraperMixin(object):
             headers['Authorization'] = 'Bearer {}'.format(bearer_token)
 
         # TODO: Determine if we really need this
-        headers.setdefault('accept-encoding', 'gzip')
+        if not scraper_config['_disable_compression']:
+            headers.setdefault('accept-encoding', 'gzip')
 
         # Explicitly set the content type we accept
         headers.setdefault('accept', 'text/plain')


### PR DESCRIPTION
### What does this PR do?

This PR adds a new internal (is it actually ?) scrapper config to disable compression when scrapping the metrics. The end goal is for another child check to override the `get_scraper_config` method and to set `_disable_compression` to `True` (would it be a good practice ?).

I'm very new to integration work, so I'm open to any kind of feedback, even if it's "do not do that at all".

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
