### PR TITLE
Migrate `ddev dep` to `ddev`

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add color output to tests in CI ([#15774](https://github.com/DataDog/integrations-core/pull/15774))
 
+***Added***:
+
+* Migrate `ddev dep` to `ddev` ([#15830](https://github.com/DataDog/integrations-core/pull/15830))
+
 ***Fixed***:
 
 * Make sure repo override in envvar makes it into config ([#15782](https://github.com/DataDog/integrations-core/pull/15782))

--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -5,9 +5,6 @@
 ***Added***:
 
 * Add color output to tests in CI ([#15774](https://github.com/DataDog/integrations-core/pull/15774))
-
-***Added***:
-
 * Migrate `ddev dep` to `ddev` ([#15830](https://github.com/DataDog/integrations-core/pull/15830))
 
 ***Fixed***:

--- a/ddev/src/ddev/cli/__init__.py
+++ b/ddev/src/ddev/cli/__init__.py
@@ -6,7 +6,6 @@ import os
 import click
 import pluggy
 from datadog_checks.dev.tooling.commands.create import create
-from datadog_checks.dev.tooling.commands.dep import dep
 from datadog_checks.dev.tooling.commands.run import run
 
 from ddev._version import __version__
@@ -14,6 +13,7 @@ from ddev.cli.application import Application
 from ddev.cli.ci import ci
 from ddev.cli.clean import clean
 from ddev.cli.config import config
+from ddev.cli.dep import dep
 from ddev.cli.docs import docs
 from ddev.cli.env import env
 from ddev.cli.meta import meta

--- a/ddev/src/ddev/cli/dep.py
+++ b/ddev/src/ddev/cli/dep.py
@@ -6,8 +6,8 @@ import copy
 from collections import defaultdict
 
 import click
-import orjson
 import httpx
+import orjson
 from packaging.markers import Marker
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
@@ -167,9 +167,9 @@ async def get_version_data(client, url):
         response = await client.get(url)
         data = orjson.loads(response.text)
     except Exception as e:
-        raise type(e)(f'Error processing URL {url}: {e}')
-    else:
-        return data['info']['name'], data['releases']
+        raise RuntimeError(f'Error processing URL {url}') from e
+
+    return data['info']['name'], data['releases']
 
 
 async def fetch_versions(urls):

--- a/ddev/src/ddev/cli/dep.py
+++ b/ddev/src/ddev/cli/dep.py
@@ -1,0 +1,291 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import asyncio
+import copy
+from collections import defaultdict
+
+import click
+import orjson
+from aiohttp import request
+from aiomultiprocess import Pool
+from datadog_checks.dev.tooling.commands.console import CONTEXT_SETTINGS, abort, echo_failure, echo_info
+from datadog_checks.dev.tooling.constants import get_agent_requirements
+from datadog_checks.dev.tooling.dependencies import (
+    get_dependency_set,
+    read_agent_dependencies,
+    read_check_dependencies,
+    update_agent_dependencies,
+    update_check_dependencies,
+    update_project_dependency,
+)
+from datadog_checks.dev.tooling.utils import get_normalized_dependency, normalize_project_name
+from packaging.markers import Marker
+from packaging.requirements import Requirement
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+# Dependencies to ignore when update dependencies
+IGNORED_DEPS = {
+    'ddtrace',  # https://github.com/DataDog/integrations-core/pull/9132
+    'flup',  # https://github.com/DataDog/integrations-core/pull/1997
+    'dnspython',
+    'pymysql',  # https://github.com/DataDog/integrations-core/pull/12612
+    'foundationdb',  # Breaking datadog_checks_base tests
+    'openstacksdk',  # Breaking openstack_controller tests
+    'pyasn1',  # Breaking snmp tests
+    'pycryptodomex',  # Breaking snmp tests
+    'pysnmp',  # Breaking snmp tests
+    'clickhouse-driver',  # Breaking clickhouse tests
+    'lz4',  # Breaking clickhouse tests
+    'pyodbc',  # Breaking sqlserver tests
+    'psutil',  # Breaking disk tests
+    'aerospike',  # v8+ breaks agent build.
+    'protobuf',  # 3.20.2->4.23.3 breaks kubernetes_state, kube_dns, gitlab and gitlab_runner tests.
+    'service-identity',  # 21.1->23.1 breaks tls tests.
+    'pyvmomi',  # 7->8 breaks vsphere tests.
+    # 4.3->4.4 changes the license field in the package metadata to something our validations cannot handle.
+    'pymongo',
+    # We need pydantic 2.0.2 for the rpm x64 agent build (see https://github.com/DataDog/datadog-agent/pull/18303)
+    'pydantic',
+}
+
+# Dependencies for the downloader that are security-related and should be updated separately from the others
+SECURITY_DEPS = {'in-toto', 'tuf', 'securesystemslib'}
+
+SUPPORTED_PYTHON_MINOR_VERSIONS = {'2': '2.7', '3': '3.9'}
+
+
+@click.group(context_settings=CONTEXT_SETTINGS, short_help='Manage dependencies')
+def dep():
+    pass
+
+
+@dep.command(context_settings=CONTEXT_SETTINGS, short_help='Pin a dependency for all checks that require it')
+@click.argument('definition')
+def pin(definition):
+    """Pin a dependency for all checks that require it."""
+    dependencies, errors = read_check_dependencies()
+
+    if errors:
+        for error in errors:
+            echo_failure(error)
+
+        abort()
+
+    requirement = Requirement(definition)
+    package = normalize_project_name(requirement.name)
+    if package not in dependencies:
+        abort(f'Unknown package: {package}')
+
+    new_dependencies = copy.deepcopy(dependencies)
+    python_versions = new_dependencies[package]
+    checks = update_project_dependency(python_versions, definition)
+    if new_dependencies == dependencies:
+        abort('No dependency definitions to update')
+
+    for check_name in sorted(checks):
+        update_check_dependencies(check_name, new_dependencies)
+
+    echo_info(f'Files updated: {len(checks)}')
+
+
+@dep.command(
+    context_settings=CONTEXT_SETTINGS, short_help="Combine all dependencies for the Agent's static environment"
+)
+def freeze():
+    """Combine all dependencies for the Agent's static environment."""
+    dependencies, errors = read_check_dependencies()
+
+    if errors:
+        for error in errors:
+            echo_failure(error)
+
+        abort()
+
+    echo_info(f'Static file: {get_agent_requirements()}')
+    update_agent_dependencies(dependencies)
+
+
+@dep.command(
+    context_settings=CONTEXT_SETTINGS,
+    short_help="Update integrations' dependencies so that they match the Agent's static environment",
+)
+def sync():
+    agent_dependencies, errors = read_agent_dependencies()
+
+    if errors:
+        for error in errors:
+            echo_failure(error)
+        abort()
+
+    check_dependencies, check_errors = read_check_dependencies()
+
+    if check_errors:
+        for error in check_errors:
+            echo_failure(error)
+        abort()
+
+    updated_checks = set()
+    for name, python_versions in check_dependencies.items():
+        check_dependency_definitions = get_dependency_set(python_versions)
+        agent_dependency_definitions = get_dependency_set(agent_dependencies[name])
+
+        if check_dependency_definitions != agent_dependency_definitions:
+            for dependency_definition in agent_dependency_definitions:
+                updated_checks.update(update_project_dependency(python_versions, dependency_definition))
+
+    if not updated_checks:
+        echo_info('All dependencies synced.')
+        return
+
+    for check_name in sorted(updated_checks):
+        update_check_dependencies(check_name, check_dependencies)
+
+    echo_info(f'Files updated: {len(updated_checks)}')
+
+
+def filter_releases(releases):
+    filtered_releases = []
+    for version, artifacts in releases.items():
+        try:
+            parsed_version = Version(version)
+        except InvalidVersion:
+            continue
+
+        if not parsed_version.is_prerelease:
+            filtered_releases.append((parsed_version, artifacts))
+
+    return filtered_releases
+
+
+def artifact_compatible_with_python(artifact, major_version):
+    requires_python = artifact['requires_python']
+    if requires_python is not None:
+        try:
+            specifiers = SpecifierSet(requires_python)
+        except InvalidSpecifier:
+            return False
+
+        return specifiers.contains(SUPPORTED_PYTHON_MINOR_VERSIONS[major_version])
+
+    python_version = artifact['python_version']
+    return f'py{major_version}' in python_version or f'cp{major_version}' in python_version
+
+
+async def get_version_data(url):
+    async with request('GET', url) as response:
+        try:
+            data = orjson.loads(await response.read())
+        except Exception as e:
+            raise type(e)(f'Error processing URL {url}: {e}')
+        else:
+            return data['info']['name'], data['releases']
+
+
+async def scrape_version_data(urls):
+    package_data = {}
+
+    async with Pool() as pool:
+        async for package_name, releases in pool.map(get_version_data, urls):
+            latest_py2 = None
+            latest_py3 = None
+
+            versions = []
+            for parsed_version, artifacts in sorted(filter_releases(releases), reverse=True):
+                version = str(parsed_version)
+                versions.append(version)
+
+                for artifact in artifacts:
+                    if artifact.get("yanked", False):
+                        continue
+
+                    if latest_py2 is None and artifact_compatible_with_python(artifact, '2'):
+                        latest_py2 = version
+                    if latest_py3 is None and artifact_compatible_with_python(artifact, '3'):
+                        latest_py3 = version
+
+                if latest_py2 is not None and latest_py3 is not None:
+                    break
+            else:
+                # Package only released source distributions
+                if latest_py2 is None and latest_py3 is None:
+                    latest_py2 = latest_py3 = versions[0]
+
+            package_data[package_name] = {'py2': latest_py2, 'py3': latest_py3}
+
+    return package_data
+
+
+@dep.command(context_settings=CONTEXT_SETTINGS, short_help='Automatically check for dependency updates')
+@click.option('--sync', '-s', 'sync_dependencies', is_flag=True, help='Update the dependency definitions')
+@click.option('--include-security-deps', '-i', is_flag=True, help="Attempt to update security dependencies")
+@click.option('--batch-size', '-b', type=int, help='The maximum number of dependencies to upgrade if syncing')
+@click.pass_context
+def updates(ctx, sync_dependencies, include_security_deps, batch_size):
+    ignore_deps = set(IGNORED_DEPS)
+    if not include_security_deps:
+        ignore_deps.update(SECURITY_DEPS)
+    ignore_deps = {normalize_project_name(d) for d in ignore_deps}
+
+    dependencies, errors = read_agent_dependencies()
+
+    if errors:
+        for error in errors:
+            echo_failure(error)
+        abort()
+
+    api_urls = [f'https://pypi.org/pypi/{package}/json' for package in dependencies]
+    package_data = asyncio.run(scrape_version_data(api_urls))
+    package_data = {normalize_project_name(package_name): versions for package_name, versions in package_data.items()}
+
+    new_dependencies = copy.deepcopy(dependencies)
+    version_updates = defaultdict(lambda: defaultdict(set))
+    updated_packages = set()
+    for name, python_versions in sorted(new_dependencies.items()):
+        if name in ignore_deps:
+            continue
+        elif batch_size is not None and len(updated_packages) >= batch_size:
+            break
+
+        new_python_versions = package_data[name]
+        dropped_py2 = len(set(new_python_versions.values())) > 1
+        for python_version, package_version in new_python_versions.items():
+            dependency_definitions = python_versions[python_version]
+            if not dependency_definitions or package_version is None:
+                continue
+            dependency_definition, checks = dependency_definitions.popitem()
+
+            requirement = Requirement(dependency_definition)
+            requirement.specifier = SpecifierSet(f'=={package_version}')
+            if dropped_py2 and 'python_version' not in dependency_definition:
+                python_marker = f'python_version {"<" if python_version == "py2" else ">"} "3.0"'
+                if not requirement.marker:
+                    requirement.marker = Marker(python_marker)
+                else:
+                    requirement.marker = Marker(f'{requirement.marker} and {python_marker}')
+
+            new_dependency_definition = get_normalized_dependency(requirement)
+
+            dependency_definitions[new_dependency_definition] = checks
+            if dependency_definition != new_dependency_definition:
+                version_updates[name][package_version].add(python_version)
+                updated_packages.add(name)
+
+    if sync_dependencies:
+        if updated_packages:
+            update_agent_dependencies(new_dependencies)
+            ctx.invoke(sync)
+            echo_info(f'Updated {len(updated_packages)} dependencies')
+    else:
+        if updated_packages:
+            echo_failure(f"{len(updated_packages)} dependencies are out of sync:")
+            for name, versions in version_updates.items():
+                for package_version, python_versions in versions.items():
+                    echo_failure(
+                        f'{name} can be updated to version {package_version} '
+                        f'on {" and ".join(sorted(python_versions))}'
+                    )
+            abort()
+        else:
+            echo_info('All dependencies are up to date')

--- a/ddev/src/ddev/cli/dep.py
+++ b/ddev/src/ddev/cli/dep.py
@@ -17,7 +17,6 @@ from packaging.version import InvalidVersion, Version
 # Dependencies to ignore when update dependencies
 IGNORED_DEPS = {
     'ddtrace',  # https://github.com/DataDog/integrations-core/pull/9132
-    'flup',  # https://github.com/DataDog/integrations-core/pull/1997
     'dnspython',
     'pymysql',  # https://github.com/DataDog/integrations-core/pull/12612
     'foundationdb',  # Breaking datadog_checks_base tests
@@ -25,8 +24,6 @@ IGNORED_DEPS = {
     'pyasn1',  # Breaking snmp tests
     'pycryptodomex',  # Breaking snmp tests
     'pysnmp',  # Breaking snmp tests
-    'clickhouse-driver',  # Breaking clickhouse tests
-    'lz4',  # Breaking clickhouse tests
     'pyodbc',  # Breaking sqlserver tests
     'psutil',  # Breaking disk tests
     'aerospike',  # v8+ breaks agent build.

--- a/ddev/src/ddev/integration/core.py
+++ b/ddev/src/ddev/integration/core.py
@@ -140,6 +140,13 @@ class Integration:
         return None
 
     @cached_property
+    def project_metadata(self) -> dict:
+        import tomli
+
+        with open(self.path / 'pyproject.toml', 'rb') as f:
+            return tomli.load(f)
+
+    @cached_property
     def is_valid(self) -> bool:
         return self.is_integration or self.is_package
 

--- a/ddev/src/ddev/integration/core.py
+++ b/ddev/src/ddev/integration/core.py
@@ -139,11 +139,11 @@ class Integration:
 
         return None
 
-    @cached_property
+    @property
     def project_metadata(self) -> dict:
         import tomli
 
-        with open(self.path / 'pyproject.toml', 'rb') as f:
+        with open(self.project_file, 'rb') as f:
             return tomli.load(f)
 
     @cached_property

--- a/ddev/src/ddev/utils/fs.py
+++ b/ddev/src/ddev/utils/fs.py
@@ -51,6 +51,11 @@ class Path(_PathBase):
         kwargs.setdefault('encoding', 'utf-8')
         return super().write_text(*args, **kwargs)
 
+    def stream_lines(self, encoding='utf-8') -> Generator[str, None, None]:
+        if self.exists():
+            with self.open(encoding=encoding) as f:
+                yield from f
+
     def open(self, **kwargs):
         if not kwargs.get('mode', 'r')[1:].startswith('b'):
             kwargs.setdefault('encoding', 'utf-8')

--- a/ddev/tests/cli/test_dep.py
+++ b/ddev/tests/cli/test_dep.py
@@ -1,6 +1,9 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import json
+from unittest import mock
+
 import pytest
 import tomli
 import tomli_w
@@ -77,6 +80,202 @@ dep-b==3.1.4
 
     assert_dependencies(fake_repo, 'foo2', ['dep-a==1.1.1', 'dep-b==3.1.4'])
     assert_dependencies(fake_repo, 'bar2', ['dep-a==1.1.1'])
+
+
+class TestUpdates:
+    @pytest.fixture(autouse=True)
+    def _setup(self, fake_repo, mock_async_http_get_json):
+        self.repo = fake_repo
+        self.dependencies = set()
+        self.mock_response = mock_async_http_get_json
+
+    def add_integration(self, name, deps):
+        create_integration(self.repo, name, deps)
+        self.dependencies.update(deps)
+
+    def add_pypi_entry(self, name, releases):
+        self.mock_response(
+            f'https://pypi.org/pypi/{name}/json',
+            {
+                "info": {"name": name},
+                "releases": releases,
+            },
+        )
+
+    def write_requirements(self):
+        self.requirements_path.write_text('\n'.join(sorted(self.dependencies)))
+
+    @property
+    def requirements_path(self):
+        return self.repo / 'datadog_checks_base' / 'datadog_checks' / 'base' / 'data' / 'agent_requirements.in'
+
+    def test_show_updates(self, ddev):
+        self.add_integration('foo', ['dep-a==1.0.0', 'dep-b==3.1.4'])
+        self.add_integration('bar', ['dep-a==1.0.0'])
+        self.write_requirements()
+
+        self.add_pypi_entry(
+            'dep-a',
+            {version: [{"python_version": "py2.py3", "requires_python": ">=2.7"}] for version in ["1.0.0", "1.2.3"]},
+        )
+        self.add_pypi_entry(
+            'dep-b',
+            {version: [{"python_version": "py2.py3", "requires_python": ">=2.7"}] for version in ["3.1.0", "3.1.4"]},
+        )
+
+        result = ddev('dep', 'updates')
+
+        assert (
+            result.output
+            == '''1 dependencies are out of sync:
+dep-a can be updated to version 1.2.3 on py2 and py3
+'''
+        )
+        assert result.exit_code != 0
+
+    def test_sync(self, ddev):
+        self.add_integration('foo', ['dep-a==1.0.0', 'dep-b==3.1.4'])
+        self.add_integration('bar', ['dep-a==1.0.0'])
+        self.write_requirements()
+
+        self.add_pypi_entry(
+            'dep-a',
+            {version: [{"python_version": "py2.py3", "requires_python": ">=2.7"}] for version in ["1.0.0", "1.2.3"]},
+        )
+        self.add_pypi_entry(
+            'dep-b',
+            {version: [{"python_version": "py2.py3", "requires_python": ">=2.7"}] for version in ["3.1.0", "3.1.4"]},
+        )
+
+        result = ddev('dep', 'updates', '--sync')
+
+        assert result.exit_code == 0
+        assert (
+            result.output
+            == '''Files updated: 2
+Updated 1 dependencies
+'''
+        )
+
+        assert_dependencies(self.repo, 'foo', ['dep-a==1.2.3', 'dep-b==3.1.4'])
+        assert_dependencies(self.repo, 'bar', ['dep-a==1.2.3'])
+
+        requirements = self.requirements_path.read_text()
+        expected = """
+dep-a==1.2.3
+dep-b==3.1.4
+"""
+        assert requirements.strip('\n') == expected.strip('\n')
+
+    def test_only_py3(self, ddev):
+        self.add_integration('foo', ["dep-a==1.0.0; python_version > '3.0'"])
+        self.write_requirements()
+
+        self.add_pypi_entry(
+            'dep-a',
+            {version: [{"python_version": "py3", "requires_python": ">=3.6"}] for version in ["1.0.0", "1.2.3"]},
+        )
+
+        result = ddev('dep', 'updates')
+
+        assert (
+            result.output
+            == '''1 dependencies are out of sync:
+dep-a can be updated to version 1.2.3 on py3
+'''
+        )
+        assert result.exit_code != 0
+
+    def test_sync_only_py3(self, ddev):
+        self.add_integration('foo', ["dep-a==1.0.0; python_version > '3.0'"])
+        self.write_requirements()
+
+        self.add_pypi_entry(
+            'dep-a',
+            {version: [{"python_version": "py3", "requires_python": ">=3.6"}] for version in ["1.0.0", "1.2.3"]},
+        )
+
+        result = ddev('dep', 'updates', '--sync')
+        assert result.exit_code == 0
+        assert (
+            result.output
+            == '''Files updated: 1
+Updated 1 dependencies
+'''
+        )
+        assert_dependencies(self.repo, 'foo', ["dep-a==1.2.3; python_version > '3.0'"])
+
+        requirements = self.requirements_path.read_text()
+        expected = """
+dep-a==1.2.3; python_version > '3.0'
+"""
+        assert requirements.strip('\n') == expected.strip('\n')
+
+    def test_ignored_deps(self, ddev):
+        self.add_integration('foo', ["ddtrace==1.0.0"])
+        self.write_requirements()
+
+        self.add_pypi_entry(
+            'ddtrace',
+            {version: [{"python_version": "py3", "requires_python": ">=3.6"}] for version in ["1.0.0", "1.2.3"]},
+        )
+
+        result = ddev('dep', 'updates')
+
+        assert result.output == 'All dependencies are up to date\n'
+        assert result.exit_code == 0
+
+    def test_batch_size(self, ddev):
+        deps = [f'dep-{suffix}' for suffix in ('a', 'b', 'c', 'd', 'e', 'f')]
+        self.add_integration('foo', [f'{dep}==1.0.0' for dep in deps])
+        self.write_requirements()
+
+        for dep in deps:
+            self.add_pypi_entry(
+                dep,
+                {version: [{"python_version": "py2.3", "requires_python": ">=2.7"}] for version in ["1.0.0", "1.2.3"]},
+            )
+
+        result = ddev('dep', 'updates', '--batch-size', '5')
+
+        assert result.output.startswith('5 dependencies are out of sync:')
+        assert result.exit_code != 0
+
+
+@pytest.fixture
+def mock_async_http_get_json():
+    """Mock `get` responses assuming a JSON value is returned in the body.
+
+    The mock will raise an exception if an unmatched URL is requested.
+
+    It is somewhat coupled to the implementation as it makes many
+    assumptions about how things are called and used.
+    """
+
+    url_responses = {}
+
+    async def response_function(url, *args, **kwargs):
+        if url in url_responses:
+            response = mock.MagicMock()
+            response.text = json.dumps(url_responses[url])
+            return response
+
+        response = mock.Mock()
+        try:
+            response.text = json.dumps(url_responses[url])
+        except KeyError:
+            # Avoid footguns and accidental requests
+            raise RuntimeError(f"{url} didn't match any registered url's")
+
+        return response
+
+    fake_get = mock.AsyncMock(side_effect=response_function)
+
+    def add_mock(url, response_value):
+        url_responses[url] = response_value
+
+    with mock.patch('httpx.AsyncClient.get', fake_get):
+        yield add_mock
 
 
 @pytest.fixture

--- a/ddev/tests/cli/test_dep.py
+++ b/ddev/tests/cli/test_dep.py
@@ -93,6 +93,12 @@ def create_integration(root, name, dependencies):
     with open(integration_dir / 'pyproject.toml', 'wb') as f:
         tomli_w.dump({'project': {'optional-dependencies': {'deps': dependencies}}}, f)
 
-    # We need the version file for it to be recognized as an integration by the old code
+    # Fill stuff needed for it to be recognized as an agent check
     (integration_dir / 'datadog_checks' / name).mkdir(parents=True)
     (integration_dir / 'datadog_checks' / name / '__about__.py').touch()
+    (integration_dir / 'datadog_checks' / name / '__init__.py').write_text(
+        """
+import a
+import b
+"""
+    )

--- a/ddev/tests/cli/test_dep.py
+++ b/ddev/tests/cli/test_dep.py
@@ -7,7 +7,6 @@ from unittest import mock
 import pytest
 import tomli
 import tomli_w
-from datadog_checks.dev.tooling.utils import get_root, set_root
 
 
 def test_pin(ddev, fake_repo):
@@ -37,8 +36,8 @@ def test_pin_non_canonical_name(ddev, fake_repo):
 
 
 def test_freeze(ddev, fake_repo):
-    create_integration(fake_repo, 'foo1', ['dep-a==1.0.0', 'dep-b==3.1.4'])
-    create_integration(fake_repo, 'bar1', ['dep-a==1.0.0', 'dep-c==5.1.0'])
+    create_integration(fake_repo, 'foo', ['dep-a==1.0.0', 'dep-b==3.1.4'])
+    create_integration(fake_repo, 'bar', ['dep-a==1.0.0', 'dep-c==5.1.0'])
     # datadog_checks_dev deps are not shipped with the agent
     create_integration(fake_repo, 'datadog_checks_dev', ['dep-d==4.4.4'])
 
@@ -62,8 +61,8 @@ dep-c==5.1.0
 
 
 def test_sync(ddev, fake_repo):
-    create_integration(fake_repo, 'foo2', ['dep-a==1.0.0', 'dep-b==3.1.4'])
-    create_integration(fake_repo, 'bar2', ['dep-a==1.0.0'])
+    create_integration(fake_repo, 'foo', ['dep-a==1.0.0', 'dep-b==3.1.4'])
+    create_integration(fake_repo, 'bar', ['dep-a==1.0.0'])
 
     requirements = """
 dep-a==1.1.1
@@ -78,8 +77,8 @@ dep-b==3.1.4
     assert result.exit_code == 0
     assert result.output == 'Files updated: 2\n'
 
-    assert_dependencies(fake_repo, 'foo2', ['dep-a==1.1.1', 'dep-b==3.1.4'])
-    assert_dependencies(fake_repo, 'bar2', ['dep-a==1.1.1'])
+    assert_dependencies(fake_repo, 'foo', ['dep-a==1.1.1', 'dep-b==3.1.4'])
+    assert_dependencies(fake_repo, 'bar', ['dep-a==1.1.1'])
 
 
 class TestUpdates:
@@ -287,11 +286,7 @@ def fake_repo(tmp_path, config_file):
     config_file.model.repos['core'] = str(tmp_path)
     config_file.save()
 
-    # XXX: Remove the root manipulation once the commands are ported over
-    old_root = get_root()
-    set_root(str(tmp_path))
     yield tmp_path
-    set_root(old_root)
 
 
 def assert_dependencies(root, name, dependencies):

--- a/ddev/tests/cli/test_dep.py
+++ b/ddev/tests/cli/test_dep.py
@@ -1,0 +1,98 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+import tomli
+import tomli_w
+from datadog_checks.dev.tooling.utils import get_root, set_root
+
+
+def test_pin(ddev, fake_repo):
+    create_integration(fake_repo, 'foo', ['dep-a==1.0.0', 'dep-b==3.1.4'])
+    create_integration(fake_repo, 'bar', ['dep-a==1.0.0'])
+
+    result = ddev('dep', 'pin', 'dep-a==1.2.3')
+
+    assert result.exit_code == 0
+    assert result.output == 'Files updated: 2\n'
+
+    assert_dependencies(fake_repo, 'foo', ['dep-a==1.2.3', 'dep-b==3.1.4'])
+    assert_dependencies(fake_repo, 'bar', ['dep-a==1.2.3'])
+
+
+def test_freeze(ddev, fake_repo):
+    create_integration(fake_repo, 'foo1', ['dep-a==1.0.0', 'dep-b==3.1.4'])
+    create_integration(fake_repo, 'bar1', ['dep-a==1.0.0', 'dep-c==5.1.0'])
+    # datadog_checks_dev deps are not shipped with the agent
+    create_integration(fake_repo, 'datadog_checks_dev', ['dep-d==4.4.4'])
+
+    result = ddev('dep', 'freeze')
+
+    agent_requirements_path = (
+        fake_repo / 'datadog_checks_base' / 'datadog_checks' / 'base' / 'data' / 'agent_requirements.in'
+    )
+
+    assert result.exit_code == 0
+    assert result.output == f'Static file: {agent_requirements_path}\n'
+
+    requirements = agent_requirements_path.read_text()
+
+    expected = """
+dep-a==1.0.0
+dep-b==3.1.4
+dep-c==5.1.0
+"""
+    assert requirements.strip('\n') == expected.strip('\n')
+
+
+def test_sync(ddev, fake_repo):
+    create_integration(fake_repo, 'foo2', ['dep-a==1.0.0', 'dep-b==3.1.4'])
+    create_integration(fake_repo, 'bar2', ['dep-a==1.0.0'])
+
+    requirements = """
+dep-a==1.1.1
+dep-b==3.1.4
+"""
+    (fake_repo / 'datadog_checks_base' / 'datadog_checks' / 'base' / 'data' / 'agent_requirements.in').write_text(
+        requirements.strip('\n')
+    )
+
+    result = ddev('dep', 'sync')
+
+    assert result.exit_code == 0
+    assert result.output == 'Files updated: 2\n'
+
+    assert_dependencies(fake_repo, 'foo2', ['dep-a==1.1.1', 'dep-b==3.1.4'])
+    assert_dependencies(fake_repo, 'bar2', ['dep-a==1.1.1'])
+
+
+@pytest.fixture
+def fake_repo(tmp_path, config_file):
+    data_folder = tmp_path / 'datadog_checks_base' / 'datadog_checks' / 'base' / 'data'
+    data_folder.mkdir(parents=True)
+
+    # Set this as core repo in the config
+    config_file.model.repos['core'] = str(tmp_path)
+    config_file.save()
+
+    # XXX: Remove the root manipulation once the commands are ported over
+    old_root = get_root()
+    set_root(str(tmp_path))
+    yield tmp_path
+    set_root(old_root)
+
+
+def assert_dependencies(root, name, dependencies):
+    with open(root / name / 'pyproject.toml', 'rb') as f:
+        assert tomli.load(f)['project']['optional-dependencies']['deps'] == dependencies
+
+
+def create_integration(root, name, dependencies):
+    integration_dir = root / name
+    integration_dir.mkdir()
+    with open(integration_dir / 'pyproject.toml', 'wb') as f:
+        tomli_w.dump({'project': {'optional-dependencies': {'deps': dependencies}}}, f)
+
+    # We need the version file for it to be recognized as an integration by the old code
+    (integration_dir / 'datadog_checks' / name).mkdir(parents=True)
+    (integration_dir / 'datadog_checks' / name / '__about__.py').touch()

--- a/ddev/tests/cli/test_dep.py
+++ b/ddev/tests/cli/test_dep.py
@@ -20,6 +20,19 @@ def test_pin(ddev, fake_repo):
     assert_dependencies(fake_repo, 'bar', ['dep-a==1.2.3'])
 
 
+def test_pin_non_canonical_name(ddev, fake_repo):
+    create_integration(fake_repo, 'foo', ['non-canonical-dep==1.0.0'])
+
+    # We use a non-canonical name, to assert that it gets recognized as the same as the
+    # existing, canonical name
+    result = ddev('dep', 'pin', 'non.Canonical_dep==1.2.3')
+
+    assert result.exit_code == 0
+    assert result.output == 'Files updated: 1\n'
+
+    assert_dependencies(fake_repo, 'foo', ['non.Canonical_dep==1.2.3'])
+
+
 def test_freeze(ddev, fake_repo):
     create_integration(fake_repo, 'foo1', ['dep-a==1.0.0', 'dep-b==3.1.4'])
     create_integration(fake_repo, 'bar1', ['dep-a==1.0.0', 'dep-c==5.1.0'])


### PR DESCRIPTION
### What does this PR do?


### Motivation

[AITS-228](https://datadoghq.atlassian.net/browse/AITS-228).

### Additional Notes

As part of the migration I've also ported the code from `aiohttp` to `httpx` and removed the use of `aiomultiprocessing`, without any performance loss as far as I could tell (I think it was even faster after some code reshuffling).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[AITS-228]: https://datadoghq.atlassian.net/browse/AITS-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ