### PR TITLE
[Release] Bumped snmp version to 6.2.3 (#15829)

### DIFF
--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -135,7 +135,7 @@ datadog-scylla==2.5.0
 datadog-sidekiq==1.3.1
 datadog-silk==2.0.0
 datadog-singlestore==2.0.0
-datadog-snmp==6.2.2
+datadog-snmp==6.2.3
 datadog-snowflake==5.0.0
 datadog-solr==1.12.1
 datadog-sonarqube==3.0.0

--- a/snmp/CHANGELOG.md
+++ b/snmp/CHANGELOG.md
@@ -7,6 +7,11 @@
 * Remove unsupported metric in riverbed-interceptor.yaml ([#15678](https://github.com/DataDog/integrations-core/pull/15678))
 * Delete unnecessary extend for ubiquiti profiles ([#15643](https://github.com/DataDog/integrations-core/pull/15643))
 * Add comment for fanSpeedSensorStatus ([#15804](https://github.com/DataDog/integrations-core/pull/15804))
+
+## 6.2.3 / 2023-09-13
+
+***Fixed***:
+
 * Update mappings in SNMP profiles ([#15826](https://github.com/DataDog/integrations-core/pull/15826))
 
 ## 6.2.2 / 2023-09-12

--- a/snmp/datadog_checks/snmp/__about__.py
+++ b/snmp/datadog_checks/snmp/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = '6.2.2'
+__version__ = '6.2.3'


### PR DESCRIPTION
### What does this PR do?
Port snmp v6.2.3 release from 7.48 to master

### Motivation
https://github.com/DataDog/integrations-core/pull/15826

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
