### PR TITLE
Remove directConnection parameter

### DIFF
--- a/mongo/datadog_checks/mongo/api.py
+++ b/mongo/datadog_checks/mongo/api.py
@@ -47,7 +47,6 @@ class MongoApi(object):
             'socketTimeoutMS': self._config.timeout,
             'connectTimeoutMS': self._config.timeout,
             'serverSelectionTimeoutMS': self._config.timeout,
-            'directConnection': True,
             'read_preference': ReadPreference.PRIMARY_PREFERRED,
             'appname': DD_APP_NAME,
         }


### PR DESCRIPTION
According to the mongo docs here https://www.mongodb.com/docs/mongodb-shell/connect/#connect-to-a-replica-set this parameter gets added anyway and it seems from this PR https://github.com/DataDog/integrations-core/pull/13454 that we are supposed to be able to specify this option but it doesn't seem like this is actually possible. Removing this from my code on the machine that runs my agent worked well for me - so it definitely is not needed in some setups.

### What does this PR do?
Removing the `directConnection: True` line that exists unnecessarily on all MongoAPI requests.

### Motivation
This allowed me to get my datadog-agent connected to my MongoDB which was a replica-set in Atlas. Without this change it would refuse because I am specifying multiple hosts (I was using the srv connection string since trying without that and pointing to a specific replica did not work)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
