### PR TITLE
test postgres connection before initializing connection pool

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Changed***:
+
+* Attempt to connect to the database and fail fast before trying to establish a connection pool ([#15839](https://github.com/DataDog/integrations-core/pull/15839))
+
 ## 14.2.4 / 2023-09-07
 
 ***Fixed***:

--- a/postgres/datadog_checks/postgres/connections.py
+++ b/postgres/datadog_checks/postgres/connections.py
@@ -172,7 +172,7 @@ class MultiDatabaseConnectionPool(object):
                     self._stats.connection_pruned += 1
                     self._terminate_connection_unsafe(conn_name)
 
-    def close_all_connections(self, timeout=None):
+    def close_all_connections(self):
         """
         Will block until all connections are terminated, unless the pre-configured timeout is hit
         :param timeout:
@@ -181,7 +181,7 @@ class MultiDatabaseConnectionPool(object):
         success = True
         with self._mu:
             for dbname in list(self._conns):
-                if not self._terminate_connection_unsafe(dbname, timeout):
+                if not self._terminate_connection_unsafe(dbname):
                     success = False
         return success
 
@@ -200,7 +200,7 @@ class MultiDatabaseConnectionPool(object):
             # Could not evict a candidate; return None
             return None
 
-    def _terminate_connection_unsafe(self, dbname: str, timeout: float = None) -> bool:
+    def _terminate_connection_unsafe(self, dbname: str) -> bool:
         if dbname not in self._conns:
             return True
 
@@ -209,7 +209,7 @@ class MultiDatabaseConnectionPool(object):
             # pyscopg3 will IMMEDIATELY close the connection when calling close().
             # if timeout is not specified, psycopg will wait for the default 5s to stop the thread in the pool
             # if timeout is 0 or negative, psycopg will not wait for worker threads to terminate
-            db.close() if timeout is None else db.close(timeout=timeout)
+            db.close(timeout=0)
             self._stats.connection_closed += 1
         except Exception:
             self._stats.connection_closed_failed += 1

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -716,7 +716,7 @@ class PostgreSql(AgentCheck):
             psycopg.connect(**args)
         except psycopg.OperationalError as e:
             self.log.error(
-                "Unable to establish connection to %s in %d. error: %s",
+                "Unable to establish connection to %s in %d seconds. error: %s",
                 self._config.dbname,
                 self._config.connection_timeout,
                 e,

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -729,10 +729,12 @@ class PostgreSql(AgentCheck):
             if connection_string:
                 psycopg.connect(
                     conninfo=connection_string,
+                    connect_timeout=self._config.connection_timeout,
                     **args,
                 )
             else:
                 psycopg.connect(
+                    connect_timeout=self._config.connection_timeout,
                     **args,
                 )
         except psycopg.OperationalError as e:

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -736,17 +736,6 @@ class PostgreSql(AgentCheck):
 
         if not self.db:
             self.db = self._new_connection(self._config.dbname, max_pool_size=1)
-            # try:
-            #     self.db.wait(timeout=self._config.connection_timeout)
-            # except PoolTimeout as e:
-            #     self.log.error(
-            #         "Unable to establish connection to %s in %d. error: %s",
-            #         self._config.dbname,
-            #         self._config.connection_timeout,
-            #         str(e),
-            #     )
-            #     self.db = None
-            #     raise e
 
     def _reconnect_failed(self, pool: ConnectionPool) -> None:
         self.log.error("Failed to reconnect to %s", pool.name)

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -102,7 +102,7 @@ class PostgreSql(AgentCheck):
         self.set_resource_tags()
         self.pg_settings = {}
         self._warnings_by_code = {}
-        self.db_pool = MultiDatabaseConnectionPool(self, self._new_connection_pool, self._config.max_connections)
+        self.db_pool = MultiDatabaseConnectionPool(self, self._new_connection, self._config.max_connections)
         self.metrics_cache = PostgresMetricsCache(self._config)
         self.statement_metrics = PostgresStatementMetrics(self, self._config)
         self.statement_samples = PostgresStatementSamples(self, self._config)
@@ -695,7 +695,7 @@ class PostgreSql(AgentCheck):
             args.update(conn_args)
             return "", args
 
-    def _new_connection_pool(self, dbname: str, min_pool_size: int = 1, max_pool_size: int = None):
+    def _new_connection(self, dbname: str, min_pool_size: int = 1, max_pool_size: int = None):
         # required for autocommit as well as using params in queries
         connection_string, args = self._new_connection_info(dbname)
         if connection_string:
@@ -757,7 +757,7 @@ class PostgreSql(AgentCheck):
             self.db = None
 
         if not self.db:
-            self.db = self._new_connection_pool(self._config.dbname, max_pool_size=1)
+            self.db = self._new_connection(self._config.dbname, max_pool_size=1)
             # try:
             #     self.db.wait(timeout=self._config.connection_timeout)
             # except PoolTimeout as e:

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -710,20 +710,18 @@ class PostgreSql(AgentCheck):
         return pool
 
     def _attempt_to_connect(self):
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            args = self._new_connection_info(self._config.dbname)
-            args['connect_timeout'] = self._config.connection_timeout
-            future = executor.submit(psycopg.connect, **args)
-            try:
-                future.result(timeout=self._config.connection_timeout)
-            except (psycopg.OperationalError, concurrent.futures.TimeoutError) as e:
-                self.log.error(
-                    "Unable to establish connection to %s in %d. error: %s",
-                    self._config.dbname,
-                    self._config.connection_timeout,
-                    e,
-                )
-                raise e
+        args = self._new_connection_info(self._config.dbname)
+        args['connect_timeout'] = self._config.connection_timeout
+        try:
+            psycopg.connect(**args)
+        except psycopg.OperationalError as e:
+            self.log.error(
+                "Unable to establish connection to %s in %d. error: %s",
+                self._config.dbname,
+                self._config.connection_timeout,
+                e,
+            )
+            raise e
 
     def _connect(self):
         """

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -663,6 +663,8 @@ class PostgreSql(AgentCheck):
                 open=True,
                 name=dbname,
                 timeout=self._config.connection_timeout,
+                reconnect_timeout=30,
+                reconnect_failed=lambda e: self.log.error("Failed to reconnect to %s: %s", dbname, e),
             )
         else:
             password = self._config.password
@@ -707,6 +709,8 @@ class PostgreSql(AgentCheck):
                 open=True,
                 name=dbname,
                 timeout=self._config.connection_timeout,
+                reconnect_timeout=30,
+                reconnect_failed=lambda e: self.log.error("Failed to reconnect to %s: %s", dbname, e),
             )
         return pool
 

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -48,7 +48,7 @@ def test_conn_pool(pg_instance):
             assert len(rows) == 1 and list(rows[0].values())[0]
     assert len(pool._conns) == 1
     assert pool._stats.connection_opened == 2
-    success = pool.close_all_connections(timeout=0)
+    success = pool.close_all_connections()
     assert success
     assert len(pool._conns) == 0
     assert pool._stats.connection_closed == 2
@@ -98,7 +98,7 @@ def test_conn_pool_no_leaks_on_close(pg_instance):
         assert pool._stats.connection_opened == conn_count
         assert len(get_activity(pool2, unique_id)) == conn_count
 
-        pool.close_all_connections(timeout=0)
+        pool.close_all_connections()
         assert pool._stats.connection_closed == conn_count
         assert pool._stats.connection_closed_failed == 0
 
@@ -151,7 +151,7 @@ def test_conn_pool_no_leaks_on_prune(pg_instance):
                     conn_pids.append(conn.info.backend_pid)
         return set(conn_pids)
 
-    pool.close_all_connections(timeout=0)
+    pool.close_all_connections()
 
     pool._stats.reset()
 
@@ -307,7 +307,7 @@ def test_conn_pool_manages_connections(pg_instance):
     assert pool._stats.connection_closed == 1
 
     # close the rest
-    pool.close_all_connections(timeout=0)
+    pool.close_all_connections()
     assert pool._stats.connection_closed == limit + 1
 
 

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -3,12 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import datetime
 import pprint
-import psycopg
-import pytest
 import threading
 import time
 import uuid
 
+import psycopg
+import pytest
 from psycopg.rows import dict_row
 from psycopg_pool import ConnectionPool
 

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -322,6 +322,7 @@ def test_conn_attempt_to_connect(pg_instance):
     # Change the port to a non-existent port
     pg_instance['password'] = 1234
     check = PostgreSql('postgres', {}, [pg_instance])
+    check._attempt_to_connect()
     with pytest.raises(psycopg.OperationalError):
         check._attempt_to_connect()
 

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -319,10 +319,9 @@ def test_conn_attempt_to_connect(pg_instance):
     We attempt to connect to the database and check that the connection is successful.
     This test is meant to be run against a database that is not running.
     """
-    # Change the port to a non-existent port
+    # Change the password to something that is not the correct password
     pg_instance['password'] = 1234
     check = PostgreSql('postgres', {}, [pg_instance])
-    check._attempt_to_connect()
     with pytest.raises(psycopg.OperationalError):
         check._attempt_to_connect()
 

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -3,12 +3,12 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import datetime
 import pprint
+import psycopg
+import pytest
 import threading
 import time
 import uuid
 
-import pytest
-import psycopg
 from psycopg.rows import dict_row
 from psycopg_pool import ConnectionPool
 

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -8,6 +8,7 @@ import time
 import uuid
 
 import pytest
+import psycopg
 from psycopg.rows import dict_row
 from psycopg_pool import ConnectionPool
 
@@ -309,6 +310,20 @@ def test_conn_pool_manages_connections(pg_instance):
     # close the rest
     pool.close_all_connections()
     assert pool._stats.connection_closed == limit + 1
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_conn_attempt_to_connect(pg_instance):
+    """
+    We attempt to connect to the database and check that the connection is successful.
+    This test is meant to be run against a database that is not running.
+    """
+    # Change the port to a non-existent port
+    pg_instance['password'] = 1234
+    check = PostgreSql('postgres', {}, [pg_instance])
+    with pytest.raises(psycopg.OperationalError):
+        check._attempt_to_connect()
 
 
 def local_pool(dbname, min_pool_size, max_pool_size):


### PR DESCRIPTION
### What does this PR do?
This PR 
- adds a safeguard to test postgres connection before trying to establish a connection pool. The check `_attempt_to_connect` will make a connection (not a connection pool) to postgres when postgres check is initialized. If the connection is failed to establish, it will immediately fail the check.
- Set the reconnect timeout to 0 (fail fast)

### Motivation
Previously, connection error will only be observed when the first query is executed. The default psycopg connection pool has default 30s reconnect timeout, which will block for 30s while retry is happening. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
