### PR TITLE
Correct codeowner name for openai/langchain integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -168,8 +168,8 @@ datadog_checks_base/tests/**/test_db_statements.py  @DataDog/database-monitoring
 /oracle/manifest.json                               @DataDog/agent-integrations @DataDog/database-monitoring @DataDog/documentation
 
 # APM Integrations
-/langchain/         @DataDog/llm-obs @DataDog/agent-integrations @DataDog/documentation
-/openai/            @DataDog/llm-obs @DataDog/agent-integrations @DataDog/documentation
+/langchain/         @DataDog/ml-observability @DataDog/agent-integrations @DataDog/documentation
+/openai/            @DataDog/ml-observability @DataDog/agent-integrations @DataDog/documentation
 
 
 # Windows agent


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR corrects the codeowner name for the openai and langchain integrations from `llm-obs` to `ml-observability`, as the Github team name was changed recently.


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
