### PR TITLE
Open a conn object per thread to prevent blocking on waiting for new connections

### DIFF
--- a/postgres/datadog_checks/postgres/connections.py
+++ b/postgres/datadog_checks/postgres/connections.py
@@ -238,7 +238,7 @@ class MultiDatabaseConnectionPool(object):
 
         return True
 
-    def get_main_db_pool(self, max_pool_conn_size: int = 3):
+    def get_main_db_pool(self, max_pool_conn_size: int = 5):
         """
         Returns a memoized, persistent psycopg connection pool to `self.dbname`.
         Is meant to be shared across multiple threads, and opens a preconfigured max number of connections.

--- a/postgres/datadog_checks/postgres/connections.py
+++ b/postgres/datadog_checks/postgres/connections.py
@@ -103,6 +103,7 @@ class MultiDatabaseConnectionPool(object):
         """
         start = datetime.datetime.now()
         cid = MultiDatabaseConnectionPool._format_cid(dbname, conn_id)
+        start_time = time.time()
         with self._mu:
             conn = self._conns.pop(cid, ConnectionInfo(None, None, None, None, None))
             db_pool = conn.connection
@@ -132,6 +133,12 @@ class MultiDatabaseConnectionPool(object):
                 last_accessed=datetime.datetime.now(),
                 persistent=persistent,
             )
+            self.histogram(
+                "dd.postgres._get_connection_pool.time",
+                (time() - start_time) * 1000,
+                tags = ["conn_id:{}".format(conn_id)],
+                hostname=self._check.resolved_hostname,
+                )
             return db_pool
 
     @staticmethod

--- a/postgres/datadog_checks/postgres/connections.py
+++ b/postgres/datadog_checks/postgres/connections.py
@@ -133,10 +133,10 @@ class MultiDatabaseConnectionPool(object):
                 last_accessed=datetime.datetime.now(),
                 persistent=persistent,
             )
-            self.histogram(
+            self._check.histogram(
                 "dd.postgres._get_connection_pool.time",
-                (time() - start_time) * 1000,
-                tags = ["conn_id:{}".format(conn_id)],
+                (time.time() - start_time) * 1000,
+                tags=["conn_id:" + cid],
                 hostname=self._check.resolved_hostname,
                 )
             return db_pool

--- a/postgres/datadog_checks/postgres/connections.py
+++ b/postgres/datadog_checks/postgres/connections.py
@@ -102,7 +102,6 @@ class MultiDatabaseConnectionPool(object):
         when re-establishing it.
         """
         start = datetime.datetime.now()
-        self.prune_connections()
         cid = MultiDatabaseConnectionPool._format_cid(dbname, conn_id)
         with self._mu:
             conn = self._conns.pop(cid, ConnectionInfo(None, None, None, None, None))

--- a/postgres/datadog_checks/postgres/discovery.py
+++ b/postgres/datadog_checks/postgres/discovery.py
@@ -69,7 +69,7 @@ class PostgresAutodiscovery(Discovery):
         return items_parsed
 
     def _get_databases(self) -> List[str]:
-        with self.db_pool.get_connection(self._db, self._default_ttl) as conn:
+        with self.db_pool.get_connection(self._db, self._default_ttl, conn_id="_get_databases") as conn:
             with conn.cursor() as cursor:
                 cursor.execute(AUTODISCOVERY_QUERY)
                 databases = list(cursor.fetchall())

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -149,6 +149,7 @@ class ExplainParameterizedQueries:
             )
         return None
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def _deallocate_prepared_statement(self, conn, query_signature):
         try:
             self._execute_query(conn, "DEALLOCATE PREPARE dd_{query_signature}".format(query_signature=query_signature))
@@ -159,11 +160,13 @@ class ExplainParameterizedQueries:
                 e,
             )
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def _execute_query(self, conn, query):
         with conn.cursor(row_factory=dict_row) as cursor:
             logger.debug('Executing query=[%s]', query)
             cursor.execute(query)
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def _execute_query_and_fetch_rows(self, conn, query):
         with conn.cursor(row_factory=dict_row) as cursor:
             logger.debug('Executing query=[%s]', query)

--- a/postgres/datadog_checks/postgres/explain_parameterized_queries.py
+++ b/postgres/datadog_checks/postgres/explain_parameterized_queries.py
@@ -75,7 +75,9 @@ class ExplainParameterizedQueries:
             return None
 
         query_signature = compute_sql_signature(obfuscated_statement)
-        with self._check.db_pool.get_connection(dbname, self._check._config.idle_connection_timeout) as conn:
+        with self._check.db_pool.get_connection(
+                dbname, self._check._config.idle_connection_timeout, conn_id="explain_statement"
+        ) as conn:
             self._set_plan_cache_mode(conn)
 
             if not self._create_prepared_statement(conn, statement, obfuscated_statement, query_signature):

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -261,6 +261,7 @@ class PostgresMetadata(DBMAsyncJob):
             return ""
         return 'v{major}.{minor}.{patch}'.format(major=version.major, minor=version.minor, patch=version.patch)
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_schema_info(self):
         databases = []
         if self._check.autodiscovery:
@@ -275,6 +276,7 @@ class PostgresMetadata(DBMAsyncJob):
         self._time_since_last_schemas_query = time.time()
         return metadata
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def _query_database_information(self, cursor: psycopg.cursor, dbname: str) -> Dict[str, Union[str, int]]:
         """
         Collect database info. Returns
@@ -288,6 +290,7 @@ class PostgresMetadata(DBMAsyncJob):
         row = cursor.fetchone()
         return row
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def _query_schema_information(self, cursor: psycopg.cursor, dbname: str) -> Dict[str, str]:
         """
         Collect user schemas. Returns
@@ -303,6 +306,7 @@ class PostgresMetadata(DBMAsyncJob):
             print(row['name'])
         return schemas
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def _get_table_info(self, cursor, dbname, schema_id):
         """
         Tables will be sorted by the number of total accesses (index_rel_scans + seq_scans) and truncated to
@@ -438,6 +442,7 @@ class PostgresMetadata(DBMAsyncJob):
 
         return table_payloads
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_metadata_for_database(self, dbname):
         metadata = {}
         with self.db_pool.get_connection(

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -440,7 +440,9 @@ class PostgresMetadata(DBMAsyncJob):
 
     def _collect_metadata_for_database(self, dbname):
         metadata = {}
-        with self.db_pool.get_connection(dbname, self._config.idle_connection_timeout) as conn:
+        with self.db_pool.get_connection(
+                dbname, self._config.idle_connection_timeout, conn_id="_collect_metadata_for_database"
+        ) as conn:
             with conn.cursor(row_factory=dict_row) as cursor:
                 database_info = self._query_database_information(cursor, dbname)
                 metadata.update(

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -545,7 +545,9 @@ class PostgreSql(AgentCheck):
         databases = self.autodiscovery.get_items()
         for db in databases:
             try:
-                with self.db_pool.get_connection(db, self._config.idle_connection_timeout) as conn:
+                with self.db_pool.get_connection(
+                        db, self._config.idle_connection_timeout, conn_id="_collect_relations_autodiscovery"
+                ) as conn:
                     with conn.cursor() as cursor:
                         for scope in relations_scopes:
                             self._query_scope(cursor, scope, instance_tags, False, db)

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -570,6 +570,7 @@ class PostgresStatementSamples(DBMAsyncJob):
 
         return None, None
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def _get_db_explain_setup_state_cached(self, dbname):
         # type: (str) -> Tuple[DBExplainError, Exception]
         strategy_cache = self._collection_strategy_cache.get(dbname)
@@ -584,6 +585,7 @@ class PostgresStatementSamples(DBMAsyncJob):
 
         return db_explain_error, err
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def _run_explain(self, dbname, statement, obfuscated_statement):
         start_time = time.time()
         with self.db_pool.get_connection(dbname, ttl_ms=self._conn_ttl_ms, conn_id=self.connection_id) as conn:

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -178,6 +178,7 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 self._stat_column_cache = col_names
                 return col_names
 
+    @tracked_method(agent_check_getter=agent_check_getter)
     def run_job(self):
         # do not emit any dd.internal metrics for DBM specific check code
         self.tags = [t for t in self._tags if not t.startswith('dd.internal')]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds a new `conn_id` parameter to the connections class, so each thread gets its own unique conn pool object when using the `get_connection` context manager function. Also, increases the max conn pool size for the "main" db connection pool to 5. This is shared across activity / metrics threads to run queries for pg_activity / pg_stat_statements.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
