### PR TITLE
Multiply the lookback interval time by 2.

### DIFF
--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -15,8 +15,6 @@
 
 * Restore the logic for the lookback time in the statement metrics query. It was previously the connection interval * 2, but was removed during a refactor. ([#15857](https://github.com/DataDog/integrations-core/pull/15857))
 
-***Fixed***:
-
 * Fix type `bytes` is not JSON serializable for dbm events ([#15763](https://github.com/DataDog/integrations-core/pull/15763))
 * Fix sqlserver file stats metrics for Azure SQL DB ([#15695](https://github.com/DataDog/integrations-core/pull/15695))
 

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-***Fixed***:
-
-* Restore the logic for the lookback time in the statement metrics query. It was previously the connection interval * 2, but was removed during a refactor. ([#15857](https://github.com/DataDog/integrations-core/pull/15857))
-
 ***Changed***:
 
 * Cache performance counter type to prevent querying for the same counter multiple times (especially for the per-db counters) ([#15714](https://github.com/DataDog/integrations-core/pull/15714))
@@ -14,6 +10,10 @@
 ***Added***:
 
 * Add `index_name` tag to `.database.avg_fragmentation_in_percent`, `.database.fragment_count`, `.database.avg_fragment_size_in_pages` metrics. Also add a new metric `sqlserver.database.index_page_count`, tagged by `database_name`, `object_name`, `index_id` and `index_name`. ([#15721](https://github.com/DataDog/integrations-core/pull/15721))
+
+***Fixed***:
+
+* Restore the logic for the lookback time in the statement metrics query. It was previously the connection interval * 2, but was removed during a refactor. ([#15857](https://github.com/DataDog/integrations-core/pull/15857))
 
 ***Fixed***:
 

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Restore the logic for the lookback time in the statement metrics query. It was previously the connection interval * 2, but was removed during a refactor. ([#15857](https://github.com/DataDog/integrations-core/pull/15857))
+
 ***Changed***:
 
 * Cache performance counter type to prevent querying for the same counter multiple times (especially for the per-db counters) ([#15714](https://github.com/DataDog/integrations-core/pull/15714))

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -194,6 +194,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         if collection_interval <= 0:
             collection_interval = DEFAULT_COLLECTION_INTERVAL
         self.collection_interval = collection_interval
+        
         super(SqlserverStatementMetrics, self).__init__(
             check,
             run_sync=is_affirmative(check.statement_metrics_config.get('run_sync', False)),
@@ -263,7 +264,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         self._statement_metrics_query = statements_query.format(
             query_metrics_columns=', '.join(available_columns),
             query_metrics_column_sums=', '.join(['sum({}) as {}'.format(c, c) for c in available_columns]),
-            collection_interval=int(math.ceil(self.collection_interval) * 2),
             limit=self.dm_exec_query_stats_row_limit,
             proc_char_limit=PROC_CHAR_LIMIT,
         )
@@ -274,7 +274,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         self.log.debug("collecting sql server statement metrics")
         statement_metrics_query = self._get_statement_metrics_query_cached(cursor)
         now = time.time()
-        query_interval = self.collection_interval
+        query_interval = self.collection_interval * 2
         if self._last_stats_query_time:
             query_interval = now - self._last_stats_query_time
         self._last_stats_query_time = now

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -194,6 +194,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         if collection_interval <= 0:
             collection_interval = DEFAULT_COLLECTION_INTERVAL
         self.collection_interval = collection_interval
+
         
         super(SqlserverStatementMetrics, self).__init__(
             check,

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -194,7 +194,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         if collection_interval <= 0:
             collection_interval = DEFAULT_COLLECTION_INTERVAL
         self.collection_interval = collection_interval
-
         
         super(SqlserverStatementMetrics, self).__init__(
             check,

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -277,7 +277,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         now = time.time()
         query_interval = self.collection_interval * 2
         if self._last_stats_query_time:
-            query_interval = now - self._last_stats_query_time
+            query_interval = max(query_interval, now - self._last_stats_query_time)
         self._last_stats_query_time = now
         params = (math.ceil(query_interval),)
         self.log.debug("Running query [%s] %s", statement_metrics_query, params)

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -194,7 +194,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
         if collection_interval <= 0:
             collection_interval = DEFAULT_COLLECTION_INTERVAL
         self.collection_interval = collection_interval
-        
         super(SqlserverStatementMetrics, self).__init__(
             check,
             run_sync=is_affirmative(check.statement_metrics_config.get('run_sync', False)),

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -95,7 +95,6 @@ def test_get_available_query_metrics_columns(dbm_instance, expected_columns, ava
             )
             assert result_available_columns == available_columns
 
-
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_get_statement_metrics_query_cached(aggregator, dbm_instance, caplog):
@@ -483,6 +482,7 @@ def test_statement_metrics_limit(
 
     # check that it's sorted
     assert sqlserver_rows == sorted(sqlserver_rows, key=lambda i: i['total_elapsed_time'], reverse=True)
+
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
@@ -910,6 +910,7 @@ def test_statement_conditional_stored_procedure_with_temp_table(
         assert event['sqlserver']['query_hash'] is not None
         assert event['sqlserver']['query_plan_hash'] is not None
 
+
 def _mock_database_list():
     Row = namedtuple('Row', 'name')
     fetchall_results = [
@@ -925,6 +926,7 @@ def _mock_database_list():
     # check excluded overrides included
     mock_cursor.fetchall.return_value = iter(fetchall_results)
     return fetchall_results, mock_cursor
+
 
 @pytest.mark.unit
 def test_metrics_lookback_multiplier(instance_docker):

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -94,6 +94,7 @@ def test_get_available_query_metrics_columns(dbm_instance, expected_columns, ava
                 cursor, expected_columns
             )
             assert result_available_columns == available_columns
+            
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -4,19 +4,19 @@
 
 from __future__ import unicode_literals
 
-from collections import namedtuple
 import logging
 import math
 import os
 import re
 import time
+from collections import namedtuple
 from concurrent.futures.thread import ThreadPoolExecutor
 from copy import copy
+from unittest.mock import ANY
 
 import mock
 import pytest
 from lxml import etree as ET
-from unittest.mock import ANY
 
 from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.utils import DBMAsyncJob

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -95,6 +95,7 @@ def test_get_available_query_metrics_columns(dbm_instance, expected_columns, ava
             )
             assert result_available_columns == available_columns
 
+
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
 def test_get_statement_metrics_query_cached(aggregator, dbm_instance, caplog):

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 
+from collections import namedtuple
 import logging
 import math
 import os
@@ -13,9 +14,9 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from copy import copy
 
 import mock
-from unittest.mock import ANY
 import pytest
 from lxml import etree as ET
+from unittest.mock import ANY
 
 from datadog_checks.base.utils.common import to_native_string
 from datadog_checks.base.utils.db.utils import DBMAsyncJob
@@ -30,8 +31,6 @@ from datadog_checks.sqlserver.const import (
 from datadog_checks.sqlserver.statements import SQL_SERVER_QUERY_METRICS_COLUMNS, obfuscate_xml_plan
 
 from .common import CHECK_NAME
-
-from collections import namedtuple
 
 try:
     import pyodbc

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -94,7 +94,6 @@ def test_get_available_query_metrics_columns(dbm_instance, expected_columns, ava
                 cursor, expected_columns
             )
             assert result_available_columns == available_columns
-            
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')


### PR DESCRIPTION
### What does this PR do?

We recently heard from a customer that certain long-running queries of theirs were missing corresponding metrics. Looking into it, this is due to the query duration exceeding the check's collection interval because we use the collection interval to calculate a lookback time window to control which statements we emit metrics for. 

In [this PR](https://github.com/DataDog/integrations-core/commit/5bc51aee49a5dd134dbc5093c7f03e89e2339b28#diff-8e277bbbdb25fa9b90a692e922e3f7e352ffa0d8ab4114441766e811b768f3bfL51-R51), we changed how we bound this lookback time into the actual query text, and we didn't bring along a corresponding multiplier which scaled the connection interval by 2 to increase the lookback window. This restores that logic in the new parameter binding.

### Motivation

A [customer reported query metrics being missing](https://datadoghq.atlassian.net/browse/SDBM-597) for some expected queries.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
