### PR TITLE
[Release] Bumped postgres version to 14.3.0 (#15863)

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 14.3.0 / 2023-09-19
+
 ***Added***:
 
 * Attempt to connect to the database and fail fast before trying to establish a connection pool ([#15839](https://github.com/DataDog/integrations-core/pull/15839))

--- a/postgres/datadog_checks/postgres/__about__.py
+++ b/postgres/datadog_checks/postgres/__about__.py
@@ -2,4 +2,4 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 
-__version__ = "14.2.4"
+__version__ = "14.3.0"

--- a/requirements-agent-release.txt
+++ b/requirements-agent-release.txt
@@ -118,7 +118,7 @@ datadog-pdh-check==2.0.0; sys_platform == 'win32'
 datadog-pgbouncer==5.0.0; sys_platform != 'win32'
 datadog-php-fpm==3.0.0
 datadog-postfix==1.13.1; sys_platform != 'win32'
-datadog-postgres==14.2.4
+datadog-postgres==14.3.0
 datadog-powerdns-recursor==2.3.1
 datadog-presto==2.7.1
 datadog-process==3.0.0


### PR DESCRIPTION
### What does this PR do?
Port postgres v14.3.0 release to master

### Motivation
https://github.com/DataDog/integrations-core/pull/15839 and https://github.com/DataDog/integrations-core/pull/15859

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
