### PR TITLE
Update README.md

### DIFF
--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -54,7 +54,7 @@ datadog-agent integration install datadog-snowflake==2.0.1
     grant imported privileges on database SNOWFLAKE to role DATADOG;
 
     -- Grant usage to your default warehouse to the role DATADOG.
-   grant usage to warehouse <WAREHOUSE> to role DATADOG;
+   grant usage on warehouse <WAREHOUSE> to role DATADOG;
 
     -- Create a user, skip this step if you are using an existing user.
     create user DATADOG_USER


### PR DESCRIPTION
Typo in Snowflake SQL syntax -- should say `grant usage on warehouse ...`, not `grant usage to warehouse ...` (i.e. replace `to` with `on`).

### What does this PR do?
This is a pure documentation typo fix, not a code change.  The example given in the docs has incorrect Snowflake SQL syntax -- it should say `grant usage on warehouse ...`, not `grant usage to warehouse ...` (i.e. replace `to` with `on`).

As written, executing the existing incorrect syntax results in: `Syntax error: unexpected 'to'.`

### Motivation
Fix documentation typo for a Snowflake SQL syntax issue

### Additional Notes
No tests should be needed, purely a doc change.

As further circumstantial evidence that is a typo error: this exact page is the [only single 1 result in Google for using the incorrect "to" syntax](https://www.google.com/search?q="grant+usage+to+warehouse+")

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
