### PR TITLE
Trigger tests on PRs for JMX metrics.yaml changes

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Trigger tests on JMX metrics.yaml updates ([#15877](https://github.com/DataDog/integrations-core/pull/15877))
+
 ## 5.1.0 / 2023-09-20
 
 ***Added***:

--- a/ddev/src/ddev/utils/scripts/ci_matrix.py
+++ b/ddev/src/ddev/utils/scripts/ci_matrix.py
@@ -49,6 +49,7 @@ TESTABLE_FILE_PATTERN = re.compile(
   | metadata\.csv
   | pyproject\.toml
   | snmp/data/default_profiles/.+
+  | data/metrics.yaml
     """,
     re.VERBOSE,
 )

--- a/ddev/src/ddev/utils/scripts/ci_matrix.py
+++ b/ddev/src/ddev/utils/scripts/ci_matrix.py
@@ -49,7 +49,7 @@ TESTABLE_FILE_PATTERN = re.compile(
   | metadata\.csv
   | pyproject\.toml
   | snmp/data/default_profiles/.+
-  | data/metrics.yaml
+  | [^/]+/datadog_checks/.+/data/metrics\.yaml
     """,
     re.VERBOSE,
 )

--- a/ddev/src/ddev/utils/scripts/ci_matrix.py
+++ b/ddev/src/ddev/utils/scripts/ci_matrix.py
@@ -49,7 +49,7 @@ TESTABLE_FILE_PATTERN = re.compile(
   | metadata\.csv
   | pyproject\.toml
   | snmp/data/default_profiles/.+
-  | [^/]+/datadog_checks/.+/data/metrics\.yaml
+  | datadog_checks/.+/data/metrics\.yaml
     """,
     re.VERBOSE,
 )

--- a/ddev/src/ddev/utils/scripts/ci_matrix.py
+++ b/ddev/src/ddev/utils/scripts/ci_matrix.py
@@ -48,8 +48,8 @@ TESTABLE_FILE_PATTERN = re.compile(
   | hatch\.toml
   | metadata\.csv
   | pyproject\.toml
-  | snmp/data/default_profiles/.+
-  | datadog_checks/.+/data/metrics\.yaml
+  | datadog_checks/[^/]+/data/metrics\.yaml
+  | datadog_checks/snmp/data/default_profiles/.+
     """,
     re.VERBOSE,
 )

--- a/tomcat/datadog_checks/tomcat/data/metrics.yaml
+++ b/tomcat/datadog_checks/tomcat/data/metrics.yaml
@@ -83,7 +83,7 @@ jmx_metrics:
             alias: tomcat.web.cache.lookup_count
             metric_type: counter
     - include:
-        domain_regex: Catalina|Tomca.
+        domain_regex: Catalina|Tomcat
         type: JspMonitor
         attribute:
           jspCount:

--- a/tomcat/datadog_checks/tomcat/data/metrics.yaml
+++ b/tomcat/datadog_checks/tomcat/data/metrics.yaml
@@ -83,7 +83,7 @@ jmx_metrics:
             alias: tomcat.web.cache.lookup_count
             metric_type: counter
     - include:
-        domain_regex: Catalina|Tomcat
+        domain_regex: Catalina|Tomca.
         type: JspMonitor
         attribute:
           jspCount:


### PR DESCRIPTION
### What does this PR do?

Triggers tests for integrations on PRs when `data/metrics.yaml` is modified.

### Motivation

Noticed tests were not being triggered on https://github.com/DataDog/integrations-core/pull/15761.

### Additional Notes

Manual testing shows that the tests get triggered. See https://github.com/DataDog/integrations-core/actions/runs/6260431555/job/16998471283?pr=15877 on https://github.com/DataDog/integrations-core/pull/15877/commits/7a91244cbf82194a8e9d6ba74fe13dfe88874be6.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
