### PR TITLE
Drop erroneous readme paragraph

### DIFF
--- a/gitlab/README.md
+++ b/gitlab/README.md
@@ -16,8 +16,6 @@ This OpenMetrics-based integration has a latest mode (enabled by setting `openme
 
 Metrics marked as `[OpenMetricsV1]` or `[OpenMetricsV2]` are only available using the corresponding mode of the GitLab integration. All other metrics are collected by both modes. 
 
-To use the legacy mode of Prometheus or OpenMetrics instead of the latest mode of OpenMetrics, change the `use_openmetrics` option to `use_prometheus`, and change the `openmetrics_endpoint` option to `prometheus_url`. For more information, see the [Prometheus and OpenMetrics metrics collection from a host documentation][30].
-
 ### Installation
 
 The GitLab check is included in the [Datadog Agent][2] package, so you don't need to install anything else on your GitLab servers.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation

When syncing tiles, the fact that the reference [30] is not present got flagged. It got in as part of #15085. Turns out the whole paragraph seems inapplicable to this integration (no `use_prometheus` here), so it probably ended up there as contamination with the rest of related PR's that we were working on simultaneously.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
