### PR TITLE
Improve CI failure message

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -169,7 +169,7 @@ notify-failed-pipeline:
   script:
     - export SLACK_CACHE_DIR="${PWD}/.slack-cache"
     - |
-      MESSAGE="The pipeline encountered an unexpected error."
+      MESSAGE="The pipeline encountered an unexpected error in job $CI_JOB_NAME. Please investigate $CI_JOB_URL for errors."
       postmessage "$NOTIFICATIONS_SLACK_CHANNEL" "$MESSAGE" alert
   tags: [ "runner:main" ]
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR updates the Slack message on integrations-core CI failure.

### Motivation
<!-- What inspired you to submit this pull request? -->
The Slack notification for failing CI is not very descriptive nor does it help fix CI issues.

<img width="394" alt="image" src="https://github.com/DataDog/integrations-core/assets/31313038/5f3e5f77-b537-4004-a409-c2fc8110f059">

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
