### PR TITLE
Documentation - Fix ArgoCD clashing tag names example

### DIFF
--- a/argocd/README.md
+++ b/argocd/README.md
@@ -128,7 +128,7 @@ metadata:
           "init_config": {},
           "instances": [
             {
-              "app_controller_endpoint": "http://%%host%%:8082/metrics"
+              "app_controller_endpoint": "http://%%host%%:8082/metrics",
               "rename_labels": {
                 "name": "argocd_app_name"
               }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The ArgoCD example for clashing tag names was missing a comma - this PR adds it.
### Motivation
<!-- What inspired you to submit this pull request? -->
The example annotation does not work without the comma.
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
