### PR TITLE
Disable WAL metric queries if aurora platform is detected

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -5,6 +5,7 @@
 ***Fixed***:
 
 * Set lower log level for relations metrics truncated ([#15903](https://github.com/DataDog/integrations-core/pull/15903))
+* Disable WAL metric queries if aurora platform is detected ([#15891](https://github.com/DataDog/integrations-core/pull/15891))
 
 ## 14.4.0 / 2023-09-19
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -233,7 +233,8 @@ class PostgreSql(AgentCheck):
         if self.version < V13:
             queries.append(SNAPSHOT_TXID_METRICS_LT_13)
         if self.version >= V14:
-            queries.append(STAT_WAL_METRICS)
+            if self.is_aurora is False:
+                queries.append(STAT_WAL_METRICS)
 
         if not queries:
             self.log.debug("no dynamic queries defined")


### PR DESCRIPTION
### What does this PR do?
Disable WAL metrics queries if aurora postgres is disabled. They are not (currently) supported by aurora postgres and fail with errors in logs.

### Motivation
Agent is trying to run queries which are not supported by aurora: https://github.com/DataDog/integrations-core/issues/15890

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
