### PR TITLE
Add dynamic port settings to sqlserver docs

### DIFF
--- a/sqlserver/README.md
+++ b/sqlserver/README.md
@@ -41,9 +41,7 @@ Proceed with the following steps in this guide only if you are installing the st
        GRANT CONNECT ANY DATABASE to datadog; 
    ```
 
-2. Make sure your SQL Server instance is listening on a specific fixed port. By default, named instances and SQL Server Express are configured for dynamic ports. See [Microsoft's documentation][4] for more details.
-
-3. (Required for AlwaysOn and `sys.master_files` metrics) To gather AlwaysOn and `sys.master_files` metrics, grant the following additional permission:
+2. (Required for AlwaysOn and `sys.master_files` metrics) To gather AlwaysOn and `sys.master_files` metrics, grant the following additional permission:
 
     ```SQL
         GRANT VIEW ANY DEFINITION to datadog;
@@ -71,14 +69,15 @@ To configure this check for an Agent running on a host:
        driver: SQL Server
    ```
 
-    See the [example check configuration][6] for a comprehensive description of all options, including how to use custom queries to create your own metrics.
+    If you use port autodiscovery, use `0` for `SQL_PORT`. See the [example check configuration][6] for a comprehensive description of all options, including how to use custom queries to create your own metrics.
 
     **Note**: The (default) provider `SQLOLEDB` is being deprecated. To use the newer `MSOLEDBSQL` provider, set the `adoprovider` variable to `MSOLEDBSQL` in your `sqlserver.d/conf.yaml` file after having downloaded the new provider from [Microsoft][7]. It is also possible to use the Windows Authentication and not specify the username/password with:
 
       ```yaml
       connection_string: "Trusted_Connection=yes"
       ```
-
+    
+    
 2. [Restart the Agent][8].
 
 ##### Linux


### PR DESCRIPTION
Currently the DBM docs imply that ports must be static. However, per the sample config files DBM can support dynamic ports, so the docs should reflect that. 

### What does this PR do?
Removes the line in `prereqs` saying a static port is required. Per this [PR](https://github.com/DataDog/integrations-core/pull/13135) DBM can support dynamic port discovery and the docs should reflect that. 

### Motivation
Implementing DBM and discovered this is possible but not documented anywhere except the sample config file. While that is useful, it contradicts the docs.  

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
