### PR TITLE
Adding check for Postgres Aurora to not collect STAT_WAL_METRICS & WAL_FILE_METRICS

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Fixed***:
 
-* Prevent Postgres integration from collecting WAL metrics from Aurora instances that cannot be collected [#15896] (https://github.com/DataDog/integrations-core/pull/15896)
+* Prevent Postgres integration from collecting WAL metrics from Aurora instances that cannot be collected ([#15896](https://github.com/DataDog/integrations-core/pull/15896))
 
 ***Fixed***:
 

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Fixed***:
 
-* Prevent Postgres integration from collecting WAL metrics from Aurora instances that cannot be collected (#15896) ([#15896] (https://github.com/DataDog/integrations-core/pull/15896))
+* Prevent Postgres integration from collecting WAL metrics from Aurora instances that cannot be collected ([#15896] (https://github.com/DataDog/integrations-core/pull/15896))
 
 ***Fixed***:
 

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -5,9 +5,6 @@
 ***Fixed***:
 
 * Prevent Postgres integration from collecting WAL metrics from Aurora instances that cannot be collected ([#15896](https://github.com/DataDog/integrations-core/pull/15896))
-
-***Fixed***:
-
 * Set lower log level for relations metrics truncated ([#15903](https://github.com/DataDog/integrations-core/pull/15903))
 
 ## 14.4.0 / 2023-09-19

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Fixed***:
 
-* Prevent Postgres integration from collecting WAL metrics from Aurora instances that cannot be collected ([#15896] (https://github.com/DataDog/integrations-core/pull/15896))
+* Prevent Postgres integration from collecting WAL metrics from Aurora instances that cannot be collected [#15896] (https://github.com/DataDog/integrations-core/pull/15896)
 
 ***Fixed***:
 

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Prevent Postgres integration from collecting WAL metrics from Aurora instances that cannot be collected (#15896) ([#15896] (https://github.com/DataDog/integrations-core/pull/15896))
+
 ***Fixed***:
 
 * Set lower log level for relations metrics truncated ([#15903](https://github.com/DataDog/integrations-core/pull/15903))

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+***Fixed***:
+
 * Prevent Postgres integration from collecting WAL metrics from Aurora instances that cannot be collected (#15896) ([#15896] (https://github.com/DataDog/integrations-core/pull/15896))
 
 ***Fixed***:

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -225,15 +225,16 @@ class PostgreSql(AgentCheck):
             # ERROR:  Function pg_stat_get_wal_receiver() is currently not supported in Aurora
             if self.is_aurora is False:
                 queries.append(QUERY_PG_STAT_WAL_RECEIVER)
+                queries.append(WAL_FILE_METRICS)
             queries.append(QUERY_PG_REPLICATION_SLOTS)
-            queries.append(WAL_FILE_METRICS)
 
         if self.version >= V13:
             queries.append(SNAPSHOT_TXID_METRICS)
         if self.version < V13:
             queries.append(SNAPSHOT_TXID_METRICS_LT_13)
         if self.version >= V14:
-            queries.append(STAT_WAL_METRICS)
+            if self.is_aurora is False:
+                queries.append(STAT_WAL_METRICS)
 
         if not queries:
             self.log.debug("no dynamic queries defined")

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -500,6 +500,10 @@ def test_query_timeout(integration_check, pg_instance):
 
 
 @requires_over_10
+@pytest.mark.parametrize(
+    'is_aurora',
+    [True, False],
+)
 def test_wal_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check = integration_check(pg_instance)
     check.is_aurora = is_aurora

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -65,14 +65,13 @@ def test_common_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check_stat_replication(aggregator, expected_tags=expected_tags)
     if is_aurora is False:
         check_wal_receiver_metrics(aggregator, expected_tags=expected_tags, connected=0)
+        check_file_wal_metrics(aggregator, expected_tags=expected_tags)
     check_uptime_metrics(aggregator, expected_tags=expected_tags)
 
     check_logical_replication_slots(aggregator, expected_tags)
     check_physical_replication_slots(aggregator, expected_tags)
     check_snapshot_txid_metrics(aggregator, expected_tags=expected_tags)
     check_stat_wal_metrics(aggregator, expected_tags=expected_tags)
-    check_file_wal_metrics(aggregator, expected_tags=expected_tags)
-
     aggregator.assert_all_metrics_covered()
 
 

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -508,7 +508,7 @@ def test_wal_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check = integration_check(pg_instance)
     check.is_aurora = is_aurora
 
-    if is_aurora is False:
+    if is_aurora is True:
         return
     # Default PG's wal size is 16MB
     wal_size = 16777216

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -500,8 +500,12 @@ def test_query_timeout(integration_check, pg_instance):
 
 
 @requires_over_10
-def test_wal_metrics(aggregator, integration_check, pg_instance):
+def test_wal_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check = integration_check(pg_instance)
+    check.is_aurora = is_aurora
+
+    if is_aurora is False:
+        return
     # Default PG's wal size is 16MB
     wal_size = 16777216
 


### PR DESCRIPTION
### What does this PR do?
Creates a condition to check whether the instance is a Postgres Aurora instance and prevents collection of metrics from `pg_stat_wal` and `pg_ls_waldir()` 

### Motivation
For PostgreSQL Aurora, our current code produces the following errors and is flooding the agent logs:

```
Error querying stat_wal_metrics: Function pg_stat_get_wal() is currently not supported for Aurora
Error querying wal_metrics: permission denied for function pg_ls_waldir
```
We're getting this error because for example, `pg_ls_waldir` is a filesystem function that is not supported by Postgres Aurora because of it being a managed service. The function is typically used to list the files in the WAL (write-ahead log) directory which is a part of Postgres’ replication and transaction log system. Since Aurora is a managed service, users usually will not have access to this directory and hence the error.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
