### PR TITLE
Quick fix to unblock CI

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -5,6 +5,7 @@
 ***Fixed***:
 
 * Exclude psycopg2 from automatic upgrades ([#15864](https://github.com/DataDog/integrations-core/pull/15864))
+* Upper-bound pydantic to quickly fix CI while we investigate what in the latest version breaks us. ([#15901](https://github.com/DataDog/integrations-core/pull/15901))
 
 ## 25.1.0 / 2023-09-15
 

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -76,7 +76,7 @@ cli = [
     "pip-tools",
     "pathspec>=0.10.0",
     "platformdirs>=2.0.0a3",
-    "pydantic>=2.0.2<2.10.0",
+    "pydantic>=2.0.2, <2.10.0",
     "pysmi>=0.3.4",
     "securesystemslib[crypto]==0.28.0",
     "semver>=2.13.0",

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -76,7 +76,7 @@ cli = [
     "pip-tools",
     "pathspec>=0.10.0",
     "platformdirs>=2.0.0a3",
-    "pydantic>=2.0.2, <2.10.0",
+    "pydantic>=2.0.2, <2.4.0",
     "pysmi>=0.3.4",
     "securesystemslib[crypto]==0.28.0",
     "semver>=2.13.0",

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -76,7 +76,7 @@ cli = [
     "pip-tools",
     "pathspec>=0.10.0",
     "platformdirs>=2.0.0a3",
-    "pydantic>=2.0.2",
+    "pydantic>=2.0.2<2.10.0",
     "pysmi>=0.3.4",
     "securesystemslib[crypto]==0.28.0",
     "semver>=2.13.0",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Set upper-bound for pydantic version we support.

### Motivation
<!-- What inspired you to submit this pull request? -->

The latest release of pydantic (2.4) doesn't jive well with datamodel_code_generator, it seems. While we investigate further, we can unblock the CI with this.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
