### PR TITLE
Add metric for status page load duration

### DIFF
--- a/php_fpm/CHANGELOG.md
+++ b/php_fpm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Added***:
+
+* Add metric for status page load duration ([#15902](https://github.com/DataDog/integrations-core/pull/15902))
+
 ## 3.0.0 / 2023-08-10 / Agent 7.48.0
 
 ***Changed***:

--- a/php_fpm/datadog_checks/php_fpm/php_fpm.py
+++ b/php_fpm/datadog_checks/php_fpm/php_fpm.py
@@ -10,6 +10,7 @@ from six import PY3, StringIO, iteritems, string_types
 from six.moves.urllib.parse import urlparse
 
 from datadog_checks.base import AgentCheck, is_affirmative
+from datadog_checks.base.utils.time import get_precise_time
 
 if PY3:
     # Flup package does not exist anymore so what's needed is vendored
@@ -51,6 +52,7 @@ class PHPFPMCheck(AgentCheck):
     """
 
     SERVICE_CHECK_NAME = 'php_fpm.can_ping'
+    STATUS_DURATION_NAME = 'php_fpm.status.duration'
 
     GAUGES = {
         'listen queue': 'php_fpm.listen_queue.size',
@@ -103,13 +105,17 @@ class PHPFPMCheck(AgentCheck):
         data = {}
         try:
             if use_fastcgi:
+                check_start_time = get_precise_time()
                 data = json.loads(self.request_fastcgi(status_url, query='json'))
+                check_duration = get_precise_time() - check_start_time
             else:
                 # TODO: adding the 'full' parameter gets you per-process detailed
                 # information, which could be nice to parse and output as metrics
                 max_attempts = 3
                 for i in range(max_attempts):
+                    check_start_time = get_precise_time()
                     resp = self.http.get(status_url, params={'json': True})
+                    check_duration = get_precise_time() - check_start_time
 
                     # Exponential backoff, wait at most (max_attempts - 1) times in case we get a 503.
                     # Delay in seconds is (2^i + random amount of seconds between 0 and 1)
@@ -132,6 +138,8 @@ class PHPFPMCheck(AgentCheck):
         metric_tags = tags + ["pool:{0}".format(pool_name)]
         if http_host is not None:
             metric_tags += ["http_host:{0}".format(http_host)]
+
+        self.gauge(self.STATUS_DURATION_NAME, check_duration, tags=metric_tags)
 
         for key, mname in iteritems(self.GAUGES):
             if key not in data:

--- a/php_fpm/tests/test_e2e.py
+++ b/php_fpm/tests/test_e2e.py
@@ -21,6 +21,7 @@ def test_status(dd_agent_check, instance, ping_url_tag):
         'php_fpm.requests.slow',
         'php_fpm.requests.accepted',
         'php_fpm.processes.max_reached',
+        'php_fpm.status.duration',
     ]
 
     expected_tags = ['fpm_cluster:forums', 'pool:www']
@@ -44,6 +45,7 @@ def test_status_fastcgi(dd_agent_check, instance_fastcgi, ping_url_tag_fastcgi):
         'php_fpm.requests.slow',
         'php_fpm.requests.accepted',
         'php_fpm.processes.max_reached',
+        'php_fpm.status.duration',
     ]
 
     expected_tags = ['fpm_cluster:forums', 'pool:www']

--- a/php_fpm/tests/test_php_fpm.py
+++ b/php_fpm/tests/test_php_fpm.py
@@ -34,6 +34,7 @@ def test_status(instance, aggregator, ping_url_tag, dd_run_check):
         'php_fpm.requests.slow',
         'php_fpm.requests.accepted',
         'php_fpm.processes.max_reached',
+        'php_fpm.status.duration',
     ]
 
     expected_tags = ['fpm_cluster:forums', 'pool:www']
@@ -57,6 +58,7 @@ def test_status_fastcgi(instance_fastcgi, aggregator, ping_url_tag_fastcgi, dd_r
         'php_fpm.requests.slow',
         'php_fpm.requests.accepted',
         'php_fpm.processes.max_reached',
+        'php_fpm.status.duration',
     ]
 
     expected_tags = ['fpm_cluster:forums', 'pool:www']


### PR DESCRIPTION
### What does this PR do?
Add a metric for how long it takes to load the FPM status page.

### Motivation
The status page requires a free FPM worker to load, so if the listen queue is backed up it can take a long time for the health check to work its way through the queue. It can be helpful to know about how long it takes to get from the end of the queue to the front.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
