### PR TITLE
Set lower log level for relations metrics truncated

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Set lower log level for relations metrics truncated ([#15903](https://github.com/DataDog/integrations-core/pull/15903))
+
 ## 14.4.0 / 2023-09-19
 
 ***Added***:

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -411,13 +411,13 @@ class PostgreSql(AgentCheck):
             return None
 
         if is_custom_metrics and len(results) > MAX_CUSTOM_RESULTS:
-            self.warning(
+            self.debug(
                 "Query: %s returned more than %s results (%s). Truncating", query, MAX_CUSTOM_RESULTS, len(results)
             )
             results = results[:MAX_CUSTOM_RESULTS]
 
         if is_relations and len(results) > self._config.max_relations:
-            self.warning(
+            self.debug(
                 "Query: %s returned more than %s results (%s). "
                 "Truncating. You can edit this limit by setting the `max_relations` config option",
                 query,

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -411,13 +411,13 @@ class PostgreSql(AgentCheck):
             return None
 
         if is_custom_metrics and len(results) > MAX_CUSTOM_RESULTS:
-            self.debug(
+            self.log.debug(
                 "Query: %s returned more than %s results (%s). Truncating", query, MAX_CUSTOM_RESULTS, len(results)
             )
             results = results[:MAX_CUSTOM_RESULTS]
 
         if is_relations and len(results) > self._config.max_relations:
-            self.debug(
+            self.log.debug(
                 "Query: %s returned more than %s results (%s). "
                 "Truncating. You can edit this limit by setting the `max_relations` config option",
                 query,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Customers will see this error frequently if they have a lot of tables in their db and because it is a `warning` level log, it will pollute agent logs even if log_level is set to `info`

Since there is nothing customers can really do about this, it makes more sense to set it as `debug` level log

### Motivation
<!-- What inspired you to submit this pull request? -->

Customer support tickets have reported the following:

> TLDR: A customer set up relation metrics and due to the 300 relation limit the agent spammed the agent log with error messages per relation it tried to collect above this limit. The customer was ingesting logs so they were alerted to this error only because of the $$ increase it cost them to ingest the agent log.

Since it makes no sense to log this outside of the `DEBUG` context, I think it makes sense to lower the log level from `warning` to `debug`

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
