### PR TITLE
Add `legacy_mode` option to init_config

### DIFF
--- a/win32_event_log/CHANGELOG.md
+++ b/win32_event_log/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Added***:
+
+* Add `legacy_mode` option to init_config ([#15907](https://github.com/DataDog/integrations-core/pull/15907))
+
 ***Fixed***:
 
 * Run all the tests on py3 ([#15798](https://github.com/DataDog/integrations-core/pull/15798))

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -96,7 +96,7 @@ To collect Windows Event Logs as Datadog events, configure channels under the `i
       filters: {}
   ```
 
-Agent versions 7.49 or later support setting `legacy_mode` in the shared `init_config` section. This sets the default for all instances and `legacy_mode` no longer needs to be set individually for each instance. The option can still be set on a per-instance basis.
+Agent versions 7.49 and later support setting `legacy_mode` in the shared `init_config` section. This sets the default for all instances and no longer requires you to set `legacy_mode` individually for each instance. However, the option can still be set on a per-instance basis.
 
   ```yaml
   init_config:

--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -96,6 +96,20 @@ To collect Windows Event Logs as Datadog events, configure channels under the `i
       filters: {}
   ```
 
+Agent versions 7.49 or later support setting `legacy_mode` in the shared `init_config` section. This sets the default for all instances and `legacy_mode` no longer needs to be set individually for each instance. The option can still be set on a per-instance basis.
+
+  ```yaml
+  init_config:
+      legacy_mode: false
+  instances:
+    - # Event Log API
+      path: Security
+      filters: {}
+
+    - path: "<CHANNEL_2>"
+      filters: {}
+  ```
+
 #### Event collection using Legacy Mode (Deprecated)
 
 The legacy method uses WMI (Windows Management Instrumentation) and was deprecated in Agent version 7.20. 

--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -303,7 +303,7 @@ files:
       value:
         type: boolean
         display_default: true
-        example: false
+        example: true
     - name: host
       description: |
         By default, the local machine's event logs are captured. To capture a remote

--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -300,7 +300,6 @@ files:
           This mode, by nature of the underlying technology, is significantly more resource intensive.
 
         Setting this option to `false` is only supported on Agent versions 7 and above.
-      enabled: true
       value:
         type: boolean
         display_default: true

--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -45,6 +45,19 @@ files:
       value:
         type: string
         example: normal
+    - name: legacy_mode
+      description: |
+        Whether or not to use a mode of operation that is now unmaintained and will be removed in a future version.
+
+          /\ WARNING /\
+          This mode, by nature of the underlying technology, is significantly more resource intensive.
+
+        Setting this option to `false` is only supported on Agent versions 7 and above.
+      enabled: true
+      value:
+        type: boolean
+        display_default: true
+        example: false
     - template: init_config/default
   - template: instances
     overrides:

--- a/win32_event_log/datadog_checks/win32_event_log/check.py
+++ b/win32_event_log/datadog_checks/win32_event_log/check.py
@@ -69,7 +69,11 @@ class Win32EventLogCheck(AgentCheck, ConfigMixin):
     def __new__(cls, name, init_config, instances):
         instance = instances[0]
 
-        if PY2 or is_affirmative(instance.get('legacy_mode', True)):
+        # default to legacy mode for configuration backwards compatibility
+        init_config_legacy_mode = is_affirmative(init_config.get('legacy_mode', True))
+        # If legacy_mode is unset for an instance, default to the init_config option
+        instance_legacy_mode = is_affirmative(instance.get('legacy_mode', init_config_legacy_mode))
+        if PY2 or instance_legacy_mode:
             return Win32EventLogWMI(name, init_config, instances)
         else:
             return super(Win32EventLogCheck, cls).__new__(cls)

--- a/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
+++ b/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
@@ -20,6 +20,10 @@ def shared_interpret_messages():
     return True
 
 
+def shared_legacy_mode():
+    return True
+
+
 def shared_tag_event_id():
     return False
 

--- a/win32_event_log/datadog_checks/win32_event_log/config_models/shared.py
+++ b/win32_event_log/datadog_checks/win32_event_log/config_models/shared.py
@@ -29,6 +29,7 @@ class SharedConfig(BaseModel):
     default_event_priority: Optional[str] = None
     event_priority: Optional[Literal['normal', 'low']] = None
     interpret_messages: Optional[bool] = None
+    legacy_mode: Optional[bool] = None
     service: Optional[str] = None
     tag_event_id: Optional[bool] = None
     tag_sid: Optional[bool] = None

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -250,7 +250,7 @@ instances:
     ##
     ## Setting this option to `false` is only supported on Agent versions 7 and above.
     #
-    # legacy_mode: false
+    # legacy_mode: true
 
     ## @param host - string - optional - default: localhost
     ## By default, the local machine's event logs are captured. To capture a remote

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -250,7 +250,7 @@ instances:
     ##
     ## Setting this option to `false` is only supported on Agent versions 7 and above.
     #
-    legacy_mode: false
+    # legacy_mode: false
 
     ## @param host - string - optional - default: localhost
     ## By default, the local machine's event logs are captured. To capture a remote

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -36,6 +36,16 @@ init_config:
     #
     # default_event_priority: normal
 
+    ## @param legacy_mode - boolean - optional - default: true
+    ## Whether or not to use a mode of operation that is now unmaintained and will be removed in a future version.
+    ##
+    ##   /\ WARNING /\
+    ##   This mode, by nature of the underlying technology, is significantly more resource intensive.
+    ##
+    ## Setting this option to `false` is only supported on Agent versions 7 and above.
+    #
+    legacy_mode: false
+
     ## @param service - string - optional
     ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
     ##

--- a/win32_event_log/tests/legacy/test_win32_integration.py
+++ b/win32_event_log/tests/legacy/test_win32_integration.py
@@ -4,8 +4,11 @@
 import platform
 
 import pytest
+from six import PY2
 
 from datadog_checks.win32_event_log import Win32EventLogCheck
+from datadog_checks.win32_event_log.legacy import Win32EventLogWMI
+
 
 from . import common
 
@@ -24,3 +27,47 @@ def test_deprecation_notice(dd_run_check):
         'This version of the check is deprecated and will be removed in a future release. '
         'Set `legacy_mode` to `false` and read about the latest options, such as `query`.'
     ) in check.get_warnings()
+
+@pytest.mark.parametrize('shared_legacy_mode', [None, False, True])
+@pytest.mark.parametrize('instance_legacy_mode', [None, False, True])
+def test_legacy_mode_select(new_check, shared_legacy_mode, instance_legacy_mode):
+    instance = {}
+    init_config = None
+
+    if shared_legacy_mode is not None:
+        init_config = {'legacy_mode': shared_legacy_mode}
+    if instance_legacy_mode is not None:
+        instance['legacy_mode'] = instance_legacy_mode
+
+    check = new_check(instance, init_config=init_config)
+
+    # if python2 should alawys choose legacy mode
+    if PY2:
+        assert type(check) is Win32EventLogWMI
+        return
+
+    # if instance option is set it should take precedence
+    if instance_legacy_mode:
+        assert type(check) is Win32EventLogWMI
+        return
+    elif instance_legacy_mode is False:
+        assert type(check) is Win32EventLogCheck
+        return
+
+    # instance option is unset
+    assert instance_legacy_mode is None
+
+    # shared/init_config option should apply now
+    if shared_legacy_mode:
+        assert type(check) is Win32EventLogWMI
+        return
+    elif shared_legacy_mode is False:
+        assert type(check) is Win32EventLogCheck
+        return
+
+    # shared/init_config option is unset
+    assert shared_legacy_mode is None
+
+    # should default to true for backwards compatibility
+    assert type(check) is Win32EventLogWMI
+

--- a/win32_event_log/tests/legacy/test_win32_integration.py
+++ b/win32_event_log/tests/legacy/test_win32_integration.py
@@ -4,9 +4,10 @@
 import platform
 
 import pytest
+from six import PY2
+
 from datadog_checks.win32_event_log import Win32EventLogCheck
 from datadog_checks.win32_event_log.legacy import Win32EventLogWMI
-from six import PY2
 
 from . import common
 

--- a/win32_event_log/tests/legacy/test_win32_integration.py
+++ b/win32_event_log/tests/legacy/test_win32_integration.py
@@ -4,11 +4,9 @@
 import platform
 
 import pytest
-from six import PY2
-
 from datadog_checks.win32_event_log import Win32EventLogCheck
 from datadog_checks.win32_event_log.legacy import Win32EventLogWMI
-
+from six import PY2
 
 from . import common
 

--- a/win32_event_log/tests/legacy/test_win32_integration.py
+++ b/win32_event_log/tests/legacy/test_win32_integration.py
@@ -28,6 +28,7 @@ def test_deprecation_notice(dd_run_check):
         'Set `legacy_mode` to `false` and read about the latest options, such as `query`.'
     ) in check.get_warnings()
 
+
 @pytest.mark.parametrize('shared_legacy_mode', [None, False, True])
 @pytest.mark.parametrize('instance_legacy_mode', [None, False, True])
 def test_legacy_mode_select(new_check, shared_legacy_mode, instance_legacy_mode):
@@ -70,4 +71,3 @@ def test_legacy_mode_select(new_check, shared_legacy_mode, instance_legacy_mode)
 
     # should default to true for backwards compatibility
     assert type(check) is Win32EventLogWMI
-

--- a/win32_event_log/tests/test_config.py
+++ b/win32_event_log/tests/test_config.py
@@ -16,3 +16,4 @@ def test_invalid_message_filter_regular_expression(dd_run_check, new_check, inst
         match='Error compiling pattern for option `{}`: invalid group reference 1 at position 1'.format(option),
     ):
         dd_run_check(check)
+

--- a/win32_event_log/tests/test_config.py
+++ b/win32_event_log/tests/test_config.py
@@ -16,4 +16,3 @@ def test_invalid_message_filter_regular_expression(dd_run_check, new_check, inst
         match='Error compiling pattern for option `{}`: invalid group reference 1 at position 1'.format(option),
     ):
         dd_run_check(check)
-


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add the `legacy_mode` option to the shared `init_config` configuration section.

Enable `legacy_mode: false` in `init_config` in the config example by default.

### Motivation
<!-- What inspired you to submit this pull request? -->
Set the option once in `init_config` rather than setting the option in every single instance.

https://datadoghq.atlassian.net/browse/WINA-265

### Additional Notes
<!-- Anything else we should know when reviewing? -->


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
