### PR TITLE
[SQLServer] - Add alloc/dealloc user and internal objects on activity events

### DIFF
--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add TempDB version store performance counters ([#15879](https://github.com/DataDog/integrations-core/pull/15879))
 * Add TempDB page counts metrics ([#15873](https://github.com/DataDog/integrations-core/pull/15873))
 * Add `index_name` tag to `.database.avg_fragmentation_in_percent`, `.database.fragment_count`, `.database.avg_fragment_size_in_pages` metrics. Also add a new metric `sqlserver.database.index_page_count`, tagged by `database_name`, `object_name`, `index_id` and `index_name`. ([#15721](https://github.com/DataDog/integrations-core/pull/15721))
+* Adds allocation/deallocation fields for user and internal objects on activity events (DBM only). ([#15913](https://github.com/DataDog/integrations-core/pull/15913))
 
 ***Added***:
 

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -103,12 +103,12 @@ SELECT
     c.client_net_address as client_address,
     sess.host_name as host_name,
     sess.program_name as program_name,
-	dbspu.user_objects_alloc_page_count as user_objects_alloc_page_count,
+    dbspu.user_objects_alloc_page_count as user_objects_alloc_page_count,
     dbspu.user_objects_dealloc_page_count as user_objects_dealloc_page_count,
     dbspu.internal_objects_alloc_page_count as internal_objects_alloc_page_count,
     dbspu.internal_objects_dealloc_page_count as internal_objects_dealloc_page_count
 FROM sys.dm_exec_sessions sess
-	INNER JOIN sys.dm_db_session_space_usage dbspu
+    INNER JOIN sys.dm_db_session_space_usage dbspu
            ON sess.session_id = dbspu.session_id
     INNER JOIN sys.dm_exec_connections c
         ON sess.session_id = c.session_id

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -68,8 +68,8 @@ SELECT
     dbspu.internal_objects_dealloc_page_count as internal_objects_dealloc_page_count,
     {exec_request_columns}
 FROM sys.dm_exec_sessions sess
-	INNER JOIN sys.dm_db_session_space_usage dbspu
-   		ON sess.session_id = dbspu.session_id
+    INNER JOIN sys.dm_db_session_space_usage dbspu
+           ON sess.session_id = dbspu.session_id
     INNER JOIN sys.dm_exec_connections c
         ON sess.session_id = c.session_id
     INNER JOIN sys.dm_exec_requests req

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -62,8 +62,14 @@ SELECT
     c.client_net_address as client_address,
     sess.host_name as host_name,
     sess.program_name as program_name,
+    dbspu.user_objects_alloc_page_count as user_objects_alloc_page_count,
+    dbspu.user_objects_dealloc_page_count as user_objects_dealloc_page_count,
+    dbspu.internal_objects_alloc_page_count as internal_objects_alloc_page_count,
+    dbspu.internal_objects_dealloc_page_count as internal_objects_dealloc_page_count,
     {exec_request_columns}
 FROM sys.dm_exec_sessions sess
+	INNER JOIN sys.dm_db_session_space_usage dbspu
+   		ON sess.session_id = dbspu.session_id
     INNER JOIN sys.dm_exec_connections c
         ON sess.session_id = c.session_id
     INNER JOIN sys.dm_exec_requests req

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -102,8 +102,14 @@ SELECT
     c.client_tcp_port as client_port,
     c.client_net_address as client_address,
     sess.host_name as host_name,
-    sess.program_name as program_name
+    sess.program_name as program_name,
+	dbspu.user_objects_alloc_page_count as user_objects_alloc_page_count,
+    dbspu.user_objects_dealloc_page_count as user_objects_dealloc_page_count,
+    dbspu.internal_objects_alloc_page_count as internal_objects_alloc_page_count,
+    dbspu.internal_objects_dealloc_page_count as internal_objects_dealloc_page_count
 FROM sys.dm_exec_sessions sess
+	INNER JOIN sys.dm_db_session_space_usage dbspu
+           ON sess.session_id = dbspu.session_id
     INNER JOIN sys.dm_exec_connections c
         ON sess.session_id = c.session_id
     CROSS APPLY sys.dm_exec_sql_text(c.most_recent_sql_handle) lqt

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -436,9 +436,7 @@ def test_activity_metadata(
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
-def test_activity_tempdb_alloc(
-    aggregator, instance_docker, dd_run_check, dbm_instance, datadog_agent
-):
+def test_activity_tempdb_alloc(aggregator, instance_docker, dd_run_check, dbm_instance, datadog_agent):
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
     TABLE_NAME = "##LockTest{}".format(str(int(time.time() * 1000)))
 
@@ -504,7 +502,13 @@ def test_activity_tempdb_alloc(
     assert dbm_activity, "should have collected at least one activity"
     rows = dbm_activity[0]['sqlserver_activity']
     assert any(activity['user_objects_alloc_page_count'] for activity in rows)
-    assert all('user_objects_alloc_page_count' in activity and 'user_objects_dealloc_page_count' in activity and 'internal_objects_alloc_page_count' in activity and 'internal_objects_dealloc_page_count' in activity for activity in rows)
+    assert all(
+        'user_objects_alloc_page_count' in activity
+        and 'user_objects_dealloc_page_count' in activity
+        and 'internal_objects_alloc_page_count' in activity
+        and 'internal_objects_dealloc_page_count' in activity
+        for activity in rows
+    )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### What does this PR do?
- Adds allocation/deallocation fields for user and internal objects on activity events (DBM only).

### Motivation
- We would like to graph allocation/deallocation of tempdb pages for user-made and internal objects by different dimensions attached to sessions (program name, client_ip, user, database etc...).

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
