### PR TITLE
Update default configuration for ssl to 'allow'

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Changed***:
+
+* Update `ssl` default configuration to 'allow' ([#15917](https://github.com/DataDog/integrations-core/pull/15917))
+
 ***Fixed***:
 
 * Set lower log level for relations metrics truncated ([#15903](https://github.com/DataDog/integrations-core/pull/15903))

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -86,7 +86,8 @@ files:
         For a detailed description of how these options work see https://www.postgresql.org/docs/current/libpq-ssl.html
       value:
         type: string
-        example: "disable"
+        example: 'allow'
+        default: 'allow'
     - name: ssl_root_cert
       description: |
         The path to the ssl root certificate.

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -60,7 +60,7 @@ class PostgresConfig:
         self.max_connections = instance.get('max_connections', 30)
         self.tags = self._build_tags(instance.get('tags', []))
 
-        ssl = instance.get('ssl', "disable")
+        ssl = instance.get('ssl', "allow")
         if ssl in SSL_MODES:
             self.ssl_mode = ssl
 

--- a/postgres/datadog_checks/postgres/config_models/defaults.py
+++ b/postgres/datadog_checks/postgres/config_models/defaults.py
@@ -113,7 +113,7 @@ def instance_query_timeout():
 
 
 def instance_ssl():
-    return 'disable'
+    return 'allow'
 
 
 def instance_table_count_limit():

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -63,7 +63,7 @@ instances:
     #   - rdsadmin
     #   - azure_maintenance
 
-    ## @param ssl - string - optional - default: disable
+    ## @param ssl - string - optional - default: allow
     ## This option determines whether or not and with what priority a secure SSL TCP/IP connection
     ## is negotiated with the server. There are six modes:
     ## - `disable`: Only tries a non-SSL connection.
@@ -78,7 +78,7 @@ instances:
     ##
     ## For a detailed description of how these options work see https://www.postgresql.org/docs/current/libpq-ssl.html
     #
-    # ssl: disable
+    # ssl: allow
 
     ## @param ssl_root_cert - string - optional
     ## The path to the ssl root certificate.


### PR DESCRIPTION
### What does this PR do?
This updates the default config for `ssl` from `disable` to `allow`. The reason is that postgres 15 on RDS is [switching the default for `force_ssl` to `true`](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/PostgreSQL.Concepts.General.SSL.html#PostgreSQL.Concepts.General.SSL.Requiring). Setting the default to `allow` means that a failure to connect without ssl will trigger an attempt to connect using ssl. 

We could also consider going a bit further and setting the default to `prefer` which means ssl would be used first but I went with a more conservative approach that's closer to our current value (prefer non-ssl and switch to ssl on failure). 

### Motivation
Help make for a smoother transition for RDS Postgres users when they upgrade to postgres 15.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
