### PR TITLE
Try to make sqlserver tests run faster by setting low coll intervals for DBM jobs

### DIFF
--- a/sqlserver/hatch.toml
+++ b/sqlserver/hatch.toml
@@ -18,13 +18,16 @@ driver = ["SQLOLEDB", "SQLNCLI11", "MSOLEDBSQL", "odbc"]
 version = ["2019"]
 setup = ["single"]
 
-# temporarily exclude high cardinality windows env. to be fixed in a follow-up PR
-[[envs.default.matrix]]
-python = ["3.9"]
-os = ["linux"]
-driver = ["odbc"]
-version = ["2019", "2022"]
-case = ["high-cardinality"]
+# The high cardinality environment is meant to be used for local dev/testing
+# for example, when we want to do performance testing on local changes to the metrics
+# query, we can do that by uncommenting this env setup. Note, you should make sure to set you
+# DD_API_KEY in order to send the related metrics to staging for evaluation.
+#[[envs.default.matrix]]
+#python = ["3.9"]
+#os = ["linux"]
+#driver = ["odbc"]
+#version = ["2019", "2022"]
+#case = ["high-cardinality"]
 
 [envs.default.env-vars]
 ODBCSYSINI = "{root}{/}tests{/}odbc"

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -53,6 +53,7 @@ def dbm_instance(instance_docker):
     # do not need query_metrics for these tests
     instance_docker['query_metrics'] = {'enabled': False}
     instance_docker['procedure_metrics'] = {'enabled': False}
+    instance_docker['collect_settings'] = {'enabled': False}
     return copy(instance_docker)
 
 

--- a/sqlserver/tests/test_connection.py
+++ b/sqlserver/tests/test_connection.py
@@ -353,6 +353,7 @@ def test_connection_failure(aggregator, dd_run_check, instance_docker):
     instance_docker['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
     instance_docker['procedure_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
     instance_docker['query_activity'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
+    instance_docker['collect_settings'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
     check = SQLServer(CHECK_NAME, {}, [instance_docker])
 
     dd_run_check(check)

--- a/sqlserver/tests/test_e2e.py
+++ b/sqlserver/tests/test_e2e.py
@@ -97,9 +97,11 @@ def test_ao_secondary_replica(dd_agent_check, init_config, instance_ao_docker_se
 @not_windows_ado
 def test_check_docker(dd_agent_check, init_config, instance_e2e):
     # run sync to ensure only a single run of both
-    instance_e2e['query_activity'] = {'run_sync': True}
-    instance_e2e['query_metrics'] = {'run_sync': True}
-    instance_e2e['procedure_metrics'] = {'run_sync': True}
+    # set a very small collection interval so the tests go fast
+    instance_e2e['query_activity'] = {'run_sync': True, 'collection_interval': 0.1}
+    instance_e2e['query_metrics'] = {'run_sync': True, 'collection_interval': 0.1}
+    instance_e2e['procedure_metrics'] = {'run_sync': True, 'collection_interval': 0.1}
+    instance_e2e['collect_settings'] = {'run_sync': True, 'collection_interval': 0.1}
     aggregator = dd_agent_check({'init_config': init_config, 'instances': [instance_e2e]}, rate=True)
 
     aggregator.assert_metric_has_tag('sqlserver.db.commit_table_entries', 'db:master')

--- a/sqlserver/tests/test_metadata.py
+++ b/sqlserver/tests/test_metadata.py
@@ -24,6 +24,7 @@ def dbm_instance(instance_docker):
     instance_docker['dbm'] = True
     instance_docker['min_collection_interval'] = 1
     instance_docker['query_metrics'] = {'enabled': False}
+    instance_docker['query_activity'] = {'enabled': False}
     instance_docker['procedure_metrics'] = {'enabled': False}
     # set a very small collection interval so the tests go fast
     instance_docker['collect_settings'] = {

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -58,7 +58,7 @@ def dbm_instance(instance_docker):
     instance_docker['min_collection_interval'] = 1
     instance_docker['procedure_metrics'] = {'enabled': False}
     instance_docker['collect_settings'] = {'enabled': False}
-    dbm_instance['query_activity'] = {'enabled': False}
+    instance_docker['query_activity'] = {'enabled': False}
     # set a very small collection interval so the tests go fast
     instance_docker['query_metrics'] = {
         'enabled': True,

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -300,6 +300,7 @@ def test_statement_metrics_and_plans(
     caplog.set_level(logging.INFO)
     if disable_secondary_tags:
         dbm_instance['query_metrics']['disable_secondary_tags'] = True
+    dbm_instance['query_activity'] = {'enabled': True, 'collection_interval': 2}
     check = SQLServer(CHECK_NAME, {}, [dbm_instance])
 
     # the check must be run three times:

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -57,6 +57,8 @@ def dbm_instance(instance_docker):
     instance_docker['dbm'] = True
     instance_docker['min_collection_interval'] = 1
     instance_docker['procedure_metrics'] = {'enabled': False}
+    instance_docker['collect_settings'] = {'enabled': False}
+    dbm_instance['query_activity'] = {'enabled': False}
     # set a very small collection interval so the tests go fast
     instance_docker['query_metrics'] = {
         'enabled': True,

--- a/sqlserver/tests/test_stored_procedures.py
+++ b/sqlserver/tests/test_stored_procedures.py
@@ -53,6 +53,8 @@ def dbm_instance(instance_docker):
     instance_docker['dbm'] = True
     instance_docker['min_collection_interval'] = 1
     instance_docker['query_metrics'] = {'enabled': False}
+    instance_docker['query_activity'] = {'enabled': False}
+    instance_docker['collect_settings'] = {'enabled': False}
     # set a very small collection interval so the tests go fast
     instance_docker['procedure_metrics'] = {
         'enabled': True,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Some tests were taking 10s to complete, which _could_ be due to us not setting low collection intervals everywhere. For example,  `test_get_available_query_metrics_columns` was taking 10+ seconds but it simply runs a query to check that columns are populated in a cache:

```
Time Delta: 10.044208 seconds - 2023-09-28T19:21:00.3845525Z tests/test_statements.py::test_get_available_query_metrics_columns[expected_columns0-available_columns0] PASSED [ 68%]
Time Delta: 10.030386 seconds - 2023-09-28T19:08:10.5933882Z tests/test_statements.py::test_get_available_query_metrics_columns[expected_columns0-available_columns0] PASSED [ 68%]
```

I've seen this before in our postgres tests when we add new jobs & its possible that is what is happening here. Currently sql server CI take 2+ hours to run, and becoming very difficult to work on due to the slow iteration process. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
