### PR TITLE
Update tags and filter by type for kube scheduler SLI metrics

### DIFF
--- a/kube_scheduler/CHANGELOG.md
+++ b/kube_scheduler/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Update kube_scheduler SLI metrics implementation for consistency across components ([#15929](https://github.com/DataDog/integrations-core/pull/15929))
+
 ## 4.7.0 / 2023-09-29
 
 ***Added***:

--- a/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/kube_scheduler.py
@@ -213,7 +213,7 @@ class KubeSchedulerCheck(KubeLeaderElectionMixin, SliMetricsScraperMixin, OpenMe
 
         if self._slis_available:
             self.log.debug('processing kube scheduler sli metrics')
-            self.process(self.slis_scraper_config)
+            self.process(self.slis_scraper_config, metric_transformers=self.sli_transformers)
 
     def _perform_service_check(self, instance):
         url = instance.get('health_url')

--- a/kube_scheduler/datadog_checks/kube_scheduler/sli_metrics.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/sli_metrics.py
@@ -73,6 +73,7 @@ class SliMetricsScraperMixin(OpenMetricsBaseCheck):
             metric_type = sample[self.SAMPLE_LABELS]["type"]
             if metric_type == "healthz":
                 self._rename_sli_tag(sample, "sli_name", "name")
+                self._remove_tag(sample, "type")
                 modified_metric.samples.append(sample)
             else:
                 self.log.debug("Skipping metric with type `%s`", metric_type)
@@ -81,3 +82,6 @@ class SliMetricsScraperMixin(OpenMetricsBaseCheck):
     def _rename_sli_tag(self, sample, new_tag_name, old_tag_name):
         sample[self.SAMPLE_LABELS][new_tag_name] = sample[self.SAMPLE_LABELS][old_tag_name]
         del sample[self.SAMPLE_LABELS][old_tag_name]
+
+    def _remove_tag(self, sample, tag_name):
+        del sample[self.SAMPLE_LABELS][tag_name]

--- a/kube_scheduler/datadog_checks/kube_scheduler/sli_metrics.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/sli_metrics.py
@@ -5,18 +5,17 @@ from __future__ import division
 
 from copy import deepcopy
 
+from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
+
 SLI_METRICS_PATH = '/slis'
 
-SLI_GAUGES = {
+SLI_METRICS_MAP = {
     'kubernetes_healthcheck': 'kubernetes_healthcheck',
-}
-
-SLI_COUNTERS = {
     'kubernetes_healthchecks_total': 'kubernetes_healthchecks_total',
 }
 
 
-class SliMetricsScraperMixin(object):
+class SliMetricsScraperMixin(OpenMetricsBaseCheck):
     """
     This class scrapes metrics for the kube scheduler "/metrics/sli" prometheus endpoint and submits
     them on behalf of a check.
@@ -25,6 +24,10 @@ class SliMetricsScraperMixin(object):
     def __init__(self, *args, **kwargs):
         super(SliMetricsScraperMixin, self).__init__(*args, **kwargs)
         self._slis_available = None
+        self.sli_transformers = {
+            'kubernetes_healthcheck': self.sli_metrics_transformer,
+            'kubernetes_healthchecks_total': self.sli_metrics_transformer,
+        }
 
     def create_sli_prometheus_instance(self, instance):
         """
@@ -38,7 +41,6 @@ class SliMetricsScraperMixin(object):
             {
                 'namespace': KUBE_SCHEDULER_SLI_NAMESPACE,
                 'prometheus_url': instance.get('prometheus_url') + SLI_METRICS_PATH,
-                'metrics': [SLI_GAUGES, SLI_COUNTERS],
             }
         )
         return sli_instance
@@ -62,3 +64,20 @@ class SliMetricsScraperMixin(object):
             )
         self._slis_available = r.status_code == 200
         return self._slis_available
+
+    def sli_metrics_transformer(self, metric, scraper_config):
+        modified_metric = deepcopy(metric)
+        modified_metric.samples = []
+
+        for sample in metric.samples:
+            metric_type = sample[self.SAMPLE_LABELS]["type"]
+            if metric_type == "healthz":
+                self._rename_sli_tag(sample, "sli_name", "name")
+                modified_metric.samples.append(sample)
+            else:
+                self.log.debug("Skipping metric with type `%s`", metric_type)
+        self.submit_openmetric(SLI_METRICS_MAP[modified_metric.name], modified_metric, scraper_config)
+
+    def _rename_sli_tag(self, sample, new_tag_name, old_tag_name):
+        sample[self.SAMPLE_LABELS][new_tag_name] = sample[self.SAMPLE_LABELS][old_tag_name]
+        del sample[self.SAMPLE_LABELS][old_tag_name]

--- a/kube_scheduler/datadog_checks/kube_scheduler/sli_metrics.py
+++ b/kube_scheduler/datadog_checks/kube_scheduler/sli_metrics.py
@@ -45,13 +45,13 @@ class SliMetricsScraperMixin(object):
 
     def detect_sli_endpoint(self, http_handler, url):
         """
-        Whether the sli metrics endpoint is available (k8s 1.26+).
-        :return: false if the endpoint throws a 404 or 403, true otherwise.
+        Whether the SLI metrics endpoint is available (k8s 1.26+).
+        :return: true if the endpoint returns 200, false otherwise.
         """
         if self._slis_available is not None:
             return self._slis_available
         try:
-            r = http_handler.head(url)
+            r = http_handler.get(url, stream=True)
         except Exception as e:
             self.log.debug("Error querying SLIs endpoint: %s", e)
             return False
@@ -60,5 +60,5 @@ class SliMetricsScraperMixin(object):
                 "The /metrics/slis endpoint was introduced in Kubernetes v1.26. If you expect to see SLI metrics, \
                 please check that your permissions are configured properly."
             )
-        self._slis_available = r.status_code != 404 and r.status_code != 403
+        self._slis_available = r.status_code == 200
         return self._slis_available

--- a/kube_scheduler/tests/fixtures/metrics_slis_1.27.3.txt
+++ b/kube_scheduler/tests/fixtures/metrics_slis_1.27.3.txt
@@ -1,6 +1,8 @@
 # HELP kubernetes_healthcheck [ALPHA] This metric records the result of a single healthcheck.
 # TYPE kubernetes_healthcheck gauge
 kubernetes_healthcheck{name="ping",type="healthz"} 1
+kubernetes_healthcheck{name="etcd",type="readyz"} 1
 # HELP kubernetes_healthchecks_total [ALPHA] This metric records the results of all healthcheck.
 # TYPE kubernetes_healthchecks_total counter
 kubernetes_healthchecks_total{name="ping",status="success",type="healthz"} 2450
+kubernetes_healthchecks_total{name="etcd",status="success",type="readyz"} 15

--- a/kube_scheduler/tests/test_sli_metrics.py
+++ b/kube_scheduler/tests/test_sli_metrics.py
@@ -39,14 +39,57 @@ def test_check_metrics_slis(aggregator, mock_metrics, mock_request, instance):
         # Wrapper to keep assertions < 120 chars
         aggregator.assert_metric("{}.{}".format(CHECK_NAME, name), **kwargs)
 
-    assert_metric('slis.kubernetes_healthcheck', value=1, tags=['name:ping', 'type:healthz'])
+    assert_metric('slis.kubernetes_healthcheck', value=1, tags=['sli_name:ping', 'type:healthz'])
     assert_metric(
         'slis.kubernetes_healthchecks_total',
         value=2450,
-        tags=['name:ping', 'status:success', 'type:healthz'],
+        tags=['sli_name:ping', 'status:success', 'type:healthz'],
     )
 
     aggregator.assert_all_metrics_covered()
+
+
+def test_check_metrics_slis_transform(aggregator, mock_metrics, mock_request, instance):
+    mock_request.get('http://localhost:10251/metrics/slis', status_code=200)
+    c = KubeSchedulerCheck(CHECK_NAME, {}, [instance])
+    c.check(instance)
+
+    def assert_metric(name, **kwargs):
+        # Wrapper to keep assertions < 120 chars
+        aggregator.assert_metric("{}.{}".format(CHECK_NAME, name), **kwargs)
+
+    # Check that no metrics with `name` tag come through
+    assert_metric(
+        'slis.kubernetes_healthcheck', count=0, metric_type=aggregator.GAUGE, tags=['name:attachdetach', 'type:healthz']
+    )
+    assert_metric(
+        'slis.kubernetes_healthchecks_total',
+        metric_type=aggregator.MONOTONIC_COUNT,
+        count=0,
+        tags=['name:attachdetach', 'status:success', 'type:healthz'],
+    )
+
+
+def test_check_metrics_slis_filter_by_type(aggregator, mock_metrics, mock_request, instance):
+    mock_request.get('http://localhost:10251/metrics/slis', status_code=200)
+    c = KubeSchedulerCheck(CHECK_NAME, {}, [instance])
+    c.check(instance)
+
+    def assert_metric(name, **kwargs):
+        # Wrapper to keep assertions < 120 chars
+        aggregator.assert_metric("{}.{}".format(CHECK_NAME, name), **kwargs)
+
+    # Check that metrics with type other than `healthz` are filtered out
+    assert_metric(
+        'slis.kubernetes_healthcheck', count=0, metric_type=aggregator.GAUGE, tags=['sli_name:etcd', 'type:readyz']
+    )
+
+    assert_metric(
+        'slis.kubernetes_healthchecks_total',
+        metric_type=aggregator.MONOTONIC_COUNT,
+        count=0,
+        tags=['sli_name:etcd', 'status:success', 'type:readyz'],
+    )
 
 
 @pytest.fixture()

--- a/kube_scheduler/tests/test_sli_metrics.py
+++ b/kube_scheduler/tests/test_sli_metrics.py
@@ -39,11 +39,11 @@ def test_check_metrics_slis(aggregator, mock_metrics, mock_request, instance):
         # Wrapper to keep assertions < 120 chars
         aggregator.assert_metric("{}.{}".format(CHECK_NAME, name), **kwargs)
 
-    assert_metric('slis.kubernetes_healthcheck', value=1, tags=['sli_name:ping', 'type:healthz'])
+    assert_metric('slis.kubernetes_healthcheck', value=1, tags=['sli_name:ping'])
     assert_metric(
         'slis.kubernetes_healthchecks_total',
         value=2450,
-        tags=['sli_name:ping', 'status:success', 'type:healthz'],
+        tags=['sli_name:ping', 'status:success'],
     )
 
     aggregator.assert_all_metrics_covered()
@@ -59,14 +59,12 @@ def test_check_metrics_slis_transform(aggregator, mock_metrics, mock_request, in
         aggregator.assert_metric("{}.{}".format(CHECK_NAME, name), **kwargs)
 
     # Check that no metrics with `name` tag come through
-    assert_metric(
-        'slis.kubernetes_healthcheck', count=0, metric_type=aggregator.GAUGE, tags=['name:attachdetach', 'type:healthz']
-    )
+    assert_metric('slis.kubernetes_healthcheck', count=0, metric_type=aggregator.GAUGE, tags=['name:attachdetach'])
     assert_metric(
         'slis.kubernetes_healthchecks_total',
         metric_type=aggregator.MONOTONIC_COUNT,
         count=0,
-        tags=['name:attachdetach', 'status:success', 'type:healthz'],
+        tags=['name:attachdetach', 'status:success'],
     )
 
 

--- a/kube_scheduler/tests/test_sli_metrics.py
+++ b/kube_scheduler/tests/test_sli_metrics.py
@@ -6,7 +6,6 @@ import os
 
 import mock
 import pytest
-import requests
 import requests_mock
 
 from datadog_checks.kube_scheduler import KubeSchedulerCheck
@@ -32,7 +31,7 @@ def mock_metrics():
 
 
 def test_check_metrics_slis(aggregator, mock_metrics, mock_request, instance):
-    mock_request.head('http://localhost:10251/metrics/slis', status_code=200)
+    mock_request.get('http://localhost:10251/metrics/slis', status_code=200)
     c = KubeSchedulerCheck(CHECK_NAME, {}, [instance])
     c.check(instance)
 
@@ -56,33 +55,25 @@ def mock_request():
         yield m
 
 
-def test_detect_sli_endpoint(mock_metrics, mock_request, instance):
-    mock_request.head('http://localhost:10251/metrics/slis', status_code=200)
-    c = KubeSchedulerCheck(CHECK_NAME, {}, [instance])
-    c.check(instance)
-    assert c._slis_available is True
-    assert mock_request.call_count == 1
+def test_detect_sli_endpoint(mock_metrics, instance):
+    with mock.patch('requests.get') as mock_request:
+        mock_request.return_value.status_code = 200
+        c = KubeSchedulerCheck(CHECK_NAME, {}, [instance])
+        c.check(instance)
+        assert c._slis_available is True
 
 
-def test_detect_sli_endpoint_404(mock_metrics, mock_request, instance):
-    mock_request.head('http://localhost:10251/metrics/slis', status_code=404)
-    c = KubeSchedulerCheck(CHECK_NAME, {}, [instance])
-    c.check(instance)
-    assert c._slis_available is False
-    assert mock_request.call_count == 1
+def test_detect_sli_endpoint_404(mock_metrics, instance):
+    with mock.patch('requests.get') as mock_request:
+        mock_request.return_value.status_code = 404
+        c = KubeSchedulerCheck(CHECK_NAME, {}, [instance])
+        c.check(instance)
+        assert c._slis_available is False
 
 
-def test_detect_sli_endpoint_403(mock_metrics, mock_request, instance):
-    mock_request.head('http://localhost:10251/metrics/slis', status_code=403)
-    c = KubeSchedulerCheck(CHECK_NAME, {}, [instance])
-    c.check(instance)
-    assert c._slis_available is False
-    assert mock_request.call_count == 1
-
-
-def test_detect_sli_endpoint_timeout(mock_metrics, mock_request, instance):
-    mock_request.head('http://localhost:10251/metrics/slis', exc=requests.exceptions.ConnectTimeout)
-    c = KubeSchedulerCheck(CHECK_NAME, {}, [instance])
-    c.check(instance)
-    assert c._slis_available is None
-    assert mock_request.call_count == 1
+def test_detect_sli_endpoint_403(mock_metrics, instance):
+    with mock.patch('requests.get') as mock_request:
+        mock_request.return_value.status_code = 403
+        c = KubeSchedulerCheck(CHECK_NAME, {}, [instance])
+        c.check(instance)
+        assert c._slis_available is False


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The kube scheduler SLI metrics are updated such that:
* The tag `name` is renamed to `sli_name` to avoid confusion with other tags
* Only metrics with type `healthz` are parsed with this metric
* Uses a `GET` request to probe for the `/metrics/slis` endpoint; initial `HEAD` request introduced in #15731 seems to be throwing a `403` preventing metrics from being collected

### Motivation
<!-- What inspired you to submit this pull request? -->
For consistency with other SLI metrics, the kube scheduler SLI metrics logic is updated to match the kube controller manager: #15914  

### Additional Notes
<!-- Anything else we should know when reviewing? -->
Would it make more sense to pull all the SLI metrics logic into a common file to avoid duplication across all kubernetes components?

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
