### PR TITLE
Don't abort on `ddev release show changes` when no changes are found

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Exclude psycopg2 from automatic upgrades ([#15864](https://github.com/DataDog/integrations-core/pull/15864))
 * Upper-bound pydantic to quickly fix CI while we investigate what in the latest version breaks us. ([#15901](https://github.com/DataDog/integrations-core/pull/15901))
 * Finalize pytest plugin logic for E2E refactor ([#15898](https://github.com/DataDog/integrations-core/pull/15898))
+* Fix `ddev release make all` so that it won't stop on the first unchanged integration ([#15932](https://github.com/DataDog/integrations-core/pull/15932))
 
 ## 25.1.0 / 2023-09-15
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
@@ -11,6 +11,7 @@ from ....utils import complete_valid_checks, get_valid_checks, get_version_strin
 from ...console import (
     CONTEXT_SETTINGS,
     abort,
+    echo_failure,
     validate_check_arg,
 )
 
@@ -59,7 +60,8 @@ def changes(ctx, check, tag_pattern, tag_prefix, dry_run, organization, since, e
             break
 
     if header_index == 4:
-        abort('There are no changes for this integration')
+        echo_failure('There are no changes for this integration')
+        return cur_version, []
 
     unreleased = log[4:header_index]
     applicable_changelog_types = []


### PR DESCRIPTION
### What does this PR do?

Stops `ddev release show changes` from aborting when no changes have been found, so that it retains behavior that other commands rely upon.

### Motivation

[AITS-247](https://datadoghq.atlassian.net/browse/AITS-247)

Aborting causes the application to exit regardless of context, which is a problem when that breaks expectations of other commands that rely on invoking this command directly.

This was causing `release make all` to abort early as soon as an integration didn't have a change. This regression was introduced in #15378; we weren't aborting under that scenario before.

### Additional Notes

Longer term, I think we should try to avoid invoking commands from within any sort of minimally complex logic, and be careful with where we call functions that can exit the interpreter completely. We can leave this as it is for now until we move this to the `ddev` package. There's also a couple of unused options that could be removed when we do that as well.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[AITS-247]: https://datadoghq.atlassian.net/browse/AITS-247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ