### PR TITLE
Add troubleshooting notes for zero metrics sampled

### DIFF
--- a/kafka_consumer/README.md
+++ b/kafka_consumer/README.md
@@ -110,6 +110,26 @@ sudo systemctl restart datadog-agent.service
 sudo service datadog-agent restart
 ```
 
+**Zero metrics sampled**
+If your check experiences 0 metrics sampled:
+
+  ```
+    kafka_consumer (4.1.2)
+    ----------------------
+      Instance ID: kafka_consumer:2677a0cdef1373a9 [OK]
+      Configuration Source: file:/etc/datadog-agent/conf.d/kafka_consumer.d/kafka_consumer.yaml
+      Total Runs: 1
+      Metric Samples: Last Run: 0, Total: 0
+      Events: Last Run: 0, Total: 0
+      Service Checks: Last Run: 0, Total: 0
+      Average Execution Time : 30.055s
+      Last Execution Date : 2023-10-02 18:07:51 UTC (1696270071000)
+      Last Successful Execution Date : 2023-10-02 18:07:51 UTC (1696270071000)
+  ```
+
+This may be caused by an invalid configuration, like setting `sasl_mechanism` to `PLAINTEXT` instead of `SSL`. You can use the [following test script][17] to attempt a connection to Kafka without the Datadog Agent to confirm that your configurations are correct.
+
+
 ## Further Reading
 
 - [Monitoring Kafka performance metrics][13]
@@ -131,3 +151,4 @@ sudo service datadog-agent restart
 [14]: https://www.datadoghq.com/blog/collecting-kafka-performance-metrics
 [15]: https://www.datadoghq.com/blog/monitor-kafka-with-datadog
 [16]: https://www.datadoghq.com/product/data-streams-monitoring/
+[17]: https://github.com/DataDog/integrations-core/blob/master/kafka_consumer/tests/python_client/script.py


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR adds a small snippet in the Troubleshooting section of the README to help with situations where the configuration is wrong and 0 metrics are collected.


### Motivation
<!-- What inspired you to submit this pull request? -->
`confluent-kafka-python` will try a connection with the creation of the `AdminClient`, but it does not raise an error even after timing out, which makes it difficult to catch any exceptions.


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
