### PR TITLE
Fix windows agent team key

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -66,7 +66,7 @@ jira_statuses = [
 github_team = "network-device-monitoring"
 
 [teams."Windows Agent"]
-jira_project = "WA"
+jira_project = "WINA"
 jira_issue_type = "QA Task"
 jira_statuses = [
   "To Do",


### PR DESCRIPTION
The team key seems to be WINA:
https://a.cl.ly/rRumlPd7

Was getting a 403 trying to create qa cards for the windows agent team.