### PR TITLE
Update "Lookups" unit to instead use "occurrence"

### DIFF
--- a/sqlserver/metadata.csv
+++ b/sqlserver/metadata.csv
@@ -62,7 +62,7 @@ sqlserver.files.write_io_stall_queued,count,,millisecond,,"Total latency from IO
 sqlserver.files.write_io_stall,count,,millisecond,,"Total time that users waited for writes on the file. Tags: `logical_name`, `file_location`, `db`, `state`",-1,sql_server,write wait time on database file,
 sqlserver.files.writes,count,,write,second,"Number of writes issued on the file. Tags: `logical_name`, `file_location`, `db`, `state`",0,sql_server,writes on database file,
 sqlserver.files.written_bytes,count,,byte,second,"Bytes written to the file. Tags: `logical_name`, `file_location`, `db`, `state`",0,sql_server,bytes written to the database file,
-sqlserver.index.user_lookups,count,,lookups,,"Number of bookmark lookups by user queries. Tags: `db`, `table`, `index_name`",-1,sql_server,lookups by user queries,
+sqlserver.index.user_lookups,count,,occurrence,,"Number of bookmark lookups by user queries. Tags: `db`, `table`, `index_name`",-1,sql_server,lookups by user queries,
 sqlserver.index.user_scans,count,,scans,,"Number of scans by user queries that did not use 'seek' predicate. Tags: `db`, `table`, `index_name`",-1,sql_server,scans by user queries,
 sqlserver.index.user_seeks,count,,seeks,,"Number of seeks by user queries. Tags: `db`, `table`, `index_name`",-1,sql_server,seeks by user queries,
 sqlserver.index.user_updates,count,,updates,,"Number of updates by user queries. This includes Insert, Delete, and Updates representing the number of operations done, not the actual rows affected. Tags: `db`, `table`, `index_name`",-1,sql_server,updates by user queries,


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
"Lookups" is not a valid metric metadata unit, and this is whats causing the production metrics issues. I switched this to be a valid unit. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
