### PR TITLE
Remove extra-performance-metrics parameter

### DIFF
--- a/mysql/README.md
+++ b/mysql/README.md
@@ -119,7 +119,6 @@ Edit the `mysql.d/conf.yaml` file, in the `conf.d/` folder at the root of your [
         galera_cluster: true
         extra_status_metrics: true
         extra_innodb_metrics: true
-        extra_performance_metrics: true
         schema_size_metrics: false
         disable_innodb_metrics: false
   ```


### PR DESCRIPTION
### What does this PR do?

Remove the extra-performance-metrics parameter because it has been deprecated.

### Motivation

[DOCS-6329](https://datadoghq.atlassian.net/browse/DOCS-6329)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
