### PR TITLE
Update Kubernetes Pods Overview dashboard

### DIFF
--- a/kubernetes/assets/dashboards/kubernetes_pods.json
+++ b/kubernetes/assets/dashboards/kubernetes_pods.json
@@ -243,7 +243,7 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes.cpu.usage.total{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "max:kubernetes.cpu.usage.total{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -315,7 +315,7 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes.memory.usage{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
+                        "query": "max:kubernetes.memory.usage{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {pod_name}",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -707,7 +707,7 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes.cpu.usage.total{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {kube_container_name,container_id}",
+                        "query": "max:kubernetes.cpu.usage.total{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {kube_container_name,container_id}",
                         "data_source": "metrics",
                         "name": "query1"
                       }
@@ -750,7 +750,7 @@
                     "on_right_yaxis": false,
                     "queries": [
                       {
-                        "query": "sum:kubernetes.memory.usage{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {kube_container_name,container_id}",
+                        "query": "max:kubernetes.memory.usage{$cluster,$namespace,$deployment,$scope,$statefulset,$daemonset,$job} by {kube_container_name,container_id}",
                         "data_source": "metrics",
                         "name": "query1"
                       }


### PR DESCRIPTION
### What does this PR do?
Updating the `Kubernetes Pods Overview` dashboard to use `max` instead of `sum` for memory and cpu utilization widgets since these metrics are a gauge and using `sum` can create an inflated number to what is actually being used.

### Motivation
Noticed some graphs that had excessive CPU and memory utilization that this should fix

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
