### PR TITLE
Improve speed of mysql CI by setting lower coll intervals for DBM jobs

### DIFF
--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -358,6 +358,12 @@ def test_complex_config_replica(aggregator, dd_run_check, instance_complex):
 )
 def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, aggregator, dd_run_check, instance_basic):
     instance_basic['dbm'] = dbm_enabled
+    if dbm_enabled:
+        # set a very small collection interval so the tests go fast
+        instance_basic['collect_settings'] = {'collection_interval': 0.1}
+        instance_basic['query_activity'] = {'collection_interval': 0.1}
+        instance_basic['query_samples'] = {'collection_interval': 0.1}
+        instance_basic['query_metrics'] = {'collection_interval': 0.1}
     instance_basic['disable_generic_tags'] = False  # This flag also affects the hostname
     instance_basic['reported_hostname'] = reported_hostname
 
@@ -656,6 +662,12 @@ def test_set_resources(aggregator, dd_run_check, instance_basic, cloud_metadata,
 @pytest.mark.usefixtures('dd_environment')
 def test_database_instance_metadata(aggregator, dd_run_check, instance_complex, dbm_enabled, reported_hostname):
     instance_complex['dbm'] = dbm_enabled
+    if dbm_enabled:
+        # set a very small collection interval so the tests go fast
+        instance_complex['collect_settings'] = {'collection_interval': 0.1}
+        instance_complex['query_activity'] = {'collection_interval': 0.1}
+        instance_complex['query_samples'] = {'collection_interval': 0.1}
+        instance_complex['query_metrics'] = {'collection_interval': 0.1}
     if reported_hostname:
         instance_complex['reported_hostname'] = reported_hostname
     expected_host = reported_hostname if reported_hostname else 'stubbed.hostname'

--- a/mysql/tests/test_query_activity.py
+++ b/mysql/tests/test_query_activity.py
@@ -44,6 +44,7 @@ def dbm_instance(instance_complex):
     }
     instance_complex['query_metrics'] = {'enabled': False}
     instance_complex['query_samples'] = {'enabled': False}
+    instance_complex['collect_settings'] = {'enabled': False}
     return copy(instance_complex)
 
 

--- a/mysql/tests/test_statements.py
+++ b/mysql/tests/test_statements.py
@@ -41,6 +41,7 @@ def dbm_instance(instance_complex):
     instance_complex['query_metrics'] = {'enabled': True, 'run_sync': True, 'collection_interval': 0.1}
     # don't need query activity for these tests
     instance_complex['query_activity'] = {'enabled': False}
+    instance_complex['collect_settings'] = {'enabled': False}
     return instance_complex
 
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Some of these tests are hanging for long periods of time, due to the fact that we are enabling DBM jobs but not setting a low collection interval. This is a similar fix to the implementation we did in https://github.com/DataDog/integrations-core/pull/15928 for SQL Server CI, which improved the test time from 2 hours -> 30 min 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
