### PR TITLE
Update metric to check for openai web usage

### DIFF
--- a/openai/manifest.json
+++ b/openai/manifest.json
@@ -48,7 +48,7 @@
       },
       "metrics": {
         "prefix": "openai.",
-        "check": "openai.request.duration",
+        "check": ["openai.request.duration", "openai.api.usage.n_requests"],
         "metadata_path": "metadata.csv"
       },
       "service_checks": {


### PR DESCRIPTION
### What does this PR do?
Fixes no-data issue for openai web usage metrics (shared tile with openai apm).

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
