### PR TITLE
Establish a dedicated main db connection with heath check

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ***Added***:
 
+* Establish main db connection from pool to ensure connection is valid ([#15962](https://github.com/DataDog/integrations-core/pull/15962))
 * Update dependencies ([#15922](https://github.com/DataDog/integrations-core/pull/15922))
 
 ***Fixed***:

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ***Added***:
 
-* Establish a dedicated main db connection with heath check ([#15962](https://github.com/DataDog/integrations-core/pull/15962))
+* Establish a dedicated main db connection to prevent the main thread db from closing prematurely ([#15962](https://github.com/DataDog/integrations-core/pull/15962))
 * Update dependencies ([#15922](https://github.com/DataDog/integrations-core/pull/15922))
 
 ***Fixed***:

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ***Added***:
 
-* Establish main db connection from pool to ensure connection is valid ([#15962](https://github.com/DataDog/integrations-core/pull/15962))
+* Establish a dedicated main db connection with heath check ([#15962](https://github.com/DataDog/integrations-core/pull/15962))
 * Update dependencies ([#15922](https://github.com/DataDog/integrations-core/pull/15922))
 
 ***Fixed***:

--- a/postgres/datadog_checks/postgres/connections.py
+++ b/postgres/datadog_checks/postgres/connections.py
@@ -97,8 +97,8 @@ class MultiDatabaseConnectionPool(object):
         start = datetime.datetime.now()
         self.prune_connections()
         with self._mu:
-            conn = self._conns.pop(dbname, ConnectionInfo(None, None, None, None, None, None))
-            db = conn.connection
+            conn = self._conns.pop(dbname, None)
+            db = conn.connection if conn else None
             if db is None or db.closed:
                 if self.max_conns is not None:
                     # try to free space until we succeed
@@ -133,7 +133,14 @@ class MultiDatabaseConnectionPool(object):
             return db
 
     @contextlib.contextmanager
-    def get_connection(self, dbname: str, ttl_ms: int, timeout: int = None, persistent: bool = False):
+    def get_connection(
+        self,
+        dbname: str,
+        ttl_ms: int,
+        timeout: int = None,
+        startup_fn: Callable[[psycopg2.extensions.connection], None] = None,
+        persistent: bool = False,
+    ):
         """
         Grab a connection from the pool if the database is already connected.
         If max_conns is specified, and the database isn't already connected,
@@ -143,17 +150,25 @@ class MultiDatabaseConnectionPool(object):
         Note that leaving a connection context here does NOT close the connection in psycopg2;
         connections must be manually closed by `close_all_connections()`.
         """
+        interrupted_error_seen = False
+
+        with self._mu:
+            db = self._get_connection_raw(dbname, ttl_ms, timeout, startup_fn, persistent)
         try:
-            with self._mu:
-                db = self._get_connection_raw(dbname, ttl_ms, timeout, persistent)
             yield db
+        except InterruptedError:
+            interrupted_error_seen = True
+            with self._mu:
+                self._terminate_connection_unsafe(dbname)
+            raise
         finally:
             with self._mu:
-                try:
-                    self._conns[dbname].active = False
-                except KeyError:
-                    # if self._get_connection_raw hit an exception, self._conns[dbname] didn't get populated
-                    pass
+                if not interrupted_error_seen and not db.closed:
+                    try:
+                        self._conns[dbname].active = False
+                    except KeyError:
+                        # if self._get_connection_raw hit an exception, self._conns[dbname] didn't get populated
+                        pass
 
     def prune_connections(self):
         """

--- a/postgres/datadog_checks/postgres/metadata.py
+++ b/postgres/datadog_checks/postgres/metadata.py
@@ -466,10 +466,11 @@ class PostgresMetadata(DBMAsyncJob):
 
     @tracked_method(agent_check_getter=agent_check_getter)
     def _collect_postgres_settings(self):
-        with self._check._get_main_db().cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
-            self._log.debug("Running query [%s]", PG_SETTINGS_QUERY)
-            self._time_since_last_settings_query = time.time()
-            cursor.execute(PG_SETTINGS_QUERY)
-            rows = cursor.fetchall()
-            self._log.debug("Loaded %s rows from pg_settings", len(rows))
-            return [dict(row) for row in rows]
+        with self._check._get_main_db() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
+                self._log.debug("Running query [%s]", PG_SETTINGS_QUERY)
+                self._time_since_last_settings_query = time.time()
+                cursor.execute(PG_SETTINGS_QUERY)
+                rows = cursor.fetchall()
+                self._log.debug("Loaded %s rows from pg_settings", len(rows))
+                return [dict(row) for row in rows]

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -635,14 +635,14 @@ class PostgreSql(AgentCheck):
             with conn.cursor() as cursor:
                 self._query_scope(cursor, archiver_instance_metrics, instance_tags, False)
 
-                if self._config.collect_activity_metrics:
-                    activity_metrics = self.metrics_cache.get_activity_metrics(self.version)
-                    with conn.cursor() as cursor:
-                        self._query_scope(cursor, activity_metrics, instance_tags, False)
+            if self._config.collect_activity_metrics:
+                activity_metrics = self.metrics_cache.get_activity_metrics(self.version)
+                with conn.cursor() as cursor:
+                    self._query_scope(cursor, activity_metrics, instance_tags, False)
 
-                for scope in list(metric_scope) + self._config.custom_metrics:
-                    with conn.cursor() as cursor:
-                        self._query_scope(cursor, scope, instance_tags, scope in self._config.custom_metrics)
+            for scope in list(metric_scope) + self._config.custom_metrics:
+                with conn.cursor() as cursor:
+                    self._query_scope(cursor, scope, instance_tags, scope in self._config.custom_metrics)
 
         if self.dynamic_queries:
             self.dynamic_queries.execute()

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -204,6 +204,9 @@ class PostgreSql(AgentCheck):
         except (psycopg2.InterfaceError, InterruptedError):
             # if we get an interface error or an interrupted error,
             # we gracefully close the connection
+            self.log.warning(
+                "Connection to the database %s has been interrupted, closing connection", self._config.dbname
+            )
             try:
                 self._db.close()
             except Exception:

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -269,10 +269,11 @@ class PostgresStatementSamples(DBMAsyncJob):
         query = PG_ACTIVE_CONNECTIONS_QUERY.format(
             pg_stat_activity_view=self._config.pg_stat_activity_view, extra_filters=extra_filters
         )
-        with self._check._get_main_db().cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
-            self._log.debug("Running query [%s] %s", query, params)
-            cursor.execute(query, params)
-            rows = cursor.fetchall()
+        with self._check._get_main_db() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
+                self._log.debug("Running query [%s] %s", query, params)
+                cursor.execute(query, params)
+                rows = cursor.fetchall()
 
         self._report_check_hist_metrics(start_time, len(rows), "get_active_connections")
         self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)
@@ -303,10 +304,11 @@ class PostgresStatementSamples(DBMAsyncJob):
             extra_filters=extra_filters,
         )
 
-        with self._check._get_main_db().cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
-            self._log.debug("Running query [%s] %s", query, params)
-            cursor.execute(query, params)
-            rows = cursor.fetchall()
+        with self._check._get_main_db() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
+                self._log.debug("Running query [%s] %s", query, params)
+                cursor.execute(query, params)
+                rows = cursor.fetchall()
 
         self._report_check_hist_metrics(start_time, len(rows), "get_new_pg_stat_activity")
         self._log.debug("Loaded %s rows from %s", len(rows), self._config.pg_stat_activity_view)
@@ -321,18 +323,19 @@ class PostgresStatementSamples(DBMAsyncJob):
 
     @tracked_method(agent_check_getter=agent_check_getter, track_result_length=True)
     def _get_available_activity_columns(self, all_expected_columns):
-        with self._check._get_main_db().cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
-            cursor.execute(
-                "select * from {pg_stat_activity_view} LIMIT 0".format(
-                    pg_stat_activity_view=self._config.pg_stat_activity_view
+        with self._check._get_main_db() as conn:
+            with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cursor:
+                cursor.execute(
+                    "select * from {pg_stat_activity_view} LIMIT 0".format(
+                        pg_stat_activity_view=self._config.pg_stat_activity_view
+                    )
                 )
-            )
-            all_columns = {i[0] for i in cursor.description}
-            available_columns = [c for c in all_expected_columns if c in all_columns]
-            missing_columns = set(all_expected_columns) - set(available_columns)
-            if missing_columns:
-                self._log.debug("missing the following expected columns from pg_stat_activity: %s", missing_columns)
-            self._log.debug("found available pg_stat_activity columns: %s", available_columns)
+                all_columns = {i[0] for i in cursor.description}
+                available_columns = [c for c in all_expected_columns if c in all_columns]
+                missing_columns = set(all_expected_columns) - set(available_columns)
+                if missing_columns:
+                    self._log.debug("missing the following expected columns from pg_stat_activity: %s", missing_columns)
+                self._log.debug("found available pg_stat_activity columns: %s", available_columns)
         return available_columns
 
     def _filter_and_normalize_statement_rows(self, rows):

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -38,7 +38,8 @@ class VersionUtils(object):
         try:
             with db as conn:
                 with conn.cursor() as cursor:
-                    # This query will pollute PG logs in non aurora versions but is the only reliable way to detect aurora
+                    # This query will pollute PG logs in non aurora versions,
+                    # but is the only reliable way to detect aurora
                     cursor.execute('select AURORA_VERSION();')
                     return True
         except Exception as e:

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -26,22 +26,23 @@ class VersionUtils(object):
 
     @staticmethod
     def get_raw_version(db):
-        with db.cursor() as cursor:
-            cursor.execute('SHOW SERVER_VERSION;')
-            raw_version = cursor.fetchone()[0]
-            return raw_version
+        with db as conn:
+            with conn.cursor() as cursor:
+                cursor.execute('SHOW SERVER_VERSION;')
+                raw_version = cursor.fetchone()[0]
+                return raw_version
 
     def is_aurora(self, db):
         if self._seen_aurora_exception:
             return False
         try:
-            with db.cursor() as cursor:
-                # This query will pollute PG logs in non aurora versions but is the only reliable way to detect aurora
-                cursor.execute('select AURORA_VERSION();')
-                return True
+            with db as conn:
+                with conn.cursor() as cursor:
+                    # This query will pollute PG logs in non aurora versions but is the only reliable way to detect aurora
+                    cursor.execute('select AURORA_VERSION();')
+                    return True
         except Exception as e:
             self.log.debug("Captured exception %s while determining if the DB is aurora. Assuming is not", str(e))
-            db.rollback()
             self._seen_aurora_exception = True
             return False
 

--- a/postgres/tests/test_connections.py
+++ b/postgres/tests/test_connections.py
@@ -9,6 +9,7 @@ import uuid
 
 import psycopg2
 import pytest
+
 from datadog_checks.postgres import PostgreSql
 from datadog_checks.postgres.connections import ConnectionPoolFullError, MultiDatabaseConnectionPool
 

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -253,17 +253,17 @@ def test_can_connect_service_check(aggregator, integration_check, pg_instance):
     aggregator.reset()
 
     # Second: keep the connection open but an unexpected error happens during check run
-    orig_get_main_db = check._get_main_db
+    orig_db = check.db
 
     # Second: keep the connection open but an unexpected error happens during check run
     with pytest.raises(AttributeError):
-        check._get_main_db = mock.MagicMock(side_effect=AttributeError('foo'))
+        check.db = mock.MagicMock(side_effect=AttributeError('foo'))
         check.check(pg_instance)
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.CRITICAL, tags=expected_tags)
     aggregator.reset()
 
     # Third: connection still open but this time no error
-    check._get_main_db = orig_get_main_db
+    check.db = orig_db
     check.check(pg_instance)
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.OK, tags=expected_tags)
 
@@ -504,7 +504,7 @@ def test_query_timeout(integration_check, pg_instance):
     check = integration_check(pg_instance)
     check._connect()
     with pytest.raises(psycopg2.errors.QueryCanceled):
-        with check._get_main_db() as conn:
+        with check.db() as conn:
             with conn.cursor() as cursor:
                 cursor.execute("select pg_sleep(2000)")
 

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -253,15 +253,17 @@ def test_can_connect_service_check(aggregator, integration_check, pg_instance):
     aggregator.reset()
 
     # Second: keep the connection open but an unexpected error happens during check run
-    orig_db = check.db
-    check.db = mock.MagicMock(spec=('closed', 'status'), closed=False, status=psycopg2.extensions.STATUS_READY)
+    orig_get_main_db = check._get_main_db
+
+    # Second: keep the connection open but an unexpected error happens during check run
     with pytest.raises(AttributeError):
+        check._get_main_db = mock.MagicMock(side_effect=AttributeError('foo'))
         check.check(pg_instance)
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.CRITICAL, tags=expected_tags)
     aggregator.reset()
 
     # Third: connection still open but this time no error
-    check.db = orig_db
+    check._get_main_db = orig_get_main_db
     check.check(pg_instance)
     aggregator.assert_service_check('postgres.can_connect', count=1, status=PostgreSql.OK, tags=expected_tags)
 
@@ -501,9 +503,10 @@ def test_query_timeout(integration_check, pg_instance):
     pg_instance['query_timeout'] = 1000
     check = integration_check(pg_instance)
     check._connect()
-    cursor = check.db.cursor()
     with pytest.raises(psycopg2.errors.QueryCanceled):
-        cursor.execute("select pg_sleep(2000)")
+        with check._get_main_db() as conn:
+            with conn.cursor() as cursor:
+                cursor.execute("select pg_sleep(2000)")
 
 
 @requires_over_10

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -364,7 +364,7 @@ def test_statement_metrics_with_duplicates(aggregator, integration_check, dbm_in
 
     # Execute the query once to begin tracking it. Execute again between checks to track the difference.
     # This should result in a single metric for that query_signature having a value of 2
-    with check._get_main_db() as conn:
+    with check.db() as conn:
         with conn.cursor() as cursor:
             with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
                 mock_agent.side_effect = obfuscate_sql

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -361,19 +361,20 @@ def test_statement_metrics_with_duplicates(aggregator, integration_check, dbm_in
 
     check = integration_check(dbm_instance)
     check._connect()
-    cursor = check.db.cursor()
 
     # Execute the query once to begin tracking it. Execute again between checks to track the difference.
     # This should result in a single metric for that query_signature having a value of 2
-    with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
-        mock_agent.side_effect = obfuscate_sql
-        cursor.execute(query, (['app1', 'app2'],))
-        cursor.execute(query, (['app1', 'app2', 'app3'],))
-        run_one_check(check, dbm_instance)
+    with check._get_main_db() as conn:
+        with conn.cursor() as cursor:
+            with mock.patch.object(datadog_agent, 'obfuscate_sql', passthrough=True) as mock_agent:
+                mock_agent.side_effect = obfuscate_sql
+                cursor.execute(query, (['app1', 'app2'],))
+                cursor.execute(query, (['app1', 'app2', 'app3'],))
+                run_one_check(check, dbm_instance)
 
-        cursor.execute(query, (['app1', 'app2'],))
-        cursor.execute(query, (['app1', 'app2', 'app3'],))
-        run_one_check(check, dbm_instance)
+                cursor.execute(query, (['app1', 'app2'],))
+                cursor.execute(query, (['app1', 'app2', 'app3'],))
+                run_one_check(check, dbm_instance)
 
     events = aggregator.get_event_platform_events("dbm-metrics")
     assert len(events) == 1
@@ -1383,7 +1384,6 @@ def test_load_pg_settings(aggregator, integration_check, dbm_instance, db_user):
     dbm_instance["dbname"] = "postgres"
     check = integration_check(dbm_instance)
     check._connect()
-    check._load_pg_settings(check.db)
     if db_user == 'datadog_no_catalog':
         aggregator.assert_metric(
             "dd.postgres.error",
@@ -1405,10 +1405,8 @@ def test_pg_settings_caching(aggregator, integration_check, dbm_instance):
     check = integration_check(dbm_instance)
     assert not check.pg_settings, "pg_settings should not have been initialized yet"
     check._connect()
-    check._get_main_db()
     assert "track_activity_query_size" in check.pg_settings
     check.pg_settings["test_key"] = True
-    check._get_main_db()
     assert (
         "test_key" in check.pg_settings
     ), "key should not have been blown away. If it was then pg_settings was not cached correctly"

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2018-present
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
+import contextlib
 import copy
 
 import mock
@@ -94,7 +95,12 @@ def test_malformed_get_custom_queries(check):
     """
     check.log = MagicMock()
     db = MagicMock()
-    check.db = db
+
+    @contextlib.contextmanager
+    def mock_get_main_db():
+        yield db
+
+    check._get_main_db = mock_get_main_db
 
     check._config.custom_queries = [{}]
 

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -97,10 +97,10 @@ def test_malformed_get_custom_queries(check):
     db = MagicMock()
 
     @contextlib.contextmanager
-    def mock_get_main_db():
+    def mock_db():
         yield db
 
-    check._get_main_db = mock_get_main_db
+    check.db = mock_db
 
     check._config.custom_queries = [{}]
 


### PR DESCRIPTION
### What does this PR do?
We are seeing main thread db being closed prematurely, causing check to error out. This PR gets rid of the persistent main thread db property and use `db` context manager to ensure a dedicated healthy main db connection is returned.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
