### PR TITLE
Don't run `black` on autogenerated `_version.py` file

### DIFF
--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -75,6 +75,7 @@ include = '\.pyi?$'
 line-length = 120
 skip-string-normalization = true
 target-version = ["py39"]
+extend-exclude = "src/ddev/_version.py"
 
 [tool.ruff]
 exclude = []


### PR DESCRIPTION
### What does this PR do?

Excludes the autogenerated `_version.py` from being linted by `black`.

### Motivation

[Linting failures](https://github.com/DataDog/integrations-core/actions/runs/6396904435/job/17363734743) for ddev on CI.

### Additional Notes

This file is already in our repo-wide .gitignore; black is therefore [supposed to ignore it anyway](https://black.readthedocs.io/en/stable/usage_and_configuration/file_collection_and_discovery.html#gitignore) (possibly because the way hatch runs things?). It looks reasonable to exclude it explicitly.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
