### PR TITLE
Exclude system.net.conntrack.helper from linux test

### DIFF
--- a/network/tests/test_integration.py
+++ b/network/tests/test_integration.py
@@ -41,9 +41,8 @@ def test_check_linux(aggregator, check, instance_blacklist):
     #   even if this metric is missing. The logic to check for conntrack metric
     #   is similar for rest of them as well, so the core conntrack metric
     #   collection logic is not compromised by removing one metric
-    common.CONNTRACK_METRICS.remove('system.net.conntrack.helper')
+    metrics_to_check = common.CONNTRACK_METRICS.copy()
+    metrics_to_check.remove('system.net.conntrack.helper')
 
-    for metric in common.CONNTRACK_METRICS:
+    for metric in metrics_to_check:
         aggregator.assert_metric(metric)
-
-    common.CONNTRACK_METRICS.append('system.net.conntrack.helper')

--- a/network/tests/test_integration.py
+++ b/network/tests/test_integration.py
@@ -41,7 +41,7 @@ def test_check_linux(aggregator, check, instance_blacklist):
     #   even if this metric is missing. The logic to check for conntrack metric
     #   is similar for rest of them as well, so the core conntrack metric
     #   collection logic is not compromised by removing one metric
-    metrics_to_check = common.CONNTRACK_METRICS.copy()
+    metrics_to_check = common.CONNTRACK_METRICS[:]
     metrics_to_check.remove('system.net.conntrack.helper')
 
     for metric in metrics_to_check:

--- a/network/tests/test_integration.py
+++ b/network/tests/test_integration.py
@@ -34,5 +34,16 @@ def test_check_linux(aggregator, check, instance_blacklist):
     check_instance = check(instance_blacklist)
     check_instance.check({})
 
+    # Remove system.net.conntrack.helper from test as it is removed since kernel 6.0-rc4
+    #   More details at https://www.spinics.net/lists/netfilter/msg60942.html
+    # Introducing an optional metric based on kernel version is an overhead
+    # Marking this as an optional metric will always make the test pass
+    #   even if this metric is missing. The logic to check for conntrack metric
+    #   is similar for rest of them as well, so the core conntrack metric
+    #   collection logic is not compromised by removing one metric
+    common.CONNTRACK_METRICS.remove('system.net.conntrack.helper')
+
     for metric in common.CONNTRACK_METRICS:
         aggregator.assert_metric(metric)
+
+    common.CONNTRACK_METRICS.append('system.net.conntrack.helper')


### PR DESCRIPTION
### What does this PR do?
Remove system.net.conntrack.helper from linux test as it is removed since kernel 6.0-rc4

### Motivation
More details at https://www.spinics.net/lists/netfilter/msg60942.html. Introducing an optional metric based on kernel version is an overhead. Marking this as an optional metric will always make the test pass even if this metric is missing. The logic to check for conntrack metric is similar for rest of them as well, so the core conntrack metric collection logic is not compromised by removing one metric

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
