### PR TITLE
[SQLServer] - set run_sync to False

### DIFF
--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***
+
+* Set stored procedure collection to `run_sync=False`, fixing the delay in collection of other SQLServer telemetry. ([#15967](https://github.com/DataDog/integrations-core/pull/15967))
+
 ## 15.0.0 / 2023-09-29
 
 ***Changed***:
@@ -19,9 +23,6 @@
 * Add `index_name` tag to `.database.avg_fragmentation_in_percent`, `.database.fragment_count`, `.database.avg_fragment_size_in_pages` metrics. Also add a new metric `sqlserver.database.index_page_count`, tagged by `database_name`, `object_name`, `index_id` and `index_name`. ([#15721](https://github.com/DataDog/integrations-core/pull/15721))
 * When DBM is enabled, starts collecting stored procedure metrics from sys.dm_exec_procedure_stats at 60s interval (configurable). Also adds the corresponding `procedure_metrics` section to the config file. The new DBM-only metrics are `sqlserver.procedures.count`, `sqlserver.procedures.time`, `sqlserver.procedures.worker_time`, `sqlserver.procedures.physical_reads`, `sqlserver.procedures.logical_reads`, `sqlserver.procedures.logical_writes` and `sqlserver.procedures.spills`. ([#15805](https://github.com/DataDog/integrations-core/pull/15805))
 * Add additional SQL Server performance counter metrics ([#15818](https://github.com/DataDog/integrations-core/pull/15818))
-
-***Added***:
-
 * Add Index Usage Metrics for SQL Server ([#15905](https://github.com/DataDog/integrations-core/pull/15905))
 
 ***Fixed***:

--- a/sqlserver/datadog_checks/sqlserver/stored_procedures.py
+++ b/sqlserver/datadog_checks/sqlserver/stored_procedures.py
@@ -81,7 +81,7 @@ class SqlserverProcedureMetrics(DBMAsyncJob):
         self.collection_interval = collection_interval
         super(SqlserverProcedureMetrics, self).__init__(
             check,
-            run_sync=is_affirmative(check.procedure_metrics_config.get('run_sync', True)),
+            run_sync=is_affirmative(check.procedure_metrics_config.get('run_sync', False)),
             enabled=is_affirmative(check.procedure_metrics_config.get('enabled', True)),
             expected_db_exceptions=(),
             min_collection_interval=check.min_collection_interval,


### PR DESCRIPTION
### What does this PR do?

Changes the stored procedure collection check to `run_sync=False` which was mistakenly set to True and merged as-is. This is blocking the rest of the SQLServer checks and causing intermittent telemetry collection. 

### Motivation

This:
<img width="1165" alt="image" src="https://github.com/DataDog/integrations-core/assets/91903666/c4472f2a-7740-42eb-9489-eecd67f98a6b">

Should actually be like this:
<img width="1167" alt="image" src="https://github.com/DataDog/integrations-core/assets/91903666/55e95351-0eba-47fc-9328-796ec31bea81">



### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
