### PR TITLE
[kube_apiserver_metrics] Add `etcd_requests_total` and `etcd_request_errors_total` new metrics

### DIFF
--- a/kube_apiserver_metrics/CHANGELOG.md
+++ b/kube_apiserver_metrics/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add etcd.db.total_size for Kubernetes 1.26, 1.27, and 1.28 ([#15940](https://github.com/DataDog/integrations-core/pull/15940))
 * Add apiserver_flowcontrol_current_inqueue_requests and apiserver_flowcontrol_dispatched_requests_total for Kubernetes >= 1.23 ([#15981](https://github.com/DataDog/integrations-core/pull/15981))
+* Add etcd_requests_total and etcd_request_errors_total for Kubernetes >= 1.28 ([#15986](https://github.com/DataDog/integrations-core/pull/15986))
 
 ## 4.0.0 / 2023-08-10 / Agent 7.48.0
 

--- a/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
+++ b/kube_apiserver_metrics/datadog_checks/kube_apiserver_metrics/kube_apiserver_metrics.py
@@ -83,6 +83,8 @@ METRICS = {
     # For Kubernetes >= 1.28
     'apiserver_storage_size_bytes': 'etcd.db.total_size',
     'apiserver_flowcontrol_nominal_limit_seats': 'flowcontrol_request_concurrency_limit',
+    'etcd_requests_total': 'etcd_requests_total',
+    'etcd_request_errors_total': 'etcd_request_errors_total',
 }
 
 

--- a/kube_apiserver_metrics/metadata.csv
+++ b/kube_apiserver_metrics/metadata.csv
@@ -7,6 +7,8 @@ kube_apiserver.go_goroutines,gauge,,,,The number of goroutines that currently ex
 kube_apiserver.APIServiceRegistrationController_depth,gauge,,,,The current depth of workqueue: APIServiceRegistrationController,0,kubernetes_api_server_metrics,service registration controller depth,
 kube_apiserver.etcd_request_duration_seconds.sum,gauge,,second,,Etcd request latencies for each operation and object type (alpha),0,kubernetes_api_server_metrics,etcd latency,
 kube_apiserver.etcd_request_duration_seconds.count,count,,,,Etcd request latencies count for each operation and object type (alpha),0,kubernetes_api_server_metrics,etcd latency,
+kube_apiserver.etcd_request_errors_total,count,,request,,Etcd failed request counts for each operation and object type,0,kubernetes_api_server_metrics,etcd request errors total,
+kube_apiserver.etcd_requests_total,count,,request,,Etcd request counts for each operation and object type,0,kubernetes_api_server_metrics,etcd requests total,
 kube_apiserver.etcd_object_counts,gauge,,object,,The number of stored objects at the time of last check split by kind (alpha; deprecated in Kubernetes 1.22),0,kubernetes_api_server_metrics,etcd object counts,
 kube_apiserver.etcd.db.total_size,gauge,,byte,,The total size of the etcd database file physically allocated in bytes (alpha; Kubernetes 1.19+),0,kubernetes_api_server_metrics,etcd db total size,
 kube_apiserver.storage_objects,gauge,,object,,The number of stored objects at the time of last check split by kind (Kubernetes 1.21+; replaces etcd_object_counts),0,kubernetes_api_server_metrics,storage objects,

--- a/kube_apiserver_metrics/tests/fixtures/metrics_1.28.0.txt
+++ b/kube_apiserver_metrics/tests/fixtures/metrics_1.28.0.txt
@@ -18203,6 +18203,9 @@ etcd_request_duration_seconds_bucket{operation="update",type="services",le="60"}
 etcd_request_duration_seconds_bucket{operation="update",type="services",le="+Inf"} 1
 etcd_request_duration_seconds_sum{operation="update",type="services"} 0.001150667
 etcd_request_duration_seconds_count{operation="update",type="services"} 1
+# HELP etcd_request_errors_total [ALPHA] Etcd failed request counts for each operation and object type.
+# TYPE etcd_request_errors_total counter
+etcd_request_errors_total{operation="manually_added_test",type="manually_added_test"} 1
 # HELP etcd_requests_total [ALPHA] Etcd request counts for each operation and object type.
 # TYPE etcd_requests_total counter
 etcd_requests_total{operation="create",type="apiservices.apiregistration.k8s.io"} 22

--- a/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_28.py
+++ b/kube_apiserver_metrics/tests/test_kube_apiserver_metrics_1_28.py
@@ -69,6 +69,8 @@ class TestKubeAPIServerMetrics:
         'flowcontrol_request_concurrency_limit',
         'flowcontrol_current_inqueue_requests',
         'flowcontrol_dispatched_requests_total',
+        'etcd_requests_total',
+        'etcd_request_errors_total',
     ]
     COUNT_METRICS = [
         'audit_event.count',


### PR DESCRIPTION
### What does this PR do?
Add `etcd_requests_total` and `etcd_request_errors_total` new metrics for Kubernetes 1.28.

The unit tests for `etcd_request_errors_total` where manually implemented since it was not easy to trigger this metric.

### Motivation
We need to support new Kubernetes versions.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
