### PR TITLE
[DBMON-2989] report sql obfuscation error count

### DIFF
--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Added***:
+
+* Add support to report SQL obfuscation errors ([#15990](https://github.com/DataDog/integrations-core/pull/15990))
+
 ## 11.2.0 / 2023-09-29
 
 ***Added***:

--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Added***:
 
-* Add support to report SQL obfuscation errors ([#15990](https://github.com/DataDog/integrations-core/pull/15990))
+* Add support for reporting SQL obfuscation errors ([#15990](https://github.com/DataDog/integrations-core/pull/15990))
 
 ## 11.2.0 / 2023-09-29
 

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -96,7 +96,6 @@ def agent_check_getter(self):
 
 
 class MySQLActivity(DBMAsyncJob):
-
     DEFAULT_COLLECTION_INTERVAL = 10
     MAX_PAYLOAD_BYTES = 19e6
 
@@ -213,6 +212,12 @@ class MySQLActivity(DBMAsyncJob):
             else:
                 self._log.debug("Failed to obfuscate query | err=[%s]", e)
             row["sql_text"] = "ERROR: failed to obfuscate"
+            self._check.count(
+                "dd.mysql.activity.error",
+                1,
+                tags=self._tags + ["error:sql-obfuscate"] + self._check._get_debug_tags(),
+                hostname=self._check.resolved_hostname,
+            )
         return row
 
     @staticmethod

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -213,9 +213,9 @@ class MySQLActivity(DBMAsyncJob):
                 self._log.debug("Failed to obfuscate query | err=[%s]", e)
             row["sql_text"] = "ERROR: failed to obfuscate"
             self._check.count(
-                "dd.mysql.activity.error",
+                "dd.mysql.obfuscation.error",
                 1,
-                tags=self._tags + ["error:sql-obfuscate"] + self._check._get_debug_tags(),
+                tags=self.tags + ["error:{}".format(type(e)), "error_msg:{}".format(e)] + self._check._get_debug_tags(),
                 hostname=self._check.resolved_hostname,
             )
         return row

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -210,6 +210,12 @@ class MySQLStatementMetrics(DBMAsyncJob):
                 obfuscated_statement = statement['query'] if row['digest_text'] is not None else None
             except Exception as e:
                 self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['digest_text'], e)
+                self._check.count(
+                    "dd.mysql.statements.error",
+                    1,
+                    tags=self._tags + ["error:sql-obfuscate"] + self._check._get_debug_tags(),
+                    hostname=self._check.resolved_hostname,
+                )
                 continue
 
             normalized_row['digest_text'] = obfuscated_statement

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -211,9 +211,11 @@ class MySQLStatementMetrics(DBMAsyncJob):
             except Exception as e:
                 self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['digest_text'], e)
                 self._check.count(
-                    "dd.mysql.statements.error",
+                    "dd.mysql.obfuscation.error",
                     1,
-                    tags=self._tags + ["error:sql-obfuscate"] + self._check._get_debug_tags(),
+                    tags=self.tags
+                    + ["error:{}".format(type(e)), "error_msg:{}".format(e)]
+                    + self._check._get_debug_tags(),
                     hostname=self._check.resolved_hostname,
                 )
                 continue

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -123,7 +123,7 @@
 * Add metrics for timeline id and checkpoint delay ([#14759](https://github.com/DataDog/integrations-core/pull/14759))
 * Add `postgresql.wal.*` metrics from `pg_stat_wal`  ([#13768](https://github.com/DataDog/integrations-core/pull/13768))
 * PG: Add metrics for wal files: count, size and age ([#13725](https://github.com/DataDog/integrations-core/pull/13725))
-* Allow explain plan collection to be configured separately from activity collection in pg agent ([#14673](https://github.com/DataDog/integrations-core/pull/14673))
+*  Allow explain plan collection to be configured separately from activity collection in pg agent ([#14673](https://github.com/DataDog/integrations-core/pull/14673))
 * Make cancel() synchronous in DBMAsyncJob ([#14717](https://github.com/DataDog/integrations-core/pull/14717))
 * Postgres: Add `postgres.snapshot.{xmin,xmax,xip_count}` metric ([#13777](https://github.com/DataDog/integrations-core/pull/13777))
 * Report per-index disk usage metrics for PostgreSQL ([#13880](https://github.com/DataDog/integrations-core/pull/13880)) Thanks [jcoleman](https://github.com/jcoleman).
@@ -866,7 +866,7 @@
 
 ***Fixed***:
 
-* Gracefully handle errors when performing custom_queries ([#2184](https://github.com/DataDog/integrations-core/pull/2184))
+*  Gracefully handle errors when performing custom_queries ([#2184](https://github.com/DataDog/integrations-core/pull/2184))
 * Gracefully handle failed version regex match ([#2178](https://github.com/DataDog/integrations-core/pull/2178))
 
 ## 2.2.0 / 2018-09-04

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Added***:
+
+* Add support to report SQL obfuscation errors ([#15990](https://github.com/DataDog/integrations-core/pull/15990))
+
 ## 15.1.0 / 2023-10-06
 
 ***Added***:
@@ -119,7 +123,7 @@
 * Add metrics for timeline id and checkpoint delay ([#14759](https://github.com/DataDog/integrations-core/pull/14759))
 * Add `postgresql.wal.*` metrics from `pg_stat_wal`  ([#13768](https://github.com/DataDog/integrations-core/pull/13768))
 * PG: Add metrics for wal files: count, size and age ([#13725](https://github.com/DataDog/integrations-core/pull/13725))
-*  Allow explain plan collection to be configured separately from activity collection in pg agent ([#14673](https://github.com/DataDog/integrations-core/pull/14673))
+* Allow explain plan collection to be configured separately from activity collection in pg agent ([#14673](https://github.com/DataDog/integrations-core/pull/14673))
 * Make cancel() synchronous in DBMAsyncJob ([#14717](https://github.com/DataDog/integrations-core/pull/14717))
 * Postgres: Add `postgres.snapshot.{xmin,xmax,xip_count}` metric ([#13777](https://github.com/DataDog/integrations-core/pull/13777))
 * Report per-index disk usage metrics for PostgreSQL ([#13880](https://github.com/DataDog/integrations-core/pull/13880)) Thanks [jcoleman](https://github.com/jcoleman).
@@ -862,7 +866,7 @@
 
 ***Fixed***:
 
-*  Gracefully handle errors when performing custom_queries ([#2184](https://github.com/DataDog/integrations-core/pull/2184))
+* Gracefully handle errors when performing custom_queries ([#2184](https://github.com/DataDog/integrations-core/pull/2184))
 * Gracefully handle failed version regex match ([#2178](https://github.com/DataDog/integrations-core/pull/2178))
 
 ## 2.2.0 / 2018-09-04

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Added***:
 
-* Add support to report SQL obfuscation errors ([#15990](https://github.com/DataDog/integrations-core/pull/15990))
+* Add support for reporting SQL obfuscation errors ([#15990](https://github.com/DataDog/integrations-core/pull/15990))
 
 ## 15.1.0 / 2023-10-06
 

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -401,6 +401,13 @@ class PostgresStatementSamples(DBMAsyncJob):
                 tags=self._dbtags(row['datname'], "error:sql-obfuscate") + self._check._get_debug_tags(),
                 hostname=self._check.resolved_hostname,
             )
+            self._check.count(
+                "dd.postgres.obfuscation.error",
+                1,
+                tags=self._dbtags(row['datname'], "error:{}".format(type(e)), "error_msg:{}".format(e))
+                + self._check._get_debug_tags(),
+                hostname=self._check.resolved_hostname,
+            )
         normalized_row['statement'] = obfuscated_query
         return normalized_row
 

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -430,9 +430,11 @@ class PostgresStatementMetrics(DBMAsyncJob):
                 else:
                     self._log.debug("Failed to obfuscate query | err=[%s]", e)
                 self._check.count(
-                    "dd.postgres.statement_metrics.error",
+                    "dd.postgres.obfuscation.error",
                     1,
-                    tags=self.tags + ["error:sql-obfuscate"] + self._check._get_debug_tags(),
+                    tags=self.tags
+                    + ["error:{}".format(type(e)), "error_msg:{}".format(e)]
+                    + self._check._get_debug_tags(),
                     hostname=self._check.resolved_hostname,
                 )
                 continue

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -429,6 +429,12 @@ class PostgresStatementMetrics(DBMAsyncJob):
                     self._log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['query'], e)
                 else:
                     self._log.debug("Failed to obfuscate query | err=[%s]", e)
+                self._check.count(
+                    "dd.postgres.statement_metrics.error",
+                    1,
+                    tags=self.tags + ["error:sql-obfuscate"] + self._check._get_debug_tags(),
+                    hostname=self._check.resolved_hostname,
+                )
                 continue
 
             obfuscated_query = statement['query']

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Added***:
+
+* Add support to report SQL obfuscation errors ([#15990](https://github.com/DataDog/integrations-core/pull/15990))
+
 ***Fixed***:
 
 * Properly decode query_hash when statement_text is None ([#15974](https://github.com/DataDog/integrations-core/pull/15974))

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Added***:
 
-* Add support to report SQL obfuscation errors ([#15990](https://github.com/DataDog/integrations-core/pull/15990))
+* Add support for reporting SQL obfuscation errors ([#15990](https://github.com/DataDog/integrations-core/pull/15990))
 
 ***Fixed***:
 

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -297,6 +297,11 @@ class SqlserverActivity(DBMAsyncJob):
             else:
                 self.log.debug("Failed to obfuscate query | err=[%s]", e)
             obfuscated_statement = "ERROR: failed to obfuscate"
+            self.check.count(
+                "dd.sqlserver.activity.error",
+                1,
+                **self.check.debug_stats_kwargs(tags=["error:obfuscate-query-{}".format(type(e))])
+            )
         row = self._sanitize_row(row, obfuscated_statement)
         return row
 

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -298,9 +298,9 @@ class SqlserverActivity(DBMAsyncJob):
                 self.log.debug("Failed to obfuscate query | err=[%s]", e)
             obfuscated_statement = "ERROR: failed to obfuscate"
             self.check.count(
-                "dd.sqlserver.activity.error",
+                "dd.sqlserver.obfuscation.error",
                 1,
-                **self.check.debug_stats_kwargs(tags=["error:obfuscate-query-{}".format(type(e))])
+                **self.check.debug_stats_kwargs(tags=["error:{}".format(type(e)), "error_msg:{}".format(e)])
             )
         row = self._sanitize_row(row, obfuscated_statement)
         return row

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -306,6 +306,11 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     1,
                     **self.check.debug_stats_kwargs(tags=["error:obfuscate-query-{}".format(type(e))])
                 )
+                self.check.count(
+                    "dd.sqlserver.obfuscation.error",
+                    1,
+                    **self.check.debug_stats_kwargs(tags=["error:{}".format(type(e)), "error_msg:{}".format(e)])
+                )
                 continue
             obfuscated_statement = statement['query']
             comments = extract_sql_comments(row['text'])


### PR DESCRIPTION
### What does this PR do?
This PR reports sql obfuscation error when obfuscator fails to obfuscate input queries. This will help us understand the number of obfuscation errors happen right now prior to the obfuscator upgrade.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
