### PR TITLE
Add exception to skip instance configurations

### DIFF
--- a/datadog_checks_base/changelog.d/16012.added
+++ b/datadog_checks_base/changelog.d/16012.added
@@ -1,0 +1,1 @@
+Add exceptions to skip instance configurations

--- a/datadog_checks_base/datadog_checks/base/errors.py
+++ b/datadog_checks_base/datadog_checks/base/errors.py
@@ -31,3 +31,34 @@ class ConfigMissingError(ConfigurationError):
     """
     The configuration file is missing settings
     """
+
+
+class ConfigNotSupportedError(ConfigurationError):
+    """
+    The instance configuration is not supported
+    """
+
+
+class SkipInstanceError(ConfigNotSupportedError):
+    """
+    Raise SkipInstanceError in a check's __new__ or __init__ to skip loading the
+    provided instance without raising an error.
+    Example usage is when the instance configuration should be processed by a
+    different version of the check (Go vs Python check loader).
+    """
+
+    # Keep this error prefix in sync with the Python check loader in datadogagent.
+    # The string is used to identify this error across the rtloader boundary.
+    PREFIX_PATTERN = "The integration refused to load the check configuration, it may be too old or too new."
+
+    def __init__(self, *args, **kwargs):
+        args = list(args)
+        if len(args) == 0:
+            # Set a default error message if none is provided
+            message = "Check the documentation for options that select the integration version to use."
+            args = [message]
+
+        # Prepend the identifying prefix.
+        # args[0] = f"{self.PREFIX_PATTERN} {args[0]}"
+        args[0] = "{} {}".format(self.PREFIX_PATTERN, args[0])
+        super(SkipInstanceError, self).__init__(*args, **kwargs)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Add new `SkipInstanceError` exception to be raised by a check to indicate it wants to skip the provided configuration. Used in the win32_event_log check https://github.com/DataDog/integrations-core/pull/16108 to switch between the Python and Go versions of the check based on the check configuration version.

See related agent PR https://github.com/DataDog/datadog-agent/pull/20114

### Motivation
<!-- What inspired you to submit this pull request? -->
To enable using the Go check as the new default implementation, and require setting a configuration option to use the previous version.

https://datadoghq.atlassian.net/browse/WINA-475

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
