### PR TITLE
[ecs_fargate] Add storage_stats support for Windows ECS Fargate

### DIFF
--- a/ecs_fargate/CHANGELOG.md
+++ b/ecs_fargate/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Fix blkio_stats bad metrics for Windows ([#16014](https://github.com/DataDog/integrations-core/pull/16014))
+
 ## 4.0.1 / 2023-08-25 / Agent 7.48.0
 
 ***Fixed***:

--- a/ecs_fargate/CHANGELOG.md
+++ b/ecs_fargate/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Added***:
+
+* Add storage_stats support for Windows ([#16014](https://github.com/DataDog/integrations-core/pull/16014))
+
 ***Fixed***:
 
 * Fix blkio_stats bad metrics for Windows ([#16014](https://github.com/DataDog/integrations-core/pull/16014))

--- a/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
@@ -334,10 +334,8 @@ class FargateCheck(AgentCheck):
 
                 blkio_stats = container_stats.get("blkio_stats", {}).get(blkio_cat)
                 # In Windows is always "None" (string), so don't report anything
-                if blkio_stats == 'None':
+                if blkio_stats is None or blkio_stats == 'None':
                     continue
-                elif blkio_stats is None:
-                    blkio_stats = []
 
                 for blkio_stat in blkio_stats:
 

--- a/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
+++ b/ecs_fargate/datadog_checks/ecs_fargate/ecs_fargate.py
@@ -66,7 +66,15 @@ MEMORY_GAUGE_METRICS = [
     'hierarchical_memsw_limit',
 ]
 MEMORY_RATE_METRICS = ['pgpgin', 'pgpgout', 'pgmajfault', 'pgfault']
+# Linux-only IO metrics
 IO_METRICS = {'io_service_bytes_recursive': 'ecs.fargate.io.bytes.', 'io_serviced_recursive': 'ecs.fargate.io.ops.'}
+# Windows-only IO metrics
+STORAGE_STATS_METRICS = {
+    'read_count_normalized': 'ecs.fargate.io.ops.read',
+    'read_size_bytes': 'ecs.fargate.io.bytes.read',
+    'write_count_normalized': 'ecs.fargate.io.ops.write',
+    'write_size_bytes': 'ecs.fargate.io.bytes.write',
+}
 NETWORK_GAUGE_METRICS = {
     'rx_errors': 'ecs.fargate.net.rcvd_errors',
     'tx_errors': 'ecs.fargate.net.sent_errors',
@@ -345,6 +353,13 @@ class FargateCheck(AgentCheck):
                         write_counter += blkio_stat["value"]
                 self.rate(metric_name + 'read', read_counter, tags)
                 self.rate(metric_name + 'write', write_counter, tags)
+
+            # Windows I/O metrics
+            storage_stats = container_stats.get('storage_stats', {})
+            for metric, metric_name in STORAGE_STATS_METRICS.items():
+                value = storage_stats.get(metric)
+                if value:
+                    self.rate(metric_name, value, tags)
 
             # Network metrics
             networks = container_stats.get('networks', {})

--- a/ecs_fargate/metadata.csv
+++ b/ecs_fargate/metadata.csv
@@ -1,8 +1,8 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
-ecs.fargate.io.ops.write,rate,,,,Number of write operations to the disk (Linux only).,0,amazon_fargate,io write count,
-ecs.fargate.io.bytes.write,rate,,byte,,Number of bytes written to the disk (Linux only).,0,amazon_fargate,io write,
-ecs.fargate.io.ops.read,rate,,,,Number of read operation on the disk (Linux only).,0,amazon_fargate,io read count,
-ecs.fargate.io.bytes.read,rate,,byte,,Number of bytes read on the disk (Linux only).,0,amazon_fargate,io read,
+ecs.fargate.io.ops.write,rate,,,,Number of write operations to the disk.,0,amazon_fargate,io write count,
+ecs.fargate.io.bytes.write,rate,,byte,,Number of bytes written to the disk.,0,amazon_fargate,io write,
+ecs.fargate.io.ops.read,rate,,,,Number of read operation on the disk.,0,amazon_fargate,io read count,
+ecs.fargate.io.bytes.read,rate,,byte,,Number of bytes read on the disk.,0,amazon_fargate,io read,
 ecs.fargate.cpu.user,rate,,nanocore,,User CPU time.,0,amazon_fargate,cpu user,
 ecs.fargate.cpu.system,rate,,nanocore,,System CPU time.,0,amazon_fargate,cpu system,
 ecs.fargate.cpu.usage,rate,,nanocore,,Total CPU Usage.,0,amazon_fargate,cpu total,

--- a/ecs_fargate/tests/conftest.py
+++ b/ecs_fargate/tests/conftest.py
@@ -48,6 +48,10 @@ EXPECTED_CONTAINER_METRICS_WINDOWS = [
     'ecs.fargate.cpu.limit',
     'ecs.fargate.mem.usage',
     'ecs.fargate.mem.max_usage',
+    'ecs.fargate.io.ops.write',
+    'ecs.fargate.io.bytes.write',
+    'ecs.fargate.io.ops.read',
+    'ecs.fargate.io.bytes.read',
 ]
 
 EXPECTED_TASK_METRICS = [


### PR DESCRIPTION
### What does this PR do?
We want to provide I/O metrics to Windows ECS users by using `Task metadata`.
The call to the `/stats` endpoint will return two I/O related sections:

* `blkio_stats` for Linux.
* `storage_stats` for Windows.

When one is set, the other one is not.
On a Windows task:
```
    "blkio_stats": {
        "io_service_bytes_recursive": null,
        "io_serviced_recursive": null,
        "io_queue_recursive": null,
        "io_service_time_recursive": null,
        "io_wait_time_recursive": null,
        "io_merged_recursive": null,
        "io_time_recursive": null,
        "sectors_recursive": null
    },
    "num_procs": 2,
    "storage_stats": {
        "read_count_normalized": 95145,
        "read_size_bytes": 709917184,
        "write_count_normalized": 217642,
        "write_size_bytes": 1126764544
    },
```

On a Linux task:
```
    "blkio_stats": {
      "io_service_bytes_recursive": [
        {
          "major": 202,
          "minor": 26368,
          "op": "Read",
          "value": 638976
        },
        {
          "major": 202,
          "minor": 26368,
          "op": "Write",
          "value": 0
        },
        {
          "major": 202,
          "minor": 26368,
          "op": "Sync",
          "value": 638976
        },
        {
          "major": 202,
          "minor": 26368,
          "op": "Async",
          "value": 0
        },
        {
          "major": 202,
          "minor": 26368,
          "op": "Total",
          "value": 638976
        }
      ],
      "io_serviced_recursive": [
        {
          "major": 202,
          "minor": 26368,
          "op": "Read",
          "value": 12
        },
        {
          "major": 202,
          "minor": 26368,
          "op": "Write",
          "value": 0
        },
        {
          "major": 202,
          "minor": 26368,
          "op": "Sync",
          "value": 12
        },
        {
          "major": 202,
          "minor": 26368,
          "op": "Async",
          "value": 0
        },
        {
          "major": 202,
          "minor": 26368,
          "op": "Total",
          "value": 12
        }
      ],
      "io_queue_recursive": [],
      "io_service_time_recursive": [],
      "io_wait_time_recursive": [],
      "io_merged_recursive": [],
      "io_time_recursive": [],
      "sectors_recursive": []
    },
    "num_procs": 0,
    "storage_stats": {},
```

The current code does not work on Windows tasks because it will actually submit 1 `read` and 1 `write` metrics when checking for the 2 `blkio_stats` metrics that we check, meaning that we will get 4 metrics that are set to `0`.

```
c:\ProgramData\Datadog\conf.d\ecs_fargate.d>agent check ecs_fargate --check-rate
=== Series ===
[
  {
    "metric": "ecs.fargate.io.ops.read",  # blkio_stats
  },
  {
    "metric": "ecs.fargate.io.read.count",
  },
  {
    "metric": "ecs.fargate.io.write.count",
  },
  {
    "metric": "ecs.fargate.io.bytes.write",  # blkio_stats
  },
  {
    "metric": "ecs.fargate.io.read.size",
  },
  {
    "metric": "ecs.fargate.io.write.size",
  },
  {
    "metric": "ecs.fargate.io.bytes.read",  # blkio_stats
  },
  {
    "metric": "ecs.fargate.io.ops.write",  # blkio_stats
  }
]
=== Service Checks ===
[
  {
    "check": "fargate_check",
    "host_name": "EC2AMAZ-JPLCK58",
    "timestamp": 1697211357,
    "status": 0,
    "message": "",
    "tags": []
  },
  {
    "check": "fargate_check",
    "host_name": "EC2AMAZ-JPLCK58",
    "timestamp": 1697211358,
    "status": 0,
    "message": "",
    "tags": []
  }
]
=========
Collector
=========

  Running Checks
  ==============

    ecs_fargate (3.3.0)
    -------------------
      Instance ID: ecs_fargate:f33784b0230b2b7f [OK]
      Configuration Source: file:c:\programdata\datadog\conf.d\ecs_fargate.d\conf.yaml
      Total Runs: 2
      Metric Samples: Last Run: 18, Total: 36
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 2
      Average Execution Time : 40ms
      Last Execution Date : 2023-10-13 15:35:58 UTC (1697211358000)
      Last Successful Execution Date : 2023-10-13 15:35:58 UTC (1697211358000)



NOTE:
The check command runs in a different user context than the running service
This could affect results if the command relies on specific permissions and/or user contexts
```

The first commit fixes this bug. Also note that the current stats endpoint does not return a `"None"` string anymore when the data is unset.

The second commit add support to I/O metrics for Windows ECS tasks. You could already see it working in the first example.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
