### PR TITLE
Sync integrations-core with logs-backend

### DIFF
--- a/strimzi/assets/logs/strimzi.yaml
+++ b/strimzi/assets/logs/strimzi.yaml
@@ -1,0 +1,55 @@
+id: strimzi
+metric_id: strimzi
+facets:
+pipeline:
+  type: pipeline
+  name: Strimzi
+  enabled: true
+  filter:
+    query: source:strimzi
+  processors:
+    - type: grok-parser
+      name: Parsing Strimzi logs
+      enabled: true
+      source: message
+      samples:
+        - "2023-09-21T08:25:27.244309295Z stdout F 2023-09-21 08:25:27 INFO  AbstractOperator:510 - Reconciliation #55(timer) Kafka(kafka/my-cluster): reconciled"
+        - "2023-04-27 09:46:39 INFO  Main:79 - ClusterOperator 0.34.0 is starting"
+        - "2023-09-26 18:38:08,49502 WARN  [vertx-blocked-thread-checker] BlockedThreadChecker: - Thread Thread[blocking-startup-ops-0,5,main] has been blocked for 323364 ms, time limit is 60000 ms"
+        - "2023-04-27 09:47:41,48424 INFO  [main] Main:38 - TopicOperator 0.34.0 is starting"
+        - "2023-09-26 18:38:26,499 INFO Committing global session 0x1001486b1980009 (org.apache.zookeeper.server.quorum.LeaderSessionTracker) [CommitProcessor:1]"
+      grok:
+        matchRules: |
+          strimzi_raw_log %{_date} %{_stream_type} %{_entry_type} %{strimzi_k8s}
+          strimzi_raw_log2 %{_date_2}\s+%{_level}\s+%{_msg}\s+\[%{_logger_name}:%{_line}\]
+          strimzi_raw_log3 %{_date_2}\s+%{_level}\s+%{_msg}\s+\[%{_logger_name}\]
+          strimzi_raw_log4 %{_date_3}\s+%{_level}\s+\[%{word}\]\s+%{_logger_name}:%{_line} - %{_msg}
+          strimzi_raw_log5 %{_date_3}\s+%{_level}\s+\[%{_logger_name}\]\s+%{_msg}
+          strimzi_k8s %{_date_k8s}\s+%{_level}\s+%{_logger_name}:%{_line} - %{_msg}
+        supportRules: |
+          _date %{date("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZ")}
+          _date_2 %{date("yyyy-MM-dd HH:mm:ss,SSS"):timestamp}
+          _date_3 %{date("yyyy-MM-dd HH:mm:ss,SSSSS"):timestamp}
+          _date_k8s %{date("yyyy-MM-dd HH:mm:ss"):timestamp}
+          _level %{word:level}
+          _logger_name %{notSpace:logger.name}
+          _line %{integer:logger.line}
+          _msg %{data:msg}
+          _logger %{notSpace:logger.name}:%{number:logger.lineno}
+          _stream_type %{word:stream_type}
+          _entry_type %{word:entry_type}
+    - type: date-remapper
+      name: Define `timestamp` as the official date of the log
+      enabled: true
+      sources:
+        - timestamp
+    - type: status-remapper
+      name: Define `level` as the official status of the log
+      enabled: true
+      sources:
+        - level
+    - type: message-remapper
+      name: Define `msg` as the official message of the log
+      enabled: true
+      sources:
+        - msg

--- a/strimzi/assets/logs/strimzi_tests.yaml
+++ b/strimzi/assets/logs/strimzi_tests.yaml
@@ -1,0 +1,93 @@
+id: "strimzi"
+tests:
+ -
+  sample: "2023-09-21T08:25:27.244309295Z stdout F 2023-09-21 08:25:27 INFO  AbstractOperator:510 - Reconciliation #55(timer) Kafka(kafka/my-cluster): reconciled"
+  result:
+    custom:
+      entry_type: "F"
+      level: "INFO"
+      logger:
+        line: 510
+        name: "AbstractOperator"
+      stream_type: "stdout"
+      timestamp: 1695284727000
+    message: "Reconciliation #55(timer) Kafka(kafka/my-cluster): reconciled"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1695284727000
+ -
+  sample: "2023-04-27 09:46:39 INFO  Main:79 - ClusterOperator 0.34.0 is starting"
+  result:
+    custom:
+      level: "INFO"
+      logger:
+        line: 79
+        name: "Main"
+      timestamp: 1682588799000
+    message: "ClusterOperator 0.34.0 is starting"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1682588799000
+ -
+  sample: "2023-09-21 08:59:04 ERROR LeaderElector:144 - Exception occurred while releasing lock 'LeaseLock: kafka - strimzi-cluster-operator (strimzi-cluster-operator-675749c788-7x546)'"
+  result:
+    custom:
+      level: "ERROR"
+      logger:
+        line: 144
+        name: "LeaderElector"
+      timestamp: 1695286744000
+    message: "Exception occurred while releasing lock 'LeaseLock: kafka - strimzi-cluster-operator (strimzi-cluster-operator-675749c788-7x546)'"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1695286744000
+ -
+  sample: "2023-09-26 18:38:08,49502 WARN  [vertx-blocked-thread-checker] BlockedThreadChecker: - Thread Thread[blocking-startup-ops-0,5,main] has been blocked for 323364 ms, time limit is 60000 ms"
+  result:
+    custom:
+      level: "WARN"
+      logger:
+        name: "vertx-blocked-thread-checker"
+      timestamp: 1695753488495
+    message: "BlockedThreadChecker: - Thread Thread[blocking-startup-ops-0,5,main] has been blocked for 323364 ms, time limit is 60000 ms"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1695753488495
+ -
+  sample: "2023-04-27 09:47:41,48424 INFO  [main] Main:38 - TopicOperator 0.34.0 is starting"
+  result:
+    custom:
+      level: "INFO"
+      logger:
+        line: 38
+        name: "Main"
+      timestamp: 1682588861484
+    message: "TopicOperator 0.34.0 is starting"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1682588861484
+ -
+  sample: "2023-09-26 18:38:26,499 INFO Committing global session 0x1001486b1980009 (org.apache.zookeeper.server.quorum.LeaderSessionTracker) [CommitProcessor:1]"
+  result:
+    custom:
+      level: "INFO"
+      logger:
+        line: 1
+        name: "CommitProcessor"
+      timestamp: 1695753506499
+    message: "Committing global session 0x1001486b1980009 (org.apache.zookeeper.server.quorum.LeaderSessionTracker)"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1695753506499
+ -
+  sample: "2023-09-29 05:59:37,261 INFO Added plugin 'org.apache.kafka.connect.connector.policy.PrincipalConnectorClientConfigOverridePolicy' (org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader) [main]"
+  result:
+    custom:
+      level: "INFO"
+      logger:
+        name: "main"
+      timestamp: 1695967177261
+    message: "Added plugin 'org.apache.kafka.connect.connector.policy.PrincipalConnectorClientConfigOverridePolicy' (org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader)"
+    tags:
+     - "source:LOGS_SOURCE"
+    timestamp: 1695967177261

--- a/tenable/assets/logs/tenable.yaml
+++ b/tenable/assets/logs/tenable.yaml
@@ -9,7 +9,6 @@ facets:
   - name: Event Outcome
     source: log
     path: evt.outcome
-    type: string
     groups:
       - Event
   - name: User Name


### PR DESCRIPTION
### What does this PR do?
Syncing integrations with logs-backend

### Motivation
Logs integrations in this repo are out of date with logs-backend. We also need to sync this as part of [LOGSC-509](https://datadoghq.atlassian.net/browse/LOGSC-509)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[LOGSC-509]: https://datadoghq.atlassian.net/browse/LOGSC-509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ