### PR TITLE
Sy/strimzi rec monitors

### DIFF
--- a/strimzi/assets/monitors/cluster_operator_resource.json
+++ b/strimzi/assets/monitors/cluster_operator_resource.json
@@ -1,0 +1,31 @@
+{
+    "version": 2,
+    "created_at": "2023-10-13",
+    "last_updated_at": "2023-10-13",
+    "title": "Strimzi Cluster Operator Resource {kind.name} on {host.name} is in a \"fail\" state\"",
+    "tags": [
+        "integration:strimzi"
+    ],
+    "definition":{
+        "name": "Strimzi Cluster Operator Resource {kind.name} on {host.name} is in a \"fail\" state\"",
+        "type": "query alert",
+        "query": "max(last_15m):avg:strimzi.cluster_operator.resource.state{*} by {kind,host} <= 0",
+        "message": "{{#is_alert}}\nStrimzi Cluster Operator Resource {kind.name} on {host.name} has been in the \"fail\" state for the last 15 mins.\n{{/is_alert}} \n\n{{#is_recovery}}\nStrimzi Cluster Operator Resource {kind.name} on {host.name} has recovered back to \"ready\" state.\n{{/is_recovery}}",
+        "tags": [
+            "integration:strimzi"
+        ],
+        "options": {
+            "thresholds": {
+                "critical": 0
+            },
+            "notify_audit": false,
+            "on_missing_data": "default",
+            "include_tags": true,
+            "new_group_delay": 60,
+            "avalanche_window": 10,
+            "silenced": {}
+        },
+        "priority": null,
+        "restricted_roles": null
+    }
+}

--- a/strimzi/assets/monitors/cluster_operator_resource.json
+++ b/strimzi/assets/monitors/cluster_operator_resource.json
@@ -20,7 +20,6 @@
                 "critical": 0
             },
             "notify_audit": false,
-            "on_missing_data": "default",
             "include_tags": true,
             "new_group_delay": 60,
             "avalanche_window": 10,

--- a/strimzi/assets/monitors/cluster_operator_resource.json
+++ b/strimzi/assets/monitors/cluster_operator_resource.json
@@ -6,6 +6,7 @@
     "tags": [
         "integration:strimzi"
     ],
+    "description": "Notify your team when a Strimzi Cluster Operator resource is in a 'fail' state",
     "definition":{
         "name": "Strimzi Cluster Operator Resource {kind.name} on {host.name} is in a \"fail\" state\"",
         "type": "query alert",

--- a/strimzi/assets/monitors/topic_operator_resource.json
+++ b/strimzi/assets/monitors/topic_operator_resource.json
@@ -20,7 +20,6 @@
             "critical": 0
         },
         "notify_audit": false,
-        "on_missing_data": "default",
         "include_tags": true,
         "new_group_delay": 60,
         "avalanche_window": 10,

--- a/strimzi/assets/monitors/topic_operator_resource.json
+++ b/strimzi/assets/monitors/topic_operator_resource.json
@@ -1,0 +1,31 @@
+{
+    "version": 2,
+    "created_at": "2023-10-13",
+    "last_updated_at": "2023-10-13",
+    "title": "Strimzi Cluster Operator Resource {kind.name} on {host.name} is in a \"fail\" state\"",
+    "tags": [
+        "integration:strimzi"
+    ],
+    "definition": {
+    "name": "Strimzi Topic Operator Resource {kind.name} on {host.name} is in a \"fail\" state\"",
+    "type": "query alert",
+    "query": "max(last_15m):avg:strimzi.topic_operator.resource.state{*} by {kind,host} <= 0",
+    "message": "{{#is_alert}}\nStrimzi Topic Operator Resource {kind.name} on {host.name} has been in the \"fail\" state for the last 15 mins.\n{{/is_alert}} \n\n{{#is_recovery}}\nStrimzi Topic Operator Resource {kind.name} on {host.name} has recovered back to \"ready\" state.\n{{/is_recovery}}",
+    "tags": [
+        "integration:strimzi"
+    ],
+    "options": {
+        "thresholds": {
+            "critical": 0
+        },
+        "notify_audit": false,
+        "on_missing_data": "default",
+        "include_tags": true,
+        "new_group_delay": 60,
+        "avalanche_window": 10,
+        "silenced": {}
+    },
+    "priority": null,
+    "restricted_roles": null
+    }
+}

--- a/strimzi/assets/monitors/topic_operator_resource.json
+++ b/strimzi/assets/monitors/topic_operator_resource.json
@@ -6,6 +6,7 @@
     "tags": [
         "integration:strimzi"
     ],
+    "description": "Notify your team when a Strimzi Topic Operator resource is in a 'fail' state",
     "definition": {
     "name": "Strimzi Topic Operator Resource {kind.name} on {host.name} is in a \"fail\" state\"",
     "type": "query alert",

--- a/strimzi/assets/monitors/topic_operator_resource.json
+++ b/strimzi/assets/monitors/topic_operator_resource.json
@@ -2,7 +2,7 @@
     "version": 2,
     "created_at": "2023-10-13",
     "last_updated_at": "2023-10-13",
-    "title": "Strimzi Cluster Operator Resource {kind.name} on {host.name} is in a \"fail\" state\"",
+    "title": "Strimzi Topic Operator Resource {kind.name} on {host.name} is in a \"fail\" state\"",
     "tags": [
         "integration:strimzi"
     ],

--- a/strimzi/manifest.json
+++ b/strimzi/manifest.json
@@ -45,6 +45,10 @@
         "metadata_path": "assets/service_checks.json"
       }
     },
+    "monitors": {
+      "cluster_operate_resource_state": "assets/monitors/cluster_operator_resource.json",
+      "topic_operate_resource_state": "assets/monitors/topic_operator_resource.json"
+    },
     "dashboards": {
       "strimzi": "assets/dashboards/overview.json"
     },


### PR DESCRIPTION
### What does this PR do?
Recommended monitors for strimzi. Fairly simple. 2 monitors, one for cluster_operator and one topic_operator. Alert logic is that if a resource is in the fail state for a full 15 min duration.

Was going to include a third one for user.operator.resource.state, but I can't seem to get that metric and can't confirm if that metric exists or not.

Staging link:
https://dd.datad0g.com/monitors/recommended?q=strimzi&only_installed=true&p=1