### PR TITLE
Fix the `timeout` config option definition

### DIFF
--- a/win32_event_log/CHANGELOG.md
+++ b/win32_event_log/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Fix the `timeout` config option definition ([#16017](https://github.com/DataDog/integrations-core/pull/16017))
+
 ## 3.1.0 / 2023-09-29
 
 ***Added***:

--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -272,10 +272,10 @@ files:
       value:
         type: string
     - name: timeout
-      description: The number of seconds to wait for new event signals.
+      description: The number of milliseconds to wait for new event signals.
       value:
-        type: number
-        example: 5
+        type: integer
+        example: 5000
     - name: payload_size
       description: |
         The number of events to request at a time.

--- a/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
+++ b/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
@@ -89,7 +89,7 @@ def instance_tag_sid():
 
 
 def instance_timeout():
-    return 5
+    return 5000
 
 
 def instance_type():

--- a/win32_event_log/datadog_checks/win32_event_log/config_models/instance.py
+++ b/win32_event_log/datadog_checks/win32_event_log/config_models/instance.py
@@ -76,7 +76,7 @@ class InstanceConfig(BaseModel):
     tag_event_id: Optional[bool] = None
     tag_sid: Optional[bool] = None
     tags: Optional[tuple[str, ...]] = None
-    timeout: Optional[float] = None
+    timeout: Optional[int] = None
     type: Optional[tuple[str, ...]] = None
     user: Optional[str] = None
 

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -222,10 +222,10 @@ instances:
     #
     # domain: <DOMAIN>
 
-    ## @param timeout - number - optional - default: 5
-    ## The number of seconds to wait for new event signals.
+    ## @param timeout - integer - optional - default: 5000
+    ## The number of milliseconds to wait for new event signals.
     #
-    # timeout: 5
+    # timeout: 5000
 
     ## @param payload_size - integer - optional - default: 10
     ## The number of events to request at a time.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix the `timeout` config option definition

### Motivation
<!-- What inspired you to submit this pull request? -->

- According to the doc mentioned in the code [here](https://github.com/DataDog/integrations-core/blob/9ad0a36fe91cc3728f8e2ce4d08a5f73a505e6ab/win32_event_log/datadog_checks/win32_event_log/check.py#L316-L318), this option is supposed to be a integer and in millisonds
- Spotted working on [this PR](https://github.com/DataDog/integrations-core/pull/15997) where I got this error: 

```
FAILED tests/test_check.py::test_sid - Exception: 
Traceback (most recent call last):
  File "D:\a\integrations-core\integrations-core\datadog_checks_base\datadog_checks\base\checks\base.py", line 1235, in run
    self.check(instance)
  File "D:\a\integrations-core\integrations-core\win32_event_log\datadog_checks\win32_event_log\check.py", line 135, in check
    for event in self.consume_events():
  File "D:\a\integrations-core\integrations-core\win32_event_log\datadog_checks\win32_event_log\check.py", line 272, in consume_events
    for event in self.poll_events():
  File "D:\a\integrations-core\integrations-core\win32_event_log\datadog_checks\win32_event_log\check.py", line 318, in poll_events
    wait_signal = win32event.WaitForSingleObjectEx(self._event_handle, self.config.timeout, True)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'float' object cannot be interpreted as an integer
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Relates to https://datadoghq.atlassian.net/browse/AITS-277

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
