### PR TITLE
Add a fixture to run the tests on a clone using the current branch instead of main

### DIFF
--- a/ddev/tests/cli/meta/scripts/test_upgrade_python.py
+++ b/ddev/tests/cli/meta/scripts/test_upgrade_python.py
@@ -6,12 +6,12 @@ from collections import defaultdict
 from ddev.repo.constants import PYTHON_VERSION
 
 
-def test_upgrade_python(ddev, repository):
+def test_upgrade_python(ddev, repository_with_current_branch):
     major, minor = PYTHON_VERSION.split('.')
     new_version = f'{major}.{int(minor) + 1}'
 
     changes = defaultdict(list)
-    for entry in repository.path.iterdir():
+    for entry in repository_with_current_branch.path.iterdir():
         config_file = entry / 'hatch.toml'
         if not config_file.is_file():
             continue
@@ -22,7 +22,7 @@ def test_upgrade_python(ddev, repository):
 
     minimum_changes = sum(map(len, changes.values()))
 
-    constant_file = repository.path / 'ddev' / 'src' / 'ddev' / 'repo' / 'constants.py'
+    constant_file = repository_with_current_branch.path / 'ddev' / 'src' / 'ddev' / 'repo' / 'constants.py'
     contents = constant_file.read_text()
 
     assert f'PYTHON_VERSION = {PYTHON_VERSION!r}' in contents


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a fixture to run the tests on a clone using the current branch instead of main

### Motivation
<!-- What inspired you to submit this pull request? -->

- The current `repository` fixture always checkouts the main branch. In some cases, such as in the `test_upgrade_python` (see [this PR](https://github.com/DataDog/integrations-core/pull/15997) that is currently failing), we need to run the tests on a clone using the local branch.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- I'm not sure I like the current implementation, even if it works. I'll be happy if you could challenge it!
- Relates to https://datadoghq.atlassian.net/browse/AITS-277

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
