### PR TITLE
Use a dummy repository to run the `upgrade_python` tests

### DIFF
--- a/ddev/tests/cli/meta/scripts/conftest.py
+++ b/ddev/tests/cli/meta/scripts/conftest.py
@@ -1,0 +1,54 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from ddev.repo.core import Repository
+
+
+@pytest.fixture
+def fake_repo(tmp_path_factory, config_file, ddev):
+    repo_path = tmp_path_factory.mktemp('integrations-core')
+    repo = Repository('integrations-core', str(repo_path))
+
+    config_file.model.repos['core'] = str(repo.path)
+    config_file.save()
+
+    write_file(
+        repo_path / 'ddev' / 'src' / 'ddev' / 'repo',
+        'constants.py',
+        """# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+CONFIG_DIRECTORY = '.ddev'
+NOT_SHIPPABLE = frozenset(['datadog_checks_dev', 'datadog_checks_tests_helper', 'ddev'])
+FULL_NAMES = {
+    'core': 'integrations-core',
+    'extras': 'integrations-extras',
+    'marketplace': 'marketplace',
+    'agent': 'datadog-agent',
+}
+
+# This is automatically maintained
+PYTHON_VERSION = '3.9'
+""",
+    )
+
+    write_file(
+        repo_path / 'dummy',
+        'hatch.toml',
+        """[env.collectors.datadog-checks]
+
+[[envs.default.matrix]]
+python = ["2.7", "3.9"]
+
+""",
+    )
+
+    yield repo
+
+
+def write_file(folder, file, content):
+    folder.mkdir(exist_ok=True, parents=True)
+    file_path = folder / file
+    file_path.write_text(content)

--- a/ddev/tests/cli/meta/scripts/test_upgrade_python.py
+++ b/ddev/tests/cli/meta/scripts/test_upgrade_python.py
@@ -1,41 +1,28 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from collections import defaultdict
-
-from ddev.repo.constants import PYTHON_VERSION
 
 
-def test_upgrade_python(ddev, repository):
-    major, minor = PYTHON_VERSION.split('.')
-    new_version = f'{major}.{int(minor) + 1}'
+def test_upgrade_python(fake_repo, ddev):
+    new_version = "3.11"
+    old_version = "3.9"
 
-    changes = defaultdict(list)
-    for entry in repository.path.iterdir():
-        config_file = entry / 'hatch.toml'
-        if not config_file.is_file():
-            continue
-
-        for i, line in enumerate(config_file.read_text().splitlines()):
-            if line.startswith('python = [') and PYTHON_VERSION in line:
-                changes[config_file].append(i)
-
-    minimum_changes = sum(map(len, changes.values()))
-
-    constant_file = repository.path / 'ddev' / 'src' / 'ddev' / 'repo' / 'constants.py'
+    constant_file = fake_repo.path / 'ddev' / 'src' / 'ddev' / 'repo' / 'constants.py'
     contents = constant_file.read_text()
 
-    assert f'PYTHON_VERSION = {PYTHON_VERSION!r}' in contents
+    assert f'PYTHON_VERSION = {old_version!r}' in contents
     assert f'PYTHON_VERSION = {new_version!r}' not in contents
 
     result = ddev('meta', 'scripts', 'upgrade-python', new_version)
 
     assert result.exit_code == 0, result.output
-    assert result.output.startswith('Python upgrades\n\nPassed: ')
-
-    passed = int(result.output.partition('Passed:')[2].strip())
-    assert passed >= minimum_changes
+    assert result.output == 'Python upgrades\n\nPassed: 2\n'
 
     contents = constant_file.read_text()
-    assert f'PYTHON_VERSION = {PYTHON_VERSION!r}' not in contents
+    assert f'PYTHON_VERSION = {old_version!r}' not in contents
     assert f'PYTHON_VERSION = {new_version!r}' in contents
+
+    hatch_file = fake_repo.path / 'dummy' / 'hatch.toml'
+    contents = hatch_file.read_text()
+    assert f'python = ["2.7", "{old_version}"]' not in contents
+    assert f'python = ["2.7", "{new_version}"]' in contents


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use a dummy repository to run the `upgrade_python` tests

### Motivation
<!-- What inspired you to submit this pull request? -->

- Stop relying on the current repo to make tests easier to write/maintain
- Needed for https://github.com/DataDog/integrations-core/pull/16000 and https://github.com/DataDog/integrations-core/pull/15997

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
