### PR TITLE
Bump the `pika` version to 1.3.2 on py3

### DIFF
--- a/rabbitmq/hatch.toml
+++ b/rabbitmq/hatch.toml
@@ -2,7 +2,8 @@
 
 [envs.default]
 dependencies = [
-  "pika==0.13.0",
+  "pika==0.13.0; python_version < '3.0'",
+  "pika==1.3.2; python_version > '3.0'",
 ]
 
 # Rabbitmq versions <3.8 must be tested on both PY2 and PY3. All these versions use RabbitMQ's management plugin as the source for data.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the `pika` version to 1.3.2

### Motivation
<!-- What inspired you to submit this pull request? -->

- Current version is 4 years old: https://pypi.org/project/pika/0.13.0/
- This version does not work well with python 3.11 in this PR: https://github.com/DataDog/integrations-core/pull/15997

### Additional Notes
<!-- Anything else we should know when reviewing? -->

![image](https://github.com/DataDog/integrations-core/assets/1266346/826c6ead-e9c9-47e9-91f5-220556e7aafe)

Relates to https://datadoghq.atlassian.net/browse/AITS-277

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
