### PR TITLE
Bump the `confluent_kafka` version to 2.2.0 on py3

### DIFF
--- a/mapr/hatch.toml
+++ b/mapr/hatch.toml
@@ -2,7 +2,8 @@
 
 [envs.default]
 dependencies = [
-  "confluent_kafka==2.2.0",
+  "confluent_kafka==1.7.0; python_version < '3.0'",
+  "confluent_kafka==2.2.0; python_version > '3.0'",
 ]
 
 [[envs.default.matrix]]

--- a/mapr/hatch.toml
+++ b/mapr/hatch.toml
@@ -2,7 +2,7 @@
 
 [envs.default]
 dependencies = [
-  "confluent_kafka==1.7.0",
+  "confluent_kafka==2.2.0",
 ]
 
 [[envs.default.matrix]]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the `confluent_kafka` version to 2.2.0 on py3

### Motivation
<!-- What inspired you to submit this pull request? -->

- There's no wheel for the 1.7.0 version on py3.11, see [this job](https://github.com/DataDog/integrations-core/actions/runs/6534891548/job/17743392376?pr=15997)
- Needed for https://github.com/DataDog/integrations-core/pull/15997

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Relaytes to https://datadoghq.atlassian.net/browse/AITS-277

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
