### PR TITLE
Set back the `timeout` option to seconds

### DIFF
--- a/win32_event_log/CHANGELOG.md
+++ b/win32_event_log/CHANGELOG.md
@@ -5,6 +5,7 @@
 ***Fixed***:
 
 * Fix the `timeout` config option definition ([#16017](https://github.com/DataDog/integrations-core/pull/16017))
+* Set back the `timeout` option to seconds ([#16024](https://github.com/DataDog/integrations-core/pull/16024))
 
 ## 3.1.0 / 2023-09-29
 

--- a/win32_event_log/assets/configuration/spec.yaml
+++ b/win32_event_log/assets/configuration/spec.yaml
@@ -272,10 +272,10 @@ files:
       value:
         type: string
     - name: timeout
-      description: The number of milliseconds to wait for new event signals.
+      description: The number of seconds to wait for new event signals.
       value:
         type: integer
-        example: 5000
+        example: 5
     - name: payload_size
       description: |
         The number of events to request at a time.

--- a/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
+++ b/win32_event_log/datadog_checks/win32_event_log/config_models/defaults.py
@@ -89,7 +89,7 @@ def instance_tag_sid():
 
 
 def instance_timeout():
-    return 5000
+    return 5
 
 
 def instance_type():

--- a/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
+++ b/win32_event_log/datadog_checks/win32_event_log/data/conf.yaml.example
@@ -222,10 +222,10 @@ instances:
     #
     # domain: <DOMAIN>
 
-    ## @param timeout - integer - optional - default: 5000
-    ## The number of milliseconds to wait for new event signals.
+    ## @param timeout - integer - optional - default: 5
+    ## The number of seconds to wait for new event signals.
     #
-    # timeout: 5000
+    # timeout: 5
 
     ## @param payload_size - integer - optional - default: 10
     ## The number of events to request at a time.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Set back the `timeout` option to seconds

### Motivation
<!-- What inspired you to submit this pull request? -->

- I updated this in my other PR: https://github.com/DataDog/integrations-core/pull/16017
- But I was wrong as this is converted [here](https://github.com/DataDog/integrations-core/blob/master/win32_event_log/datadog_checks/win32_event_log/config_models/validators.py#L24-L25)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Relates to https://datadoghq.atlassian.net/browse/AITS-277

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
