### PR TITLE
Update EKS Fargate token setup

### DIFF
--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -170,6 +170,7 @@ You have two options for this to work properly:
 
 * Use an hardcoded token value (`clusterAgent.token` in Helm, `credentials.token` in the Datadog Operator); convenient, but less secure.
 * Use a manually-created secret (`clusterAgent.tokenExistingSecret` in Helm, not available in the Datadog Operator) and replicate it in all namespaces where Fargate tasks need to be monitored; secure, but requires extra operations.
+  ** note:  `token` value requires 32 character minimum
 
 If the EKS cluster runs only Fargate workloads, you need a standalone Cluster Agent deployment. And, as described above, choose one of the two options for making the token reachable.
 

--- a/eks_fargate/README.md
+++ b/eks_fargate/README.md
@@ -170,7 +170,7 @@ You have two options for this to work properly:
 
 * Use an hardcoded token value (`clusterAgent.token` in Helm, `credentials.token` in the Datadog Operator); convenient, but less secure.
 * Use a manually-created secret (`clusterAgent.tokenExistingSecret` in Helm, not available in the Datadog Operator) and replicate it in all namespaces where Fargate tasks need to be monitored; secure, but requires extra operations.
-  ** note:  `token` value requires 32 character minimum
+**Note**:  The `token` value requires a minimum of 32 characters.
 
 If the EKS cluster runs only Fargate workloads, you need a standalone Cluster Agent deployment. And, as described above, choose one of the two options for making the token reachable.
 


### PR DESCRIPTION
The token requires a 32 char min.  If not an error will show up in the container sidecar as such... "Could not detect the Datadog Cluster Agent's endpoint: temporary failure in clusterAgentClient, will retry later: cluster agent authentication token length must be greater than 32, currently: 7"

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Documentation change on the EKS Fargate configuration setup.  The token between the DCA and agent sidecar requires a 32 char min.

### Motivation
<!-- What inspired you to submit this pull request? -->
Not list in the doc which is a important requirement.

### Additional Notes
<!-- Anything else we should know when reviewing? -->
If an example block of the Datadog Helm chart where we specify the `token` that would be even more helpful.

> datadog:
>   clusterName: <their-cluster-name>
> agents:
>   enabled: false # No DaemonSet generated
> clusterAgent:
>   enabled: true
>   replicas: 1
>   token: "<some 32 chars random-token>" # Some token, random, it needs to be hardcoded to avoid issue when running `helm upgrade`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
