### PR TITLE
Make dbm async job cancel non-blocking

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Fix check cancellation timeout due to `DBMAsyncJob` cancellation being blocked ([#16028](https://github.com/DataDog/integrations-core/pull/16028))
+
 ## 34.0.0 / 2023-09-29
 
 ***Changed***:

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -264,9 +264,6 @@ class DBMAsyncJob(object):
         Send a signal to cancel the job loop asynchronously.
         """
         self._cancel_event.set()
-        # after setting cancel event, wait for job loop to fully shutdown
-        if self._job_loop_future:
-            self._job_loop_future.result()
 
     def run_job_loop(self, tags):
         """
@@ -300,7 +297,11 @@ class DBMAsyncJob(object):
                     self._check.count("dd.{}.async_job.cancel".format(self._dbms), 1, tags=self._job_tags, raw=True)
                     break
                 if time.time() - self._last_check_run > self._min_collection_interval * 2:
-                    self._log.info("[%s] Job loop stopping due to check inactivity", self._job_tags_str)
+                    self._log.info(
+                        "[%s] Job loop stopping due to check inactivity, last check run at %s",
+                        self._job_tags_str,
+                        self._last_check_run,
+                    )
                     self._check.count(
                         "dd.{}.async_job.inactive_stop".format(self._dbms), 1, tags=self._job_tags, raw=True
                     )

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -297,11 +297,7 @@ class DBMAsyncJob(object):
                     self._check.count("dd.{}.async_job.cancel".format(self._dbms), 1, tags=self._job_tags, raw=True)
                     break
                 if time.time() - self._last_check_run > self._min_collection_interval * 2:
-                    self._log.info(
-                        "[%s] Job loop stopping due to check inactivity, last check run at %s",
-                        self._job_tags_str,
-                        self._last_check_run,
-                    )
+                    self._log.info("[%s] Job loop stopping due to check inactivity", self._job_tags_str)
                     self._check.count(
                         "dd.{}.async_job.inactive_stop".format(self._dbms), 1, tags=self._job_tags, raw=True
                     )

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Fix check cancellation timeout due to `DBMAsyncJob` cancellation being blocked ([#16028](https://github.com/DataDog/integrations-core/pull/16028))
+
 ***Added***:
 
 * Upgrade `psycopg2-binary` to `v2.9.8` ([#15949](https://github.com/DataDog/integrations-core/pull/15949))

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 ## Unreleased
 
-***Fixed***:
-
-* Fix check cancellation timeout due to `DBMAsyncJob` cancellation being blocked ([#16028](https://github.com/DataDog/integrations-core/pull/16028))
-
 ***Added***:
 
 * Upgrade `psycopg2-binary` to `v2.9.8` ([#15949](https://github.com/DataDog/integrations-core/pull/15949))
 * Add support for reporting SQL obfuscation errors ([#15990](https://github.com/DataDog/integrations-core/pull/15990))
+
+***Fixed***:
+
+* Fix check cancellation timeout due to `DBMAsyncJob` cancellation being blocked ([#16028](https://github.com/DataDog/integrations-core/pull/16028))
 
 ## 15.1.0 / 2023-10-06
 

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -289,11 +289,15 @@ class PostgreSql(AgentCheck):
 
     def cancel(self):
         """
-        Cancels and waits for all threads to stop.
+        Cancels and sends cancel signal to all threads.
         """
-        self.statement_samples.cancel()
-        self.statement_metrics.cancel()
-        self.metadata_samples.cancel()
+        if self._config.dbm_enabled:
+            self.statement_samples.cancel()
+            self.statement_metrics.cancel()
+            self.metadata_samples.cancel()
+        self._close_db_pool()
+        if self._db:
+            self._db.close()
 
     def _clean_state(self):
         self.log.debug("Cleaning state")

--- a/postgres/datadog_checks/postgres/version_utils.py
+++ b/postgres/datadog_checks/postgres/version_utils.py
@@ -35,17 +35,19 @@ class VersionUtils(object):
     def is_aurora(self, db):
         if self._seen_aurora_exception:
             return False
-        try:
-            with db as conn:
-                with conn.cursor() as cursor:
-                    # This query will pollute PG logs in non aurora versions,
-                    # but is the only reliable way to detect aurora
+        with db as conn:
+            with conn.cursor() as cursor:
+                # This query will pollute PG logs in non aurora versions,
+                # but is the only reliable way to detect aurora
+                try:
                     cursor.execute('select AURORA_VERSION();')
                     return True
-        except Exception as e:
-            self.log.debug("Captured exception %s while determining if the DB is aurora. Assuming is not", str(e))
-            self._seen_aurora_exception = True
-            return False
+                except Exception as e:
+                    self.log.debug(
+                        "Captured exception %s while determining if the DB is aurora. Assuming is not", str(e)
+                    )
+                    self._seen_aurora_exception = True
+                    return False
 
     @staticmethod
     def parse_version(raw_version):

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -38,7 +38,7 @@ from .common import (
     check_wal_receiver_metrics,
     requires_static_version,
 )
-from .utils import _get_conn, _get_superconn, requires_over_10, requires_over_14
+from .utils import _get_conn, _get_superconn, requires_over_10, requires_over_14, run_one_check
 
 CONNECTION_METRICS = ['postgresql.max_connections', 'postgresql.percent_usage_connections']
 
@@ -663,7 +663,7 @@ def test_database_instance_metadata(aggregator, dd_run_check, pg_instance, dbm_e
     expected_host = reported_hostname if reported_hostname else 'stubbed.hostname'
     expected_tags = pg_instance['tags'] + ['port:{}'.format(pg_instance['port'])]
     check = PostgreSql('test_instance', {}, [pg_instance])
-    dd_run_check(check)
+    run_one_check(check, pg_instance)
 
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
     event = next((e for e in dbm_metadata if e['kind'] == 'database_instance'), None)
@@ -680,7 +680,7 @@ def test_database_instance_metadata(aggregator, dd_run_check, pg_instance, dbm_e
 
     # Run a second time and expect the metadata to not be emitted again because of the cache TTL
     aggregator.reset()
-    dd_run_check(check)
+    run_one_check(check, pg_instance)
 
     dbm_metadata = aggregator.get_event_platform_events("dbm-metadata")
     event = next((e for e in dbm_metadata if e['kind'] == 'database_instance'), None)

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -33,7 +33,6 @@ def test_common_replica_metrics(aggregator, integration_check, metrics_cache_rep
     check = integration_check(pg_replica_instance)
     check._connect()
     check.initialize_is_aurora()
-    aggregator.reset()
     check.check(pg_replica_instance)
 
     expected_tags = _get_expected_tags(check, pg_replica_instance)

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -33,6 +33,7 @@ def test_common_replica_metrics(aggregator, integration_check, metrics_cache_rep
     check = integration_check(pg_replica_instance)
     check._connect()
     check.initialize_is_aurora()
+    aggregator.reset()
     check.check(pg_replica_instance)
 
     expected_tags = _get_expected_tags(check, pg_replica_instance)

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -143,16 +143,16 @@ def test_statement_metrics(
 
     check = integration_check(dbm_instance)
     check._connect()
-    run_one_check(check, dbm_instance)
+    run_one_check(check, dbm_instance, cancel=False)
 
     # We can't change track_io_timing at runtime, but we can change what the integration thinks the runtime value is
     # This must be done after the first check since postgres settings are loaded from the database then
     check.pg_settings["track_io_timing"] = "on" if track_io_timing_enabled else "off"
 
     _run_queries()
-    run_one_check(check, dbm_instance)
+    run_one_check(check, dbm_instance, cancel=False)
     _run_queries()
-    run_one_check(check, dbm_instance)
+    run_one_check(check, dbm_instance, cancel=False)
 
     def _should_catch_query(dbname):
         # we can always catch it if the query originals in the same DB
@@ -370,7 +370,7 @@ def test_statement_metrics_with_duplicates(aggregator, integration_check, dbm_in
                 mock_agent.side_effect = obfuscate_sql
                 cursor.execute(query, (['app1', 'app2'],))
                 cursor.execute(query, (['app1', 'app2', 'app3'],))
-                run_one_check(check, dbm_instance)
+                check.check(dbm_instance)
 
                 cursor.execute(query, (['app1', 'app2'],))
                 cursor.execute(query, (['app1', 'app2', 'app3'],))

--- a/postgres/tests/utils.py
+++ b/postgres/tests/utils.py
@@ -55,13 +55,14 @@ def _wait_for_value(db_instance, lower_threshold, query):
                 time.sleep(0.1)
 
 
-def run_one_check(check, db_instance):
+def run_one_check(check, db_instance, cancel=True):
     """
     Run check and immediately cancel.
     Waits for all threads to close before continuing.
     """
     check.check(db_instance)
-    check.cancel()
+    if cancel:
+        check.cancel()
     if check.statement_samples._job_loop_future is not None:
         check.statement_samples._job_loop_future.result()
     if check.statement_metrics._job_loop_future is not None:


### PR DESCRIPTION
### What does this PR do?
This PR makes dbm async job cancel non-blocking to resolve error
```
an error occurred while calling check.Cancel(): timeout while calling check.Cancel()
```

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
