### PR TITLE
Align package version in integration template with changelog

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Align package version in integration template with changelog. ([#16029](https://github.com/DataDog/integrations-core/pull/16029))
+
 ## 27.0.0 / 2023-10-12
 
 ***Changed***:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/__about__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/check/{check_name}/datadog_checks/{check_name}/__about__.py
@@ -1,2 +1,2 @@
 {license_header}
-__version__ = '0.0.1'
+__version__ = '1.0.0'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/__about__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/jmx/{check_name}/datadog_checks/{check_name}/__about__.py
@@ -1,2 +1,2 @@
 {license_header}
-__version__ = '0.0.1'
+__version__ = '1.0.0'

--- a/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/datadog_checks/{check_name}/__about__.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/templates/integration/logs/{check_name}/datadog_checks/{check_name}/__about__.py
@@ -1,2 +1,2 @@
 {license_header}
-__version__ = '0.0.1'
+__version__ = '1.0.0'


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Initial version in `__about__.py` is the same as the initial version in the `CHANGELOG.md`.

### Motivation
<!-- What inspired you to submit this pull request? -->
Found this while reviewing the nvidia triton PR

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
