### PR TITLE
Allow bumping the version of `pyodbc`

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Allow bumping the version of `pyodbc` ([#16030](https://github.com/DataDog/integrations-core/pull/16030))
+
 ## 27.0.0 / 2023-10-12
 
 ***Changed***:

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/dep.py
@@ -36,7 +36,6 @@ IGNORED_DEPS = {
     'pyasn1',  # Breaking snmp tests
     'pycryptodomex',  # Breaking snmp tests
     'pysnmp',  # Breaking snmp tests
-    'pyodbc',  # Breaking sqlserver tests
     'psutil',  # Breaking disk tests
     'aerospike',  # v8+ breaks agent build.
     'protobuf',  # 3.20.2->4.23.3 breaks kubernetes_state, kube_dns, gitlab and gitlab_runner tests.


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Allow bumping the version of `pyodbc`

### Motivation
<!-- What inspired you to submit this pull request? -->

It's now safe to update it https://github.com/DataDog/integrations-core/pull/16021

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Relates to https://datadoghq.atlassian.net/browse/AITS-277

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
