### PR TITLE
Use `material.extensions.emoji.twemoji` instead of `materialx.emoji.twemoji`

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -1,7 +1,7 @@
 [envs.docs]
 dependencies = [
   "mkdocs~=1.5.2",
-  "mkdocs-material~=9.3.1",
+  "mkdocs-material~=9.4.6",
   # Plugins
   "mkdocs-minify-plugin~=0.7.1",
   "mkdocs-git-revision-date-localized-plugin~=1.2.0",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,8 +148,8 @@ markdown_extensions:
   - pymdownx.emoji:
       # https://github.com/twitter/twemoji
       # https://raw.githubusercontent.com/facelessuser/pymdown-extensions/master/pymdownx/twemoji_db.py
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       guess_lang: false
       linenums_style: pymdownx-inline


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Use `material.extensions.emoji.twemoji` instead of `materialx.emoji.twemoji`

### Motivation
<!-- What inspired you to submit this pull request? -->

- https://github.com/DataDog/integrations-core/actions/runs/6546603485/job/17777385830?pr=16030

```
Material emoji logic has been officially moved into mkdocs-material
version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
as mkdocs_material_extensions is deprecated and will no longer be
supported moving forward. This is the last release.

  File "/home/runner/.local/share/hatch/env/virtual/integrations-core/9U2N5cW6/docs/lib/python3.9/site-packages/materialx/emoji.py", line 106, in twemoji
    return _patch_index(options)
  File "/home/runner/.local/share/hatch/env/virtual/integrations-core/9U2N5cW6/docs/lib/python3.9/site-packages/materialx/emoji.py", line 59, in _deprecated_func
    warnings.warn(

WARNING -  Material emoji logic has been officially moved into mkdocs-material
version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
as mkdocs_material_extensions is deprecated and will no longer be
supported moving forward. This is the last release.
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
