### PR TITLE
Prevent `aggregate_last_24_hours` option from affecting global state

### DIFF
--- a/snowflake/CHANGELOG.md
+++ b/snowflake/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Fixed bug where setting the `aggregate_last_24_hours` option to `true` would not be honored when other instances had it set it to `false` (the default) ([#16033](https://github.com/DataDog/integrations-core/pull/16033))
+
 ## 5.0.0 / 2023-08-10 / Agent 7.48.0
 
 ***Changed***:

--- a/snowflake/CHANGELOG.md
+++ b/snowflake/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Fixed***:
 
-* Fixed bug where setting the `aggregate_last_24_hours` option to `true` would not be honored when other instances had it set it to `false` (the default) ([#16033](https://github.com/DataDog/integrations-core/pull/16033))
+* Fixed bug where setting the `aggregate_last_24_hours` option to `true` was not honored when other instances had it set to `false` (the default) ([#16033](https://github.com/DataDog/integrations-core/pull/16033))
 
 ## 5.0.0 / 2023-08-10 / Agent 7.48.0
 

--- a/snowflake/datadog_checks/snowflake/check.py
+++ b/snowflake/datadog_checks/snowflake/check.py
@@ -1,6 +1,7 @@
 # (C) Datadog, Inc. 2020-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import copy
 from contextlib import closing
 
 import snowflake.connector as sf
@@ -70,7 +71,7 @@ class SnowflakeCheck(AgentCheck):
                 'Snowflake `role` is set as `ACCOUNTADMIN` which should be used cautiously, '
                 'refer to docs about custom roles.'
             )
-        metric_groups = (
+        metric_groups = copy.deepcopy(
             ORGANIZATION_USAGE_METRIC_GROUPS
             if (self._config.schema == 'ORGANIZATION_USAGE')
             else ACCOUNT_USAGE_METRIC_GROUPS

--- a/snowflake/tests/common.py
+++ b/snowflake/tests/common.py
@@ -17,6 +17,7 @@ INSTANCE = {
     'role': 'ACCOUNTADMIN',
     'disable_generic_tags': True,
     'login_timeout': 3,
+    'aggregate_last_24_hours': True,
 }
 
 OAUTH_INSTANCE = {


### PR DESCRIPTION
### What does this PR do?

It fixes a bug causing instance-specific configuration affecting all instances by avoiding modification of global variables.

### Motivation

A bug was found where instances with `aggregate_last_24_hours` set to `true` would still be seen to be using the `date_trunc` function in the query, which turned out to be because of other instances on the same Agent, with that setting set to `false`, were influencing global behavior.

[AGENT-10283](https://datadoghq.atlassian.net/browse/AGENT-10283)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[AGENT-10283]: https://datadoghq.atlassian.net/browse/AGENT-10283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ