### PR TITLE
add note about IIS log folder permissions

### DIFF
--- a/iis/README.md
+++ b/iis/README.md
@@ -46,7 +46,7 @@ To configure this check for an Agent running on a host:
 
 3. [Restart the Agent][6].
 
-**Note**: Ensure the `datadog-agent` user has read access to tail the log files you want to collect from. See [Permission issues tailing log files][12] for more information.
+**Note**: Ensure the `datadog-agent` user has read access to tail the log files you want to collect from. In the case that IIS creates a new sub-folder, the permissions of the parent folder are not automatically inherited. See [Permission issues tailing log files][12] for more information.
 
 
 ### Validation


### PR DESCRIPTION
### What does this PR do?
IIS is a special case in that it disables inheritance(https://superuser.com/questions/625975/iis-log-folder-permissions-not-being-inherited) when it creates new log folders. Even though it is out of the control of the DD agent, some customers have been caught off-guard by this behavior by IIS.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-192

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
