### PR TITLE
Add support for Elasticsearch 8.8.2

### DIFF
--- a/elastic/hatch.toml
+++ b/elastic/hatch.toml
@@ -4,7 +4,7 @@ base-package-features = ["deps", "http"]
 [[envs.default.matrix]]
 python = ["2.7", "3.9"]
 flavor = ["elasticsearch"]
-version = ["7.2", "7.7", "7.9", "7.10", "8.6", "8.8"]
+version = ["7.2", "7.7", "7.9", "7.10", "8.8"]
 
 [[envs.default.matrix]]
 python = ["2.7", "3.9"]
@@ -26,7 +26,6 @@ matrix.version.env-vars = [
     { key = "ELASTIC_IMAGE", value = "7.9.0", if = ["7.9"] },
     { key = "ELASTIC_IMAGE", value = "7.10.2", if = ["7.10"] },
     # EOL 2024-08-10
-    { key = "ELASTIC_IMAGE", value = "8.6.2", if = ["8.6"] },
     { key = "ELASTIC_IMAGE", value = "8.8.2", if = ["8.8"] },
 ]
 matrix.flavor.env-vars = [

--- a/elastic/hatch.toml
+++ b/elastic/hatch.toml
@@ -4,7 +4,7 @@ base-package-features = ["deps", "http"]
 [[envs.default.matrix]]
 python = ["2.7", "3.9"]
 flavor = ["elasticsearch"]
-version = ["7.2", "7.7", "7.9", "7.10", "8.6"]
+version = ["7.2", "7.7", "7.9", "7.10", "8.6", "8.8"]
 
 [[envs.default.matrix]]
 python = ["2.7", "3.9"]
@@ -27,6 +27,7 @@ matrix.version.env-vars = [
     { key = "ELASTIC_IMAGE", value = "7.10.2", if = ["7.10"] },
     # EOL 2024-08-10
     { key = "ELASTIC_IMAGE", value = "8.6.2", if = ["8.6"] },
+    { key = "ELASTIC_IMAGE", value = "8.8.2", if = ["8.8"] },
 ]
 matrix.flavor.env-vars = [
     { key = "ELASTIC_REGISTRY", value = "docker.elastic.co/elasticsearch/elasticsearch", if = ["elasticsearch"] },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

This PR adds support for Elasticsearch `8.8.2`. It also removes version `8.6.2`, since having one Elasticsearch 8 version is enough.

### Motivation
<!-- What inspired you to submit this pull request? -->

Use a newer Elasticsearch version that fixes some bugs found in previous ES8 version. This is one the main ones https://github.com/apache/lucene/pull/12072.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
