### PR TITLE
Bump the `pyodbc` version to 5.0.1

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ***Fixed***:
 
-* Bump the `pyodbc` version to 4.0.39 ([#16021](https://github.com/DataDog/integrations-core/pull/16021))
 * Bump the `pymysql` version to 1.1.0 on Python 3 ([#16042](https://github.com/DataDog/integrations-core/pull/16042))
+* Bump the `pyodbc` version to 5.0.1 ([#16041](https://github.com/DataDog/integrations-core/pull/16041))
 
 ## 34.0.1 / 2023-10-17
 

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -69,7 +69,7 @@ pymongo[srv]==4.3.3; python_version >= '3.9'
 pymqi==1.12.10; sys_platform != 'darwin' or platform_machine != 'arm64'
 pymysql==0.10.1; python_version < '3.0'
 pymysql==1.1.0; python_version > '3.0'
-pyodbc==4.0.39; sys_platform != 'darwin' or platform_machine != 'arm64'
+pyodbc==5.0.1; (sys_platform != 'darwin' or platform_machine != 'arm64') and python_version > '3.0'
 pyro4==4.82; sys_platform == 'win32'
 pysmi==0.3.4
 pysnmp-mibs==0.1.6

--- a/ibm_i/CHANGELOG.md
+++ b/ibm_i/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ***Fixed***:
 
-* Bump the `pyodbc` version to 4.0.39 ([#16021](https://github.com/DataDog/integrations-core/pull/16021))
+* Bump the `pyodbc` version to 5.0.1 ([#16041](https://github.com/DataDog/integrations-core/pull/16041))
 
 ## 2.0.0 / 2023-08-10 / Agent 7.48.0
 

--- a/ibm_i/pyproject.toml
+++ b/ibm_i/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "pyodbc==4.0.39; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "pyodbc==5.0.1; (sys_platform != 'darwin' or platform_machine != 'arm64') and python_version > '3.0'",
 ]
 
 [project.urls]

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 * Properly decode query_hash when statement_text is None ([#15974](https://github.com/DataDog/integrations-core/pull/15974))
 * Strip sql comments before parsing procedure name ([#16004](https://github.com/DataDog/integrations-core/pull/16004))
-* Bump the `pyodbc` version to 4.0.39 ([#16021](https://github.com/DataDog/integrations-core/pull/16021))
+* Bump the `pyodbc` version to 5.0.1 ([#16041](https://github.com/DataDog/integrations-core/pull/16041))
 
 ## 15.0.1 / 2023-10-06
 

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -38,7 +38,7 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "lxml==4.9.3",
-    "pyodbc==4.0.39; sys_platform != 'darwin' or platform_machine != 'arm64'",
+    "pyodbc==5.0.1; (sys_platform != 'darwin' or platform_machine != 'arm64') and python_version > '3.0'",
     "pyro4==4.82; sys_platform == 'win32'",
     "pywin32==306; sys_platform == 'win32' and python_version > '3.0'",
     "serpent==1.41; sys_platform == 'win32' and python_version > '3.0'",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the `pyodbc` version to 5.0.1

### Motivation
<!-- What inspired you to submit this pull request? -->

- I bumped the version for both py2 and py3 [here](https://github.com/DataDog/integrations-core/pull/16021), but turns out we could directly bump it to 5.0.1. They dropped py2 support with version 5
- Also I missed that these two integrations do not support py2 anymore 🙈 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- We need to keep the `python_version > '3.0'` specifier because otherwise this library is installed with Python 2 on Agent 6 and we don't need it there (and can't in fact)

- Relates to https://datadoghq.atlassian.net/browse/AITS-277

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
