### PR TITLE
Bump the `pymysql` version to 1.1.0 on Python 3

### DIFF
--- a/cacti/CHANGELOG.md
+++ b/cacti/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Bump the `pymysql` version to 1.1.0 on Python 3 ([#16042](https://github.com/DataDog/integrations-core/pull/16042))
+
 ## 2.0.0 / 2023-08-10 / Agent 7.48.0
 
 ***Changed***:

--- a/cacti/pyproject.toml
+++ b/cacti/pyproject.toml
@@ -39,7 +39,8 @@ dynamic = [
 
 [project.optional-dependencies]
 deps = [
-    "pymysql==0.10.1",
+    "pymysql==0.10.1; python_version < '3.0'",
+    "pymysql==1.1.0; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Fix check cancellation timeout due to `DBMAsyncJob` cancellation being blocked ([#16028](https://github.com/DataDog/integrations-core/pull/16028))
 * Bump the `pyodbc` version to 4.0.39 ([#16021](https://github.com/DataDog/integrations-core/pull/16021))
+* Bump the `pymysql` version to 1.1.0 on Python 3 ([#16042](https://github.com/DataDog/integrations-core/pull/16042))
 
 ## 34.0.0 / 2023-09-29
 

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -67,7 +67,8 @@ pyjwt==1.7.1; python_version < '3.0'
 pyjwt==2.8.0; python_version > '3.0'
 pymongo[srv]==4.3.3; python_version >= '3.9'
 pymqi==1.12.10; sys_platform != 'darwin' or platform_machine != 'arm64'
-pymysql==0.10.1
+pymysql==0.10.1; python_version < '3.0'
+pymysql==1.1.0; python_version > '3.0'
 pyodbc==4.0.39; sys_platform != 'darwin' or platform_machine != 'arm64'
 pyro4==4.82; sys_platform == 'win32'
 pysmi==0.3.4

--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add support for reporting SQL obfuscation errors ([#15990](https://github.com/DataDog/integrations-core/pull/15990))
 
+***Fixed***:
+
+* Bump the `pymysql` version to 1.1.0 on Python 3 ([#16042](https://github.com/DataDog/integrations-core/pull/16042))
+
 ## 11.2.0 / 2023-09-29
 
 ***Added***:

--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -11,7 +11,7 @@ mypy-args = [
 mypy-deps = [
   "types-cachetools==0.1.10",
   "types-enum34==1.1.1",
-  "types-pymysql==1.0.4",
+  "types-pymysql==1.1.0.1",
 ]
 
 [[envs.default.matrix]]

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -44,7 +44,8 @@ deps = [
     "cryptography==3.3.2; python_version < '3.0'",
     "cryptography==41.0.4; python_version > '3.0'",
     "futures==3.4.0; python_version < '3.0'",
-    "pymysql==0.10.1",
+    "pymysql==0.10.1; python_version < '3.0'",
+    "pymysql==1.1.0; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/proxysql/CHANGELOG.md
+++ b/proxysql/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Bump the `pymysql` version to 1.1.0 on Python 3 ([#16042](https://github.com/DataDog/integrations-core/pull/16042))
+
 ## 5.0.0 / 2023-08-10 / Agent 7.48.0
 
 ***Changed***:

--- a/proxysql/pyproject.toml
+++ b/proxysql/pyproject.toml
@@ -39,7 +39,8 @@ dynamic = [
 
 [project.optional-dependencies]
 deps = [
-    "pymysql==0.10.1",
+    "pymysql==0.10.1; python_version < '3.0'",
+    "pymysql==1.1.0; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/singlestore/CHANGELOG.md
+++ b/singlestore/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Bump the `pymysql` version to 1.1.0 on Python 3 ([#16042](https://github.com/DataDog/integrations-core/pull/16042))
+
 ## 2.0.0 / 2023-08-10 / Agent 7.48.0
 
 ***Changed***:

--- a/singlestore/hatch.toml
+++ b/singlestore/hatch.toml
@@ -9,7 +9,7 @@ mypy-args = [
     "datadog_checks/singlestore",
 ]
 mypy-deps = [
-  "types-PyMySQL==1.0.4",
+  "types-PyMySQL==1.1.0.1",
 ]
 
 [[envs.default.matrix]]

--- a/singlestore/pyproject.toml
+++ b/singlestore/pyproject.toml
@@ -39,7 +39,8 @@ dynamic = [
 
 [project.optional-dependencies]
 deps = [
-    "pymysql==0.10.1",
+    "pymysql==0.10.1; python_version < '3.0'",
+    "pymysql==1.1.0; python_version > '3.0'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the `pymysql` version to 1.1.0 on Python 3

### Motivation
<!-- What inspired you to submit this pull request? -->

- This version was pinned in [this PR](https://github.com/DataDog/integrations-core/pull/12612) because of a bug in the version 1.0.2
- The bug got fixed in 1.0.3
- The version we use does not officially support Python 3.11, so I'd like to bump it to 1.1.0 which does

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Relates to https://datadoghq.atlassian.net/browse/AITS-277

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
