### PR TITLE
Display changes on `ddev show changes` when found

### DIFF
--- a/datadog_checks_dev/CHANGELOG.md
+++ b/datadog_checks_dev/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Align package version in integration template with changelog. ([#16029](https://github.com/DataDog/integrations-core/pull/16029))
 * Allow bumping the version of `pyodbc` ([#16030](https://github.com/DataDog/integrations-core/pull/16030))
+* Display changes on `ddev show changes` when changes are found ([#16045](https://github.com/DataDog/integrations-core/pull/16045))
 
 ## 27.0.0 / 2023-10-12
 

--- a/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
+++ b/datadog_checks_dev/datadog_checks/dev/tooling/commands/release/show/changes.py
@@ -12,6 +12,8 @@ from ...console import (
     CONTEXT_SETTINGS,
     abort,
     echo_failure,
+    echo_info,
+    echo_success,
     validate_check_arg,
 )
 
@@ -69,5 +71,9 @@ def changes(ctx, check, tag_pattern, tag_prefix, dry_run, organization, since, e
     for line in unreleased:
         if line.startswith('***'):
             applicable_changelog_types.append(line[3:-5])
+            echo_success(line)
+
+        elif line.strip():
+            echo_info(line)
 
     return cur_version, applicable_changelog_types


### PR DESCRIPTION
### What does this PR do?

Restores displaying pending changes for a release.

### Motivation

This got lost when switching to using the changelog as the source for changes (#15378). Just realized it while preparing a release for an integration.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
