### PR TITLE
Increase the timeout for the validate-agent-build job to 3 hours

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,7 +102,7 @@ trigger-agent-build:
 validate-agent-build:
   stage: validate
   image: $VALIDATE_AGENT_BUILD
-  timeout: 2 hours
+  timeout: 3 hours
   cache:
     <<: *slack-cache
   script:

--- a/.gitlab/validate-agent-build/validate_agent_build.py
+++ b/.gitlab/validate-agent-build/validate_agent_build.py
@@ -9,7 +9,8 @@ DATADOG_AGENT_PIPELINE_URL = os.environ['DATADOG_AGENT_PIPELINE_URL'].rstrip('/'
 BASE_URL = os.environ['CI_API_V4_URL']
 GITLAB_TOKEN = os.environ['GITLAB_TOKEN']
 STAGES_TO_CHECK = ['deps_fetch', 'source_test', 'binary_build', 'package_build']
-TIMEOUT_IN_SEC = (60+55)*60  # Time out after 1h55, just before gitlab cancels the job.
+TIMEOUT_IN_SEC = (60 * 2 + 55) * 60  # Time out after 2h55, just before gitlab cancels the job.
+
 
 def _get_jobs(pipeline_id, scope=None):
     all_jobs = []
@@ -70,7 +71,7 @@ if __name__ == '__main__':
     retry_failed_jobs(pipeline_id)
 
     # Wait for jobs to end and exit immediately if any failure.
-    # If it takes more than 1h55 minutes, cancel the job. Otherwise gitlab will cancel the job on its own without
+    # If it takes more than 2h55 minutes, cancel the job. Otherwise gitlab will cancel the job on its own without
     # notifying the author.
     while (time.time() - t0) < TIMEOUT_IN_SEC:
         remaining_jobs = get_remaining_jobs(pipeline_id)
@@ -90,10 +91,7 @@ if __name__ == '__main__':
         print("Waiting 1 min before next check.")
         time.sleep(60)
     else:
-        # The job has run for 1h55 minutes and there are still some pending jobs.
+        # The job has run for 2h55 minutes and there are still some pending jobs.
         # Fail and notify the author
         print("Job is timing out, please retry it.")
         sys.exit(1)
-
-
-


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Increase the timeout for the validate-agent-build job to 3 hours

I'm sorry, I do not have a better short-term solution. If you have one, please let me know.

### Motivation
<!-- What inspired you to submit this pull request? -->

The job timed out a couple of times: 
- https://gitlab.ddbuild.io/DataDog/integrations-core/-/jobs/351999212
- https://gitlab.ddbuild.io/DataDog/integrations-core/-/jobs/352000584

There was only one job left (a windows one)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

![image](https://github.com/DataDog/integrations-core/assets/1266346/a165815e-c5a0-48af-bcf9-c4524568ef2f)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
