### PR TITLE
 Renaming integration category: messaging -> message queues

### DIFF
--- a/activemq/manifest.json
+++ b/activemq/manifest.json
@@ -13,7 +13,7 @@
     "media": [],
     "classifier_tags": [
       "Category::Log Collection",
-      "Category::Messaging",
+      "Category::Message Queues",
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"

--- a/activemq_xml/manifest.json
+++ b/activemq_xml/manifest.json
@@ -13,7 +13,7 @@
     "media": [],
     "classifier_tags": [
       "Category::Log Collection",
-      "Category::Messaging",
+      "Category::Message Queues",
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"

--- a/hivemq/manifest.json
+++ b/hivemq/manifest.json
@@ -14,7 +14,7 @@
     "classifier_tags": [
       "Category::IoT",
       "Category::Log Collection",
-      "Category::Messaging",
+      "Category::Message Queues",
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"

--- a/ibm_mq/manifest.json
+++ b/ibm_mq/manifest.json
@@ -13,7 +13,7 @@
     "media": [],
     "classifier_tags": [
       "Category::Log Collection",
-      "Category::Messaging",
+      "Category::Message Queues",
       "Category::Network",
       "Supported OS::Linux",
       "Supported OS::Windows",

--- a/kafka/manifest.json
+++ b/kafka/manifest.json
@@ -13,7 +13,7 @@
     "media": [],
     "classifier_tags": [
       "Category::Log Collection",
-      "Category::Messaging",
+      "Category::Message Queues",
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"

--- a/kafka_consumer/manifest.json
+++ b/kafka_consumer/manifest.json
@@ -12,7 +12,7 @@
     "title": "Kafka Consumer",
     "media": [],
     "classifier_tags": [
-      "Category::Messaging",
+      "Category::Message Queues",
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"

--- a/pulsar/manifest.json
+++ b/pulsar/manifest.json
@@ -13,7 +13,7 @@
     "media": [],
     "classifier_tags": [
       "Category::Log Collection",
-      "Category::Messaging",
+      "Category::Message Queues",
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"

--- a/rabbitmq/manifest.json
+++ b/rabbitmq/manifest.json
@@ -13,7 +13,7 @@
     "media": [],
     "classifier_tags": [
       "Category::Log Collection",
-      "Category::Messaging",
+      "Category::Message Queues",
       "Supported OS::Linux",
       "Supported OS::Windows",
       "Supported OS::macOS"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Renaming messaging category to message queues based on feedback

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
