### PR TITLE
Clarify deprecation of ssl: true in CHANGELOG

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -91,7 +91,7 @@
 
 ***Fixed***:
 
-* Fix InstanceConfig loading error for `ssl` config ([#15611](https://github.com/DataDog/integrations-core/pull/15611))
+* Fix InstanceConfig loading error for `ssl` config because `true` is not a valid value. Please, use `require` instead of `true` ([#15611](https://github.com/DataDog/integrations-core/pull/15611))
 
 ## 14.1.0 / 2023-08-10
 


### PR DESCRIPTION
### What does this PR do?
Changes in the config validation made `true` an invalid value for `ssl` in the postgres integration. In order to surface this change a little better, this updates the CHANGELOG for 7.48.0 to describe the change and advise users to replace `ssl: true` with `ssl: require`. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
