### PR TITLE
Remove hardcoded Python versions in the `test_upgrade_python` test file

### DIFF
--- a/ddev/tests/cli/meta/scripts/conftest.py
+++ b/ddev/tests/cli/meta/scripts/conftest.py
@@ -5,6 +5,9 @@ import pytest
 
 from ddev.repo.core import Repository
 
+OLD_PYTHON_VERSION = "3.9"
+NEW_PYTHON_VERSION = "3.11"
+
 
 @pytest.fixture
 def fake_repo(tmp_path_factory, config_file, ddev):
@@ -17,30 +20,30 @@ def fake_repo(tmp_path_factory, config_file, ddev):
     write_file(
         repo_path / 'ddev' / 'src' / 'ddev' / 'repo',
         'constants.py',
-        """# (C) Datadog, Inc. 2022-present
+        f"""# (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 CONFIG_DIRECTORY = '.ddev'
 NOT_SHIPPABLE = frozenset(['datadog_checks_dev', 'datadog_checks_tests_helper', 'ddev'])
-FULL_NAMES = {
+FULL_NAMES = {{
     'core': 'integrations-core',
     'extras': 'integrations-extras',
     'marketplace': 'marketplace',
     'agent': 'datadog-agent',
-}
+}}
 
 # This is automatically maintained
-PYTHON_VERSION = '3.9'
+PYTHON_VERSION = '{OLD_PYTHON_VERSION}'
 """,
     )
 
     write_file(
         repo_path / 'dummy',
         'hatch.toml',
-        """[env.collectors.datadog-checks]
+        f"""[env.collectors.datadog-checks]
 
 [[envs.default.matrix]]
-python = ["2.7", "3.9"]
+python = ["2.7", "{OLD_PYTHON_VERSION}"]
 
 """,
     )
@@ -48,7 +51,7 @@ python = ["2.7", "3.9"]
     write_file(
         repo_path / 'dummy',
         'pyproject.toml',
-        """[project]
+        f"""[project]
 name = "dummy"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -58,7 +61,7 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: {OLD_PYTHON_VERSION}",
 ]
 """,
     )
@@ -66,10 +69,10 @@ classifiers = [
     write_file(
         repo_path / '.github' / 'workflows',
         'build-ddev.yml',
-        """name: build ddev
+        f"""name: build ddev
 env:
   APP_NAME: ddev
-  PYTHON_VERSION: "3.9"
+  PYTHON_VERSION: "{OLD_PYTHON_VERSION}"
   PYOXIDIZER_VERSION: "0.24.0"
 """,
     )
@@ -77,11 +80,11 @@ env:
     write_file(
         repo_path / 'ddev',
         'pyproject.toml',
-        """[tool.black]
-target-version = ["py39"]
+        f"""[tool.black]
+target-version = ["py{OLD_PYTHON_VERSION.replace('.', '')}"]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py{OLD_PYTHON_VERSION.replace('.', '')}"
 """,
     )
 
@@ -96,7 +99,7 @@ target-version = "py39"
         / 'check'
         / '{check_name}',
         'pyproject.toml',
-        """[project]
+        f"""[project]
 name = "dummy"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -106,7 +109,7 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: {OLD_PYTHON_VERSION}",
 ]
 """,
     )

--- a/ddev/tests/cli/meta/scripts/test_upgrade_python.py
+++ b/ddev/tests/cli/meta/scripts/test_upgrade_python.py
@@ -1,41 +1,39 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+from .conftest import NEW_PYTHON_VERSION, OLD_PYTHON_VERSION
 
 
 def test_upgrade_python(fake_repo, ddev):
-    new_version = "3.11"
-    old_version = "3.9"
-
     constant_file = fake_repo.path / 'ddev' / 'src' / 'ddev' / 'repo' / 'constants.py'
     contents = constant_file.read_text()
 
-    assert f'PYTHON_VERSION = {old_version!r}' in contents
-    assert f'PYTHON_VERSION = {new_version!r}' not in contents
+    assert f'PYTHON_VERSION = {OLD_PYTHON_VERSION!r}' in contents
+    assert f'PYTHON_VERSION = {NEW_PYTHON_VERSION!r}' not in contents
 
-    result = ddev('meta', 'scripts', 'upgrade-python', new_version)
+    result = ddev('meta', 'scripts', 'upgrade-python', NEW_PYTHON_VERSION)
 
     assert result.exit_code == 0, result.output
     assert result.output.endswith('Python upgrades\n\nPassed: 7\n')
 
     contents = constant_file.read_text()
-    assert f'PYTHON_VERSION = {old_version!r}' not in contents
-    assert f'PYTHON_VERSION = {new_version!r}' in contents
+    assert f'PYTHON_VERSION = {OLD_PYTHON_VERSION!r}' not in contents
+    assert f'PYTHON_VERSION = {NEW_PYTHON_VERSION!r}' in contents
 
     ci_file = fake_repo.path / '.github' / 'workflows' / 'build-ddev.yml'
     contents = ci_file.read_text()
-    assert f'PYTHON_VERSION: "{old_version}"' not in contents
-    assert f'PYTHON_VERSION: "{new_version}"' in contents
+    assert f'PYTHON_VERSION: "{OLD_PYTHON_VERSION}"' not in contents
+    assert f'PYTHON_VERSION: "{NEW_PYTHON_VERSION}"' in contents
 
     hatch_file = fake_repo.path / 'dummy' / 'hatch.toml'
     contents = hatch_file.read_text()
-    assert f'python = ["2.7", "{old_version}"]' not in contents
-    assert f'python = ["2.7", "{new_version}"]' in contents
+    assert f'python = ["2.7", "{OLD_PYTHON_VERSION}"]' not in contents
+    assert f'python = ["2.7", "{NEW_PYTHON_VERSION}"]' in contents
 
     pyproject_file = fake_repo.path / 'dummy' / 'pyproject.toml'
     contents = pyproject_file.read_text()
-    assert f'Programming Language :: Python :: {old_version}' not in contents
-    assert f'Programming Language :: Python :: {new_version}' in contents
+    assert f'Programming Language :: Python :: {OLD_PYTHON_VERSION}' not in contents
+    assert f'Programming Language :: Python :: {NEW_PYTHON_VERSION}' in contents
 
     template_file = (
         fake_repo.path
@@ -50,5 +48,5 @@ def test_upgrade_python(fake_repo, ddev):
         / 'pyproject.toml'
     )
     contents = template_file.read_text()
-    assert f'Programming Language :: Python :: {old_version}' not in contents
-    assert f'Programming Language :: Python :: {new_version}' in contents
+    assert f'Programming Language :: Python :: {OLD_PYTHON_VERSION}' not in contents
+    assert f'Programming Language :: Python :: {NEW_PYTHON_VERSION}' in contents


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove hardcoded Python versions in the `test_upgrade_python` test file

### Motivation
<!-- What inspired you to submit this pull request? -->

- Remove code duplication and hardcoded values
- Make it easier to bump the versions if needed in the future

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Relates to https://datadoghq.atlassian.net/browse/AITS-283

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
