### PR TITLE
Mark some `object_store` metrics optional

### DIFF
--- a/ray/tests/common.py
+++ b/ray/tests/common.py
@@ -273,6 +273,9 @@ OPTIONAL_METRICS = [
     'pull_manager.object_request_time.sum',
     'pull_manager.object_request_time.bucket',
     'pull_manager.object_request_time.count',
+    'object_store.size.sum',
+    'object_store.size.count',
+    'object_store.size.bucket',
 ]
 OPTIONAL_METRICS = ['ray.' + m for m in OPTIONAL_METRICS]
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Mark some `object_store` metrics optional

### Motivation
<!-- What inspired you to submit this pull request? -->

None of these metrics are exposed in this job: https://github.com/DataDog/integrations-core/actions/runs/6571259966/job/17850155794

```
FAILED tests/test_integration.py::test_check[worker] - AssertionError: Needed at least 1 candidates for 'ray.object_store.size.sum', got 0
Expected:
        MetricStub(name='ray.object_store.size.sum', type=None, value=None, tags=None, hostname=None, device=None, flush_first_value=None)
Similar submitted:
Score   Most similar
0.79    MetricStub(name='ray.object_store.memory', type=0, value=0.0, tags=['Component:raylet', 'Location:SPILLED', 'NodeAddress:172.18.0.3', 'ObjectState:', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.79    MetricStub(name='ray.object_store.memory', type=0, value=0.0, tags=['Component:raylet', 'Location:MMAP_SHM', 'NodeAddress:172.18.0.3', 'ObjectState:UNSEALED', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.79    MetricStub(name='ray.object_store.memory', type=0, value=0.0, tags=['Component:raylet', 'Location:MMAP_SHM', 'NodeAddress:172.18.0.3', 'ObjectState:SEALED', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.79    MetricStub(name='ray.object_store.memory', type=0, value=0.0, tags=['Component:raylet', 'Location:MMAP_DISK', 'NodeAddress:172.18.0.3', 'ObjectState:UNSEALED', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.79    MetricStub(name='ray.object_store.memory', type=0, value=0.0, tags=['Component:raylet', 'Location:MMAP_DISK', 'NodeAddress:172.18.0.3', 'ObjectState:SEALED', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.79    MetricStub(name='ray.object_store.memory', type=0, value=0.0, tags=['Component:core_worker', 'Location:WORKER_HEAP', 'NodeAddress:172.18.0.3', 'ObjectState:', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:cac66fbe872ecde322f30e00d2956939af7b13533864a8798fbf4f67', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.79    MetricStub(name='ray.object_store.memory', type=0, value=0.0, tags=['Component:core_worker', 'Location:WORKER_HEAP', 'NodeAddress:172.18.0.3', 'ObjectState:', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:933e21dfd23d34988a73c585014b35dc18d1db24cbfb758e24af2e6b', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.79    MetricStub(name='ray.object_store.memory', type=0, value=0.0, tags=['Component:core_worker', 'Location:WORKER_HEAP', 'NodeAddress:172.18.0.3', 'ObjectState:', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:397e5cfe94ace5ce0517afa4049726b8e2c40a3586ad8aa6f0d41caf', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.75    MetricStub(name='ray.object_store.used_memory', type=0, value=0.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.69    MetricStub(name='ray.object_store.available_memory', type=0, value=2143619481.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.67    MetricStub(name='ray.object_store.fallback_memory', type=0, value=0.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.64    MetricStub(name='ray.object_store.num_local_objects', type=0, value=0.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.60    MetricStub(name='ray.object_directory.updates', type=0, value=0.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.60    MetricStub(name='ray.object_directory.lookups', type=0, value=0.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.58    MetricStub(name='ray.object_directory.subscriptions', type=0, value=0.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'SessionName:session_2023-10-19_00-32-47_834579_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

These metrics are tested in the unit tests

Relates to https://datadoghq.atlassian.net/browse/AI-3621

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
