### PR TITLE
Fix `ddev env test` so that tests run for all environments properly

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Improve the upgrade-python script ([#16000](https://github.com/DataDog/integrations-core/pull/16000))
 
+***Fixed***:
+
+* Fix `ddev env test` so that tests run for all environments properly when no environment is specified ([#16054](https://github.com/DataDog/integrations-core/pull/16054))
+
 ## 5.2.1 / 2023-10-12
 
 ***Fixed***:

--- a/ddev/src/ddev/cli/env/test.py
+++ b/ddev/src/ddev/cli/env/test.py
@@ -98,7 +98,7 @@ def test_command(
             name
             for name, data in environments.items()
             if data.get('e2e-env')
-            and (not (platforms := data.get('python')) or app.platform.name in platforms)
+            and (not data.get('platform') or app.platform.name in data['platform'])
             and (python_filter is None or data.get('python') == python_filter)
         ]
     elif environment == 'active':


### PR DESCRIPTION
### What does this PR do?

Fixes the field where platforms are obtained from environment data so that `ddev env test <check>` works as before when an environment is not specified.

### Motivation

Realized that E2E tests were not actually running on CI.

### Additional Notes

I chose to remove the walrus thingy from the conditional because I found it obfuscated a little bit the conditional on an already somewhat complex conditional.

Also, I haven't looked into whether any tests are covering this (I think that restoring E2E tests on CI is urgent enough to leave that for later).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
