### PR TITLE
Manually add agent versions to releases.

### DIFF
--- a/datadog_checks_downloader/CHANGELOG.md
+++ b/datadog_checks_downloader/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * Override the default test options for some integrations ([#15779](https://github.com/DataDog/integrations-core/pull/15779))
 
-## 4.3.0 / 2023-08-25
+## 4.3.0 / 2023-08-25 / Agent 7.48.0
 
 ***Security***:
 
@@ -16,7 +16,7 @@
   * in-toto: 2.0.0
   * securesystemslib: 0.28.0
 
-## 4.2.2 / 2023-07-10
+## 4.2.2 / 2023-07-10 / Agent 7.47.0
 
 ***Fixed***:
 


### PR DESCRIPTION
Our tooling should have done it, but it didn't.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->
Our release pipeline failed recently. While investigating it we noticed that the changelog for the downloader package hasn't been updated with the last  2 releases of the Agent. I'm fixing this manually here, there's a jira ticket to track the bug.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
