### PR TITLE
Fix coverage for ddev's src

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -9,6 +9,7 @@
 ***Fixed***:
 
 * Fix `ddev env test` so that tests run for all environments properly when no environment is specified ([#16054](https://github.com/DataDog/integrations-core/pull/16054))
+* Include ddev's source code when measuring its coverage ([#16057](https://github.com/DataDog/integrations-core/pull/16057))
 
 ## 5.2.1 / 2023-10-12
 

--- a/ddev/src/ddev/plugin/external/hatch/environment_collector.py
+++ b/ddev/src/ddev/plugin/external/hatch/environment_collector.py
@@ -27,7 +27,7 @@ class DatadogChecksEnvironmentCollector(EnvironmentCollectorInterface):
     def package_directory(self):
         name = self.root.name
         if name == 'ddev':
-            return 'ddev/src/ddev'
+            return 'src/ddev'
 
         if name == 'datadog_checks_base':
             directory = 'base'


### PR DESCRIPTION
### What does this PR do?

Fixes the way we include the `src` folder for `ddev`.

### Motivation

I realized we were only measuring coverage under `tests` for ddev, meaning we lost visibility onto our test coverage for the actual code.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
