### PR TITLE
Mark some `worker` metrics optional

### DIFF
--- a/ray/tests/common.py
+++ b/ray/tests/common.py
@@ -276,6 +276,9 @@ OPTIONAL_METRICS = [
     'object_store.size.sum',
     'object_store.size.count',
     'object_store.size.bucket',
+    'worker.register_time.sum',
+    'worker.register_time.count',
+    'worker.register_time.bucket',
 ]
 OPTIONAL_METRICS = ['ray.' + m for m in OPTIONAL_METRICS]
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Mark some worker metrics optional

### Motivation
<!-- What inspired you to submit this pull request? -->

None of these metrics are exposed in this job: https://github.com/DataDog/integrations-core/actions/runs/6580779512/job/17879563864

```
FAILED tests/test_integration.py::test_check[worker] - AssertionError: Needed at least 1 candidates for 'ray.worker.register_time.sum', got 0
Expected:
        MetricStub(name='ray.worker.register_time.sum', type=None, value=None, tags=None, hostname=None, device=None, flush_first_value=None)
Similar submitted:
Score   Most similar
0.60    MetricStub(name='ray.process.start_time', type=0, value=1697753917.95, tags=['endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.55    MetricStub(name='ray.process.resident_memory', type=0, value=111812608.0, tags=['endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.53    MetricStub(name='ray.grpc_server.req.process_time', type=0, value=0.222636, tags=['Component:raylet', 'Method:NodeManagerService.grpc_server.RequestWorkerLease', 'NodeAddress:172.18.0.3', 'SessionName:session_2023-10-19_15-18-15_434216_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.53    MetricStub(name='ray.grpc_server.req.process_time', type=0, value=0.164436, tags=['Component:raylet', 'Method:NodeManagerService.grpc_server.GetResourceLoad', 'NodeAddress:172.18.0.3', 'SessionName:session_2023-10-19_15-18-15_434216_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.52    MetricStub(name='ray.node.network.receive.speed', type=0, value=0.00012220027626952209, tags=['SessionName:session_2023-10-19_15-18-15_434216_7', 'endpoint:http://localhost:8081', 'ip:172.18.0.3'], hostname='', device=None, flush_first_value=False)
0.50    MetricStub(name='ray.node.disk.write.iops', type=0, value=2.9121416805845014e-05, tags=['SessionName:session_2023-10-19_15-18-15_434216_7', 'endpoint:http://localhost:8081', 'ip:172.18.0.3'], hostname='', device=None, flush_first_value=False)
0.49    MetricStub(name='ray.node.network.received', type=0, value=207466.0, tags=['SessionName:session_2023-10-19_15-18-15_434216_7', 'endpoint:http://localhost:8081', 'ip:172.18.0.3'], hostname='', device=None, flush_first_value=False)
0.49    MetricStub(name='ray.node.mem.used', type=0, value=508133376.0, tags=['SessionName:session_2023-10-19_15-18-15_434216_7', 'endpoint:http://localhost:8081', 'ip:172.18.0.3'], hostname='', device=None, flush_first_value=False)
0.48    MetricStub(name='ray.pull_manager.requested_bundles', type=0, value=1.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'SessionName:session_2023-10-19_15-18-15_434216_7', 'Type:CumulativeTotal', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.48    MetricStub(name='ray.pull_manager.requested_bundles', type=0, value=0.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'SessionName:session_2023-10-19_15-18-15_434216_7', 'Type:Wait', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.48    MetricStub(name='ray.pull_manager.requested_bundles', type=0, value=0.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'SessionName:session_2023-10-19_15-18-15_434216_7', 'Type:TaskArgs', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.48    MetricStub(name='ray.pull_manager.requested_bundles', type=0, value=0.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'SessionName:session_2023-10-19_15-18-15_434216_7', 'Type:Get', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.48    MetricStub(name='ray.scheduler.failed_worker_startup', type=0, value=0.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'Reason:RegistrationTimedOut', 'SessionName:session_2023-10-19_15-18-15_434216_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.48    MetricStub(name='ray.scheduler.failed_worker_startup', type=0, value=0.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'Reason:RateLimited', 'SessionName:session_2023-10-19_15-18-15_434216_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
0.48    MetricStub(name='ray.scheduler.failed_worker_startup', type=0, value=0.0, tags=['Component:raylet', 'NodeAddress:172.18.0.3', 'Reason:JobConfigMissing', 'SessionName:session_2023-10-19_15-18-15_434216_7', 'Version:2.6.1', 'WorkerId:', 'endpoint:http://localhost:8081'], hostname='', device=None, flush_first_value=False)
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

https://datadoghq.atlassian.net/browse/AI-3622

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
