### PR TITLE
[DBMON-3030] Report metrics query operation time

### DIFF
--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -5,6 +5,7 @@
 ***Added***:
 
 * Add support for reporting SQL obfuscation errors ([#15990](https://github.com/DataDog/integrations-core/pull/15990))
+* Emit MySQL metrics queries operation time ([#16065](https://github.com/DataDog/integrations-core/pull/16065))
 
 ***Fixed***:
 

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -19,6 +19,7 @@ from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.db import QueryExecutor, QueryManager
 from datadog_checks.base.utils.db.utils import (
     default_json_event_encoding,
+    tracked_query,
 )
 from datadog_checks.base.utils.db.utils import (
     resolve_db_host as agent_host_resolver,
@@ -251,6 +252,13 @@ class MySql(AgentCheck):
     def _get_debug_tags(self):
         return ['agent_hostname:{}'.format(datadog_agent.get_hostname())]
 
+    def debug_stats_kwargs(self, tags=None):
+        tags = self.tags + self._get_debug_tags() + (tags or [])
+        return {
+            'tags': tags,
+            "hostname": self.resolved_hostname,
+        }
+
     @classmethod
     def get_library_versions(cls):
         return {'pymysql': pymysql.__version__}
@@ -321,6 +329,7 @@ class MySql(AgentCheck):
             self,
             queries=queries,
             hostname=self.resolved_hostname,
+            track_operation_time=True,
         )
 
     @property
@@ -428,18 +437,22 @@ class MySql(AgentCheck):
         metrics = copy.deepcopy(STATUS_VARS)
 
         # collect results from db
-        results = self._get_stats_from_status(db)
-        results.update(self._get_stats_from_variables(db))
+        with tracked_query(self, operation="status_metrics"):
+            results = self._get_stats_from_status(db)
+        with tracked_query(self, operation="variables_metrics"):
+            results.update(self._get_stats_from_variables(db))
 
         if not is_affirmative(
             self._config.options.get('disable_innodb_metrics', False)
         ) and self._is_innodb_engine_enabled(db):
-            results.update(self.innodb_stats.get_stats_from_innodb_status(db))
+            with tracked_query(self, operation="innodb_metrics"):
+                results.update(self.innodb_stats.get_stats_from_innodb_status(db))
             self.innodb_stats.process_innodb_stats(results, self._config.options, metrics)
 
         # Binary log statistics
         if self._get_variable_enabled(results, 'log_bin'):
-            results['Binlog_space_usage_bytes'] = self._get_binary_log_stats(db)
+            with tracked_query(self, operation="binary_log_metrics"):
+                results['Binlog_space_usage_bytes'] = self._get_binary_log_stats(db)
 
         # Compute key cache utilization metric
         key_blocks_unused = collect_scalar('Key_blocks_unused', results)
@@ -486,33 +499,39 @@ class MySql(AgentCheck):
                 "[Deprecated] The `extra_performance_metrics` option will be removed in a future release. "
                 "Utilize the `custom_queries` feature if the functionality is needed.",
             )
-            results['perf_digest_95th_percentile_avg_us'] = self._get_query_exec_time_95th_us(db)
-            results['query_run_time_avg'] = self._query_exec_time_per_schema(db)
+            with tracked_query(self, operation="exec_time_95th_metrics"):
+                results['perf_digest_95th_percentile_avg_us'] = self._get_query_exec_time_95th_us(db)
+            with tracked_query(self, operation="exec_time_per_schema_metrics"):
+                results['query_run_time_avg'] = self._query_exec_time_per_schema(db)
             metrics.update(PERFORMANCE_VARS)
 
         if is_affirmative(self._config.options.get('schema_size_metrics', False)):
             # report avg query response time per schema to Datadog
-            results['information_schema_size'] = self._query_size_per_schema(db)
+            with tracked_query(self, operation="schema_size_metrics"):
+                results['information_schema_size'] = self._query_size_per_schema(db)
             metrics.update(SCHEMA_VARS)
 
         if is_affirmative(self._config.options.get('table_rows_stats_metrics', False)) and self.userstat_enabled:
             # report size of tables in MiB to Datadog
             self.log.debug("Collecting Table Row Stats Metrics.")
-            (rows_read_total, rows_changed_total) = self._query_rows_stats_per_table(db)
+            with tracked_query(self, operation="table_rows_stats_metrics"):
+                (rows_read_total, rows_changed_total) = self._query_rows_stats_per_table(db)
             results['information_table_rows_read_total'] = rows_read_total
             results['information_table_rows_changed_total'] = rows_changed_total
             metrics.update(TABLE_ROWS_STATS_VARS)
 
         if is_affirmative(self._config.options.get('table_size_metrics', False)):
             # report size of tables in MiB to Datadog
-            (table_index_size, table_data_size) = self._query_size_per_table(db)
+            with tracked_query(self, operation="table_size_metrics"):
+                (table_index_size, table_data_size) = self._query_size_per_table(db)
             results['information_table_index_size'] = table_index_size
             results['information_table_data_size'] = table_data_size
             metrics.update(TABLE_VARS)
 
         if is_affirmative(self._config.options.get('system_table_size_metrics', False)):
             # report size of tables in MiB to Datadog
-            (table_index_size, table_data_size) = self._query_size_per_table(db, system_tables=True)
+            with tracked_query(self, operation="system_table_size_metrics"):
+                (table_index_size, table_data_size) = self._query_size_per_table(db, system_tables=True)
             if results.get('information_table_index_size'):
                 results['information_table_index_size'].update(table_index_size)
             else:
@@ -526,9 +545,11 @@ class MySql(AgentCheck):
         if is_affirmative(self._config.options.get('replication', self._config.dbm_enabled)):
             if self.performance_schema_enabled and self._is_group_replication_active(db):
                 self.log.debug('Collecting group replication metrics.')
-                self._collect_group_replica_metrics(db, results)
+                with tracked_query(self, operation="group_replication_metrics"):
+                    self._collect_group_replica_metrics(db, results)
             else:
-                replication_metrics = self._collect_replication_metrics(db, results, above_560)
+                with tracked_query(self, operation="replication_metrics"):
+                    replication_metrics = self._collect_replication_metrics(db, results, above_560)
                 metrics.update(replication_metrics)
                 self._check_replication_status(results)
 

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=32.6.0",
+    "datadog-checks-base>=34.1.0",
 ]
 dynamic = [
     "version",

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -89,7 +89,7 @@ def test_minimal_config(aggregator, dd_run_check, instance_basic):
 
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
-        get_metadata_metrics(), check_submission_type=True, exclude=['dd.mysql.operation.time']
+        get_metadata_metrics(), check_submission_type=True, exclude=[variables.OPERATION_TIME_METRIC_NAME]
     )
 
 
@@ -107,7 +107,7 @@ def test_complex_config(aggregator, dd_run_check, instance_complex):
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(),
         check_submission_type=True,
-        exclude=['alice.age', 'bob.age', 'dd.mysql.operation.time'] + variables.STATEMENT_VARS,
+        exclude=['alice.age', 'bob.age', variables.OPERATION_TIME_METRIC_NAME] + variables.STATEMENT_VARS,
     )
 
 
@@ -122,7 +122,8 @@ def test_e2e(dd_agent_check, dd_default_hostname, instance_complex):
         e2e=True,
     )
     aggregator.assert_metrics_using_metadata(
-        get_metadata_metrics(), exclude=['alice.age', 'bob.age', 'dd.mysql.operation.time'] + variables.STATEMENT_VARS
+        get_metadata_metrics(),
+        exclude=['alice.age', 'bob.age'] + variables.E2E_OPERATION_TIME_METRIC_NAME + variables.STATEMENT_VARS,
     )
 
 
@@ -377,7 +378,7 @@ def test_complex_config_replica(aggregator, dd_run_check, instance_complex):
     aggregator.assert_metrics_using_metadata(
         get_metadata_metrics(),
         check_submission_type=True,
-        exclude=['alice.age', 'bob.age', 'dd.mysql.operation.time'] + variables.STATEMENT_VARS,
+        exclude=['alice.age', 'bob.age', variables.OPERATION_TIME_METRIC_NAME] + variables.STATEMENT_VARS,
     )
 
     # Make sure group replication is not detected
@@ -473,15 +474,17 @@ def _test_optional_metrics(aggregator, optional_metrics):
 def _test_operation_time_metrics(aggregator, operation_time_metrics, tags, e2e=False):
     for operation_time_metric in operation_time_metrics:
         if e2e:
-            for suffix in ('avg', 'max'):
+            for metric_name in variables.E2E_OPERATION_TIME_METRIC_NAME:
                 aggregator.assert_metric(
-                    'dd.mysql.operation.time.{}'.format(suffix),
+                    metric_name,
                     tags=tags + ['operation:{}'.format(operation_time_metric)],
                     count=1,
                 )
         else:
             aggregator.assert_metric(
-                'dd.mysql.operation.time', tags=tags + ['operation:{}'.format(operation_time_metric)], count=1
+                variables.OPERATION_TIME_METRIC_NAME,
+                tags=tags + ['operation:{}'.format(operation_time_metric)],
+                count=1,
             )
 
 

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -273,3 +273,24 @@ GROUP_REPLICATION_VARS = [
     'mysql.replication.group.transactions_rollback',
     'mysql.replication.group.transactions_validating',
 ]
+
+SIMPLE_OPERATION_TIME_METRICS = [
+    'status_metrics',
+    'innodb_metrics',
+    'variables_metrics',
+    'binary_log_metrics',
+]
+
+COMPLEX_OPERATION_TIME_METRICS = [
+    'schema_size_metrics',
+    'system_table_size_metrics',
+    'table_size_metrics',
+]
+
+REPLICATION_OPERATION_TIME_METRICS = ['replication_metrics']
+
+GROUP_REPLICATION_OPERATION_TIME_METRICS = ['group_replication_metrics']
+
+PERFORMANCE_OPERATION_TIME_METRICS = ['exec_time_95th_metrics', 'exec_time_per_schema_metrics']
+
+COMMON_PERFORMANCE_OPERATION_TIME_METRICS = ['performance_schema.threads']

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -294,3 +294,9 @@ GROUP_REPLICATION_OPERATION_TIME_METRICS = ['group_replication_metrics']
 PERFORMANCE_OPERATION_TIME_METRICS = ['exec_time_95th_metrics', 'exec_time_per_schema_metrics']
 
 COMMON_PERFORMANCE_OPERATION_TIME_METRICS = ['performance_schema.threads']
+
+OPERATION_TIME_METRIC_NAME = 'dd.mysql.operation.time'
+
+E2E_OPERATION_TIME_METRIC_NAME = [
+    'dd.mysql.operation.time.{}'.format(suffix) for suffix in ('avg', 'max', '95percentile', 'count', 'median')
+]


### PR DESCRIPTION
### What does this PR do?
This PR starts emitting mysql metrics queries operation time.

### Motivation
Emitting the metrics queries operation time will help us understand how long each metrics query take. When troubleshooting long running integration checks, query level operation time will provide more insights into delays caused by particular metric queries. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
