### PR TITLE
Add a ping to clickhouse in the e2e tests setup

### DIFF
--- a/clickhouse/tests/conftest.py
+++ b/clickhouse/tests/conftest.py
@@ -3,6 +3,7 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 from copy import deepcopy
 
+import clickhouse_driver
 import pytest
 
 from datadog_checks.dev import docker_run
@@ -14,6 +15,7 @@ from . import common
 @pytest.fixture(scope='session')
 def dd_environment():
     conditions = []
+
     for i in range(6):
         conditions.append(CheckEndpoints(['http://{}:{}'.format(common.HOST, common.HTTP_START_PORT + i)]))
         conditions.append(
@@ -21,6 +23,16 @@ def dd_environment():
                 'clickhouse-0{}'.format(i + 1), 'Logging errors to /var/log/clickhouse-server/clickhouse-server.err.log'
             )
         )
+
+    conditions.append(
+        ping_clickhouse(
+            common.CONFIG['server'],
+            common.CONFIG['port'],
+            common.CONFIG['username'],
+            common.CONFIG['password'],
+        )
+    )
+
     with docker_run(common.COMPOSE_FILE, conditions=conditions, sleep=10, attempts=2):
         yield common.CONFIG
 
@@ -28,3 +40,18 @@ def dd_environment():
 @pytest.fixture
 def instance():
     return deepcopy(common.CONFIG)
+
+
+def ping_clickhouse(host, port, username, password):
+    def _ping_clickhouse():
+        client = clickhouse_driver.Client(
+            host=host,
+            port=port,
+            user=username,
+            password=password,
+        )
+        client.connection.connect()
+        client.connection.ping()
+        return True
+
+    return _ping_clickhouse


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a ping to clickhouse in the e2e tests setup

### Motivation
<!-- What inspired you to submit this pull request? -->

The env is a bit flaky: https://github.com/DataDog/integrations-core/actions/runs/6608937843/job/17948410687

```
__________________________________ test_check __________________________________
tests/test_clickhouse.py:17: in test_check
    dd_run_check(check)
../datadog_checks_dev/datadog_checks/dev/plugin/pytest.py:259: in run_check
    raise Exception('\n'.join(exc_lines))
E   Exception: 
E   Traceback (most recent call last):
E     File "/home/runner/.local/share/hatch/env/virtual/datadog-clickhouse/KY25C-l6/py3.9-18/lib/python3.9/site-packages/datadog_checks/base/checks/base.py", line 1129, in run
E       self.check(instance)
E     File "/home/runner/work/integrations-core/integrations-core/clickhouse/datadog_checks/clickhouse/clickhouse.py", line 60, in check
E       self.connect()
E     File "/home/runner/work/integrations-core/integrations-core/clickhouse/datadog_checks/clickhouse/clickhouse.py", line 125, in connect
E       raise_from(type(e)(error), None)
E     File "<string>", line 3, in raise_from
E   clickhouse_driver.errors.NetworkError: Code: 210. Unable to connect to ClickHouse: Code: 210. Connection reset by peer (localhost:9001)
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

https://datadoghq.atlassian.net/browse/AI-3623

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
