### PR TITLE
Deprecate init_config.profiles

### DIFF
--- a/snmp/CHANGELOG.md
+++ b/snmp/CHANGELOG.md
@@ -5,6 +5,7 @@
 ***Fixed***:
 
 * Update default profiles column to symbol ([#15998](https://github.com/DataDog/integrations-core/pull/15998))
+* Deprecate init_config.profiles ([#16068](https://github.com/DataDog/integrations-core/pull/16068))
 
 ## 7.0.0 / 2023-09-29
 

--- a/snmp/assets/configuration/spec.yaml
+++ b/snmp/assets/configuration/spec.yaml
@@ -87,6 +87,7 @@ files:
               definition_file: f5-big-ip.yaml
             cisco-asr:
               definition_file: cisco-asr.yaml
+        hidden: true
       - name: refresh_oids_cache_interval
         description: |
           Note: Beta feature, only available using python SNMP integration.

--- a/snmp/datadog_checks/snmp/data/conf.yaml.example
+++ b/snmp/datadog_checks/snmp/data/conf.yaml.example
@@ -53,22 +53,6 @@ init_config:
     #     metric_tags:
     #     - TCP
 
-    ## @param profiles - mapping - optional
-    ## Specify profiles to be able to reference a set of metrics by name.
-    ## Either `definition_file` or `definition` must be defined.
-    ## `definition_file` points to a file with a profile, and `definition` inlines
-    ## it directly.
-    ## When using a profile present on the profiles directory of the
-    ## configuration, you can directly pass the filename.
-    ## By default, if the file doesn't start with an underscore, it loads all of the profiles
-    ## installed in the python package and in the configuration directory.
-    #
-    # profiles:
-    #   f5-big-ip:
-    #     definition_file: f5-big-ip.yaml
-    #   cisco-asr:
-    #     definition_file: cisco-asr.yaml
-
     ## @param refresh_oids_cache_interval - integer - optional - default: 0
     ## Note: Beta feature, only available using python SNMP integration.
     ## Set this option to enable caching of OIDs. The value is the number of seconds before the


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Deprecate init_config.profiles

### Motivation
<!-- What inspired you to submit this pull request? -->

Deprecate init_config.profiles in favour of other profiles sources (RC, downloaded, yaml profiles folder)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
