### PR TITLE
Bump the Python version in the dependency provider when bumping the Python version

### DIFF
--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -13,7 +13,7 @@
 * Include ddev's source code when measuring its coverage ([#16057](https://github.com/DataDog/integrations-core/pull/16057))
 * Fix Github API search query ([#15943](https://github.com/DataDog/integrations-core/pull/15943))
 * Do not modify the Agent build name if provided by the user when running the e2e environments ([#16052](https://github.com/DataDog/integrations-core/pull/16052))
-* Also bump the Python version in the dependency provider when bumping the Python version ([#16070](https://github.com/DataDog/integrations-core/pull/16070))
+* Bump the Python version in the dependency provider when bumping the Python version ([#16070](https://github.com/DataDog/integrations-core/pull/16070))
 
 ## 5.2.1 / 2023-10-12
 

--- a/ddev/CHANGELOG.md
+++ b/ddev/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Include ddev's source code when measuring its coverage ([#16057](https://github.com/DataDog/integrations-core/pull/16057))
 * Fix Github API search query ([#15943](https://github.com/DataDog/integrations-core/pull/15943))
 * Do not modify the Agent build name if provided by the user when running the e2e environments ([#16052](https://github.com/DataDog/integrations-core/pull/16052))
+* Also bump the Python version in the dependency provider when bumping the Python version ([#16070](https://github.com/DataDog/integrations-core/pull/16070))
 
 ## 5.2.1 / 2023-10-12
 

--- a/ddev/tests/cli/meta/scripts/conftest.py
+++ b/ddev/tests/cli/meta/scripts/conftest.py
@@ -48,23 +48,24 @@ python = ["2.7", "{OLD_PYTHON_VERSION}"]
 """,
     )
 
-    write_file(
-        repo_path / 'dummy',
-        'pyproject.toml',
-        f"""[project]
-name = "dummy"
-classifiers = [
-    "Development Status :: 5 - Production/Stable",
-    "Intended Audience :: Developers",
-    "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: BSD License",
-    "Natural Language :: English",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: {OLD_PYTHON_VERSION}",
-]
-""",
-    )
+    for integration in ('dummy', 'datadog_checks_dependency_provider'):
+        write_file(
+            repo_path / integration,
+            'pyproject.toml',
+            f"""[project]
+    name = "dummy"
+    classifiers = [
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: {OLD_PYTHON_VERSION}",
+    ]
+    """,
+        )
 
     write_file(
         repo_path / '.github' / 'workflows',

--- a/ddev/tests/cli/meta/scripts/test_upgrade_python.py
+++ b/ddev/tests/cli/meta/scripts/test_upgrade_python.py
@@ -14,7 +14,7 @@ def test_upgrade_python(fake_repo, ddev):
     result = ddev('meta', 'scripts', 'upgrade-python', NEW_PYTHON_VERSION)
 
     assert result.exit_code == 0, result.output
-    assert result.output.endswith('Python upgrades\n\nPassed: 7\n')
+    assert result.output.endswith('Python upgrades\n\nPassed: 8\n')
 
     contents = constant_file.read_text()
     assert f'PYTHON_VERSION = {OLD_PYTHON_VERSION!r}' not in contents
@@ -30,10 +30,11 @@ def test_upgrade_python(fake_repo, ddev):
     assert f'python = ["2.7", "{OLD_PYTHON_VERSION}"]' not in contents
     assert f'python = ["2.7", "{NEW_PYTHON_VERSION}"]' in contents
 
-    pyproject_file = fake_repo.path / 'dummy' / 'pyproject.toml'
-    contents = pyproject_file.read_text()
-    assert f'Programming Language :: Python :: {OLD_PYTHON_VERSION}' not in contents
-    assert f'Programming Language :: Python :: {NEW_PYTHON_VERSION}' in contents
+    for integration in ('dummy', 'datadog_checks_dependency_provider'):
+        pyproject_file = fake_repo.path / integration / 'pyproject.toml'
+        contents = pyproject_file.read_text()
+        assert f'Programming Language :: Python :: {OLD_PYTHON_VERSION}' not in contents
+        assert f'Programming Language :: Python :: {NEW_PYTHON_VERSION}' in contents
 
     template_file = (
         fake_repo.path


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the Python version in the dependency provider when bumping the Python version

### Motivation
<!-- What inspired you to submit this pull request? -->

We missed it because it has no `hatch` file

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
