### PR TITLE
[DBMON-3050] Collect dynamic relation metrics for autodiscovered databases

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 * Add cloudsqladmin to default list of databases to exclude from autodiscovery and databases to ignore to prevent failures on Postgres 15 on Google CloudSQL ([#16027](https://github.com/DataDog/integrations-core/pull/16027))
 * Bump the minimum base check version to 34.1.0 ([#16062](https://github.com/DataDog/integrations-core/pull/16062))
+* Collect Postgres size metrics for auto-discovered databases ([#16076](https://github.com/DataDog/integrations-core/pull/16076))
 
 ## 15.1.1 / 2023-10-17
 

--- a/postgres/tests/test_discovery.py
+++ b/postgres/tests/test_discovery.py
@@ -42,6 +42,17 @@ RELATION_METRICS = {
     'postgresql.autoanalyzed',
 }
 
+DYNAMIC_RELATION_METRICS = {
+    'postgresql.relation.pages',
+    'postgresql.relation.tuples',
+    'postgresql.relation.all_visible',
+    'postgresql.table_size',
+    'postgresql.relation_size',
+    'postgresql.index_size',
+    'postgresql.toast_size',
+    'postgresql.total_size',
+}
+
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
@@ -171,6 +182,8 @@ def test_autodiscovery_collect_all_relations(aggregator, integration_check, pg_i
     for db in databases:
         expected_tags = _get_expected_tags(check, pg_instance, db=db, table='breed', schema='public')
         for metric in RELATION_METRICS:
+            aggregator.assert_metric(metric, tags=expected_tags)
+        for metric in DYNAMIC_RELATION_METRICS:
             aggregator.assert_metric(metric, tags=expected_tags)
 
     aggregator.assert_metric(

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -798,7 +798,7 @@ def test_statement_metadata(
     if POSTGRES_VERSION.split('.')[0] == "9" and pg_stat_statements_view == "pg_stat_statements":
         # cannot catch any queries from other users
         # only can see own queries
-        return False
+        return
 
     fqt_samples = [
         s for s in samples if s.get('dbm_type') == 'fqt' and s['db']['query_signature'] == normalized_query_signature


### PR DESCRIPTION
### What does this PR do?
This PR fixes issue relates to not collecting dynamic relation metrics for auto-discovered databases. One side effect of this issue is that the `table_size` of auto-discovered tables are not populated in DBM Schema tab. 

After fix:
![image](https://github.com/DataDog/integrations-core/assets/4964070/3b9e051a-65bc-431f-babf-e68030e86c28)
![image](https://github.com/DataDog/integrations-core/assets/4964070/80cc625d-787d-4e08-9d13-19d29d131cff)

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
