### PR TITLE
safeguard to ensure dbm_enabled is a boolean

### DIFF
--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Properly decode query_hash when statement_text is None ([#15974](https://github.com/DataDog/integrations-core/pull/15974))
 * Strip sql comments before parsing procedure name ([#16004](https://github.com/DataDog/integrations-core/pull/16004))
 * Bump the `pyodbc` version to 5.0.1 ([#16041](https://github.com/DataDog/integrations-core/pull/16041))
+* Fix config option `dbm_enabled` type to ensure it is a boolean ([#16078](https://github.com/DataDog/integrations-core/pull/16078))
 
 ## 15.0.1 / 2023-10-06
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -125,7 +125,7 @@ class SQLServer(AgentCheck):
         self.custom_metrics = init_config.get('custom_metrics', [])
 
         # DBM
-        self.dbm_enabled = self.instance.get('dbm', False)
+        self.dbm_enabled = is_affirmative(self.instance.get('dbm', False))
         self.statement_metrics_config = self.instance.get('query_metrics', {}) or {}
         self.procedure_metrics_config = self.instance.get('procedure_metrics', {}) or {}
         self.settings_config = self.instance.get('collect_settings', {}) or {}

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -56,6 +56,16 @@ def test_check_invalid_password(aggregator, dd_run_check, init_config, instance_
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize('dbm_enabled', [True, False, 'true', 'false', None])
+def test_check_dbm_enabled_config(aggregator, dd_run_check, init_config, instance_docker, dbm_enabled):
+    if dbm_enabled is not None:
+        instance_docker['dbm'] = dbm_enabled
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
+    assert isinstance(sqlserver_check.dbm_enabled, bool)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
 @pytest.mark.parametrize(
     'database_autodiscovery,dbm_enabled', [(True, True), (True, False), (False, True), (False, False)]
 )


### PR DESCRIPTION
### What does this PR do?
Add type cast to ensure `dbm_enabled` is a boolean. This was to fix issue when customer put `dbm: "true"|"false"` in yml config. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
