### PR TITLE
Fix some metric names in the dashboard

### DIFF
--- a/kafka/assets/dashboards/kafka_dashboard.json
+++ b/kafka/assets/dashboards/kafka_dashboard.json
@@ -1064,12 +1064,12 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:kafka.consumer.lag{$datacenter,$consumer_group} by {host,consumer_group}"
+                                            "query": "sum:kafka.consumer_lag{$datacenter,$consumer_group} by {host,consumer_group}"
                                         },
                                         {
                                             "data_source": "metrics",
                                             "name": "query2",
-                                            "query": "sum:kafka.consumer.offset{$datacenter,$consumer_group} by {host,consumer_group}"
+                                            "query": "sum:kafka.consumer_offset{$datacenter,$consumer_group} by {host,consumer_group}"
                                         }
                                     ],
                                     "response_format": "timeseries",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix some metric names in the dashboard

### Motivation
<!-- What inspired you to submit this pull request? -->

`kafka.consumer.lag` and `kafka.consumer.offset` are from a custom integration. The OOTB one has `kafka.consumer_lag` and `kafka.consumer_offset`

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
