### PR TITLE
Downgrade lxml version to fix DBMON-3047

### DIFF
--- a/datadog_checks_base/changelog.d/16080.fixed
+++ b/datadog_checks_base/changelog.d/16080.fixed
@@ -1,0 +1,1 @@
+Fix `aarch64` compatibility of the `sqlserver` check by downgrading `lxml` to version 4.9.2 ([16080](https://github.com/DataDog/integrations-core/pull/16080))

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -39,7 +39,7 @@ jpype1==1.4.1; python_version > '3.0'
 kubernetes==18.20.0; python_version < '3.0'
 kubernetes==28.1.0; python_version > '3.0'
 ldap3==2.9.1
-lxml==4.9.3
+lxml==4.9.2
 lz4==2.2.1; python_version < '3.0'
 lz4==4.3.2; python_version > '3.0'
 mmh3==2.5.1; python_version < '3.0'

--- a/ibm_was/changelog.d/16080.fixed
+++ b/ibm_was/changelog.d/16080.fixed
@@ -1,0 +1,1 @@
+Fix `aarch64` compatibility of the `sqlserver` check by downgrading `lxml` to version 4.9.2 ([16080](https://github.com/DataDog/integrations-core/pull/16080))

--- a/ibm_was/pyproject.toml
+++ b/ibm_was/pyproject.toml
@@ -39,7 +39,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "lxml==4.9.3",
+    "lxml==4.9.2",
 ]
 
 [project.urls]

--- a/sqlserver/changelog.d/16080.fixed
+++ b/sqlserver/changelog.d/16080.fixed
@@ -1,0 +1,1 @@
+Fix `aarch64` compatibility of the `sqlserver` check by downgrading `lxml` to version 4.9.2 ([16080](https://github.com/DataDog/integrations-core/pull/16080))

--- a/sqlserver/pyproject.toml
+++ b/sqlserver/pyproject.toml
@@ -37,7 +37,7 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "lxml==4.9.3",
+    "lxml==4.9.2",
     "pyodbc==5.0.1; (sys_platform != 'darwin' or platform_machine != 'arm64') and python_version > '3.0'",
     "pyro4==4.82; sys_platform == 'win32'",
     "pywin32==306; sys_platform == 'win32' and python_version > '3.0'",


### PR DESCRIPTION
### What does this PR do?

This downgrades the `lxml` dependency to v4.9.2.

### Motivation

We are seeing the Agent fail to load the `sqlserver` check in v7.48, only on arm64 architectures. We tracked this down to a failure to load the `lxml` Python library. Looking at the `lxml` release history, [they made some changes to the Cython version used](https://pypi.org/project/lxml/4.9.3/), which sounds like a likely cause of architecture incompatibilities.

I successfully built and tested an agent with the `lxml` dependency downgraded to 4.9.2 on arm64, so this will allow the check to properly load for customers.

### Additional Notes

We will look into fixing the root issue as a followup so that we can get back to the latest released version of `lxml` (4.93). I'll also open an issue on their repo to see if this is a known issue. In the meantime, I think we should release this change because the `sqlserver` check doesn't work at all on arm64 processors. Customers have already reached out about this.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
