### PR TITLE
Update manifest.json to include openmetrics version of health check

### DIFF
--- a/linkerd/manifest.json
+++ b/linkerd/manifest.json
@@ -37,10 +37,10 @@
       },
       "metrics": {
         "prefix": "linkerd.",
-        "check": {
+        "check": [
           "linkerd.prometheus.health",
           "linkerd.openmetrics.health"
-        },
+        ],
         "metadata_path": "metadata.csv"
       },
       "service_checks": {

--- a/linkerd/manifest.json
+++ b/linkerd/manifest.json
@@ -37,7 +37,10 @@
       },
       "metrics": {
         "prefix": "linkerd.",
-        "check": "linkerd.prometheus.health",
+        "check": {
+          "linkerd.prometheus.health",
+          "linkerd.openmetrics.health"
+        },
         "metadata_path": "metadata.csv"
       },
       "service_checks": {

--- a/linkerd/metadata.csv
+++ b/linkerd/metadata.csv
@@ -1,5 +1,6 @@
 metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
 linkerd.prometheus.health,gauge,,,,Whether the check is able to connect to the metrics endpoint.,0,linkerd,,
+linkerd.openmetrics.health,gauge,,,,[OpenMetrics V2] Whether the check is able to connect to the metrics endpoint.,0,linkerd,,
 linkerd.jvm.start_time,gauge,,millisecond,,A gauge of the start time of the Java virtual machine in milliseconds since the epoch (Linkerd v1 only).,0,linkerd,,
 linkerd.jvm.thread.count,gauge,,thread,,A gauge of the number of live threads including both daemon and non-daemon threads (Linkerd v1 only).,0,linkerd,,
 linkerd.jvm.nonheap.committed,gauge,,byte,,"For the non-heap memory, a gauge of the amount of memory, in bytes, committed for the JVM to use (Linkerd v1 only).",-1,linkerd,,


### PR DESCRIPTION
### What does this PR do?
With this change, either linkerd.openmetrics.health or linkerd.prometheus.health should cause the integration tile to show as healthy.
<!-- A brief description of the change being made with this pull request. -->

### Motivation
https://datadog.zendesk.com/agent/tickets/1388328
https://dd.slack.com/archives/CB9QX75H6/p1697841212331629
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
