### PR TITLE
Bump the `cryptography` version to 41.0.5

### DIFF
--- a/cisco_aci/CHANGELOG.md
+++ b/cisco_aci/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Bump the `cryptography` version to 41.0.5 ([#16083](https://github.com/DataDog/integrations-core/pull/16083))
+
 ## 2.4.0 / 2023-09-29
 
 ***Added***:

--- a/cisco_aci/pyproject.toml
+++ b/cisco_aci/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==41.0.4; python_version > '3.0'",
+    "cryptography==41.0.5; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Bump the `cryptography` version to 41.0.5 ([#16083](https://github.com/DataDog/integrations-core/pull/16083))
+
 ## 34.1.0 / 2023-10-20
 
 ***Added***:

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -20,7 +20,7 @@ cm-client==45.0.4
 confluent-kafka==2.2.0; python_version > '3.0'
 contextlib2==0.6.0.post1; python_version < '3.0'
 cryptography==3.3.2; python_version < '3.0'
-cryptography==41.0.4; python_version > '3.0'
+cryptography==41.0.5; python_version > '3.0'
 ddtrace==0.32.2; sys_platform == 'win32' and python_version < '3.0'
 ddtrace==0.53.2; sys_platform != 'win32' and python_version < '3.0'
 ddtrace==1.11.2; python_version > '3.0'

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -43,7 +43,7 @@ deps = [
     "cachetools==5.3.1; python_version > '3.0'",
     "contextlib2==0.6.0.post1; python_version < '3.0'",
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==41.0.4; python_version > '3.0'",
+    "cryptography==41.0.5; python_version > '3.0'",
     "ddtrace==0.32.2; sys_platform == 'win32' and python_version < '3.0'",
     "ddtrace==0.53.2; sys_platform != 'win32' and python_version < '3.0'",
     "ddtrace==1.11.2; python_version > '3.0'",

--- a/http_check/CHANGELOG.md
+++ b/http_check/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Bump the `cryptography` version to 41.0.5 ([#16083](https://github.com/DataDog/integrations-core/pull/16083))
+
 ## 9.2.0 / 2023-09-29
 
 ***Added***:

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==41.0.4; python_version > '3.0'",
+    "cryptography==41.0.5; python_version > '3.0'",
     "requests-ntlm==1.1.0; python_version < '3.0'",
     "requests-ntlm==1.2.0; python_version > '3.0'",
 ]

--- a/mysql/CHANGELOG.md
+++ b/mysql/CHANGELOG.md
@@ -10,6 +10,7 @@
 ***Fixed***:
 
 * Bump the `pymysql` version to 1.1.0 on Python 3 ([#16042](https://github.com/DataDog/integrations-core/pull/16042))
+* Bump the `cryptography` version to 41.0.5 ([#16083](https://github.com/DataDog/integrations-core/pull/16083))
 
 ## 11.2.0 / 2023-09-29
 

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -42,7 +42,7 @@ deps = [
     "cachetools==3.1.1; python_version < '3.0'",
     "cachetools==5.3.1; python_version > '3.0'",
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==41.0.4; python_version > '3.0'",
+    "cryptography==41.0.5; python_version > '3.0'",
     "futures==3.4.0; python_version < '3.0'",
     "pymysql==0.10.1; python_version < '3.0'",
     "pymysql==1.1.0; python_version > '3.0'",

--- a/tls/CHANGELOG.md
+++ b/tls/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+***Fixed***:
+
+* Bump the `cryptography` version to 41.0.5 ([#16083](https://github.com/DataDog/integrations-core/pull/16083))
+
 ## 2.13.0 / 2023-09-29
 
 ***Added***:

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==41.0.4; python_version > '3.0'",
+    "cryptography==41.0.5; python_version > '3.0'",
     "ipaddress==1.0.23; python_version < '3.0'",
     "service-identity[idna]==21.1.0",
 ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the `cryptography` version to 41.0.5

### Motivation
<!-- What inspired you to submit this pull request? -->

- [pyopenssl](https://pypi.org/project/pyOpenSSL/23.3.0/) was released earlier today
- This version requires `cryptography>=41.0.5` : `pyopenssl 23.3.0 has requirement cryptography<42,>=41.0.5, but you have cryptography 41.0.4.`
- The agent is broken on master and on the release branch 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I'll backport this patch to the release branch

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
