### PR TITLE
Pin the `pyopenssl` version to 23.3.0

### DIFF
--- a/datadog_checks_base/changelog.d/16094.fixed
+++ b/datadog_checks_base/changelog.d/16094.fixed
@@ -1,0 +1,1 @@
+Pin the `pyopenssl` version to 23.3.0

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -70,6 +70,7 @@ pymqi==1.12.10; sys_platform != 'darwin' or platform_machine != 'arm64'
 pymysql==0.10.1; python_version < '3.0'
 pymysql==1.1.0; python_version > '3.0'
 pyodbc==5.0.1; (sys_platform != 'darwin' or platform_machine != 'arm64') and python_version > '3.0'
+pyopenssl==23.3.0; python_version > '3.0'
 pyro4==4.82; sys_platform == 'win32'
 pysmi==0.3.4
 pysnmp-mibs==0.1.6

--- a/snowflake/changelog.d/16094.fixed
+++ b/snowflake/changelog.d/16094.fixed
@@ -1,0 +1,1 @@
+Pin the `pyopenssl` version to 23.3.0

--- a/snowflake/pyproject.toml
+++ b/snowflake/pyproject.toml
@@ -39,6 +39,7 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "snowflake-connector-python==3.1.0; python_version > '3.0'",
+    "pyopenssl==23.3.0; python_version > '3.0'",
 ]
 
 [project.urls]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Pin the `pyopenssl` version to 23.3.0

### Motivation
<!-- What inspired you to submit this pull request? -->

To avoid this kind of issues in the future https://github.com/DataDog/integrations-core/pull/16083

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
