### PR TITLE
Add the ability to assert the `external_tags` when running tests

### DIFF
--- a/datadog_checks_base/changelog.d/16089.fixed
+++ b/datadog_checks_base/changelog.d/16089.fixed
@@ -1,0 +1,1 @@
+Add the ability to assert the `external_tags` when running tests

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -22,6 +22,7 @@ class DatadogAgentStub(object):
         self._config = self.get_default_config()
         self._hostname = 'stubbed.hostname'
         self._process_start_time = 0
+        self._external_tags = []
 
     def get_default_config(self):
         return {'enable_metadata_collection': True, 'disable_unsafe_yaml': True}
@@ -31,6 +32,7 @@ class DatadogAgentStub(object):
         self._cache.clear()
         self._config = self.get_default_config()
         self._process_start_time = 0
+        self._external_tags = []
 
     def assert_metadata(self, check_id, data):
         actual = {}
@@ -44,6 +46,24 @@ class DatadogAgentStub(object):
         metadata_items = len(self._metadata)
         assert metadata_items == count, 'Expected {} metadata items, found {}. Submitted metadata: {}'.format(
             count, metadata_items, repr(self._metadata)
+        )
+
+    def assert_external_tags(self, hostname, external_tags):
+        for h, tags in self._external_tags:
+            if h == hostname:
+                assert (
+                    external_tags == tags
+                ), 'Expected {} external tags for hostname {}, found {}. Submitted external tags: {}'.format(
+                    external_tags, hostname, tags, repr(self._external_tags)
+                )
+                return
+
+        raise AssertionError('Hostname {} not found in external tags {}'.format(hostname, repr(self._external_tags)))
+
+    def assert_external_tags_count(self, count):
+        tags_count = len(self._external_tags)
+        assert tags_count == count, 'Expected {} external tags items, found {}. Submitted external tags: {}'.format(
+            count, tags_count, repr(self._external_tags)
         )
 
     def get_hostname(self):
@@ -67,8 +87,8 @@ class DatadogAgentStub(object):
     def set_check_metadata(self, check_id, name, value):
         self._metadata[(check_id, name)] = value
 
-    def set_external_tags(self, *args, **kwargs):
-        pass
+    def set_external_tags(self, external_tags):
+        self._external_tags = external_tags
 
     def tracemalloc_enabled(self, *args, **kwargs):
         return False

--- a/datadog_checks_base/tests/stubs/test_datadog_agent.py
+++ b/datadog_checks_base/tests/stubs/test_datadog_agent.py
@@ -1,0 +1,49 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+DEFAULT_EXTERNAL_TAGS = [
+    ('hostname1', {'src1_name': ['test1:t1']}),
+    ('hostname2', {'src2_name': ['test2:t2']}),
+    ('hostname3', {'src3_name': ['test3:t3']}),
+]
+
+
+@pytest.mark.parametrize(
+    'hostname, tags, raise_exception',
+    [
+        pytest.param('hostname1', {'src1_name': ['test1:t1']}, False, id="hostname1 and tags found"),
+        pytest.param('hostname2', {'src2_name': ['test2:t2']}, False, id="hostname2 and tags found"),
+        pytest.param('hostname3', {'src3_name': ['test3:t3']}, False, id="hostname3 and tags found"),
+        pytest.param('hostname4', {'src4_name': ['test4:t4']}, True, id="hostname4 and tags not found"),
+        pytest.param('hostname1', {'src2_name': ['test2:t2']}, True, id="hostname1 found and tags are wrong"),
+    ],
+)
+def test_assert_external_tags(datadog_agent, hostname, tags, raise_exception):
+    datadog_agent.set_external_tags(DEFAULT_EXTERNAL_TAGS)
+
+    try:
+        datadog_agent.assert_external_tags(hostname, tags)
+    except AssertionError:
+        if not raise_exception:
+            raise
+
+
+@pytest.mark.parametrize(
+    'external_tags, count, raise_exception',
+    [
+        pytest.param(DEFAULT_EXTERNAL_TAGS, 3, False, id="correct count"),
+        pytest.param([], 0, False, id="no tags"),
+        pytest.param([('hostname1', {'src1_name': ['test1:t1']})], 1, False, id="one tag"),
+        pytest.param([('hostname1', {'src1_name': ['test1:t1']})], 2, True, id="wrong count"),
+    ],
+)
+def test_assert_external_tags_count(datadog_agent, external_tags, count, raise_exception):
+    datadog_agent.set_external_tags(external_tags)
+
+    try:
+        datadog_agent.assert_external_tags_count(count)
+    except AssertionError:
+        if not raise_exception:
+            raise


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add the ability to assert the `external_tags` when running tests

### Motivation
<!-- What inspired you to submit this pull request? -->

The Platform integrations team uses them and would like to have a way to assert them without mocking the function.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- I'll update the ambari tests to use this to avoid issues with the changelog [in another PR](https://github.com/DataDog/integrations-core/pull/16091)
- Relates to https://datadoghq.atlassian.net/browse/AITS-287

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
