### PR TITLE
Do not verify the tags order by default when testing the external tags

### DIFF
--- a/datadog_checks_base/changelog.d/16105.fixed
+++ b/datadog_checks_base/changelog.d/16105.fixed
@@ -1,0 +1,1 @@
+Do not verify the tags order by default when testing the external tags

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -48,9 +48,13 @@ class DatadogAgentStub(object):
             count, metadata_items, repr(self._metadata)
         )
 
-    def assert_external_tags(self, hostname, external_tags):
+    def assert_external_tags(self, hostname, external_tags, match_tags_order=False):
         for h, tags in self._external_tags:
             if h == hostname:
+                if not match_tags_order:
+                    external_tags = {k: sorted(v) for (k, v) in external_tags.items()}
+                    tags = {k: sorted(v) for (k, v) in tags.items()}
+
                 assert (
                     external_tags == tags
                 ), 'Expected {} external tags for hostname {}, found {}. Submitted external tags: {}'.format(

--- a/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
+++ b/datadog_checks_base/datadog_checks/base/stubs/datadog_agent.py
@@ -3,6 +3,8 @@
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import re
 
+from six import iteritems
+
 from datadog_checks.base.utils.serialization import json
 
 
@@ -52,8 +54,8 @@ class DatadogAgentStub(object):
         for h, tags in self._external_tags:
             if h == hostname:
                 if not match_tags_order:
-                    external_tags = {k: sorted(v) for (k, v) in external_tags.items()}
-                    tags = {k: sorted(v) for (k, v) in tags.items()}
+                    external_tags = {k: sorted(v) for (k, v) in iteritems(external_tags)}
+                    tags = {k: sorted(v) for (k, v) in iteritems(tags)}
 
                 assert (
                     external_tags == tags

--- a/datadog_checks_base/tests/stubs/test_datadog_agent.py
+++ b/datadog_checks_base/tests/stubs/test_datadog_agent.py
@@ -7,24 +7,53 @@ DEFAULT_EXTERNAL_TAGS = [
     ('hostname1', {'src1_name': ['test1:t1']}),
     ('hostname2', {'src2_name': ['test2:t2']}),
     ('hostname3', {'src3_name': ['test3:t3']}),
+    ('hostname4', {'src4_name': ['test4a:t4a', 'test4b:t4b']}),
 ]
 
 
 @pytest.mark.parametrize(
-    'hostname, tags, raise_exception',
+    'hostname, tags, match_tags_order, raise_exception',
     [
-        pytest.param('hostname1', {'src1_name': ['test1:t1']}, False, id="hostname1 and tags found"),
-        pytest.param('hostname2', {'src2_name': ['test2:t2']}, False, id="hostname2 and tags found"),
-        pytest.param('hostname3', {'src3_name': ['test3:t3']}, False, id="hostname3 and tags found"),
-        pytest.param('hostname4', {'src4_name': ['test4:t4']}, True, id="hostname4 and tags not found"),
-        pytest.param('hostname1', {'src2_name': ['test2:t2']}, True, id="hostname1 found and tags are wrong"),
+        pytest.param('hostname1', {'src1_name': ['test1:t1']}, False, False, id="hostname1 and tags found"),
+        pytest.param('hostname2', {'src2_name': ['test2:t2']}, False, False, id="hostname2 and tags found"),
+        pytest.param('hostname3', {'src3_name': ['test3:t3']}, False, False, id="hostname3 and tags found"),
+        pytest.param(
+            'hostname4',
+            {'src4_name': ['test4a:t4a', 'test4b:t4b']},
+            False,
+            False,
+            id="tags with correct order and not match_tags_order",
+        ),
+        pytest.param(
+            'hostname4',
+            {'src4_name': ['test4a:t4a', 'test4b:t4b']},
+            True,
+            False,
+            id="tags with correct order and match_tags_order",
+        ),
+        pytest.param(
+            'hostname4',
+            {'src4_name': ['test4b:t4b', 'test4a:t4a']},
+            False,
+            False,
+            id="hotags with incorrect order and not match_tags_order",
+        ),
+        pytest.param(
+            'hostname4',
+            {'src4_name': ['test4b:t4b', 'test4a:t4a']},
+            True,
+            True,
+            id="hotags with incorrect order and match_tags_order",
+        ),
+        pytest.param('hostname5', {'src5_name': ['test5:t5']}, False, True, id="hostname5 and tags not found"),
+        pytest.param('hostname1', {'src2_name': ['test2:t2']}, False, True, id="hostname1 found and tags are wrong"),
     ],
 )
-def test_assert_external_tags(datadog_agent, hostname, tags, raise_exception):
+def test_assert_external_tags(datadog_agent, hostname, tags, raise_exception, match_tags_order):
     datadog_agent.set_external_tags(DEFAULT_EXTERNAL_TAGS)
 
     try:
-        datadog_agent.assert_external_tags(hostname, tags)
+        datadog_agent.assert_external_tags(hostname, tags, match_tags_order)
     except AssertionError:
         if not raise_exception:
             raise
@@ -33,7 +62,7 @@ def test_assert_external_tags(datadog_agent, hostname, tags, raise_exception):
 @pytest.mark.parametrize(
     'external_tags, count, raise_exception',
     [
-        pytest.param(DEFAULT_EXTERNAL_TAGS, 3, False, id="correct count"),
+        pytest.param(DEFAULT_EXTERNAL_TAGS, 4, False, id="correct count"),
         pytest.param([], 0, False, id="no tags"),
         pytest.param([('hostname1', {'src1_name': ['test1:t1']})], 1, False, id="one tag"),
         pytest.param([('hostname1', {'src1_name': ['test1:t1']})], 2, True, id="wrong count"),


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not verify the tags order by default when testing the external tags

### Motivation
<!-- What inspired you to submit this pull request? -->

Tags order does not matter in general.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

Relates to https://datadoghq.atlassian.net/browse/AITS-287

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
