### PR TITLE
Manually install the right version of librdkafka if needed

### DIFF
--- a/kafka_consumer/hatch.toml
+++ b/kafka_consumer/hatch.toml
@@ -2,6 +2,7 @@
 
 [envs.default]
 # If you bump the `confluent-kafka` version, also bump the `librdkafka` version in the `32_install_kerberos.sh` file
+# Also bump the LIBRDKAFKA_VERSION version in this file
 post-install-commands = [
   "python -m pip uninstall -y confluent-kafka",
   "python -m pip install --no-binary confluent-kafka confluent-kafka==2.3.0",
@@ -10,6 +11,12 @@ post-install-commands = [
 [envs.default.env-vars]
 ZK_VERSION = "3.6.4"
 AUTHENTICATION = "noauth"
+# The format is MMmmrr with MM = Major version, mm = minor version, rr = revision
+# This is needed to manually install the right version of librdkafka when we bump confluent-kafka
+# Thanks to this, the kerberos tests will be green even if the agent is still shipped with an older version
+# Bump them when you bump the confluent-kafka version
+LIBRDKAFKA_VERSION = "020300"
+CONFLUENT_KAFKA_VERSION = "2.3.0"
 
 [[envs.default.matrix]]
 python = ["3.9"]
@@ -30,3 +37,6 @@ matrix.auth.env-vars = "AUTHENTICATION"
 [envs.latest.env-vars]
 KAFKA_VERSION = "latest"
 ZK_VERSION = "3.6.4"
+# Bump them when you bump the confluent-kafka version
+LIBRDKAFKA_VERSION = "020300"
+CONFLUENT_KAFKA_VERSION = "2.3.0"

--- a/kafka_consumer/tests/common.py
+++ b/kafka_consumer/tests/common.py
@@ -34,7 +34,15 @@ E2E_METADATA = {
     'docker_volumes': [
         f'{HERE}/docker/ssl/certificate:/tmp/certificate',
         f'{HERE}/docker/kerberos/kdc/krb5_agent.conf:/etc/krb5.conf',
+        f'{HERE}/docker/scripts/install_librdkafka.bash:/tmp/install_librdkafka.bash',
     ],
+    'start_commands': [
+        'bash /tmp/install_librdkafka.bash',
+    ],
+    'env_vars': {
+        'LIBRDKAFKA_VERSION': os.environ["LIBRDKAFKA_VERSION"],
+        'CONFLUENT_KAFKA_VERSION': os.environ["CONFLUENT_KAFKA_VERSION"],
+    },
 }
 
 if AUTHENTICATION == "ssl":

--- a/kafka_consumer/tests/docker/scripts/install_librdkafka.bash
+++ b/kafka_consumer/tests/docker/scripts/install_librdkafka.bash
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# This script allows you to install the latest version of librdkafka in the agent container
+# Thanks to this you can run the kerberos test even if the agent is shipped with a different version of librdkafka
+# WARN: YOU STILL NEED TO BUMP THE VERSION OF LIBRDKAFKA IN THE AGENT REPO
+
+# Format:
+# define RD_KAFKA_VERSION   0x020200ff
+# Interpreted as hex MM.mm.rr.xx:
+#
+# MM = Major
+# mm = minor
+# rr = revision
+# xx = pre-release id (0xff is the final release)
+# So in the example: 2.2.0
+VERSION_HEX=$(grep "#define RD_KAFKA_VERSION" /opt/datadog-agent/embedded/include/librdkafka/rdkafka.h | cut -d ' ' -f 3)
+
+if [ "$VERSION_HEX" != "0x${LIBRDKAFKA_VERSION}ff" ]; then
+    apt-get update
+    apt-get install --no-install-recommends --yes \
+                build-essential \
+                git \
+                libsasl2-dev \
+                libssl-dev \
+                libzstd-dev
+
+    git clone --branch v$CONFLUENT_KAFKA_VERSION https://github.com/edenhill/librdkafka.git
+
+    cd librdkafka
+
+    export LDFLAGS="-L/opt/datadog-agent/embedded/lib -I/opt/datadog-agent/embedded/include"
+    export CFLAGS="-L/opt/datadog-agent/embedded/lib -I/opt/datadog-agent/embedded/include"
+    export LD_RUN_PATH="/opt/datadog-agent/embedded/lib"
+
+    ./configure --enable-sasl --prefix=/opt/datadog-agent/embedded
+    make
+    make install
+
+    pip uninstall -y confluent-kafka
+    pip install --no-binary confluent-kafka confluent-kafka==$CONFLUENT_KAFKA_VERSION
+fi
+


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Manually install the right version of librdkafka if needed

### Motivation
<!-- What inspired you to submit this pull request? -->

Context: 
- The kafka_consumer integration uses confluent-kafka which in turns relies on librdkafka
- We use a manually built version of librdkafka to support kerberos authentication on linux
- librdkafka is built directly on the agent with a patch in omnibus: https://github.com/DataDog/datadog-agent/blob/bf082c7f571b5e7770be5257cbc362377d8c3973/omnibus/config/software/librdkafka.rb#L4

Problem:
- In our case you can not have confluent-kafka 2.3.0 with librdkafka 2.2.0 for instance
- When we bump the version of confluent-kafka, we need to bump the librdkafka version too on the agent
- At the moment when you bump this version the kerberos e2e tests fail because the agent that is used still does not have the right librdkafka version so we need to wait for the agent PR to be merged and their CI pushes the image to rerun the CI here and make sure everything is working properly. Not great.

Solution: 
- I know this solution is a bit convoluted and make the `hatch.toml` a bit more complex, but I added a script to automatically bump the librdkafka version that is shipped with the agent if needed. This way our e2e tests will be green and we will be sure that everything is working BEFORE merging the agent PR. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- If the agent already has the right version, we do not touch anything to make sure that the installation done in omnibus is working properly (it also allows us to avoid having a longer test setup)
- You can test this solution running `ddev env test kafka_consumer --base --new-env -a datadog/agent:7.48.1 py3.9-3.3-kerberos`. On master it should be red and it will be green on this branch because agent 7.48.1 has librdkafka 2.2.0 and this branch needs 2.3.0
- If you have a way to make the setup a bit less complex, please let me know

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
