### PR TITLE
Stop automatically upgrading `lxml` when bumping the dependencies

### DIFF
--- a/ddev/changelog.d/16112.fixed
+++ b/ddev/changelog.d/16112.fixed
@@ -1,0 +1,1 @@
+Stop automatically upgrading `lxml` when bumping the dependencies

--- a/ddev/src/ddev/cli/dep.py
+++ b/ddev/src/ddev/cli/dep.py
@@ -34,6 +34,8 @@ IGNORED_DEPS = {
     'pymongo',
     # We need pydantic 2.0.2 for the rpm x64 agent build (see https://github.com/DataDog/datadog-agent/pull/18303)
     'pydantic',
+    # https://github.com/DataDog/integrations-core/pull/16080
+    'lxml',
 }
 
 # Dependencies for the downloader that are security-related and should be updated separately from the others


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Stop automatically upgrading `lxml` when bumping the dependencies

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/pull/16080

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
