### PR TITLE
[SQLServer] - Ensure we have the same host tag for can_connect metric

### DIFF
--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- towncrier release notes start -->
 
+## Unreleased
+
+***Fixed***:
+
+* Stabilizes the `host` tag on the `sqlserver.can_connect` metric and adds the `connection_host` tag on the same metric. ([#16114](https://github.com/DataDog/integrations-core/pull/16114))
+
 ## 15.1.0 / 2023-10-26
 
 ***Added***:

--- a/sqlserver/CHANGELOG.md
+++ b/sqlserver/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 <!-- towncrier release notes start -->
 
-## Unreleased
-
-***Fixed***:
-
-* Stabilizes the `host` tag on the `sqlserver.can_connect` metric and adds the `connection_host` tag on the same metric. ([#16114](https://github.com/DataDog/integrations-core/pull/16114))
-
 ## 15.1.0 / 2023-10-26
 
 ***Added***:

--- a/sqlserver/changelog.d/16114.fixed
+++ b/sqlserver/changelog.d/16114.fixed
@@ -1,0 +1,1 @@
+Stabilizes the `host` tag on the `sqlserver.can_connect` metric and adds the `connection_host` tag on the same metric.

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -324,13 +324,14 @@ class Connection(object):
                 tcp_connection_status,
                 exception_msg,
                 host=self._check.resolved_hostname,
+                connection_host=host,
                 database=database,
                 code=conn_warn_msg.value,
                 connector=self.connector,
                 driver=driver,
             )
             self.service_check_handler(
-                AgentCheck.CRITICAL, self._check.resolved_hostname, database, check_err_message, is_default=is_default
+                AgentCheck.CRITICAL, host, database, check_err_message, is_default=is_default
             )
 
             # Only raise exception on the default instance database

--- a/sqlserver/datadog_checks/sqlserver/connection.py
+++ b/sqlserver/datadog_checks/sqlserver/connection.py
@@ -330,9 +330,7 @@ class Connection(object):
                 connector=self.connector,
                 driver=driver,
             )
-            self.service_check_handler(
-                AgentCheck.CRITICAL, host, database, check_err_message, is_default=is_default
-            )
+            self.service_check_handler(AgentCheck.CRITICAL, host, database, check_err_message, is_default=is_default)
 
             # Only raise exception on the default instance database
             if is_default:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -396,16 +396,14 @@ class SQLServer(AgentCheck):
         except Exception as e:
             self.log.exception("Initialization exception %s", e)
 
-    def handle_service_check(self, status, host, database, message=None, is_default=True):
+    def handle_service_check(self, status, connection_host, database, message=None, is_default=True):
         custom_tags = self.instance.get("tags", [])
         disable_generic_tags = self.instance.get('disable_generic_tags', False)
-        if custom_tags is None:
-            custom_tags = []
-        if disable_generic_tags:
-            service_check_tags = ['sqlserver_host:{}'.format(host), 'db:{}'.format(database)]
-        else:
-            service_check_tags = ['host:{}'.format(host), 'sqlserver_host:{}'.format(host), 'db:{}'.format(database)]
-        service_check_tags.extend(custom_tags)
+        service_check_tags = ['sqlserver_host:{}'.format(self.resolved_hostname), 'db:{}'.format(database), 'connection_host:{}'.format(connection_host)]
+        if not disable_generic_tags:
+            service_check_tags.append('host:{}'.format(self.resolved_hostname))
+        if custom_tags is not None:
+            service_check_tags.extend(custom_tags)
         service_check_tags = list(set(service_check_tags))
 
         if status is AgentCheck.OK:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -399,7 +399,11 @@ class SQLServer(AgentCheck):
     def handle_service_check(self, status, connection_host, database, message=None, is_default=True):
         custom_tags = self.instance.get("tags", [])
         disable_generic_tags = self.instance.get('disable_generic_tags', False)
-        service_check_tags = ['sqlserver_host:{}'.format(self.resolved_hostname), 'db:{}'.format(database), 'connection_host:{}'.format(connection_host)]
+        service_check_tags = [
+            'sqlserver_host:{}'.format(self.resolved_hostname),
+            'db:{}'.format(database),
+            'connection_host:{}'.format(connection_host),
+        ]
         if not disable_generic_tags:
             service_check_tags.append('host:{}'.format(self.resolved_hostname))
         if custom_tags is not None:

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -87,7 +87,7 @@ def test_check_docker(aggregator, dd_run_check, init_config, instance_docker, da
     dd_run_check(sqlserver_check)
     expected_tags = instance_docker.get('tags', []) + [
         'connection_host:{}'.format(instance_docker.get('host')),
-        'sqlserver_host:{}'.format(instance_docker.get('reported_hostname')),
+        'sqlserver_host:{}'.format(sqlserver_check.resolved_hostname),
         'db:master',
     ]
     assert_metrics(
@@ -222,7 +222,7 @@ def test_autodiscovery_db_service_checks(
     # verify that the old status check returns OK
     aggregator.assert_service_check(
         'sqlserver.can_connect',
-        tags=['db:master', 'sqlserver_host:localhost,1433'] + instance_tags,
+        tags=['db:master', 'sqlserver_host:{}'.format(check.resolved_hostname), 'connection_host:{}'.format(instance_autodiscovery.get('host'))] + instance_tags,
         status=SQLServer.OK,
     )
 
@@ -230,7 +230,7 @@ def test_autodiscovery_db_service_checks(
     aggregator.assert_service_check(
         'sqlserver.database.can_connect',
         count=extra_count,
-        tags=['db:msdb', 'sqlserver_host:localhost,1433'] + instance_tags,
+        tags=['db:msdb', 'sqlserver_host:{}'.format(check.resolved_hostname), 'connection_host:{}'.format(instance_autodiscovery.get('host'))] + instance_tags,
         status=SQLServer.OK,
     )
     # unavailable_db is an 'offline' database which prevents connections, so we expect this service check to be
@@ -239,7 +239,7 @@ def test_autodiscovery_db_service_checks(
     # to match against, so this assertion does not require the exact string
     sc = aggregator.service_checks('sqlserver.database.can_connect')
     db_critical_exists = False
-    critical_tags = instance_tags + ['db:unavailable_db', 'sqlserver_host:{}'.format(check.resolved_hostname)]
+    critical_tags = instance_tags + ['db:unavailable_db', 'sqlserver_host:{}'.format(check.resolved_hostname), 'connection_host:{}'.format(instance_autodiscovery.get('host'))]
     for c in sc:
         if c.status == SQLServer.CRITICAL:
             db_critical_exists = True
@@ -261,13 +261,13 @@ def test_autodiscovery_exclude_db_service_checks(aggregator, dd_run_check, insta
     # assert no connection is created for an excluded database
     aggregator.assert_service_check(
         'sqlserver.database.can_connect',
-        tags=['db:msdb', 'sqlserver_host:localhost,1433'] + instance_tags,
+        tags=['db:msdb', 'sqlserver_host:{}'.format(check.resolved_hostname), 'connection_host:{}'.format(instance_autodiscovery.get('host'))] + instance_tags,
         status=SQLServer.OK,
         count=0,
     )
     aggregator.assert_service_check(
         'sqlserver.database.can_connect',
-        tags=['db:master', 'sqlserver_host:localhost,1433'] + instance_tags,
+        tags=['db:master', 'sqlserver_host:{}'.format(check.resolved_hostname), 'connection_host:{}'.format(instance_autodiscovery.get('host'))] + instance_tags,
         status=SQLServer.OK,
     )
 

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -227,7 +227,12 @@ def test_autodiscovery_db_service_checks(
     # verify that the old status check returns OK
     aggregator.assert_service_check(
         'sqlserver.can_connect',
-        tags=['db:master', 'sqlserver_host:{}'.format(check.resolved_hostname), 'connection_host:{}'.format(instance_autodiscovery.get('host'))] + instance_tags,
+        tags=[
+            'db:master',
+            'sqlserver_host:{}'.format(check.resolved_hostname),
+            'connection_host:{}'.format(instance_autodiscovery.get('host')),
+        ]
+        + instance_tags,
         status=SQLServer.OK,
     )
 
@@ -235,7 +240,12 @@ def test_autodiscovery_db_service_checks(
     aggregator.assert_service_check(
         'sqlserver.database.can_connect',
         count=extra_count,
-        tags=['db:msdb', 'sqlserver_host:{}'.format(check.resolved_hostname), 'connection_host:{}'.format(instance_autodiscovery.get('host'))] + instance_tags,
+        tags=[
+            'db:msdb',
+            'sqlserver_host:{}'.format(check.resolved_hostname),
+            'connection_host:{}'.format(instance_autodiscovery.get('host')),
+        ]
+        + instance_tags,
         status=SQLServer.OK,
     )
     # unavailable_db is an 'offline' database which prevents connections, so we expect this service check to be
@@ -244,7 +254,11 @@ def test_autodiscovery_db_service_checks(
     # to match against, so this assertion does not require the exact string
     sc = aggregator.service_checks('sqlserver.database.can_connect')
     db_critical_exists = False
-    critical_tags = instance_tags + ['db:unavailable_db', 'sqlserver_host:{}'.format(check.resolved_hostname), 'connection_host:{}'.format(instance_autodiscovery.get('host'))]
+    critical_tags = instance_tags + [
+        'db:unavailable_db',
+        'sqlserver_host:{}'.format(check.resolved_hostname),
+        'connection_host:{}'.format(instance_autodiscovery.get('host')),
+    ]
     for c in sc:
         if c.status == SQLServer.CRITICAL:
             db_critical_exists = True
@@ -266,13 +280,23 @@ def test_autodiscovery_exclude_db_service_checks(aggregator, dd_run_check, insta
     # assert no connection is created for an excluded database
     aggregator.assert_service_check(
         'sqlserver.database.can_connect',
-        tags=['db:msdb', 'sqlserver_host:{}'.format(check.resolved_hostname), 'connection_host:{}'.format(instance_autodiscovery.get('host'))] + instance_tags,
+        tags=[
+            'db:msdb',
+            'sqlserver_host:{}'.format(check.resolved_hostname),
+            'connection_host:{}'.format(instance_autodiscovery.get('host')),
+        ]
+        + instance_tags,
         status=SQLServer.OK,
         count=0,
     )
     aggregator.assert_service_check(
         'sqlserver.database.can_connect',
-        tags=['db:master', 'sqlserver_host:{}'.format(check.resolved_hostname), 'connection_host:{}'.format(instance_autodiscovery.get('host'))] + instance_tags,
+        tags=[
+            'db:master',
+            'sqlserver_host:{}'.format(check.resolved_hostname),
+            'connection_host:{}'.format(instance_autodiscovery.get('host')),
+        ]
+        + instance_tags,
         status=SQLServer.OK,
     )
 

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -49,7 +49,12 @@ def test_check_invalid_password(aggregator, dd_run_check, init_config, instance_
     aggregator.assert_service_check(
         'sqlserver.can_connect',
         status=sqlserver_check.CRITICAL,
-        tags=['sqlserver_host:{}'.format(sqlserver_check.resolved_hostname), 'db:master', 'connection_host:{}'.format(instance_docker.get('host'))] + instance_tags,
+        tags=[
+            'sqlserver_host:{}'.format(sqlserver_check.resolved_hostname),
+            'db:master',
+            'connection_host:{}'.format(instance_docker.get('host')),
+        ]
+        + instance_tags,
         message=str(excinfo.value),
     )
 

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -49,7 +49,7 @@ def test_check_invalid_password(aggregator, dd_run_check, init_config, instance_
     aggregator.assert_service_check(
         'sqlserver.can_connect',
         status=sqlserver_check.CRITICAL,
-        tags=['sqlserver_host:{}'.format(sqlserver_check.resolved_hostname), 'db:master'] + instance_tags,
+        tags=['sqlserver_host:{}'.format(sqlserver_check.resolved_hostname), 'db:master', 'connection_host:{}'.format(instance_docker.get('host'))] + instance_tags,
         message=str(excinfo.value),
     )
 
@@ -86,7 +86,8 @@ def test_check_docker(aggregator, dd_run_check, init_config, instance_docker, da
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
     expected_tags = instance_docker.get('tags', []) + [
-        'sqlserver_host:{}'.format(instance_docker.get('host')),
+        'connection_host:{}'.format(instance_docker.get('host')),
+        'sqlserver_host:{}'.format(instance_docker.get('reported_hostname')),
         'db:master',
     ]
     assert_metrics(

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -442,7 +442,7 @@ def test_check_local(aggregator, dd_run_check, init_config, instance_docker):
     dd_run_check(sqlserver_check)
     check_tags = instance_docker.get('tags', [])
     expected_tags = check_tags + [
-        'sqlserver_host:{}'.format(instance_docker.get('reported_hostname')),
+        'sqlserver_host:{}'.format(sqlserver_check.resolved_hostname),
         'connection_host:{}'.format(DOCKER_SERVER),
         'db:master',
     ]

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -441,7 +441,11 @@ def test_check_local(aggregator, dd_run_check, init_config, instance_docker):
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
     check_tags = instance_docker.get('tags', [])
-    expected_tags = check_tags + ['sqlserver_host:{}'.format(DOCKER_SERVER), 'db:master']
+    expected_tags = check_tags + [
+        'sqlserver_host:{}'.format(instance_docker.get('reported_hostname')),
+        'connection_host:{}'.format(DOCKER_SERVER),
+        'db:master',
+    ]
     assert_metrics(instance_docker, aggregator, check_tags, expected_tags, hostname=sqlserver_check.resolved_hostname)
 
 


### PR DESCRIPTION
### What does this PR do?

The SQLServer integration was tagging the `sqlserver.can_connect` metric with different `host` tags when it was emitting `OK` vs `CRITICAL`. This fixes the issue by always using the same `host` tag and adding the connection string host via the `connection_host` tag. 

The overall result is:

- `host` will be tagged with the agent host
- `sqlserver_host` will be tagged with the resolved hostname (i.e. reported_hostname or connection host without the port)
- `connection_host` will always be exactly what the user put in the `host` value in their integration config.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
