### PR TITLE
Operator dashboard fixes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,8 @@ assets/               @DataDog/documentation @DataDog/agent-integrations
 /crio/manifest.json                       @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /datadog_cluster_agent/                   @DataDog/container-integrations @DataDog/agent-integrations
 /datadog_cluster_agent/*.md               @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
+/datadog_operator/                        @DataDog/container-ecosystems @DataDog/agent-integrations
+/datadog_operator/*.md                    @DataDog/container-ecosystems @DataDog/agent-integrations @DataDog/documentation
 /docker_daemon/                           @DataDog/container-integrations @DataDog/agent-integrations
 /docker_daemon/*.md                       @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation
 /docker_daemon/metadata.csv               @DataDog/container-integrations @DataDog/agent-integrations @DataDog/documentation

--- a/datadog_operator/CHANGELOG.md
+++ b/datadog_operator/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 1.0.0 / 2023-10-30
+
+* Fixed queries in the Operator Dashboard to improve accuracy of Agent resources.
+
 ## 1.0.0 / 2023-03-30
 
 ***Added***:

--- a/datadog_operator/assets/dashboards/operator_overview.json
+++ b/datadog_operator/assets/dashboards/operator_overview.json
@@ -365,7 +365,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "sum:datadog.operator.go_info{$scope,$cluster,kube_app_name:datadog-operator,kube_deployment:*} by {kube_deployment,kube_cluster_name,kube_namespace}",
+                                            "query": "sum:datadog.operator.go_info{$scope,$cluster,kube_app_name:datadog-operator,kube_deployment:*, kube_cluster_name:*} by {kube_deployment,kube_cluster_name,kube_namespace}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "avg"
@@ -400,7 +400,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "avg:kubernetes.memory.rss{$scope,$cluster,kube_app_managed_by:datadog-operator,kube_app_name:datadog-agent-deployment} by {kube_cluster_name}",
+                                            "query": "avg:kubernetes.memory.rss{$scope,$cluster,kube_app_managed_by:datadog-operator,kube_app_component:agent, kube_cluster_name:*} by {kube_cluster_name,kube_namespace}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "last"
@@ -435,7 +435,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "sum:kubernetes.memory.rss{$scope,$cluster,kube_app_managed_by:datadog-operator,kube_app_instance:datadog-cluster-agent,kube_deployment:*} by {kube_deployment,kube_cluster_name,kube_namespace}",
+                                            "query": "sum:kubernetes.memory.rss{$scope,$cluster,kube_app_managed_by:datadog-operator,kube_app_component:cluster-agent, kube_cluster_name:*} by {kube_cluster_name,kube_namespace}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "last"
@@ -470,7 +470,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "sum:kubernetes.memory.rss{$scope,$cluster,kube_app_component:cluster-checks-runner,kube_app_managed_by:datadog-operator,kube_deployment:*} by {kube_deployment,kube_cluster_name,kube_namespace}",
+                                            "query": "sum:kubernetes.memory.rss{$scope,$cluster,kube_app_managed_by:datadog-operator, kube_app_component:cluster-checks-runner, kube_cluster_name:*} by {kube_cluster_name,kube_namespace}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "last"
@@ -540,7 +540,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "sum:datadog.operator.go_info{$scope,$cluster,kube_app_name:datadog-operator}",
+                                            "query": "sum:datadog.operator.go_info{$scope,$cluster,kube_app_name:datadog-operator, kube_cluster_name:*}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "last"
@@ -575,7 +575,7 @@
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "sum:kubernetes.pods.running{$scope,$cluster,kube_app_managed_by:datadog-operator,kube_app_instance:datadog-agent}",
+                                            "query": "avg:kubernetes.memory.rss{$scope,$cluster,kube_app_managed_by:datadog-operator,kube_app_component:agent, kube_cluster_name:*} by {pod_name}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "last"
@@ -583,7 +583,7 @@
                                     ],
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "count_not_null(query1)"
                                         }
                                     ]
                                 }
@@ -609,13 +609,13 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "count_not_null(query1)"
                                         }
                                     ],
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "sum:kubernetes.pods.running{$scope,$cluster,kube_app_managed_by:datadog-operator,kube_app_instance:datadog-cluster-agent}",
+                                            "query": "avg:kubernetes.memory.rss{$scope,$cluster,kube_app_managed_by:datadog-operator,kube_app_component:cluster-agent, kube_cluster_name:*} by {pod_name}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "last"
@@ -644,13 +644,13 @@
                                 {
                                     "formulas": [
                                         {
-                                            "formula": "query1"
+                                            "formula": "count_not_null(query1)"
                                         }
                                     ],
                                     "response_format": "scalar",
                                     "queries": [
                                         {
-                                            "query": "sum:kubernetes.pods.running{$scope,$cluster,kube_app_managed_by:datadog-operator,kube_deployment:*,kube_app_instance:datadog-cluster-checks-runner}",
+                                            "query": "avg:kubernetes.memory.rss{$scope,$cluster,kube_app_managed_by:datadog-operator,kube_app_component:cluster-checks-runner, kube_cluster_name:*} by {pod_name}",
                                             "data_source": "metrics",
                                             "name": "query1",
                                             "aggregator": "last"


### PR DESCRIPTION
### What does this PR do?
Fixes Operator Dashboard queries. 
[Current dashboard](https://ddstaging.datadoghq.com/dash/integration/30955/datadog-operator?refresh_mode=sliding&from_ts=1698675112980&to_ts=1698678712980&live=true)

[Updated dashboard](https://ddstaging.datadoghq.com/dashboard/czn-wmx-cck?refresh_mode=sliding&from_ts=1698676278832&to_ts=1698679878832&live=true) (renamed).


### Motivation
DS, Deployment, Pod number inaccurate in the current dashboard.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
