### PR TITLE
Handle prefix patterns by sorting

### DIFF
--- a/windows_service/changelog.d/16120.fixed
+++ b/windows_service/changelog.d/16120.fixed
@@ -1,0 +1,1 @@
+Fix regression introduced in Agent 7.41.0 when handling service name patterns that are a prefix of another pattern

--- a/windows_service/tests/common.py
+++ b/windows_service/tests/common.py
@@ -30,7 +30,16 @@ INSTANCE_WILDCARD_DICT = {
     'disable_legacy_service_tag': True,
 }
 INSTANCE_ALL = {'services': ['ALL']}
-
+INSTANCE_PREFIX_MATCH = {
+    'services': [
+        # Intentionally use different letter cases to test the sorting
+        'event',
+        'EventLog',
+        'EventSystem',
+        {'startup_type': 'automatic'},
+    ],
+    'disable_legacy_service_tag': True,
+}
 INSTANCE_TRIGGER_START = {
     'services': [
         {'name': 'eventlog', 'startup_type': 'automatic', 'trigger_start': False},

--- a/windows_service/tests/common.py
+++ b/windows_service/tests/common.py
@@ -32,11 +32,15 @@ INSTANCE_WILDCARD_DICT = {
 INSTANCE_ALL = {'services': ['ALL']}
 INSTANCE_PREFIX_MATCH = {
     'services': [
+        # Include a non-name filter that should match to test that it isn't
+        # responsible for the match.
+        {'startup_type': 'automatic'},
         # Intentionally use different letter cases to test the sorting
         'event',
+        # The more specific filters should come last so our check must
+        # do something to ensure they are responsible for the match.
         'EventLog',
         'EventSystem',
-        {'startup_type': 'automatic'},
     ],
     'disable_legacy_service_tag': True,
 }

--- a/windows_service/tests/conftest.py
+++ b/windows_service/tests/conftest.py
@@ -63,3 +63,8 @@ def instance_startup_type_filter():
 @pytest.fixture
 def instance_trigger_start():
     return deepcopy(common.INSTANCE_TRIGGER_START)
+
+
+@pytest.fixture
+def instance_name_regex_prefix():
+    return deepcopy(common.INSTANCE_PREFIX_MATCH)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Restores functionality provided by https://github.com/DataDog/integrations-core/pull/4503

Adds a comment and a test so we don't unintentionally remove it again.

### Motivation
<!-- What inspired you to submit this pull request? -->
Unintentionally removed this in https://github.com/DataDog/integrations-core/pull/12940

https://datadoghq.atlassian.net/browse/AGENT-10543

### Additional Notes
<!-- Anything else we should know when reviewing? -->

The original PR reverse sorted the names, but did so case sensitively so it would fix the issue for configs like
```
services:
  - dfs
  - dfsr
```
but not for configs like
```
services:
  - Dfs
  - DFSR
```
This PR sorts on the length instead, so longer/more specific names are checked first, regardless of letter case.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
