### PR TITLE
Properly show extra output for failed Docker Agent E2E

### DIFF
--- a/ddev/changelog.d/16123.fixed
+++ b/ddev/changelog.d/16123.fixed
@@ -1,0 +1,1 @@
+Properly show extra output for failed Docker Agent E2E

--- a/ddev/src/ddev/e2e/agent/docker.py
+++ b/ddev/src/ddev/e2e/agent/docker.py
@@ -219,9 +219,7 @@ class DockerAgent(AgentInterface):
                 process = self._run_command(formatted_command)
                 if process.returncode:
                     self._show_logs()
-                    raise RuntimeError(
-                        f'Unable to run start-up command in Agent container `{self._container_name}`'
-                    )
+                    raise RuntimeError(f'Unable to run start-up command in Agent container `{self._container_name}`')
 
         if local_packages:
             base_pip_command = self._format_command(

--- a/ddev/src/ddev/e2e/agent/docker.py
+++ b/ddev/src/ddev/e2e/agent/docker.py
@@ -79,6 +79,9 @@ class DockerAgent(AgentInterface):
         with EnvVars({'DOCKER_CLI_HINTS': 'false'}):
             return self.platform.run_command(command, **kwargs)
 
+    def _show_logs(self) -> None:
+        self._run_command(['docker', 'logs', self._container_name])
+
     def get_id(self) -> str:
         return self._container_name
 
@@ -215,9 +218,9 @@ class DockerAgent(AgentInterface):
                 formatted_command = self._format_command(self.platform.modules.shlex.split(start_command))
                 process = self._run_command(formatted_command)
                 if process.returncode:
+                    self._show_logs()
                     raise RuntimeError(
-                        f'Unable to run start-up command in Agent container `{self._container_name}`: '
-                        f'{process.stdout.decode("utf-8")}'
+                        f'Unable to run start-up command in Agent container `{self._container_name}`'
                     )
 
         if local_packages:
@@ -228,9 +231,10 @@ class DockerAgent(AgentInterface):
                 package_mount = f'{self._package_mount_dir}{local_package.name}{features}'
                 process = self._run_command([*base_pip_command, package_mount])
                 if process.returncode:
+                    self._show_logs()
                     raise RuntimeError(
                         f'Unable to install package `{local_package.name}` in Agent container '
-                        f'`{self._container_name}`: {process.stdout.decode("utf-8")}'
+                        f'`{self._container_name}`'
                     )
 
         post_install_commands = self.metadata.get('post_install_commands', [])
@@ -239,9 +243,9 @@ class DockerAgent(AgentInterface):
                 formatted_command = self._format_command(self.platform.modules.shlex.split(post_install_command))
                 process = self._run_command(formatted_command)
                 if process.returncode:
+                    self._show_logs()
                     raise RuntimeError(
-                        f'Unable to run post-install command in Agent container `{self._container_name}`: '
-                        f'{process.stdout.decode("utf-8")}'
+                        f'Unable to run post-install command in Agent container `{self._container_name}`'
                     )
 
         if local_packages or start_commands or post_install_commands:
@@ -254,10 +258,8 @@ class DockerAgent(AgentInterface):
                 formatted_command = self._format_command(self.platform.modules.shlex.split(stop_command))
                 process = self._run_command(formatted_command)
                 if process.returncode:
-                    raise RuntimeError(
-                        f'Unable to run stop command in Agent container `{self._container_name}`: '
-                        f'{process.stdout.decode("utf-8")}'
-                    )
+                    self._show_logs()
+                    raise RuntimeError(f'Unable to run stop command in Agent container `{self._container_name}`')
 
         for command in (
             ['docker', 'stop', '-t', '0', self._container_name],


### PR DESCRIPTION
### Motivation

The `_run_command` method does not capture output and therefore it was decoding a None value, now we have even more output

### Additional Notes

![image](https://github.com/DataDog/integrations-core/assets/9677399/925cfff0-cbdd-4f61-8039-18d174603ef5)