### PR TITLE
[DBMON-3053] Add obfuscation_mode config option to allow enabling obfuscation with go-sqllexer

### DIFF
--- a/sqlserver/changelog.d/16125.added
+++ b/sqlserver/changelog.d/16125.added
@@ -1,0 +1,1 @@
+* Add obfuscation_mode config option to allow enabling obfuscation with go-sqllexer ([#16125](https://github.com/DataDog/integrations-core/pull/16125))

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -165,6 +165,9 @@ class SQLServer(AgentCheck):
                     'table_names': is_affirmative(obfuscator_options_config.get('collect_tables', True)),
                     'collect_commands': is_affirmative(obfuscator_options_config.get('collect_commands', True)),
                     'collect_comments': is_affirmative(obfuscator_options_config.get('collect_comments', True)),
+                    # Config to enable/disable obfuscation of sql statements with go-sqllexer pkg
+                    # Valid values for this can be found at https://github.com/DataDog/datadog-agent/blob/main/pkg/obfuscate/obfuscate.go#L108
+                    'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', ''),
                 }
             )
         )


### PR DESCRIPTION
### What does this PR do?
Add `obfuscation_mode` config option to allow enabling obfuscation with go-sqllexer. This config option is hidden to end user on purpose as we are testing and finalizing the new obfuscation implementation witg go-sqllexer pkg.

### Motivation
Add this "hidden" config option gives us a way to work with customer to enable the new obfuscation behavior if needed.  

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
