### PR TITLE
Add admission controller lib injection widgets back to cluster agent dashboard

### DIFF
--- a/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
+++ b/datadog_cluster_agent/assets/dashboards/datadog_cluster_agent_overview.json
@@ -1708,6 +1708,112 @@
                 "width": 4,
                 "height": 2
             }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "bars",
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "query": "sum:datadog.cluster_agent.admission_webhooks.library_injection_attempts{$cluster, $namespace} by {injected}.as_count()"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "show_legend": true,
+                "title": "Library injection attempts by injected state",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 2296693691691567,
+            "layout": {
+                "height": 2,
+                "width": 4,
+                "x": 4,
+                "y": 20
+            }
+        },
+        {
+            "definition": {
+                "legend_columns": [
+                    "avg",
+                    "min",
+                    "max",
+                    "value",
+                    "sum"
+                ],
+                "legend_layout": "auto",
+                "markers": [],
+                "requests": [
+                    {
+                        "display_type": "bars",
+                        "formulas": [
+                            {
+                                "formula": "query1"
+                            }
+                        ],
+                        "on_right_yaxis": false,
+                        "queries": [
+                            {
+                                "data_source": "metrics",
+                                "name": "query1",
+                                "query": "sum:datadog.cluster_agent.admission_webhooks.library_injection_errors{$cluster, $namespace} by {reason}.as_count()"
+                            }
+                        ],
+                        "response_format": "timeseries",
+                        "style": {
+                            "line_type": "solid",
+                            "line_width": "normal",
+                            "palette": "dog_classic"
+                        }
+                    }
+                ],
+                "show_legend": true,
+                "title": "Library injection errors by reason",
+                "type": "timeseries",
+                "yaxis": {
+                    "include_zero": true,
+                    "max": "auto",
+                    "min": "auto",
+                    "scale": "linear"
+                }
+            },
+            "id": 6764287346346728,
+            "layout": {
+                "height": 2,
+                "width": 4,
+                "x": 8,
+                "y": 20
+            }
         }
     ],
     "template_variables": [


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds the widgets from #15796 back to the Datadog Cluster Agent dashboard.

### Motivation
<!-- What inspired you to submit this pull request? -->
These changes were removed from the main branch by accident when new widgets were added to the dashboard.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
