### PR TITLE
switch logs and events tabs

### DIFF
--- a/win32_event_log/README.md
+++ b/win32_event_log/README.md
@@ -71,6 +71,32 @@ To find the channel name for an Event Log in the Windows Event Viewer, open the 
 
 <!-- xxx tabs xxx -->
 
+<!-- xxx tab "Logs" xxx -->
+
+#### Log collection
+
+_Available for Agent versions 6.0 or later_
+
+Log collection is disabled by default in the Datadog Agent. To collect Windows Event Logs as Datadog logs, [activate log collection][18] by setting `logs_enabled: true` in your `datadog.yaml` file.
+
+To collect Windows Event Logs as Datadog logs, configure channels under the `logs:` section of your `win32_event_log.d/conf.yaml` configuration file. This example shows entries for the `Security` and `<CHANNEL_2>` channels:
+
+```yaml
+logs:
+  - type: windows_event
+    channel_path: Security
+    source: windows.events
+    service: Windows
+
+  - type: windows_event
+    channel_path: "<CHANNEL_2>"
+    source: windows.events
+    service: myservice
+```
+
+Set the corresponding `source` parameter to `windows.events` to benefit from the [integration automatic processing pipeline][5].
+
+<!-- xxz tab xxx -->
 <!-- xxx tab "Events" xxx -->
 
 #### Event collection using the Event Log API (Recommended)
@@ -136,32 +162,6 @@ To collect Windows Event Logs as Datadog events, configure channels under the `i
   For more information, see [Add event log files to the `Win32_NTLogEvent` WMI class][28].
 
 <!-- xxz tab xxx -->
-<!-- xxx tab "Logs" xxx -->
-
-#### Log collection
-
-_Available for Agent versions 6.0 or later_
-
-Log collection is disabled by default in the Datadog Agent. To collect Windows Event Logs as Datadog logs, [activate log collection][18] by setting `logs_enabled: true` in your `datadog.yaml` file.
-
-To collect Windows Event Logs as Datadog logs, configure channels under the `logs:` section of your `win32_event_log.d/conf.yaml` configuration file. This example shows entries for the `Security` and `<CHANNEL_2>` channels:
-
-```yaml
-logs:
-  - type: windows_event
-    channel_path: Security
-    source: windows.events
-    service: Windows
-
-  - type: windows_event
-    channel_path: "<CHANNEL_2>"
-    source: windows.events
-    service: myservice
-```
-
-Set the corresponding `source` parameter to `windows.events` to benefit from the [integration automatic processing pipeline][5].
-
-<!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
 
 Edit the `<CHANNEL_2>` parameters with the Windows channel name you want to collect events from.
@@ -175,116 +175,7 @@ Finally, [restart the Agent][4].
 Configure one or more filters for the event log. A filter allows you to choose what log events you want to get into Datadog.
 
 <!-- xxx tabs xxx -->
-<!-- xxx tab "Events" xxx -->
 
-Use the Windows Event Viewer GUI to list all the event logs available for capture with this integration.
-
-To determine the exact values, set your filters to use the following PowerShell command:
-
-```text
-Get-WmiObject -Class Win32_NTLogEvent
-```
-
-For example, to see the latest event logged in the `Security` log file, use the following:
-
-```text
-Get-WmiObject -Class Win32_NTLogEvent -Filter "LogFile='Security'" | select -First 1
-```
-
-The values listed in the output of the command can be set in `win32_event_log.d/conf.yaml` to capture the same kind of events.
-
-<div class="alert alert-info">
-The information given by the  <code>Get-EventLog</code> PowerShell command or the Windows Event ViewerGUI may slightly differ from <code>Get-WmiObject</code>.<br> Double check your filters' values with <code>Get-WmiObject</code> if the integration does not capture the events you set up.
-</div>
-
-#### Filtering events using the Event Log API (Recommended)
-
-The configuration option using the Event Log API includes the following filters:
-
-  - `path`: `Application`, `System`, `Setup`, `Security`
-  - `type`: `Critical`, `Error`, `Warning`, `Information`, `Success Audit`, `Failure Audit`
-  - `source`: Any available source name
-  - `id`: event_id: Windows EventLog ID
-
-  See the [sample win32_event_log.d/conf.yaml][3] for all available filter options. 
-
-  This example filter uses Event Log API method.
-
-  ```yaml
-  instances:
-    - legacy_mode: false
-      path: System
-      filters:
-        source:
-        - Microsoft-Windows-Ntfs
-        - Service Control Manager
-        type:
-        - Error
-        - Warning
-        - Information
-        - Success Audit
-        - Failure Audit
-        id:
-        - 7036
-  ```
-
-You can use the [`query` option][20] to filter events with an [XPATH or structured XML query][21]. Datadog recommends creating the query in Event Viewer's filter editor until the events shown in Event Viewer match what you want the Datadog Agent to collect. The `filters` option is ignored when the `query` option is used.
-
-  ```yaml
-  init_config:
-  instances:
-    # collect Critical, Warning, and Error events
-    - path: Application
-      legacy_mode: false
-      query: '*[System[(Level=1 or Level=2 or Level=3)]]'
-      
-    - path: Application
-      legacy_mode: false
-      query: |
-        <QueryList>
-          <Query Id="0" Path="Application">
-            <Select Path="Application">*[System[(Level=1 or Level=2 or Level=3)]]</Select>
-          </Query>
-        </QueryList>
- ```
-
-#### Filtering events using Legacy Mode (Deprecated)
-
-The configuration option using the Legacy Mode includes the following filters:
-
-  - `log_file`: `Application`, `System`, `Setup`, `Security`
-  - `type`: `Critical`, `Error`, `Warning`, `Information`, `Audit Success`, `Audit Failure`
-  - `source_name`: Any available source name
-  - `event_id`: Windows EventLog ID
-
-  This example filter uses the Legacy Mode method.
-
-  ```yaml
-  instances:
-    # Legacy
-    # The following captures errors and warnings from SQL Server which
-    # puts all events under the MSSQLSERVER source and tag them with #sqlserver.
-    - tags:
-        - sqlserver
-      type:
-        - Warning
-        - Error
-      log_file:
-        - Application
-      source_name:
-        - MSSQLSERVER
-
-    # This instance captures all system errors and tags them with #system.
-    - tags:
-        - system
-      type:
-        - Error
-      log_file:
-        - System
-  ```
-The legacy method does not support the `query` option. Only the Event Log API method (setting `legacy_mode: false`) and the Logs Tailer supports the `query` option.
-
-<!-- xxz tab xxx -->
 <!-- xxx tab "Logs" xxx -->
 
 You can use the `query`, as well as the `log_processing_rules` regex option, to filter event logs. Datadog recommends using the `query` option which is faster at high rates of Windows Event Log generation and requires less CPU and memory than the `log_processing_rules` filters. When using the `log_processing_rules` filters, the Agent is forced to process and format each event, even if it will be excluded by `log_processing_rules` regex. With the `query` option, these events are not reported to the Agent.
@@ -415,6 +306,116 @@ logs:
 ```
 
 <!-- xxz tab xxx -->
+<!-- xxx tab "Events" xxx -->
+
+Use the Windows Event Viewer GUI to list all the event logs available for capture with this integration.
+
+To determine the exact values, set your filters to use the following PowerShell command:
+
+```text
+Get-WmiObject -Class Win32_NTLogEvent
+```
+
+For example, to see the latest event logged in the `Security` log file, use the following:
+
+```text
+Get-WmiObject -Class Win32_NTLogEvent -Filter "LogFile='Security'" | select -First 1
+```
+
+The values listed in the output of the command can be set in `win32_event_log.d/conf.yaml` to capture the same kind of events.
+
+<div class="alert alert-info">
+The information given by the  <code>Get-EventLog</code> PowerShell command or the Windows Event ViewerGUI may slightly differ from <code>Get-WmiObject</code>.<br> Double check your filters' values with <code>Get-WmiObject</code> if the integration does not capture the events you set up.
+</div>
+
+#### Filtering events using the Event Log API (Recommended)
+
+The configuration option using the Event Log API includes the following filters:
+
+  - `path`: `Application`, `System`, `Setup`, `Security`
+  - `type`: `Critical`, `Error`, `Warning`, `Information`, `Success Audit`, `Failure Audit`
+  - `source`: Any available source name
+  - `id`: event_id: Windows EventLog ID
+
+  See the [sample win32_event_log.d/conf.yaml][3] for all available filter options. 
+
+  This example filter uses Event Log API method.
+
+  ```yaml
+  instances:
+    - legacy_mode: false
+      path: System
+      filters:
+        source:
+        - Microsoft-Windows-Ntfs
+        - Service Control Manager
+        type:
+        - Error
+        - Warning
+        - Information
+        - Success Audit
+        - Failure Audit
+        id:
+        - 7036
+  ```
+
+You can use the [`query` option][20] to filter events with an [XPATH or structured XML query][21]. Datadog recommends creating the query in Event Viewer's filter editor until the events shown in Event Viewer match what you want the Datadog Agent to collect. The `filters` option is ignored when the `query` option is used.
+
+  ```yaml
+  init_config:
+  instances:
+    # collect Critical, Warning, and Error events
+    - path: Application
+      legacy_mode: false
+      query: '*[System[(Level=1 or Level=2 or Level=3)]]'
+      
+    - path: Application
+      legacy_mode: false
+      query: |
+        <QueryList>
+          <Query Id="0" Path="Application">
+            <Select Path="Application">*[System[(Level=1 or Level=2 or Level=3)]]</Select>
+          </Query>
+        </QueryList>
+ ```
+
+#### Filtering events using Legacy Mode (Deprecated)
+
+The configuration option using the Legacy Mode includes the following filters:
+
+  - `log_file`: `Application`, `System`, `Setup`, `Security`
+  - `type`: `Critical`, `Error`, `Warning`, `Information`, `Audit Success`, `Audit Failure`
+  - `source_name`: Any available source name
+  - `event_id`: Windows EventLog ID
+
+  This example filter uses the Legacy Mode method.
+
+  ```yaml
+  instances:
+    # Legacy
+    # The following captures errors and warnings from SQL Server which
+    # puts all events under the MSSQLSERVER source and tag them with #sqlserver.
+    - tags:
+        - sqlserver
+      type:
+        - Warning
+        - Error
+      log_file:
+        - Application
+      source_name:
+        - MSSQLSERVER
+
+    # This instance captures all system errors and tags them with #system.
+    - tags:
+        - system
+      type:
+        - Error
+      log_file:
+        - System
+  ```
+The legacy method does not support the `query` option. Only the Event Log API method (setting `legacy_mode: false`) and the Logs Tailer supports the `query` option.
+
+<!-- xxz tab xxx -->
 <!-- xxz tabs xxx -->
 
 When you're done setting up filters, [restart the Agent][4] using the Agent Manager, or restart the service.
@@ -422,25 +423,6 @@ When you're done setting up filters, [restart the Agent][4] using the Agent Mana
 ### Validation
 
 <!-- xxx tabs xxx -->
-<!-- xxx tab "Events" xxx -->
-
-Check the information page in the Datadog Agent Manager or run the [Agent's `status` subcommand][6] and look for `win32_event_log` under the Checks section. 
-
-It should display a section similar to the following:
-
-```shell
-Checks
-======
-
-  [...]
-
-  win32_event_log
-  ---------------
-      - instance #0 [OK]
-      - Collected 0 metrics, 2 events & 1 service check
-```
-
-<!-- xxz tab xxx -->
 <!-- xxx tab "Logs" xxx -->
 
 Check the information page in the Datadog Agent Manager or run the [Agent's `status` subcommand][6] and look for `win32_event_log` under the Logs Agent section. 
@@ -458,6 +440,25 @@ Logs Agent
     - Type: windows_event
       ChannelPath: System
       Status: OK
+```
+
+<!-- xxz tab xxx -->
+<!-- xxx tab "Events" xxx -->
+
+Check the information page in the Datadog Agent Manager or run the [Agent's `status` subcommand][6] and look for `win32_event_log` under the Checks section. 
+
+It should display a section similar to the following:
+
+```shell
+Checks
+======
+
+  [...]
+
+  win32_event_log
+  ---------------
+      - instance #0 [OK]
+      - Collected 0 metrics, 2 events & 1 service check
 ```
 
 <!-- xxz tab xxx -->


### PR DESCRIPTION
### What does this PR do?
Switch the order of the Events and Logs tabs on the Event Log integration page. Even though customers can send data both as event and logs, we want to show Logs first.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-34

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
