### PR TITLE
[DBMON-3054] Add unit tests to assert every configurable metrics collection

### DIFF
--- a/sqlserver/changelog.d/16136.added
+++ b/sqlserver/changelog.d/16136.added
@@ -1,0 +1,1 @@
+DBMON-3054] Add unit tests to assert every configurable metrics collection

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -134,12 +134,17 @@ INSTANCE_METRICS_DATABASE = [
 
 # AlwaysOn metrics
 # datadog metric name, sql table, column name, tag
-AO_METRICS = [
+AO_AG_SYNC_METRICS = [
     ('sqlserver.ao.ag_sync_health', 'sys.dm_hadr_availability_group_states', 'synchronization_health'),
+]
+AO_REPLICA_SYNC_METRICS = [
     ('sqlserver.ao.replica_sync_state', 'sys.dm_hadr_database_replica_states', 'synchronization_state'),
+]
+AO_REPLICA_FAILOVER_METRICS = [
     ('sqlserver.ao.replica_failover_mode', 'sys.availability_replicas', 'failover_mode'),
     ('sqlserver.ao.replica_failover_readiness', 'sys.availability_replicas', 'is_failover_ready'),
 ]
+AO_METRICS = AO_AG_SYNC_METRICS + AO_REPLICA_SYNC_METRICS + AO_REPLICA_FAILOVER_METRICS
 
 AO_METRICS_PRIMARY = [
     ('sqlserver.ao.primary_replica_health', 'sys.dm_hadr_availability_group_states', 'primary_recovery_health'),

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -151,17 +151,20 @@ AO_METRICS_SECONDARY = [
 
 # Non-performance table metrics - can be database specific
 # datadog metric name, sql table, column name
-TASK_SCHEDULER_METRICS = [
+OS_SCHEDULER_METRICS = [
     ('sqlserver.scheduler.current_tasks_count', 'sys.dm_os_schedulers', 'current_tasks_count'),
     ('sqlserver.scheduler.current_workers_count', 'sys.dm_os_schedulers', 'current_workers_count'),
     ('sqlserver.scheduler.active_workers_count', 'sys.dm_os_schedulers', 'active_workers_count'),
     ('sqlserver.scheduler.runnable_tasks_count', 'sys.dm_os_schedulers', 'runnable_tasks_count'),
     ('sqlserver.scheduler.work_queue_count', 'sys.dm_os_schedulers', 'work_queue_count'),
+]
+OS_TASK_METRICS = [
     ('sqlserver.task.context_switches_count', 'sys.dm_os_tasks', 'context_switches_count'),
     ('sqlserver.task.pending_io_count', 'sys.dm_os_tasks', 'pending_io_count'),
     ('sqlserver.task.pending_io_byte_count', 'sys.dm_os_tasks', 'pending_io_byte_count'),
     ('sqlserver.task.pending_io_byte_average', 'sys.dm_os_tasks', 'pending_io_byte_average'),
 ]
+TASK_SCHEDULER_METRICS = OS_SCHEDULER_METRICS + OS_TASK_METRICS
 
 # Non-performance table metrics
 # datadog metric name, sql table, column name
@@ -173,13 +176,18 @@ TASK_SCHEDULER_METRICS = [
 #   4 = Suspect, 5 = Emergency, 6 = Offline, 7 = Copying, 10 = Offline_Secondary
 # Is Sync with Backup enum:
 #   0 = False, 1 = True
-DATABASE_METRICS = [
+DATABASE_FILES_METRICS = [
     ('sqlserver.database.files.size', 'sys.database_files', 'size'),
     ('sqlserver.database.files.state', 'sys.database_files', 'state'),
+]
+DATABASE_STATS_METRICS = [
     ('sqlserver.database.state', 'sys.databases', 'state'),
     ('sqlserver.database.is_sync_with_backup', 'sys.databases', 'is_sync_with_backup'),
+]
+DATABASE_BACKUP_METRICS = [
     ('sqlserver.database.backup_count', 'msdb.dbo.backupset', 'backup_set_id_count'),
 ]
+DATABASE_METRICS = DATABASE_FILES_METRICS + DATABASE_STATS_METRICS + DATABASE_BACKUP_METRICS
 
 DATABASE_INDEX_METRICS = [
     ('sqlserver.index.user_seeks', 'sys.dm_db_index_usage_stats', 'user_seeks'),

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -118,14 +118,24 @@ EXPECTED_QUERY_EXECUTOR_AO_METRICS_SECONDARY = [
     'sqlserver.ao.redo_rate',
     'sqlserver.ao.filestream_send_rate',
 ]
-EXPECTED_QUERY_EXECUTOR_AO_METRICS_COMMON = [
+EXPECTED_QUERY_EXECUTOR_AO_METRICS_REPLICA_COMMON = [
     'sqlserver.ao.is_primary_replica',
     'sqlserver.ao.replica_status',
+]
+EXPECTED_QUERY_EXECUTOR_AO_METRICS_QUORUM_COMMON = [
     'sqlserver.ao.quorum_type',
     'sqlserver.ao.quorum_state',
+]
+EXPECTED_QUERY_EXECUTOR_AO_METRICS_MEMBER_COMMON = [
     'sqlserver.ao.member.type',
     'sqlserver.ao.member.state',
 ]
+EXPECTED_QUERY_EXECUTOR_AO_METRICS_COMMON = (
+    EXPECTED_QUERY_EXECUTOR_AO_METRICS_REPLICA_COMMON
+    + EXPECTED_QUERY_EXECUTOR_AO_METRICS_QUORUM_COMMON
+    + EXPECTED_QUERY_EXECUTOR_AO_METRICS_MEMBER_COMMON
+)
+
 # Our test environment does not have failover clustering enabled, so these metrics are not expected.
 # To test them follow this guide:
 # https://cloud.google.com/compute/docs/instances/sql-server/configure-failover-cluster-instance

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -145,14 +145,26 @@ def datadog_conn_docker(instance_docker):
 
 
 @pytest.fixture
-def bob_conn(instance_docker):
-    # Make DB connection
-
+def bob_conn_str(instance_docker):
     conn_str = 'DRIVER={};Server={};Database=master;UID={};PWD={};'.format(
         instance_docker['driver'], instance_docker['host'], "bob", "Password12!"
     )
-    conn = SelfHealingConnection(conn_str)
+    return conn_str
+
+
+@pytest.fixture
+def bob_conn(bob_conn_str):
+    # Make DB connection
+    conn = SelfHealingConnection(bob_conn_str)
     conn.reconnect()
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def bob_conn_raw(bob_conn_str):
+    # Make DB connection
+    conn = _common_pyodbc_connect(bob_conn_str)
     yield conn
     conn.close()
 

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -73,6 +73,20 @@ def instance_docker_defaults(instance_session_default):
 
 
 @pytest.fixture
+def instance_docker_metrics(instance_session_default):
+    '''
+    This fixture is used to test the metrics that are emitted from the integration main check.
+    We disable all DBM checks and only care about the main check metrics.
+    '''
+    instance = deepcopy(instance_session_default)
+    instance['query_metrics'] = {'enabled': False}
+    instance['procedure_metrics'] = {'enabled': False}
+    instance['query_activity'] = {'enabled': False}
+    instance['collect_settings'] = {'enabled': False}
+    return instance
+
+
+@pytest.fixture
 def instance_minimal_defaults():
     return {
         'host': DOCKER_SERVER,
@@ -178,6 +192,7 @@ class SelfHealingConnection:
                     cursor.execute(query, params)
                     if return_result:
                         return cursor.fetchall()
+                    return
             except Exception:
                 tracebacks.append(",".join(traceback.format_exception(*sys.exc_info())))
                 logging.exception("failed to execute query attempt=%s", attempt)

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -79,7 +79,7 @@ def instance_docker_metrics(instance_session_default):
     We disable all DBM checks and only care about the main check metrics.
     '''
     instance = deepcopy(instance_session_default)
-    instance['dbm'] = {'enabled': False}
+    instance['dbm'] = False
     return instance
 
 

--- a/sqlserver/tests/conftest.py
+++ b/sqlserver/tests/conftest.py
@@ -79,10 +79,7 @@ def instance_docker_metrics(instance_session_default):
     We disable all DBM checks and only care about the main check metrics.
     '''
     instance = deepcopy(instance_session_default)
-    instance['query_metrics'] = {'enabled': False}
-    instance['procedure_metrics'] = {'enabled': False}
-    instance['query_activity'] = {'enabled': False}
-    instance['collect_settings'] = {'enabled': False}
+    instance['dbm'] = {'enabled': False}
     return instance
 
 

--- a/sqlserver/tests/test_metrics.py
+++ b/sqlserver/tests/test_metrics.py
@@ -383,7 +383,6 @@ def test_check_incr_fraction_metrics(
     '''
     )
     sqlserver_check.run()
-    print(sqlserver_check.sqlserver_incr_fraction_metric_previous_values)
     cursor.close()
 
     tags = instance_docker_metrics.get('tags', [])

--- a/sqlserver/tests/test_metrics.py
+++ b/sqlserver/tests/test_metrics.py
@@ -1,0 +1,330 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import pytest
+
+from datadog_checks.sqlserver import SQLServer
+from datadog_checks.sqlserver.const import (
+    DATABASE_BACKUP_METRICS,
+    DATABASE_FILES_METRICS,
+    DATABASE_FRAGMENTATION_METRICS,
+    DATABASE_INDEX_METRICS,
+    DATABASE_MASTER_FILES,
+    DATABASE_STATS_METRICS,
+    DBM_MIGRATED_METRICS,
+    INSTANCE_METRICS,
+    INSTANCE_METRICS_DATABASE,
+    OS_SCHEDULER_METRICS,
+    TASK_SCHEDULER_METRICS,
+    TEMPDB_FILE_SPACE_USAGE_METRICS,
+)
+
+from .common import (
+    CHECK_NAME,
+    SERVER_METRICS,
+)
+
+INCR_FRACTION_METRICS = {'sqlserver.latches.latch_wait_time'}
+AUTODISCOVERY_DBS = ['master', 'msdb', 'datadog_test']
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_check_server_metrics(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+):
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+    dd_run_check(sqlserver_check)
+
+    tags = instance_docker_metrics.get('tags', [])
+
+    check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
+
+    for metric_name in SERVER_METRICS:
+        expected_tags = tags
+        aggregator.assert_metric(metric_name, tags=expected_tags, hostname=sqlserver_check.resolved_hostname, count=1)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize("database_autodiscovery", [True, False])
+@pytest.mark.parametrize("dbm_enabled", [True, False])
+def test_check_instance_metrics(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+    database_autodiscovery,
+    dbm_enabled,
+):
+    instance_docker_metrics['database_autodiscovery'] = database_autodiscovery
+    instance_docker_metrics['dbm'] = dbm_enabled
+    instance_docker_metrics['include_instance_metrics'] = True
+    if database_autodiscovery:
+        instance_docker_metrics['autodiscovery_include'] = AUTODISCOVERY_DBS
+
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+    dd_run_check(sqlserver_check)
+
+    tags = instance_docker_metrics.get('tags', [])
+
+    check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
+
+    for metric_name, _, _ in INSTANCE_METRICS:
+        # TODO: we should find a better way to test these metrics
+        # remove SQL Server incremental sql fraction metrics for now
+        if metric_name in INCR_FRACTION_METRICS:
+            continue
+        aggregator.assert_metric(metric_name, tags=tags, hostname=sqlserver_check.resolved_hostname, count=1)
+
+    if not database_autodiscovery:
+        for metric_name, _, _ in INSTANCE_METRICS_DATABASE:
+            aggregator.assert_metric(metric_name, tags=tags, hostname=sqlserver_check.resolved_hostname, count=1)
+    else:
+        for db in AUTODISCOVERY_DBS:
+            for metric_name, _, _ in INSTANCE_METRICS_DATABASE:
+                aggregator.assert_metric(
+                    metric_name,
+                    tags=tags + ['database:{}'.format(db)],
+                    hostname=sqlserver_check.resolved_hostname,
+                    count=1,
+                )
+    if not dbm_enabled:
+        for metric_name, _, _ in DBM_MIGRATED_METRICS:
+            aggregator.assert_metric(metric_name, tags=tags, hostname=sqlserver_check.resolved_hostname, count=1)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize("database_autodiscovery", [True, False])
+def test_check_database_metrics(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+    database_autodiscovery,
+):
+    instance_docker_metrics['database_autodiscovery'] = database_autodiscovery
+    if database_autodiscovery:
+        instance_docker_metrics['autodiscovery_include'] = AUTODISCOVERY_DBS
+
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+    dd_run_check(sqlserver_check)
+
+    tags = instance_docker_metrics.get('tags', [])
+
+    check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
+
+    dbs = AUTODISCOVERY_DBS if database_autodiscovery else ['master']
+
+    for db in dbs:
+        db_tags = tags + ['database:{}'.format(db), 'db:{}'.format(db)]
+        for metric_name, _, _ in DATABASE_FILES_METRICS:
+            for tag in db_tags + ['database_files_state_desc:ONLINE']:
+                aggregator.assert_metric_has_tag(
+                    metric_name,
+                    tag=tag,
+                )
+            for tag_prefix in ('file_id', 'file_type', 'file_location'):
+                aggregator.assert_metric_has_tag_prefix(
+                    metric_name,
+                    tag_prefix=tag_prefix,
+                )
+
+        for metric_name, _, _ in DATABASE_STATS_METRICS:
+            for tag in db_tags + ['database_state_desc:ONLINE']:
+                aggregator.assert_metric_has_tag(metric_name, tag=tag)
+            aggregator.assert_metric_has_tag_prefix(
+                metric_name,
+                tag_prefix='database_recovery_model_desc',
+            )
+
+        for metric_name, _, _ in DATABASE_BACKUP_METRICS:
+            aggregator.assert_metric(metric_name, tags=db_tags, hostname=sqlserver_check.resolved_hostname, count=1)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_check_index_usage_metrics(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+    bob_conn,
+):
+    instance_docker_metrics['database'] = 'datadog_test'
+    instance_docker_metrics['include_index_usage_metrics'] = True
+
+    # Cause an index seek
+    bob_conn.execute_with_retries(
+        query="SELECT * FROM datadog_test.dbo.ϑings WHERE name = 'foo'",
+        database=instance_docker_metrics['database'],
+        retries=1,
+        return_result=False,
+    )
+    # Cause an index scan
+    bob_conn.execute_with_retries(
+        query="SELECT * FROM datadog_test.dbo.ϑings WHERE name LIKE '%foo%'",
+        database=instance_docker_metrics['database'],
+        retries=1,
+        return_result=False,
+    )
+    # Cause an index lookup
+    bob_conn.execute_with_retries(
+        query="SELECT id FROM datadog_test.dbo.ϑings WHERE name = 'foo'",
+        database=instance_docker_metrics['database'],
+        retries=1,
+        return_result=False,
+    )
+    # Cause an index update
+    bob_conn.execute_with_retries(
+        query="UPDATE datadog_test.dbo.ϑings SET id = 1 WHERE name = 'foo'",
+        database=instance_docker_metrics['database'],
+        retries=1,
+        return_result=False,
+    )
+
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+    dd_run_check(sqlserver_check)
+
+    tags = instance_docker_metrics.get('tags', [])
+
+    check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
+
+    for metric_name, _, _ in DATABASE_INDEX_METRICS:
+        expected_tags = tags + [
+            'db:{}'.format(instance_docker_metrics['database']),
+            'index_name:thingsindex',
+            'table:ϑings',
+        ]
+        aggregator.assert_metric(metric_name, tags=expected_tags, hostname=sqlserver_check.resolved_hostname, count=1)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_check_task_scheduler_metrics(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+):
+    instance_docker_metrics['include_task_scheduler_metrics'] = True
+
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+    dd_run_check(sqlserver_check)
+
+    tags = instance_docker_metrics.get('tags', [])
+
+    check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
+
+    for metric_name, _, _ in TASK_SCHEDULER_METRICS:
+        for tag in tags:
+            aggregator.assert_metric_has_tag(metric_name, tag=tag)
+        for tag_prefix in ('scheduler_id',):
+            aggregator.assert_metric_has_tag_prefix(metric_name, tag_prefix=tag_prefix)
+
+    for metric_name, _, _ in OS_SCHEDULER_METRICS:
+        for tag_prefix in ('parent_node_id',):
+            aggregator.assert_metric_has_tag_prefix(metric_name, tag_prefix=tag_prefix)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_check_master_files_metrics(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+):
+    instance_docker_metrics['include_master_files_metrics'] = True
+
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+    dd_run_check(sqlserver_check)
+
+    tags = instance_docker_metrics.get('tags', [])
+
+    check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
+
+    dbs = AUTODISCOVERY_DBS + ['model', 'tempdb']
+
+    for db in dbs:
+        for metric_name, _, _ in DATABASE_MASTER_FILES:
+            db_tags = tags + ['database:{}'.format(db), 'db:{}'.format(db)]
+            for tag in db_tags + ['database_files_state_desc:ONLINE']:
+                aggregator.assert_metric_has_tag(
+                    metric_name,
+                    tag=tag,
+                )
+            for tag_prefix in ('file_id', 'file_type', 'file_location'):
+                aggregator.assert_metric_has_tag_prefix(
+                    metric_name,
+                    tag_prefix=tag_prefix,
+                )
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+@pytest.mark.parametrize("database_autodiscovery", [True, False])
+def test_check_db_fragmentation_metrics(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+    database_autodiscovery,
+):
+    instance_docker_metrics['include_db_fragmentation_metrics'] = True
+    instance_docker_metrics['database_autodiscovery'] = database_autodiscovery
+    if database_autodiscovery:
+        instance_docker_metrics['autodiscovery_include'] = AUTODISCOVERY_DBS
+
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+    dd_run_check(sqlserver_check)
+
+    tags = instance_docker_metrics.get('tags', [])
+
+    check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
+
+    dbs = AUTODISCOVERY_DBS if database_autodiscovery else ['master']
+
+    for db in dbs:
+        db_tags = tags + ['database_name:{}'.format(db), 'db:{}'.format(db)]
+        for metric_name, _, _ in DATABASE_FRAGMENTATION_METRICS:
+            for tag in db_tags:
+                aggregator.assert_metric_has_tag(metric_name, tag=tag)
+            for tag_prefix in ('index_id', 'index_name', 'object_name'):
+                aggregator.assert_metric_has_tag_prefix(metric_name, tag_prefix=tag_prefix)
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures('dd_environment')
+def test_check_tempdb_file_space_usage_metrics(
+    aggregator,
+    dd_run_check,
+    init_config,
+    instance_docker_metrics,
+):
+    instance_docker_metrics['include_tempdb_file_space_usage_metrics'] = True
+
+    sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker_metrics])
+    dd_run_check(sqlserver_check)
+
+    tags = instance_docker_metrics.get('tags', [])
+
+    check_sqlserver_can_connect(aggregator, instance_docker_metrics['host'], sqlserver_check.resolved_hostname, tags)
+
+    for metric_name, _, _ in TEMPDB_FILE_SPACE_USAGE_METRICS:
+        expected_tags = tags + ['database:tempdb', 'database_id:2', 'db:tempdb']
+        aggregator.assert_metric(metric_name, tags=expected_tags, hostname=sqlserver_check.resolved_hostname, count=1)
+
+
+def check_sqlserver_can_connect(aggregator, host, resolved_hostname, tags):
+    expected_tags = tags + [
+        'connection_host:{}'.format(host),
+        'sqlserver_host:{}'.format(resolved_hostname),
+        'db:master',
+    ]
+    aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK, tags=expected_tags)


### PR DESCRIPTION
### What does this PR do?
This PR adds dedicated unit test `test_metrics` to independently assert (almost) every configurable SQLServer metrics with expected tags. 
We will NOT remove existing unit tests for now until we are comfortable that the new tests can fully replacing what we had in `test_e2e` and `test_integration`.

### Motivation
Previously, we rely on (sort of) e2e tests to assert SQLServer metrics, and often without asserting expected tags. This is not only leaving gaps in test coverage, but also makes adding/removing metrics hard without proper unit tests to specifically assert the changes. This PR is to create dedicated tests for each and every metrics that we collect. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
