### PR TITLE
Bump the minimum base check version to 34.1.2

### DIFF
--- a/ambari/changelog.d/16139.changed
+++ b/ambari/changelog.d/16139.changed
@@ -1,0 +1,1 @@
+Bump the minimum base check version to 34.1.2

--- a/ambari/pyproject.toml
+++ b/ambari/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=32.6.0",
+    "datadog-checks-base>=34.1.2",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the minimum base check version to 34.1.2

### Motivation
<!-- What inspired you to submit this pull request? -->

Following https://github.com/DataDog/integrations-core/pull/16091, we now use https://github.com/DataDog/integrations-core/pull/16089 that's released with https://github.com/DataDog/integrations-core/pull/16137

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
