### PR TITLE
Add more attempts to the ping clickhouse condition when setting up the e2e environment

### DIFF
--- a/clickhouse/tests/conftest.py
+++ b/clickhouse/tests/conftest.py
@@ -7,7 +7,7 @@ import clickhouse_driver
 import pytest
 
 from datadog_checks.dev import docker_run
-from datadog_checks.dev.conditions import CheckDockerLogs, CheckEndpoints
+from datadog_checks.dev.conditions import CheckDockerLogs, CheckEndpoints, WaitFor
 
 from . import common
 
@@ -25,11 +25,13 @@ def dd_environment():
         )
 
     conditions.append(
-        ping_clickhouse(
-            common.CONFIG['server'],
-            common.CONFIG['port'],
-            common.CONFIG['username'],
-            common.CONFIG['password'],
+        WaitFor(
+            ping_clickhouse(
+                common.CONFIG['server'],
+                common.CONFIG['port'],
+                common.CONFIG['username'],
+                common.CONFIG['password'],
+            )
         )
     )
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add more attempts to the ping clickhouse condition when setting up the e2e environment

### Motivation
<!-- What inspired you to submit this pull request? -->

In https://github.com/DataDog/integrations-core/pull/16067 I added a condition to ping clickhouse. However there was no retries to this particular condition and the e2e env was shutdown as a whole if clickhouse is not reachable. `WaitFor` allows us to retry several times this specific condition.

Example on master: https://github.com/DataDog/integrations-core/actions/runs/6732626133/job/18299747619

### Additional Notes
<!-- Anything else we should know when reviewing? -->

https://datadoghq.atlassian.net/browse/AI-3623

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
