### PR TITLE
Do not validate the codecov file in marketplace when running the `validate ci` command

### DIFF
--- a/ddev/changelog.d/16144.fixed
+++ b/ddev/changelog.d/16144.fixed
@@ -1,0 +1,1 @@
+Do not validate the codecov file in marketplace when running the `validate ci` command

--- a/ddev/src/ddev/cli/validate/ci.py
+++ b/ddev/src/ddev/cli/validate/ci.py
@@ -136,6 +136,10 @@ def ci(app: Application, sync: bool):
     if repo_choice not in valid_repos:
         app.abort(f'Unknown repository `{repo_choice}`')
 
+    # marketplace does not have a .codecov.yml file
+    if app.repo.name == 'marketplace':
+        return
+
     testable_checks = {integration.name for integration in app.repo.integrations.iter_testable('all')}
 
     cached_display_names: defaultdict[str, str] = defaultdict(str)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Do not validate the codecov file in marketplace when running the `validate ci` command

### Motivation
<!-- What inspired you to submit this pull request? -->

They do not have this file, but we should still validate the matrix. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
