### PR TITLE
Database instance metadata payloads should not contain duplicate `db` tags

### DIFF
--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -987,8 +987,4 @@
 
 ***Added***:
 
-***Fixed***:
-
-* Database instance metadata payloads should not contain duplicate `db` tags ([#16146](https://github.com/DataDog/integrations-core/pull/16146))
-
 * adds postgres integration.

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -987,4 +987,8 @@
 
 ***Added***:
 
+***Fixed***:
+
+* Database instance metadata payloads should not contain duplicate `db` tags ([#16146](https://github.com/DataDog/integrations-core/pull/16146))
+
 * adds postgres integration.

--- a/postgres/changelog.d/16146.fixed
+++ b/postgres/changelog.d/16146.fixed
@@ -1,0 +1,1 @@
+Database instance metadata payloads should not contain duplicate `db` tags

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -902,7 +902,7 @@ class PostgreSql(AgentCheck):
                 "collection_interval": self._config.database_instance_collection_interval,
                 'dbms_version': payload_pg_version(self.version),
                 'integration_version': __version__,
-                "tags": self._non_internal_tags,
+                "tags": [t for t in self._non_internal_tags if not t.startswith('db:')],
                 "timestamp": time() * 1000,
                 "cloud_metadata": self._config.cloud_metadata,
                 "metadata": {


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Note: **this is something we are going to fix in our backend first, to prevent customers from being affected by this issue on 7.48**. 

This PR fixes a bug, which was introduced in the 7.48 version of the postgres agent that resulted in multiple `db` tags being applied to all metrics generated by the integration. For example, see `postgresql.queries.count` after upgrading to 7.48:

<img width="855" alt="Screen Shot 2023-11-06 at 11 13 37 AM" src="https://github.com/DataDog/integrations-core/assets/14317240/6f0bd6e0-482a-49df-9e37-e778a868c9dd">

... downgrading by to 7.47 fixes the issue 

<img width="841" alt="Screen Shot 2023-11-06 at 11 13 43 AM" src="https://github.com/DataDog/integrations-core/assets/14317240/0bb79a76-7f85-4b48-87ab-93b107de04b5">

&& finally, this fix resolves the issue:

<img width="837" alt="Screen Shot 2023-11-06 at 11 13 53 AM" src="https://github.com/DataDog/integrations-core/assets/14317240/da51285e-0d37-46bd-9f64-aa721b560be1">


### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
