### PR TITLE
Add `oracledb` to the ignored dependencies when we bump them before a release

### DIFF
--- a/ddev/changelog.d/16155.fixed
+++ b/ddev/changelog.d/16155.fixed
@@ -1,0 +1,1 @@
+Add `oracledb` to the ignored dependencies when we bump them before a release

--- a/ddev/src/ddev/cli/dep.py
+++ b/ddev/src/ddev/cli/dep.py
@@ -36,6 +36,10 @@ IGNORED_DEPS = {
     'pydantic',
     # https://github.com/DataDog/integrations-core/pull/16080
     'lxml',
+    # We need to keep an `oracledb` version that uses the same version of odpi that is used in godror in the agent repo.
+    # Somehow we do not load the right version. Until we find out how and why, we need to keep both
+    # libs in sync with the same version of odpi.
+    'oracledb',
 }
 
 # Dependencies for the downloader that are security-related and should be updated separately from the others


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add `oracledb` to the ignored dependencies when we bump them before a release

### Motivation
<!-- What inspired you to submit this pull request? -->

We are facing issues with the verison of odpi that is loaded. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

[This card](https://datadoghq.atlassian.net/browse/AI-3442) tracks the issue

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
