### PR TITLE
Add a retry mechanism when pulling the agent docker image

### DIFF
--- a/ddev/changelog.d/16157.fixed
+++ b/ddev/changelog.d/16157.fixed
@@ -1,0 +1,1 @@
+Add a retry mechanism when pulling the agent docker image

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "jsonpointer",
     "pluggy",
     "rich>=12.5.1",
+    "stamina==23.2.0",
     "tomli; python_version < '3.11'",
     "tomli-w",
     "tomlkit",

--- a/ddev/src/ddev/e2e/agent/docker.py
+++ b/ddev/src/ddev/e2e/agent/docker.py
@@ -9,7 +9,7 @@ import sys
 from functools import cache, cached_property
 from typing import TYPE_CHECKING, Callable
 
-from tenacity import retry, stop_after_attempt, wait_fixed
+import stamina
 
 from ddev.e2e.agent.interface import AgentInterface
 from ddev.utils.structures import EnvVars
@@ -282,7 +282,7 @@ class DockerAgent(AgentInterface):
     def enter_shell(self) -> None:
         self._run_command(self._format_command(['cmd' if self._is_windows_container else 'bash']), check=True)
 
-    @retry(wait=wait_fixed(2), stop=stop_after_attempt(3))
+    @stamina.retry(on=RuntimeError, attempts=3)
     def __pull_image(self, agent_build):
         process = self._run_command(['docker', 'pull', agent_build])
         if process.returncode:

--- a/ddev/src/ddev/e2e/agent/docker.py
+++ b/ddev/src/ddev/e2e/agent/docker.py
@@ -9,7 +9,7 @@ import sys
 from functools import cache, cached_property
 from typing import TYPE_CHECKING, Callable
 
-from tenacity import retry, wait_fixed
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 from ddev.e2e.agent.interface import AgentInterface
 from ddev.utils.structures import EnvVars
@@ -282,7 +282,7 @@ class DockerAgent(AgentInterface):
     def enter_shell(self) -> None:
         self._run_command(self._format_command(['cmd' if self._is_windows_container else 'bash']), check=True)
 
-    @retry(wait=wait_fixed(2))
+    @retry(wait=wait_fixed(2), stop=stop_after_attempt(3))
     def __pull_image(self, agent_build):
         process = self._run_command(['docker', 'pull', agent_build])
         if process.returncode:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a retry mechanism when pulling the agent docker image

### Motivation
<!-- What inspired you to submit this pull request? -->

Sometimes we do not manage to get the image and we fail the tests: https://github.com/DataDog/integrations-core/actions/runs/6772328879/job/18404845840#step:15:645

### Additional Notes
<!-- Anything else we should know when reviewing? -->

https://datadoghq.atlassian.net/browse/AI-3635

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
