### PR TITLE
Correct adoprovider default value

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -207,14 +207,13 @@ files:
         example: true
     - name: adoprovider
       description: |
-        Choose the ADO provider.  Note that the (default) provider
-        SQLOLEDB is being deprecated.  To use the newer MSOLEDBSQL
-        provider, set the adoprovider to "MSOLEDBSQL" below or "MSOLEDBSQL19" for version 19 of the driver.
-        You will also need to download the new provider from
+        Choose the ADO provider. The (default) provider is MSOLEDBSQL.
+        Set the adoprovider to "MSOLEDBSQL19" for version 19 of the driver. Note that the provider SQLOLEDB is being deprecated.
+        You can download the provider from
         https://docs.microsoft.com/en-us/sql/connect/oledb/oledb-driver-for-sql-server?view=sql-server-2017
       value:
         type: string
-        example: SQLOLEDB
+        example: MSOLEDBSQL
     - name: connector
       description: |
         Change the connection method from adodbapi (the default) to

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -209,8 +209,6 @@ files:
       description: |
         Choose the ADO provider. The default provider is MSOLEDBSQL.
         Set the adoprovider to "MSOLEDBSQL19" for version 19 of the driver. Note the provider SQLOLEDB is being deprecated.
-        You can download the provider from
-        https://docs.microsoft.com/en-us/sql/connect/oledb/oledb-driver-for-sql-server?view=sql-server-2017
       value:
         type: string
         example: MSOLEDBSQL

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -210,6 +210,8 @@ files:
         Choose the ADO provider. The default provider is MSOLEDBSQL.
         Set the adoprovider to "MSOLEDBSQL19" for version 19 of the driver.
         Note the provider SQLOLEDB is being deprecated.
+        You can download the new provider from
+        https://docs.microsoft.com/en-us/sql/connect/oledb/oledb-driver-for-sql-server?view=sql-server-2017
       value:
         type: string
         example: MSOLEDBSQL

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -207,8 +207,8 @@ files:
         example: true
     - name: adoprovider
       description: |
-        Choose the ADO provider. The (default) provider is MSOLEDBSQL.
-        Set the adoprovider to "MSOLEDBSQL19" for version 19 of the driver. Note that the provider SQLOLEDB is being deprecated.
+        Choose the ADO provider. The default provider is MSOLEDBSQL.
+        Set the adoprovider to "MSOLEDBSQL19" for version 19 of the driver. Note the provider SQLOLEDB is being deprecated.
         You can download the provider from
         https://docs.microsoft.com/en-us/sql/connect/oledb/oledb-driver-for-sql-server?view=sql-server-2017
       value:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -207,7 +207,7 @@ files:
         example: true
     - name: adoprovider
       description: |
-        Choose the ADO provider. The default provider is MSOLEDBSQL.
+        Choose the ADO provider. Default provider is MSOLEDBSQL.
         Set the adoprovider to "MSOLEDBSQL19" for version 19 of the driver. Note the provider SQLOLEDB is being deprecated.
       value:
         type: string

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -207,8 +207,9 @@ files:
         example: true
     - name: adoprovider
       description: |
-        Choose the ADO provider. Default provider is MSOLEDBSQL.
-        Set the adoprovider to "MSOLEDBSQL19" for version 19 of the driver. Note the provider SQLOLEDB is being deprecated.
+        Choose the ADO provider. The default provider is MSOLEDBSQL.
+        Set the adoprovider to "MSOLEDBSQL19" for version 19 of the driver.
+        Note the provider SQLOLEDB is being deprecated.
       value:
         type: string
         example: MSOLEDBSQL

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -193,14 +193,14 @@ instances:
     #
     # include_tempdb_file_space_usage_metrics: true
 
-    ## @param adoprovider - string - optional - default: SQLOLEDB
-    ## Choose the ADO provider.  Note that the (default) provider
-    ## SQLOLEDB is being deprecated.  To use the newer MSOLEDBSQL
-    ## provider, set the adoprovider to "MSOLEDBSQL" below or "MSOLEDBSQL19" for version 19 of the driver.
-    ## You will also need to download the new provider from
+    ## @param adoprovider - string - optional - default: MSOLEDBSQL
+    ## Choose the ADO provider. The default provider is MSOLEDBSQL.
+    ## Set the adoprovider to "MSOLEDBSQL19" for version 19 of the driver.
+    ## Note the provider SQLOLEDB is being deprecated.
+    ## You can download the new provider from
     ## https://docs.microsoft.com/en-us/sql/connect/oledb/oledb-driver-for-sql-server?view=sql-server-2017
     #
-    # adoprovider: SQLOLEDB
+    # adoprovider: MSOLEDBSQL
 
     ## @param connector - string - optional - default: adodbapi
     ## Change the connection method from adodbapi (the default) to


### PR DESCRIPTION
### What does this PR do?
Update spec.yaml to correct default value which was changed on the following PR:
https://github.com/DataDog/integrations-core/pull/13436

### Motivation
https://datadoghq.atlassian.net/browse/SDBM-643 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
