### PR TITLE
Allow to use an integer for the expected status code in the config

### DIFF
--- a/http_check/assets/configuration/spec.yaml
+++ b/http_check/assets/configuration/spec.yaml
@@ -79,6 +79,7 @@ files:
           - type: string
           - type: integer
         example: (1|2|3)\d\d
+        default: (1|2|3)\d\d
     - name: include_content
       description: |
         The include_content parameter will instruct the check

--- a/http_check/assets/configuration/spec.yaml
+++ b/http_check/assets/configuration/spec.yaml
@@ -75,7 +75,9 @@ files:
         The check will report as DOWN if status code returned differs.
         This defaults to 1xx, 2xx and 3xx HTTP status code.
       value:
-        type: string
+        anyOf:
+          - type: string
+          - type: integer
         example: (1|2|3)\d\d
     - name: include_content
       description: |

--- a/http_check/changelog.d/16163.fixed
+++ b/http_check/changelog.d/16163.fixed
@@ -1,0 +1,1 @@
+Allow using an integer for the expected status code in the config

--- a/http_check/datadog_checks/http_check/config_models/defaults.py
+++ b/http_check/datadog_checks/http_check/config_models/defaults.py
@@ -40,6 +40,10 @@ def instance_empty_default_hostname():
     return False
 
 
+def instance_http_response_status_code():
+    return '(1|2|3)\\d\\d'
+
+
 def instance_include_content():
     return False
 

--- a/http_check/datadog_checks/http_check/config_models/defaults.py
+++ b/http_check/datadog_checks/http_check/config_models/defaults.py
@@ -40,10 +40,6 @@ def instance_empty_default_hostname():
     return False
 
 
-def instance_http_response_status_code():
-    return '(1|2|3)\\d\\d'
-
-
 def instance_include_content():
     return False
 

--- a/http_check/datadog_checks/http_check/config_models/instance.py
+++ b/http_check/datadog_checks/http_check/config_models/instance.py
@@ -71,7 +71,7 @@ class InstanceConfig(BaseModel):
     empty_default_hostname: Optional[bool] = None
     extra_headers: Optional[MappingProxyType[str, Any]] = None
     headers: Optional[MappingProxyType[str, Any]] = None
-    http_response_status_code: Optional[str] = None
+    http_response_status_code: Optional[Union[str, int]] = None
     include_content: Optional[bool] = None
     include_default_headers: Optional[bool] = None
     kerberos_auth: Optional[str] = None

--- a/http_check/datadog_checks/http_check/data/conf.yaml.example
+++ b/http_check/datadog_checks/http_check/data/conf.yaml.example
@@ -94,7 +94,7 @@ instances:
     #
     # reverse_content_match: false
 
-    ## @param http_response_status_code - string - optional - default: (1|2|3)\d\d
+    ## @param http_response_status_code - string or integer - optional - default: (1|2|3)\d\d
     ## The http_response_status_code parameter will instruct the check
     ## to look for a particular HTTP response status code or a Regex identifying
     ## a set of possible status codes.

--- a/http_check/tests/test_http_integration.py
+++ b/http_check/tests/test_http_integration.py
@@ -605,3 +605,15 @@ def test_case_insensitive_header_content_type(dd_run_check, headers):
         assert check.http.options["headers"] == default_headers
     else:
         assert check.http.options["headers"] == headers
+
+
+def test_http_response_status_code_accepts_int_value(aggregator, dd_run_check):
+    instance = {
+        'name': 'foobar',
+        'url': 'http://something.com',
+        'http_response_status_code': 404,
+    }
+    check = HTTPCheck('http_check', {'ca_certs': 'foo'}, [instance])
+
+    dd_run_check(check)
+    aggregator.assert_service_check(HTTPCheck.SC_STATUS, status=AgentCheck.CRITICAL)


### PR DESCRIPTION
### What does this PR do?

It makes `http_check` accept `integer` as a valid type for the `http_response_status_code` option.

### Motivation

#16008.

The Pydantic update made types stricter, which is affecting users of the `http_check` who might have been setting `http_response_status_code` to a single code. Since YAML has implicit typing, it's not necessarily obvious for everyone that quotes might be necessary for something to be interpreted as a string.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
