### PR TITLE
Use correct query for langchain request latency monitor

### DIFF
--- a/langchain/assets/monitors/request_duration.json
+++ b/langchain/assets/monitors/request_duration.json
@@ -21,7 +21,7 @@
       }
     },
     "priority": null,
-    "query": "avg(last_5m):avg:system.load.1{*} > 10",
+    "query": "avg(last_5m):avg:langchain.request.duration{*} > 10",
     "restricted_roles": null,
     "tags": [
       "integration:langchain"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR fixes the langchain integration's recommended monitor for request latency. Previously it was querying `system.load` which was incorrect, this was fixed by querying the correct `langchain.request.duration` metric.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
