### PR TITLE
Revert dashboard ID change

### DIFF
--- a/openstack_controller/manifest.json
+++ b/openstack_controller/manifest.json
@@ -45,7 +45,7 @@
       }
     },
     "dashboards": {
-      "OpenStack Controller Overview [Legacy]": "assets/dashboards/openstack-controller.json",
+      "OpenStack Controller Overview": "assets/dashboards/openstack-controller.json",
       "OpenStack Controller Overview [Default Microversion]": "assets/dashboards/openstack_controller_overview_[default_microversion].json"
     },
     "logs": {


### PR DESCRIPTION
### What does this PR do?
Reverts dashboard ID change (from https://github.com/DataDog/integrations-core/pull/15918) to ensure a smooth transition for those using the current dashboard. This has no effects on the UI 

### Motivation

### Additional Notes
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
