### PR TITLE
[PLINT-245] Add support for glance component 

### DIFF
--- a/openstack_controller/assets/configuration/spec.yaml
+++ b/openstack_controller/assets/configuration/spec.yaml
@@ -600,6 +600,13 @@ files:
                                   type: string
                               - name: interval
                                 type: integer
+              - name: image
+                anyOf:
+                  - type: boolean
+                  - type: object
+                    properties:
+                      - name: images
+                        type: boolean
             example:
               compute: false
         - name: projects

--- a/openstack_controller/assets/service_checks.json
+++ b/openstack_controller/assets/service_checks.json
@@ -98,6 +98,22 @@
         "description": "Returns `CRITICAL` if the Agent is unable to query the Octavia API and `UNKNOWN` if endpoint is not found in the catalog. Returns `OK` otherwise."
     },
     {
+        "agent_version": "7.50.0",
+        "check": "openstack.glance.api.up",
+        "statuses": [
+            "ok",
+            "critical"
+        ],
+        "integration": "OpenStack",
+        "name": "OpenStack Glance API Up",
+        "groups": [
+            "host",
+            "keystone_server",
+            "region_id"
+        ],
+        "description": "Returns `CRITICAL` if the Agent is unable to query the Glance API and `UNKNOWN` if endpoint is not found in the catalog. Returns `OK` otherwise."
+    },
+    {
         "agent_version": "5.6.0",
         "check": "openstack.nova.hypervisor.up",
         "statuses": [

--- a/openstack_controller/changelog.d/16186.added
+++ b/openstack_controller/changelog.d/16186.added
@@ -1,0 +1,1 @@
+Add support for glance component.

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
@@ -417,3 +417,8 @@ class ApiRest(Api):
         )
         response.raise_for_status()
         return response.json().get('amphora_stats', [])
+
+    def get_glance_images(self):
+        response = self.http.get('{}/v2/images'.format(self._catalog.get_endpoint_by_type(Component.Types.IMAGE.value)))
+        response.raise_for_status()
+        return response.json().get('images', [])

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_sdk.py
@@ -266,3 +266,6 @@ class ApiSdk(Api):
         )
         response.raise_for_status()
         return response.json().get('amphora_stats', [])
+
+    def get_glance_images(self):
+        return [image.to_dict(original_names=True) for image in self.connection.image.images()]

--- a/openstack_controller/datadog_checks/openstack_controller/components/component.py
+++ b/openstack_controller/datadog_checks/openstack_controller/components/component.py
@@ -47,6 +47,7 @@ class Component:
         BLOCK_STORAGE = 'block-storage'
         BAREMETAL = 'baremetal'
         LOAD_BALANCER = 'load-balancer'
+        IMAGE = 'image'
 
     @unique
     class Types(list, Enum):
@@ -56,6 +57,7 @@ class Component:
         BLOCK_STORAGE = ['block-storage', 'volumev3']
         BAREMETAL = ['baremetal']
         LOAD_BALANCER = ['load-balancer']
+        IMAGE = ['image']
 
     def http_error(report_service_check=False):
         def decorator_http_error(func):

--- a/openstack_controller/datadog_checks/openstack_controller/components/image.py
+++ b/openstack_controller/datadog_checks/openstack_controller/components/image.py
@@ -1,0 +1,48 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+from datadog_checks.openstack_controller.components.component import Component
+from datadog_checks.openstack_controller.metrics import (
+    GLANCE_IMAGE_COUNT,
+    GLANCE_IMAGE_TAGS,
+    GLANCE_METRICS_PREFIX,
+    GLANCE_RESPONSE_TIME,
+    GLANCE_SERVICE_CHECK,
+    get_metrics_and_tags,
+)
+
+
+class Image(Component):
+    ID = Component.Id.IMAGE
+    TYPES = Component.Types.IMAGE
+    SERVICE_CHECK = GLANCE_SERVICE_CHECK
+
+    def __init__(self, check):
+        super(Image, self).__init__(check)
+
+    @Component.register_global_metrics(ID)
+    @Component.http_error(report_service_check=True)
+    def _report_response_time(self, global_components_config, tags):
+        self.check.log.debug("reporting `%s` response time", Image.ID.value)
+        response_time = self.check.api.get_response_time(Image.TYPES.value)
+        self.check.log.debug("`%s` response time: %s", Image.ID.value, response_time)
+        self.check.gauge(GLANCE_RESPONSE_TIME, response_time, tags=tags)
+
+    @Component.register_global_metrics(ID)
+    @Component.http_error()
+    def _report_images(self, config, tags):
+        report_images = config.get('images', True)
+        if report_images:
+            data = self.check.api.get_glance_images()
+            for item in data:
+
+                image = get_metrics_and_tags(
+                    item,
+                    tags=GLANCE_IMAGE_TAGS,
+                    prefix=GLANCE_METRICS_PREFIX,
+                    metrics=[GLANCE_IMAGE_COUNT],
+                )
+                self.check.log.debug("image: %s", image)
+                self.check.gauge(GLANCE_IMAGE_COUNT, 1, tags=tags + image['tags'])

--- a/openstack_controller/datadog_checks/openstack_controller/components/image.py
+++ b/openstack_controller/datadog_checks/openstack_controller/components/image.py
@@ -37,7 +37,6 @@ class Image(Component):
         if report_images:
             data = self.check.api.get_glance_images()
             for item in data:
-
                 image = get_metrics_and_tags(
                     item,
                     tags=GLANCE_IMAGE_TAGS,

--- a/openstack_controller/datadog_checks/openstack_controller/config_models/instance.py
+++ b/openstack_controller/datadog_checks/openstack_controller/config_models/instance.py
@@ -117,6 +117,14 @@ class IdentityItem(BaseModel):
     users: Optional[bool] = None
 
 
+class ImageItem(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        frozen=True,
+    )
+    images: Optional[bool] = None
+
+
 class IncludeItem3(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
@@ -286,6 +294,7 @@ class Components(BaseModel):
     block_storage: Optional[Union[bool, MappingProxyType[str, Any]]] = Field(None, alias='block-storage')
     compute: Optional[Union[bool, ComputeItem]] = None
     identity: Optional[Union[bool, IdentityItem]] = None
+    image: Optional[Union[bool, ImageItem]] = None
     load_balancer: Optional[Union[bool, LoadBalancerItem]] = Field(None, alias='load-balancer')
     network: Optional[Union[bool, NetworkItem]] = None
 

--- a/openstack_controller/datadog_checks/openstack_controller/metrics.py
+++ b/openstack_controller/datadog_checks/openstack_controller/metrics.py
@@ -532,6 +532,16 @@ OCTAVIA_AMPHORA_STATS_METRICS = {
     f"{OCTAVIA_AMPHORA_STATS_METRICS_PREFIX}.total_connections": {},
 }
 
+GLANCE_METRICS_PREFIX = "openstack.glance"
+GLANCE_SERVICE_CHECK = f"{GLANCE_METRICS_PREFIX}.api.up"
+GLANCE_RESPONSE_TIME = f"{GLANCE_METRICS_PREFIX}.response_time"
+GLANCE_IMAGE_COUNT = f"{GLANCE_METRICS_PREFIX}.image.count"
+GLANCE_IMAGE_TAGS = {
+    'name': 'image_name',
+    'status': 'status',
+    'container_format': 'container_format',
+}
+
 
 def is_interface_metric(label):
     return any(seg in label for seg in ['_rx', '_tx'])

--- a/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
+++ b/openstack_controller/datadog_checks/openstack_controller/openstack_controller.py
@@ -12,6 +12,7 @@ from datadog_checks.openstack_controller.components.bare_metal import BareMetal
 from datadog_checks.openstack_controller.components.block_storage import BlockStorage
 from datadog_checks.openstack_controller.components.compute import Compute
 from datadog_checks.openstack_controller.components.identity import Identity
+from datadog_checks.openstack_controller.components.image import Image
 from datadog_checks.openstack_controller.components.load_balancer import LoadBalancer
 from datadog_checks.openstack_controller.components.network import Network
 from datadog_checks.openstack_controller.config import OpenstackConfig, normalize_discover_config_include
@@ -49,6 +50,7 @@ class OpenStackControllerCheck(AgentCheck, ConfigMixin):
             BlockStorage(self),
             BareMetal(self),
             LoadBalancer(self),
+            Image(self),
         ]
         self.projects_discovery = None
         if self.config.projects:

--- a/openstack_controller/metadata.csv
+++ b/openstack_controller/metadata.csv
@@ -248,4 +248,4 @@ openstack.octavia.amphora.stats.bytes_out,gauge,,,,"The total bytes sent",0,open
 openstack.octavia.amphora.stats.request_errors,gauge,,,,"The total requests that were unable to be fulfilled",0,openstack_controller,octavia amphora req err,
 openstack.octavia.amphora.stats.total_connections,gauge,,,,"The total connections handled",0,openstack_controller,octavia amphora total connections,
 openstack.glance.image.count,gauge,,,,"Number of public virtual machine images",0,openstack_controller,glance image ct,
-openstack.glance.response_time,gauge,,millisecond,,"Duration that an HTTP request takes to complete when making a request to keystone endpoint",0,openstack_controller,glance response time,
+openstack.glance.response_time,gauge,,millisecond,,"Duration that an HTTP request takes to complete when making a request to glance endpoint",0,openstack_controller,glance response time,

--- a/openstack_controller/metadata.csv
+++ b/openstack_controller/metadata.csv
@@ -247,3 +247,5 @@ openstack.octavia.amphora.stats.bytes_in,gauge,,,,"The total bytes received",0,o
 openstack.octavia.amphora.stats.bytes_out,gauge,,,,"The total bytes sent",0,openstack_controller,octavia amphora bytes sent,
 openstack.octavia.amphora.stats.request_errors,gauge,,,,"The total requests that were unable to be fulfilled",0,openstack_controller,octavia amphora req err,
 openstack.octavia.amphora.stats.total_connections,gauge,,,,"The total connections handled",0,openstack_controller,octavia amphora total connections,
+openstack.glance.image.count,gauge,,,,"Number of public virtual machine images",0,openstack_controller,glance image ct,
+openstack.glance.response_time,gauge,,millisecond,,"Duration that an HTTP request takes to complete when making a request to keystone endpoint",0,openstack_controller,glance response time,

--- a/openstack_controller/tests/docker/docker-compose.yaml
+++ b/openstack_controller/tests/docker/docker-compose.yaml
@@ -50,3 +50,11 @@ services:
       - ./etc/caddy/octavia:/etc/caddy/
     ports:
       - "9876:80"
+  openstack-glance:
+    image: caddy:2.6.2-alpine
+    container_name: openstack-glance
+    volumes:
+      - ../fixtures:/usr/share/caddy
+      - ./etc/caddy/glance:/etc/caddy/
+    ports:
+      - "9292:80"

--- a/openstack_controller/tests/docker/etc/caddy/glance/Caddyfile
+++ b/openstack_controller/tests/docker/etc/caddy/glance/Caddyfile
@@ -1,0 +1,25 @@
+{
+    debug
+    admin :2019
+}
+:80 {
+    root * /usr/share/caddy/
+    @get_image {
+        method GET
+        path /image
+    }
+    route @get_image {
+        rewrite * /GET{http.request.uri.path}/response.json
+        file_server
+    }
+
+    @get_image_v2_images {
+        method GET
+        path /image/v2/images
+    }
+    route @get_image_v2_images {
+        rewrite * /GET{http.request.uri.path}/response.json
+        file_server
+    }
+    file_server browse
+}

--- a/openstack_controller/tests/docker/fixtures/image/v2/images/get.json
+++ b/openstack_controller/tests/docker/fixtures/image/v2/images/get.json
@@ -1,0 +1,34 @@
+{
+    "images": [
+        {
+            "owner_specified.openstack.object": "images/cirros-1.5.2-x86_64-disk",
+            "owner_specified.openstack.sha256": "",
+            "owner_specified.openstack.md5": "",
+            "hw_rng_model": "virtio",
+            "name": "cirros-1.5.2-x86_64-disk",
+            "disk_format": "qcow2",
+            "container_format": "bare",
+            "visibility": "public",
+            "size": 46310543,
+            "virtual_size": 217940522,
+            "status": "active",
+            "checksum": "b873c39491a1377c8490f5f1e89261a9",
+            "protected": false,
+            "min_ram": 0,
+            "min_disk": 0,
+            "owner": "c09ccb52463d49c89595d2194a367298",
+            "os_hidden": false,
+            "os_hash_algo": "sha512",
+            "os_hash_value": "7b813aa46bb90b4da216a4d19376593fa3f3fc7e617f03a92b7fe11e9a3981cbe9f0959dbebe36225e5f53dc4492341a4863cac4ed1ee0909f3fc78ef9c3e861",
+            "id": "a4dcf3f7-e4d6-45d5-be2b-a939f2bbedfc",
+            "created_at": "2023-10-28T15:03:09Z",
+            "updated_at": "2023-10-28T15:03:10Z",
+            "tags": [],
+            "self": "/v2/images/a4dcf3f7-e4d6-45d5-be2b-a939f2bbedfc",
+            "file": "/v2/images/a4dcf3f7-e4d6-45d5-be2b-a939f2bbedfc/file",
+            "schema": "/v2/schemas/image"
+        }
+    ],
+    "first": "/v2/images",
+    "schema": "/v2/schemas/images"
+}

--- a/openstack_controller/tests/fixtures/GET/image/response.json
+++ b/openstack_controller/tests/fixtures/GET/image/response.json
@@ -1,0 +1,124 @@
+{
+    "versions": [
+        {
+            "id": "v2.16",
+            "status": "CURRENT",
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "http://10.164.0.71/image/v2/"
+                }
+            ]
+        },
+        {
+            "id": "v2.15",
+            "status": "SUPPORTED",
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "http://10.164.0.71/image/v2/"
+                }
+            ]
+        },
+        {
+            "id": "v2.14",
+            "status": "SUPPORTED",
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "http://10.164.0.71/image/v2/"
+                }
+            ]
+        },
+        {
+            "id": "v2.9",
+            "status": "SUPPORTED",
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "http://10.164.0.71/image/v2/"
+                }
+            ]
+        },
+        {
+            "id": "v2.7",
+            "status": "SUPPORTED",
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "http://10.164.0.71/image/v2/"
+                }
+            ]
+        },
+        {
+            "id": "v2.6",
+            "status": "SUPPORTED",
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "http://10.164.0.71/image/v2/"
+                }
+            ]
+        },
+        {
+            "id": "v2.5",
+            "status": "SUPPORTED",
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "http://10.164.0.71/image/v2/"
+                }
+            ]
+        },
+        {
+            "id": "v2.4",
+            "status": "SUPPORTED",
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "http://10.164.0.71/image/v2/"
+                }
+            ]
+        },
+        {
+            "id": "v2.3",
+            "status": "SUPPORTED",
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "http://10.164.0.71/image/v2/"
+                }
+            ]
+        },
+        {
+            "id": "v2.2",
+            "status": "SUPPORTED",
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "http://10.164.0.71/image/v2/"
+                }
+            ]
+        },
+        {
+            "id": "v2.1",
+            "status": "SUPPORTED",
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "http://10.164.0.71/image/v2/"
+                }
+            ]
+        },
+        {
+            "id": "v2.0",
+            "status": "SUPPORTED",
+            "links": [
+                {
+                    "rel": "self",
+                    "href": "http://10.164.0.71/image/v2/"
+                }
+            ]
+        }
+    ]
+}

--- a/openstack_controller/tests/fixtures/GET/image/v2/images/response.json
+++ b/openstack_controller/tests/fixtures/GET/image/v2/images/response.json
@@ -1,0 +1,34 @@
+{
+    "images": [
+        {
+            "owner_specified.openstack.object": "images/cirros-1.5.2-x86_64-disk",
+            "owner_specified.openstack.sha256": "",
+            "owner_specified.openstack.md5": "",
+            "hw_rng_model": "virtio",
+            "name": "cirros-1.5.2-x86_64-disk",
+            "disk_format": "qcow2",
+            "container_format": "bare",
+            "visibility": "public",
+            "size": 46310543,
+            "virtual_size": 217940522,
+            "status": "active",
+            "checksum": "b873c39491a1377c8490f5f1e89261a9",
+            "protected": false,
+            "min_ram": 0,
+            "min_disk": 0,
+            "owner": "c09ccb52463d49c89595d2194a367298",
+            "os_hidden": false,
+            "os_hash_algo": "sha512",
+            "os_hash_value": "7b813aa46bb90b4da216a4d19376593fa3f3fc7e617f03a92b7fe11e9a3981cbe9f0959dbebe36225e5f53dc4492341a4863cac4ed1ee0909f3fc78ef9c3e861",
+            "id": "a4dcf3f7-e4d6-45d5-be2b-a939f2bbedfc",
+            "created_at": "2023-10-28T15:03:09Z",
+            "updated_at": "2023-10-28T15:03:10Z",
+            "tags": [],
+            "self": "/v2/images/a4dcf3f7-e4d6-45d5-be2b-a939f2bbedfc",
+            "file": "/v2/images/a4dcf3f7-e4d6-45d5-be2b-a939f2bbedfc/file",
+            "schema": "/v2/schemas/image"
+        }
+    ],
+    "first": "/v2/images",
+    "schema": "/v2/schemas/images"
+}

--- a/openstack_controller/tests/fixtures/POST/identity/v3/auth/tokens/1e6e233e637d4d55a50a62b63398ad15.json
+++ b/openstack_controller/tests/fixtures/POST/identity/v3/auth/tokens/1e6e233e637d4d55a50a62b63398ad15.json
@@ -131,7 +131,7 @@
             "id": "b8af839f440c4603ae2189173ffc8786",
             "interface": "public",
             "region_id": "RegionOne",
-            "url": "http://10.164.0.11/image",
+            "url": "http://127.0.0.1:9292/image",
             "region": "RegionOne"
           }
         ],

--- a/openstack_controller/tests/fixtures/POST/identity/v3/auth/tokens/6e39099cccde4f809b003d9e0dd09304.json
+++ b/openstack_controller/tests/fixtures/POST/identity/v3/auth/tokens/6e39099cccde4f809b003d9e0dd09304.json
@@ -139,7 +139,7 @@
             "id": "b8af839f440c4603ae2189173ffc8786",
             "interface": "public",
             "region_id": "RegionOne",
-            "url": "http://10.164.0.11/image",
+            "url": "http://127.0.0.1:9292/image",
             "region": "RegionOne"
           }
         ],

--- a/openstack_controller/tests/metrics.py
+++ b/openstack_controller/tests/metrics.py
@@ -4528,3 +4528,18 @@ CONDUCTORS_METRICS_IRONIC_MICROVERSION_1_80 = [
         ],
     },
 ]
+
+
+IMAGES_METRICS_GLANCE = [
+    {
+        'name': 'openstack.glance.image.count',
+        'count': 1,
+        'value': 1,
+        'tags': [
+            'container_format:bare',
+            'image_name:cirros-1.5.2-x86_64-disk',
+            'status:active',
+            'keystone_server:http://127.0.0.1:8080/identity',
+        ],
+    },
+]

--- a/openstack_controller/tests/test_unit_glance.py
+++ b/openstack_controller/tests/test_unit_glance.py
@@ -1,0 +1,259 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import logging
+import os
+
+import pytest
+
+import tests.configs as configs
+from datadog_checks.base import AgentCheck
+from datadog_checks.dev.http import MockResponse
+from datadog_checks.openstack_controller.api.type import ApiType
+from tests.common import remove_service_from_catalog
+from tests.metrics import (
+    IMAGES_METRICS_GLANCE,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.skipif(os.environ.get('OPENSTACK_E2E_LEGACY') == 'true', reason='Not Legacy test'),
+]
+
+
+@pytest.mark.parametrize(
+    ('instance'),
+    [
+        pytest.param(
+            configs.REST,
+            id='api rest',
+        ),
+        pytest.param(
+            configs.SDK,
+            id='api sdk',
+        ),
+    ],
+)
+@pytest.mark.usefixtures('mock_http_get', 'mock_http_post', 'openstack_connection')
+def test_disable_glance_metrics(aggregator, dd_run_check, instance, openstack_controller_check):
+    instance = instance | {
+        "components": {
+            "image": False,
+        },
+    }
+    check = openstack_controller_check(instance)
+    dd_run_check(check)
+    for metric in aggregator.metric_names:
+        assert not metric.startswith('openstack.glance')
+
+
+@pytest.mark.parametrize(
+    ('instance'),
+    [
+        pytest.param(
+            configs.REST,
+            id='api rest',
+        ),
+        pytest.param(
+            configs.SDK,
+            id='api sdk',
+        ),
+    ],
+)
+@pytest.mark.usefixtures('mock_http_get', 'mock_http_post', 'openstack_connection')
+def test_disable_glance_images_metrics(aggregator, dd_run_check, instance, openstack_controller_check):
+    instance = instance | {
+        "components": {
+            "image": {
+                "images": False,
+            },
+        },
+    }
+    check = openstack_controller_check(instance)
+    dd_run_check(check)
+    for metric in aggregator.metric_names:
+        assert not metric.startswith('openstack.glance.image.')
+
+
+@pytest.mark.parametrize(
+    ('mock_http_post', 'session_auth', 'instance', 'api_type'),
+    [
+        pytest.param(
+            {'replace': {'/identity/v3/auth/tokens': lambda d: remove_service_from_catalog(d, ['image'])}},
+            None,
+            configs.REST,
+            ApiType.REST,
+            id='api rest',
+        ),
+        pytest.param(
+            None,
+            {'catalog': []},
+            configs.SDK,
+            ApiType.SDK,
+            id='api sdk',
+        ),
+    ],
+    indirect=['mock_http_post', 'session_auth'],
+)
+@pytest.mark.usefixtures('mock_http_get', 'mock_http_post', 'openstack_connection')
+def test_not_in_catalog(aggregator, check, dd_run_check, caplog, mock_http_post, session_auth, api_type):
+    with caplog.at_level(logging.DEBUG):
+        dd_run_check(check)
+
+    aggregator.assert_metric(
+        'openstack.glance.response_time',
+        count=0,
+    )
+    aggregator.assert_service_check(
+        'openstack.glance.api.up',
+        status=AgentCheck.UNKNOWN,
+        tags=['keystone_server:http://127.0.0.1:8080/identity'],
+    )
+    args_list = []
+    for call in mock_http_post.call_args_list:
+        args, kwargs = call
+        args_list += list(args)
+    assert args_list.count('http://127.0.0.1:9292/image') == 0
+    if api_type == ApiType.REST:
+        args_list = []
+        for call in mock_http_post.call_args_list:
+            args, _ = call
+            args_list += list(args)
+        assert args_list.count('http://127.0.0.1:8080/identity/v3/auth/tokens') == 4
+    if api_type == ApiType.SDK:
+        assert session_auth.get_access.call_count == 4
+    assert '`image` component not found in catalog' in caplog.text
+
+
+@pytest.mark.parametrize(
+    ('mock_http_get', 'instance'),
+    [
+        pytest.param(
+            {'http_error': {'/image': MockResponse(status_code=500)}},
+            configs.REST,
+            id='api rest',
+        ),
+        pytest.param(
+            {'http_error': {'/image': MockResponse(status_code=500)}},
+            configs.SDK,
+            id='api sdk',
+        ),
+    ],
+    indirect=['mock_http_get'],
+)
+@pytest.mark.usefixtures('mock_http_get', 'mock_http_post', 'openstack_connection')
+def test_response_time_exception(aggregator, check, dd_run_check, mock_http_get):
+    dd_run_check(check)
+    aggregator.assert_metric(
+        'openstack.glance.response_time',
+        count=0,
+    )
+    aggregator.assert_service_check(
+        'openstack.glance.api.up',
+        status=AgentCheck.CRITICAL,
+        tags=['keystone_server:http://127.0.0.1:8080/identity'],
+    )
+    args_list = []
+    for call in mock_http_get.call_args_list:
+        args, kwargs = call
+        args_list += list(args)
+    assert args_list.count('http://127.0.0.1:9292/image') == 2
+
+
+@pytest.mark.parametrize(
+    ('instance'),
+    [
+        pytest.param(
+            configs.REST,
+            id='api rest',
+        ),
+        pytest.param(
+            configs.SDK,
+            id='api sdk',
+        ),
+    ],
+)
+@pytest.mark.usefixtures('mock_http_get', 'mock_http_post', 'openstack_connection')
+def test_response_time(aggregator, check, dd_run_check, mock_http_get):
+    dd_run_check(check)
+    aggregator.assert_metric(
+        'openstack.glance.response_time',
+        count=1,
+        tags=['keystone_server:http://127.0.0.1:8080/identity'],
+    )
+    aggregator.assert_service_check(
+        'openstack.glance.api.up',
+        status=AgentCheck.OK,
+        tags=['keystone_server:http://127.0.0.1:8080/identity'],
+    )
+    args_list = []
+    for call in mock_http_get.call_args_list:
+        args, kwargs = call
+        args_list += list(args)
+    assert args_list.count('http://127.0.0.1:9292/image') == 1
+
+
+@pytest.mark.parametrize(
+    ('mock_http_get', 'connection_image', 'instance', 'api_type'),
+    [
+        pytest.param(
+            {'http_error': {'/image/v2/images': MockResponse(status_code=500)}},
+            None,
+            configs.REST,
+            ApiType.REST,
+            id='api rest',
+        ),
+        pytest.param(
+            None,
+            {'http_error': {'images': MockResponse(status_code=500)}},
+            configs.SDK,
+            ApiType.SDK,
+            id='api sdk',
+        ),
+    ],
+    indirect=['mock_http_get', 'connection_image'],
+)
+@pytest.mark.usefixtures('mock_http_get', 'mock_http_post', 'openstack_connection')
+def test_images_exception(aggregator, check, dd_run_check, mock_http_get, connection_image, api_type):
+    dd_run_check(check)
+    aggregator.assert_metric(
+        'openstack.glance.image.count',
+        count=0,
+    )
+    if api_type == ApiType.REST:
+        args_list = []
+        for call in mock_http_get.call_args_list:
+            args, _ = call
+            args_list += list(args)
+        assert args_list.count('http://127.0.0.1:9292/image/v2/images') == 2
+    if api_type == ApiType.SDK:
+        assert connection_image.images.call_count == 2
+
+
+@pytest.mark.parametrize(
+    ('instance', 'metrics'),
+    [
+        pytest.param(
+            configs.REST,
+            IMAGES_METRICS_GLANCE,
+            id='api rest',
+        ),
+        pytest.param(
+            configs.SDK,
+            IMAGES_METRICS_GLANCE,
+            id='api sdk',
+        ),
+    ],
+)
+@pytest.mark.usefixtures('mock_http_get', 'mock_http_post', 'openstack_connection')
+def test_images_metrics(aggregator, check, dd_run_check, metrics):
+    dd_run_check(check)
+    for metric in metrics:
+        aggregator.assert_metric(
+            metric['name'],
+            count=metric['count'],
+            value=metric['value'],
+            tags=metric['tags'],
+            hostname=metric.get('hostname'),
+        )


### PR DESCRIPTION
### What does this PR do?
Adds support for the glance component in openstack, adding a service check, response time metric, and image count metric.
### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
