### PR TITLE
[CONTINT-3443] fix(kubelet): centralize `get_prometheus_url` call

### DIFF
--- a/kubelet/changelog.d/16192.fixed
+++ b/kubelet/changelog.d/16192.fixed
@@ -1,0 +1,1 @@
+Centralize `get_prometheus_url` function call in the init function and defer log warning after super() call.

--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -107,12 +107,15 @@ def get_container_label(labels, l_name):
 
 
 def get_prometheus_url(default_url):
+    """
+    Use to retrieve the prometheus URL configuration from the get_connection_info()
+    :param default_url: the default prometheus URL
+    :rtype: (string, error)
+    :return: a tuple (the prometheus url, possible get_connection_info() call error )
+    """
     kubelet_conn_info = get_connection_info()
     kubelet_conn_info = {} if kubelet_conn_info is None else kubelet_conn_info
-    error = kubelet_conn_info.get("err")
-    if error:
-        log.warning(error)
-    return kubelet_conn_info.get("url", default_url)
+    return kubelet_conn_info.get("url", default_url), kubelet_conn_info.get("err")
 
 
 class PodListUtils(object):

--- a/kubelet/datadog_checks/kubelet/common.py
+++ b/kubelet/datadog_checks/kubelet/common.py
@@ -2,20 +2,19 @@
 # All rights reserved
 # Licensed under Simplified BSD License (see LICENSE)
 
-import logging
 import re
 
 from kubeutil import get_connection_info
 
 from datadog_checks.base.utils.tagging import tagger
 
-log = logging.getLogger(__name__)
-
 try:
     from containers import is_excluded as c_is_excluded
 except ImportError:
     # Don't fail on < 6.2
-    log.info('Agent does not provide filtering logic, disabling container filtering')
+    import logging
+
+    logging.getLogger(__name__).info('Agent does not provide filtering logic, disabling container filtering')
 
     def c_is_excluded(name, image, namespace=""):
         return False

--- a/kubelet/datadog_checks/kubelet/kubelet.py
+++ b/kubelet/datadog_checks/kubelet/kubelet.py
@@ -3,7 +3,6 @@
 # Licensed under Simplified BSD License (see LICENSE)
 from __future__ import division
 
-import logging
 import re
 import sys
 from collections import defaultdict
@@ -132,8 +131,6 @@ DEFAULT_ENABLED_GAUGES = [
 ]
 DEFAULT_POD_LEVEL_METRICS = ['network.*']
 
-log = logging.getLogger(__name__)
-
 
 class KubeletCheck(
     CadvisorPrometheusScraperMixin,
@@ -202,9 +199,9 @@ class KubeletCheck(
 
         super(KubeletCheck, self).__init__(name, init_config, generic_instances)
 
-        # we need to wait that `super()` was exectued to have the self.log instance created
+        # we need to wait that `super()` was executed to have the self.log instance created
         if get_prom_url_err:
-            self.log.warning('get_prometheus_url() failed: %s', get_prom_url_err)
+            self.log.warning('get_prometheus_url() failed to query the kublet, err: %s', get_prom_url_err)
 
         self.cadvisor_legacy_port = inst.get('cadvisor_port', CADVISOR_DEFAULT_PORT)
         self.cadvisor_legacy_url = None

--- a/kubelet/datadog_checks/kubelet/probes.py
+++ b/kubelet/datadog_checks/kubelet/probes.py
@@ -9,7 +9,7 @@ from datadog_checks.base.checks.kubelet_base.base import urljoin
 from datadog_checks.base.checks.openmetrics import OpenMetricsBaseCheck
 from datadog_checks.base.utils.tagging import tagger
 
-from .common import get_container_label, get_prometheus_url, replace_container_rt_prefix, tags_for_docker
+from .common import get_container_label, replace_container_rt_prefix, tags_for_docker
 
 PROBES_METRICS_PATH = '/metrics/probes'
 
@@ -28,17 +28,16 @@ class ProbesPrometheusScraperMixin(object):
             'prober_probe_total': self.prober_probe_total,
         }
 
-    def _create_probes_prometheus_instance(self, instance):
+    def _create_probes_prometheus_instance(self, instance, prom_url):
         """
         Create a copy of the instance and set default values.
         This is so the base class can create a scraper_config with the proper values.
         """
-        endpoint = get_prometheus_url("dummy_url/probes")
         probes_instance = deepcopy(instance)
         probes_instance.update(
             {
                 'namespace': self.NAMESPACE,
-                'prometheus_url': instance.get('probes_metrics_endpoint', urljoin(endpoint, PROBES_METRICS_PATH)),
+                'prometheus_url': instance.get('probes_metrics_endpoint', urljoin(prom_url, PROBES_METRICS_PATH)),
             }
         )
         return probes_instance

--- a/kubelet/datadog_checks/kubelet/prometheus.py
+++ b/kubelet/datadog_checks/kubelet/prometheus.py
@@ -14,7 +14,6 @@ from datadog_checks.base.utils.tagging import tagger
 from .common import (
     get_container_label,
     get_pod_by_uid,
-    get_prometheus_url,
     is_static_pending_pod,
     replace_container_rt_prefix,
 )
@@ -73,17 +72,16 @@ class CadvisorPrometheusScraperMixin(object):
             'container_spec_memory_swap_limit_bytes': self.container_spec_memory_swap_limit_bytes,
         }
 
-    def _create_cadvisor_prometheus_instance(self, instance):
+    def _create_cadvisor_prometheus_instance(self, instance, prom_url):
         """
         Create a copy of the instance and set default values.
         This is so the base class can create a scraper_config with the proper values.
         """
-        endpoint = get_prometheus_url("dummy_url/cadvisor")
         cadvisor_instance = deepcopy(instance)
         cadvisor_instance.update(
             {
                 'namespace': self.NAMESPACE,
-                'prometheus_url': instance.get('cadvisor_metrics_endpoint', urljoin(endpoint, CADVISOR_METRICS_PATH)),
+                'prometheus_url': instance.get('cadvisor_metrics_endpoint', urljoin(prom_url, CADVISOR_METRICS_PATH)),
                 'ignore_metrics': [
                     'container_fs_inodes_free',
                     'container_fs_inodes_total',


### PR DESCRIPTION
### What does this PR do?

centralize the `get_prometheus_url()` function call in the kubelet check.
Wait the `super()` function are call before trying to log a warning with `self.log`

Fixes: CONTINT-3443

### Motivation

* Send the warning to the correct logger.
* Simplify code

### Additional Notes

This PR is a follow up of https://github.com/DataDog/integrations-core/pull/16187 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
