### PR TITLE
feat(php_fpm): track maximum active processes

### DIFF
--- a/php_fpm/changelog.d/16193.added
+++ b/php_fpm/changelog.d/16193.added
@@ -1,0 +1,1 @@
+Added support for max_active_processes metric

--- a/php_fpm/datadog_checks/php_fpm/php_fpm.py
+++ b/php_fpm/datadog_checks/php_fpm/php_fpm.py
@@ -59,6 +59,7 @@ class PHPFPMCheck(AgentCheck):
         'idle processes': 'php_fpm.processes.idle',
         'active processes': 'php_fpm.processes.active',
         'total processes': 'php_fpm.processes.total',
+        'max active processes': 'php_fpm.processes.max_active',
     }
 
     MONOTONIC_COUNTS = {

--- a/php_fpm/tests/test_e2e.py
+++ b/php_fpm/tests/test_e2e.py
@@ -21,6 +21,7 @@ def test_status(dd_agent_check, instance, ping_url_tag):
         'php_fpm.requests.slow',
         'php_fpm.requests.accepted',
         'php_fpm.processes.max_reached',
+        'php_fpm.processes.max_active',
         'php_fpm.status.duration',
     ]
 
@@ -45,6 +46,7 @@ def test_status_fastcgi(dd_agent_check, instance_fastcgi, ping_url_tag_fastcgi):
         'php_fpm.requests.slow',
         'php_fpm.requests.accepted',
         'php_fpm.processes.max_reached',
+        'php_fpm.processes.max_active',
         'php_fpm.status.duration',
     ]
 


### PR DESCRIPTION
### What does this PR do?

The PHP-FPM status page also provides the "max active processes" statistic, which translates to the maximum number of processes that can be executed at once. This is particularly useful in understanding saturation within the PHP-FPM container, in a manner that allows horizontal scaling in a more intelligent way than the built-in CPU and memory metrics in Kubernetes. This pairs well with the Datadog External Metrics functionality as well

### Motivation

We turned on the External Metrics functionality with Datadog. I wanted to implement saturation-based scaling signals that the Datadog Agent provides through the various `php_fpm.*` metrics, but unfortunately there isn't a metric yet for detecting the maximum number of workers yet. So, here it is! 

### Additional Notes

I've been going off of the status pages for our internal PHP-FPM pods, an example of the `/status` output:

```json
{
  "pool": "www",
  "process manager": "dynamic",
  "start time": 1699639472,
  "start since": 8056,
  "accepted conn": 3006,
  "listen queue": 0,
  "max listen queue": 0,
  "listen queue len": 511,
  "idle processes": 4,
  "active processes": 1,
  "total processes": 5,
  "max active processes": 9,
  "max children reached": 0,
  "slow requests": 0
}
```

I went with `php_fpm.processes.max` but we could change this to `php_fpm.processes.max_active` to tie it closer to the actual name.

Lastly, a [support ticket was opened](https://help.datadoghq.com/hc/en-us/requests/1429779) for this feature request

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
