### PR TITLE
INCIDENT-23437 Always resolve hostname regardless or dbm or generic tags enabled or not

### DIFF
--- a/postgres/changelog.d/16199.changed
+++ b/postgres/changelog.d/16199.changed
@@ -1,0 +1,1 @@
+INCIDENT-23437 Always resolve hostname instead of returning agent hostname regardless or dbm or generic tags enabled or not

--- a/postgres/changelog.d/16199.changed
+++ b/postgres/changelog.d/16199.changed
@@ -1,1 +1,1 @@
-INCIDENT-23437 Always resolve hostname instead of returning agent hostname regardless or dbm or generic tags enabled or not
+Always use the database instance's resolved hostname for metrics regardless of how dbm and disable_generic_tags is set. For non-dbm customers or users of disable_generic_tags, this change will result in the host tag having a different value than before. It is possible that dashboards and monitors using the integration's metrics will need to be updated if they relied on the faulty host tagging.

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -389,10 +389,8 @@ class PostgreSql(AgentCheck):
         if self._resolved_hostname is None:
             if self._config.reported_hostname:
                 self._resolved_hostname = self._config.reported_hostname
-            elif self._config.dbm_enabled or self.disable_generic_tags:
-                self._resolved_hostname = self.resolve_db_host()
             else:
-                self._resolved_hostname = self.agent_hostname
+                self._resolved_hostname = self.resolve_db_host()            
         return self._resolved_hostname
 
     def set_resolved_hostname_metadata(self):

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -390,7 +390,7 @@ class PostgreSql(AgentCheck):
             if self._config.reported_hostname:
                 self._resolved_hostname = self._config.reported_hostname
             else:
-                self._resolved_hostname = self.resolve_db_host()            
+                self._resolved_hostname = self.resolve_db_host()
         return self._resolved_hostname
 
     def set_resolved_hostname_metadata(self):

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -585,7 +585,7 @@ def test_config_tags_is_unchanged_between_checks(integration_check, pg_instance)
     'dbm_enabled, reported_hostname, expected_hostname',
     [
         (True, '', 'resolved.hostname'),
-        (False, '', 'stubbed.hostname'),
+        (False, '', 'resolved.hostname'),
         (False, 'forced_hostname', 'forced_hostname'),
         (True, 'forced_hostname', 'forced_hostname'),
     ],
@@ -609,7 +609,7 @@ def test_correct_hostname(dbm_enabled, reported_hostname, expected_hostname, agg
         if reported_hostname:
             assert resolve_db_host.called is False, 'Expected resolve_db_host.called to be False'
         else:
-            assert resolve_db_host.called == dbm_enabled, 'Expected resolve_db_host.called to be ' + str(dbm_enabled)
+            assert resolve_db_host.called is True
 
     expected_tags_no_db = _get_expected_tags(check, pg_instance, server=HOST)
     expected_tags_with_db = expected_tags_no_db + ['db:datadog_test']

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -353,7 +353,7 @@ def test_server_tag_(disable_generic_tags, expected_tags, pg_instance):
 
 
 @pytest.mark.parametrize(
-    'disable_generic_tags, expected_hostname', [(True, 'resolved.hostname'), (False, 'stubbed.hostname')]
+    'disable_generic_tags, expected_hostname', [(True, 'resolved.hostname'), (False, 'resolved.hostname')]
 )
 def test_resolved_hostname(disable_generic_tags, expected_hostname, pg_instance):
     instance = copy.deepcopy(pg_instance)
@@ -364,6 +364,4 @@ def test_resolved_hostname(disable_generic_tags, expected_hostname, pg_instance)
     ) as resolve_db_host_mock:
         check = PostgreSql('test_instance', {}, [instance])
         assert check.resolved_hostname == expected_hostname
-        assert resolve_db_host_mock.called == disable_generic_tags, 'Expected resolve_db_host.called to be ' + str(
-            disable_generic_tags
-        )
+        assert resolve_db_host_mock.called is True


### PR DESCRIPTION
### What does this PR do?
This change makes sure that the check's `resolved_hostname` always represents the database instance. The previous behavior of the `resolved_hostname` property was to use the agent hostname as the `host` when dbm was disabled or `disable_generic_tags` was enabled. This caused issues when, with agent 7.48.0, we started sending `database_instance` metadata. With the `agent_hostname` being used instance of each instance's host value, agents with multiple databases being monitored would end up creating and clobbering the same `database_instance` which, in turn, caused tag interference between database instances monitored by the same agent. 

Very importantly, that problem surfaced the broken experience when dbm is disabled in regards to the host used on integration metrics: instead of having the postgres metrics tagged by the database instance's host, they were tagged by the agent hostname which would only be correct when the agent is running on the same host as the database. 

Here is an example showing this deployment of a GCP cloud sql database instance with dbm disabled:
```
  - dbms: postgres
    dbms_version: cloudsql-postgres-15-sandbox
    cloud: true
    instances:
      - host: '10.x.x.x'
        dbm: false
        port: 5432
        ssl: "allow"   
        autodiscovery_exclude:
          - cloudsqladmin
```

This, running in kubernetes, was deployed on a pod / host named `postgres-f06e6baf-7cb8dcd888-tmds4`. 
Looking at the metrics emitted by the integration, we can see that the host tag is `postgres-f06e6baf-7cb8dcd888-tmds4`, the agent host`, rather than `10.x.x.x`. 
<img width="838" alt="Screenshot 2023-11-13 at 3 53 47 PM" src="https://github.com/DataDog/integrations-core/assets/788439/099851a0-f225-47d2-b9a9-f38f40ae0a25">


Note that this is going to be a breaking change but given the currently broken experience, this is something we want to do in order to improve the experience _and_ to avoid potential future incidents resulting in the confusing implementation of `resolved_hostname`. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
* We considered an alternative of creating a new property (`database_instance_name`) that would be used for everything except the core integration metrics. It would essentially be the same implementation as the resolved_hostname property from this PR but would leave `resolved_hostname` as-is. We decided to go with the better approach of fixing the broken experience at the risk of causing friction for users relying on that broken behavior.

* It's also worth noting that the experience for aws rds instances was _less_ broken than others because of some custom inference of additional host, hostname and aws tags [here](https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/config.py#L167-L170). The metric points were still _also_ tagged with the monitoring agent's hostname which was not correct but easier to deal with when filtering on aws rds instance was possible. 

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
