### PR TITLE
Use params argument over manual url encoding for requests with query params

### DIFF
--- a/openstack_controller/changelog.d/16200.fixed
+++ b/openstack_controller/changelog.d/16200.fixed
@@ -1,0 +1,1 @@
+Use params arg over manual url encoding for requests with query params

--- a/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
+++ b/openstack_controller/datadog_checks/openstack_controller/api/api_rest.py
@@ -195,10 +195,9 @@ class ApiRest(Api):
         return response.json().get('limits', [])
 
     def get_compute_limits(self, project_id):
+        params = {'tenant_id': project_id}
         response = self.http.get(
-            '{}/limits?tenant_id={}'.format(
-                self._catalog.get_endpoint_by_type(Component.Types.COMPUTE.value), project_id
-            )
+            '{}/limits'.format(self._catalog.get_endpoint_by_type(Component.Types.COMPUTE.value)), params=params
         )
         response.raise_for_status()
         return response.json().get('limits', {})
@@ -218,10 +217,9 @@ class ApiRest(Api):
         return response.json().get('quota_set', {})
 
     def get_compute_servers(self, project_id):
+        params = {'project_id': project_id}
         response = self.http.get(
-            '{}/servers/detail?project_id={}'.format(
-                self._catalog.get_endpoint_by_type(Component.Types.COMPUTE.value), project_id
-            )
+            '{}/servers/detail'.format(self._catalog.get_endpoint_by_type(Component.Types.COMPUTE.value)), params=params
         )
         response.raise_for_status()
         return response.json().get('servers', [])
@@ -280,10 +278,9 @@ class ApiRest(Api):
         return response.json().get('agents', [])
 
     def get_network_networks(self, project_id):
+        params = {'project_id': project_id}
         response = self.http.get(
-            '{}/v2.0/networks?project_id={}'.format(
-                self._catalog.get_endpoint_by_type(Component.Types.NETWORK.value), project_id
-            )
+            '{}/v2.0/networks'.format(self._catalog.get_endpoint_by_type(Component.Types.NETWORK.value)), params=params
         )
         response.raise_for_status()
         return response.json().get('networks', [])
@@ -312,12 +309,15 @@ class ApiRest(Api):
             return legacy_microversion
 
         self.log.debug("getting baremetal nodes [microversion=%s]", self.config.ironic_microversion)
-        response = self.http.get(
-            '{}/v1/{}'.format(
-                self._catalog.get_endpoint_by_type(Component.Types.BAREMETAL.value),
-                ('nodes/detail' if use_legacy_nodes_resource(self.config.ironic_microversion) else 'nodes?detail=True'),
-            )
-        )
+        ironic_endpoint = self._catalog.get_endpoint_by_type(Component.Types.BAREMETAL.value)
+
+        if use_legacy_nodes_resource(self.config.ironic_microversion):
+            response = self.http.get('{}/v1/nodes/detail'.format(ironic_endpoint))
+        else:
+            params = {'detail': True}
+
+            response = self.http.get('{}/v1/nodes'.format(ironic_endpoint), params=params)
+
         response.raise_for_status()
         return response.json().get('nodes', [])
 
@@ -329,10 +329,10 @@ class ApiRest(Api):
         return response.json().get('conductors', [])
 
     def get_load_balancer_loadbalancers(self, project_id):
+        params = {'project_id': project_id}
         response = self.http.get(
-            '{}/v2/lbaas/loadbalancers?project_id={}'.format(
-                self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value), project_id
-            )
+            '{}/v2/lbaas/loadbalancers'.format(self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value)),
+            params=params,
         )
         response.raise_for_status()
         return response.json().get('loadbalancers', [])
@@ -347,10 +347,10 @@ class ApiRest(Api):
         return response.json().get('stats', {})
 
     def get_load_balancer_listeners(self, project_id):
+        params = {'project_id': project_id}
         response = self.http.get(
-            '{}/v2/lbaas/listeners?project_id={}'.format(
-                self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value), project_id
-            )
+            '{}/v2/lbaas/listeners'.format(self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value)),
+            params=params,
         )
         response.raise_for_status()
         return response.json().get('listeners', [])
@@ -365,46 +365,50 @@ class ApiRest(Api):
         return response.json().get('stats', {})
 
     def get_load_balancer_pools(self, project_id):
+        params = {'project_id': project_id}
         response = self.http.get(
-            '{}/v2/lbaas/pools?project_id={}'.format(
-                self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value), project_id
-            )
+            '{}/v2/lbaas/pools'.format(self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value)),
+            params=params,
         )
         response.raise_for_status()
         return response.json().get('pools', [])
 
     def get_load_balancer_pool_members(self, pool_id, project_id):
+        params = {'project_id': project_id}
         response = self.http.get(
-            '{}/v2/lbaas/pools/{}/members?project_id={}'.format(
-                self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value), pool_id, project_id
-            )
+            '{}/v2/lbaas/pools/{}/members'.format(
+                self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value), pool_id
+            ),
+            params=params,
         )
         response.raise_for_status()
         return response.json().get('members', [])
 
     def get_load_balancer_healthmonitors(self, project_id):
+        params = {'project_id': project_id}
         response = self.http.get(
-            '{}/v2/lbaas/healthmonitors?project_id={}'.format(
-                self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value), project_id
-            )
+            '{}/v2/lbaas/healthmonitors'.format(
+                self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value)
+            ),
+            params=params,
         )
         response.raise_for_status()
         return response.json().get('healthmonitors', [])
 
     def get_load_balancer_quotas(self, project_id):
+        params = {'project_id': project_id}
         response = self.http.get(
-            '{}/v2/lbaas/quotas?project_id={}'.format(
-                self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value), project_id
-            )
+            '{}/v2/lbaas/quotas'.format(self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value)),
+            params=params,
         )
         response.raise_for_status()
         return response.json().get('quotas', [])
 
     def get_load_balancer_amphorae(self, project_id):
+        params = {'project_id': project_id}
         response = self.http.get(
-            '{}/v2/octavia/amphorae?project_id={}'.format(
-                self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value), project_id
-            )
+            '{}/v2/octavia/amphorae'.format(self._catalog.get_endpoint_by_type(Component.Types.LOAD_BALANCER.value)),
+            params=params,
         )
         response.raise_for_status()
         return response.json().get('amphorae', [])

--- a/openstack_controller/tests/conftest.py
+++ b/openstack_controller/tests/conftest.py
@@ -163,16 +163,21 @@ def mock_responses(microversion_headers):
         for ironic_subdir in ironic_subdirs:
             process_dir(ironic_subdir, responses_map)
 
-    def method(method, url, file='response', headers=None):
+    def method(method, url, file='response', headers=None, params=None):
         filename = file
-        url = url.replace("?", "/")
-        if any(re.search(pattern, url) for pattern in NOVA_ENDPOINTS):
+        request_path = url
+        request_path = request_path.replace('?', '/')
+        if params is not None:
+            param_string = '/'.join('{}={}'.format(key, str(val)) for key, val in params.items())
+            request_path = '{}/{}'.format(url, param_string)
+        if any(re.search(pattern, request_path) for pattern in NOVA_ENDPOINTS):
             microversion = headers.get('X-OpenStack-Nova-API-Version') if headers else microversion_headers[0]
             filename = f'{file}-{microversion}' if microversion else file
-        if any(re.search(pattern, url) for pattern in IRONIC_ENDPOINTS):
+        if any(re.search(pattern, request_path) for pattern in IRONIC_ENDPOINTS):
             microversion = headers.get('X-OpenStack-Ironic-API-Version') if headers else microversion_headers[1]
             filename = f'{file}-{microversion}' if microversion else file
-        response = responses_map.get(method, {}).get(url, {}).get(filename)
+
+        response = responses_map.get(method, {}).get(request_path, {}).get(filename)
         return response
 
     create_responses_tree()
@@ -181,8 +186,8 @@ def mock_responses(microversion_headers):
 
 @pytest.fixture
 def mock_http_call(mock_responses):
-    def call(method, url, file='response', headers=None):
-        response = mock_responses(method, url, file=file, headers=headers)
+    def call(method, url, file='response', headers=None, params=None):
+        response = mock_responses(method, url, file=file, headers=headers, params=params)
         if response:
             return response
         http_response = requests.models.Response()
@@ -768,7 +773,7 @@ def mock_http_get(request, monkeypatch, mock_http_call):
         url = get_url_path(url)
         if http_error and url in http_error:
             raise requests.exceptions.HTTPError(response=http_error[url])
-        json_data = mock_http_call(method, url, headers=kwargs.get('headers'))
+        json_data = mock_http_call(method, url, headers=kwargs.get('headers'), params=kwargs.get('params'))
         return MockResponse(json_data=json_data, status_code=200)
 
     mock_get = mock.MagicMock(side_effect=get)

--- a/openstack_controller/tests/test_unit_neutron.py
+++ b/openstack_controller/tests/test_unit_neutron.py
@@ -510,7 +510,7 @@ def test_networks_exception(aggregator, check, dd_run_check, mock_http_get, conn
         args_list = []
         for call in mock_http_get.call_args_list:
             args, kwargs = call
-            project_id = kwargs.get('params', {}).get('project_id', None)
+            project_id = kwargs.get('params', {}).get('project_id')
             args_list += [(list(args), project_id)]
 
         assert (

--- a/openstack_controller/tests/test_unit_neutron.py
+++ b/openstack_controller/tests/test_unit_neutron.py
@@ -514,11 +514,11 @@ def test_networks_exception(aggregator, check, dd_run_check, mock_http_get, conn
             args_list += [(list(args), project_id)]
 
         assert (
-            args_list.count((['http://127.0.0.1:9696/networking/v2.0/networks'], '6e39099cccde4f809b003d9e0dd09304'))
+            args_list.count((['http://127.0.0.1:9696/networking/v2.0/networks'], '1e6e233e637d4d55a50a62b63398ad15'))
             == 1
         )
         assert (
-            args_list.count((['http://127.0.0.1:9696/networking/v2.0/networks'], '1e6e233e637d4d55a50a62b63398ad15'))
+            args_list.count((['http://127.0.0.1:9696/networking/v2.0/networks'], '6e39099cccde4f809b003d9e0dd09304'))
             == 1
         )
 

--- a/openstack_controller/tests/test_unit_neutron.py
+++ b/openstack_controller/tests/test_unit_neutron.py
@@ -509,9 +509,19 @@ def test_networks_exception(aggregator, check, dd_run_check, mock_http_get, conn
     if api_type == ApiType.REST:
         args_list = []
         for call in mock_http_get.call_args_list:
-            args, _ = call
-            args_list += list(args)
-        assert args_list.count('http://127.0.0.1:9696/networking/v2.0/networks') == 2
+            args, kwargs = call
+            project_id = kwargs.get('params', {}).get('project_id', None)
+            args_list += [(list(args), project_id)]
+
+        assert (
+            args_list.count((['http://127.0.0.1:9696/networking/v2.0/networks'], '6e39099cccde4f809b003d9e0dd09304'))
+            == 1
+        )
+        assert (
+            args_list.count((['http://127.0.0.1:9696/networking/v2.0/networks'], '1e6e233e637d4d55a50a62b63398ad15'))
+            == 1
+        )
+
     if api_type == ApiType.SDK:
         assert connection_network.networks.call_count == 2
         assert (

--- a/openstack_controller/tests/test_unit_neutron.py
+++ b/openstack_controller/tests/test_unit_neutron.py
@@ -474,12 +474,7 @@ def test_disable_quotas_collect_for_all_projects(aggregator, dd_run_check, insta
         pytest.param(
             {
                 'http_error': {
-                    '/networking/v2.0/networks?project_id=1e6e233e637d4d55a50a62b63398ad15': MockResponse(
-                        status_code=500
-                    ),
-                    '/networking/v2.0/networks?project_id=6e39099cccde4f809b003d9e0dd09304': MockResponse(
-                        status_code=500
-                    ),
+                    '/networking/v2.0/networks': MockResponse(status_code=500),
                 }
             },
             None,
@@ -516,18 +511,7 @@ def test_networks_exception(aggregator, check, dd_run_check, mock_http_get, conn
         for call in mock_http_get.call_args_list:
             args, _ = call
             args_list += list(args)
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9696/networking/v2.0/networks?project_id=1e6e233e637d4d55a50a62b63398ad15'
-            )
-            == 1
-        )
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9696/networking/v2.0/networks?project_id=6e39099cccde4f809b003d9e0dd09304'
-            )
-            == 1
-        )
+        assert args_list.count('http://127.0.0.1:9696/networking/v2.0/networks') == 2
     if api_type == ApiType.SDK:
         assert connection_network.networks.call_count == 2
         assert (

--- a/openstack_controller/tests/test_unit_nova.py
+++ b/openstack_controller/tests/test_unit_nova.py
@@ -1719,7 +1719,6 @@ def test_servers_exception(aggregator, check, dd_run_check, mock_http_get, conne
             == 1
         )
 
-
     if api_type == ApiType.SDK:
         assert connection_compute.servers.call_count == 2
         assert (

--- a/openstack_controller/tests/test_unit_nova.py
+++ b/openstack_controller/tests/test_unit_nova.py
@@ -504,8 +504,7 @@ def test_response_time(aggregator, check, dd_run_check, mock_http_get):
         pytest.param(
             {
                 'http_error': {
-                    '/compute/v2.1/limits?tenant_id=1e6e233e637d4d55a50a62b63398ad15': MockResponse(status_code=500),
-                    '/compute/v2.1/limits?tenant_id=6e39099cccde4f809b003d9e0dd09304': MockResponse(status_code=500),
+                    '/compute/v2.1/limits': MockResponse(status_code=500),
                 }
             },
             None,
@@ -554,7 +553,7 @@ def test_limits_exception(aggregator, check, dd_run_check, mock_http_get, connec
         for call in mock_http_get.call_args_list:
             args, _ = call
             args_list += list(args)
-        num_calls = sum('http://127.0.0.1:8774/compute/v2.1/limits?tenant_id=' in arg for arg in args_list)
+        num_calls = sum('http://127.0.0.1:8774/compute/v2.1/limits' in arg for arg in args_list)
         assert num_calls == 2
     if api_type == ApiType.SDK:
         assert connection_compute.get_limits.call_count == 2
@@ -1670,12 +1669,7 @@ def test_quota_sets_metrics_excluding_demo_project(aggregator, check, dd_run_che
         pytest.param(
             {
                 'http_error': {
-                    '/compute/v2.1/servers/detail?project_id=1e6e233e637d4d55a50a62b63398ad15': MockResponse(
-                        status_code=500
-                    ),
-                    '/compute/v2.1/servers/detail?project_id=6e39099cccde4f809b003d9e0dd09304': MockResponse(
-                        status_code=500
-                    ),
+                    '/compute/v2.1/servers/detail': MockResponse(status_code=500),
                 }
             },
             None,
@@ -1712,18 +1706,8 @@ def test_servers_exception(aggregator, check, dd_run_check, mock_http_get, conne
         for call in mock_http_get.call_args_list:
             args, _ = call
             args_list += list(args)
-        assert (
-            args_list.count(
-                'http://127.0.0.1:8774/compute/v2.1/servers/detail?project_id=1e6e233e637d4d55a50a62b63398ad15'
-            )
-            == 1
-        )
-        assert (
-            args_list.count(
-                'http://127.0.0.1:8774/compute/v2.1/servers/detail?project_id=6e39099cccde4f809b003d9e0dd09304'
-            )
-            == 1
-        )
+        assert args_list.count('http://127.0.0.1:8774/compute/v2.1/servers/detail') == 2
+
     if api_type == ApiType.SDK:
         assert connection_compute.servers.call_count == 2
         assert (
@@ -1792,18 +1776,7 @@ def test_servers_disable_call(aggregator, check, dd_run_check, mock_http_get, co
         for call in mock_http_get.call_args_list:
             args, _ = call
             args_list += list(args)
-        assert (
-            args_list.count(
-                'http://127.0.0.1:8774/compute/v2.1/servers/detail?project_id=1e6e233e637d4d55a50a62b63398ad15'
-            )
-            == 0
-        )
-        assert (
-            args_list.count(
-                'http://127.0.0.1:8774/compute/v2.1/servers/detail?project_id=6e39099cccde4f809b003d9e0dd09304'
-            )
-            == 1
-        )
+        assert args_list.count('http://127.0.0.1:8774/compute/v2.1/servers/detail') == 1
     if api_type == ApiType.SDK:
         assert connection_compute.servers.call_count == 1
         assert (

--- a/openstack_controller/tests/test_unit_nova.py
+++ b/openstack_controller/tests/test_unit_nova.py
@@ -552,7 +552,7 @@ def test_limits_exception(aggregator, check, dd_run_check, mock_http_get, connec
         args_list = []
         for call in mock_http_get.call_args_list:
             args, kwargs = call
-            tenant_id = kwargs.get('params', {}).get('tenant_id', None)
+            tenant_id = kwargs.get('params', {}).get('tenant_id')
             args_list += [(list(args), tenant_id)]
 
         assert args_list.count((['http://127.0.0.1:8774/compute/v2.1/limits'], '6e39099cccde4f809b003d9e0dd09304')) == 1
@@ -1778,7 +1778,7 @@ def test_servers_disable_call(aggregator, check, dd_run_check, mock_http_get, co
         args_list = []
         for call in mock_http_get.call_args_list:
             args, kwargs = call
-            project_id = kwargs.get('params', {}).get('project_id', None)
+            project_id = kwargs.get('params', {}).get('project_id')
             args_list += [(list(args), project_id)]
 
         assert (

--- a/openstack_controller/tests/test_unit_nova.py
+++ b/openstack_controller/tests/test_unit_nova.py
@@ -555,8 +555,8 @@ def test_limits_exception(aggregator, check, dd_run_check, mock_http_get, connec
             tenant_id = kwargs.get('params', {}).get('tenant_id')
             args_list += [(list(args), tenant_id)]
 
-        assert args_list.count((['http://127.0.0.1:8774/compute/v2.1/limits'], '6e39099cccde4f809b003d9e0dd09304')) == 1
         assert args_list.count((['http://127.0.0.1:8774/compute/v2.1/limits'], '1e6e233e637d4d55a50a62b63398ad15')) == 1
+        assert args_list.count((['http://127.0.0.1:8774/compute/v2.1/limits'], '6e39099cccde4f809b003d9e0dd09304')) == 1
 
     if api_type == ApiType.SDK:
         assert connection_compute.get_limits.call_count == 2
@@ -1718,6 +1718,7 @@ def test_servers_exception(aggregator, check, dd_run_check, mock_http_get, conne
             args_list.count((['http://127.0.0.1:8774/compute/v2.1/servers/detail'], '6e39099cccde4f809b003d9e0dd09304'))
             == 1
         )
+
 
     if api_type == ApiType.SDK:
         assert connection_compute.servers.call_count == 2

--- a/openstack_controller/tests/test_unit_nova.py
+++ b/openstack_controller/tests/test_unit_nova.py
@@ -1707,9 +1707,17 @@ def test_servers_exception(aggregator, check, dd_run_check, mock_http_get, conne
     if api_type == ApiType.REST:
         args_list = []
         for call in mock_http_get.call_args_list:
-            args, _ = call
-            args_list += list(args)
-        assert args_list.count('http://127.0.0.1:8774/compute/v2.1/servers/detail') == 2
+            args, kwargs = call
+            project_id = kwargs.get('params', {}).get('project_id')
+            args_list += [(list(args), project_id)]
+        assert (
+            args_list.count((['http://127.0.0.1:8774/compute/v2.1/servers/detail'], '1e6e233e637d4d55a50a62b63398ad15'))
+            == 1
+        )
+        assert (
+            args_list.count((['http://127.0.0.1:8774/compute/v2.1/servers/detail'], '6e39099cccde4f809b003d9e0dd09304'))
+            == 1
+        )
 
     if api_type == ApiType.SDK:
         assert connection_compute.servers.call_count == 2

--- a/openstack_controller/tests/test_unit_nova.py
+++ b/openstack_controller/tests/test_unit_nova.py
@@ -551,10 +551,13 @@ def test_limits_exception(aggregator, check, dd_run_check, mock_http_get, connec
     if api_type == ApiType.REST:
         args_list = []
         for call in mock_http_get.call_args_list:
-            args, _ = call
-            args_list += list(args)
-        num_calls = sum('http://127.0.0.1:8774/compute/v2.1/limits' in arg for arg in args_list)
-        assert num_calls == 2
+            args, kwargs = call
+            tenant_id = kwargs.get('params', {}).get('tenant_id', None)
+            args_list += [(list(args), tenant_id)]
+
+        assert args_list.count((['http://127.0.0.1:8774/compute/v2.1/limits'], '6e39099cccde4f809b003d9e0dd09304')) == 1
+        assert args_list.count((['http://127.0.0.1:8774/compute/v2.1/limits'], '1e6e233e637d4d55a50a62b63398ad15')) == 1
+
     if api_type == ApiType.SDK:
         assert connection_compute.get_limits.call_count == 2
 
@@ -1774,9 +1777,18 @@ def test_servers_disable_call(aggregator, check, dd_run_check, mock_http_get, co
     if api_type == ApiType.REST:
         args_list = []
         for call in mock_http_get.call_args_list:
-            args, _ = call
-            args_list += list(args)
-        assert args_list.count('http://127.0.0.1:8774/compute/v2.1/servers/detail') == 1
+            args, kwargs = call
+            project_id = kwargs.get('params', {}).get('project_id', None)
+            args_list += [(list(args), project_id)]
+
+        assert (
+            args_list.count((['http://127.0.0.1:8774/compute/v2.1/servers/detail'], '1e6e233e637d4d55a50a62b63398ad15'))
+            == 0
+        )
+        assert (
+            args_list.count((['http://127.0.0.1:8774/compute/v2.1/servers/detail'], '6e39099cccde4f809b003d9e0dd09304'))
+            == 1
+        )
     if api_type == ApiType.SDK:
         assert connection_compute.servers.call_count == 1
         assert (

--- a/openstack_controller/tests/test_unit_octavia.py
+++ b/openstack_controller/tests/test_unit_octavia.py
@@ -601,7 +601,7 @@ def test_loadbalancers_exception(aggregator, check, dd_run_check, mock_http_get,
         args_list = []
         for call in mock_http_get.call_args_list:
             args, kwargs = call
-            project_id = kwargs.get('params', {}).get('project_id', None)
+            project_id = kwargs.get('params', {}).get('project_id')
             args_list += [(list(args), project_id)]
 
         assert (
@@ -804,7 +804,7 @@ def test_listeners_exception(aggregator, check, dd_run_check, mock_http_get, con
         args_list = []
         for call in mock_http_get.call_args_list:
             args, kwargs = call
-            project_id = kwargs.get('params', {}).get('project_id', None)
+            project_id = kwargs.get('params', {}).get('project_id')
             args_list += [(list(args), project_id)]
 
         assert (
@@ -1390,7 +1390,7 @@ def test_pools_exception(aggregator, dd_run_check, check, mock_http_get, connect
         args_list = []
         for call in mock_http_get.call_args_list:
             args, kwargs = call
-            project_id = kwargs.get('params', {}).get('project_id', None)
+            project_id = kwargs.get('params', {}).get('project_id')
             args_list += [(list(args), project_id)]
 
         assert (
@@ -1498,7 +1498,7 @@ def test_pool_members_exception(aggregator, check, dd_run_check, mock_http_get, 
         args_list = []
         for call in mock_http_get.call_args_list:
             args, kwargs = call
-            project_id = kwargs.get('params', {}).get('project_id', None)
+            project_id = kwargs.get('params', {}).get('project_id')
             args_list += [(list(args), project_id)]
 
         assert (
@@ -1672,7 +1672,7 @@ def test_healthmonitors_exception(aggregator, check, dd_run_check, mock_http_get
         args_list = []
         for call in mock_http_get.call_args_list:
             args, kwargs = call
-            project_id = kwargs.get('params', {}).get('project_id', None)
+            project_id = kwargs.get('params', {}).get('project_id')
             args_list += [(list(args), project_id)]
 
         assert (
@@ -1842,7 +1842,7 @@ def test_quotas_exception(aggregator, check, dd_run_check, mock_http_get, connec
         args_list = []
         for call in mock_http_get.call_args_list:
             args, kwargs = call
-            project_id = kwargs.get('params', {}).get('project_id', None)
+            project_id = kwargs.get('params', {}).get('project_id')
             args_list += [(list(args), project_id)]
 
         assert (
@@ -2133,7 +2133,7 @@ def test_amphorae_exception(aggregator, check, dd_run_check, mock_http_get, conn
         args_list = []
         for call in mock_http_get.call_args_list:
             args, kwargs = call
-            project_id = kwargs.get('params', {}).get('project_id', None)
+            project_id = kwargs.get('params', {}).get('project_id')
             args_list += [(list(args), project_id)]
 
         assert (

--- a/openstack_controller/tests/test_unit_octavia.py
+++ b/openstack_controller/tests/test_unit_octavia.py
@@ -1395,13 +1395,13 @@ def test_pools_exception(aggregator, dd_run_check, check, mock_http_get, connect
 
         assert (
             args_list.count(
-                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/pools'], '6e39099cccde4f809b003d9e0dd09304')
+                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/pools'], '1e6e233e637d4d55a50a62b63398ad15')
             )
             == 1
         )
         assert (
             args_list.count(
-                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/pools'], '1e6e233e637d4d55a50a62b63398ad15')
+                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/pools'], '6e39099cccde4f809b003d9e0dd09304')
             )
             == 1
         )
@@ -1505,7 +1505,7 @@ def test_pool_members_exception(aggregator, check, dd_run_check, mock_http_get, 
             args_list.count(
                 (
                     ['http://127.0.0.1:9876/load-balancer/v2/lbaas/pools/d0335b34-3115-4b3b-9a1a-7e2363ebfee3/members'],
-                    '6e39099cccde4f809b003d9e0dd09304',
+                    '1e6e233e637d4d55a50a62b63398ad15',
                 )
             )
             == 0
@@ -1514,7 +1514,7 @@ def test_pool_members_exception(aggregator, check, dd_run_check, mock_http_get, 
             args_list.count(
                 (
                     ['http://127.0.0.1:9876/load-balancer/v2/lbaas/pools/d0335b34-3115-4b3b-9a1a-7e2363ebfee3/members'],
-                    '1e6e233e637d4d55a50a62b63398ad15',
+                    '6e39099cccde4f809b003d9e0dd09304',
                 )
             )
             == 1

--- a/openstack_controller/tests/test_unit_octavia.py
+++ b/openstack_controller/tests/test_unit_octavia.py
@@ -565,12 +565,7 @@ def test_response_time(aggregator, check, dd_run_check, mock_http_get):
         pytest.param(
             {
                 'http_error': {
-                    '/load-balancer/v2/lbaas/loadbalancers?project_id=1e6e233e637d4d55a50a62b63398ad15': MockResponse(
-                        status_code=500
-                    ),
-                    '/load-balancer/v2/lbaas/loadbalancers?project_id=6e39099cccde4f809b003d9e0dd09304': MockResponse(
-                        status_code=500
-                    ),
+                    '/load-balancer/v2/lbaas/loadbalancers': MockResponse(status_code=500),
                 }
             },
             None,
@@ -607,18 +602,7 @@ def test_loadbalancers_exception(aggregator, check, dd_run_check, mock_http_get,
         for call in mock_http_get.call_args_list:
             args, _ = call
             args_list += list(args)
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/lbaas/loadbalancers?project_id=1e6e233e637d4d55a50a62b63398ad15'
-            )
-            == 1
-        )
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/lbaas/loadbalancers?project_id=6e39099cccde4f809b003d9e0dd09304'
-            )
-            == 1
-        )
+        assert args_list.count('http://127.0.0.1:9876/load-balancer/v2/lbaas/loadbalancers') == 2
     if api_type == ApiType.SDK:
         assert connection_load_balancer.load_balancers.call_count == 2
         assert (
@@ -771,12 +755,7 @@ def test_loadbalancers_metrics(aggregator, check, dd_run_check):
         pytest.param(
             {
                 'http_error': {
-                    '/load-balancer/v2/lbaas/listeners?project_id=1e6e233e637d4d55a50a62b63398ad15': MockResponse(
-                        status_code=500
-                    ),
-                    '/load-balancer/v2/lbaas/listeners?project_id=6e39099cccde4f809b003d9e0dd09304': MockResponse(
-                        status_code=500
-                    ),
+                    '/load-balancer/v2/lbaas/listeners': MockResponse(status_code=500),
                 }
             },
             None,
@@ -813,18 +792,7 @@ def test_listeners_exception(aggregator, check, dd_run_check, mock_http_get, con
         for call in mock_http_get.call_args_list:
             args, _ = call
             args_list += list(args)
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/lbaas/listeners?project_id=1e6e233e637d4d55a50a62b63398ad15'
-            )
-            == 1
-        )
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/lbaas/listeners?project_id=6e39099cccde4f809b003d9e0dd09304'
-            )
-            == 1
-        )
+        assert args_list.count('http://127.0.0.1:9876/load-balancer/v2/lbaas/listeners') == 2
     if api_type == ApiType.SDK:
         assert connection_load_balancer.listeners.call_count == 2
         assert (
@@ -1360,12 +1328,7 @@ def test_listeners_metrics(aggregator, check, dd_run_check):
         pytest.param(
             {
                 'http_error': {
-                    '/load-balancer/v2/lbaas/pools?project_id=1e6e233e637d4d55a50a62b63398ad15': MockResponse(
-                        status_code=500
-                    ),
-                    '/load-balancer/v2/lbaas/pools?project_id=6e39099cccde4f809b003d9e0dd09304': MockResponse(
-                        status_code=500
-                    ),
+                    '/load-balancer/v2/lbaas/pools': MockResponse(status_code=500),
                 }
             },
             None,
@@ -1402,18 +1365,7 @@ def test_pools_exception(aggregator, dd_run_check, check, mock_http_get, connect
         for call in mock_http_get.call_args_list:
             args, _ = call
             args_list += list(args)
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/lbaas/pools?project_id=1e6e233e637d4d55a50a62b63398ad15'
-            )
-            == 1
-        )
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/lbaas/pools?project_id=6e39099cccde4f809b003d9e0dd09304'
-            )
-            == 1
-        )
+        assert args_list.count('http://127.0.0.1:9876/load-balancer/v2/lbaas/pools') == 2
     if api_type == ApiType.SDK:
         assert connection_load_balancer.pools.call_count == 2
         assert (
@@ -1470,8 +1422,9 @@ def test_pools_metrics(aggregator, check, dd_run_check):
         pytest.param(
             {
                 'http_error': {
-                    '/load-balancer/v2/lbaas/pools/d0335b34-3115-4b3b-9a1a-7e2363ebfee3/members'
-                    '?project_id=1e6e233e637d4d55a50a62b63398ad15': MockResponse(status_code=500),
+                    '/load-balancer/v2/lbaas/pools/d0335b34-3115-4b3b-9a1a-7e2363ebfee3/members': MockResponse(
+                        status_code=500
+                    ),
                 }
             },
             None,
@@ -1509,8 +1462,7 @@ def test_pool_members_exception(aggregator, check, dd_run_check, mock_http_get, 
             args_list += list(args)
         assert (
             args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/lbaas/pools/d0335b34-3115-4b3b-9a1a-7e2363ebfee3'
-                '/members?project_id=1e6e233e637d4d55a50a62b63398ad15'
+                'http://127.0.0.1:9876/load-balancer/v2/lbaas/pools/d0335b34-3115-4b3b-9a1a-7e2363ebfee3' '/members'
             )
             == 1
         )
@@ -1631,12 +1583,7 @@ def test_pool_members_metrics(aggregator, check, dd_run_check):
         pytest.param(
             {
                 'http_error': {
-                    '/load-balancer/v2/lbaas/healthmonitors?project_id=1e6e233e637d4d55a50a62b63398ad15': MockResponse(
-                        status_code=500
-                    ),
-                    '/load-balancer/v2/lbaas/healthmonitors?project_id=6e39099cccde4f809b003d9e0dd09304': MockResponse(
-                        status_code=500
-                    ),
+                    '/load-balancer/v2/lbaas/healthmonitors': MockResponse(status_code=500),
                 }
             },
             None,
@@ -1673,18 +1620,8 @@ def test_healthmonitors_exception(aggregator, check, dd_run_check, mock_http_get
         for call in mock_http_get.call_args_list:
             args, _ = call
             args_list += list(args)
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/lbaas/healthmonitors?project_id=1e6e233e637d4d55a50a62b63398ad15'
-            )
-            == 1
-        )
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/lbaas/healthmonitors?project_id=6e39099cccde4f809b003d9e0dd09304'
-            )
-            == 1
-        )
+        assert args_list.count('http://127.0.0.1:9876/load-balancer/v2/lbaas/healthmonitors') == 2
+
     if api_type == ApiType.SDK:
         assert (
             connection_load_balancer.health_monitors.call_args_list.count(
@@ -1804,12 +1741,7 @@ def test_healthmonitors_metrics(aggregator, check, dd_run_check):
         pytest.param(
             {
                 'http_error': {
-                    '/load-balancer/v2/lbaas/quotas?project_id=1e6e233e637d4d55a50a62b63398ad15': MockResponse(
-                        status_code=500
-                    ),
-                    '/load-balancer/v2/lbaas/quotas?project_id=6e39099cccde4f809b003d9e0dd09304': MockResponse(
-                        status_code=500
-                    ),
+                    '/load-balancer/v2/lbaas/quotas': MockResponse(status_code=500),
                 }
             },
             None,
@@ -1846,18 +1778,7 @@ def test_quotas_exception(aggregator, check, dd_run_check, mock_http_get, connec
         for call in mock_http_get.call_args_list:
             args, _ = call
             args_list += list(args)
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/lbaas/quotas?project_id=1e6e233e637d4d55a50a62b63398ad15'
-            )
-            == 1
-        )
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/lbaas/quotas?project_id=6e39099cccde4f809b003d9e0dd09304'
-            )
-            == 1
-        )
+        assert args_list.count('http://127.0.0.1:9876/load-balancer/v2/lbaas/quotas') == 2
     if api_type == ApiType.SDK:
         assert connection_load_balancer.quotas.call_count == 2
         assert (
@@ -2098,12 +2019,7 @@ def test_quotas_metrics(aggregator, check, dd_run_check):
         pytest.param(
             {
                 'http_error': {
-                    '/load-balancer/v2/octavia/amphorae?project_id=1e6e233e637d4d55a50a62b63398ad15': MockResponse(
-                        status_code=500
-                    ),
-                    '/load-balancer/v2/octavia/amphorae?project_id=6e39099cccde4f809b003d9e0dd09304': MockResponse(
-                        status_code=500
-                    ),
+                    '/load-balancer/v2/octavia/amphorae': MockResponse(status_code=500),
                 }
             },
             None,
@@ -2140,18 +2056,8 @@ def test_amphorae_exception(aggregator, check, dd_run_check, mock_http_get, conn
         for call in mock_http_get.call_args_list:
             args, _ = call
             args_list += list(args)
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/octavia/amphorae?project_id=1e6e233e637d4d55a50a62b63398ad15'
-            )
-            == 1
-        )
-        assert (
-            args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/octavia/amphorae?project_id=6e39099cccde4f809b003d9e0dd09304'
-            )
-            == 1
-        )
+        assert args_list.count('http://127.0.0.1:9876/load-balancer/v2/octavia/amphorae') == 2
+
     if api_type == ApiType.SDK:
         assert connection_load_balancer.quotas.call_count == 2
         assert (

--- a/openstack_controller/tests/test_unit_octavia.py
+++ b/openstack_controller/tests/test_unit_octavia.py
@@ -600,9 +600,22 @@ def test_loadbalancers_exception(aggregator, check, dd_run_check, mock_http_get,
     if api_type == ApiType.REST:
         args_list = []
         for call in mock_http_get.call_args_list:
-            args, _ = call
-            args_list += list(args)
-        assert args_list.count('http://127.0.0.1:9876/load-balancer/v2/lbaas/loadbalancers') == 2
+            args, kwargs = call
+            project_id = kwargs.get('params', {}).get('project_id', None)
+            args_list += [(list(args), project_id)]
+
+        assert (
+            args_list.count(
+                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/loadbalancers'], '1e6e233e637d4d55a50a62b63398ad15')
+            )
+            == 1
+        )
+        assert (
+            args_list.count(
+                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/loadbalancers'], '6e39099cccde4f809b003d9e0dd09304')
+            )
+            == 1
+        )
     if api_type == ApiType.SDK:
         assert connection_load_balancer.load_balancers.call_count == 2
         assert (
@@ -790,9 +803,22 @@ def test_listeners_exception(aggregator, check, dd_run_check, mock_http_get, con
     if api_type == ApiType.REST:
         args_list = []
         for call in mock_http_get.call_args_list:
-            args, _ = call
-            args_list += list(args)
-        assert args_list.count('http://127.0.0.1:9876/load-balancer/v2/lbaas/listeners') == 2
+            args, kwargs = call
+            project_id = kwargs.get('params', {}).get('project_id', None)
+            args_list += [(list(args), project_id)]
+
+        assert (
+            args_list.count(
+                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/listeners'], '6e39099cccde4f809b003d9e0dd09304')
+            )
+            == 1
+        )
+        assert (
+            args_list.count(
+                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/listeners'], '1e6e233e637d4d55a50a62b63398ad15')
+            )
+            == 1
+        )
     if api_type == ApiType.SDK:
         assert connection_load_balancer.listeners.call_count == 2
         assert (
@@ -1363,9 +1389,22 @@ def test_pools_exception(aggregator, dd_run_check, check, mock_http_get, connect
     if api_type == ApiType.REST:
         args_list = []
         for call in mock_http_get.call_args_list:
-            args, _ = call
-            args_list += list(args)
-        assert args_list.count('http://127.0.0.1:9876/load-balancer/v2/lbaas/pools') == 2
+            args, kwargs = call
+            project_id = kwargs.get('params', {}).get('project_id', None)
+            args_list += [(list(args), project_id)]
+
+        assert (
+            args_list.count(
+                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/pools'], '6e39099cccde4f809b003d9e0dd09304')
+            )
+            == 1
+        )
+        assert (
+            args_list.count(
+                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/pools'], '1e6e233e637d4d55a50a62b63398ad15')
+            )
+            == 1
+        )
     if api_type == ApiType.SDK:
         assert connection_load_balancer.pools.call_count == 2
         assert (
@@ -1458,11 +1497,25 @@ def test_pool_members_exception(aggregator, check, dd_run_check, mock_http_get, 
     if api_type == ApiType.REST:
         args_list = []
         for call in mock_http_get.call_args_list:
-            args, _ = call
-            args_list += list(args)
+            args, kwargs = call
+            project_id = kwargs.get('params', {}).get('project_id', None)
+            args_list += [(list(args), project_id)]
+
         assert (
             args_list.count(
-                'http://127.0.0.1:9876/load-balancer/v2/lbaas/pools/d0335b34-3115-4b3b-9a1a-7e2363ebfee3' '/members'
+                (
+                    ['http://127.0.0.1:9876/load-balancer/v2/lbaas/pools/d0335b34-3115-4b3b-9a1a-7e2363ebfee3/members'],
+                    '6e39099cccde4f809b003d9e0dd09304',
+                )
+            )
+            == 0
+        )
+        assert (
+            args_list.count(
+                (
+                    ['http://127.0.0.1:9876/load-balancer/v2/lbaas/pools/d0335b34-3115-4b3b-9a1a-7e2363ebfee3/members'],
+                    '1e6e233e637d4d55a50a62b63398ad15',
+                )
             )
             == 1
         )
@@ -1618,10 +1671,22 @@ def test_healthmonitors_exception(aggregator, check, dd_run_check, mock_http_get
     if api_type == ApiType.REST:
         args_list = []
         for call in mock_http_get.call_args_list:
-            args, _ = call
-            args_list += list(args)
-        assert args_list.count('http://127.0.0.1:9876/load-balancer/v2/lbaas/healthmonitors') == 2
+            args, kwargs = call
+            project_id = kwargs.get('params', {}).get('project_id', None)
+            args_list += [(list(args), project_id)]
 
+        assert (
+            args_list.count(
+                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/healthmonitors'], '1e6e233e637d4d55a50a62b63398ad15')
+            )
+            == 1
+        )
+        assert (
+            args_list.count(
+                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/healthmonitors'], '6e39099cccde4f809b003d9e0dd09304')
+            )
+            == 1
+        )
     if api_type == ApiType.SDK:
         assert (
             connection_load_balancer.health_monitors.call_args_list.count(
@@ -1776,9 +1841,22 @@ def test_quotas_exception(aggregator, check, dd_run_check, mock_http_get, connec
     if api_type == ApiType.REST:
         args_list = []
         for call in mock_http_get.call_args_list:
-            args, _ = call
-            args_list += list(args)
-        assert args_list.count('http://127.0.0.1:9876/load-balancer/v2/lbaas/quotas') == 2
+            args, kwargs = call
+            project_id = kwargs.get('params', {}).get('project_id', None)
+            args_list += [(list(args), project_id)]
+
+        assert (
+            args_list.count(
+                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/quotas'], '1e6e233e637d4d55a50a62b63398ad15')
+            )
+            == 1
+        )
+        assert (
+            args_list.count(
+                (['http://127.0.0.1:9876/load-balancer/v2/lbaas/quotas'], '6e39099cccde4f809b003d9e0dd09304')
+            )
+            == 1
+        )
     if api_type == ApiType.SDK:
         assert connection_load_balancer.quotas.call_count == 2
         assert (
@@ -2054,9 +2132,22 @@ def test_amphorae_exception(aggregator, check, dd_run_check, mock_http_get, conn
     if api_type == ApiType.REST:
         args_list = []
         for call in mock_http_get.call_args_list:
-            args, _ = call
-            args_list += list(args)
-        assert args_list.count('http://127.0.0.1:9876/load-balancer/v2/octavia/amphorae') == 2
+            args, kwargs = call
+            project_id = kwargs.get('params', {}).get('project_id', None)
+            args_list += [(list(args), project_id)]
+
+        assert (
+            args_list.count(
+                (['http://127.0.0.1:9876/load-balancer/v2/octavia/amphorae'], '1e6e233e637d4d55a50a62b63398ad15')
+            )
+            == 1
+        )
+        assert (
+            args_list.count(
+                (['http://127.0.0.1:9876/load-balancer/v2/octavia/amphorae'], '6e39099cccde4f809b003d9e0dd09304')
+            )
+            == 1
+        )
 
     if api_type == ApiType.SDK:
         assert connection_load_balancer.quotas.call_count == 2

--- a/openstack_controller/tests/test_unit_octavia.py
+++ b/openstack_controller/tests/test_unit_octavia.py
@@ -1508,7 +1508,7 @@ def test_pool_members_exception(aggregator, check, dd_run_check, mock_http_get, 
                     '1e6e233e637d4d55a50a62b63398ad15',
                 )
             )
-            == 0
+            == 1
         )
         assert (
             args_list.count(
@@ -1517,7 +1517,7 @@ def test_pool_members_exception(aggregator, check, dd_run_check, mock_http_get, 
                     '6e39099cccde4f809b003d9e0dd09304',
                 )
             )
-            == 1
+            == 0
         )
     if api_type == ApiType.SDK:
         assert (


### PR DESCRIPTION
### What does this PR do?
Use params arg over manual url encoding for requests with query params 

### Motivation
- will make paginated endpoint support simpler and cleaner
- It's recommended to allow the requests lib to encode the URL rather than manually doing so
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
