### PR TITLE
[DOCS-6660] Editorial review of Karpenter integration doc

### DIFF
--- a/karpenter/README.md
+++ b/karpenter/README.md
@@ -12,7 +12,7 @@ Follow the instructions below to install and configure this check for an Agent r
 
 Starting from Agent release 7.50.0, the Karpenter check is included in the [Datadog Agent][2] package. No additional installation is needed in your environment.
 
-This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoint that TorchServe exposes, which requires Python 3.
+This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoint that Karpenter exposes, which requires Python 3.
 
 ### Configuration
 

--- a/karpenter/README.md
+++ b/karpenter/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This check monitors [Karpenter][1] through the Datadog Agent. For more information, see [Karpenter monitoring][10]
+This check monitors [Karpenter][1] through the Datadog Agent. For more information, see [Karpenter monitoring][10].
 
 ## Setup
 
@@ -12,13 +12,13 @@ Follow the instructions below to install and configure this check for an Agent r
 
 Starting from Agent release 7.50.0, the Karpenter check is included in the [Datadog Agent][2] package. No additional installation is needed in your environment.
 
-This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoint TorchServe can expose, which requires Python 3.
+This check uses [OpenMetrics][5] to collect metrics from the OpenMetrics endpoint that TorchServe exposes, which requires Python 3.
 
 ### Configuration
 
 #### Metric collection
 
-Make sure that the Prometheus-formatted metrics are exposed in your Karpenter cluster and which port. You can configure the port by following the instructions on the [Metrics][10] page in the Karpenter documentation. For the Agent to start collecting metrics, the Karpenter pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample karpenter.d/conf.yaml][4].
+Make sure that the Prometheus-formatted metrics are exposed in your Karpenter cluster and on which port. You can configure the port by following the instructions on the [Metrics][10] page in the Karpenter documentation. For the Agent to start collecting metrics, the Karpenter pods need to be annotated. For more information about annotations, refer to the [Autodiscovery Integration Templates][3] for guidance. You can find additional configuration options by reviewing the [sample karpenter.d/conf.yaml][4].
 
 **Note**: The listed metrics can only be collected if they are available. Some metrics are generated only when certain actions are performed. For example, the `karpenter.nodes.terminated` metric is exposed only after a node is terminated.
 
@@ -75,10 +75,10 @@ Need help? Contact [Datadog support][9].
 
 [1]: https://karpenter.sh/
 [2]: https://app.datadoghq.com/account/settings/agent/latest
-[3]: https://docs.datadoghq.com/agent/kubernetes/integrations/
+[3]: https://docs.datadoghq.com/containers/kubernetes/integrations/
 [4]: https://github.com/DataDog/integrations-core/blob/master/karpenter/datadog_checks/karpenter/data/conf.yaml.example
 [5]: https://docs.datadoghq.com/integrations/openmetrics/
-[6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[6]: https://docs.datadoghq.com/agent/configuration/agent-commands/?tab=agentv6v7#agent-status-and-information
 [7]: https://github.com/DataDog/integrations-core/blob/master/karpenter/metadata.csv
 [8]: https://github.com/DataDog/integrations-core/blob/master/karpenter/assets/service_checks.json
 [9]: https://docs.datadoghq.com/help/

--- a/karpenter/datadog_checks/karpenter/data/conf.yaml.example
+++ b/karpenter/datadog_checks/karpenter/data/conf.yaml.example
@@ -25,7 +25,7 @@ init_config:
 
     ## @param skip_proxy - boolean - optional - default: false
     ## If set to `true`, this makes the check bypass any proxy
-    ## settings enabled and attempt to reach services directly.
+    ## settings enabled and any attempts to reach services directly.
     #
     # skip_proxy: false
 
@@ -108,7 +108,7 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
-    ## In order to exclude all metrics but the ones matching a specific filter,
+    ## To exclude all metrics but the ones matching a specific filter,
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$
     #
@@ -134,7 +134,7 @@ instances:
     ## @param exclude_labels - list of strings - optional
     ## A list of labels to exclude, useful for high cardinality values like timestamps or UUIDs.
     ## May be used in conjunction with `include_labels`.
-    ## Labels defined in `exclude_labels` will take precedence in case of overlap.
+    ## Labels defined in `exclude_labels` take precedence in cases of overlap.
     ##
     ## Note: Label filtering happens before `rename_labels`.
     #
@@ -142,7 +142,7 @@ instances:
 
     ## @param include_labels - list of strings - optional
     ## A list of labels to include. May be used in conjunction with `exclude_labels`.
-    ## Labels defined in `exclude_labels` will take precedence in case of overlap.
+    ## Labels defined in `exclude_labels` take precedence in cases of overlap.
     ##
     ## Note: Label filtering happens before `rename_labels`.
     #
@@ -301,7 +301,7 @@ instances:
     ## This overrides the `skip_proxy` setting in `init_config`.
     ##
     ## If set to `true`, this makes the check bypass any proxy
-    ## settings enabled and attempt to reach services directly.
+    ## settings enabled and any attempts to reach services directly.
     #
     # skip_proxy: false
 
@@ -612,7 +612,7 @@ instances:
     ## @param metric_patterns - mapping - optional
     ## A mapping of metrics to include or exclude, with each entry being a regular expression.
     ##
-    ## Metrics defined in `exclude` will take precedence in case of overlap.
+    ## Metrics defined in `exclude` take precedence in cases of overlap.
     #
     # metric_patterns:
     #   include:

--- a/karpenter/datadog_checks/karpenter/data/conf.yaml.example
+++ b/karpenter/datadog_checks/karpenter/data/conf.yaml.example
@@ -25,7 +25,7 @@ init_config:
 
     ## @param skip_proxy - boolean - optional - default: false
     ## If set to `true`, this makes the check bypass any proxy
-    ## settings enabled and any attempts to reach services directly.
+    ## settings enabled and attempt to reach services directly.
     #
     # skip_proxy: false
 
@@ -108,7 +108,7 @@ instances:
     ## @param exclude_metrics - list of strings - optional
     ## A list of metrics to exclude, with each entry being either
     ## the exact metric name or a regular expression.
-    ## To exclude all metrics but the ones matching a specific filter,
+    ## In order to exclude all metrics but the ones matching a specific filter,
     ## you can use a negative lookahead regex like:
     ##   - ^(?!foo).*$
     #
@@ -134,7 +134,7 @@ instances:
     ## @param exclude_labels - list of strings - optional
     ## A list of labels to exclude, useful for high cardinality values like timestamps or UUIDs.
     ## May be used in conjunction with `include_labels`.
-    ## Labels defined in `exclude_labels` take precedence in cases of overlap.
+    ## Labels defined in `exclude_labels` will take precedence in case of overlap.
     ##
     ## Note: Label filtering happens before `rename_labels`.
     #
@@ -142,7 +142,7 @@ instances:
 
     ## @param include_labels - list of strings - optional
     ## A list of labels to include. May be used in conjunction with `exclude_labels`.
-    ## Labels defined in `exclude_labels` take precedence in cases of overlap.
+    ## Labels defined in `exclude_labels` will take precedence in case of overlap.
     ##
     ## Note: Label filtering happens before `rename_labels`.
     #
@@ -301,7 +301,7 @@ instances:
     ## This overrides the `skip_proxy` setting in `init_config`.
     ##
     ## If set to `true`, this makes the check bypass any proxy
-    ## settings enabled and any attempts to reach services directly.
+    ## settings enabled and attempt to reach services directly.
     #
     # skip_proxy: false
 
@@ -612,7 +612,7 @@ instances:
     ## @param metric_patterns - mapping - optional
     ## A mapping of metrics to include or exclude, with each entry being a regular expression.
     ##
-    ## Metrics defined in `exclude` take precedence in cases of overlap.
+    ## Metrics defined in `exclude` will take precedence in case of overlap.
     #
     # metric_patterns:
     #   include:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

The Karpenter [PR](https://github.com/DataDog/integrations-core/pull/16082) was merged before docs could do an editorial review so I'm opening a PR with a couple editorial edits.

I also updated a couple of links in the doc because the links used were aliases.

### Motivation
<!-- What inspired you to submit this pull request? -->

[DOCS-6660](https://datadoghq.atlassian.net/browse/DOCS-6660)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[DOCS-6660]: https://datadoghq.atlassian.net/browse/DOCS-6660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ