### PR TITLE
PostgreSQL: Exclude manually launched vacuum from pg_stat_activity

### DIFF
--- a/postgres/changelog.d/16206.changed
+++ b/postgres/changelog.d/16206.changed
@@ -1,0 +1,1 @@
+PostgreSQL: Exclude manually launched vacuum from pg_stat_activity metrics

--- a/postgres/datadog_checks/postgres/metrics_cache.py
+++ b/postgres/datadog_checks/postgres/metrics_cache.py
@@ -239,7 +239,7 @@ class PostgresMetricsCache:
                 if '{dd__user}' in q:
                     metrics_query[i] = q.format(dd__user=self.config.user)
 
-            metrics = {k: v for k, v in zip(metrics_query, ACTIVITY_DD_METRICS)}
+            metrics = dict(zip(metrics_query, ACTIVITY_DD_METRICS))
             self.activity_metrics = (metrics, query, descriptors)
         else:
             metrics, query, descriptors = metrics_data

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -481,10 +481,12 @@ SELECT s.schemaname,
 ACTIVITY_METRICS_9_6 = [
     "SUM(CASE WHEN xact_start IS NOT NULL THEN 1 ELSE 0 END)",
     "SUM(CASE WHEN state = 'idle in transaction' THEN 1 ELSE 0 END)",
-    "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{dd__user}'))"
+    "COUNT(CASE WHEN state = 'active' AND (query !~* '^vacuum ' AND query !~ '^autovacuum:' "
+    "AND usename NOT IN ('postgres', '{dd__user}')) THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN wait_event is NOT NULL AND query !~* '^vacuum ' AND query !~ '^autovacuum:' "
     "THEN 1 ELSE null END )",
-    "COUNT(CASE WHEN wait_event is NOT NULL AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
-    "COUNT(CASE WHEN wait_event is NOT NULL AND query !~ '^autovacuum:' AND state = 'active' THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN wait_event is NOT NULL AND query !~* '^vacuum ' AND query !~ '^autovacuum:' AND state = 'active' "
+    "THEN 1 ELSE null END )",
     "max(EXTRACT(EPOCH FROM (clock_timestamp() - xact_start)))",
     "max(age(backend_xid))",
     "max(age(backend_xmin))",
@@ -494,10 +496,11 @@ ACTIVITY_METRICS_9_6 = [
 ACTIVITY_METRICS_9_2 = [
     "SUM(CASE WHEN xact_start IS NOT NULL THEN 1 ELSE 0 END)",
     "SUM(CASE WHEN state = 'idle in transaction' THEN 1 ELSE 0 END)",
-    "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{dd__user}'))"
-    "THEN 1 ELSE null END )",
-    "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
-    "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' AND state = 'active' THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN state = 'active' AND (query !~* '^vacuum ' AND query !~ '^autovacuum:' "
+    "AND usename NOT IN ('postgres', '{dd__user}')) THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN waiting = 't' AND query !~* '^vacuum ' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN waiting = 't' AND query !~* '^vacuum ' AND query !~ '^autovacuum:' "
+    "AND state = 'active' THEN 1 ELSE null END )",
     "max(EXTRACT(EPOCH FROM (clock_timestamp() - xact_start)))",
     "null",  # backend_xid is not available
     "null",  # backend_xmin is not available
@@ -507,10 +510,11 @@ ACTIVITY_METRICS_9_2 = [
 ACTIVITY_METRICS_8_3 = [
     "SUM(CASE WHEN xact_start IS NOT NULL THEN 1 ELSE 0 END)",
     "SUM(CASE WHEN current_query LIKE '<IDLE> in transaction' THEN 1 ELSE 0 END)",
-    "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{dd__user}'))"
-    "THEN 1 ELSE null END )",
-    "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
-    "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' AND state = 'active' THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN state = 'active' AND (query !~* '^vacuum ' AND query !~ '^autovacuum:' "
+    "AND usename NOT IN ('postgres', '{dd__user}')) THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN waiting = 't' AND query !~* '^vacuum ' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN waiting = 't' AND query !~* '^vacuum ' AND query !~ '^autovacuum:' "
+    "AND state = 'active' THEN 1 ELSE null END )",
     "max(EXTRACT(EPOCH FROM (clock_timestamp() - xact_start)))",
     "null",  # backend_xid is not available
     "null",  # backend_xmin is not available
@@ -520,10 +524,11 @@ ACTIVITY_METRICS_8_3 = [
 ACTIVITY_METRICS_LT_8_3 = [
     "SUM(CASE WHEN query_start IS NOT NULL THEN 1 ELSE 0 END)",
     "SUM(CASE WHEN current_query LIKE '<IDLE> in transaction' THEN 1 ELSE 0 END)",
-    "COUNT(CASE WHEN state = 'active' AND (query !~ '^autovacuum:' AND usename NOT IN ('postgres', '{dd__user}'))"
-    "THEN 1 ELSE null END )",
-    "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
-    "COUNT(CASE WHEN waiting = 't' AND query !~ '^autovacuum:' AND state = 'active' THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN state = 'active' AND (query !~* '^vacuum ' AND query !~ '^autovacuum:' "
+    "AND usename NOT IN ('postgres', '{dd__user}')) THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN waiting = 't' AND query !~* '^vacuum ' AND query !~ '^autovacuum:' THEN 1 ELSE null END )",
+    "COUNT(CASE WHEN waiting = 't' AND query !~* '^vacuum ' AND query !~ '^autovacuum:' "
+    "AND state = 'active' THEN 1 ELSE null END )",
     "max(EXTRACT(EPOCH FROM (clock_timestamp() - query_start)))",
     "null",  # backend_xid is not available
     "null",  # backend_xmin is not available

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -17,7 +17,9 @@ from .common import (
     DB_NAME,
     DBM_MIGRATED_METRICS,
     HOST,
+    PASSWORD_ADMIN,
     POSTGRES_VERSION,
+    USER_ADMIN,
     _get_expected_tags,
     assert_metric_at_least,
     check_activity_metrics,
@@ -343,6 +345,19 @@ def test_activity_metrics_no_aggregations(aggregator, integration_check, pg_inst
 
     expected_tags = _get_expected_tags(check, pg_instance, db=DB_NAME)
     check_activity_metrics(aggregator, expected_tags)
+
+
+def test_activity_vacuum_excluded(aggregator, integration_check, pg_instance):
+    pg_instance['collect_activity_metrics'] = True
+    check = integration_check(pg_instance)
+
+    conn = _get_conn(pg_instance, user=USER_ADMIN, password=PASSWORD_ADMIN)
+    cur = conn.cursor()
+    cur.execute('VACUUM analyze persons')
+
+    check.check(pg_instance)
+    dd_agent_tags = _get_expected_tags(check, pg_instance, db=DB_NAME, app='test', user=USER_ADMIN)
+    aggregator.assert_metric('postgresql.waiting_queries', value=0, count=1, tags=dd_agent_tags)
 
 
 def test_backend_transaction_age(aggregator, integration_check, pg_instance):


### PR DESCRIPTION
### What does this PR do?
Exclude manual vacuum from `pg_stat_activity` results.

### Motivation
Manually launched vacuum behaves the more or less the same way as autovacuum and won't keep the transaction and MVCC snapshot opened during the vacuum. We want to be able to monitor xact age and xmin without vacuums.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
