### PR TITLE
INCIDENT-23437 Always resolve hostname regardless of whether is dbm enabled or not

### DIFF
--- a/sqlserver/changelog.d/16207.changed
+++ b/sqlserver/changelog.d/16207.changed
@@ -1,0 +1,2 @@
+Always use the database instance's resolved hostname for metrics regardless of whether dbm is enabled or not. For non-dbm customers, this change
+ will result in the host tag having a different value than before. It is possible that dashboards and monitors using the integration's metrics will need to be updated if they relied on the faulty host tagging.

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -224,7 +224,7 @@ class SQLServer(AgentCheck):
         if self._resolved_hostname is None:
             if self._config.reported_hostname:
                 self._resolved_hostname = self._config.reported_hostname
-            elif self._config.dbm_enabled:
+            else:
                 host, _ = split_sqlserver_host_port(self.instance.get('host'))
                 self._resolved_hostname = resolve_db_host(host)
                 engine_edition = self.static_info_cache.get(STATIC_INFO_ENGINE_EDITION)
@@ -248,8 +248,6 @@ class SQLServer(AgentCheck):
                     # meaning that the agent is only able to see query activity for the specific database it's
                     # connected to. For this reason, each Azure SQL database is modeled as an independent host.
                     self._resolved_hostname = "{}/{}".format(host, configured_database)
-            else:
-                self._resolved_hostname = self.agent_hostname
         # set resource tags to properly tag with updated hostname
         self.set_resource_tags()
 

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -617,7 +617,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             'master',
             None,
             ENGINE_EDITION_SQL_DATABASE,
-            'stubbed.hostname',
+            'localhost/master',
             {},
             [],
         ),
@@ -626,7 +626,7 @@ def test_file_space_usage_metrics(aggregator, dd_run_check, instance_docker, dat
             '',
             None,
             ENGINE_EDITION_SQL_DATABASE,
-            'stubbed.hostname',
+            'localhost/master',
             {
                 'aws': {
                     'instance_endpoint': 'foo.aws.com',


### PR DESCRIPTION
### What does this PR do?
This change makes sure that the check's `resolved_hostname` always represents the database instance. The previous behavior of the `resolved_hostname` property was to use the agent hostname as the `host` when dbm was disabled. This caused issues when, with agent 7.48.0, we started sending `database_instance` metadata. With the `agent_hostname` being used instance of each instance's host value, agents with multiple databases being monitored would end up creating and clobbering the same `database_instance` which, in turn, caused tag interference between database instances monitored by the same agent. 

Very importantly, that problem surfaced the broken experience when dbm is disabled in regards to the host used on integration metrics: instead of having the sqlserver metrics tagged by the database instance's host, they were tagged by the agent hostname which would only be correct when the agent is running on the same host as the database. 

Note that this is going to be a breaking change but given the currently broken experience, this is something we want to do in order to improve the experience _and_ to avoid potential future incidents resulting in the confusing implementation of `resolved_hostname`. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
* We considered an alternative of creating a new property (`database_instance_name`) that would be used for everything except the core integration metrics. It would essentially be the same implementation as the resolved_hostname property from this PR but would leave `resolved_hostname` as-is. We decided to go with the better approach of fixing the broken experience at the risk of causing friction for users relying on that broken behavior.

* It's also worth noting that the experience for aws rds instances was _less_ broken than others because of some custom inference of additional host, hostname and aws tags [here](https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/config.py#L167-L170). The metric points were still _also_ tagged with the monitoring agent's hostname which was not correct but easier to deal with when filtering on aws rds instance was possible. 

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [x] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
