### PR TITLE
Update the labeler and ddqa configs to automatically assign QA cards

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -21,9 +21,7 @@ jira_statuses = [
   "Done",
 ]
 github_team = "agent-integrations"
-exclude_members = [
-  "hithwen",
-]
+github_labels = ["team/agent-integrations"]
 
 [teams."Platform Integrations"]
 jira_project = "PLINT"
@@ -37,6 +35,7 @@ github_team = "platform-integrations"
 exclude_members = [
   "hithwen",
 ]
+github_labels = ["team/platform-integrations"]
 
 [teams."Container Integrations"]
 jira_project = "CONTINT"
@@ -47,6 +46,7 @@ jira_statuses = [
   "Done",
 ]
 github_team = "container-integrations"
+github_labels = ["team/container-integrations"]
 
 [teams."Database Monitoring"]
 jira_project = "DBMON"
@@ -57,6 +57,7 @@ jira_statuses = [
   "Done",
 ]
 github_team = "database-monitoring"
+github_labels = ["team/database-monitoring"]
 
 [teams."Network Device Monitoring"]
 jira_project = "NDMII"
@@ -67,6 +68,7 @@ jira_statuses = [
   "Done",
 ]
 github_team = "network-device-monitoring"
+github_labels = ["team/network-device-monitoring"]
 
 [teams."Windows Agent"]
 jira_project = "WINA"
@@ -77,3 +79,4 @@ jira_statuses = [
   "Done",
 ]
 github_team = "windows-agent"
+github_labels = ["team/windows-agent"]

--- a/.github/workflows/config/labeler.yml
+++ b/.github/workflows/config/labeler.yml
@@ -478,3 +478,57 @@ integration/zk:
 release:
 - requirements-agent-release.txt
 - '*/__about__.py'
+team/container-integrations:
+- /cert_manager/**/*
+- /container/**/*
+- /containerd/**/*
+- /cri/**/*
+- /crio/**/*
+- /datadog_cluster_agent/**/*
+- /datadog_operator/**/*
+- /docker_daemon/**/*
+- /ecs_fargate/**/*
+- /eks_fargate/**/*
+- /helm/**/*
+- /kube_apiserver_metrics/**/*
+- /kube_controller_manager/**/*
+- /kube_dns/**/*
+- /kube_metrics_server/**/*
+- /kube_proxy/**/*
+- /kube_scheduler/**/*
+- /kubelet/**/*
+- /kubernetes/**/*
+- /kubernetes_state/**/*
+- /kubernetes_state_core/**/*
+- /nginx_ingress_controller/**/*
+- /oom_kill/**/*
+- /openmetrics/**/*
+- /podman/**/*
+- /tcp_queue_length/**/*
+team/network-device-monitoring:
+- /snmp/**/*
+team/platform-integrations:
+- /citrix_hypervisor/**/*
+- /cloudera/**/*
+- /cloud_foundry_api/**/*
+- /openstack/**/*
+- /openstack_controller/**/*
+- /vsphere/**/*
+team/database-monitoring:
+- /postgres/**/*
+- /mysql/**/*
+- /sqlserver/**/*
+team/windows-agent:
+- /active_directory/**/*
+- /aspdotnet/**/*
+- /dotnetclr/**/*
+- /exchange_server/**/*
+- /hyperv/**/*
+- /iis/**/*
+- /pdh_check/**/*
+- /win32_event_log/**/*
+- /windows_performance_counters/**/*
+- /windows_service/**/*
+- /wmi_check/**/*
+team/agent-platform:
+- /nvidia_jetson/**/*


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Update the label config to add a `team/<TEAM>` label to the PRs
- Configure DDQA to use this label to automatically assign QA cards to the right team

### Motivation
<!-- What inspired you to submit this pull request? -->

Save time when we create QA cards

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
