### PR TITLE
Add source_type_id to nvidia_triton

### DIFF
--- a/nvidia_triton/manifest.json
+++ b/nvidia_triton/manifest.json
@@ -20,7 +20,7 @@
   "assets": {
     "integration": {
       "source_type_name": "Nvidia Triton",
-      "source_type_id": "10416",
+      "source_type_id": 10416,
       "configuration": {
         "spec": "assets/configuration/spec.yaml"
       },

--- a/nvidia_triton/manifest.json
+++ b/nvidia_triton/manifest.json
@@ -20,6 +20,7 @@
   "assets": {
     "integration": {
       "source_type_name": "Nvidia Triton",
+      "source_type_id": "10416",
       "configuration": {
         "spec": "assets/configuration/spec.yaml"
       },


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
Adds the source_type_id of this integration to the manifest (note it matches the one that was autogenerated for it during its staging sync). 

### Motivation
<!-- What inspired you to submit this pull request? -->
This should be a no-op, but its in the perfect case for me to test out some new functionality we're introducing to APW. 


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
