### PR TITLE
Update openai readme, clarify which metrics are available based on setup method

### DIFF
--- a/openai/README.md
+++ b/openai/README.md
@@ -10,6 +10,8 @@ Get cost estimation, prompt and completion sampling, error tracking, performance
 <!-- xxx tabs xxx -->
 <!-- xxx tab "Python" xxx -->
 
+**Note**: This setup method will not collect `openai.api.usage.*` metrics, unless you also follow the API key setup instructions.
+
 ### Installation
 
 <!-- NOTE: This section is overwritten by the OpenAI configuration component exported in -->
@@ -98,6 +100,8 @@ DEBUG:ddtrace.contrib.openai._logging.py:sent 2 logs to 'http-intake.logs.datado
 <!-- xxz tab xxx -->
 <!-- xxx tab "Node.js" xxx -->
 
+**Note**: This setup method will not collect `openai.api.usage.*` metrics, unless you also follow the API key setup instructions.
+
 ### Installation
 
 1. Enable APM and StatsD in your Datadog Agent. For example, in Docker:
@@ -176,6 +180,8 @@ Validate that the APM Node.js library can communicate with your Agent by examini
 <!-- xxz tabs xxx -->
 <!-- xxx tab "API Key" xxx -->
 
+**Note**: This setup method will only collect  `openai.api.usage.*` metrics. To collect all metrics provided by this integration, also follow the APM setup instructions.
+
 ### Installation
 
 1. Login to your [OpenAI Account][10].
@@ -194,6 +200,8 @@ Validate that the APM Node.js library can communicate with your Agent by examini
 ## Data Collected
 
 ### Metrics
+
+**Note**: The `openai.api.usage.*` metrics are only collected with the API key setup method. All remaining metrics below are collected with the APM setup methods.
 
 See [metadata.csv][4] for a list of metrics provided by this integration.
 

--- a/openai/README.md
+++ b/openai/README.md
@@ -10,7 +10,7 @@ Get cost estimation, prompt and completion sampling, error tracking, performance
 <!-- xxx tabs xxx -->
 <!-- xxx tab "Python" xxx -->
 
-**Note**: This setup method will not collect `openai.api.usage.*` metrics, unless you also follow the API key setup instructions.
+**Note**: This setup method does not collect `openai.api.usage.*` metrics. To collect these metrics, also follow the API key setup instructions.
 
 ### Installation
 
@@ -100,7 +100,7 @@ DEBUG:ddtrace.contrib.openai._logging.py:sent 2 logs to 'http-intake.logs.datado
 <!-- xxz tab xxx -->
 <!-- xxx tab "Node.js" xxx -->
 
-**Note**: This setup method will not collect `openai.api.usage.*` metrics, unless you also follow the API key setup instructions.
+**Note**: This setup method does not collect `openai.api.usage.*` metrics. To collect these metrics, also follow the API key setup instructions.
 
 ### Installation
 
@@ -180,7 +180,7 @@ Validate that the APM Node.js library can communicate with your Agent by examini
 <!-- xxz tabs xxx -->
 <!-- xxx tab "API Key" xxx -->
 
-**Note**: This setup method will only collect  `openai.api.usage.*` metrics. To collect all metrics provided by this integration, also follow the APM setup instructions.
+**Note**: This setup method only collects `openai.api.usage.*` metrics. To collect all metrics provided by this integration, also follow the APM setup instructions.
 
 ### Installation
 
@@ -201,7 +201,7 @@ Validate that the APM Node.js library can communicate with your Agent by examini
 
 ### Metrics
 
-**Note**: The `openai.api.usage.*` metrics are only collected with the API key setup method. All remaining metrics below are collected with the APM setup methods.
+The `openai.api.usage.*` metrics are only collected with the API key setup method. All remaining metrics below are collected with the APM setup methods.
 
 See [metadata.csv][4] for a list of metrics provided by this integration.
 


### PR DESCRIPTION
### What does this PR do?
This PR adds a note to the openai integration README, clarifying which metrics will be collected based on the setup method (APM vs Web API key).

### Motivation
The OpenAI integration involves two separate components, which provide two different sets of metrics:
1. APM: all `openai.request*`, `openai.tokens.*`, `openai.organization.*`, `openai.ratelimit*` metrics
2. Web API key: `openai.api.usage.*` metrics

A support issue was found where a customer wasn't sure about this differentiation between metrics collected, so this PR serves to clarify which metrics will be collected, based on the setup method.


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
