### PR TITLE
Add team labels to the DDQA config

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -21,9 +21,7 @@ jira_statuses = [
   "Done",
 ]
 github_team = "agent-integrations"
-exclude_members = [
-  "hithwen",
-]
+github_labels = ["team/agent-integrations"]
 
 [teams."Platform Integrations"]
 jira_project = "PLINT"
@@ -37,6 +35,7 @@ github_team = "platform-integrations"
 exclude_members = [
   "hithwen",
 ]
+github_labels = ["team/platform-integrations"]
 
 [teams."Container Integrations"]
 jira_project = "CONTINT"
@@ -47,6 +46,7 @@ jira_statuses = [
   "Done",
 ]
 github_team = "container-integrations"
+github_labels = ["team/container-integrations"]
 
 [teams."Database Monitoring"]
 jira_project = "DBMON"
@@ -57,6 +57,7 @@ jira_statuses = [
   "Done",
 ]
 github_team = "database-monitoring"
+github_labels = ["team/database-monitoring"]
 
 [teams."Network Device Monitoring"]
 jira_project = "NDMII"
@@ -67,6 +68,7 @@ jira_statuses = [
   "Done",
 ]
 github_team = "network-device-monitoring"
+github_labels = ["team/network-device-monitoring"]
 
 [teams."Windows Agent"]
 jira_project = "WINA"
@@ -77,3 +79,4 @@ jira_statuses = [
   "Done",
 ]
 github_team = "windows-agent"
+github_labels = ["team/windows-agent"]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Remove Julia from our exclusion because she's not in our GitHub team anymore
- Add `team/<TEAM_NAME>` as a `github_labels` to all the teams

### Motivation
<!-- What inspired you to submit this pull request? -->

This will allow us to automatically assign QA cards to the right teams. This label is not yet used in this repository, I'll work on that during the hackathon.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
