### PR TITLE
Update AWS IAM Access Analyzer docs for clarity

### DIFF
--- a/iam_access_analyzer/README.md
+++ b/iam_access_analyzer/README.md
@@ -30,7 +30,7 @@ Use AWS Identity and Access Management (IAM) Access Analyzer across your Amazon 
 
 ### Metrics
 
-This integration does not not collect metrics
+This integration does not include any metrics.
 
 ### Service Checks
 
@@ -38,11 +38,11 @@ This integration does not include any service checks.
 
 ### Logs
 
-This integration can be configured to send Logs.
+This integration can be configured to send logs.
 
 ### Events
 
-This integration does not send events
+This integration does not include any events.
 
 ## Troubleshooting
 

--- a/iam_access_analyzer/README.md
+++ b/iam_access_analyzer/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Use AWS Identity and Access Management (IAM) Access Analyzer across your Amazon account to continuously analyze IAM permissions granted with any of your account policies. Datadog integrates with Amazon IAM Access Analyzer using a Lambda function that ships its logs to Datadog.
+Use AWS Identity and Access Management (IAM) Access Analyzer across your Amazon account to continuously analyze IAM permissions granted with any of your account policies. Datadog integrates with Amazon IAM Access Analyzer using a Lambda function that ships its findings as logs to Datadog.
 
 ## Setup
 
@@ -10,9 +10,9 @@ Use AWS Identity and Access Management (IAM) Access Analyzer across your Amazon 
 
 1. If you haven't already, set up the [Datadog Forwarder][1] Lambda function.
 
-2. Create a new rule in AWS EventBridge.
+2. Create a new rule with type `Rule with an event pattern` in AWS EventBridge.
 
-3. Define a custom event pattern with the following:
+3. For the event source configuration, select `Other`. For `Creation method`, select `Custom pattern (JSON editor)`. For `Event pattern`, copy and paste the following JSON:
 
     ```json
     {
@@ -20,17 +20,17 @@ Use AWS Identity and Access Management (IAM) Access Analyzer across your Amazon 
     }
     ```
 
-4. Select an event bus and define the Datadog Lambda function as the target.
+4. Select `AWS service` to use as the target type. Select `Lambda function` as the target and select the Datadog Forwarder Lambda or enter the ARN.
 
 5. Save your rule.
 
-6. See the [Log Explorer][2] to start exploring your logs.
+6. Once the AWS Access Analyzer runs and produces findings, the events will be picked up by the Datadog Lambda Forwarder tagged with `source:access-analyzer`. See the [Log Explorer][2] to start exploring your logs.
 
 ## Data Collected
 
 ### Metrics
 
-This integration does not not collect metrics 
+This integration does not not collect metrics
 
 ### Service Checks
 
@@ -49,5 +49,5 @@ This integration does not send events
 Need help? Contact [Datadog support][3].
 
 [1]: /logs/guide/forwarder/
-[2]: https://app.datadoghq.com/logs
+[2]: https://app.datadoghq.com/logs?query=source%3Aaccess-analyzer
 [3]: https://docs.datadoghq.com/help


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
The docs were unclear/misleading for how to set up the EventBridge trigger to send AWS IAM Access Analyzer findings via the Lambda Forwarder. This updates the docs to more closely follow the steps in AWS.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
