### PR TITLE
[cert-manager][doc] Multiple values for `name` tag troubleshooting note

### DIFF
--- a/cert_manager/README.md
+++ b/cert_manager/README.md
@@ -43,7 +43,7 @@ See [service_checks.json][8] for a list of service checks provided by this integ
 
 ### Duplicate name tags
 
-Each certificate name is exposed within the `name` label in the Prometheus payload and is converted to this tag by the Datadog Agent. For that reason, if your hosts also make use of the `name` tag (for instance, automatically collected by the [AWS integration][9]), metrics coming from this integration will present both values. To avoid this situation, you can use the [`rename_labels`][10] configuration parameter to map the Prometheus label `name` to the Datadog tag `cert_name` to ensure you have a single value within the tag `cert_name` to identify your certificates :
+Each certificate name is exposed within the `name` label in the Prometheus payload and is converted to a tag by the Datadog Agent. If your hosts also use the `name` tag (for instance, automatically collected by the [AWS integration][9]), metrics coming from this integration will present both values. To avoid duplicate `name` tags, you can use the [`rename_labels`configuration parameter][10] to map the Prometheus label `name` to the Datadog tag `cert_name`. This ensures you have a single value within the tag `cert_name` to identify your certificates :
 ```yaml
 init_config:
 instances:

--- a/cert_manager/README.md
+++ b/cert_manager/README.md
@@ -41,7 +41,18 @@ See [service_checks.json][8] for a list of service checks provided by this integ
 
 ## Troubleshooting
 
-Need help? Contact [Datadog support][9].
+### Duplicate name tags
+
+Each certificate name is exposed within the `name` label in the Prometheus payload and is converted to this tag by the Datadog Agent. For that reason, if your hosts also make use of the `name` tag (for instance, automatically collected by the [AWS integration][9]), metrics coming from this integration will present both values. To avoid this situation, you can use the [`rename_labels`][10] configuration parameter to map the Prometheus label `name` to the Datadog tag `cert_name` to ensure you have a single value within the tag `cert_name` to identify your certificates :
+```yaml
+init_config:
+instances:
+- openmetrics_endpoint: <OPENMETRICS_ENDPOINT>
+  rename_labels:
+    name: cert_name
+```
+
+Need further help? Contact [Datadog support][11].
 
 [1]: https://github.com/jetstack/cert-manager
 [2]: https://raw.githubusercontent.com/DataDog/integrations-core/master/cert_manager/images/overview_dashboard.png
@@ -51,4 +62,6 @@ Need help? Contact [Datadog support][9].
 [6]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [7]: https://github.com/DataDog/integrations-core/blob/master/cert_manager/metadata.csv
 [8]: https://github.com/DataDog/integrations-core/blob/master/cert_manager/assets/service_checks.json
-[9]: https://docs.datadoghq.com/help/
+[9]: https://docs.datadoghq.com/integrations/amazon_web_services/
+[10]: https://github.com/DataDog/integrations-core/blob/81b91a54328f174c5c1e92cb818640cba1ddfec3/cert_manager/datadog_checks/cert_manager/data/conf.yaml.example#L153-L155
+[11]: https://docs.datadoghq.com/help/


### PR DESCRIPTION
### What does this PR do?
* Adds a troubleshooting section on the "common" issues with multiple values for the `name` tag due to this tag also being collected by the AWS integration for each host

### Motivation
* Multiple customer tickets trying to understand the origin of these duplicate values

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
