### PR TITLE
Add the `python-version` param to the `pr-test` workflow

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: ""
         type: string
+      python-version:
+        required: false
+        default: ""
+        type: string
 
 jobs:
   compute-matrix:
@@ -42,6 +46,7 @@ jobs:
 
       # For other repositories
       setup-env-vars: "${{ inputs.setup-env-vars }}"
+      python-version: "${{ inputs.python-version }}"
     secrets: inherit
 
   save-event:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add the `python-version` param to the `pr-test` workflow.

### Motivation
<!-- What inspired you to submit this pull request? -->

If we bump the Python version from let's say 3.9 to 3.11 in integrations-core, there's currently no way for other repositories that use the `pr-test` workflow to specify their version. So their CI starts to use Python 3.11 on PRs, while their repos is not ready yet. 

Note that this feature is already implemented for [`test-all`](https://github.com/DataDog/integrations-core/blob/395d163218893afb221d99fdab899a737b32c75c/.github/workflows/test-all.yml#L10-L13) workflow which is used on master branches

### Additional Notes
<!-- Anything else we should know when reviewing? -->

For reference, this will be used [here](https://github.com/DataDog/integrations-extras/blob/master/.github/workflows/pr.yml#L12-L17) and [there](https://github.com/DataDog/marketplace/blob/master/.github/workflows/pr.yml#L12-L17), same for some other internal repos 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
