### PR TITLE
Stop emit metrics query operation time

### DIFF
--- a/mysql/changelog.d/16278.fixed
+++ b/mysql/changelog.d/16278.fixed
@@ -1,0 +1,1 @@
+Stop emit metrics query operation time

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -19,7 +19,6 @@ from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.db import QueryExecutor, QueryManager
 from datadog_checks.base.utils.db.utils import (
     default_json_event_encoding,
-    tracked_query,
 )
 from datadog_checks.base.utils.db.utils import (
     resolve_db_host as agent_host_resolver,
@@ -331,7 +330,6 @@ class MySql(AgentCheck):
             self,
             queries=queries,
             hostname=self.resolved_hostname,
-            track_operation_time=True,
         )
 
     @property
@@ -439,22 +437,18 @@ class MySql(AgentCheck):
         metrics = copy.deepcopy(STATUS_VARS)
 
         # collect results from db
-        with tracked_query(self, operation="status_metrics"):
-            results = self._get_stats_from_status(db)
-        with tracked_query(self, operation="variables_metrics"):
-            results.update(self._get_stats_from_variables(db))
+        results = self._get_stats_from_status(db)
+        results.update(self._get_stats_from_variables(db))
 
         if not is_affirmative(
             self._config.options.get('disable_innodb_metrics', False)
         ) and self._is_innodb_engine_enabled(db):
-            with tracked_query(self, operation="innodb_metrics"):
-                results.update(self.innodb_stats.get_stats_from_innodb_status(db))
+            results.update(self.innodb_stats.get_stats_from_innodb_status(db))
             self.innodb_stats.process_innodb_stats(results, self._config.options, metrics)
 
         # Binary log statistics
         if self._get_variable_enabled(results, 'log_bin'):
-            with tracked_query(self, operation="binary_log_metrics"):
-                results['Binlog_space_usage_bytes'] = self._get_binary_log_stats(db)
+            results['Binlog_space_usage_bytes'] = self._get_binary_log_stats(db)
 
         # Compute key cache utilization metric
         key_blocks_unused = collect_scalar('Key_blocks_unused', results)
@@ -501,39 +495,33 @@ class MySql(AgentCheck):
                 "[Deprecated] The `extra_performance_metrics` option will be removed in a future release. "
                 "Utilize the `custom_queries` feature if the functionality is needed.",
             )
-            with tracked_query(self, operation="exec_time_95th_metrics"):
-                results['perf_digest_95th_percentile_avg_us'] = self._get_query_exec_time_95th_us(db)
-            with tracked_query(self, operation="exec_time_per_schema_metrics"):
-                results['query_run_time_avg'] = self._query_exec_time_per_schema(db)
+            results['perf_digest_95th_percentile_avg_us'] = self._get_query_exec_time_95th_us(db)
+            results['query_run_time_avg'] = self._query_exec_time_per_schema(db)
             metrics.update(PERFORMANCE_VARS)
 
         if is_affirmative(self._config.options.get('schema_size_metrics', False)):
             # report avg query response time per schema to Datadog
-            with tracked_query(self, operation="schema_size_metrics"):
-                results['information_schema_size'] = self._query_size_per_schema(db)
+            results['information_schema_size'] = self._query_size_per_schema(db)
             metrics.update(SCHEMA_VARS)
 
         if is_affirmative(self._config.options.get('table_rows_stats_metrics', False)) and self.userstat_enabled:
             # report size of tables in MiB to Datadog
             self.log.debug("Collecting Table Row Stats Metrics.")
-            with tracked_query(self, operation="table_rows_stats_metrics"):
-                (rows_read_total, rows_changed_total) = self._query_rows_stats_per_table(db)
+            (rows_read_total, rows_changed_total) = self._query_rows_stats_per_table(db)
             results['information_table_rows_read_total'] = rows_read_total
             results['information_table_rows_changed_total'] = rows_changed_total
             metrics.update(TABLE_ROWS_STATS_VARS)
 
         if is_affirmative(self._config.options.get('table_size_metrics', False)):
             # report size of tables in MiB to Datadog
-            with tracked_query(self, operation="table_size_metrics"):
-                (table_index_size, table_data_size) = self._query_size_per_table(db)
+            (table_index_size, table_data_size) = self._query_size_per_table(db)
             results['information_table_index_size'] = table_index_size
             results['information_table_data_size'] = table_data_size
             metrics.update(TABLE_VARS)
 
         if is_affirmative(self._config.options.get('system_table_size_metrics', False)):
             # report size of tables in MiB to Datadog
-            with tracked_query(self, operation="system_table_size_metrics"):
-                (table_index_size, table_data_size) = self._query_size_per_table(db, system_tables=True)
+            (table_index_size, table_data_size) = self._query_size_per_table(db, system_tables=True)
             if results.get('information_table_index_size'):
                 results['information_table_index_size'].update(table_index_size)
             else:
@@ -547,11 +535,9 @@ class MySql(AgentCheck):
         if is_affirmative(self._config.options.get('replication', self._config.dbm_enabled)):
             if self.performance_schema_enabled and self._is_group_replication_active(db):
                 self.log.debug('Collecting group replication metrics.')
-                with tracked_query(self, operation="group_replication_metrics"):
-                    self._collect_group_replica_metrics(db, results)
+                self._collect_group_replica_metrics(db, results)
             else:
-                with tracked_query(self, operation="replication_metrics"):
-                    replication_metrics = self._collect_replication_metrics(db, results, above_560)
+                replication_metrics = self._collect_replication_metrics(db, results, above_560)
                 metrics.update(replication_metrics)
                 self._check_replication_status(results)
 

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -273,30 +273,3 @@ GROUP_REPLICATION_VARS = [
     'mysql.replication.group.transactions_rollback',
     'mysql.replication.group.transactions_validating',
 ]
-
-SIMPLE_OPERATION_TIME_METRICS = [
-    'status_metrics',
-    'innodb_metrics',
-    'variables_metrics',
-    'binary_log_metrics',
-]
-
-COMPLEX_OPERATION_TIME_METRICS = [
-    'schema_size_metrics',
-    'system_table_size_metrics',
-    'table_size_metrics',
-]
-
-REPLICATION_OPERATION_TIME_METRICS = ['replication_metrics']
-
-GROUP_REPLICATION_OPERATION_TIME_METRICS = ['group_replication_metrics']
-
-PERFORMANCE_OPERATION_TIME_METRICS = ['exec_time_95th_metrics', 'exec_time_per_schema_metrics']
-
-COMMON_PERFORMANCE_OPERATION_TIME_METRICS = ['performance_schema.threads']
-
-OPERATION_TIME_METRIC_NAME = 'dd.mysql.operation.time'
-
-E2E_OPERATION_TIME_METRIC_NAME = [
-    'dd.mysql.operation.time.{}'.format(suffix) for suffix in ('avg', 'max', '95percentile', 'count', 'median')
-]

--- a/postgres/changelog.d/16278.fixed
+++ b/postgres/changelog.d/16278.fixed
@@ -1,0 +1,1 @@
+Stop emit metrics query operation time

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -96,17 +96,6 @@ CONNECTION_METRICS = ['postgresql.max_connections', 'postgresql.percent_usage_co
 CONNECTION_METRICS_DB = ['postgresql.connections']
 COMMON_DBS = ['dogs', 'postgres', 'dogs_nofunc', 'dogs_noschema', DB_NAME]
 
-CHECK_PERFORMANCE_METRICS = [
-    'archiver_metrics',
-    'bgw_metrics',
-    'connections_metrics',
-    'count_metrics',
-    'instance_metrics',
-    'replication_metrics',
-    'replication_stats_metrics',
-    'slru_metrics',
-]
-
 requires_static_version = pytest.mark.skipif(USING_LATEST, reason='Version `latest` is ever-changing, skipping')
 
 
@@ -324,17 +313,3 @@ def check_stat_wal_metrics(aggregator, expected_tags, count=1):
 
     for metric_name in _iterate_metric_name(STAT_WAL_METRICS):
         aggregator.assert_metric(metric_name, count=count, tags=expected_tags)
-
-
-def check_performance_metrics(aggregator, expected_tags, count=1, is_aurora=False):
-    expected_metrics = set(CHECK_PERFORMANCE_METRICS)
-    if is_aurora:
-        expected_metrics = expected_metrics - {'replication_metrics'}
-    if float(POSTGRES_VERSION) < 13.0:
-        expected_metrics = expected_metrics - {'slru_metrics'}
-    if float(POSTGRES_VERSION) < 10.0:
-        expected_metrics = expected_metrics - {'replication_stats_metrics'}
-    for name in expected_metrics:
-        aggregator.assert_metric(
-            'dd.postgres.operation.time', count=count, tags=expected_tags + ['operation:{}'.format(name)]
-        )

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -32,7 +32,6 @@ from .common import (
     check_db_count,
     check_file_wal_metrics,
     check_logical_replication_slots,
-    check_performance_metrics,
     check_physical_replication_slots,
     check_slru_metrics,
     check_snapshot_txid_metrics,
@@ -76,8 +75,6 @@ def test_common_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check_logical_replication_slots(aggregator, expected_tags)
     check_physical_replication_slots(aggregator, expected_tags)
     check_snapshot_txid_metrics(aggregator, expected_tags=expected_tags)
-
-    check_performance_metrics(aggregator, expected_tags=check.debug_stats_kwargs()['tags'], is_aurora=is_aurora)
 
     aggregator.assert_all_metrics_covered()
 

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -16,7 +16,6 @@ from .common import (
     check_control_metrics,
     check_db_count,
     check_file_wal_metrics,
-    check_performance_metrics,
     check_replication_delay,
     check_slru_metrics,
     check_snapshot_txid_metrics,
@@ -50,8 +49,6 @@ def test_common_replica_metrics(aggregator, integration_check, metrics_cache_rep
     check_snapshot_txid_metrics(aggregator, expected_tags=expected_tags)
     check_stat_wal_metrics(aggregator, expected_tags=expected_tags)
     check_file_wal_metrics(aggregator, expected_tags=expected_tags)
-
-    check_performance_metrics(aggregator, expected_tags=check.debug_stats_kwargs()['tags'])
 
     aggregator.assert_all_metrics_covered()
 

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -14,7 +14,7 @@ from six import iteritems
 
 from datadog_checks.postgres import PostgreSql, util
 
-from .common import PORT, check_performance_metrics
+from .common import PORT
 from .utils import requires_over_10
 
 pytestmark = pytest.mark.unit
@@ -269,8 +269,6 @@ def test_replication_stats(aggregator, integration_check, pg_instance):
         metric_name = 'postgresql.replication.{}'.format(suffix)
         aggregator.assert_metric(metric_name, 12, app1_tags)
         aggregator.assert_metric(metric_name, 13, app2_tags)
-
-    check_performance_metrics(aggregator, check.debug_stats_kwargs()['tags'])
 
     aggregator.assert_all_metrics_covered()
 

--- a/sqlserver/changelog.d/16278.fixed
+++ b/sqlserver/changelog.d/16278.fixed
@@ -1,0 +1,1 @@
+Stop emit metrics query operation time

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -13,7 +13,7 @@ from cachetools import TTLCache
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.utils.db import QueryExecutor, QueryManager
-from datadog_checks.base.utils.db.utils import default_json_event_encoding, resolve_db_host, tracked_query
+from datadog_checks.base.utils.db.utils import default_json_event_encoding, resolve_db_host
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.sqlserver.activity import SqlserverActivity
 from datadog_checks.sqlserver.config import SQLServerConfig
@@ -790,10 +790,9 @@ class SQLServer(AgentCheck):
                                 self.instance.get('database', self.connection.DEFAULT_DATABASE)
                             ]
                             metric_cls = getattr(metrics, cls)
-                            with tracked_query(self, operation=metric_cls.OPERATION_NAME):
-                                rows, cols = metric_cls.fetch_all_values(
-                                    cursor, list(metric_names), self.log, databases=db_names
-                                )
+                            rows, cols = metric_cls.fetch_all_values(
+                                cursor, list(metric_names), self.log, databases=db_names
+                            )
                         except Exception as e:
                             self.log.error("Error running `fetch_all` for metrics %s - skipping.  Error: %s", cls, e)
                             rows, cols = None, None

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -3,7 +3,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
-from copy import deepcopy
 from itertools import chain
 
 from datadog_checks.dev import get_docker_hostname, get_here
@@ -230,26 +229,10 @@ INIT_CONFIG_ALT_TABLES = {
     ]
 }
 
-OPERATION_TIME_METRICS = [
-    'simple_metrics',
-    'database_stats_metrics',
-    'fraction_metrics',
-    'db_file_space_usage_metrics',
-    'database_backup_metrics',
-    'database_file_stats_metrics',
-    'incr_fraction_metrics',
-    'db_index_usage_stats_metrics',
-]
-
 OPERATION_TIME_METRIC_NAME = 'dd.sqlserver.operation.time'
-
-E2E_OPERATION_TIME_METRIC_NAME = [
-    'dd.sqlserver.operation.time.{}'.format(suffix) for suffix in ('avg', 'max', '95percentile', 'count', 'median')
-]
 
 
 def assert_metrics(
-    instance,
     aggregator,
     check_tags,
     service_tags,
@@ -287,31 +270,5 @@ def assert_metrics(
         aggregator.assert_metric(mname, hostname=hostname)
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK, tags=service_tags)
 
-    operation_time_metric_tags = check_tags + ['agent_hostname:{}'.format(hostname)]
-    for operation_name in get_operation_time_metrics(instance):
-        aggregator.assert_metric(
-            OPERATION_TIME_METRIC_NAME,
-            tags=['operation:{}'.format(operation_name)] + operation_time_metric_tags,
-            hostname=hostname,
-            count=1,
-        )
-
     aggregator.assert_all_metrics_covered()
     aggregator.assert_no_duplicate_metrics()
-
-
-def get_operation_time_metrics(instance):
-    """
-    Return a list of all operation time metrics
-    """
-    operation_time_metrics = deepcopy(OPERATION_TIME_METRICS)
-    if instance.get('include_task_scheduler_metrics', False):
-        operation_time_metrics.append('os_schedulers_metrics')
-        operation_time_metrics.append('os_tasks_metrics')
-    if instance.get('include_db_fragmentation_metrics', False):
-        operation_time_metrics.append('db_fragmentation_metrics')
-    if instance.get('include_ao_metrics', False):
-        operation_time_metrics.append('availability_groups_metrics')
-    if instance.get('include_master_files_metrics', False):
-        operation_time_metrics.append('master_database_file_stats_metrics')
-    return operation_time_metrics

--- a/sqlserver/tests/test_e2e.py
+++ b/sqlserver/tests/test_e2e.py
@@ -9,7 +9,6 @@ from datadog_checks.sqlserver.const import DATABASE_INDEX_METRICS
 
 from .common import (
     CUSTOM_METRICS,
-    E2E_OPERATION_TIME_METRIC_NAME,
     EXPECTED_AO_METRICS_COMMON,
     EXPECTED_AO_METRICS_PRIMARY,
     EXPECTED_AO_METRICS_SECONDARY,
@@ -52,9 +51,7 @@ def test_ao_primary_replica(dd_agent_check, init_config, instance_ao_docker_prim
     for mname in EXPECTED_AO_METRICS_SECONDARY:
         aggregator.assert_metric(mname, count=0)
 
-    aggregator.assert_metrics_using_metadata(
-        get_metadata_metrics(), exclude=CUSTOM_METRICS + E2E_OPERATION_TIME_METRIC_NAME
-    )
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=CUSTOM_METRICS)
 
 
 @not_windows_ci
@@ -94,9 +91,7 @@ def test_ao_secondary_replica(dd_agent_check, init_config, instance_ao_docker_se
     for mname in EXPECTED_AO_METRICS_PRIMARY + EXPECTED_QUERY_EXECUTOR_AO_METRICS_PRIMARY:
         aggregator.assert_metric(mname, count=0)
 
-    aggregator.assert_metrics_using_metadata(
-        get_metadata_metrics(), exclude=CUSTOM_METRICS + E2E_OPERATION_TIME_METRIC_NAME
-    )
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=CUSTOM_METRICS)
 
 
 @not_windows_ado
@@ -138,6 +133,4 @@ def test_check_docker(dd_agent_check, init_config, instance_e2e):
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK)
     aggregator.assert_all_metrics_covered()
 
-    aggregator.assert_metrics_using_metadata(
-        get_metadata_metrics(), exclude=CUSTOM_METRICS + E2E_OPERATION_TIME_METRIC_NAME
-    )
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=CUSTOM_METRICS)

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -23,9 +23,7 @@ from .common import (
     CHECK_NAME,
     CUSTOM_METRICS,
     EXPECTED_DEFAULT_METRICS,
-    OPERATION_TIME_METRIC_NAME,
     assert_metrics,
-    get_operation_time_metrics,
 )
 from .conftest import DEFAULT_TIMEOUT
 from .utils import not_windows_ci, windows_ci
@@ -96,7 +94,6 @@ def test_check_docker(aggregator, dd_run_check, init_config, instance_docker, da
         'db:master',
     ]
     assert_metrics(
-        instance_docker,
         aggregator,
         check_tags=instance_docker.get('tags', []),
         service_tags=expected_tags,
@@ -432,14 +429,6 @@ def test_check_windows_defaults(aggregator, dd_run_check, init_config, instance_
         aggregator.assert_metric(mname)
 
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK)
-
-    for operation_name in get_operation_time_metrics(instance_docker_defaults):
-        aggregator.assert_metric(
-            OPERATION_TIME_METRIC_NAME,
-            tags=['operation:{}'.format(operation_name)] + check.debug_stats_kwargs()['tags'],
-            hostname=check.resolved_hostname,
-            count=1,
-        )
 
     aggregator.assert_all_metrics_covered()
 

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -446,7 +446,7 @@ def test_check_local(aggregator, dd_run_check, init_config, instance_docker):
         'connection_host:{}'.format(DOCKER_SERVER),
         'db:master',
     ]
-    assert_metrics(instance_docker, aggregator, check_tags, expected_tags, hostname=sqlserver_check.resolved_hostname)
+    assert_metrics(aggregator, check_tags, expected_tags, hostname=sqlserver_check.resolved_hostname)
 
 
 SQL_SERVER_2012_VERSION_EXAMPLE = """\


### PR DESCRIPTION
### What does this PR do?
This PR removes the contextmanager that calculates and emits query operation time (wall time). 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
