### PR TITLE
Skip tests that assert external tags if the base check version is too old

### DIFF
--- a/openstack_controller/tests/test_unit_nova.py
+++ b/openstack_controller/tests/test_unit_nova.py
@@ -5,9 +5,11 @@
 
 import logging
 import os
+from importlib.metadata import metadata
 
 import mock
 import pytest
+from packaging.version import Version
 
 import tests.configs as configs
 import tests.metrics as metrics
@@ -36,6 +38,10 @@ pytestmark = [
     ],
 )
 @pytest.mark.usefixtures('mock_http_get', 'mock_http_post', 'openstack_connection')
+@pytest.mark.skipif(
+    Version(metadata("datadog_checks_base")["VERSION"]) < Version("34.1.2"),
+    reason='assert_external_tags was added in version 34.1.2',
+)
 def test_external_tags(datadog_agent, dd_run_check, check):
     dd_run_check(check)
     datadog_agent.assert_external_tags(


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Skip the tests that make use of `assert_external_tags` if the version of the base check is too old and does not provide this method.

### Motivation
<!-- What inspired you to submit this pull request? -->

I don't manage to find a better approach for now, especially because I can't do anything on older release version of the base check. I think this mock should live somewhere else (probably in `datadog_checks_dev`) and injected at runtime when running the tests instead of being imported [that way](https://github.com/DataDog/integrations-core/blob/fc38712fc34d2f027d9801b753fa6f2c52fc49bc/datadog_checks_base/datadog_checks/base/checks/base.py#L62-L66). I'll work on that later.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

You can test this running: 

```
❯ ddev test --compat openstack_controller:py3.11-gcp -- -k test_external_tags
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── OpenStack Controller ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── py3.11-gcp ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Finished creating environment: py3.11-gcp
<TON OF DEPS STUFF>...
Finished running post-installation commands
Finished checking dependencies
cmd [1] | pytest -vv --benchmark-skip --tb short -k test_external_tags
======================================================================================================================================================================== test session starts ========================================================================================================================================================================
platform darwin -- Python 3.11.5, pytest-7.4.3, pluggy-1.3.0 -- /Users/florent.clarret/Library/Application Support/hatch/env/virtual/datadog-openstack-controller/-5eK_Xhm/py3.11-gcp/bin/python
cachedir: .pytest_cache
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/florent.clarret/go/src/github.com/DataDog/integrations-core/openstack_controller
plugins: flaky-3.7.0, cov-4.1.0, ddtrace-1.11.2, asyncio-0.21.1, memray-1.5.0, mock-3.12.0, benchmark-4.0.0, datadog-checks-dev-28.0.1
asyncio: mode=Mode.STRICT
collected 444 items / 442 deselected / 2 selected                                                                                                                                                                                                                                                                                                                   

tests/test_unit_nova.py::test_external_tags[api rest] SKIPPED (assert_external_tags was added in version 34.1.2)                                                                                                                                                                                                                                              [ 50%]
tests/test_unit_nova.py::test_external_tags[api sdk] SKIPPED (assert_external_tags was added in version 34.1.2)                                                                                                                                                                                                                                               [100%]

================================================================================================================================================================ 2 skipped, 442 deselected in 0.20s =================================================================================================================================================================
Finished removing environment: py3.11-gcp

```

With the latest version of the base check: 

```
❯ ddev test openstack_controller:py3.11-gcp -- -k test_external_tags
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── OpenStack Controller ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── py3.11-gcp ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
Finished checking dependencies
cmd [1] | pytest -vv --benchmark-skip --tb short -k test_external_tags
======================================================================================================================================================================== test session starts ========================================================================================================================================================================
platform darwin -- Python 3.11.5, pytest-7.4.3, pluggy-1.3.0 -- /Users/florent.clarret/Library/Application Support/hatch/env/virtual/datadog-openstack-controller/-5eK_Xhm/py3.11-gcp/bin/python
cachedir: .pytest_cache
benchmark: 4.0.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /Users/florent.clarret/go/src/github.com/DataDog/integrations-core/openstack_controller
plugins: flaky-3.7.0, cov-4.1.0, ddtrace-1.11.2, asyncio-0.21.1, memray-1.5.0, mock-3.12.0, benchmark-4.0.0, datadog-checks-dev-28.0.1
asyncio: mode=Mode.STRICT
collected 444 items / 442 deselected / 2 selected                                                                                                                                                                                                                                                                                                                   

tests/test_unit_nova.py::test_external_tags[api rest] PASSED                                                                                                                                                                                                                                                                                                  [ 50%]
tests/test_unit_nova.py::test_external_tags[api sdk] PASSED                                                                                                                                                                                                                                                                                                   [100%]

================================================================================================================================================================= 2 passed, 442 deselected in 0.33s =================================================================================================================================================================
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
