### PR TITLE
Fix the tests

### DIFF
--- a/snmp/tests/common.py
+++ b/snmp/tests/common.py
@@ -238,7 +238,7 @@ def generate_container_profile_config(community_string, profile=None):
 
 def generate_container_profile_config_with_ad(profile):
     host = socket.gethostbyname(get_container_ip(SNMP_CONTAINER_NAME))
-    network = ipaddress.ip_network(u'{}/29'.format(host)).with_prefixlen
+    network = ipaddress.ip_network(u'{}/29'.format(host), strict=False).with_prefixlen
     conf = {
         # Make sure the check handles bytes
         'network_address': to_native_string(network),

--- a/snmp/tests/test_check.py
+++ b/snmp/tests/test_check.py
@@ -865,7 +865,7 @@ def test_profile_sys_object_unknown(aggregator, caplog):
     # Via network discovery...
 
     host = socket.gethostbyname(common.HOST)
-    network = ipaddress.ip_network(u'{}/29'.format(host)).with_prefixlen
+    network = ipaddress.ip_network(u'{}/29'.format(host), strict=False).with_prefixlen
     instance = {
         'name': 'snmp_conf',
         'network_address': network,
@@ -898,7 +898,7 @@ def test_profile_sys_object_no_metrics():
 
 def test_discovery(aggregator):
     host = socket.gethostbyname(common.HOST)
-    network = ipaddress.ip_network(u'{}/29'.format(host)).with_prefixlen
+    network = ipaddress.ip_network(u'{}/29'.format(host), strict=False).with_prefixlen
     check_tags = [
         'snmp_device:{}'.format(host),
         'snmp_profile:profile1',
@@ -949,7 +949,7 @@ def test_discovery_devices_monitored_count(read_mock, aggregator):
     read_mock.return_value = '["192.168.0.1","192.168.0.2"]'
 
     host = socket.gethostbyname(common.HOST)
-    network = ipaddress.ip_network(u'{}/29'.format(host)).with_prefixlen
+    network = ipaddress.ip_network(u'{}/29'.format(host), strict=False).with_prefixlen
     check_tags = [
         'autodiscovery_subnet:{}'.format(to_native_string(network)),
     ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fix the tests, adding back the `strict` option to the `ip_network` calls.

### Motivation
<!-- What inspired you to submit this pull request? -->

I messed up with the tests in [this PR](https://github.com/DataDog/integrations-core/pull/15997) where I also modified some `zip` calls that uses a `strict` parameter too since Python 3.11.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I'm sorry, I'll be extra careful next time. 

![sorry-barack-obama](https://github.com/DataDog/integrations-core/assets/1266346/5aecb7bc-a595-4f39-87c0-412bf85991f1)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
