### PR TITLE
Add a CI job to check `do-not-merge` labels

### DIFF
--- a/.github/workflows/do-not-merge-label.yml
+++ b/.github/workflows/do-not-merge-label.yml
@@ -1,0 +1,23 @@
+name: Check do-not-merge labels
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - synchronize
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: Check do-not-merge labels
+    steps:
+      - name: Get PR labels
+        id: pr-labels
+        uses: joerick/pr-labels-action@v1.0.9
+
+      - run: |
+          echo "A 'do-not-merge/*' label has been found in this PR."
+          exit 1
+        if: contains(steps.pr-labels.outputs.labels, 'do-not-merge')


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a CI job to check `do-not-merge` labels. If one of this label is found, fail the CI.

### Motivation
<!-- What inspired you to submit this pull request? -->

We use this PR to notify reviewers that the PR is not ready to be merged. We do not always use the Draft PR because when we undraft PRs we need to seek for reviewers once again as team approval are not applied on draft PRs.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- Feel free to play with this PR to test the workflow (and to spam me)
- https://datadoghq.atlassian.net/browse/AITS-318

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
