### PR TITLE
Try to make the GitLab runner e2e less flaky

### DIFF
--- a/gitlab_runner/tests/conftest.py
+++ b/gitlab_runner/tests/conftest.py
@@ -36,16 +36,24 @@ def dd_environment():
         'GITLAB_LOCAL_RUNNER_PORT': str(GITLAB_LOCAL_RUNNER_PORT),
     }
     compose_file = os.path.join(HERE, 'compose', 'docker-compose.yml')
+
+    conditions = [
+        CheckDockerLogs(compose_file, patterns='Gitlab is up!', wait=5),
+        CheckDockerLogs(compose_file, patterns='Configuration loaded', wait=5),
+        CheckDockerLogs(compose_file, patterns='Metrics server listening', wait=5),
+    ]
+
+    for _ in range(2):
+        conditions.extend(
+            [
+                CheckEndpoints(GITLAB_RUNNER_URL, attempts=180, wait=3),
+                CheckEndpoints('{}/ci'.format(GITLAB_MASTER_URL), attempts=90, wait=3),
+            ]
+        )
+
     with docker_run(
         compose_file=compose_file,
         env_vars=env,
-        conditions=[
-            CheckDockerLogs(compose_file, patterns='Gitlab is up!', wait=5),
-            CheckDockerLogs(compose_file, patterns='Configuration loaded', wait=5),
-            CheckDockerLogs(compose_file, patterns='Metrics server listening', wait=5),
-            CheckEndpoints(GITLAB_RUNNER_URL, attempts=180),
-            CheckEndpoints('{}/ci'.format(GITLAB_MASTER_URL), attempts=90),
-        ],
-        attempts=2,
+        conditions=conditions,
     ):
         yield CONFIG, E2E_METADATA


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Try to make the GitLab runner e2e less flaky running the same conditions that check the endpoints twice

### Motivation
<!-- What inspired you to submit this pull request? -->

From master: 

```
___________________________________ test_e2e ___________________________________
tests/test_e2e.py:12: in test_e2e
    aggregator = dd_agent_check(CONFIG, rate=True)
../datadog_checks_dev/datadog_checks/dev/plugin/pytest.py:233: in run_check
    replay_check_run(collector, aggregator, datadog_agent)
../datadog_checks_dev/datadog_checks/dev/_env.py:173: in replay_check_run
    raise Exception("\n".join("Message: {}\n{}".format(err['message'], err['traceback']) for err in errors))
E   Exception: Message: Http status code 502 on url http://localhost:8085/ci
E   Traceback (most recent call last):
E     File "/home/datadog_checks_base/datadog_checks/base/checks/base.py", line 1235, in run
E       self.check(instance)
E     File "/home/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py", line 63, in check
E       self._check_connectivity_to_master(instance, custom_tags)
E     File "/home/gitlab_runner/datadog_checks/gitlab_runner/gitlab_runner.py", line 127, in _check_connectivity_to_master
E       raise Exception("Http status code {} on url {}".format(r.status_code, url))
E   Exception: Http status code 502 on url http://localhost:8085/ci
- generated xml file: /home/runner/work/integrations-core/integrations-core/gitlab_runner/.junit/test-e2e-py3.11-10.8.0.xml -
```

TLDR: The condition is OK, it returns a 200 but then it returns a 502. The idea is to check several times the same endpoint hoping that it will stabilize.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

https://datadoghq.atlassian.net/browse/AI-3665

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
