### PR TITLE
Add missings asserts and make the tests less flaky

### DIFF
--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -106,8 +106,10 @@ def test_snapshot_xmin(aggregator, integration_check, pg_instance):
     check.check(pg_instance)
 
     expected_tags = _get_expected_tags(check, pg_instance)
-    aggregator.assert_metric('postgresql.snapshot.xmin', value=xmin, count=1, tags=expected_tags)
-    aggregator.assert_metric('postgresql.snapshot.xmax', value=xmin, count=1, tags=expected_tags)
+    aggregator.assert_metric('postgresql.snapshot.xmin', count=1, tags=expected_tags)
+    assert aggregator.metrics('postgresql.snapshot.xmin')[0].value >= xmin
+    aggregator.assert_metric('postgresql.snapshot.xmax', count=1, tags=expected_tags)
+    assert aggregator.metrics('postgresql.snapshot.xmax')[0].value >= xmin
 
     with psycopg2.connect(host=HOST, dbname=DB_NAME, user="postgres", password="datad0g") as conn:
         # Force autocommit
@@ -119,9 +121,9 @@ def test_snapshot_xmin(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
     check.check(pg_instance)
     aggregator.assert_metric('postgresql.snapshot.xmin', count=1, tags=expected_tags)
-    aggregator.metrics('postgresql.snapshot.xmin')[0].value > xmin
+    assert aggregator.metrics('postgresql.snapshot.xmin')[0].value > xmin
     aggregator.assert_metric('postgresql.snapshot.xmax', count=1, tags=expected_tags)
-    aggregator.metrics('postgresql.snapshot.xmax')[0].value > xmin
+    assert aggregator.metrics('postgresql.snapshot.xmax')[0].value > xmin
 
 
 def test_snapshot_xip(aggregator, integration_check, pg_instance):


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Add missing assert statements added in https://github.com/DataDog/integrations-core/pull/16263/files
- Apply the same logic to the previous assertion in the tests

### Motivation
<!-- What inspired you to submit this pull request? -->

- We're not asserting anything right now
- The CI is still flaky https://github.com/DataDog/integrations-core/actions/runs/7015727525/job/19085619262#step:13:1771

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
