### PR TITLE
[ddev] Bump pysmi version to master

### DIFF
--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -77,7 +77,7 @@ cli = [
     "pathspec>=0.10.0",
     "platformdirs>=2.0.0a3",
     "pydantic>=2.0.2, <2.4.0",
-    "pysmi>=0.3.4",
+    "pysmi @ git+https://github.com/etingof/pysmi@58f2bf29cccff633af703f319dc237e17e16e3d3#egg=pysmi",
     "securesystemslib[crypto]==0.28.0",
     "semver>=2.13.0",
     "tabulate>=0.8.9",
@@ -120,6 +120,9 @@ include = [
 dev-mode-dirs = [
     ".",
 ]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.pytest.ini_options]
 testpaths = "tests"

--- a/datadog_checks_dev/pyproject.toml
+++ b/datadog_checks_dev/pyproject.toml
@@ -77,6 +77,7 @@ cli = [
     "pathspec>=0.10.0",
     "platformdirs>=2.0.0a3",
     "pydantic>=2.0.2, <2.4.0",
+    # pysmi is unmaintained at the moment, with unreleased bugfixes so we pin it to the last commit
     "pysmi @ git+https://github.com/etingof/pysmi@58f2bf29cccff633af703f319dc237e17e16e3d3#egg=pysmi",
     "securesystemslib[crypto]==0.28.0",
     "semver>=2.13.0",


### PR DESCRIPTION
### What does this PR do?
pysmi has a bug where v1 traps OIDs are generated in the shape <ENTERPRISE_OID>0.<TRAP_ID> instead of <ENTERPRISE_OID>.0.<TRAP_ID>

The issue was fixed upstream but in an unreleased version of pysmi, in this PR: https://github.com/etingof/pysmi/pull/41

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
