### PR TITLE
[Tooling] Update devcontainer to use pip for ddev installation & docker-in-docker for `ddev env start` commands

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,14 @@
 # This dockerfile is used to build the devcontainer environment.
 # more info about vscode devcontainer: https://code.visualstudio.com/docs/devcontainers/containers
 FROM mcr.microsoft.com/devcontainers/python:1-3.11-bullseye
-RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y liblz4-dev libunwind-dev
+RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y liblz4-dev libunwind-dev ca-certificates curl gnupg
+# Docker and docker-compose installation
+RUN install -m 0755 -d /etc/apt/keyrings
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+RUN chmod a+r /etc/apt/keyrings/docker.gpg
+# Add the repository to Apt sources:
+RUN echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN apt update
+RUN DEBIAN_FRONTEND=noninteractive apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,8 +14,10 @@
 		"ghcr.io/devcontainers/features/python:1": {}
 	},
 
-	// Install the local ddev cli at start time and set the location of the integrations-core folder, start docker service
-	"postCreateCommand": "pipx install -e /workspaces/integrations-core/ddev && ddev config find && sed -i 's|core = \"~/dd/integrations-core\"|core = \"/workspaces/integrations-core\"|' /root/.local/share/dd-checks-dev/config.toml && service docker start",
+	// Install the local ddev cli at creation time and set the location of the integrations-core folder
+	"postCreateCommand": "pip install -e /workspaces/integrations-core/datadog_checks_dev[cli] && pip install -e /workspaces/integrations-core/ddev && ddev config set repos.core /workspaces/integrations-core && ddev config set repo core",
+	// Start docker-in-docker service when the container is started
+	"postStartCommand": "service docker start",
 
 	// To access docker socket/service
 	"remoteUser": "root"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,22 +8,15 @@
 		// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
 		"dockerfile": "./Dockerfile"
 	},
+	// To run docker in docker
+	"privileged": true,
 	"features": {
 		"ghcr.io/devcontainers/features/python:1": {}
 	},
 
-	// Install the local ddev cli at start time.
-	"postCreateCommand": "pip install -e /workspaces/integrations-core/ddev"
+	// Install the local ddev cli at start time and set the location of the integrations-core folder, start docker service
+	"postCreateCommand": "pipx install -e /workspaces/integrations-core/ddev && ddev config find && sed -i 's|core = \"~/dd/integrations-core\"|core = \"/workspaces/integrations-core\"|' /root/.local/share/dd-checks-dev/config.toml && service docker start",
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "devcontainer"
+	// To access docker socket/service
+	"remoteUser": "root"
 }


### PR DESCRIPTION
### What does this PR do?
* Updates the devcontainer to install `datadog_checks_dev[cli]`
* Adds `docker` packages to be able to use `ddev env start` commands

### Motivation
* Self-testing, current devcontainer has limited usefulness
* We cannot share the docker socket from the host as ddev tests are meant to be run from a host (targetting localhost from the forwarded test containers ports), so we use docker-in-docker instead

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
