### PR TITLE
Bump Python version from py3.9 to py3.11

### DIFF
--- a/flink/changelog.d/16302.added
+++ b/flink/changelog.d/16302.added
@@ -1,0 +1,1 @@
+Bump Python version from py3.9 to py3.11

--- a/flink/pyproject.toml
+++ b/flink/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.11",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/flink/setup.py
+++ b/flink/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.11',
     ],
     # The package we're going to ship
     packages=['datadog_checks.flink'],

--- a/journald/changelog.d/16302.added
+++ b/journald/changelog.d/16302.added
@@ -1,0 +1,1 @@
+Bump Python version from py3.9 to py3.11

--- a/journald/pyproject.toml
+++ b/journald/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.11",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/journald/setup.py
+++ b/journald/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.11',
     ],
     # The package we're going to ship
     packages=['datadog_checks.journald'],

--- a/pan_firewall/changelog.d/16302.added
+++ b/pan_firewall/changelog.d/16302.added
@@ -1,0 +1,1 @@
+Bump Python version from py3.9 to py3.11

--- a/pan_firewall/pyproject.toml
+++ b/pan_firewall/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.11",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/pan_firewall/setup.py
+++ b/pan_firewall/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.11',
     ],
     # The package we're going to ship
     packages=['datadog_checks.pan_firewall'],

--- a/sidekiq/changelog.d/16302.added
+++ b/sidekiq/changelog.d/16302.added
@@ -1,0 +1,1 @@
+Bump Python version from py3.9 to py3.11

--- a/sidekiq/pyproject.toml
+++ b/sidekiq/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.11",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/sidekiq/setup.py
+++ b/sidekiq/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.11',
     ],
     # The package we're going to ship
     packages=['datadog_checks.sidekiq'],

--- a/tenable/changelog.d/16302.added
+++ b/tenable/changelog.d/16302.added
@@ -1,0 +1,1 @@
+Bump Python version from py3.9 to py3.11

--- a/tenable/pyproject.toml
+++ b/tenable/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.11",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
 ]

--- a/tenable/setup.py
+++ b/tenable/setup.py
@@ -67,7 +67,7 @@ setup(
         'Topic :: System :: Monitoring',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.11',
     ],
     # The package we're going to ship
     packages=['datadog_checks.tenable'],


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump Python version from py3.9 to py3.11 in log integrations.

This has almost no effect since they are not Python integrations. We only have a config file to configure the log collection

### Motivation
<!-- What inspired you to submit this pull request? -->

Missed in https://github.com/DataDog/integrations-core/pull/15997, I'll fix the script

### Additional Notes
<!-- Anything else we should know when reviewing? -->

https://datadoghq.atlassian.net/browse/AITS-277

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
