### PR TITLE
Take into account logs only integrations when bumping the Python version

### DIFF
--- a/ddev/changelog.d/16303.fixed
+++ b/ddev/changelog.d/16303.fixed
@@ -1,0 +1,1 @@
+Take into account logs only integrations when bumping the Python version

--- a/ddev/src/ddev/cli/meta/scripts/upgrade_python.py
+++ b/ddev/src/ddev/cli/meta/scripts/upgrade_python.py
@@ -55,7 +55,7 @@ def integrations(app):
         names = ["datadog_checks_dependency_provider"]
         extra_integrations = [Integration(app.repo.path / name, app.repo.path, app.repo.config) for name in names]
 
-    return itertools.chain(app.repo.integrations.iter_testable(['all']), extra_integrations)
+    return itertools.chain(app.repo.integrations.iter_packages(['all']), extra_integrations)
 
 
 def update_ci_files(app: Application, new_version: str, old_version: str, tracker: ValidationTracker):

--- a/ddev/tests/cli/meta/scripts/conftest.py
+++ b/ddev/tests/cli/meta/scripts/conftest.py
@@ -68,6 +68,24 @@ python = ["2.7", "{OLD_PYTHON_VERSION}"]
         )
 
     write_file(
+        repo_path / 'logs_only',
+        'pyproject.toml',
+        f"""[project]
+    name = "dummy"
+    classifiers = [
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: {OLD_PYTHON_VERSION}",
+    ]
+    """,
+    )
+
+    write_file(
         repo_path / '.github' / 'workflows',
         'build-ddev.yml',
         f"""name: build ddev

--- a/ddev/tests/cli/meta/scripts/test_upgrade_python.py
+++ b/ddev/tests/cli/meta/scripts/test_upgrade_python.py
@@ -14,7 +14,7 @@ def test_upgrade_python(fake_repo, ddev):
     result = ddev('meta', 'scripts', 'upgrade-python', NEW_PYTHON_VERSION)
 
     assert result.exit_code == 0, result.output
-    assert result.output.endswith('Python upgrades\n\nPassed: 8\n')
+    assert result.output.endswith('Python upgrades\n\nPassed: 9\n')
 
     contents = constant_file.read_text()
     assert f'PYTHON_VERSION = {OLD_PYTHON_VERSION!r}' not in contents
@@ -30,7 +30,7 @@ def test_upgrade_python(fake_repo, ddev):
     assert f'python = ["2.7", "{OLD_PYTHON_VERSION}"]' not in contents
     assert f'python = ["2.7", "{NEW_PYTHON_VERSION}"]' in contents
 
-    for integration in ('dummy', 'datadog_checks_dependency_provider'):
+    for integration in ('dummy', 'datadog_checks_dependency_provider', 'logs_only'):
         pyproject_file = fake_repo.path / integration / 'pyproject.toml'
         contents = pyproject_file.read_text()
         assert f'Programming Language :: Python :: {OLD_PYTHON_VERSION}' not in contents


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Take into account logs only integrations when bumping the Python version

### Motivation
<!-- What inspired you to submit this pull request? -->

Currently we iterate only over testable integrations, the ones which have a `hatch.toml` file. That's not right because some integrations do not have one, such as logs only integration.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

https://datadoghq.atlassian.net/browse/AITS-283

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
