### PR TITLE
Remove the `requirements-dev.txt` files

### DIFF
--- a/flink/requirements-dev.txt
+++ b/flink/requirements-dev.txt
@@ -1,1 +1,0 @@
--e ../datadog_checks_dev

--- a/journald/requirements-dev.txt
+++ b/journald/requirements-dev.txt
@@ -1,1 +1,0 @@
--e ../datadog_checks_dev

--- a/pan_firewall/requirements-dev.txt
+++ b/pan_firewall/requirements-dev.txt
@@ -1,1 +1,0 @@
--e ../datadog_checks_dev

--- a/sidekiq/requirements-dev.txt
+++ b/sidekiq/requirements-dev.txt
@@ -1,1 +1,0 @@
--e ../datadog_checks_dev

--- a/tenable/requirements-dev.txt
+++ b/tenable/requirements-dev.txt
@@ -1,1 +1,0 @@
--e ../datadog_checks_dev


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove the `requirements-dev.txt` files

### Motivation
<!-- What inspired you to submit this pull request? -->

We do not use them anymore because we no longer use tox and this is include in our hatch setup. They are not used in logs integrations anyway

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
