### PR TITLE
Fix typo in log line

### DIFF
--- a/vsphere/changelog.d/16314.fixed
+++ b/vsphere/changelog.d/16314.fixed
@@ -1,0 +1,1 @@
+Fix typo in log line

--- a/vsphere/datadog_checks/vsphere/vsphere.py
+++ b/vsphere/datadog_checks/vsphere/vsphere.py
@@ -699,7 +699,7 @@ class VSphereCheck(AgentCheck):
             if no_additional_tags:
                 if metric_value is None:
                     self.log.debug(
-                        "Could not sumbit property metric- no metric data: name=`%s`, value=`%s`, hostname=`%s`, "
+                        "Could not submit property metric- no metric data: name=`%s`, value=`%s`, hostname=`%s`, "
                         "base tags=`%s` additional tags=`%s`",
                         metric_full_name,
                         metric_value,
@@ -721,7 +721,7 @@ class VSphereCheck(AgentCheck):
                 metric_value = float(metric_value)
             except Exception:
                 self.log.debug(
-                    "Could not sumbit property metric- unexpected metric value: name=`%s`, value=`%s`, hostname=`%s`, "
+                    "Could not submit property metric- unexpected metric value: name=`%s`, value=`%s`, hostname=`%s`, "
                     "base tags=`%s` additional tags=`%s`",
                     metric_full_name,
                     metric_value,

--- a/vsphere/tests/test_unit.py
+++ b/vsphere/tests/test_unit.py
@@ -2333,7 +2333,7 @@ def test_vm_property_metrics(aggregator, realtime_instance, dd_run_check, caplog
         hostname='vm1',
     )
     assert (
-        "Could not sumbit property metric- no metric data: name=`vm.guest.guestFullName`, "
+        "Could not submit property metric- no metric data: name=`vm.guest.guestFullName`, "
         "value=`None`, hostname=`vm1`, base tags=`['vcenter_server:FAKE', 'vsphere_host:host1', "
         "'vsphere_folder:unknown', 'vsphere_type:vm']` additional tags=`{}`"
     ) in caplog.text
@@ -2393,7 +2393,7 @@ def test_vm_property_metrics(aggregator, realtime_instance, dd_run_check, caplog
         hostname='vm1',
     )
     assert (
-        "Could not sumbit property metric- no metric data: name=`vm.guest.toolsRunningStatus`, "
+        "Could not submit property metric- no metric data: name=`vm.guest.toolsRunningStatus`, "
         "value=`None`, hostname=`vm1`, base tags=`['vcenter_server:FAKE', 'vsphere_host:host1', "
         "'vsphere_folder:unknown', 'vsphere_type:vm']` additional tags=`{}`"
     ) in caplog.text
@@ -2485,7 +2485,7 @@ def test_vm_property_metrics(aggregator, realtime_instance, dd_run_check, caplog
         hostname='vm1',
     )
     assert (
-        "Could not sumbit property metric- unexpected metric value: "
+        "Could not submit property metric- unexpected metric value: "
         "name=`vm.config.cpuAllocation.overheadLimit`, value=`None`, hostname=`vm1`, "
         "base tags=`['vcenter_server:FAKE', 'vsphere_host:host1', 'vsphere_folder:unknown', "
         "'vsphere_type:vm']` additional tags=`{}`"
@@ -2497,7 +2497,7 @@ def test_vm_property_metrics(aggregator, realtime_instance, dd_run_check, caplog
         hostname='vm1',
     )
     assert (
-        "Could not sumbit property metric- unexpected metric value: "
+        "Could not submit property metric- unexpected metric value: "
         "name=`vm.config.memoryAllocation.overheadLimit`, value=`None`, hostname=`vm1`, "
         "base tags=`['vcenter_server:FAKE', 'vsphere_host:host1', 'vsphere_folder:unknown', "
         "'vsphere_type:vm']` additional tags=`{}`"
@@ -2559,7 +2559,7 @@ def test_vm_property_metrics(aggregator, realtime_instance, dd_run_check, caplog
         hostname='vm3',
     )
     assert (
-        "Could not sumbit property metric- unexpected metric value: name=`vm.summary.config.memorySizeMB`, "
+        "Could not submit property metric- unexpected metric value: name=`vm.summary.config.memorySizeMB`, "
         "value=`None`, hostname=`vm3`, base tags=`['vcenter_server:FAKE', 'vsphere_host:host2', "
         "'vsphere_folder:unknown', 'vsphere_type:vm']` additional tags=`{}`"
     ) in caplog.text
@@ -2692,7 +2692,7 @@ def test_host_property_metrics(aggregator, realtime_instance, dd_run_check, capl
     )
 
     assert (
-        "Could not sumbit property metric- no metric data: "
+        "Could not submit property metric- no metric data: "
         "name=`host.hardware.cpuPowerManagementInfo.currentPolicy`, value=`None`, "
         "hostname=`host2`, base tags=`['vcenter_server:FAKE', 'vsphere_type:host']` "
         "additional tags=`{}`"


### PR DESCRIPTION
### What does this PR do?
Fixes a typo in log line when collecting property metrics
### Motivation
https://github.com/DataDog/integrations-core/pull/16296#discussion_r1408998421
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
