### PR TITLE
Revert "Remove SQL Server logs from tests"

### DIFF
--- a/sqlserver/tests/compose/docker-compose.yaml
+++ b/sqlserver/tests/compose/docker-compose.yaml
@@ -14,4 +14,6 @@ services:
       - ACCEPT_EULA=Y
       - SA_PASSWORD=Password123
     ports:
-      - "1433:1433"     
+      - "1433:1433"
+    volumes:
+      - ${DD_LOG_1}:/var/opt/mssql/log/errorlog


### PR DESCRIPTION
Reverts DataDog/integrations-core#16307

We do use them when we want to test the logs product, see:

- https://datadoghq.dev/integrations-core/ddev/test/#logs
- https://github.com/DataDog/integrations-core/blob/d4233a46329b8c446c06d363b2ce4f3721a81f9b/sqlserver/tests/conftest.py#L329