### PR TITLE
Update openai dashboard model pricing to latest

### DIFF
--- a/openai/assets/dashboards/overview_dashboard.json
+++ b/openai/assets/dashboards/overview_dashboard.json
@@ -217,93 +217,141 @@
                 {
                   "formulas": [
                     {
-                      "formula": "((query1 / 1000) * 0.0004) + ((query2 / 1000) * 0.002) + ((query3 / 1000) * 0.002) + ((query4 / 1000) * 0.0005) + ((query5 / 1000) * 0.02) + ((query6 / 1000) * 0.03) + ((query7 / 1000) * 0.06) + ((query8 / 1000) * 0.06) + ((query9 / 1000) * 0.12) + ((query10 / 1000) * 0.0004) + ((query11 / 1000) * 0.02) + ((query12 / 1000) * 0.002) + ((query13 / 1000) * 0.0005) + ((query14 / 1000) * 0.0004)"
+                      "formula": "0.001 * (((gpt_4_1106_preview_prompt * 0.01) + (gpt_4_1106_preview_completion * 0.03)) + ((gpt_4_prompt * 0.03) + (gpt_4_completion * 0.06)) + ((gpt_4_32k_prompt * 0.06) + (gpt_4_32k_completion * 0.12)) + ((gpt_3_5_turbo_1106_prompt * 0.001) + (gpt_3_5_turbo_1106_completion * 0.002)) + ((gpt_3_5_turbo_instruct_prompt * 0.0015) + (gpt_3_5_turbo_instruct_completion * 0.002)) + ((gpt_3_5_turbo_0613_prompt * 0.0015) + (gpt_3_5_turbo_0613_completion * 0.002)) + ((gpt_3_5_turbo_16k_0613_prompt * 0.003) + (gpt_3_5_turbo_16k_0613_completion * 0.004)) + (text_embedding_ada_002 * 0.0001) + (davinci_002 * 0.002) + (babbage_002 * 0.0004) + (ada_001 * 0.0004) + (babbage_001 * 0.0005) + (curie_001 * 0.002) + (davinci * 0.02))"
                     }
                   ],
                   "queries": [
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query1",
-                      "query": "sum:openai.tokens.total{openai.request.model:ada*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_4_1106_preview_prompt",
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-4-*-preview,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query2",
-                      "query": "sum:openai.tokens.total{openai.request.model:gpt-3.5*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_4_1106_preview_completion",
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-4-*-preview,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query3",
-                      "query": "sum:openai.tokens.total{openai.request.model:curie*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
-                    },
-                    {
-                      "aggregator": "sum",
-                      "data_source": "metrics",
-                      "name": "query4",
-                      "query": "sum:openai.tokens.total{openai.request.model:babbage*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
-                    },
-                    {
-                      "aggregator": "sum",
-                      "data_source": "metrics",
-                      "name": "query5",
-                      "query": "sum:openai.tokens.total{openai.request.model:davinci*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
-                    },
-                    {
-                      "aggregator": "sum",
-                      "data_source": "metrics",
-                      "name": "query6",
+                      "name": "gpt_4_prompt",
                       "query": "sum:openai.tokens.prompt{openai.request.model:gpt-4,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query7",
+                      "name": "gpt_4_completion",
                       "query": "sum:openai.tokens.completion{openai.request.model:gpt-4,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query8",
-                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-4-32k*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_4_32k_prompt",
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-4-32k,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query9",
-                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-4-32k*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_4_32k_completion",
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-4-32k,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query10",
-                      "query": "sum:openai.tokens.total{openai.request.model:text-embedding-ada*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_3_5_turbo_1106_prompt",
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-3.5-turbo-1106,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query11",
-                      "query": "sum:openai.tokens.total{openai.request.model:text-davinci*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_3_5_turbo_1106_completion",
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-3.5-turbo-1106,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query12",
-                      "query": "sum:openai.tokens.total{openai.request.model:text-curie*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_3_5_turbo_instruct_prompt",
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-3.5-turbo-instruct,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query13",
-                      "query": "sum:openai.tokens.total{openai.request.model:text-babbage*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_3_5_turbo_instruct_completion",
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-3.5-turbo-instruct,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "query14",
-                      "query": "sum:openai.tokens.total{openai.request.model:text-ada*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_3_5_turbo_0613_prompt",
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-3.5-turbo-0613,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "gpt_3_5_turbo_0613_completion",
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-3.5-turbo-0613,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "gpt_3_5_turbo_16k_0613_prompt",
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-3.5-turbo-16k-0613,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "gpt_3_5_turbo_16k_0613_completion",
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-3.5-turbo-16k-0613,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "text_embedding_ada_002",
+                      "query": "sum:openai.tokens.total{openai.request.model:text-embedding-ada-002,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "davinci_002",
+                      "query": "sum:openai.tokens.total{openai.request.model:davinci-002,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "babbage_002",
+                      "query": "sum:openai.tokens.total{openai.request.model:babbage-002,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "text_ada_001",
+                      "query": "sum:openai.tokens.total{openai.request.model:text-ada-001,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "ada_001",
+                      "query": "sum:openai.tokens.total{openai.request.model:text-ada-001 or openai.request.model:ada,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "babbage_001",
+                      "query": "sum:openai.tokens.total{openai.request.model:text-babbage-001 or openai.request.model:babbage,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "curie_001",
+                      "query": "sum:openai.tokens.total{openai.request.model:text-curie-001 or openai.request.model:curie,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "davinci",
+                      "query": "sum:openai.tokens.total{openai.request.model:text-davinci-* or openai.request.model:davinci,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     }
                   ],
                   "response_format": "scalar"
@@ -799,99 +847,135 @@
                 {
                   "formulas": [
                     {
-                      "formula": "((ada / 1000) * 0.0004) + ((gpt_3_5_4k_prompt / 1000) * 0.0015) + ((gpt_3_5_4k_completion / 1000) * 0.002) + ((gpt_3_5_16k_prompt / 1000) * 0.003) + ((gpt_3_5_16k_completion / 1000) * 0.004) + ((curie / 1000) * 0.002) + ((babbage / 1000) * 0.0004) + ((davinci / 1000) * 0.002) + ((gpt_4_8k_prompt / 1000) * 0.03) + ((gpt_4_8k_completion / 1000) * 0.06) + ((gpt_4_32k_prompt / 1000) * 0.06) + ((gpt_4_32k_completion / 1000) * 0.12) + ((text_ada_embedding / 1000) * 0.0001) + ((text_babbage / 1000) * 0.0005) + ((text_ada / 1000) * 0.0004)"
+                      "formula": "0.001 * (((gpt_4_1106_preview_prompt * 0.01) + (gpt_4_1106_preview_completion * 0.03)) + ((gpt_4_prompt * 0.03) + (gpt_4_completion * 0.06)) + ((gpt_4_32k_prompt * 0.06) + (gpt_4_32k_completion * 0.12)) + ((gpt_3_5_turbo_1106_prompt * 0.001) + (gpt_3_5_turbo_1106_completion * 0.002)) + ((gpt_3_5_turbo_instruct_prompt * 0.0015) + (gpt_3_5_turbo_instruct_completion * 0.002)) + ((gpt_3_5_turbo_0613_prompt * 0.0015) + (gpt_3_5_turbo_0613_completion * 0.002)) + ((gpt_3_5_turbo_16k_0613_prompt * 0.003) + (gpt_3_5_turbo_16k_0613_completion * 0.004)) + (text_embedding_ada_002 * 0.0001) + (davinci_002 * 0.002) + (babbage_002 * 0.0004) + (ada_001 * 0.0004) + (babbage_001 * 0.0005) + (curie_001 * 0.002) + (davinci * 0.02))"
                     }
                   ],
                   "queries": [
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "ada",
-                      "query": "sum:openai.tokens.total{openai.request.model:ada*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_4_1106_preview_prompt",
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-4-*-preview,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "gpt_3_5_4k_prompt",
-                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-3.5-turbo,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_4_1106_preview_completion",
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-4-*-preview,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "gpt_3_5_4k_completion",
-                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-3.5-turbo,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
-                    },
-                                        {
-                      "aggregator": "sum",
-                      "data_source": "metrics",
-                      "name": "gpt_3_5_16k_prompt",
-                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-3.5-turbo-16k*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
-                    },
-                    {
-                      "aggregator": "sum",
-                      "data_source": "metrics",
-                      "name": "gpt_3_5_16k_completion",
-                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-3.5-turbo-16k*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
-                    },
-                    {
-                      "aggregator": "sum",
-                      "data_source": "metrics",
-                      "name": "curie",
-                      "query": "sum:openai.tokens.total{openai.request.model:*curie*,$model,$env,$version,$service,$organization,$openai.user.api_key}.as_count()"
-                    },
-                    {
-                      "aggregator": "sum",
-                      "data_source": "metrics",
-                      "name": "babbage",
-                      "query": "sum:openai.tokens.total{openai.request.model:babbage*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
-                    },
-                    {
-                      "aggregator": "sum",
-                      "data_source": "metrics",
-                      "name": "davinci",
-                      "query": "sum:openai.tokens.total{openai.request.model:*davinci*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
-                    },
-                    {
-                      "aggregator": "sum",
-                      "data_source": "metrics",
-                      "name": "gpt_4_8k_prompt",
+                      "name": "gpt_4_prompt",
                       "query": "sum:openai.tokens.prompt{openai.request.model:gpt-4,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "gpt_4_8k_completion",
+                      "name": "gpt_4_completion",
                       "query": "sum:openai.tokens.completion{openai.request.model:gpt-4,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "gpt_4_32k_prompt",
-                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-4-32k*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-4-32k,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
                       "name": "gpt_4_32k_completion",
-                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-4-32k*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-4-32k,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "text_ada_embedding",
-                      "query": "sum:openai.tokens.total{openai.request.model:text-embedding-ada*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_3_5_turbo_1106_prompt",
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-3.5-turbo-1106,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "text_babbage",
-                      "query": "sum:openai.tokens.total{openai.request.model:text-babbage*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_3_5_turbo_1106_completion",
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-3.5-turbo-1106,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     },
                     {
                       "aggregator": "sum",
                       "data_source": "metrics",
-                      "name": "text_ada",
-                      "query": "sum:openai.tokens.total{openai.request.model:text-ada*,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                      "name": "gpt_3_5_turbo_instruct_prompt",
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-3.5-turbo-instruct,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "gpt_3_5_turbo_instruct_completion",
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-3.5-turbo-instruct,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "gpt_3_5_turbo_0613_prompt",
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-3.5-turbo-0613,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "gpt_3_5_turbo_0613_completion",
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-3.5-turbo-0613,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "gpt_3_5_turbo_16k_0613_prompt",
+                      "query": "sum:openai.tokens.prompt{openai.request.model:gpt-3.5-turbo-16k-0613,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "gpt_3_5_turbo_16k_0613_completion",
+                      "query": "sum:openai.tokens.completion{openai.request.model:gpt-3.5-turbo-16k-0613,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "text_embedding_ada_002",
+                      "query": "sum:openai.tokens.total{openai.request.model:text-embedding-ada-002,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "davinci_002",
+                      "query": "sum:openai.tokens.total{openai.request.model:davinci-002,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "babbage_002",
+                      "query": "sum:openai.tokens.total{openai.request.model:babbage-002,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "ada_001",
+                      "query": "sum:openai.tokens.total{openai.request.model:text-ada-001 or openai.request.model:ada,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "babbage_001",
+                      "query": "sum:openai.tokens.total{openai.request.model:text-babbage-001 or openai.request.model:babbage,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "curie_001",
+                      "query": "sum:openai.tokens.total{openai.request.model:text-curie-001 or openai.request.model:curie,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
+                    },
+                    {
+                      "aggregator": "sum",
+                      "data_source": "metrics",
+                      "name": "davinci",
+                      "query": "sum:openai.tokens.total{openai.request.model:text-davinci-* or openai.request.model:davinci,$model,$env,$service,$version,$organization,$openai.user.api_key}.as_count()"
                     }
                   ],
                   "response_format": "scalar"
@@ -913,7 +997,7 @@
             "id": 3868770172430520,
             "definition": {
               "type": "note",
-              "content": "OpenAI base model pricing (per 1K tokens)\n- **ada**: $0.0001\n- **babbage**: $0.0004\n- **curie**: $0.002\n- **davinci**: $0.002\n- **gpt-3.5-turbo-4k**: $0.0015 prompt, $0.002 completion\n- **gpt-3.5-turbo-16k**: $0.003 prompt, $0.004 completion\n- **gpt-4-8k**: $0.03 prompt, $0.06 completion\n- **gpt-4-32k**: $0.06 prompt, $0.12 completion\n\n\n\nhttps://openai.com/pricing (2023-09-01)",
+              "content": "OpenAI base model pricing (per 1K tokens)\n- **gpt-4-turbo-preview**: $0.01 prompt, $0.03 completion\n- **gpt-4**: $0.03 prompt, $0.06 completion\n- **gpt-4-32k**: $0.06 prompt, $0.12 completion\n- **gpt-3.5-turbo-1106**: $0.001 prompt, $0.00 completion\n- **gpt-3.5-turbo-instruct**: $0.0015 prompt, $0.002 completion\n- **gpt-3.5-turbo-0613**: $0.0015 prompt, $0.002 completion\n- **gpt-3.5-turbo-16k**: $0.003 prompt, $0.004 completion\n- **text-embedding-ada-002**: $0.0001\n- **davinci-002**: $0.002\n- **babbage-002**: $0.002\n- **ada-001**: $0.0004\n- **babbage-001**: $0.005\n- **curie-001**: $0.002\n- **text-davinci-001/002/003**: $0.02\n\n\n\nhttps://openai.com/pricing (2023-11-06)",
               "background_color": "orange",
               "font_size": "14",
               "text_align": "left",


### PR DESCRIPTION
This PR updates the estimated cost calculation query in the openAI overview dashboard to use the correct formula that reflects the correct OpenAI model prices as of November 6, 2023 (includes new gpt-4-preview models). Additionally, this PR applies the same changes to the second `estimated cost` widget that was missed in the previous PR (#15738). This PR also updates the pricing text block the dashboard provides to reflect correct model prices as of November 6, 2023.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
