### PR TITLE
Return an exit code 0 when running the tests without specifying envs but none are found with the `test` command

### DIFF
--- a/ddev/changelog.d/16321.fixed
+++ b/ddev/changelog.d/16321.fixed
@@ -1,0 +1,1 @@
+Return an exit code 0 when running the tests without specifying envs but none are found with the `test` command

--- a/ddev/src/ddev/cli/test/__init__.py
+++ b/ddev/src/ddev/cli/test/__init__.py
@@ -228,7 +228,17 @@ def test(
                     for env_name in chosen_environments:
                         app.platform.check_command([sys.executable, '-m', 'hatch', 'env', 'remove', env_name])
 
-            app.platform.check_command(command)
+            import subprocess
+
+            process = app.platform.run_command(command, stderr=subprocess.PIPE)
+
+            if process.returncode:
+                app.display_error(process.stderr.decode('utf-8'))
+                if chosen_environments == ["default"] and "No environments were selected" in str(process.stderr):
+                    continue
+                else:
+                    app.platform.exit_with_code(process.returncode)
+
             if standard_tests and coverage:
                 app.display_header('Coverage report')
                 app.platform.check_command([sys.executable, '-m', 'coverage', 'report', '--rcfile=../.coveragerc'])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Return an exit code 0 when running the tests without specifying envs but none are found with the `test` command

### Motivation
<!-- What inspired you to submit this pull request? -->

When we do not specify any environments to run with the `ddev test` commands for a given integration, the commands will return an exit code 1 if no envs are found. This leads to some issues for example in this CI https://github.com/DataDog/integrations-core/actions/runs/7055597290/job/19206334916 because most of these errors are due to the fact that these integrations don't have py2 environments. However, we will still print the error message. 

The commands will keep returning an error code if you try to use an environment that does not exist, I only changed the behavior if you try to run them all. 

Before without env: 

```
❯ ddev test --cov --junit temporal --python-filter 2.7; echo $?
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Temporal ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
No environments were selected

1
```

After without env: 

```
❯ ddev test --cov --junit temporal --python-filter 2.7; echo $?
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Temporal ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
No environments were selected

0
```

After with an env:
```
❯ ddev test --cov --junit temporal:unknown --python-filter 2.7; echo $?
───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── Temporal ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
No environments were selected

1
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
