### PR TITLE
Bump the cryptography version to 41.0.6

### DIFF
--- a/cisco_aci/changelog.d/16322.fixed
+++ b/cisco_aci/changelog.d/16322.fixed
@@ -1,0 +1,1 @@
+Bump the cryptography version to 41.0.6

--- a/cisco_aci/pyproject.toml
+++ b/cisco_aci/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==41.0.5; python_version > '3.0'",
+    "cryptography==41.0.6; python_version > '3.0'",
 ]
 
 [project.urls]

--- a/datadog_checks_base/changelog.d/16322.fixed
+++ b/datadog_checks_base/changelog.d/16322.fixed
@@ -1,0 +1,1 @@
+Bump the cryptography version to 41.0.6

--- a/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
+++ b/datadog_checks_base/datadog_checks/base/data/agent_requirements.in
@@ -20,7 +20,7 @@ cm-client==45.0.4
 confluent-kafka==2.3.0; python_version > '3.0'
 contextlib2==0.6.0.post1; python_version < '3.0'
 cryptography==3.3.2; python_version < '3.0'
-cryptography==41.0.5; python_version > '3.0'
+cryptography==41.0.6; python_version > '3.0'
 ddtrace==0.32.2; sys_platform == 'win32' and python_version < '3.0'
 ddtrace==0.53.2; sys_platform != 'win32' and python_version < '3.0'
 ddtrace==1.11.2; python_version > '3.0'

--- a/datadog_checks_base/pyproject.toml
+++ b/datadog_checks_base/pyproject.toml
@@ -43,7 +43,7 @@ deps = [
     "cachetools==5.3.2; python_version > '3.0'",
     "contextlib2==0.6.0.post1; python_version < '3.0'",
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==41.0.5; python_version > '3.0'",
+    "cryptography==41.0.6; python_version > '3.0'",
     "ddtrace==0.32.2; sys_platform == 'win32' and python_version < '3.0'",
     "ddtrace==0.53.2; sys_platform != 'win32' and python_version < '3.0'",
     "ddtrace==1.11.2; python_version > '3.0'",

--- a/http_check/changelog.d/16322.fixed
+++ b/http_check/changelog.d/16322.fixed
@@ -1,0 +1,1 @@
+Bump the cryptography version to 41.0.6

--- a/http_check/pyproject.toml
+++ b/http_check/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==41.0.5; python_version > '3.0'",
+    "cryptography==41.0.6; python_version > '3.0'",
     "requests-ntlm==1.1.0; python_version < '3.0'",
     "requests-ntlm==1.2.0; python_version > '3.0'",
 ]

--- a/mysql/changelog.d/16322.fixed
+++ b/mysql/changelog.d/16322.fixed
@@ -1,0 +1,1 @@
+Bump the cryptography version to 41.0.6

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -42,7 +42,7 @@ deps = [
     "cachetools==3.1.1; python_version < '3.0'",
     "cachetools==5.3.2; python_version > '3.0'",
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==41.0.5; python_version > '3.0'",
+    "cryptography==41.0.6; python_version > '3.0'",
     "futures==3.4.0; python_version < '3.0'",
     "pymysql==0.10.1; python_version < '3.0'",
     "pymysql==1.1.0; python_version > '3.0'",

--- a/tls/changelog.d/16322.fixed
+++ b/tls/changelog.d/16322.fixed
@@ -1,0 +1,1 @@
+Bump the cryptography version to 41.0.6

--- a/tls/pyproject.toml
+++ b/tls/pyproject.toml
@@ -40,7 +40,7 @@ license = "BSD-3-Clause"
 [project.optional-dependencies]
 deps = [
     "cryptography==3.3.2; python_version < '3.0'",
-    "cryptography==41.0.5; python_version > '3.0'",
+    "cryptography==41.0.6; python_version > '3.0'",
     "ipaddress==1.0.23; python_version < '3.0'",
     "service-identity[idna]==21.1.0",
 ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Bump the cryptography version to 41.0.6

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/image-vuln-scans/issues/1241

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.


[CONTINT-3443]: https://datadoghq.atlassian.net/browse/CONTINT-3443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ