### PR TITLE
Bump the base check version to 32.6.0

### DIFF
--- a/snmp/changelog.d/16323.added
+++ b/snmp/changelog.d/16323.added
@@ -1,0 +1,1 @@
+Bump the base check version to 32.6.0

--- a/snmp/pyproject.toml
+++ b/snmp/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=25.1.0",
+    "datadog-checks-base>=32.6.0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Bump the base check version to 32.6.0

### Motivation
<!-- What inspired you to submit this pull request? -->

The old version is not compatible with Py 3.11

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This check is deprecated so it won't make a huge different for customers since they are now supposed to use the go version of this check. Also this is not a breaking change.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
