### PR TITLE
Try to make the E2E environment a bit less flaky

### DIFF
--- a/gitlab/tests/conftest.py
+++ b/gitlab/tests/conftest.py
@@ -62,18 +62,25 @@ def dd_environment():
         'GITLAB_LOCAL_GITALY_PROMETHEUS_PORT': str(GITLAB_LOCAL_GITALY_PROMETHEUS_PORT),
     }
 
+    conditions = []
+
+    for _ in range(2):
+        conditions.extend(
+            [
+                CheckEndpoints(GITLAB_URL, attempts=100, wait=6),
+                CheckEndpoints(GITLAB_PROMETHEUS_ENDPOINT, attempts=100, wait=6),
+                CheckEndpoints(PROMETHEUS_ENDPOINT, attempts=100, wait=6),
+                CheckEndpoints(GITLAB_GITALY_PROMETHEUS_ENDPOINT, attempts=100, wait=10),
+                CheckEndpoints(GITLAB_READINESS_ENDPOINT, attempts=100, wait=10),
+                CheckEndpoints(GITLAB_LIVENESS_ENDPOINT, attempts=100, wait=10),
+                CheckEndpoints(GITLAB_HEALTH_ENDPOINT, attempts=100, wait=10),
+            ]
+        )
+
     with docker_run(
         compose_file=os.path.join(HERE, 'compose', 'docker-compose.yml'),
         env_vars=env,
-        conditions=[
-            CheckEndpoints(GITLAB_URL, attempts=100, wait=6),
-            CheckEndpoints(GITLAB_PROMETHEUS_ENDPOINT, attempts=100, wait=6),
-            CheckEndpoints(PROMETHEUS_ENDPOINT, attempts=100, wait=6),
-            CheckEndpoints(GITLAB_GITALY_PROMETHEUS_ENDPOINT, attempts=100, wait=10),
-            CheckEndpoints(GITLAB_READINESS_ENDPOINT, attempts=100, wait=10),
-            CheckEndpoints(GITLAB_LIVENESS_ENDPOINT, attempts=100, wait=10),
-            CheckEndpoints(GITLAB_HEALTH_ENDPOINT, attempts=100, wait=10),
-        ],
+        conditions=conditions,
         wrappers=[create_log_volumes()],
     ):
         # run pre-test commands


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Try to make the E2E environment a bit less flaky

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/actions/runs/7065180137/job/19234744746

That's the same issue we faced with the GitLab runner integration: https://github.com/DataDog/integrations-core/pull/16287. This workaround is not perfect but seems to work so far 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
