### PR TITLE
Automatically add a team labels to the PRs

### DIFF
--- a/.github/workflows/pr-add-team-labels.yml
+++ b/.github/workflows/pr-add-team-labels.yml
@@ -1,0 +1,23 @@
+name: Add team labels
+on:
+  pull_request:
+    types:
+      - review_requested
+
+jobs:
+  add_team_label:
+    runs-on: ubuntu-latest
+    name: Add team label
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add labels
+        run: |
+          for team in $(jq -r '.event.pull_request.requested_teams[].name' <<< "$GITHUB_CONTEXT"); do 
+            gh pr edit $NUMBER --add-label "team/$team"
+          done
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Automatically add a team labels to the PRs

### Motivation
<!-- What inspired you to submit this pull request? -->

Our QA tool can use labels to automatically pre-assign the cards to the right teams. In order to do that, the agent repo is using `team/<team-name>` labels to do so. However their process is manual, the author of a PR has to do it manually. I do not want to do this manually in this repo since we can use the codeowners file (through the reviewers) to do so.

It will also be easier to filter PRs on the right team if needed

### Additional Notes
<!-- Anything else we should know when reviewing? -->

This job will not enforce a label to be present, if the author decides to remove a label (or add an extra team) for whatever good reason, it's ok. This job is a convenient way to add labels automatically, not a way to enforce something. 

Relates to https://datadoghq.atlassian.net/browse/AITS-313 but also related to a hackathon project

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
