### PR TITLE
Make the `spec.yaml` mandatory in integrations-core if there are configuration files

### DIFF
--- a/datadog_checks_dev/changelog.d/16345.added
+++ b/datadog_checks_dev/changelog.d/16345.added
@@ -1,0 +1,1 @@
+Make the `spec.yaml` mandatory in integrations-core if there are configuration files

--- a/datadog_checks_dev/tests/tooling/commands/validate/data/my_check/datadog_checks/my_check/data/conf.example.yaml
+++ b/datadog_checks_dev/tests/tooling/commands/validate/data/my_check/datadog_checks/my_check/data/conf.example.yaml
@@ -1,0 +1,31 @@
+## All options defined here are available to all instances.
+#
+init_config:
+
+    ## @param service - string - optional
+    ## Attach the tag `service:<SERVICE>` to every metric, event, and service check emitted by this integration.
+    ##
+    ## Additionally, this sets the default `service` for every log source.
+    #
+    # service: <SERVICE>
+
+## Every instance is scheduled independently of the others.
+#
+instances:
+
+  -
+    ## @param tags - list of strings - optional
+    ## A list of tags to attach to every metric and service check emitted by this instance.
+    ##
+    ## Learn more about tagging at https://docs.datadoghq.com/tagging
+    #
+    # tags:
+    #   - <KEY_1>:<VALUE_1>
+    #   - <KEY_2>:<VALUE_2>
+
+    ## @param empty_default_hostname - boolean - optional - default: false
+    ## This forces the check to send metrics with no hostname.
+    ##
+    ## This is useful for cluster-level checks.
+    #
+    # empty_default_hostname: false

--- a/datadog_checks_dev/tests/tooling/commands/validate/test_config.py
+++ b/datadog_checks_dev/tests/tooling/commands/validate/test_config.py
@@ -1,4 +1,4 @@
-# (C) Datadog, Inc. 2022-present
+# (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 

--- a/datadog_checks_dev/tests/tooling/commands/validate/test_config.py
+++ b/datadog_checks_dev/tests/tooling/commands/validate/test_config.py
@@ -1,0 +1,51 @@
+# (C) Datadog, Inc. 2022-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+import os
+import shutil
+import sys
+
+import pytest
+from click.testing import CliRunner
+
+from datadog_checks.dev import run_command
+
+
+@pytest.mark.parametrize(
+    'repo,expect_failure',
+    [
+        ("core", True),
+        ("extras", False),
+        ("marketplace", False),
+        ("internal", False),
+    ],
+)
+def test_validate_config_spec_file_mandatory_in_core(repo, expect_failure):
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+
+        # Generate the check structure
+        working_repo = 'integrations-{}'.format(repo)
+        shutil.copytree(
+            os.path.dirname(os.path.realpath(__file__)) + "/data/my_check", "./{}/my_check".format(working_repo)
+        )
+        os.chdir(working_repo)
+        os.remove("my_check/assets/configuration/spec.yaml")
+
+        result = run_command(
+            [sys.executable, '-m', 'datadog_checks.dev', '--here', 'validate', 'config', 'my_check'],
+            capture=True,
+        )
+
+        if expect_failure:
+            assert 1 == result.code
+            assert 'Files with errors: 1' in result.stdout
+        else:
+            assert 0 == result.code
+
+        assert 'Validating default configuration files for 1 checks...' in result.stdout
+        assert 'my_check:' in result.stdout
+        assert 'Did not find spec file' in result.stdout
+        assert '' == result.stderr


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Make the `spec.yaml` mandatory in integrations-core if there are configuration files

### Motivation
<!-- What inspired you to submit this pull request? -->

We want to enforce using the spec file to generate the examples in integrations-core. 

- https://datadoghq.atlassian.net/browse/AITS-145

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
