### PR TITLE
Add an Action to remove stale branches

### DIFF
--- a/.github/workflows/remove-stale-branches.yml
+++ b/.github/workflows/remove-stale-branches.yml
@@ -1,0 +1,19 @@
+on:
+  schedule:
+    # Every day at midnight
+    - cron: "0 0 * * *"
+
+jobs:
+  remove-stale-branches:
+    name: Remove Stale Branches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fpicalausa/remove-stale-branches@v1
+        with:
+          dry-run: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          exempt-protected-branches: true
+          operations-per-run: 100
+          days-before-branch-stale: 150
+          days-before-branch-delete: 7
+          stale-branch-message: "Hello @{author} :wave: Your branch [{branchName}]({branchUrl}) hasn't been updated in the last 150 days and is marked as stale. It will be removed in a week.\r\nIf you want to keep this branch around, delete this comment or add new commits to this branch."

--- a/.github/workflows/remove-stale-branches.yml
+++ b/.github/workflows/remove-stale-branches.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    # Every day at midnight
+    # Every day at midnight (UTC)
     - cron: "0 0 * * *"
 
 jobs:
@@ -8,7 +8,7 @@ jobs:
     name: Remove Stale Branches
     runs-on: ubuntu-latest
     steps:
-      - uses: fpicalausa/remove-stale-branches@v1
+      - uses: fpicalausa/remove-stale-branches@f4ff4608bf8df11f330a0c92453e52605015d561
         with:
           dry-run: true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/repository.datadog.yaml
+++ b/repository.datadog.yaml
@@ -1,4 +1,0 @@
-# https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3176367142/Cleanup+Stale+Branches
-schema-version: v1
-kind: stale-branches
-max_age: 4380h # 6 months


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add an Action to remove stale branches

For now we're using the dry-mode. We are not going to drop anything once this PR is merged.

### Motivation
<!-- What inspired you to submit this pull request? -->

We tried to use another workflow [here](https://github.com/DataDog/integrations-core/pull/16185) but it does not seem to work.

Also this action is a bit more flexible because: 

- We do not directly drop the branch but warn the user a week before
- We can configure how long we want to keep the branches
- There's a dry mode

More info [here](https://github.com/marketplace/actions/remove-stale-branches)

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
