### PR TITLE
Add an action to automatically update the dependencies

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,0 +1,70 @@
+name: Update the dependencies
+
+on:
+  schedule:
+  # At 4AM on Monday (UTC)
+  - cron: "0 4 * * 1"
+
+jobs:
+  update_dependencies:
+    name: Update the dependencies
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    - name: Install ddev from local folder
+      run: |-
+        pip install -e ./datadog_checks_dev[cli]
+        pip install -e ./ddev
+    - name: Configure ddev
+      run: |-
+        ddev config set repos.core .
+        ddev config set repo core
+    - name: Update dependencies
+      run: |-
+        ddev dep updates --sync
+    - name: Update licenses
+      run: |-
+        ddev validate licenses --sync
+      env:
+        DD_GITHUB_USER: "${{ github.actor }}"
+        DD_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Generate changelogs
+      run: |-
+        ddev release changelog new fixed -m "Update dependencies"
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        # TODO Change once we have another bot account for this pipeline
+        token: ${{ secrets.DD_CHANGELOG_CHECK_TOKEN }}
+        commit-message: Update dependencies
+        body: |
+          ### What does this PR do?
+          Update the dependencies
+
+          ### Motivation
+          
+          Some of the dependencies are outdated
+
+          ### Additional Notes
+          <!-- Anything else we should know when reviewing? -->
+          
+          This PR was automatically generated.
+
+          ### Review checklist (to be filled by reviewers)
+
+          - [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
+          - [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
+          - [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
+        title: Update dependencies
+        branch: bot/update-dependencies
+        branch-suffix: timestamp
+        delete-branch: true
+        base: master
+        labels: bot


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add an action to automatically update the dependencies

A PR will be created every Monday at 4AM if a dependency got bumped. Example PR: https://github.com/DataDog/integrations-core/pull/16358

### Motivation
<!-- What inspired you to submit this pull request? -->

We do this only once per release, and right before the freeze. This is not ideal and manual. It will allow us to catch issues sooner

### Additional Notes
<!-- Anything else we should know when reviewing? -->

- The CI on the created branch is failing because of issues with the CLI we use. I'll try to fix the issues in another PR but it's not related to this workflow. 
- I'm using the labeler's token because we need a real token to trigger the actions on the created PRs. I'm borrowing this one, but I'll ask for another one.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
