### PR TITLE
Remove kafka.replication.leader_elections from OOTB Dashboard

### DIFF
--- a/kafka/assets/dashboards/kafka_dashboard.json
+++ b/kafka/assets/dashboards/kafka_dashboard.json
@@ -526,13 +526,8 @@
                   "queries": [
                     {
                       "data_source": "metrics",
-                      "name": "query1",
-                      "query": "sum:kafka.replication.leader_elections{$datacenter}.weighted()"
-                    },
-                    {
-                      "data_source": "metrics",
                       "name": "query2",
-                      "query": "sum:kafka.replication.leader_elections.rate{$datacenter}.weighted()"
+                      "query": "sum:kafka.replication.leader_elections.rate{$datacenter}"
                     }
                   ],
                   "response_format": "timeseries",


### PR DESCRIPTION
### What does this PR do?
This PR removes metrics `kafka.replication.leader_elections` from the kafka OOTB Dashboard. This metric is not collected by the kafka check: https://github.com/DataDog/integrations-core/blob/master/kafka/datadog_checks/kafka/data/metrics.yaml.

This PR also removes `.weighted()` from `kafka.replication.leader_elections.rate` query, as this is not supported.

![Kafka, Zookeeper and Kafka Consumer Overview (cloned) Datadog 2023-12-06 at 2 25 43 PM](https://github.com/DataDog/integrations-core/assets/63265430/0154fe7a-4ca8-4820-9a02-6f5e4ed75d80)

### Motivation

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
