### PR TITLE
INCIDENT-24014 Revert base changes from #16040

### DIFF
--- a/datadog_checks_base/changelog.d/16361.removed
+++ b/datadog_checks_base/changelog.d/16361.removed
@@ -1,0 +1,1 @@
+Remove tracked_query function

--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -12,7 +12,7 @@ from ...config import is_affirmative
 from ..containers import iter_unique
 from .query import Query
 from .transform import COLUMN_TRANSFORMERS, EXTRA_TRANSFORMERS
-from .utils import SUBMISSION_METHODS, create_submission_transformer, tracked_query
+from .utils import SUBMISSION_METHODS, create_submission_transformer
 
 
 class QueryExecutor(object):
@@ -31,7 +31,6 @@ class QueryExecutor(object):
         error_handler=None,  # type: Callable[[str], str]
         hostname=None,  # type: str
         logger=None,
-        track_operation_time=False,  # type: bool
     ):  # type: (...) -> QueryExecutor
         self.executor = executor  # type: QueriesExecutor
         self.submitter = submitter  # type: QueriesSubmitter
@@ -46,7 +45,6 @@ class QueryExecutor(object):
         self.queries = [Query(payload) for payload in queries or []]  # type: List[Query]
         self.hostname = hostname  # type: str
         self.logger = logger or logging.getLogger(__name__)
-        self.track_operation_time = track_operation_time
 
     def compile_queries(self):
         """This method compiles every `Query` object."""
@@ -74,11 +72,7 @@ class QueryExecutor(object):
             query_tags = query.base_tags
 
             try:
-                if self.track_operation_time:
-                    with tracked_query(check=self.submitter, operation=query_name):
-                        rows = self.execute_query(query.query)
-                else:
-                    rows = self.execute_query(query.query)
+                rows = self.execute_query(query.query)
             except Exception as e:
                 if self.error_handler:
                     self.logger.error('Error querying %s: %s', query_name, self.error_handler(str(e)))

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import contextlib
 import datetime
 import decimal
 import functools
@@ -352,33 +351,3 @@ class DBMAsyncJob(object):
 
     def run_job(self):
         raise NotImplementedError()
-
-
-@contextlib.contextmanager
-def tracked_query(check, operation, tags=None):
-    """
-    A simple context manager that tracks the time spent in a given query operation
-
-    The intention is to use this for context manager is to wrap the execution of a query,
-    that way the time spent waiting for query execution can be tracked as a metric. For example,
-    '''
-    with tracked_query(check, "my_metric_query", tags):
-        cursor.execute(query)
-    '''
-
-    if debug_stats_kwargs is defined on the check instance,
-    it will be called to set additional kwargs when submitting the metric.
-
-    :param check: The check instance
-    :param operation: The name of the query operation being performed.
-    :param tags: A list of tags to apply to the metric.
-    """
-    start_time = time.time()
-    stats_kwargs = {}
-    if hasattr(check, 'debug_stats_kwargs'):
-        stats_kwargs = dict(check.debug_stats_kwargs())
-    stats_kwargs['tags'] = stats_kwargs.get('tags', []) + ["operation:{}".format(operation)] + (tags or [])
-    stats_kwargs['raw'] = True  # always submit as raw to ignore any defined namespace prefix
-    yield
-    elapsed_ms = (time.time() - start_time) * 1000
-    check.histogram("dd.{}.operation.time".format(check.name), elapsed_ms, **stats_kwargs)

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -20,7 +20,6 @@ from datadog_checks.base.utils.db.utils import (
     default_json_event_encoding,
     obfuscate_sql_with_metadata,
     resolve_db_host,
-    tracked_query,
 )
 from datadog_checks.base.utils.serialization import json
 
@@ -277,16 +276,3 @@ def test_dbm_async_job_inactive_stop(aggregator):
 def test_default_json_event_encoding(input):
     # assert that the default json event encoding can handle all defined types without raising TypeError
     assert json.dumps(input, default=default_json_event_encoding)
-
-
-def test_tracked_query(aggregator):
-    with mock.patch('time.time', side_effect=[100, 101]):
-        with tracked_query(
-            check=AgentCheck(name="testcheck"),
-            operation="test_query",
-            tags=["test:tag"],
-        ):
-            pass
-        aggregator.assert_metric(
-            "dd.testcheck.operation.time", tags=["test:tag", "operation:test_query"], count=1, value=1000.0
-        )

--- a/mysql/changelog.d/16361.removed
+++ b/mysql/changelog.d/16361.removed
@@ -1,0 +1,1 @@
+Remove tracking of mysql metrics queries operation time (Reverts [#16065](https://github.com/DataDog/integrations-core/pull/16065))

--- a/mysql/datadog_checks/mysql/mysql.py
+++ b/mysql/datadog_checks/mysql/mysql.py
@@ -19,7 +19,6 @@ from datadog_checks.base import AgentCheck, is_affirmative
 from datadog_checks.base.utils.db import QueryExecutor, QueryManager
 from datadog_checks.base.utils.db.utils import (
     default_json_event_encoding,
-    tracked_query,
 )
 from datadog_checks.base.utils.db.utils import (
     resolve_db_host as agent_host_resolver,
@@ -254,13 +253,6 @@ class MySql(AgentCheck):
     def _get_debug_tags(self):
         return ['agent_hostname:{}'.format(datadog_agent.get_hostname())]
 
-    def debug_stats_kwargs(self, tags=None):
-        tags = self.tags + self._get_debug_tags() + (tags or [])
-        return {
-            'tags': tags,
-            "hostname": self.resolved_hostname,
-        }
-
     @classmethod
     def get_library_versions(cls):
         return {'pymysql': pymysql.__version__}
@@ -331,7 +323,6 @@ class MySql(AgentCheck):
             self,
             queries=queries,
             hostname=self.resolved_hostname,
-            track_operation_time=True,
         )
 
     @property
@@ -439,22 +430,18 @@ class MySql(AgentCheck):
         metrics = copy.deepcopy(STATUS_VARS)
 
         # collect results from db
-        with tracked_query(self, operation="status_metrics"):
-            results = self._get_stats_from_status(db)
-        with tracked_query(self, operation="variables_metrics"):
-            results.update(self._get_stats_from_variables(db))
+        results = self._get_stats_from_status(db)
+        results.update(self._get_stats_from_variables(db))
 
         if not is_affirmative(
             self._config.options.get('disable_innodb_metrics', False)
         ) and self._is_innodb_engine_enabled(db):
-            with tracked_query(self, operation="innodb_metrics"):
-                results.update(self.innodb_stats.get_stats_from_innodb_status(db))
+            results.update(self.innodb_stats.get_stats_from_innodb_status(db))
             self.innodb_stats.process_innodb_stats(results, self._config.options, metrics)
 
         # Binary log statistics
         if self._get_variable_enabled(results, 'log_bin'):
-            with tracked_query(self, operation="binary_log_metrics"):
-                results['Binlog_space_usage_bytes'] = self._get_binary_log_stats(db)
+            results['Binlog_space_usage_bytes'] = self._get_binary_log_stats(db)
 
         # Compute key cache utilization metric
         key_blocks_unused = collect_scalar('Key_blocks_unused', results)
@@ -501,39 +488,33 @@ class MySql(AgentCheck):
                 "[Deprecated] The `extra_performance_metrics` option will be removed in a future release. "
                 "Utilize the `custom_queries` feature if the functionality is needed.",
             )
-            with tracked_query(self, operation="exec_time_95th_metrics"):
-                results['perf_digest_95th_percentile_avg_us'] = self._get_query_exec_time_95th_us(db)
-            with tracked_query(self, operation="exec_time_per_schema_metrics"):
-                results['query_run_time_avg'] = self._query_exec_time_per_schema(db)
+            results['perf_digest_95th_percentile_avg_us'] = self._get_query_exec_time_95th_us(db)
+            results['query_run_time_avg'] = self._query_exec_time_per_schema(db)
             metrics.update(PERFORMANCE_VARS)
 
         if is_affirmative(self._config.options.get('schema_size_metrics', False)):
             # report avg query response time per schema to Datadog
-            with tracked_query(self, operation="schema_size_metrics"):
-                results['information_schema_size'] = self._query_size_per_schema(db)
+            results['information_schema_size'] = self._query_size_per_schema(db)
             metrics.update(SCHEMA_VARS)
 
         if is_affirmative(self._config.options.get('table_rows_stats_metrics', False)) and self.userstat_enabled:
             # report size of tables in MiB to Datadog
             self.log.debug("Collecting Table Row Stats Metrics.")
-            with tracked_query(self, operation="table_rows_stats_metrics"):
-                (rows_read_total, rows_changed_total) = self._query_rows_stats_per_table(db)
+            (rows_read_total, rows_changed_total) = self._query_rows_stats_per_table(db)
             results['information_table_rows_read_total'] = rows_read_total
             results['information_table_rows_changed_total'] = rows_changed_total
             metrics.update(TABLE_ROWS_STATS_VARS)
 
         if is_affirmative(self._config.options.get('table_size_metrics', False)):
             # report size of tables in MiB to Datadog
-            with tracked_query(self, operation="table_size_metrics"):
-                (table_index_size, table_data_size) = self._query_size_per_table(db)
+            (table_index_size, table_data_size) = self._query_size_per_table(db)
             results['information_table_index_size'] = table_index_size
             results['information_table_data_size'] = table_data_size
             metrics.update(TABLE_VARS)
 
         if is_affirmative(self._config.options.get('system_table_size_metrics', False)):
             # report size of tables in MiB to Datadog
-            with tracked_query(self, operation="system_table_size_metrics"):
-                (table_index_size, table_data_size) = self._query_size_per_table(db, system_tables=True)
+            (table_index_size, table_data_size) = self._query_size_per_table(db, system_tables=True)
             if results.get('information_table_index_size'):
                 results['information_table_index_size'].update(table_index_size)
             else:
@@ -547,11 +528,9 @@ class MySql(AgentCheck):
         if is_affirmative(self._config.options.get('replication', self._config.dbm_enabled)):
             if self.performance_schema_enabled and self._is_group_replication_active(db):
                 self.log.debug('Collecting group replication metrics.')
-                with tracked_query(self, operation="group_replication_metrics"):
-                    self._collect_group_replica_metrics(db, results)
+                self._collect_group_replica_metrics(db, results)
             else:
-                with tracked_query(self, operation="replication_metrics"):
-                    replication_metrics = self._collect_replication_metrics(db, results, above_560)
+                replication_metrics = self._collect_replication_metrics(db, results, above_560)
                 metrics.update(replication_metrics)
                 self._check_replication_status(results)
 

--- a/mysql/tests/test_mysql.py
+++ b/mysql/tests/test_mysql.py
@@ -50,10 +50,6 @@ def test_minimal_config(aggregator, dd_run_check, instance_basic):
         + variables.COMMON_PERFORMANCE_VARS
     )
 
-    operation_time_metrics = (
-        variables.SIMPLE_OPERATION_TIME_METRICS + variables.COMMON_PERFORMANCE_OPERATION_TIME_METRICS
-    )
-
     for mname in testable_metrics:
         # Adding condition to no longer test for innodb_os_log_fsyncs in mariadb 10.8+
         # (https://mariadb.com/kb/en/innodb-status-variables/#innodb_os_log_fsyncs)
@@ -84,13 +80,8 @@ def test_minimal_config(aggregator, dd_run_check, instance_basic):
     )
 
     _test_optional_metrics(aggregator, optional_metrics)
-
-    _test_operation_time_metrics(aggregator, operation_time_metrics, mysql_check.debug_stats_kwargs()['tags'])
-
     aggregator.assert_all_metrics_covered()
-    aggregator.assert_metrics_using_metadata(
-        get_metadata_metrics(), check_submission_type=True, exclude=[variables.OPERATION_TIME_METRIC_NAME]
-    )
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), check_submission_type=True)
 
 
 @pytest.mark.integration
@@ -105,9 +96,7 @@ def test_complex_config(aggregator, dd_run_check, instance_complex):
         tags.METRIC_TAGS_WITH_RESOURCE,
     )
     aggregator.assert_metrics_using_metadata(
-        get_metadata_metrics(),
-        check_submission_type=True,
-        exclude=['alice.age', 'bob.age', variables.OPERATION_TIME_METRIC_NAME] + variables.STATEMENT_VARS,
+        get_metadata_metrics(), check_submission_type=True, exclude=['alice.age', 'bob.age'] + variables.STATEMENT_VARS
     )
 
 
@@ -119,15 +108,13 @@ def test_e2e(dd_agent_check, dd_default_hostname, instance_complex):
         tags.SC_TAGS + [tags.DATABASE_INSTANCE_RESOURCE_TAG.format(hostname=dd_default_hostname)],
         tags.METRIC_TAGS,
         hostname=dd_default_hostname,
-        e2e=True,
     )
     aggregator.assert_metrics_using_metadata(
-        get_metadata_metrics(),
-        exclude=['alice.age', 'bob.age'] + variables.E2E_OPERATION_TIME_METRIC_NAME + variables.STATEMENT_VARS,
+        get_metadata_metrics(), exclude=['alice.age', 'bob.age'] + variables.STATEMENT_VARS
     )
 
 
-def _assert_complex_config(aggregator, service_check_tags, metric_tags, hostname='stubbed.hostname', e2e=False):
+def _assert_complex_config(aggregator, service_check_tags, metric_tags, hostname='stubbed.hostname'):
     # Test service check
     aggregator.assert_service_check(
         'mysql.can_connect',
@@ -162,9 +149,6 @@ def _assert_complex_config(aggregator, service_check_tags, metric_tags, hostname
         + variables.TABLE_VARS
         + variables.ROW_TABLE_STATS_VARS
     )
-
-    operation_time_metrics = variables.SIMPLE_OPERATION_TIME_METRICS + variables.COMPLEX_OPERATION_TIME_METRICS
-
     if MYSQL_REPLICATION == 'group':
         testable_metrics.extend(variables.GROUP_REPLICATION_VARS)
         aggregator.assert_service_check(
@@ -174,15 +158,9 @@ def _assert_complex_config(aggregator, service_check_tags, metric_tags, hostname
             + ['channel_name:group_replication_applier', 'member_role:PRIMARY', 'member_state:ONLINE'],
             count=1,
         )
-        operation_time_metrics.extend(variables.GROUP_REPLICATION_OPERATION_TIME_METRICS)
-    else:
-        testable_metrics.extend(variables.REPLICATION_OPERATION_TIME_METRICS)
 
     if MYSQL_VERSION_PARSED >= parse_version('5.6'):
         testable_metrics.extend(variables.PERFORMANCE_VARS + variables.COMMON_PERFORMANCE_VARS)
-        operation_time_metrics.extend(
-            variables.COMMON_PERFORMANCE_OPERATION_TIME_METRICS + variables.PERFORMANCE_OPERATION_TIME_METRICS
-        )
 
     # Test metrics
     for mname in testable_metrics:
@@ -239,10 +217,6 @@ def _assert_complex_config(aggregator, service_check_tags, metric_tags, hostname
     # Note, this assertion will pass even if some metrics are not present.
     # Manual testing is required for optional metrics
     _test_optional_metrics(aggregator, optional_metrics)
-
-    _test_operation_time_metrics(
-        aggregator, operation_time_metrics, metric_tags + ['agent_hostname:{}'.format(hostname)], e2e=e2e
-    )
 
     # Raises when coverage < 100%
     aggregator.assert_all_metrics_covered()
@@ -302,17 +276,8 @@ def test_complex_config_replica(aggregator, dd_run_check, instance_complex):
         + variables.ROW_TABLE_STATS_VARS
     )
 
-    operation_time_metrics = (
-        variables.SIMPLE_OPERATION_TIME_METRICS
-        + variables.COMPLEX_OPERATION_TIME_METRICS
-        + variables.REPLICATION_OPERATION_TIME_METRICS
-    )
-
     if MYSQL_VERSION_PARSED >= parse_version('5.6') and environ.get('MYSQL_FLAVOR') != 'mariadb':
         testable_metrics.extend(variables.PERFORMANCE_VARS + variables.COMMON_PERFORMANCE_VARS)
-        operation_time_metrics.extend(
-            variables.COMMON_PERFORMANCE_OPERATION_TIME_METRICS + variables.PERFORMANCE_OPERATION_TIME_METRICS
-        )
 
     # Test metrics
     for mname in testable_metrics:
@@ -371,14 +336,10 @@ def test_complex_config_replica(aggregator, dd_run_check, instance_complex):
     # Manual testing is required for optional metrics
     _test_optional_metrics(aggregator, optional_metrics)
 
-    _test_operation_time_metrics(aggregator, operation_time_metrics, mysql_check.debug_stats_kwargs()['tags'])
-
     # Raises when coverage < 100%
     aggregator.assert_all_metrics_covered()
     aggregator.assert_metrics_using_metadata(
-        get_metadata_metrics(),
-        check_submission_type=True,
-        exclude=['alice.age', 'bob.age', variables.OPERATION_TIME_METRIC_NAME] + variables.STATEMENT_VARS,
+        get_metadata_metrics(), check_submission_type=True, exclude=['alice.age', 'bob.age'] + variables.STATEMENT_VARS
     )
 
     # Make sure group replication is not detected
@@ -469,23 +430,6 @@ def _test_optional_metrics(aggregator, optional_metrics):
     after = len(aggregator.not_asserted())
 
     assert before > after
-
-
-def _test_operation_time_metrics(aggregator, operation_time_metrics, tags, e2e=False):
-    for operation_time_metric in operation_time_metrics:
-        if e2e:
-            for metric_name in variables.E2E_OPERATION_TIME_METRIC_NAME:
-                aggregator.assert_metric(
-                    metric_name,
-                    tags=tags + ['operation:{}'.format(operation_time_metric)],
-                    count=1,
-                )
-        else:
-            aggregator.assert_metric(
-                variables.OPERATION_TIME_METRIC_NAME,
-                tags=tags + ['operation:{}'.format(operation_time_metric)],
-                count=1,
-            )
 
 
 @requires_static_version

--- a/mysql/tests/variables.py
+++ b/mysql/tests/variables.py
@@ -273,30 +273,3 @@ GROUP_REPLICATION_VARS = [
     'mysql.replication.group.transactions_rollback',
     'mysql.replication.group.transactions_validating',
 ]
-
-SIMPLE_OPERATION_TIME_METRICS = [
-    'status_metrics',
-    'innodb_metrics',
-    'variables_metrics',
-    'binary_log_metrics',
-]
-
-COMPLEX_OPERATION_TIME_METRICS = [
-    'schema_size_metrics',
-    'system_table_size_metrics',
-    'table_size_metrics',
-]
-
-REPLICATION_OPERATION_TIME_METRICS = ['replication_metrics']
-
-GROUP_REPLICATION_OPERATION_TIME_METRICS = ['group_replication_metrics']
-
-PERFORMANCE_OPERATION_TIME_METRICS = ['exec_time_95th_metrics', 'exec_time_per_schema_metrics']
-
-COMMON_PERFORMANCE_OPERATION_TIME_METRICS = ['performance_schema.threads']
-
-OPERATION_TIME_METRIC_NAME = 'dd.mysql.operation.time'
-
-E2E_OPERATION_TIME_METRIC_NAME = [
-    'dd.mysql.operation.time.{}'.format(suffix) for suffix in ('avg', 'max', '95percentile', 'count', 'median')
-]

--- a/postgres/changelog.d/16361.removed
+++ b/postgres/changelog.d/16361.removed
@@ -1,0 +1,1 @@
+Remove tracking of postgres metrics queries operation time (Reverts [#16040](https://github.com/DataDog/integrations-core/pull/16040))

--- a/postgres/datadog_checks/postgres/metrics_cache.py
+++ b/postgres/datadog_checks/postgres/metrics_cache.py
@@ -96,7 +96,6 @@ class PostgresMetricsCache:
             "FROM pg_stat_database psd "
             "JOIN pg_database pd ON psd.datname = pd.datname",
             'relation': False,
-            'name': 'instance_metrics',
         }
 
         res["query"] += " WHERE " + " AND ".join(
@@ -130,7 +129,6 @@ class PostgresMetricsCache:
             'metrics': self.bgw_metrics,
             'query': "select {metrics_columns} FROM pg_stat_bgwriter",
             'relation': False,
-            'name': 'bgw_metrics',
         }
 
     def get_count_metrics(self):
@@ -161,7 +159,6 @@ class PostgresMetricsCache:
             'metrics': self.archiver_metrics,
             'query': "select {metrics_columns} FROM pg_stat_archiver",
             'relation': False,
-            'name': 'archiver_metrics',
         }
 
     def get_replication_metrics(self, version, is_aurora):
@@ -253,5 +250,4 @@ class PostgresMetricsCache:
             'metrics': metrics,
             'query': query,
             'relation': False,
-            'name': 'activity_metrics',
         }

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -15,7 +15,6 @@ from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.db import QueryExecutor
 from datadog_checks.base.utils.db.utils import (
     default_json_event_encoding,
-    tracked_query,
 )
 from datadog_checks.base.utils.db.utils import resolve_db_host as agent_host_resolver
 from datadog_checks.base.utils.serialization import json
@@ -189,7 +188,6 @@ class PostgreSql(AgentCheck):
             queries=queries,
             tags=self.tags_without_db,
             hostname=self.resolved_hostname,
-            track_operation_time=True,
         )
 
     def execute_query_raw(self, query, db):
@@ -444,17 +442,16 @@ class PostgreSql(AgentCheck):
         is_relations = scope.get('relation') and self._relations_manager.has_relations
         try:
             query = fmt.format(scope['query'], metrics_columns=", ".join(cols))
-            with tracked_query(check=self, operation='custom_metrics' if is_custom_metrics else scope['name']):
-                # if this is a relation-specific query, we need to list all relations last
-                if is_relations:
-                    schema_field = get_schema_field(descriptors)
-                    formatted_query = self._relations_manager.filter_relation_query(query, schema_field)
-                    cursor.execute(formatted_query)
-                else:
-                    self.log.debug("Running query: %s", str(query))
-                    cursor.execute(query.replace(r'%', r'%%'))
+            # if this is a relation-specific query, we need to list all relations last
+            if is_relations:
+                schema_field = get_schema_field(descriptors)
+                formatted_query = self._relations_manager.filter_relation_query(query, schema_field)
+                cursor.execute(formatted_query)
+            else:
+                self.log.debug("Running query: %s", str(query))
+                cursor.execute(query.replace(r'%', r'%%'))
 
-                results = cursor.fetchall()
+            results = cursor.fetchall()
         except psycopg2.errors.FeatureNotSupported as e:
             # This happens for example when trying to get replication metrics from readers in Aurora. Let's ignore it.
             log_func(e)
@@ -686,13 +683,9 @@ class PostgreSql(AgentCheck):
                 with conn.cursor() as cursor:
                     self._query_scope(cursor, activity_metrics, instance_tags, False)
 
-            for scope in list(metric_scope):
+            for scope in list(metric_scope) + self._config.custom_metrics:
                 with conn.cursor() as cursor:
-                    self._query_scope(cursor, scope, instance_tags, False)
-
-            for scope in self._config.custom_metrics:
-                with conn.cursor() as cursor:
-                    self._query_scope(cursor, scope, instance_tags, True)
+                    self._query_scope(cursor, scope, instance_tags, scope in self._config.custom_metrics)
 
         if self.dynamic_queries:
             for dynamic_query in self.dynamic_queries:
@@ -829,10 +822,7 @@ class PostgreSql(AgentCheck):
                 with conn.cursor() as cursor:
                     try:
                         self.log.debug("Running query: %s", query)
-                        with tracked_query(
-                            check=self, operation='custom_queries', tags=['metric_prefix:{}'.format(metric_prefix)]
-                        ):
-                            cursor.execute(query)
+                        cursor.execute(query)
                     except (psycopg2.ProgrammingError, psycopg2.errors.QueryCanceled) as e:
                         self.log.error("Error executing query for metric_prefix %s: %s", metric_prefix, str(e))
                         continue
@@ -936,13 +926,6 @@ class PostgreSql(AgentCheck):
             }
             self._database_instance_emitted[self.resolved_hostname] = event
             self.database_monitoring_metadata(json.dumps(event, default=default_json_event_encoding))
-
-    def debug_stats_kwargs(self, tags=None):
-        tags = self.tags + self._get_debug_tags() + (tags or [])
-        return {
-            'tags': tags,
-            "hostname": self.resolved_hostname,
-        }
 
     def check(self, _):
         tags = copy.copy(self.tags)

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -55,7 +55,6 @@ SELECT mode,
    AND pc.relname NOT LIKE 'pg^_%%' ESCAPE '^'
  GROUP BY pd.datname, pc.relname, pn.nspname, locktype, mode, granted""",
     'relation': True,
-    'name': 'lock_metrics',
 }
 
 # The pg_stat_all_tables contain one row for each table in the current database,
@@ -88,7 +87,6 @@ SELECT relname,schemaname,{metrics_columns}
   FROM pg_stat_user_tables
  WHERE {relations}""",
     'relation': True,
-    'name': 'rel_metrics',
 }
 
 
@@ -111,7 +109,6 @@ SELECT relname,
   FROM pg_stat_user_indexes
  WHERE {relations}""",
     'relation': True,
-    'name': 'idx_metrics',
 }
 
 
@@ -199,9 +196,7 @@ SELECT relname,
   FROM pg_statio_user_tables
  WHERE {relations}""",
     'relation': True,
-    'name': 'statio_metrics',
 }
-
 # adapted from https://wiki.postgresql.org/wiki/Show_database_bloat and https://github.com/bucardo/check_postgres/
 TABLE_BLOAT_QUERY = """
 SELECT
@@ -252,7 +247,6 @@ TABLE_BLOAT = {
     },
     'query': TABLE_BLOAT_QUERY,
     'relation': True,
-    'name': 'table_bloat_metrics',
 }
 
 
@@ -308,7 +302,6 @@ INDEX_BLOAT = {
     },
     'query': INDEX_BLOAT_QUERY,
     'relation': True,
-    'name': 'index_bloat_metrics',
 }
 
 RELATION_METRICS = [LOCK_METRICS, REL_METRICS, IDX_METRICS, STATIO_METRICS]

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -209,7 +209,6 @@ LIMIT {table_count_limit}
 ) AS subquery GROUP BY schemaname
     """
     ),
-    'name': 'count_metrics',
 }
 
 q1 = (
@@ -253,7 +252,6 @@ REPLICATION_METRICS = {
     'query': """
 SELECT {metrics_columns}
  WHERE (SELECT pg_is_in_recovery())""",
-    'name': 'replication_metrics',
 }
 
 # Requires postgres 10+
@@ -287,7 +285,6 @@ REPLICATION_STATS_METRICS = {
 SELECT application_name, state, sync_state, client_addr, {metrics_columns}
 FROM pg_stat_replication
 """,
-    'name': 'replication_stats_metrics',
 }
 
 
@@ -381,7 +378,6 @@ WITH max_con AS (SELECT setting::float FROM pg_settings WHERE name = 'max_connec
 SELECT {metrics_columns}
   FROM pg_stat_database, max_con
 """,
-    'name': 'connections_metrics',
 }
 
 SLRU_METRICS = {
@@ -400,7 +396,6 @@ SLRU_METRICS = {
 SELECT name, {metrics_columns}
   FROM pg_stat_slru
 """,
-    'name': 'slru_metrics',
 }
 
 SNAPSHOT_TXID_METRICS = {
@@ -578,7 +573,6 @@ SELECT s.schemaname,
     ON o.funcname = s.funcname;
 """,
     'relation': False,
-    'name': 'function_metrics',
 }
 
 # The metrics we retrieve from pg_stat_activity when the postgres version >= 10

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -97,17 +97,6 @@ CONNECTION_METRICS = ['postgresql.max_connections', 'postgresql.percent_usage_co
 CONNECTION_METRICS_DB = ['postgresql.connections']
 COMMON_DBS = ['dogs', 'postgres', 'dogs_nofunc', 'dogs_noschema', DB_NAME]
 
-CHECK_PERFORMANCE_METRICS = [
-    'archiver_metrics',
-    'bgw_metrics',
-    'connections_metrics',
-    'count_metrics',
-    'instance_metrics',
-    'replication_metrics',
-    'replication_stats_metrics',
-    'slru_metrics',
-]
-
 requires_static_version = pytest.mark.skipif(USING_LATEST, reason='Version `latest` is ever-changing, skipping')
 
 
@@ -333,17 +322,3 @@ def check_stat_wal_metrics(aggregator, expected_tags, count=1):
 
     for metric_name in _iterate_metric_name(STAT_WAL_METRICS):
         aggregator.assert_metric(metric_name, count=count, tags=expected_tags)
-
-
-def check_performance_metrics(aggregator, expected_tags, count=1, is_aurora=False):
-    expected_metrics = set(CHECK_PERFORMANCE_METRICS)
-    if is_aurora:
-        expected_metrics = expected_metrics - {'replication_metrics'}
-    if float(POSTGRES_VERSION) < 13.0:
-        expected_metrics = expected_metrics - {'slru_metrics'}
-    if float(POSTGRES_VERSION) < 10.0:
-        expected_metrics = expected_metrics - {'replication_stats_metrics'}
-    for name in expected_metrics:
-        aggregator.assert_metric(
-            'dd.postgres.operation.time', count=count, tags=expected_tags + ['operation:{}'.format(name)]
-        )

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -119,7 +119,7 @@ def mock_cursor_for_replica_stats():
                 data.appendleft(['app1', 'streaming', 'async', '1.1.1.1', 12, 12, 12, 12])
                 data.appendleft(['app2', 'backup', 'sync', '1.1.1.1', 13, 13, 13, 13])
             elif query == 'SHOW SERVER_VERSION;':
-                data.appendleft([POSTGRES_VERSION])
+                data.appendleft(['10.15'])
 
         def cursor_fetchall():
             while data:

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -32,7 +32,6 @@ from .common import (
     check_db_count,
     check_file_wal_metrics,
     check_logical_replication_slots,
-    check_performance_metrics,
     check_physical_replication_slots,
     check_slru_metrics,
     check_snapshot_txid_metrics,
@@ -85,9 +84,6 @@ def test_common_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check_logical_replication_slots(aggregator, expected_tags)
     check_physical_replication_slots(aggregator, expected_tags)
     check_snapshot_txid_metrics(aggregator, expected_tags=expected_tags)
-
-    check_performance_metrics(aggregator, expected_tags=check.debug_stats_kwargs()['tags'], is_aurora=is_aurora)
-
     aggregator.assert_all_metrics_covered()
 
 

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -16,7 +16,6 @@ from .common import (
     check_control_metrics,
     check_db_count,
     check_file_wal_metrics,
-    check_performance_metrics,
     check_replication_delay,
     check_slru_metrics,
     check_snapshot_txid_metrics,
@@ -50,8 +49,6 @@ def test_common_replica_metrics(aggregator, integration_check, metrics_cache_rep
     check_snapshot_txid_metrics(aggregator, expected_tags=expected_tags)
     check_stat_wal_metrics(aggregator, expected_tags=expected_tags)
     check_file_wal_metrics(aggregator, expected_tags=expected_tags)
-
-    check_performance_metrics(aggregator, expected_tags=check.debug_stats_kwargs()['tags'])
 
     aggregator.assert_all_metrics_covered()
 

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -14,8 +14,7 @@ from six import iteritems
 
 from datadog_checks.postgres import PostgreSql, util
 
-from .common import PORT, check_performance_metrics
-from .utils import requires_over_10
+from .common import PORT
 
 pytestmark = pytest.mark.unit
 
@@ -241,36 +240,24 @@ def test_resolved_hostname_metadata(check, test_case):
         m.assert_any_call('test:123', 'resolved_hostname', test_case)
 
 
-@requires_over_10
 @pytest.mark.usefixtures('mock_cursor_for_replica_stats')
 def test_replication_stats(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
     check.check(pg_instance)
-    base_tags = [
-        'foo:bar',
-        'port:5432',
-        'dd.internal.resource:database_instance:{}'.format(check.resolved_hostname),
-    ]
+    base_tags = ['foo:bar', 'port:5432', 'dd.internal.resource:database_instance:{}'.format(check.resolved_hostname)]
     app1_tags = base_tags + [
         'wal_sync_state:async',
         'wal_state:streaming',
         'wal_app_name:app1',
         'wal_client_addr:1.1.1.1',
     ]
-    app2_tags = base_tags + [
-        'wal_sync_state:sync',
-        'wal_state:backup',
-        'wal_app_name:app2',
-        'wal_client_addr:1.1.1.1',
-    ]
+    app2_tags = base_tags + ['wal_sync_state:sync', 'wal_state:backup', 'wal_app_name:app2', 'wal_client_addr:1.1.1.1']
 
     aggregator.assert_metric('postgresql.db.count', 0, base_tags)
     for suffix in ('wal_write_lag', 'wal_flush_lag', 'wal_replay_lag', 'backend_xmin_age'):
         metric_name = 'postgresql.replication.{}'.format(suffix)
         aggregator.assert_metric(metric_name, 12, app1_tags)
         aggregator.assert_metric(metric_name, 13, app2_tags)
-
-    check_performance_metrics(aggregator, check.debug_stats_kwargs()['tags'])
 
     aggregator.assert_all_metrics_covered()
 

--- a/sqlserver/changelog.d/16361.removed
+++ b/sqlserver/changelog.d/16361.removed
@@ -1,0 +1,1 @@
+Remove tracking of sqlserver metrics queries operation time (Reverts [#16066](https://github.com/DataDog/integrations-core/pull/16066))

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -34,7 +34,6 @@ class BaseSqlServerMetric(object):
     TABLE = None
     DEFAULT_METRIC_TYPE = None
     QUERY_BASE = None
-    OPERATION_NAME = 'base_metrics'
 
     # Flag to indicate if this subclass/table is available for custom queries
     CUSTOM_QUERIES_AVAILABLE = True
@@ -95,7 +94,6 @@ class SqlSimpleMetric(BaseSqlServerMetric):
                     from {table} where counter_name in ({{placeholders}})""".format(
         table=TABLE
     )
-    OPERATION_NAME = 'simple_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -133,7 +131,6 @@ class SqlFractionMetric(BaseSqlServerMetric):
                     order by cntr_type;""".format(
         table=TABLE
     )
-    OPERATION_NAME = 'fraction_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -224,8 +221,6 @@ class SqlIncrFractionMetric(SqlFractionMetric):
     the current value and the base value (denominator) between two collection points that are one second apart.
     """
 
-    OPERATION_NAME = 'incr_fraction_metrics'
-
     def report_fraction(self, value, base, metric_tags, previous_values):
         # return if nil is passed as the values cache, as this should be instantiated
         # at check instantiation
@@ -251,7 +246,6 @@ class SqlOsWaitStat(BaseSqlServerMetric):
     TABLE = 'sys.dm_os_wait_stats'
     DEFAULT_METRIC_TYPE = 'gauge'
     QUERY_BASE = """select * from {table} where wait_type in ({{placeholders}})""".format(table=TABLE)
-    OPERATION_NAME = 'os_wait_stat_metric'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -283,7 +277,6 @@ class SqlIoVirtualFileStat(BaseSqlServerMetric):
             table=TABLE
         )
     )
-    OPERATION_NAME = 'io_virtual_file_stats_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -343,7 +336,6 @@ class SqlOsMemoryClerksStat(BaseSqlServerMetric):
     TABLE = 'sys.dm_os_memory_clerks'
     DEFAULT_METRIC_TYPE = 'gauge'
     QUERY_BASE = """select * from {table} where type in ({{placeholders}})""".format(table=TABLE)
-    OPERATION_NAME = 'os_memory_clerks_stat_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -375,7 +367,6 @@ class SqlOsSchedulers(BaseSqlServerMetric):
     TABLE = 'sys.dm_os_schedulers'
     DEFAULT_METRIC_TYPE = 'gauge'
     QUERY_BASE = "select * from {table}".format(table=TABLE)
-    OPERATION_NAME = 'os_schedulers_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -412,7 +403,6 @@ class SqlOsTasks(BaseSqlServerMetric):
     """.format(
         table=TABLE
     )
-    OPERATION_NAME = 'os_tasks_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -445,7 +435,6 @@ class SqlMasterDatabaseFileStats(BaseSqlServerMetric):
         table=TABLE
     )
     DB_TYPE_MAP = {0: 'data', 1: 'transaction_log', 2: 'filestream', 3: 'unknown', 4: 'full_text'}
-    OPERATION_NAME = 'master_database_file_stats_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -491,7 +480,6 @@ class SqlDatabaseFileStats(BaseSqlServerMetric):
     TABLE = 'sys.database_files'
     DEFAULT_METRIC_TYPE = 'gauge'
     QUERY_BASE = "select * from {table}".format(table=TABLE)
-    OPERATION_NAME = 'database_file_stats_metrics'
 
     DB_TYPE_MAP = {0: 'data', 1: 'transaction_log', 2: 'filestream', 3: 'unknown', 4: 'full_text'}
 
@@ -593,7 +581,6 @@ class SqlDatabaseStats(BaseSqlServerMetric):
     TABLE = 'sys.databases'
     DEFAULT_METRIC_TYPE = 'gauge'
     QUERY_BASE = "select * from {table}".format(table=TABLE)
-    OPERATION_NAME = 'database_stats_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -639,7 +626,6 @@ class SqlDatabaseBackup(BaseSqlServerMetric):
         group by sys.databases.name""".format(
         table=TABLE
     )
-    OPERATION_NAME = 'database_backup_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -690,7 +676,6 @@ class SqlDbFragmentation(BaseSqlServerMetric):
         "AND DDIPS.index_id = I.index_id "
         "WHERE DDIPS.fragment_count is not null".format(table=TABLE)
     )
-    OPERATION_NAME = 'db_fragmentation_metrics'
 
     def __init__(self, cfg_instance, base_name, report_function, column, logger):
         super(SqlDbFragmentation, self).__init__(cfg_instance, base_name, report_function, column, logger)
@@ -776,7 +761,6 @@ class SqlDbReplicaStates(BaseSqlServerMetric):
                  on dhdrs.replica_id = ar.replica_id""".format(
         table=TABLE
     )
-    OPERATION_NAME = 'db_replica_states_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -831,7 +815,6 @@ class SqlAvailabilityGroups(BaseSqlServerMetric):
                     on ag.group_id = dhdrcs.group_id""".format(
         table=TABLE
     )
-    OPERATION_NAME = 'availability_groups_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -885,7 +868,6 @@ class SqlAvailabilityReplicas(BaseSqlServerMetric):
                     on ag.group_id = ar.group_id""".format(
         table=TABLE
     )
-    OPERATION_NAME = 'availability_replicas_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -962,7 +944,6 @@ class SqlDbFileSpaceUsage(BaseSqlServerMetric):
         FROM {table} group by database_id""".format(
         table=TABLE
     )
-    OPERATION_NAME = 'db_file_space_usage_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):
@@ -1052,7 +1033,6 @@ class SqlDbIndexUsageStats(BaseSqlServerMetric):
         sql_columns=','.join(f'ixus.{col}' for col in columns),
         table=TABLE,
     ).strip()
-    OPERATION_NAME = 'db_index_usage_stats_metrics'
 
     @classmethod
     def fetch_all_values(cls, cursor, counters_list, logger, databases=None):

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -13,7 +13,7 @@ from cachetools import TTLCache
 from datadog_checks.base import AgentCheck, ConfigurationError
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.utils.db import QueryExecutor, QueryManager
-from datadog_checks.base.utils.db.utils import default_json_event_encoding, resolve_db_host, tracked_query
+from datadog_checks.base.utils.db.utils import default_json_event_encoding, resolve_db_host
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.sqlserver.activity import SqlserverActivity
 from datadog_checks.sqlserver.config import SQLServerConfig
@@ -789,11 +789,9 @@ class SQLServer(AgentCheck):
                             db_names = [d.name for d in self.databases] or [
                                 self.instance.get('database', self.connection.DEFAULT_DATABASE)
                             ]
-                            metric_cls = getattr(metrics, cls)
-                            with tracked_query(self, operation=metric_cls.OPERATION_NAME):
-                                rows, cols = metric_cls.fetch_all_values(
-                                    cursor, list(metric_names), self.log, databases=db_names
-                                )
+                            rows, cols = getattr(metrics, cls).fetch_all_values(
+                                cursor, list(metric_names), self.log, databases=db_names
+                            )
                         except Exception as e:
                             self.log.error("Error running `fetch_all` for metrics %s - skipping.  Error: %s", cls, e)
                             rows, cols = None, None

--- a/sqlserver/tests/common.py
+++ b/sqlserver/tests/common.py
@@ -3,7 +3,6 @@
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
 import os
-from copy import deepcopy
 from itertools import chain
 
 from datadog_checks.dev import get_docker_hostname, get_here
@@ -230,33 +229,9 @@ INIT_CONFIG_ALT_TABLES = {
     ]
 }
 
-OPERATION_TIME_METRICS = [
-    'simple_metrics',
-    'database_stats_metrics',
-    'fraction_metrics',
-    'db_file_space_usage_metrics',
-    'database_backup_metrics',
-    'database_file_stats_metrics',
-    'incr_fraction_metrics',
-    'db_index_usage_stats_metrics',
-]
-
-OPERATION_TIME_METRIC_NAME = 'dd.sqlserver.operation.time'
-
-E2E_OPERATION_TIME_METRIC_NAME = [
-    'dd.sqlserver.operation.time.{}'.format(suffix) for suffix in ('avg', 'max', '95percentile', 'count', 'median')
-]
-
 
 def assert_metrics(
-    instance,
-    aggregator,
-    check_tags,
-    service_tags,
-    dbm_enabled=False,
-    hostname=None,
-    database_autodiscovery=False,
-    dbs=None,
+    aggregator, check_tags, service_tags, dbm_enabled=False, hostname=None, database_autodiscovery=False, dbs=None
 ):
     """
     Boilerplate asserting all the expected metrics and service checks.
@@ -286,32 +261,5 @@ def assert_metrics(
         assert hostname is not None, "hostname must be explicitly specified for all metrics"
         aggregator.assert_metric(mname, hostname=hostname)
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK, tags=service_tags)
-
-    operation_time_metric_tags = check_tags + ['agent_hostname:{}'.format(hostname)]
-    for operation_name in get_operation_time_metrics(instance):
-        aggregator.assert_metric(
-            OPERATION_TIME_METRIC_NAME,
-            tags=['operation:{}'.format(operation_name)] + operation_time_metric_tags,
-            hostname=hostname,
-            count=1,
-        )
-
     aggregator.assert_all_metrics_covered()
     aggregator.assert_no_duplicate_metrics()
-
-
-def get_operation_time_metrics(instance):
-    """
-    Return a list of all operation time metrics
-    """
-    operation_time_metrics = deepcopy(OPERATION_TIME_METRICS)
-    if instance.get('include_task_scheduler_metrics', False):
-        operation_time_metrics.append('os_schedulers_metrics')
-        operation_time_metrics.append('os_tasks_metrics')
-    if instance.get('include_db_fragmentation_metrics', False):
-        operation_time_metrics.append('db_fragmentation_metrics')
-    if instance.get('include_ao_metrics', False):
-        operation_time_metrics.append('availability_groups_metrics')
-    if instance.get('include_master_files_metrics', False):
-        operation_time_metrics.append('master_database_file_stats_metrics')
-    return operation_time_metrics

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -22,7 +22,7 @@ from datadog_checks.base.utils.db.utils import DBMAsyncJob, default_json_event_e
 from datadog_checks.sqlserver import SQLServer
 from datadog_checks.sqlserver.activity import DM_EXEC_REQUESTS_COLS, _hash_to_hex
 
-from .common import CHECK_NAME, OPERATION_TIME_METRIC_NAME
+from .common import CHECK_NAME
 from .conftest import DEFAULT_TIMEOUT
 
 try:
@@ -196,7 +196,7 @@ def test_collect_load_activity(
 
     # internal debug metrics
     aggregator.assert_metric(
-        OPERATION_TIME_METRIC_NAME,
+        "dd.sqlserver.operation.time",
         tags=['agent_hostname:stubbed.hostname', 'operation:collect_activity']
         + _expected_dbm_instance_tags(dbm_instance),
     )

--- a/sqlserver/tests/test_e2e.py
+++ b/sqlserver/tests/test_e2e.py
@@ -9,7 +9,6 @@ from datadog_checks.sqlserver.const import DATABASE_INDEX_METRICS
 
 from .common import (
     CUSTOM_METRICS,
-    E2E_OPERATION_TIME_METRIC_NAME,
     EXPECTED_AO_METRICS_COMMON,
     EXPECTED_AO_METRICS_PRIMARY,
     EXPECTED_AO_METRICS_SECONDARY,
@@ -52,9 +51,7 @@ def test_ao_primary_replica(dd_agent_check, init_config, instance_ao_docker_prim
     for mname in EXPECTED_AO_METRICS_SECONDARY:
         aggregator.assert_metric(mname, count=0)
 
-    aggregator.assert_metrics_using_metadata(
-        get_metadata_metrics(), exclude=CUSTOM_METRICS + E2E_OPERATION_TIME_METRIC_NAME
-    )
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=CUSTOM_METRICS)
 
 
 @not_windows_ci
@@ -94,9 +91,7 @@ def test_ao_secondary_replica(dd_agent_check, init_config, instance_ao_docker_se
     for mname in EXPECTED_AO_METRICS_PRIMARY + EXPECTED_QUERY_EXECUTOR_AO_METRICS_PRIMARY:
         aggregator.assert_metric(mname, count=0)
 
-    aggregator.assert_metrics_using_metadata(
-        get_metadata_metrics(), exclude=CUSTOM_METRICS + E2E_OPERATION_TIME_METRIC_NAME
-    )
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=CUSTOM_METRICS)
 
 
 @not_windows_ado
@@ -138,6 +133,4 @@ def test_check_docker(dd_agent_check, init_config, instance_e2e):
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK)
     aggregator.assert_all_metrics_covered()
 
-    aggregator.assert_metrics_using_metadata(
-        get_metadata_metrics(), exclude=CUSTOM_METRICS + E2E_OPERATION_TIME_METRIC_NAME
-    )
+    aggregator.assert_metrics_using_metadata(get_metadata_metrics(), exclude=CUSTOM_METRICS)

--- a/sqlserver/tests/test_integration.py
+++ b/sqlserver/tests/test_integration.py
@@ -19,14 +19,7 @@ from datadog_checks.sqlserver.const import (
     STATIC_INFO_VERSION,
 )
 
-from .common import (
-    CHECK_NAME,
-    CUSTOM_METRICS,
-    EXPECTED_DEFAULT_METRICS,
-    OPERATION_TIME_METRIC_NAME,
-    assert_metrics,
-    get_operation_time_metrics,
-)
+from .common import CHECK_NAME, CUSTOM_METRICS, EXPECTED_DEFAULT_METRICS, assert_metrics
 from .conftest import DEFAULT_TIMEOUT
 from .utils import not_windows_ci, windows_ci
 
@@ -96,7 +89,6 @@ def test_check_docker(aggregator, dd_run_check, init_config, instance_docker, da
         'db:master',
     ]
     assert_metrics(
-        instance_docker,
         aggregator,
         check_tags=instance_docker.get('tags', []),
         service_tags=expected_tags,
@@ -432,15 +424,6 @@ def test_check_windows_defaults(aggregator, dd_run_check, init_config, instance_
         aggregator.assert_metric(mname)
 
     aggregator.assert_service_check('sqlserver.can_connect', status=SQLServer.OK)
-
-    for operation_name in get_operation_time_metrics(instance_docker_defaults):
-        aggregator.assert_metric(
-            OPERATION_TIME_METRIC_NAME,
-            tags=['operation:{}'.format(operation_name)] + check.debug_stats_kwargs()['tags'],
-            hostname=check.resolved_hostname,
-            count=1,
-        )
-
     aggregator.assert_all_metrics_covered()
 
 

--- a/sqlserver/tests/test_statements.py
+++ b/sqlserver/tests/test_statements.py
@@ -30,7 +30,7 @@ from datadog_checks.sqlserver.const import (
 )
 from datadog_checks.sqlserver.statements import SQL_SERVER_QUERY_METRICS_COLUMNS, obfuscate_xml_plan
 
-from .common import CHECK_NAME, OPERATION_TIME_METRIC_NAME
+from .common import CHECK_NAME
 
 try:
     import pyodbc
@@ -432,7 +432,7 @@ def test_statement_metrics_and_plans(
 
     # internal debug metrics
     aggregator.assert_metric(
-        OPERATION_TIME_METRIC_NAME,
+        "dd.sqlserver.operation.time",
         tags=['agent_hostname:stubbed.hostname', 'operation:collect_statement_metrics_and_plans']
         + _expected_dbm_instance_tags(dbm_instance),
     )

--- a/sqlserver/tests/test_stored_procedures.py
+++ b/sqlserver/tests/test_stored_procedures.py
@@ -20,7 +20,7 @@ from datadog_checks.sqlserver.const import (
 )
 from datadog_checks.sqlserver.stored_procedures import SQL_SERVER_PROCEDURE_METRICS_COLUMNS
 
-from .common import CHECK_NAME, OPERATION_TIME_METRIC_NAME
+from .common import CHECK_NAME
 
 try:
     import pyodbc
@@ -279,7 +279,7 @@ def test_procedure_metrics(
 
     # internal debug metrics
     aggregator.assert_metric(
-        OPERATION_TIME_METRIC_NAME,
+        "dd.sqlserver.operation.time",
         tags=['agent_hostname:stubbed.hostname', 'operation:collect_procedure_metrics']
         + _expected_dbm_instance_tags(dbm_instance),
     )

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -441,12 +441,17 @@ def test_check_local(aggregator, dd_run_check, init_config, instance_docker):
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
     check_tags = instance_docker.get('tags', [])
+<<<<<<< HEAD
     expected_tags = check_tags + [
         'sqlserver_host:{}'.format(sqlserver_check.resolved_hostname),
         'connection_host:{}'.format(DOCKER_SERVER),
         'db:master',
     ]
     assert_metrics(instance_docker, aggregator, check_tags, expected_tags, hostname=sqlserver_check.resolved_hostname)
+=======
+    expected_tags = check_tags + ['sqlserver_host:{}'.format(DOCKER_SERVER), 'db:master']
+    assert_metrics(aggregator, check_tags, expected_tags, hostname=sqlserver_check.resolved_hostname)
+>>>>>>> parent of 5dc82133cb ([DBMON-3030] Report metrics query operation time (#16066))
 
 
 SQL_SERVER_2012_VERSION_EXAMPLE = """\

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -441,17 +441,12 @@ def test_check_local(aggregator, dd_run_check, init_config, instance_docker):
     sqlserver_check = SQLServer(CHECK_NAME, init_config, [instance_docker])
     dd_run_check(sqlserver_check)
     check_tags = instance_docker.get('tags', [])
-<<<<<<< HEAD
     expected_tags = check_tags + [
         'sqlserver_host:{}'.format(sqlserver_check.resolved_hostname),
         'connection_host:{}'.format(DOCKER_SERVER),
         'db:master',
     ]
     assert_metrics(instance_docker, aggregator, check_tags, expected_tags, hostname=sqlserver_check.resolved_hostname)
-=======
-    expected_tags = check_tags + ['sqlserver_host:{}'.format(DOCKER_SERVER), 'db:master']
-    assert_metrics(aggregator, check_tags, expected_tags, hostname=sqlserver_check.resolved_hostname)
->>>>>>> parent of 5dc82133cb ([DBMON-3030] Report metrics query operation time (#16066))
 
 
 SQL_SERVER_2012_VERSION_EXAMPLE = """\


### PR DESCRIPTION
### What does this PR do?
While we still don't fully understand why, the addition of the `tracked_query` decorator seems to have been causing out of memory kills. In order to unblock things, this PR reverts those changes. This is the first part of the revert that removes the new decorator and, following, we'll revert the usages in `mysql`, `postgres` and `sqlserver` integrations. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
