### PR TITLE
Take into account the base check when bumping the dependencies

### DIFF
--- a/ddev/changelog.d/16365.fixed
+++ b/ddev/changelog.d/16365.fixed
@@ -1,0 +1,1 @@
+Take into account the base check when bumping the dependencies

--- a/ddev/src/ddev/cli/dep.py
+++ b/ddev/src/ddev/cli/dep.py
@@ -322,6 +322,7 @@ def read_check_dependencies(repo, integrations=None):
         integrations = [repo.integrations.get(integration) for integration in integrations]
     elif integrations is None:
         integrations = list(repo.integrations.iter_agent_checks('all'))
+        integrations.append(repo.integrations.get('datadog_checks_base'))
     else:
         integrations = [repo.integrations.get(integrations)]
 

--- a/ddev/tests/cli/test_dep.py
+++ b/ddev/tests/cli/test_dep.py
@@ -63,6 +63,7 @@ dep-c==5.1.0
 def test_sync(ddev, fake_repo):
     create_integration(fake_repo, 'foo', ['dep-a==1.0.0', 'dep-b==3.1.4'])
     create_integration(fake_repo, 'bar', ['dep-a==1.0.0'])
+    create_integration(fake_repo, 'datadog_checks_base', ['dep-a==1.0.0'])
 
     requirements = """
 dep-a==1.1.1
@@ -75,10 +76,11 @@ dep-b==3.1.4
     result = ddev('dep', 'sync')
 
     assert result.exit_code == 0
-    assert result.output == 'Files updated: 2\n'
+    assert result.output == 'Files updated: 3\n'
 
     assert_dependencies(fake_repo, 'foo', ['dep-a==1.1.1', 'dep-b==3.1.4'])
     assert_dependencies(fake_repo, 'bar', ['dep-a==1.1.1'])
+    assert_dependencies(fake_repo, 'datadog_checks_base', ['dep-a==1.1.1'])
 
 
 class TestUpdates:
@@ -135,6 +137,7 @@ dep-a can be updated to version 1.2.3 on py2 and py3
     def test_sync(self, ddev):
         self.add_integration('foo', ['dep-a==1.0.0', 'dep-b==3.1.4'])
         self.add_integration('bar', ['dep-a==1.0.0'])
+        self.add_integration('datadog_checks_base', ['dep-a==1.0.0', 'dep-b==3.1.4'])
         self.write_requirements()
 
         self.add_pypi_entry(
@@ -151,13 +154,14 @@ dep-a can be updated to version 1.2.3 on py2 and py3
         assert result.exit_code == 0
         assert (
             result.output
-            == '''Files updated: 2
+            == '''Files updated: 3
 Updated 1 dependencies
 '''
         )
 
         assert_dependencies(self.repo, 'foo', ['dep-a==1.2.3', 'dep-b==3.1.4'])
         assert_dependencies(self.repo, 'bar', ['dep-a==1.2.3'])
+        assert_dependencies(self.repo, 'datadog_checks_base', ['dep-a==1.2.3', 'dep-b==3.1.4'])
 
         requirements = self.requirements_path.read_text()
         expected = """
@@ -296,7 +300,7 @@ def assert_dependencies(root, name, dependencies):
 
 def create_integration(root, name, dependencies):
     integration_dir = root / name
-    integration_dir.mkdir()
+    integration_dir.mkdir(exist_ok=True)
     with open(integration_dir / 'pyproject.toml', 'wb') as f:
         tomli_w.dump({'project': {'optional-dependencies': {'deps': dependencies}}}, f)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Take into account the base check when bumping the dependencies. Right now only agent checks are take into account, not the base check which is not directly an agent check.

### Motivation
<!-- What inspired you to submit this pull request? -->

On https://github.com/DataDog/integrations-core/pull/16358 which was created with https://github.com/DataDog/integrations-core/pull/16348 I got a validation error. Turns out it's because the base check is not updated by the new `ddev dep updates --sync` command. The base check is not considered an agent_check because it's not really a check. I don't think it's worth it to add a new method to the Integration class because it seems to be an edge case here so it should be fine to manually add it here.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
