### PR TITLE
Add one GitHub label for Database Monitoring

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -58,7 +58,7 @@ jira_statuses = [
   "Done",
 ]
 github_team = "database-monitoring"
-github_labels = ["team/database-monitoring"]
+github_labels = ["team/database-monitoring", "team/database-monitoring-agent"]
 
 [teams."Network Device Monitoring"]
 jira_project = "NDMII"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add one GitHub label for Database Monitoring

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/integrations-core/pull/16331

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
