### PR TITLE
require python 3 for mysql integration

### DIFF
--- a/mysql/hatch.toml
+++ b/mysql/hatch.toml
@@ -2,7 +2,6 @@
 base-package-features = ["deps", "db", "json"]
 check-types = false
 mypy-args = [
-  "--py2",
   "--check-untyped-defs",
   "--follow-imports",
   "silent",

--- a/mysql/pyproject.toml
+++ b/mysql/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "hatchling>=0.11.2",
     "setuptools>=66; python_version > '3.0'",
-    "setuptools; python_version < '3.0'",
 ]
 build-backend = "hatchling.build"
 
@@ -24,7 +23,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: BSD License",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3.11",
     "Topic :: System :: Monitoring",
     "Private :: Do Not Upload",
@@ -39,12 +37,8 @@ license = "BSD-3-Clause"
 
 [project.optional-dependencies]
 deps = [
-    "cachetools==3.1.1; python_version < '3.0'",
     "cachetools==5.3.2; python_version > '3.0'",
-    "cryptography==3.3.2; python_version < '3.0'",
     "cryptography==41.0.6; python_version > '3.0'",
-    "futures==3.4.0; python_version < '3.0'",
-    "pymysql==0.10.1; python_version < '3.0'",
     "pymysql==1.1.0; python_version > '3.0'",
 ]
 


### PR DESCRIPTION
### What does this PR do?
This PR drops `python2` support for mysql integration.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
