### PR TITLE
Add team labels once the labeler is done

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   labeler:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # only PRs from this repo
-    uses: ./.github/workflows/labeler-reusable.yml
-    secrets:
-      repo-token: "${{ secrets.DD_CHANGELOG_CHECK_TOKEN }}"
+    steps:
+    - if: ${{ github.event.pull_request.head.repo.full_name == github.repository }} # only PRs from this repo
+      uses: ./.github/workflows/labeler-reusable.yml
+      with:
+        repo-token: "${{ secrets.DD_CHANGELOG_CHECK_TOKEN }}"

--- a/.github/workflows/pr-add-team-labels.yml
+++ b/.github/workflows/pr-add-team-labels.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   add_team_label:
     runs-on: ubuntu-latest
-    name: Add team label
+    name: Add team labels
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add team labels once the labeler is done

### Motivation
<!-- What inspired you to submit this pull request? -->

We have a race condition between the two jobs and if we add team labels first, the labeler will drop some of the team labels. Example in [this PR](https://github.com/DataDog/integrations-core/pull/16375). We want to let the labeler drop some labels if they are not needed anymore because the PR was updated. The easy solution is to make sure they do not run in parallel

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
