### PR TITLE
Update Airflow README.md to warn users relative to the use of statsd_datadog_enabled

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -49,6 +49,8 @@ Connect Airflow to DogStatsD (included in the Datadog Agent) by using the Airflo
 
 2. Update the Airflow configuration file `airflow.cfg` by adding the following configs:
 
+   <div class="alert alert-warning"> Do not set `statsd_datadog_enabled` to true. Enabling `statsd_datadog_enabled` can create conflicts. To prevent issues, ensure that the variable is set to `False`.</div>
+   
    ```conf
    [scheduler]
    statsd_on = True


### PR DESCRIPTION
### What does this PR do?
The update adds an warning to set the variable **statsd_datadog_enabled** to false.

### Motivation
We've a few customers with the same issue when they follow the Airflow integration, adding this will help reduce the number of tickets.

### Additional Notes
 **Reason**: 
- When "statsd_datadog_enabled" is set to true, the connection between airflow and dogstatsd doesn't seem to function properly.

**Context**: 
Airflow has in his configuration documentation page the variable **statsd_datadog_enabled**. However in our integration we don't recommend use it. When customers use it, it seems to create a conflict with dogstatsd.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
