### PR TITLE
add simple replacement logic to replace ` ` with `-` in team labels

### DIFF
--- a/.github/workflows/labeler-reusable.yml
+++ b/.github/workflows/labeler-reusable.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Add team labels
         run: |
           for team in $(jq -r '.event.pull_request.requested_teams[].name' <<< "$GITHUB_CONTEXT"); do 
-            gh pr edit $NUMBER --add-label "team/$team"
+            # Replace spaces with dashes "Platform Integrations" -> "Platform-Integrations"
+            team_normalized=$(echo "$team" | sed 's/ /-/g')
+            gh pr edit $NUMBER --add-label "team/$team_normalized"
           done
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}


### PR DESCRIPTION
### What does this PR do?
Platform Integrations team name has a space inside of it. This causes the labeler to break. The label they have is `team/platform-integration`. 

I checked all other teams that have a label currently and I don't see any negative side affects from adding this label. The teams that this will affect are:

Platform Integration : team/platform-integration
Network Device Monitoring: team/network-device-monitoring

Labels are case insensitive. https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/using-labels-with-self-hosted-runners#creating-a-custom-label
