### PR TITLE
Remove unused template variables in dashboard

### DIFF
--- a/openstack_controller/assets/dashboards/openstack_controller_overview_[default_microversion].json
+++ b/openstack_controller/assets/dashboards/openstack_controller_overview_[default_microversion].json
@@ -177,6 +177,7 @@
                             "tags": [
                                 "$Keystone_Server_URL"
                             ],
+                            "time": {},
                             "title": "Keystone",
                             "title_align": "left",
                             "title_size": "16",
@@ -195,12 +196,10 @@
                             "check": "openstack.nova.api.up",
                             "group": "$Project",
                             "group_by": [
-                                "domain_id",
                                 "keystone_server"
                             ],
                             "grouping": "cluster",
                             "tags": [
-                                "$Domain",
                                 "$Keystone_Server_URL"
                             ],
                             "title": "Nova",
@@ -221,12 +220,10 @@
                             "check": "openstack.neutron.api.up",
                             "group": "$Project",
                             "group_by": [
-                                "domain_id",
                                 "keystone_server"
                             ],
                             "grouping": "cluster",
                             "tags": [
-                                "$Domain",
                                 "$Keystone_Server_URL"
                             ],
                             "title": "Neutron",
@@ -296,12 +293,13 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.nova.response_time{$Domain,$Project,$Keystone_Server_URL,$RegionId}"
+                                            "query": "avg:openstack.nova.response_time{$Keystone_Server_URL,$RegionId}"
                                         }
                                     ],
                                     "response_format": "scalar"
                                 }
                             ],
+                            "time": {},
                             "timeseries_background": {
                                 "type": "area"
                             },
@@ -334,12 +332,13 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.neutron.response_time{$Domain,$Project,$Keystone_Server_URL,$RegionId}"
+                                            "query": "avg:openstack.neutron.response_time{$Keystone_Server_URL,$RegionId}"
                                         }
                                     ],
                                     "response_format": "scalar"
                                 }
                             ],
+                            "time": {},
                             "timeseries_background": {
                                 "type": "area"
                             },
@@ -360,12 +359,10 @@
                         "definition": {
                             "check": "openstack.cinder.api.up",
                             "group_by": [
-                                "domain_id",
                                 "keystone_server"
                             ],
                             "grouping": "cluster",
                             "tags": [
-                                "$Domain",
                                 "$Keystone_Server_URL"
                             ],
                             "title": "Cinder",
@@ -385,14 +382,12 @@
                         "definition": {
                             "check": "openstack.ironic.api.up",
                             "group": "$Project",
-                            "group_by": [
-                                "domain_id"
-                            ],
+                            "group_by": [],
                             "grouping": "cluster",
                             "tags": [
-                                "$Domain",
                                 "$Keystone_Server_URL"
                             ],
+                            "time": {},
                             "title": "Ironic",
                             "title_align": "left",
                             "title_size": "16",
@@ -410,16 +405,12 @@
                         "definition": {
                             "check": "openstack.octavia.api.up",
                             "group": "$Project",
-                            "group_by": [
-                                "domain_id",
-                                "project_name"
-                            ],
+                            "group_by": [],
                             "grouping": "cluster",
                             "tags": [
-                                "$Domain",
-                                "$Project",
                                 "$Keystone_Server_URL"
                             ],
+                            "time": {},
                             "title": "Octavia",
                             "title_align": "left",
                             "title_size": "16",
@@ -449,12 +440,13 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.cinder.response_time{$Domain,$Project,$Keystone_Server_URL,$RegionId}"
+                                            "query": "avg:openstack.cinder.response_time{$Keystone_Server_URL,$RegionId}"
                                         }
                                     ],
                                     "response_format": "scalar"
                                 }
                             ],
+                            "time": {},
                             "timeseries_background": {
                                 "type": "area"
                             },
@@ -487,12 +479,13 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.ironic.response_time{$Domain,$Project,$Keystone_Server_URL,$RegionId}"
+                                            "query": "avg:openstack.ironic.response_time{$Keystone_Server_URL,$RegionId}"
                                         }
                                     ],
                                     "response_format": "scalar"
                                 }
                             ],
+                            "time": {},
                             "timeseries_background": {
                                 "type": "area"
                             },
@@ -525,12 +518,13 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.response_time{$Domain,$Project,$Keystone_Server_URL,$RegionId}"
+                                            "query": "avg:openstack.octavia.response_time{$Keystone_Server_URL,$RegionId}"
                                         }
                                     ],
                                     "response_format": "scalar"
                                 }
                             ],
+                            "time": {},
                             "timeseries_background": {
                                 "type": "area"
                             },
@@ -1178,13 +1172,13 @@
                                             "aggregator": "last",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:openstack.keystone.service.count{$Domain,$Keystone_Server_URL,$RegionId}"
+                                            "query": "sum:openstack.keystone.service.count{$Keystone_Server_URL,$RegionId}"
                                         },
                                         {
                                             "aggregator": "last",
                                             "data_source": "metrics",
                                             "name": "query2",
-                                            "query": "sum:openstack.controller{$Domain,$Keystone_Server_URL,$RegionId}"
+                                            "query": "sum:openstack.controller{$Keystone_Server_URL,$RegionId}"
                                         }
                                     ],
                                     "response_format": "scalar"
@@ -1219,13 +1213,13 @@
                                             "aggregator": "last",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:openstack.keystone.service.enabled{$Domain,$Keystone_Server_URL,$RegionId}"
+                                            "query": "sum:openstack.keystone.service.enabled{$Keystone_Server_URL,$RegionId}"
                                         },
                                         {
                                             "aggregator": "last",
                                             "data_source": "metrics",
                                             "name": "query2",
-                                            "query": "sum:openstack.controller{$Domain,$Keystone_Server_URL,$RegionId}"
+                                            "query": "sum:openstack.controller{$Keystone_Server_URL,$RegionId}"
                                         }
                                     ],
                                     "response_format": "scalar"
@@ -1265,7 +1259,7 @@
                                             "aggregator": "last",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.keystone.limit.limit{$Domain,$Keystone_Server_URL,$RegionId} by {service_id,region_id,resource_name}"
+                                            "query": "avg:openstack.keystone.limit.limit{$Keystone_Server_URL,$RegionId} by {service_id,region_id,resource_name}"
                                         }
                                     ],
                                     "response_format": "scalar"
@@ -1305,7 +1299,7 @@
                                             "aggregator": "last",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.keystone.service.enabled{$Domain,$Keystone_Server_URL,$RegionId} by {service_id,service_name,service_type,region_id}"
+                                            "query": "avg:openstack.keystone.service.enabled{$Keystone_Server_URL,$RegionId} by {service_id,service_name,service_type,region_id}"
                                         }
                                     ],
                                     "response_format": "scalar"
@@ -2550,12 +2544,13 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.nova.service.up{$Server,$Domain,$Server_Status,$Hypervisor,$Flavor,$Keystone_Server_URL,$RegionId} by {service_name,service_state,service_status,service_id,service_host}"
+                                            "query": "avg:openstack.nova.service.up{$Keystone_Server_URL} by {service_name,service_state,service_status,service_id,service_host}"
                                         }
                                     ],
                                     "response_format": "scalar"
                                 }
                             ],
+                            "time": {},
                             "title": " ",
                             "title_align": "left",
                             "title_size": "16",
@@ -2881,16 +2876,13 @@
                                     "formulas": [
                                         {
                                             "formula": "query1"
-                                        },
-                                        {
-                                            "formula": "query1"
                                         }
                                     ],
                                     "queries": [
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.nova.server.diagnostic.memory_details.maximum{$Keystone_Server_URL,$Domain,$Project,$Server,$Hypervisor,$Flavor,$RegionId} by {project_name,server_name}"
+                                            "query": "avg:openstack.nova.server.diagnostic.memory_details.maximum{$Keystone_Server_URL,$Domain,$Project,$Server,$Hypervisor,$RegionId} by {project_name,server_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -2902,6 +2894,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Maximum Memory",
                             "title_align": "left",
                             "title_size": "16",
@@ -2952,13 +2945,13 @@
                                             "aggregator": "last",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "sum:openstack.nova.hypervisor.count{$Keystone_Server_URL, $RegionId, $Domain}"
+                                            "query": "sum:openstack.nova.hypervisor.count{$Keystone_Server_URL, $RegionId}"
                                         },
                                         {
                                             "aggregator": "last",
                                             "data_source": "metrics",
                                             "name": "query2",
-                                            "query": "sum:openstack.controller{$Keystone_Server_URL, $RegionId, $Domain}"
+                                            "query": "sum:openstack.controller{$Keystone_Server_URL, $RegionId}"
                                         }
                                     ],
                                     "response_format": "scalar"
@@ -3015,17 +3008,17 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.nova.hypervisor.load_1{$Domain,$Hypervisor,$Keystone_Server_URL,$RegionId} by {hypervisor_name}"
+                                            "query": "avg:openstack.nova.hypervisor.load_1{$Keystone_Server_URL, $RegionId} by {hypervisor_name}"
                                         },
                                         {
                                             "data_source": "metrics",
                                             "name": "query2",
-                                            "query": "avg:openstack.nova.hypervisor.load_5{$Domain,$Hypervisor,$Keystone_Server_URL,$RegionId} by {hypervisor_name}"
+                                            "query": "avg:openstack.nova.hypervisor.load_5{$Keystone_Server_URL,$RegionId} by {hypervisor_name}"
                                         },
                                         {
                                             "data_source": "metrics",
                                             "name": "query3",
-                                            "query": "avg:openstack.nova.hypervisor.load_15{$Domain,$Hypervisor,$Keystone_Server_URL,$RegionId} by {hypervisor_name}"
+                                            "query": "avg:openstack.nova.hypervisor.load_15{$Keystone_Server_URL,$RegionId} by {hypervisor_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -3037,6 +3030,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Hypervisor Load",
                             "title_align": "left",
                             "title_size": "16",
@@ -3071,12 +3065,13 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.nova.hypervisor.up{$Domain,$Hypervisor,$Keystone_Server_URL,$RegionId} by {hypervisor_id,hypervisor_name,hypervisor_state,hypervisor_status,hypervisor_type}"
+                                            "query": "avg:openstack.nova.hypervisor.up{$Keystone_Server_URL,$RegionId} by {hypervisor_id,hypervisor_name,hypervisor_state,hypervisor_status,hypervisor_type}"
                                         }
                                     ],
                                     "response_format": "scalar"
                                 }
                             ],
+                            "time": {},
                             "title": " ",
                             "title_align": "left",
                             "title_size": "16",
@@ -3168,25 +3163,25 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.nova.flavor.vcpus{$Domain,$Flavor,$Keystone_Server_URL,$RegionId} by {flavor_name}"
+                                            "query": "avg:openstack.nova.flavor.vcpus{$Flavor,$Keystone_Server_URL,$RegionId} by {flavor_name}"
                                         },
                                         {
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query2",
-                                            "query": "avg:openstack.nova.flavor.ram{$Domain,$Flavor,$Keystone_Server_URL,$RegionId} by {flavor_name}"
+                                            "query": "avg:openstack.nova.flavor.ram{$Flavor,$Keystone_Server_URL,$RegionId} by {flavor_name}"
                                         },
                                         {
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query3",
-                                            "query": "avg:openstack.nova.flavor.disk{$Domain,$Flavor,$Keystone_Server_URL,$RegionId} by {flavor_name}"
+                                            "query": "avg:openstack.nova.flavor.disk{$Flavor,$Keystone_Server_URL,$RegionId} by {flavor_name}"
                                         },
                                         {
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query4",
-                                            "query": "avg:openstack.nova.flavor.swap{$Domain,$Flavor,$Keystone_Server_URL,$RegionId} by {flavor_name}"
+                                            "query": "avg:openstack.nova.flavor.swap{$Flavor,$Keystone_Server_URL,$RegionId} by {flavor_name}"
                                         }
                                     ],
                                     "response_format": "scalar"
@@ -3475,7 +3470,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.loadbalancer.stats.active_connections{$Keystone_Server_URL,$Domain,$Project,$LoadBalancer,$Listener,$RegionId} by {loadbalancer_name}"
+                                            "query": "avg:openstack.octavia.loadbalancer.stats.active_connections{$Keystone_Server_URL,$Domain,$Project,$LoadBalancer,$RegionId} by {loadbalancer_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -3487,6 +3482,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Active Connections",
                             "title_align": "left",
                             "title_size": "16",
@@ -3523,7 +3519,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.loadbalancer.stats.total_connections{$Keystone_Server_URL,$Domain,$Project,$LoadBalancer,$Listener,$RegionId} by {loadbalancer_id}"
+                                            "query": "avg:openstack.octavia.loadbalancer.stats.total_connections{$Keystone_Server_URL,$Domain,$Project,$LoadBalancer,$RegionId} by {loadbalancer_id}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -3535,6 +3531,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Total Connections",
                             "title_align": "left",
                             "title_size": "16",
@@ -3581,12 +3578,13 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.loadbalancer.admin_state_up{$Keystone_Server_URL,$Domain,$Project,$LoadBalancer,$Listener,$RegionId} by {domain_id,project_name,loadbalancer_name,loadbalancer_id,operating_status,provisioning_status}"
+                                            "query": "avg:openstack.octavia.loadbalancer.admin_state_up{$Keystone_Server_URL,$Domain,$Project,$LoadBalancer,$RegionId} by {domain_id,project_name,loadbalancer_name,loadbalancer_id,operating_status,provisioning_status}"
                                         }
                                     ],
                                     "response_format": "scalar"
                                 }
                             ],
+                            "time": {},
                             "title": "Load Balancers Status",
                             "title_align": "left",
                             "title_size": "16",
@@ -3623,7 +3621,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.loadbalancer.stats.bytes_in{$Keystone_Server_URL,$Domain,$Project,$LoadBalancer,$Listener,$RegionId} by {loadbalancer_name}"
+                                            "query": "avg:openstack.octavia.loadbalancer.stats.bytes_in{$Keystone_Server_URL,$Domain,$Project,$LoadBalancer,$RegionId} by {loadbalancer_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -3635,6 +3633,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Bytes In",
                             "title_align": "left",
                             "title_size": "16",
@@ -3671,7 +3670,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.loadbalancer.stats.bytes_out{$Keystone_Server_URL,$Domain,$Project,$LoadBalancer,$Listener,$RegionId} by {loadbalancer_name}"
+                                            "query": "avg:openstack.octavia.loadbalancer.stats.bytes_out{$Keystone_Server_URL,$Domain,$Project,$LoadBalancer,$RegionId} by {loadbalancer_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -3683,6 +3682,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Bytes Out",
                             "title_align": "left",
                             "title_size": "16",
@@ -3719,7 +3719,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.loadbalancer.stats.request_errors{$Keystone_Server_URL,$Domain,$Project,$LoadBalancer,$Listener,$RegionId} by {loadbalancer_name}"
+                                            "query": "avg:openstack.octavia.loadbalancer.stats.request_errors{$Keystone_Server_URL,$Domain,$Project,$LoadBalancer,$RegionId} by {loadbalancer_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -3731,6 +3731,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Request Errors",
                             "title_align": "left",
                             "title_size": "16",
@@ -3844,22 +3845,22 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.listener.timeout_client_data{$Keystone_Server_URL,$Domain,$Project,$Listener,$LoadBalancer,$RegionId} by {listener_name}"
+                                            "query": "avg:openstack.octavia.listener.timeout_client_data{$Keystone_Server_URL,$Domain,$Project,$Listener,$RegionId} by {listener_name}"
                                         },
                                         {
                                             "data_source": "metrics",
                                             "name": "query2",
-                                            "query": "avg:openstack.octavia.listener.timeout_member_connect{$Keystone_Server_URL,$Domain,$Project,$Listener,$LoadBalancer,$RegionId} by {listener_name}"
+                                            "query": "avg:openstack.octavia.listener.timeout_member_connect{$Keystone_Server_URL,$Domain,$Project,$Listener,$RegionId} by {listener_name}"
                                         },
                                         {
                                             "data_source": "metrics",
                                             "name": "query3",
-                                            "query": "avg:openstack.octavia.listener.timeout_member_data{$Keystone_Server_URL,$Domain,$Project,$Listener,$LoadBalancer,$RegionId} by {listener_name}"
+                                            "query": "avg:openstack.octavia.listener.timeout_member_data{$Keystone_Server_URL,$Domain,$Project,$Listener,$RegionId} by {listener_name}"
                                         },
                                         {
                                             "data_source": "metrics",
                                             "name": "query4",
-                                            "query": "avg:openstack.octavia.listener.timeout_tcp_inspect{$Keystone_Server_URL,$Domain,$Project,$Listener,$LoadBalancer,$RegionId} by {listener_name}"
+                                            "query": "avg:openstack.octavia.listener.timeout_tcp_inspect{$Keystone_Server_URL,$Domain,$Project,$Listener,$RegionId} by {listener_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -3871,6 +3872,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Timeouts",
                             "title_align": "left",
                             "title_size": "16",
@@ -3907,7 +3909,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.listener.stats.active_connections{$Keystone_Server_URL,$Domain,$Project,$Listener,$LoadBalancer,$RegionId} by {listener_name}"
+                                            "query": "avg:openstack.octavia.listener.stats.active_connections{$Keystone_Server_URL,$Domain,$Project,$Listener,$RegionId} by {listener_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -3919,6 +3921,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Active Connections",
                             "title_align": "left",
                             "title_size": "16",
@@ -3955,7 +3958,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.listener.stats.total_connections{$Keystone_Server_URL,$Domain,$Project,$Listener,$LoadBalancer,$RegionId} by {listener_name}"
+                                            "query": "avg:openstack.octavia.listener.stats.total_connections{$Keystone_Server_URL,$Domain,$Project,$Listener,$RegionId} by {listener_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -3967,6 +3970,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Total Connections",
                             "title_align": "left",
                             "title_size": "16",
@@ -4001,12 +4005,13 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.listener.stats.active_connections{$Keystone_Server_URL,$Domain,$Project,$Listener,$LoadBalancer,$RegionId} by {domain_id,project_name,listener_name,listener_id,loadbalancer_id}"
+                                            "query": "avg:openstack.octavia.listener.stats.active_connections{$Keystone_Server_URL,$Domain,$Project,$Listener,$RegionId} by {domain_id,project_name,listener_name,listener_id,loadbalancer_id}"
                                         }
                                     ],
                                     "response_format": "scalar"
                                 }
                             ],
+                            "time": {},
                             "title": "Listener Status",
                             "title_align": "left",
                             "title_size": "16",
@@ -4043,7 +4048,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.listener.stats.bytes_in{$Keystone_Server_URL,$Domain,$Project,$Listener,$LoadBalancer,$RegionId} by {listener_name}"
+                                            "query": "avg:openstack.octavia.listener.stats.bytes_in{$Keystone_Server_URL,$Domain,$Project,$Listener,$RegionId} by {listener_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -4055,6 +4060,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Bytes In",
                             "title_align": "left",
                             "title_size": "16",
@@ -4091,7 +4097,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.listener.stats.bytes_out{$Keystone_Server_URL,$Domain,$Project,$Listener,$LoadBalancer,$RegionId} by {listener_name}"
+                                            "query": "avg:openstack.octavia.listener.stats.bytes_out{$Keystone_Server_URL,$Domain,$Project,$Listener,$RegionId} by {listener_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -4103,6 +4109,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Bytes Out",
                             "title_align": "left",
                             "title_size": "16",
@@ -4139,7 +4146,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.listener.stats.request_errors{$Keystone_Server_URL,$Domain,$Project,$Listener,$LoadBalancer,$RegionId} by {listener_name}"
+                                            "query": "avg:openstack.octavia.listener.stats.request_errors{$Keystone_Server_URL,$Domain,$Project,$Listener,$RegionId} by {listener_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -4151,6 +4158,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Request Errors",
                             "title_align": "left",
                             "title_size": "16",
@@ -4408,12 +4416,13 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.pool.admin_state_up{$Keystone_Server_URL,$Domain,$Project,$Pool,$Listener,$HealthMonitor,$RegionId} by {domain_id,project_name,pool_name,pool_id,provisioning_status,operating_status}"
+                                            "query": "avg:openstack.octavia.pool.admin_state_up{$Keystone_Server_URL,$Domain,$Project,$Pool,$RegionId} by {domain_id,project_name,pool_name,pool_id,provisioning_status,operating_status}"
                                         }
                                     ],
                                     "response_format": "scalar"
                                 }
                             ],
+                            "time": {},
                             "title": "Pools Status",
                             "title_align": "left",
                             "title_size": "16",
@@ -4572,7 +4581,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.pool.member.weight{$Keystone_Server_URL,$Domain,$Project,$Pool,$HealthMonitor,$RegionId} by {member_name}"
+                                            "query": "avg:openstack.octavia.pool.member.weight{$Keystone_Server_URL, $Domain, $Project, $RegionId} by {member_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -4584,6 +4593,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Weight",
                             "title_align": "left",
                             "title_size": "16",
@@ -4618,12 +4628,13 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.pool.member.admin_state_up{$Keystone_Server_URL,$Domain,$Project,$Pool,$HealthMonitor,$RegionId} by {domain_id,project_name,pool_name,operating_status,provisioning_status,pool_id}"
+                                            "query": "avg:openstack.octavia.pool.member.admin_state_up{$Keystone_Server_URL,$Domain,$Project,$RegionId} by {domain_id,project_name,pool_name,operating_status,provisioning_status,pool_id}"
                                         }
                                     ],
                                     "response_format": "scalar"
                                 }
                             ],
+                            "time": {},
                             "title": "Members Status",
                             "title_align": "left",
                             "title_size": "16",
@@ -4782,7 +4793,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.healthmonitor.delay{$Keystone_Server_URL,$Domain,$Project,$HealthMonitor,$Pool,$RegionId}"
+                                            "query": "avg:openstack.octavia.healthmonitor.delay{$Keystone_Server_URL,$Domain,$Project,$HealthMonitor,$RegionId}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -4794,6 +4805,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Delay",
                             "title_align": "left",
                             "title_size": "16",
@@ -4828,12 +4840,13 @@
                                             "aggregator": "avg",
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.healthmonitor.admin_state_up{$Keystone_Server_URL,$Domain,$Project,$HealthMonitor,$Pool,$RegionId} by {domain_id,project_name,healthmonitor_name,healthmonitor_id,type,operating_status,provisioning_status}"
+                                            "query": "avg:openstack.octavia.healthmonitor.admin_state_up{$Keystone_Server_URL,$Domain,$Project,$HealthMonitor,$RegionId} by {domain_id,project_name,healthmonitor_name,healthmonitor_id,type,operating_status,provisioning_status}"
                                         }
                                     ],
                                     "response_format": "scalar"
                                 }
                             ],
+                            "time": {},
                             "title": "Health Monitors Status",
                             "title_align": "left",
                             "title_size": "16",
@@ -4874,12 +4887,12 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.healthmonitor.max_retries{$Keystone_Server_URL,$Domain,$Project,$HealthMonitor,$Pool,$RegionId} by {healthmonitor_name}"
+                                            "query": "avg:openstack.octavia.healthmonitor.max_retries{$Keystone_Server_URL,$Domain,$Project,$HealthMonitor,$RegionId} by {healthmonitor_name}"
                                         },
                                         {
                                             "data_source": "metrics",
                                             "name": "query2",
-                                            "query": "avg:openstack.octavia.healthmonitor.max_retries_down{$Keystone_Server_URL,$Domain,$Project,$HealthMonitor,$Pool,$RegionId} by {healthmonitor_name}"
+                                            "query": "avg:openstack.octavia.healthmonitor.max_retries_down{$Keystone_Server_URL,$Domain,$Project,$HealthMonitor,$RegionId} by {healthmonitor_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -4891,6 +4904,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Max Retries and Max Retries Down",
                             "title_align": "left",
                             "title_size": "16",
@@ -4927,7 +4941,7 @@
                                         {
                                             "data_source": "metrics",
                                             "name": "query1",
-                                            "query": "avg:openstack.octavia.healthmonitor.timeout{$Keystone_Server_URL,$Domain,$Project,$HealthMonitor,$Pool,$RegionId} by {healthmonitor_name}"
+                                            "query": "avg:openstack.octavia.healthmonitor.timeout{$Keystone_Server_URL,$Domain,$Project,$HealthMonitor,$RegionId} by {healthmonitor_name}"
                                         }
                                     ],
                                     "response_format": "timeseries",
@@ -4939,6 +4953,7 @@
                                 }
                             ],
                             "show_legend": true,
+                            "time": {},
                             "title": "Timeout",
                             "title_align": "left",
                             "title_size": "16",


### PR DESCRIPTION
### What does this PR do?
Removes unused template variables in openstack dashboard
### Motivation
when filtering by a template variable of a tag that doesn't exist on a metric, that metric graph is broken
### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
