### PR TITLE
Generate the changelogs only if a PR was created

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -2,8 +2,8 @@ name: Update the dependencies
 
 on:
   schedule:
-  # At 4AM on Monday (UTC)
-  - cron: "0 4 * * 1"
+  # At 2AM on Monday (UTC)
+  - cron: "0 2 * * 1"
 
 jobs:
   update_dependencies:
@@ -35,10 +35,8 @@ jobs:
       env:
         DD_GITHUB_USER: "${{ github.actor }}"
         DD_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-    - name: Generate changelogs
-      run: |-
-        ddev release changelog new fixed -m "Update dependencies"
     - name: Create Pull Request
+      id: cpr
       uses: peter-evans/create-pull-request@v5
       with:
         # TODO Change once we have another bot account for this pipeline
@@ -68,3 +66,18 @@ jobs:
         delete-branch: true
         base: master
         labels: bot
+        draft: false
+    # We generate the changelog if and only if the PR was created
+    - name: Update changelogs
+      if: ${{ steps.cpr.outputs.pull-request-number }}
+      env:
+        GH_TOKEN:
+          ${{ github.token }}
+      run: |-
+        gh pr checkout ${{ steps.cpr.outputs.pull-request-number }}
+        ddev release changelog new added -m "Update dependencies"
+        git config --global user.email "agent-integrations-dependency-bot@datadoghq.com"
+        git config --global user.name "Agent Integrations Dependency Bot"
+        git add .
+        git commit -am "Update changelogs"
+        git push origin HEAD


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

- Generate the changelogs only if a PR was created
- Trigger the pipeline earlier when we have less traffic on GitLab

### Motivation
<!-- What inspired you to submit this pull request? -->

- No need to run this command if nothing changed
- Running it before the PR is created is not always reliable. The command will try to guess the PR number, which in some cases do not pick the right number. If we open the PR first the command will use the PR number from GitHub

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
