### PR TITLE
kubeproxy.network_programming.duration - Documentation update

### DIFF
--- a/kube_proxy/metadata.csv
+++ b/kube_proxy/metadata.csv
@@ -2,7 +2,6 @@ metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation
 kubeproxy.cpu.time,gauge,,second,,Total user and system CPU time spent in seconds,0,kube_proxy,cpu time,
 kubeproxy.mem.resident,gauge,,byte,,Resident memory size in bytes,0,kube_proxy,resident memory,
 kubeproxy.mem.virtual,gauge,,byte,,Virtual memory size in bytes,0,kube_proxy,virtual memory,
-kubeproxy.network_programming.duration,gauge,,second,,In Cluster Network Programming Latency in seconds (alpha),0,kube_proxy,network programming latency,
 kubeproxy.sync_proxy.rules.duration,gauge,,second,,SyncProxyRules latency in seconds (alpha),-1,kube_proxy,rules latency,
 kubeproxy.sync_proxy.rules.endpoint_changes.pending,gauge,,,,Pending proxy rules Endpoint changes (alpha),0,kube_proxy,rules sync pending endpoint changes,
 kubeproxy.sync_proxy.rules.endpoint_changes.total,gauge,,,,Cumulative proxy rules Endpoint changes (alpha),0,kube_proxy,rules sync total endpoint changes,


### PR DESCRIPTION
### What does this PR do?
This PR removes the metric `kubeproxy.network_programming.duration` from the CSV document that list available metrics as confirmed in this [PR](https://github.com/DataDog/integrations-core/pull/11182).

### Motivation
Question raised by customer about why this metric still appear in the list of captured metric while we do not capture it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
