### PR TITLE
Pin the `hatch` version to 1.7.0

### DIFF
--- a/ddev/changelog.d/16405.fixed
+++ b/ddev/changelog.d/16405.fixed
@@ -1,0 +1,1 @@
+Pin the `hatch` version to 1.7.0

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "click~=8.1.6",
     "coverage",
     "datadog-checks-dev[cli]~=28.0",
-    "hatch>=1.6.3",
+    "hatch==1.7.0",
     "httpx",
     "jsonpointer",
     "pluggy",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Pin the hatch version to 1.7.0

### Motivation
<!-- What inspired you to submit this pull request? -->

Hatch 1.8.0 broke [some of our tests](https://github.com/DataDog/integrations-core/actions/runs/7179040309/job/19548524127). Ofek is on it but I pin it to unblock the CI

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
