### PR TITLE
Mount the logs volumes inside the agent with the `env start` command

### DIFF
--- a/ddev/changelog.d/16411.fixed
+++ b/ddev/changelog.d/16411.fixed
@@ -1,0 +1,1 @@
+Mount the logs volumes inside the agent with the `env start` command

--- a/ddev/src/ddev/cli/env/start.py
+++ b/ddev/src/ddev/cli/env/start.py
@@ -60,6 +60,8 @@ def start(
     import os
     from contextlib import suppress
 
+    from datadog_checks.dev._env import deserialize_data
+
     from ddev.e2e.agent import get_agent_interface
     from ddev.e2e.config import EnvDataStorage
     from ddev.e2e.constants import DEFAULT_AGENT_TYPE, E2EEnvVars, E2EMetadata
@@ -121,6 +123,13 @@ def start(
         result = json.loads(result_file.read_text())
 
     metadata = result['metadata']
+
+    # TODO Remove once we have migrated the `docker_run` function
+    if serialized_volumes := metadata.get(E2EMetadata.ENV_VARS, {}).get(E2EEnvVars.DOCKER_VOLUMES):
+        volumes = metadata.get(E2EMetadata.DOCKER_VOLUMES, [])
+        volumes.extend(deserialize_data(serialized_volumes))
+        metadata[E2EMetadata.DOCKER_VOLUMES] = volumes
+
     env_data.write_metadata(metadata)
 
     config = result['config']

--- a/ddev/src/ddev/e2e/constants.py
+++ b/ddev/src/ddev/e2e/constants.py
@@ -11,8 +11,10 @@ class E2EEnvVars:
     PARENT_PYTHON = 'DDEV_E2E_PYTHON_PATH'
     RESULT_FILE = 'DDEV_E2E_RESULT_FILE'
     LOGS_DIR_PREFIX = 'DDEV_E2E_ENV_TEMP_DIR_DD_LOG_'
+    DOCKER_VOLUMES = 'DDEV_E2E_ENV_docker_volumes'
 
 
 class E2EMetadata:
     AGENT_TYPE = 'agent_type'
     ENV_VARS = 'e2e_env_vars'
+    DOCKER_VOLUMES = 'docker_volumes'

--- a/ddev/tests/cli/env/test_start.py
+++ b/ddev/tests/cli/env/test_start.py
@@ -1,9 +1,11 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import copy
 import os
 
 import pytest
+from datadog_checks.dev._env import serialize_data
 
 from ddev.e2e.config import EnvDataStorage
 from ddev.e2e.constants import DEFAULT_DOGSTATSD_PORT, E2EEnvVars, E2EMetadata
@@ -441,5 +443,60 @@ def test_dogstatsd(ddev, helpers, data_dir, write_result_file, mocker):
             'DD_DOGSTATSD_PORT': str(DEFAULT_DOGSTATSD_PORT),
             'DD_DOGSTATSD_NON_LOCAL_TRAFFIC': 'true',
             'DD_DOGSTATSD_METRICS_STATS_ENABLE': 'true',
+        },
+    )
+
+
+def test_mount_log(ddev, helpers, data_dir, write_result_file, mocker):
+    config = {}
+    metadata = {
+        'e2e_env_vars': {
+            'DDEV_E2E_ENV_docker_volumes': serialize_data(
+                [
+                    "/tmp/123456/apache_dd_log_1.log:/var/log/apache/dd_log_1",
+                    "/tmp/123456/apache_dd_log_2.log:/var/log/apache/dd_log_2",
+                ]
+            )
+        }
+    }
+    mocker.patch('subprocess.run', side_effect=write_result_file({'metadata': metadata, 'config': config}))
+    start = mocker.patch('ddev.e2e.agent.docker.DockerAgent.start')
+
+    integration = 'postgres'
+    environment = 'py3.12'
+    env_data = EnvDataStorage(data_dir).get(integration, environment)
+
+    result = ddev('env', 'start', integration, environment)
+
+    assert result.exit_code == 0, result.output
+    assert result.output == helpers.dedent(
+        f"""
+        ─────────────────────────────── Starting: py3.12 ───────────────────────────────
+
+        Stop environment -> ddev env stop {integration} {environment}
+        Execute tests -> ddev env test {integration} {environment}
+        Check status -> ddev env agent {integration} {environment} status
+        Trigger run -> ddev env agent {integration} {environment} check
+        Reload config -> ddev env reload {integration} {environment}
+        Manage config -> ddev env config
+        Config file -> {env_data.config_file}
+        """
+    )
+
+    assert env_data.read_config() == {'instances': [config]}
+
+    expected_metadata = copy.deepcopy(metadata)
+    expected_metadata['docker_volumes'] = [
+        '/tmp/123456/apache_dd_log_1.log:/var/log/apache/dd_log_1',
+        '/tmp/123456/apache_dd_log_2.log:/var/log/apache/dd_log_2',
+    ]
+    assert env_data.read_metadata() == expected_metadata
+
+    start.assert_called_once_with(
+        agent_build='datadog/agent-dev:master',
+        local_packages={},
+        env_vars={
+            'DD_DD_URL': 'https://app.datadoghq.com',
+            'DD_SITE': 'datadoghq.com',
         },
     )

--- a/ddev/tests/cli/env/test_start.py
+++ b/ddev/tests/cli/env/test_start.py
@@ -5,7 +5,7 @@ import copy
 import os
 
 import pytest
-from datadog_checks.dev._env import serialize_data
+from datadog_checks.dev.env import serialize_data
 
 from ddev.e2e.config import EnvDataStorage
 from ddev.e2e.constants import DEFAULT_DOGSTATSD_PORT, E2EEnvVars, E2EMetadata


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Mount the logs volumes inside the agent with the `env start` command

### Motivation
<!-- What inspired you to submit this pull request? -->

- When we use [`mount_logs=True`](https://github.com/DataDog/integrations-core/blob/fc38712fc34d2f027d9801b753fa6f2c52fc49bc/datadog_checks_dev/datadog_checks/dev/docker.py#L120), `datadog_checks_dev` adds the automatically generated volume's paths to the env variables using [`save_state`](https://github.com/DataDog/integrations-core/blob/fc38712fc34d2f027d9801b753fa6f2c52fc49bc/datadog_checks_dev/datadog_checks/dev/docker.py#L103)
- When we switched the `env start` (and `env test` etc...) commands to `ddev`, we started [to only use the `docker_volumes`](https://github.com/DataDog/integrations-core/blob/f824c47f1e9e37ba5ca557af9577ce7d8dd71870/ddev/src/ddev/e2e/agent/docker.py#L140) declared in the metadata by the tests. In case you do not know, [this is an example of where you can declare them](https://github.com/DataDog/integrations-core/blob/01a1bc6adce0473971ecba914fee23244b793a7c/kafka_consumer/tests/conftest.py#L56), with [these volumes](https://github.com/DataDog/integrations-core/blob/639d31055d45da9741c3b4d17396c1d224d77016/kafka_consumer/tests/common.py#L34-L38).
- This means that no logs volumes are mounted anymore. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
