### PR TITLE
Revert key PRs from postgres integration

### DIFF
--- a/datadog_checks_base/CHANGELOG.md
+++ b/datadog_checks_base/CHANGELOG.md
@@ -41,10 +41,6 @@
 
 ## 34.1.0 / 2023-10-20
 
-***Added***:
-
-* Add util to track db query operation time ([#16040](https://github.com/DataDog/integrations-core/pull/16040))
-
 ***Fixed***:
 
 * Bump the `pymysql` version to 1.1.0 on Python 3 ([#16042](https://github.com/DataDog/integrations-core/pull/16042))

--- a/datadog_checks_base/datadog_checks/base/utils/db/core.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/core.py
@@ -12,7 +12,7 @@ from ...config import is_affirmative
 from ..containers import iter_unique
 from .query import Query
 from .transform import COLUMN_TRANSFORMERS, EXTRA_TRANSFORMERS
-from .utils import SUBMISSION_METHODS, create_submission_transformer, tracked_query
+from .utils import SUBMISSION_METHODS, create_submission_transformer
 
 
 class QueryExecutor(object):
@@ -31,7 +31,6 @@ class QueryExecutor(object):
         error_handler=None,  # type: Callable[[str], str]
         hostname=None,  # type: str
         logger=None,
-        track_operation_time=False,  # type: bool
     ):  # type: (...) -> QueryExecutor
         self.executor = executor  # type: QueriesExecutor
         self.submitter = submitter  # type: QueriesSubmitter
@@ -46,7 +45,6 @@ class QueryExecutor(object):
         self.queries = [Query(payload) for payload in queries or []]  # type: List[Query]
         self.hostname = hostname  # type: str
         self.logger = logger or logging.getLogger(__name__)
-        self.track_operation_time = track_operation_time
 
     def compile_queries(self):
         """This method compiles every `Query` object."""
@@ -74,11 +72,7 @@ class QueryExecutor(object):
             query_tags = query.base_tags
 
             try:
-                if self.track_operation_time:
-                    with tracked_query(check=self.submitter, operation=query_name):
-                        rows = self.execute_query(query.query)
-                else:
-                    rows = self.execute_query(query.query)
+                rows = self.execute_query(query.query)
             except Exception as e:
                 if self.error_handler:
                     self.logger.error('Error querying %s: %s', query_name, self.error_handler(str(e)))

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -1,7 +1,6 @@
 # (C) Datadog, Inc. 2019-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-import contextlib
 import datetime
 import decimal
 import functools
@@ -352,33 +351,3 @@ class DBMAsyncJob(object):
 
     def run_job(self):
         raise NotImplementedError()
-
-
-@contextlib.contextmanager
-def tracked_query(check, operation, tags=None):
-    """
-    A simple context manager that tracks the time spent in a given query operation
-
-    The intention is to use this for context manager is to wrap the execution of a query,
-    that way the time spent waiting for query execution can be tracked as a metric. For example,
-    '''
-    with tracked_query(check, "my_metric_query", tags):
-        cursor.execute(query)
-    '''
-
-    if debug_stats_kwargs is defined on the check instance,
-    it will be called to set additional kwargs when submitting the metric.
-
-    :param check: The check instance
-    :param operation: The name of the query operation being performed.
-    :param tags: A list of tags to apply to the metric.
-    """
-    start_time = time.time()
-    stats_kwargs = {}
-    if hasattr(check, 'debug_stats_kwargs'):
-        stats_kwargs = dict(check.debug_stats_kwargs())
-    stats_kwargs['tags'] = stats_kwargs.get('tags', []) + ["operation:{}".format(operation)] + (tags or [])
-    stats_kwargs['raw'] = True  # always submit as raw to ignore any defined namespace prefix
-    yield
-    elapsed_ms = (time.time() - start_time) * 1000
-    check.histogram("dd.{}.operation.time".format(check.name), elapsed_ms, **stats_kwargs)

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -20,7 +20,6 @@ from datadog_checks.base.utils.db.utils import (
     default_json_event_encoding,
     obfuscate_sql_with_metadata,
     resolve_db_host,
-    tracked_query,
 )
 from datadog_checks.base.utils.serialization import json
 
@@ -277,16 +276,3 @@ def test_dbm_async_job_inactive_stop(aggregator):
 def test_default_json_event_encoding(input):
     # assert that the default json event encoding can handle all defined types without raising TypeError
     assert json.dumps(input, default=default_json_event_encoding)
-
-
-def test_tracked_query(aggregator):
-    with mock.patch('time.time', side_effect=[100, 101]):
-        with tracked_query(
-            check=AgentCheck(name="testcheck"),
-            operation="test_query",
-            tags=["test:tag"],
-        ):
-            pass
-        aggregator.assert_metric(
-            "dd.testcheck.operation.time", tags=["test:tag", "operation:test_query"], count=1, value=1000.0
-        )

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -20,7 +20,6 @@
 
 * Upgrade `psycopg2-binary` to `v2.9.8` ([#15949](https://github.com/DataDog/integrations-core/pull/15949))
 * Add support for reporting SQL obfuscation errors ([#15990](https://github.com/DataDog/integrations-core/pull/15990))
-* Emit postgres metrics queries operation time ([#16040](https://github.com/DataDog/integrations-core/pull/16040))
 * Add obfuscation_mode config option to allow enabling obfuscation with go-sqllexer ([#16071](https://github.com/DataDog/integrations-core/pull/16071))
 
 ***Fixed***:

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -27,7 +27,6 @@
 
 * Add cloudsqladmin to default list of databases to exclude from autodiscovery and databases to ignore to prevent failures on Postgres 15 on Google CloudSQL ([#16027](https://github.com/DataDog/integrations-core/pull/16027))
 * Bump the minimum base check version to 34.1.0 ([#16062](https://github.com/DataDog/integrations-core/pull/16062))
-* Collect Postgres size metrics for auto-discovered databases ([#16076](https://github.com/DataDog/integrations-core/pull/16076))
 
 ## 15.1.1 / 2023-10-17 / Agent 7.49.0
 

--- a/postgres/CHANGELOG.md
+++ b/postgres/CHANGELOG.md
@@ -26,7 +26,6 @@
 ***Fixed***:
 
 * Add cloudsqladmin to default list of databases to exclude from autodiscovery and databases to ignore to prevent failures on Postgres 15 on Google CloudSQL ([#16027](https://github.com/DataDog/integrations-core/pull/16027))
-* Bump the minimum base check version to 34.1.0 ([#16062](https://github.com/DataDog/integrations-core/pull/16062))
 
 ## 15.1.1 / 2023-10-17 / Agent 7.49.0
 

--- a/postgres/datadog_checks/postgres/metrics_cache.py
+++ b/postgres/datadog_checks/postgres/metrics_cache.py
@@ -95,7 +95,6 @@ class PostgresMetricsCache:
             "FROM pg_stat_database psd "
             "JOIN pg_database pd ON psd.datname = pd.datname",
             'relation': False,
-            'name': 'instance_metrics',
         }
 
         res["query"] += " WHERE " + " AND ".join(
@@ -129,7 +128,6 @@ class PostgresMetricsCache:
             'metrics': self.bgw_metrics,
             'query': "select {metrics_columns} FROM pg_stat_bgwriter",
             'relation': False,
-            'name': 'bgw_metrics',
         }
 
     def get_count_metrics(self):
@@ -160,7 +158,6 @@ class PostgresMetricsCache:
             'metrics': self.archiver_metrics,
             'query': "select {metrics_columns} FROM pg_stat_archiver",
             'relation': False,
-            'name': 'archiver_metrics',
         }
 
     def get_replication_metrics(self, version, is_aurora):
@@ -249,5 +246,4 @@ class PostgresMetricsCache:
             'metrics': metrics,
             'query': query,
             'relation': False,
-            'name': 'activity_metrics',
         }

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -3,7 +3,6 @@
 # Licensed under Simplified BSD License (see LICENSE)
 import contextlib
 import copy
-import functools
 import os
 from time import time
 
@@ -115,7 +114,7 @@ class PostgreSql(AgentCheck):
         self.check_initializations.append(self.initialize_is_aurora)
         self.tags_without_db = [t for t in copy.copy(self.tags) if not t.startswith("db:")]
         self.autodiscovery = self._build_autodiscovery()
-        self._dynamic_queries = []
+        self._dynamic_queries = None
         # _database_instance_emitted: limit the collection and transmission of the database instance metadata
         self._database_instance_emitted = TTLCache(
             maxsize=1,
@@ -173,9 +172,9 @@ class PostgreSql(AgentCheck):
             )
         )
 
-    def _new_query_executor(self, queries, db):
+    def _new_query_executor(self, queries):
         return QueryExecutor(
-            functools.partial(self.execute_query_raw, db=db),
+            self.execute_query_raw,
             self,
             queries=queries,
             tags=self.tags_without_db,
@@ -183,8 +182,8 @@ class PostgreSql(AgentCheck):
             track_operation_time=True,
         )
 
-    def execute_query_raw(self, query, db):
-        with db() as conn:
+    def execute_query_raw(self, query):
+        with self.db() as conn:
             with conn.cursor() as cursor:
                 cursor.execute(query)
                 rows = cursor.fetchall()
@@ -232,7 +231,6 @@ class PostgreSql(AgentCheck):
 
         self.log.debug("Generating dynamic queries")
         queries = []
-        per_database_queries = []  # queries that need to be run per database, used for autodiscovery
         if self.version >= V9_2:
             q_pg_stat_database = copy.deepcopy(QUERY_PG_STAT_DATABASE)
             if len(self._config.ignore_databases) > 0:
@@ -283,15 +281,10 @@ class PostgreSql(AgentCheck):
                 query = copy.copy(query)
                 formatted_query = self._relations_manager.filter_relation_query(query['query'], 'nspname')
                 query['query'] = formatted_query
-                per_database_queries.append(query)
+                queries.append(query)
 
-        if self.autodiscovery:
-            self._collect_dynamic_queries_autodiscovery(per_database_queries)
-        else:
-            queries.extend(per_database_queries)
-        self._dynamic_queries.append(self._new_query_executor(queries, db=self.db))
-        for dynamic_query in self._dynamic_queries:
-            dynamic_query.compile_queries()
+        self._dynamic_queries = self._new_query_executor(queries)
+        self._dynamic_queries.compile_queries()
         self.log.debug("initialized %s dynamic querie(s)", len(queries))
 
         return self._dynamic_queries
@@ -311,7 +304,7 @@ class PostgreSql(AgentCheck):
     def _clean_state(self):
         self.log.debug("Cleaning state")
         self.metrics_cache.clean_state()
-        self._dynamic_queries = []
+        self._dynamic_queries = None
 
     def _get_debug_tags(self):
         return ['agent_hostname:{}'.format(self.agent_hostname)]
@@ -593,17 +586,6 @@ class PostgreSql(AgentCheck):
                 ),
             )
 
-    def _collect_dynamic_queries_autodiscovery(self, queries):
-        if not self.autodiscovery:
-            return
-
-        databases = self.autodiscovery.get_items()
-        for dbname in databases:
-            db = functools.partial(
-                self.db_pool.get_connection, dbname=dbname, ttl_ms=self._config.idle_connection_timeout
-            )
-            self._dynamic_queries.append(self._new_query_executor(queries, db=db))
-
     def _collect_stats(self, instance_tags):
         """Query pg_stat_* for various metrics
         If relations is not an empty list, gather per-relation metrics
@@ -677,8 +659,7 @@ class PostgreSql(AgentCheck):
                     self._query_scope(cursor, scope, instance_tags, True)
 
         if self.dynamic_queries:
-            for dynamic_query in self.dynamic_queries:
-                dynamic_query.execute()
+            self.dynamic_queries.execute()
 
     def _new_connection(self, dbname):
         if self._config.host == 'localhost' and self._config.password == '':

--- a/postgres/datadog_checks/postgres/postgres.py
+++ b/postgres/datadog_checks/postgres/postgres.py
@@ -14,7 +14,6 @@ from datadog_checks.base import AgentCheck
 from datadog_checks.base.utils.db import QueryExecutor
 from datadog_checks.base.utils.db.utils import (
     default_json_event_encoding,
-    tracked_query,
 )
 from datadog_checks.base.utils.db.utils import resolve_db_host as agent_host_resolver
 from datadog_checks.base.utils.serialization import json
@@ -179,7 +178,6 @@ class PostgreSql(AgentCheck):
             queries=queries,
             tags=self.tags_without_db,
             hostname=self.resolved_hostname,
-            track_operation_time=True,
         )
 
     def execute_query_raw(self, query):
@@ -419,17 +417,16 @@ class PostgreSql(AgentCheck):
         is_relations = scope.get('relation') and self._relations_manager.has_relations
         try:
             query = fmt.format(scope['query'], metrics_columns=", ".join(cols))
-            with tracked_query(check=self, operation='custom_metrics' if is_custom_metrics else scope['name']):
-                # if this is a relation-specific query, we need to list all relations last
-                if is_relations:
-                    schema_field = get_schema_field(descriptors)
-                    formatted_query = self._relations_manager.filter_relation_query(query, schema_field)
-                    cursor.execute(formatted_query)
-                else:
-                    self.log.debug("Running query: %s", str(query))
-                    cursor.execute(query.replace(r'%', r'%%'))
+            # if this is a relation-specific query, we need to list all relations last
+            if is_relations:
+                schema_field = get_schema_field(descriptors)
+                formatted_query = self._relations_manager.filter_relation_query(query, schema_field)
+                cursor.execute(formatted_query)
+            else:
+                self.log.debug("Running query: %s", str(query))
+                cursor.execute(query.replace(r'%', r'%%'))
 
-                results = cursor.fetchall()
+            results = cursor.fetchall()
         except psycopg2.errors.FeatureNotSupported as e:
             # This happens for example when trying to get replication metrics from readers in Aurora. Let's ignore it.
             log_func(e)
@@ -650,13 +647,9 @@ class PostgreSql(AgentCheck):
                 with conn.cursor() as cursor:
                     self._query_scope(cursor, activity_metrics, instance_tags, False)
 
-            for scope in list(metric_scope):
+            for scope in list(metric_scope) + self._config.custom_metrics:
                 with conn.cursor() as cursor:
-                    self._query_scope(cursor, scope, instance_tags, False)
-
-            for scope in self._config.custom_metrics:
-                with conn.cursor() as cursor:
-                    self._query_scope(cursor, scope, instance_tags, True)
+                    self._query_scope(cursor, scope, instance_tags, scope in self._config.custom_metrics)
 
         if self.dynamic_queries:
             self.dynamic_queries.execute()
@@ -786,10 +779,7 @@ class PostgreSql(AgentCheck):
                 with conn.cursor() as cursor:
                     try:
                         self.log.debug("Running query: %s", query)
-                        with tracked_query(
-                            check=self, operation='custom_queries', tags=['metric_prefix:{}'.format(metric_prefix)]
-                        ):
-                            cursor.execute(query)
+                        cursor.execute(query)
                     except (psycopg2.ProgrammingError, psycopg2.errors.QueryCanceled) as e:
                         self.log.error("Error executing query for metric_prefix %s: %s", metric_prefix, str(e))
                         continue
@@ -893,13 +883,6 @@ class PostgreSql(AgentCheck):
             }
             self._database_instance_emitted[self.resolved_hostname] = event
             self.database_monitoring_metadata(json.dumps(event, default=default_json_event_encoding))
-
-    def debug_stats_kwargs(self, tags=None):
-        tags = self.tags + self._get_debug_tags() + (tags or [])
-        return {
-            'tags': tags,
-            "hostname": self.resolved_hostname,
-        }
 
     def check(self, _):
         tags = copy.copy(self.tags)

--- a/postgres/datadog_checks/postgres/relationsmanager.py
+++ b/postgres/datadog_checks/postgres/relationsmanager.py
@@ -53,7 +53,6 @@ SELECT mode,
    AND pc.relname NOT LIKE 'pg^_%%' ESCAPE '^'
  GROUP BY pd.datname, pc.relname, pn.nspname, locktype, mode""",
     'relation': True,
-    'name': 'lock_metrics',
 }
 
 # The pg_stat_all_tables contain one row for each table in the current database,
@@ -82,7 +81,6 @@ SELECT relname,schemaname,{metrics_columns}
   FROM pg_stat_user_tables
  WHERE {relations}""",
     'relation': True,
-    'name': 'rel_metrics',
 }
 
 
@@ -105,7 +103,6 @@ SELECT relname,
   FROM pg_stat_user_indexes
  WHERE {relations}""",
     'relation': True,
-    'name': 'idx_metrics',
 }
 
 
@@ -193,9 +190,7 @@ SELECT relname,
   FROM pg_statio_user_tables
  WHERE {relations}""",
     'relation': True,
-    'name': 'statio_metrics',
 }
-
 # adapted from https://wiki.postgresql.org/wiki/Show_database_bloat and https://github.com/bucardo/check_postgres/
 TABLE_BLOAT_QUERY = """
 SELECT
@@ -246,7 +241,6 @@ TABLE_BLOAT = {
     },
     'query': TABLE_BLOAT_QUERY,
     'relation': True,
-    'name': 'table_bloat_metrics',
 }
 
 
@@ -302,7 +296,6 @@ INDEX_BLOAT = {
     },
     'query': INDEX_BLOAT_QUERY,
     'relation': True,
-    'name': 'index_bloat_metrics',
 }
 
 RELATION_METRICS = [LOCK_METRICS, REL_METRICS, IDX_METRICS, STATIO_METRICS]

--- a/postgres/datadog_checks/postgres/util.py
+++ b/postgres/datadog_checks/postgres/util.py
@@ -209,7 +209,6 @@ LIMIT {table_count_limit}
 ) AS subquery GROUP BY schemaname
     """
     ),
-    'name': 'count_metrics',
 }
 
 q1 = (
@@ -253,7 +252,6 @@ REPLICATION_METRICS = {
     'query': """
 SELECT {metrics_columns}
  WHERE (SELECT pg_is_in_recovery())""",
-    'name': 'replication_metrics',
 }
 
 # Requires postgres 10+
@@ -287,7 +285,6 @@ REPLICATION_STATS_METRICS = {
 SELECT application_name, state, sync_state, client_addr, {metrics_columns}
 FROM pg_stat_replication
 """,
-    'name': 'replication_stats_metrics',
 }
 
 
@@ -352,7 +349,6 @@ WITH max_con AS (SELECT setting::float FROM pg_settings WHERE name = 'max_connec
 SELECT {metrics_columns}
   FROM pg_stat_database, max_con
 """,
-    'name': 'connections_metrics',
 }
 
 SLRU_METRICS = {
@@ -371,7 +367,6 @@ SLRU_METRICS = {
 SELECT name, {metrics_columns}
   FROM pg_stat_slru
 """,
-    'name': 'slru_metrics',
 }
 
 SNAPSHOT_TXID_METRICS = {
@@ -474,7 +469,6 @@ SELECT s.schemaname,
     ON o.funcname = s.funcname;
 """,
     'relation': False,
-    'name': 'function_metrics',
 }
 
 # The metrics we retrieve from pg_stat_activity when the postgres version >= 9.6

--- a/postgres/pyproject.toml
+++ b/postgres/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 dependencies = [
-    "datadog-checks-base>=34.1.0",
+    "datadog-checks-base>=32.6.0",
 ]
 dynamic = [
     "version",

--- a/postgres/tests/common.py
+++ b/postgres/tests/common.py
@@ -96,17 +96,6 @@ CONNECTION_METRICS = ['postgresql.max_connections', 'postgresql.percent_usage_co
 CONNECTION_METRICS_DB = ['postgresql.connections']
 COMMON_DBS = ['dogs', 'postgres', 'dogs_nofunc', 'dogs_noschema', DB_NAME]
 
-CHECK_PERFORMANCE_METRICS = [
-    'archiver_metrics',
-    'bgw_metrics',
-    'connections_metrics',
-    'count_metrics',
-    'instance_metrics',
-    'replication_metrics',
-    'replication_stats_metrics',
-    'slru_metrics',
-]
-
 requires_static_version = pytest.mark.skipif(USING_LATEST, reason='Version `latest` is ever-changing, skipping')
 
 
@@ -324,17 +313,3 @@ def check_stat_wal_metrics(aggregator, expected_tags, count=1):
 
     for metric_name in _iterate_metric_name(STAT_WAL_METRICS):
         aggregator.assert_metric(metric_name, count=count, tags=expected_tags)
-
-
-def check_performance_metrics(aggregator, expected_tags, count=1, is_aurora=False):
-    expected_metrics = set(CHECK_PERFORMANCE_METRICS)
-    if is_aurora:
-        expected_metrics = expected_metrics - {'replication_metrics'}
-    if float(POSTGRES_VERSION) < 13.0:
-        expected_metrics = expected_metrics - {'slru_metrics'}
-    if float(POSTGRES_VERSION) < 10.0:
-        expected_metrics = expected_metrics - {'replication_stats_metrics'}
-    for name in expected_metrics:
-        aggregator.assert_metric(
-            'dd.postgres.operation.time', count=count, tags=expected_tags + ['operation:{}'.format(name)]
-        )

--- a/postgres/tests/conftest.py
+++ b/postgres/tests/conftest.py
@@ -119,7 +119,7 @@ def mock_cursor_for_replica_stats():
                 data.appendleft(['app1', 'streaming', 'async', '1.1.1.1', 12, 12, 12, 12])
                 data.appendleft(['app2', 'backup', 'sync', '1.1.1.1', 13, 13, 13, 13])
             elif query == 'SHOW SERVER_VERSION;':
-                data.appendleft([POSTGRES_VERSION])
+                data.appendleft(['10.15'])
 
         def cursor_fetchall():
             while data:

--- a/postgres/tests/test_discovery.py
+++ b/postgres/tests/test_discovery.py
@@ -42,17 +42,6 @@ RELATION_METRICS = {
     'postgresql.autoanalyzed',
 }
 
-DYNAMIC_RELATION_METRICS = {
-    'postgresql.relation.pages',
-    'postgresql.relation.tuples',
-    'postgresql.relation.all_visible',
-    'postgresql.table_size',
-    'postgresql.relation_size',
-    'postgresql.index_size',
-    'postgresql.toast_size',
-    'postgresql.total_size',
-}
-
 
 @pytest.mark.integration
 @pytest.mark.usefixtures('dd_environment')
@@ -182,8 +171,6 @@ def test_autodiscovery_collect_all_relations(aggregator, integration_check, pg_i
     for db in databases:
         expected_tags = _get_expected_tags(check, pg_instance, db=db, table='breed', schema='public')
         for metric in RELATION_METRICS:
-            aggregator.assert_metric(metric, tags=expected_tags)
-        for metric in DYNAMIC_RELATION_METRICS:
             aggregator.assert_metric(metric, tags=expected_tags)
 
     aggregator.assert_metric(

--- a/postgres/tests/test_pg_integration.py
+++ b/postgres/tests/test_pg_integration.py
@@ -29,7 +29,6 @@ from .common import (
     check_db_count,
     check_file_wal_metrics,
     check_logical_replication_slots,
-    check_performance_metrics,
     check_physical_replication_slots,
     check_slru_metrics,
     check_snapshot_txid_metrics,
@@ -73,9 +72,6 @@ def test_common_metrics(aggregator, integration_check, pg_instance, is_aurora):
     check_logical_replication_slots(aggregator, expected_tags)
     check_physical_replication_slots(aggregator, expected_tags)
     check_snapshot_txid_metrics(aggregator, expected_tags=expected_tags)
-
-    check_performance_metrics(aggregator, expected_tags=check.debug_stats_kwargs()['tags'], is_aurora=is_aurora)
-
     aggregator.assert_all_metrics_covered()
 
 

--- a/postgres/tests/test_pg_replication.py
+++ b/postgres/tests/test_pg_replication.py
@@ -16,7 +16,6 @@ from .common import (
     check_control_metrics,
     check_db_count,
     check_file_wal_metrics,
-    check_performance_metrics,
     check_replication_delay,
     check_slru_metrics,
     check_snapshot_txid_metrics,
@@ -50,8 +49,6 @@ def test_common_replica_metrics(aggregator, integration_check, metrics_cache_rep
     check_snapshot_txid_metrics(aggregator, expected_tags=expected_tags)
     check_stat_wal_metrics(aggregator, expected_tags=expected_tags)
     check_file_wal_metrics(aggregator, expected_tags=expected_tags)
-
-    check_performance_metrics(aggregator, expected_tags=check.debug_stats_kwargs()['tags'])
 
     aggregator.assert_all_metrics_covered()
 

--- a/postgres/tests/test_statements.py
+++ b/postgres/tests/test_statements.py
@@ -798,7 +798,7 @@ def test_statement_metadata(
     if POSTGRES_VERSION.split('.')[0] == "9" and pg_stat_statements_view == "pg_stat_statements":
         # cannot catch any queries from other users
         # only can see own queries
-        return
+        return False
 
     fqt_samples = [
         s for s in samples if s.get('dbm_type') == 'fqt' and s['db']['query_signature'] == normalized_query_signature

--- a/postgres/tests/test_unit.py
+++ b/postgres/tests/test_unit.py
@@ -14,8 +14,7 @@ from six import iteritems
 
 from datadog_checks.postgres import PostgreSql, util
 
-from .common import PORT, check_performance_metrics
-from .utils import requires_over_10
+from .common import PORT
 
 pytestmark = pytest.mark.unit
 
@@ -241,36 +240,24 @@ def test_resolved_hostname_metadata(check, test_case):
         m.assert_any_call('test:123', 'resolved_hostname', test_case)
 
 
-@requires_over_10
 @pytest.mark.usefixtures('mock_cursor_for_replica_stats')
 def test_replication_stats(aggregator, integration_check, pg_instance):
     check = integration_check(pg_instance)
     check.check(pg_instance)
-    base_tags = [
-        'foo:bar',
-        'port:5432',
-        'dd.internal.resource:database_instance:{}'.format(check.resolved_hostname),
-    ]
+    base_tags = ['foo:bar', 'port:5432', 'dd.internal.resource:database_instance:{}'.format(check.resolved_hostname)]
     app1_tags = base_tags + [
         'wal_sync_state:async',
         'wal_state:streaming',
         'wal_app_name:app1',
         'wal_client_addr:1.1.1.1',
     ]
-    app2_tags = base_tags + [
-        'wal_sync_state:sync',
-        'wal_state:backup',
-        'wal_app_name:app2',
-        'wal_client_addr:1.1.1.1',
-    ]
+    app2_tags = base_tags + ['wal_sync_state:sync', 'wal_state:backup', 'wal_app_name:app2', 'wal_client_addr:1.1.1.1']
 
     aggregator.assert_metric('postgresql.db.count', 0, base_tags)
     for suffix in ('wal_write_lag', 'wal_flush_lag', 'wal_replay_lag', 'backend_xmin_age'):
         metric_name = 'postgresql.replication.{}'.format(suffix)
         aggregator.assert_metric(metric_name, 12, app1_tags)
         aggregator.assert_metric(metric_name, 13, app2_tags)
-
-    check_performance_metrics(aggregator, check.debug_stats_kwargs()['tags'])
 
     aggregator.assert_all_metrics_covered()
 


### PR DESCRIPTION
### What does this PR do?
This reverts the following PRs:
* https://github.com/DataDog/integrations-core/pull/16040
* https://github.com/DataDog/integrations-core/pull/16062
* https://github.com/DataDog/integrations-core/pull/16076

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
