### PR TITLE
Revert "Pin the hatch version to 1.7.0 (#16405)"

### DIFF
--- a/ddev/changelog.d/16427.fixed
+++ b/ddev/changelog.d/16427.fixed
@@ -1,0 +1,1 @@
+Unpin the `hatch` version

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "click~=8.1.6",
     "coverage",
     "datadog-checks-dev[cli]~=29.0",
-    "hatch==1.7.0",
+    "hatch>=1.8.1",
     "httpx",
     "jsonpointer",
     "pluggy",


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Revert "Pin the hatch version to 1.7.0 (#16405)"

### Motivation
<!-- What inspired you to submit this pull request? -->

Will fix the docs job

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
