### PR TITLE
[DBMON-3271] add new obfuscator options to customize SQL obfuscation and normalization

### DIFF
--- a/mysql/assets/configuration/spec.yaml
+++ b/mysql/assets/configuration/spec.yaml
@@ -566,6 +566,16 @@ files:
               Configure how the SQL obfuscator behaves.
               Note: This option only applies when `dbm` is enabled.
             options:
+              - name: obfuscation_mode
+                description: |
+                  Set the obfuscation mode. The obfuscation mode determines how the SQL obfuscator will obfuscate your SQL
+                  statements. The following modes are supported:
+                  - `obfuscate_only`: Obfuscate the SQL statement without normalizing the statement.
+                  - `obfuscate_and_normalize`: Obfuscate the SQL statement and normalize the statement.
+                value:
+                  type: string
+                  example: obfuscate_and_normalize
+                  display_default: obfuscate_and_normalize
               - name: replace_digits
                 description: |
                   Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
@@ -612,6 +622,48 @@ files:
                   type: boolean
                   example: true
                   display_default: true
+              - name: remove_space_between_parentheses
+                description: |
+                  Set to `true` to remove spaces between parentheses in your normalized SQL statements.
+                value:
+                  type: boolean
+                  example: false
+                  display_default: false
+              - name: keep_null
+                description: |
+                  Set to `true` to keep the keyword `NULL` in your obfuscated SQL statements.
+                value:
+                  type: boolean
+                  example: false
+                  display_default: false
+              - name: keep_boolean
+                description: |
+                  Set to `true` to keep the keywords `TRUE` and `FALSE` in your obfuscated SQL statements.
+                value:
+                  type: boolean
+                  example: false
+                  display_default: false
+              - name: keep_positional_parameter
+                description: |
+                  Set to `true` to keep positional parameters (e.g. `$1`) in your obfuscated SQL statements.
+                value:
+                  type: boolean
+                  example: false
+                  display_default: false
+              - name: keep_trailing_semicolon
+                description: |
+                  Set to `true` to keep trailing semicolons in your normalized SQL statements.
+                value:
+                  type: boolean
+                  example: false
+                  display_default: false
+              - name: keep_identifier_quotation
+                description: |
+                  Set to `true` to keep identifier quotations (e.g. `"my_table"`) in your normalized SQL statements.
+                value:
+                  type: boolean
+                  example: false
+                  display_default: false
           - name: log_unobfuscated_queries
             hidden: true
             description: |

--- a/mysql/changelog.d/16429.added
+++ b/mysql/changelog.d/16429.added
@@ -1,0 +1,1 @@
+add new obfuscator options to customize SQL obfuscation and normaliza…

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -73,6 +73,12 @@ class MySQLConfig(object):
             # Config to enable/disable obfuscation of sql statements with go-sqllexer pkg
             # Valid values for this can be found at https://github.com/DataDog/datadog-agent/blob/main/pkg/obfuscate/obfuscate.go#L108
             'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', ''),
+            'remove_space_between_parentheses': is_affirmative(obfuscator_options_config.get('remove_space_between_parentheses', False)),
+            'keep_null': is_affirmative(obfuscator_options_config.get('keep_null', False)),
+            'keep_boolean': is_affirmative(obfuscator_options_config.get('keep_boolean', False)),
+            'keep_positional_parameter': is_affirmative(obfuscator_options_config.get('keep_positional_parameter', False)),
+            'keep_trailing_semicolon': is_affirmative(obfuscator_options_config.get('keep_trailing_semicolon', False)),
+            'keep_identifier_quotation': is_affirmative(obfuscator_options_config.get('keep_identifier_quotation', False)),
         }
         self.log_unobfuscated_queries = is_affirmative(instance.get('log_unobfuscated_queries', False))
         self.log_unobfuscated_plans = is_affirmative(instance.get('log_unobfuscated_plans', False))

--- a/mysql/datadog_checks/mysql/config.py
+++ b/mysql/datadog_checks/mysql/config.py
@@ -73,12 +73,18 @@ class MySQLConfig(object):
             # Config to enable/disable obfuscation of sql statements with go-sqllexer pkg
             # Valid values for this can be found at https://github.com/DataDog/datadog-agent/blob/main/pkg/obfuscate/obfuscate.go#L108
             'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', ''),
-            'remove_space_between_parentheses': is_affirmative(obfuscator_options_config.get('remove_space_between_parentheses', False)),
+            'remove_space_between_parentheses': is_affirmative(
+                obfuscator_options_config.get('remove_space_between_parentheses', False)
+            ),
             'keep_null': is_affirmative(obfuscator_options_config.get('keep_null', False)),
             'keep_boolean': is_affirmative(obfuscator_options_config.get('keep_boolean', False)),
-            'keep_positional_parameter': is_affirmative(obfuscator_options_config.get('keep_positional_parameter', False)),
+            'keep_positional_parameter': is_affirmative(
+                obfuscator_options_config.get('keep_positional_parameter', False)
+            ),
             'keep_trailing_semicolon': is_affirmative(obfuscator_options_config.get('keep_trailing_semicolon', False)),
-            'keep_identifier_quotation': is_affirmative(obfuscator_options_config.get('keep_identifier_quotation', False)),
+            'keep_identifier_quotation': is_affirmative(
+                obfuscator_options_config.get('keep_identifier_quotation', False)
+            ),
         }
         self.log_unobfuscated_queries = is_affirmative(instance.get('log_unobfuscated_queries', False))
         self.log_unobfuscated_plans = is_affirmative(instance.get('log_unobfuscated_plans', False))

--- a/mysql/datadog_checks/mysql/config_models/instance.py
+++ b/mysql/datadog_checks/mysql/config_models/instance.py
@@ -83,7 +83,14 @@ class ObfuscatorOptions(BaseModel):
     collect_comments: Optional[bool] = None
     collect_metadata: Optional[bool] = None
     collect_tables: Optional[bool] = None
+    keep_boolean: Optional[bool] = None
+    keep_identifier_quotation: Optional[bool] = None
+    keep_null: Optional[bool] = None
+    keep_positional_parameter: Optional[bool] = None
     keep_sql_alias: Optional[bool] = None
+    keep_trailing_semicolon: Optional[bool] = None
+    obfuscation_mode: Optional[str] = None
+    remove_space_between_parentheses: Optional[bool] = None
     replace_digits: Optional[bool] = None
 
 

--- a/mysql/datadog_checks/mysql/data/conf.yaml.example
+++ b/mysql/datadog_checks/mysql/data/conf.yaml.example
@@ -542,6 +542,14 @@ instances:
     #
     # obfuscator_options:
 
+        ## @param obfuscation_mode - string - optional - default: obfuscate_and_normalize
+        ## Set the obfuscation mode. The obfuscation mode determines how the SQL obfuscator will obfuscate your SQL
+        ## statements. The following modes are supported:
+        ## - `obfuscate_only`: Obfuscate the SQL statement without normalizing the statement.
+        ## - `obfuscate_and_normalize`: Obfuscate the SQL statement and normalize the statement.
+        #
+        # obfuscation_mode: obfuscate_and_normalize
+
         ## @param replace_digits - boolean - optional - default: false
         ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
         ## Note: This option also applies to extracted tables using `collect_tables`.
@@ -580,6 +588,36 @@ instances:
         ## When `true` these aliases will not be removed.
         #
         # keep_sql_alias: true
+
+        ## @param remove_space_between_parentheses - boolean - optional - default: false
+        ## Set to `true` to remove spaces between parentheses in your normalized SQL statements.
+        #
+        # remove_space_between_parentheses: false
+
+        ## @param keep_null - boolean - optional - default: false
+        ## Set to `true` to keep the keyword `NULL` in your obfuscated SQL statements.
+        #
+        # keep_null: false
+
+        ## @param keep_boolean - boolean - optional - default: false
+        ## Set to `true` to keep the keywords `TRUE` and `FALSE` in your obfuscated SQL statements.
+        #
+        # keep_boolean: false
+
+        ## @param keep_positional_parameter - boolean - optional - default: false
+        ## Set to `true` to keep positional parameters (e.g. `$1`) in your obfuscated SQL statements.
+        #
+        # keep_positional_parameter: false
+
+        ## @param keep_trailing_semicolon - boolean - optional - default: false
+        ## Set to `true` to keep trailing semicolons in your normalized SQL statements.
+        #
+        # keep_trailing_semicolon: false
+
+        ## @param keep_identifier_quotation - boolean - optional - default: false
+        ## Set to `true` to keep identifier quotations (e.g. `"my_table"`) in your normalized SQL statements.
+        #
+        # keep_identifier_quotation: false
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/postgres/assets/configuration/spec.yaml
+++ b/postgres/assets/configuration/spec.yaml
@@ -715,6 +715,16 @@ files:
         Configure how the SQL obfuscator behaves.
         Note: This option only applies when `dbm` is enabled.
       options:
+        - name: obfuscation_mode
+          description: |
+            Set the obfuscation mode. The obfuscation mode determines how the SQL obfuscator will obfuscate your SQL
+            statements. The following modes are supported:
+            - `obfuscate_only`: Obfuscate the SQL statement without normalizing the statement.
+            - `obfuscate_and_normalize`: Obfuscate the SQL statement and normalize the statement.
+          value:
+            type: string
+            example: obfuscate_and_normalize
+            display_default: obfuscate_and_normalize
         - name: replace_digits
           description: |
             Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
@@ -770,6 +780,48 @@ files:
             type: boolean
             example: true
             display_default: true
+        - name: remove_space_between_parentheses
+          description: |
+            Set to `true` to remove spaces between parentheses in your normalized SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
+        - name: keep_null
+          description: |
+            Set to `true` to keep the keyword `NULL` in your obfuscated SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
+        - name: keep_boolean
+          description: |
+            Set to `true` to keep the keywords `TRUE` and `FALSE` in your obfuscated SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
+        - name: keep_positional_parameter
+          description: |
+            Set to `true` to keep positional parameters (e.g. `$1`) in your obfuscated SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
+        - name: keep_trailing_semicolon
+          description: |
+            Set to `true` to keep trailing semicolons in your normalized SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
+        - name: keep_identifier_quotation
+          description: |
+            Set to `true` to keep identifier quotations (e.g. `"my_table"`) in your normalized SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
     - name: log_unobfuscated_queries
       hidden: true
       description: |

--- a/postgres/changelog.d/16429.added
+++ b/postgres/changelog.d/16429.added
@@ -1,0 +1,1 @@
+add new obfuscator options to customize SQL obfuscation and normaliza…

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -142,12 +142,18 @@ class PostgresConfig:
             # Config to enable/disable obfuscation of sql statements with go-sqllexer pkg
             # Valid values for this can be found at https://github.com/DataDog/datadog-agent/blob/main/pkg/obfuscate/obfuscate.go#L108
             'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', ''),
-            'remove_space_between_parentheses': is_affirmative(obfuscator_options_config.get('remove_space_between_parentheses', False)),
+            'remove_space_between_parentheses': is_affirmative(
+                obfuscator_options_config.get('remove_space_between_parentheses', False)
+            ),
             'keep_null': is_affirmative(obfuscator_options_config.get('keep_null', False)),
             'keep_boolean': is_affirmative(obfuscator_options_config.get('keep_boolean', False)),
-            'keep_positional_parameter': is_affirmative(obfuscator_options_config.get('keep_positional_parameter', False)),
+            'keep_positional_parameter': is_affirmative(
+                obfuscator_options_config.get('keep_positional_parameter', False)
+            ),
             'keep_trailing_semicolon': is_affirmative(obfuscator_options_config.get('keep_trailing_semicolon', False)),
-            'keep_identifier_quotation': is_affirmative(obfuscator_options_config.get('keep_identifier_quotation', False)),
+            'keep_identifier_quotation': is_affirmative(
+                obfuscator_options_config.get('keep_identifier_quotation', False)
+            ),
         }
         self.log_unobfuscated_queries = is_affirmative(instance.get('log_unobfuscated_queries', False))
         self.log_unobfuscated_plans = is_affirmative(instance.get('log_unobfuscated_plans', False))

--- a/postgres/datadog_checks/postgres/config.py
+++ b/postgres/datadog_checks/postgres/config.py
@@ -142,6 +142,12 @@ class PostgresConfig:
             # Config to enable/disable obfuscation of sql statements with go-sqllexer pkg
             # Valid values for this can be found at https://github.com/DataDog/datadog-agent/blob/main/pkg/obfuscate/obfuscate.go#L108
             'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', ''),
+            'remove_space_between_parentheses': is_affirmative(obfuscator_options_config.get('remove_space_between_parentheses', False)),
+            'keep_null': is_affirmative(obfuscator_options_config.get('keep_null', False)),
+            'keep_boolean': is_affirmative(obfuscator_options_config.get('keep_boolean', False)),
+            'keep_positional_parameter': is_affirmative(obfuscator_options_config.get('keep_positional_parameter', False)),
+            'keep_trailing_semicolon': is_affirmative(obfuscator_options_config.get('keep_trailing_semicolon', False)),
+            'keep_identifier_quotation': is_affirmative(obfuscator_options_config.get('keep_identifier_quotation', False)),
         }
         self.log_unobfuscated_queries = is_affirmative(instance.get('log_unobfuscated_queries', False))
         self.log_unobfuscated_plans = is_affirmative(instance.get('log_unobfuscated_plans', False))

--- a/postgres/datadog_checks/postgres/config_models/instance.py
+++ b/postgres/datadog_checks/postgres/config_models/instance.py
@@ -126,8 +126,15 @@ class ObfuscatorOptions(BaseModel):
     collect_comments: Optional[bool] = None
     collect_metadata: Optional[bool] = None
     collect_tables: Optional[bool] = None
+    keep_boolean: Optional[bool] = None
     keep_dollar_quoted_func: Optional[bool] = None
+    keep_identifier_quotation: Optional[bool] = None
+    keep_null: Optional[bool] = None
+    keep_positional_parameter: Optional[bool] = None
     keep_sql_alias: Optional[bool] = None
+    keep_trailing_semicolon: Optional[bool] = None
+    obfuscation_mode: Optional[str] = None
+    remove_space_between_parentheses: Optional[bool] = None
     replace_digits: Optional[bool] = None
 
 

--- a/postgres/datadog_checks/postgres/data/conf.yaml.example
+++ b/postgres/datadog_checks/postgres/data/conf.yaml.example
@@ -582,6 +582,14 @@ instances:
     #
     # obfuscator_options:
 
+        ## @param obfuscation_mode - string - optional - default: obfuscate_and_normalize
+        ## Set the obfuscation mode. The obfuscation mode determines how the SQL obfuscator will obfuscate your SQL
+        ## statements. The following modes are supported:
+        ## - `obfuscate_only`: Obfuscate the SQL statement without normalizing the statement.
+        ## - `obfuscate_and_normalize`: Obfuscate the SQL statement and normalize the statement.
+        #
+        # obfuscation_mode: obfuscate_and_normalize
+
         ## @param replace_digits - boolean - optional - default: false
         ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
         ## Note: This option also applies to extracted tables using `collect_tables`.
@@ -627,6 +635,36 @@ instances:
         ## Only strings with the tag `$func$` are supported.
         #
         # keep_dollar_quoted_func: true
+
+        ## @param remove_space_between_parentheses - boolean - optional - default: false
+        ## Set to `true` to remove spaces between parentheses in your normalized SQL statements.
+        #
+        # remove_space_between_parentheses: false
+
+        ## @param keep_null - boolean - optional - default: false
+        ## Set to `true` to keep the keyword `NULL` in your obfuscated SQL statements.
+        #
+        # keep_null: false
+
+        ## @param keep_boolean - boolean - optional - default: false
+        ## Set to `true` to keep the keywords `TRUE` and `FALSE` in your obfuscated SQL statements.
+        #
+        # keep_boolean: false
+
+        ## @param keep_positional_parameter - boolean - optional - default: false
+        ## Set to `true` to keep positional parameters (e.g. `$1`) in your obfuscated SQL statements.
+        #
+        # keep_positional_parameter: false
+
+        ## @param keep_trailing_semicolon - boolean - optional - default: false
+        ## Set to `true` to keep trailing semicolons in your normalized SQL statements.
+        #
+        # keep_trailing_semicolon: false
+
+        ## @param keep_identifier_quotation - boolean - optional - default: false
+        ## Set to `true` to keep identifier quotations (e.g. `"my_table"`) in your normalized SQL statements.
+        #
+        # keep_identifier_quotation: false
 
     ## @param tags - list of strings - optional
     ## A list of tags to attach to every metric and service check emitted by this instance.

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -511,6 +511,16 @@ files:
         Configure how the SQL obfuscator behaves.
         Note: This option only applies when `dbm` is enabled.
       options:
+        - name: obfuscation_mode
+          description: |
+            Set the obfuscation mode. The obfuscation mode determines how the SQL obfuscator will obfuscate your SQL
+            statements. The following modes are supported:
+            - `obfuscate_only`: Obfuscate the SQL statement without normalizing the statement.
+            - `obfuscate_and_normalize`: Obfuscate the SQL statement and normalize the statement.
+          value:
+            type: string
+            example: obfuscate_and_normalize
+            display_default: obfuscate_and_normalize
         - name: replace_digits
           description: |
             Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
@@ -557,6 +567,48 @@ files:
             type: boolean
             example: true
             display_default: true
+        - name: remove_space_between_parentheses
+          description: |
+            Set to `true` to remove spaces between parentheses in your normalized SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
+        - name: keep_null
+          description: |
+            Set to `true` to keep the keyword `NULL` in your obfuscated SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
+        - name: keep_boolean
+          description: |
+            Set to `true` to keep the keywords `TRUE` and `FALSE` in your obfuscated SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
+        - name: keep_positional_parameter
+          description: |
+            Set to `true` to keep positional parameters (e.g. `$1`) in your obfuscated SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
+        - name: keep_trailing_semicolon
+          description: |
+            Set to `true` to keep trailing semicolons in your normalized SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
+        - name: keep_identifier_quotation
+          description: |
+            Set to `true` to keep identifier quotations (e.g. `"my_table"`) in your normalized SQL statements.
+          value:
+            type: boolean
+            example: false
+            display_default: false
     - name: log_unobfuscated_queries
       hidden: true
       description: |

--- a/sqlserver/changelog.d/16429.added
+++ b/sqlserver/changelog.d/16429.added
@@ -1,0 +1,1 @@
+add new obfuscator options to customize SQL obfuscation and normaliza…

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -67,12 +67,20 @@ class SQLServerConfig:
                     # Config to enable/disable obfuscation of sql statements with go-sqllexer pkg
                     # Valid values for this can be found at https://github.com/DataDog/datadog-agent/blob/main/pkg/obfuscate/obfuscate.go#L108
                     'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', ''),
-                    'remove_space_between_parentheses': is_affirmative(obfuscator_options_config.get('remove_space_between_parentheses', False)),
+                    'remove_space_between_parentheses': is_affirmative(
+                        obfuscator_options_config.get('remove_space_between_parentheses', False)
+                    ),
                     'keep_null': is_affirmative(obfuscator_options_config.get('keep_null', False)),
                     'keep_boolean': is_affirmative(obfuscator_options_config.get('keep_boolean', False)),
-                    'keep_positional_parameter': is_affirmative(obfuscator_options_config.get('keep_positional_parameter', False)),
-                    'keep_trailing_semicolon': is_affirmative(obfuscator_options_config.get('keep_trailing_semicolon', False)),
-                    'keep_identifier_quotation': is_affirmative(obfuscator_options_config.get('keep_identifier_quotation', False)),
+                    'keep_positional_parameter': is_affirmative(
+                        obfuscator_options_config.get('keep_positional_parameter', False)
+                    ),
+                    'keep_trailing_semicolon': is_affirmative(
+                        obfuscator_options_config.get('keep_trailing_semicolon', False)
+                    ),
+                    'keep_identifier_quotation': is_affirmative(
+                        obfuscator_options_config.get('keep_identifier_quotation', False)
+                    ),
                 }
             )
         )

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -67,6 +67,12 @@ class SQLServerConfig:
                     # Config to enable/disable obfuscation of sql statements with go-sqllexer pkg
                     # Valid values for this can be found at https://github.com/DataDog/datadog-agent/blob/main/pkg/obfuscate/obfuscate.go#L108
                     'obfuscation_mode': obfuscator_options_config.get('obfuscation_mode', ''),
+                    'remove_space_between_parentheses': is_affirmative(obfuscator_options_config.get('remove_space_between_parentheses', False)),
+                    'keep_null': is_affirmative(obfuscator_options_config.get('keep_null', False)),
+                    'keep_boolean': is_affirmative(obfuscator_options_config.get('keep_boolean', False)),
+                    'keep_positional_parameter': is_affirmative(obfuscator_options_config.get('keep_positional_parameter', False)),
+                    'keep_trailing_semicolon': is_affirmative(obfuscator_options_config.get('keep_trailing_semicolon', False)),
+                    'keep_identifier_quotation': is_affirmative(obfuscator_options_config.get('keep_identifier_quotation', False)),
                 }
             )
         )

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -92,7 +92,14 @@ class ObfuscatorOptions(BaseModel):
     collect_comments: Optional[bool] = None
     collect_metadata: Optional[bool] = None
     collect_tables: Optional[bool] = None
+    keep_boolean: Optional[bool] = None
+    keep_identifier_quotation: Optional[bool] = None
+    keep_null: Optional[bool] = None
+    keep_positional_parameter: Optional[bool] = None
     keep_sql_alias: Optional[bool] = None
+    keep_trailing_semicolon: Optional[bool] = None
+    obfuscation_mode: Optional[str] = None
+    remove_space_between_parentheses: Optional[bool] = None
     replace_digits: Optional[bool] = None
 
 

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -437,6 +437,14 @@ instances:
     #
     # obfuscator_options:
 
+        ## @param obfuscation_mode - string - optional - default: obfuscate_and_normalize
+        ## Set the obfuscation mode. The obfuscation mode determines how the SQL obfuscator will obfuscate your SQL
+        ## statements. The following modes are supported:
+        ## - `obfuscate_only`: Obfuscate the SQL statement without normalizing the statement.
+        ## - `obfuscate_and_normalize`: Obfuscate the SQL statement and normalize the statement.
+        #
+        # obfuscation_mode: obfuscate_and_normalize
+
         ## @param replace_digits - boolean - optional - default: false
         ## Set to `true` to replace digits in identifiers and table names with question marks in your SQL statements.
         ## Note: This option also applies to extracted tables using `collect_tables`.
@@ -475,6 +483,36 @@ instances:
         ## When `true` these aliases will not be removed.
         #
         # keep_sql_alias: true
+
+        ## @param remove_space_between_parentheses - boolean - optional - default: false
+        ## Set to `true` to remove spaces between parentheses in your normalized SQL statements.
+        #
+        # remove_space_between_parentheses: false
+
+        ## @param keep_null - boolean - optional - default: false
+        ## Set to `true` to keep the keyword `NULL` in your obfuscated SQL statements.
+        #
+        # keep_null: false
+
+        ## @param keep_boolean - boolean - optional - default: false
+        ## Set to `true` to keep the keywords `TRUE` and `FALSE` in your obfuscated SQL statements.
+        #
+        # keep_boolean: false
+
+        ## @param keep_positional_parameter - boolean - optional - default: false
+        ## Set to `true` to keep positional parameters (e.g. `$1`) in your obfuscated SQL statements.
+        #
+        # keep_positional_parameter: false
+
+        ## @param keep_trailing_semicolon - boolean - optional - default: false
+        ## Set to `true` to keep trailing semicolons in your normalized SQL statements.
+        #
+        # keep_trailing_semicolon: false
+
+        ## @param keep_identifier_quotation - boolean - optional - default: false
+        ## Set to `true` to keep identifier quotations (e.g. `"my_table"`) in your normalized SQL statements.
+        #
+        # keep_identifier_quotation: false
 
     ## @param command_timeout - integer - optional - default: 10
     ## Timeout in seconds for the connection and each command run


### PR DESCRIPTION
### What does this PR do?
This PR adds new SQL obfuscation options to `postgres`, `mysql` and `sqlserver` integration. The new options includes
- `obfuscation_mode`: enables/disables SQL obfuscation with new obfuscator from `go-sqllexer`
- `remove_space_between_parentheses`: remove spaces between parentheses in your normalized SQL statements.
- `keep_null`: keep the keyword `NULL` in your obfuscated SQL statements.
- `keep_boolean`: keep the keywords `TRUE` and `FALSE` in your obfuscated SQL statements.
- `keep_positional_parameter`: keep positional parameters (e.g. `$1`) in your obfuscated SQL statements.
- `keep_trailing_semicolon`: keep trailing semicolons in your normalized SQL statements.
- `keep_identifier_quotation`: keep identifier quotations (e.g. `"my_table"`) in your normalized SQL statements.

The new options are depend on https://github.com/DataDog/datadog-agent/pull/21568 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
