### PR TITLE
Add ODBC driver support for the SQL Server agent

### DIFF
--- a/sqlserver/changelog.d/16431.added
+++ b/sqlserver/changelog.d/16431.added
@@ -1,0 +1,1 @@
+Add ODBC driver support for the SQL Server agent

--- a/sqlserver/datadog_checks/sqlserver/data/driver_config/odbcinst.ini
+++ b/sqlserver/datadog_checks/sqlserver/data/driver_config/odbcinst.ini
@@ -6,5 +6,5 @@ Driver=/opt/datadog-agent/embedded/lib/libtdsodbc.so
 
 [ODBC Driver 18 for SQL Server]
 Description=Microsoft ODBC Driver 18 for SQL Server
-Driver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.3.so.2.1
+Driver=/opt/datadog-agent/embedded/msodbcsql/lib64/libmsodbcsql-18.3.so.2.1
 UsageCount=1

--- a/sqlserver/datadog_checks/sqlserver/data/driver_config/odbcinst.ini
+++ b/sqlserver/datadog_checks/sqlserver/data/driver_config/odbcinst.ini
@@ -3,3 +3,8 @@ FreeTDS=Installed
 
 [FreeTDS]
 Driver=/opt/datadog-agent/embedded/lib/libtdsodbc.so
+
+[ODBC Driver 18 for SQL Server]
+Description=Microsoft ODBC Driver 18 for SQL Server
+Driver=/opt/microsoft/msodbcsql18/lib64/libmsodbcsql-18.3.so.2.1
+UsageCount=1


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Adds support for using the Microsoft ODBC driver in the SQL Server agent for dockerized builds. This relies on this [change in the datadog-agent](https://github.com/DataDog/datadog-agent/pull/20825). I tested this on a sandbox instance using the following docker command (with a test internal docker image)
```
docker run -d \
  -e "DD_API_KEY=${DD_API_KEY}" \
  -v /var/run/docker.sock:/var/run/docker.sock:ro \
  -l com.datadoghq.ad.check_names='["sqlserver"]' \
  -l com.datadoghq.ad.init_configs='[{}]' \
  -l com.datadoghq.ad.instances='[{
    "dbm": true,
    "host": "dbm-agent-integration-managed-instance-ao.cfcc2366ab90.database.windows.net,1433",
    "connector": "odbc",
    "ssl": "require",
    "driver": "{ODBC Driver 18 for SQL Server}",
    "tags": [
      "service:jm-test-odbc-mi",
      "env:dev"
    ],
    "managed_identity": {
      "client_id": "c8d2cd7d-3e43-46cb-9bd9-050706399f52"
    },
    "azure": {
      "deployment_type": "managed_instance",
      "fully_qualified_domain_name": "dbm-agent-integration-managed-instance-ao.cfcc2366ab90.database.windows.net"
    }
  }]' \
  registry.ddbuild.io/datadog-agent:dbm-e42db67-73ab9acfdc

```

... inspecting the logs / looking in the UI it looks like we are collecting information correctly (note I am generating no load, so its just agent queries)

<img width="1210" alt="Screenshot 2023-12-14 at 10 35 00 AM" src="https://github.com/DataDog/integrations-core/assets/14317240/e3f9796b-4b74-4a69-982d-38812c8fcf3b">

The `agent status` output looks like this, which shows we are collecting DBM data properly:


```
    sqlserver (15.0.1)
    ------------------
      Instance ID: sqlserver:a591d2bd90702c92 [OK]
      Configuration Source: container:docker://34cef60ae06f79a9cf0825f9813ca55079b26eff2b8d0fdd94e53f28b88224b8
      Total Runs: 2
      Metric Samples: Last Run: 316, Total: 603
      Events: Last Run: 0, Total: 0
      Database Monitoring Activity Samples: Last Run: 2, Total: 2
      Database Monitoring Metadata Samples: Last Run: 1, Total: 1
      Database Monitoring Query Metrics: Last Run: 1, Total: 1
      Database Monitoring Query Samples: Last Run: 6, Total: 6
      Service Checks: Last Run: 7, Total: 11
      Average Execution Time : 6.207s
      Last Execution Date : 2023-12-14 18:38:12 UTC (1702579092000)
      Last Successful Execution Date : 2023-12-14 18:38:12 UTC (1702579092000)
      metadata:
        resolved_hostname: dbm-agent-integration-managed-instance-ao.cfcc2366ab90.database.windows.net
```

### Motivation
<!-- What inspired you to submit this pull request? -->

We added support to connect to SQL Server using Azure managed authentication a few agent versions ago https://github.com/DataDog/integrations-core/pull/15591. However, the ODBC driver 17+ is required to use [Managed Auth](https://docs.datadoghq.com/database_monitoring/guide/managed_authentication/#connect-to-sql-server). Prior to this commit, the agent could not use the ODBC driver in docker. This limited customers ability to use this type of authentication to only self-install agents. This limits peoples ability to automate deployments / automation of the agent. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

During testing I noticed this being logged frequently 

```
2023-12-14 18:33:44 UTC | CORE | INFO | (pkg/collector/python/datadog_agent.go:133 in LogMessage) | - | (_universal.py:514) | Request URL: 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=REDACTED&resource=REDACTED&client_id=REDACTED'
Request method: 'GET'
Request headers:
    'Metadata': 'REDACTED'
    'User-Agent': 'azsdk-python-identity/1.14.0 Python/3.9.18 (Linux-5.15.0-1042-azure-x86_64-with-glibc2.38)'
No body was attached to the request
2023-12-14 18:33:44 UTC | CORE | INFO | (pkg/collector/python/datadog_agent.go:133 in LogMessage) | - | (_universal.py:550) | Response status: 200
Response headers:
    'Content-Type': 'application/json; charset=utf-8'
    'Server': 'IMDS/150.870.65.1125'
    'Date': 'Thu, 14 Dec 2023 18:33:44 GMT'
    'Content-Length': '2056'
```

Since we frequently open/connections in the agent we re-request the token every time. AFAIK these tokens have TTLs associated with them, so a nice improvement might be to cache the token locally & only re-request the token after it expires. That would prevent frequent Azure API requests while using this feature.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
