### PR TITLE
Remove the mysql certificates

### DIFF
--- a/airflow/tests/compose/Dockerfile
+++ b/airflow/tests/compose/Dockerfile
@@ -3,8 +3,9 @@ ARG AIRFLOW_VERSION
 FROM apache/airflow:$AIRFLOW_VERSION
 USER root
 # INSTALL TOOLS
-RUN apt-get update \
-&& apt-get -y install libaio-dev postgresql-client
+RUN rm -f /etc/apt/sources.list.d/mysql.list  # Their certificates expired and we don't really need them
+RUN apt-get update
+RUN apt-get -y install libaio-dev postgresql-client
 RUN mkdir extra
 USER airflow
 # ENTRYPOINT SCRIPT


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Remove the mysql certificates

### Motivation
<!-- What inspired you to submit this pull request? -->

- Their certificates expired yesterday night and we don't really need them in our test suite. 
- https://github.com/apache/airflow/issues/36231

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
