### PR TITLE
Revert "[DBMON-2989] report sql obfuscation error count (#15990)"

### DIFF
--- a/mysql/changelog.d/16439.fixed
+++ b/mysql/changelog.d/16439.fixed
@@ -1,0 +1,1 @@
+Revert "[DBMON-2989] report sql obfuscation error count (#15990)"

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -96,6 +96,7 @@ def agent_check_getter(self):
 
 
 class MySQLActivity(DBMAsyncJob):
+
     DEFAULT_COLLECTION_INTERVAL = 10
     MAX_PAYLOAD_BYTES = 19e6
 
@@ -212,12 +213,6 @@ class MySQLActivity(DBMAsyncJob):
             else:
                 self._log.debug("Failed to obfuscate query | err=[%s]", e)
             row["sql_text"] = "ERROR: failed to obfuscate"
-            self._check.count(
-                "dd.mysql.obfuscation.error",
-                1,
-                tags=self.tags + ["error:{}".format(type(e)), "error_msg:{}".format(e)] + self._check._get_debug_tags(),
-                hostname=self._check.resolved_hostname,
-            )
         return row
 
     @staticmethod

--- a/mysql/datadog_checks/mysql/statements.py
+++ b/mysql/datadog_checks/mysql/statements.py
@@ -210,14 +210,6 @@ class MySQLStatementMetrics(DBMAsyncJob):
                 obfuscated_statement = statement['query'] if row['digest_text'] is not None else None
             except Exception as e:
                 self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['digest_text'], e)
-                self._check.count(
-                    "dd.mysql.obfuscation.error",
-                    1,
-                    tags=self.tags
-                    + ["error:{}".format(type(e)), "error_msg:{}".format(e)]
-                    + self._check._get_debug_tags(),
-                    hostname=self._check.resolved_hostname,
-                )
                 continue
 
             normalized_row['digest_text'] = obfuscated_statement

--- a/postgres/changelog.d/16439.fixed
+++ b/postgres/changelog.d/16439.fixed
@@ -1,0 +1,1 @@
+Revert "[DBMON-2989] report sql obfuscation error count (#15990)"

--- a/postgres/datadog_checks/postgres/statement_samples.py
+++ b/postgres/datadog_checks/postgres/statement_samples.py
@@ -401,13 +401,6 @@ class PostgresStatementSamples(DBMAsyncJob):
                 tags=self._dbtags(row['datname'], "error:sql-obfuscate") + self._check._get_debug_tags(),
                 hostname=self._check.resolved_hostname,
             )
-            self._check.count(
-                "dd.postgres.obfuscation.error",
-                1,
-                tags=self._dbtags(row['datname'], "error:{}".format(type(e)), "error_msg:{}".format(e))
-                + self._check._get_debug_tags(),
-                hostname=self._check.resolved_hostname,
-            )
         normalized_row['statement'] = obfuscated_query
         return normalized_row
 

--- a/postgres/datadog_checks/postgres/statements.py
+++ b/postgres/datadog_checks/postgres/statements.py
@@ -429,14 +429,6 @@ class PostgresStatementMetrics(DBMAsyncJob):
                     self._log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['query'], e)
                 else:
                     self._log.debug("Failed to obfuscate query | err=[%s]", e)
-                self._check.count(
-                    "dd.postgres.obfuscation.error",
-                    1,
-                    tags=self.tags
-                    + ["error:{}".format(type(e)), "error_msg:{}".format(e)]
-                    + self._check._get_debug_tags(),
-                    hostname=self._check.resolved_hostname,
-                )
                 continue
 
             obfuscated_query = statement['query']

--- a/sqlserver/changelog.d/16439.fixed
+++ b/sqlserver/changelog.d/16439.fixed
@@ -1,0 +1,1 @@
+Revert "[DBMON-2989] report sql obfuscation error count (#15990)"

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -300,11 +300,6 @@ class SqlserverActivity(DBMAsyncJob):
             else:
                 self.log.debug("Failed to obfuscate query | err=[%s]", e)
             obfuscated_statement = "ERROR: failed to obfuscate"
-            self._check.count(
-                "dd.sqlserver.obfuscation.error",
-                1,
-                **self._check.debug_stats_kwargs(tags=["error:{}".format(type(e)), "error_msg:{}".format(e)])
-            )
         row = self._sanitize_row(row, obfuscated_statement)
         return row
 

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -328,11 +328,6 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     1,
                     **self._check.debug_stats_kwargs(tags=["error:obfuscate-query-{}".format(type(e))])
                 )
-                self._check.count(
-                    "dd.sqlserver.obfuscation.error",
-                    1,
-                    **self._check.debug_stats_kwargs(tags=["error:{}".format(type(e)), "error_msg:{}".format(e)])
-                )
                 continue
 
             # Extract obfuscated statement and update row fields


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
[INCIDENT-24014] This reverts commit 5ba30fc8c999591b53f924ac5a4832fb6ab2959d.

### Motivation
<!-- What inspired you to submit this pull request? -->
We've noticed increased memory usage with databases with high cardinality, for example, Postgres with exploded pg_stat_statements, due to this change. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
