### PR TITLE
adding execute to the needed permissions to tail the logs files

### DIFF
--- a/iis/README.md
+++ b/iis/README.md
@@ -46,7 +46,7 @@ To configure this check for an Agent running on a host:
 
 3. [Restart the Agent][6].
 
-**Note**: Ensure the `datadog-agent` user has read access to tail the log files you want to collect from. When IIS creates a new sub-folder (such as when a new site is created), the permissions of the parent folder are not automatically inherited. See [Permission issues tailing log files][12] for more information.
+**Note**: Ensure the `datadog-agent` user has read and execute access to tail the log files you want to collect from. When IIS creates a new sub-folder (such as when a new site is created), the permissions of the parent folder are not automatically inherited. See [Permission issues tailing log files][12] for more information.
 
 
 ### Validation


### PR DESCRIPTION
The Datadog agent user needs read and execute permissions to be able to tail logs files.

### What does this PR do?
Correct the needed permissions for the Datadog agent user to tail logs files

### Motivation
This was brought up in a slack conversation https://dd.slack.com/archives/C046YU1V0SK/p1702457801831989
Which lead to creating this Jira escalation: https://datadoghq.atlassian.net/browse/AGENT-10762


### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
