### PR TITLE
Ignore `rethinkdb` when bumping the deps

### DIFF
--- a/ddev/changelog.d/16449.fixed
+++ b/ddev/changelog.d/16449.fixed
@@ -1,0 +1,1 @@
+Ignore `rethinkdb` when bumping the deps

--- a/ddev/src/ddev/cli/dep.py
+++ b/ddev/src/ddev/cli/dep.py
@@ -49,6 +49,8 @@ IGNORED_DEPS = {
     # Here's orjson switching to rustc 1.65:
     # https://github.com/ijl/orjson/commit/ce9bae876657ed377d761bf1234b040e2cc13d3c
     'orjson',
+    # 2.4.10 is broken on py2 and they did not yank the version
+    'rethinkdb'
 }
 
 # Dependencies for the downloader that are security-related and should be updated separately from the others

--- a/ddev/src/ddev/cli/dep.py
+++ b/ddev/src/ddev/cli/dep.py
@@ -50,7 +50,7 @@ IGNORED_DEPS = {
     # https://github.com/ijl/orjson/commit/ce9bae876657ed377d761bf1234b040e2cc13d3c
     'orjson',
     # 2.4.10 is broken on py2 and they did not yank the version
-    'rethinkdb'
+    'rethinkdb',
 }
 
 # Dependencies for the downloader that are security-related and should be updated separately from the others


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Ignore rethinkdb when bumping the deps

### Motivation
<!-- What inspired you to submit this pull request? -->

They forgot to add some deps on version `2.4.10` and created a `2.4.10.post1` version which breaks the py2 env. Waiting for a proper `2.4.11`

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
