### PR TITLE
Fix the logs source name in the manifest

### DIFF
--- a/nginx_ingress_controller/manifest.json
+++ b/nginx_ingress_controller/manifest.json
@@ -57,7 +57,7 @@
       "bot_errors": "assets/saved_views/bot_errors.json"
     },
     "logs": {
-      "source": "nginx_ingress_controller"
+      "source": "nginx-ingress-controller"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Switch the logs source name to `nginx-ingress-controller`, the README already has it

### Motivation
<!-- What inspired you to submit this pull request? -->

https://github.com/DataDog/security-monitoring/pull/3874

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
