### PR TITLE
[DBMON-3207] use single quotes in activity query to fix char set issue

### DIFF
--- a/mysql/changelog.d/16454.fixed
+++ b/mysql/changelog.d/16454.fixed
@@ -1,0 +1,1 @@
+use single quotes in activity query to fix char set issue

--- a/mysql/datadog_checks/mysql/activity.py
+++ b/mysql/datadog_checks/mysql/activity.py
@@ -78,7 +78,7 @@ WHERE
     ) OR waits_a.event_id is NULL)
     -- We ignore rows without SQL text because there will be rows for background operations that do not have
     -- SQL text associated with it.
-    AND COALESCE(statement.sql_text, thread_a.PROCESSLIST_info) != "";
+    AND COALESCE(statement.sql_text, thread_a.PROCESSLIST_info) != '';
 """
 
 


### PR DESCRIPTION
### What does this PR do?
In Aurora MySQL with some character sets, these double quotes in our activity query cause an error which blocks activity collection. Swap to single quotes.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
