### PR TITLE
[DBMON-3197] ensure accurate collection of query activity with statement when stored procedure is failed to obfuscate

### DIFF
--- a/sqlserver/changelog.d/16455.fixed
+++ b/sqlserver/changelog.d/16455.fixed
@@ -1,0 +1,1 @@
+[DBMON-3197] ensure accurate collection of query activity with statement when stored procedure is failed to obfuscate

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -276,27 +276,32 @@ class SqlserverActivity(DBMAsyncJob):
             return self._sanitize_row(row)
         try:
             statement = obfuscate_sql_with_metadata(row['statement_text'], self._config.obfuscator_options)
-            procedure_statement = None
             # sqlserver doesn't have a boolean data type so convert integer to boolean
             comments, row['is_proc'], procedure_name = extract_sql_comments_and_procedure_name(row['text'])
             if row['is_proc'] and 'text' in row:
-                procedure_statement = obfuscate_sql_with_metadata(row['text'], self._config.obfuscator_options)
+                try:
+                    procedure_statement = obfuscate_sql_with_metadata(row['text'], self._config.obfuscator_options)
+                    # procedure_signature is used to link this activity event with
+                    # its related plan events
+                    row['procedure_signature'] = compute_sql_signature(procedure_statement['query'])
+                except Exception as e:
+                    # if we fail to obfuscate the procedure text,
+                    # we should not mark query statement as failed to obfuscate
+                    if self._config.log_unobfuscated_queries:
+                        self.log.warning("Failed to obfuscate stored procedure=[%s] | err=[%s]", row['text'], e)
+                    else:
+                        self.log.debug("Failed to obfuscate stored procedure | err=[%s]", e)
             obfuscated_statement = statement['query']
             metadata = statement['metadata']
             row['dd_commands'] = metadata.get('commands', None)
             row['dd_tables'] = metadata.get('tables', None)
             row['dd_comments'] = comments
             row['query_signature'] = compute_sql_signature(obfuscated_statement)
-            # procedure_signature is used to link this activity event with
-            # its related plan events
-            if procedure_statement:
-                row['procedure_signature'] = compute_sql_signature(procedure_statement['query'])
             if procedure_name:
                 row['procedure_name'] = procedure_name
         except Exception as e:
             if self._config.log_unobfuscated_queries:
-                raw_query_text = row['text'] if row.get('is_proc', False) else row['statement_text']
-                self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", raw_query_text, e)
+                self.log.warning("Failed to obfuscate query=[%s] | err=[%s]", row['statement_text'], e)
             else:
                 self.log.debug("Failed to obfuscate query | err=[%s]", e)
             obfuscated_statement = "ERROR: failed to obfuscate"

--- a/sqlserver/tests/compose-ha/sql/aoag_primary.sql
+++ b/sqlserver/tests/compose-ha/sql/aoag_primary.sql
@@ -69,6 +69,23 @@ GRANT EXECUTE on bobProc to bob;
 GRANT EXECUTE on bobProc to fred;
 GO
 
+CREATE PROCEDURE procedureWithLargeCommment AS
+/* 
+author: Datadog 
+usage: some random comments
+test: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+description: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+this comment has no actual meanings, just to test large sp with truncation
+the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog
+*/
+BEGIN
+    SELECT * FROM ϑings;
+END;
+GO
+GRANT EXECUTE on procedureWithLargeCommment to bob;
+GRANT EXECUTE on procedureWithLargeCommment to fred;
+GO
+
 -- create test procedure for metrics loading feature
 USE master;
 GO

--- a/sqlserver/tests/compose-high-cardinality-windows/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality-windows/setup.sql
@@ -72,6 +72,23 @@ GRANT EXECUTE on bobProc to bob;
 GRANT EXECUTE on bobProc to fred;
 GO
 
+CREATE PROCEDURE procedureWithLargeCommment AS
+/* 
+author: Datadog 
+usage: some random comments
+test: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+description: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+this comment has no actual meanings, just to test large sp with truncation
+the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog
+*/
+BEGIN
+    SELECT * FROM ϑings;
+END;
+GO
+GRANT EXECUTE on procedureWithLargeCommment to bob;
+GRANT EXECUTE on procedureWithLargeCommment to fred;
+GO
+
 -- create an offline database to have an unavailable database to test with
 CREATE DATABASE unavailable_db;
 GO

--- a/sqlserver/tests/compose-high-cardinality/setup.sql
+++ b/sqlserver/tests/compose-high-cardinality/setup.sql
@@ -95,6 +95,23 @@ GO
 GRANT EXECUTE on conditionalPlanTest to bob;
 GO
 
+CREATE PROCEDURE procedureWithLargeCommment AS
+/* 
+author: Datadog 
+usage: some random comments
+test: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+description: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+this comment has no actual meanings, just to test large sp with truncation
+the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog
+*/
+BEGIN
+    SELECT * FROM ϑings;
+END;
+GO
+GRANT EXECUTE on procedureWithLargeCommment to bob;
+GRANT EXECUTE on procedureWithLargeCommment to fred;
+GO
+
 -- Create test database for integration tests.
 -- Only bob and fred have read/write access to this database.
 CREATE DATABASE datadog_test;

--- a/sqlserver/tests/compose-windows/setup.sql
+++ b/sqlserver/tests/compose-windows/setup.sql
@@ -71,6 +71,24 @@ GRANT EXECUTE on bobProc to bob;
 GRANT EXECUTE on bobProc to fred;
 GO
 
+
+CREATE PROCEDURE procedureWithLargeCommment AS
+/* 
+author: Datadog 
+usage: some random comments
+test: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+description: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+this comment has no actual meanings, just to test large sp with truncation
+the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog
+*/
+BEGIN
+    SELECT * FROM ϑings;
+END;
+GO
+GRANT EXECUTE on procedureWithLargeCommment to bob;
+GRANT EXECUTE on procedureWithLargeCommment to fred;
+GO
+
 -- create an offline database to have an unavailable database to test with
 CREATE DATABASE unavailable_db;
 GO

--- a/sqlserver/tests/compose/setup.sql
+++ b/sqlserver/tests/compose/setup.sql
@@ -52,6 +52,23 @@ GRANT EXECUTE on bobProc to bob;
 GRANT EXECUTE on bobProc to fred;
 GO
 
+CREATE PROCEDURE procedureWithLargeCommment AS
+/* 
+author: Datadog 
+usage: some random comments
+test: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+description: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+this comment has no actual meanings, just to test large sp with truncation
+the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog
+*/
+BEGIN
+    SELECT * FROM ϑings;
+END;
+GO
+GRANT EXECUTE on procedureWithLargeCommment to bob;
+GRANT EXECUTE on procedureWithLargeCommment to fred;
+GO
+
 -- create an offline database to have an unavailable database to test with
 CREATE DATABASE unavailable_db;
 GO


### PR DESCRIPTION
### What does this PR do?
In sqlserver query activity collection, query statement is wrongly marked as `ERROR: failed to obfuscate` when the query is part of a truncated stored procedure. 

The stored procedure is truncated when it exceeds the `PROC_CHAR_LIMIT`, which is `500` characters. Although the stored procedure is truncated and fails obfuscation due to statement ends at an incomplete position, the actual executed statement from the procedure is often collected and obfuscated without issue. 

The integration did not distinguish the difference between SQL statement obfuscation error and stored procedure obfuscation error, result in SQL statement always be marked as `ERROR: failed to obfuscate` when either one fails to obfuscate.

For example, a stored procedure starts with large comment block like below is truncated in the middle of the comment block
```sql
CREATE PROCEDURE usp_DummyProcedure
/*
    Description: This stored procedure is designed to perform a specific task in the database.
                 It retrieves data from certain tables based on given criteria.
    
    Author: John Doe

    Change Log:
    ----------------------------------------------------------------------------
    Date        | Author        | Description
    ------------|---------------|-----------------------------------------------
    2023-01-01  | John Doe      | Initial creation of the procedure.
    2023-02-15  | Jane Smith    | Modified the procedure to include additional filters.
    2023-03-20  | John Doe      | Optimized query for better performance.
    ----------------------------------------------------------------------------

    Procedure: usp_DummyProcedure
    Purpose:   To demonstrate a template with a comment block for source control.
*/
    @Parameter1 INT,
    @Parameter2 VARCHAR(100)
AS
BEGIN
    SET NOCOUNT ON;

    -- Dummy SQL code
    SELECT * 
    FROM SomeTable
    WHERE Column1 = @Parameter1
    AND Column2 LIKE '%' + @Parameter2 + '%';

    -- More SQL code can be added here

    SET NOCOUNT OFF;
END;
GO
```
But the below executed SQL statement should be correctly collected.
```sql
SELECT * 
    FROM SomeTable
    WHERE Column1 = @Parameter1
    AND Column2 LIKE ? + @Parameter2 + ?
```
This PR fixes this issue to ensure the accurate collection of query activity with statement.
TODO: Make `PROC_CHAR_LIMIT` configurable.

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
