### PR TITLE
Remove the `github_labels` for Agent Integrations in the ddqa config

### DIFF
--- a/.ddqa/config.toml
+++ b/.ddqa/config.toml
@@ -21,7 +21,9 @@ jira_statuses = [
   "Done",
 ]
 github_team = "agent-integrations"
-github_labels = ["team/agent-integrations"]
+# Our team stopped doing QA so stop assigning QA tasks to us directly
+# Leaving the team in the config so we can manually assign our team if needed
+# github_labels = ["team/agent-integrations"]
 
 [teams."Platform Integrations"]
 jira_project = "PLINT"


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
