### PR TITLE
Fetch all the tags before generating the Agent changelog

### DIFF
--- a/ddev/changelog.d/16460.added
+++ b/ddev/changelog.d/16460.added
@@ -1,0 +1,1 @@
+Fetch all the tags before generating the Agent changelog

--- a/ddev/src/ddev/cli/release/agent/changelog.py
+++ b/ddev/src/ddev/cli/release/agent/changelog.py
@@ -47,6 +47,8 @@ def changelog(app: Application, since: str, to: str, write: bool, force: bool):
     """
     from ddev.cli.release.agent.common import get_changes_per_agent
 
+    app.repo.git.fetch_tags()
+
     changes_per_agent = get_changes_per_agent(app.repo, since, to)
 
     # store the changelog in memory

--- a/ddev/src/ddev/utils/git.py
+++ b/ddev/src/ddev/utils/git.py
@@ -60,6 +60,10 @@ class GitManager:
     def tags(self) -> list[str]:
         return sorted(set(self.capture('tag', '--list').splitlines()))
 
+    def fetch_tags(self) -> None:
+        # We force because, in very rare cases, we move tags
+        self.capture('fetch', '--all', '--tags', '--force')
+
     def get_tags(self) -> list[str]:
         with suppress(AttributeError):
             del self.tags

--- a/ddev/tests/utils/test_git.py
+++ b/ddev/tests/utils/test_git.py
@@ -1,6 +1,8 @@
 # (C) Datadog, Inc. 2022-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
+import subprocess
+
 from ddev.repo.core import Repository
 
 
@@ -94,3 +96,18 @@ def test_filtered_tags(repository):
     repo.git.capture('tag', 'baz')
 
     assert repo.git.filter_tags('^ba') == ['bar', 'baz']
+
+
+def test_fetch_tags(repository, mocker):
+    mock = mocker.patch('subprocess.run')
+    repo = Repository(repository.path.name, str(repository.path))
+    repo.git.fetch_tags()
+    assert mock.call_args_list == [
+        mocker.call(
+            ['git', 'fetch', '--all', '--tags', '--force'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            encoding='utf-8',
+            check=True,
+        ),
+    ]


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Fetch all the tags before generating the Agent changelog

### Motivation
<!-- What inspired you to submit this pull request? -->

On https://github.com/DataDog/integrations-core/pull/16458, @iliakur faced some issues which were due to the fact that he was missing some tags locally. The fact he also updated some old versions also shows this problem (previous RMs probably did not have some tags locally when they ran the command). 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
