### PR TITLE
fix unexpected exception when reporting sqlserver statements obfuscate xml plan error

### DIFF
--- a/sqlserver/changelog.d/16461.fixed
+++ b/sqlserver/changelog.d/16461.fixed
@@ -1,0 +1,1 @@
+fix unexpected exception when reporting sqlserver statements obfuscate xml plan error

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -512,7 +512,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
                     else:
                         self.log.debug("Failed to obfuscate plan | %s", context)
                     collection_errors = [{'code': "obfuscate_xml_plan_error", 'message': str(e)}]
-                    self._config.count(
+                    self._check.count(
                         "dd.sqlserver.statements.error",
                         1,
                         **self._check.debug_stats_kwargs(tags=["error:obfuscate-xml-plan-{}".format(type(e))])


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->
This PR fixes an unexpected exception when reporting `obfuscate-xml-plan` error metric. 

### Motivation
<!-- What inspired you to submit this pull request? -->

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
