### PR TITLE
[DBMON-3197] add config option to set character limit of stored procedure text

### DIFF
--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -395,6 +395,16 @@ files:
           value:
             type: number
             example: 10
+    - name: stored_procedure_characters_limit
+      description: |
+        Limit the number of characters of the text of a stored procedure that is collected.
+        The characters limit is applicable to both query metrics and query activity.
+        Increasing this value will increase the amount of data collected from the database,
+        and increase the amount of data sent to Datadog.
+      value:
+        type: integer
+        example: 500
+        display_default: 500
 
     - name: aws
       description: |

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -398,7 +398,7 @@ files:
     - name: stored_procedure_characters_limit
       description: |
         Limit the number of characters of the text of a stored procedure that is collected.
-        The characters limit is applicable to both query metrics and query activity.
+        The characters limit is applicable to both query metrics and query samples.
         Increasing this value will increase the amount of data collected from the database,
         and increase the amount of data sent to Datadog.
       value:

--- a/sqlserver/assets/configuration/spec.yaml
+++ b/sqlserver/assets/configuration/spec.yaml
@@ -399,8 +399,8 @@ files:
       description: |
         Limit the number of characters of the text of a stored procedure that is collected.
         The characters limit is applicable to both query metrics and query samples.
-        Increasing this value will increase the amount of data collected from the database,
-        and increase the amount of data sent to Datadog.
+        Please be aware that increasing this value may affect performance,
+        as more data will be gathered from the database and sent to Datadog.
       value:
         type: integer
         example: 500

--- a/sqlserver/changelog.d/16462.added
+++ b/sqlserver/changelog.d/16462.added
@@ -1,0 +1,1 @@
+[DBMON-3197] add config option to set character limit of stored procedure text

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -14,7 +14,7 @@ from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.sqlserver.config import SQLServerConfig
 from datadog_checks.sqlserver.const import STATIC_INFO_ENGINE_EDITION, STATIC_INFO_VERSION
-from datadog_checks.sqlserver.utils import PROC_CHAR_LIMIT, extract_sql_comments_and_procedure_name
+from datadog_checks.sqlserver.utils import extract_sql_comments_and_procedure_name
 
 try:
     import datadog_agent
@@ -193,7 +193,8 @@ class SqlserverActivity(DBMAsyncJob):
     def _get_idle_blocking_sessions(self, cursor, blocking_session_ids):
         # The IDLE_BLOCKING_SESSIONS_QUERY contains minimum information on idle blocker
         query = IDLE_BLOCKING_SESSIONS_QUERY.format(
-            blocking_session_ids=",".join(map(str, blocking_session_ids)), proc_char_limit=PROC_CHAR_LIMIT
+            blocking_session_ids=",".join(map(str, blocking_session_ids)),
+            proc_char_limit=self._config.stored_procedure_characters_limit,
         )
         self.log.debug("Running query [%s]", query)
         cursor.execute(query)
@@ -206,7 +207,7 @@ class SqlserverActivity(DBMAsyncJob):
         self.log.debug("collecting sql server activity")
         query = ACTIVITY_QUERY.format(
             exec_request_columns=', '.join(['req.{}'.format(r) for r in exec_request_columns]),
-            proc_char_limit=PROC_CHAR_LIMIT,
+            proc_char_limit=self._config.stored_procedure_characters_limit,
         )
         self.log.debug("Running query [%s]", query)
         cursor.execute(query)

--- a/sqlserver/datadog_checks/sqlserver/config.py
+++ b/sqlserver/datadog_checks/sqlserver/config.py
@@ -7,7 +7,7 @@ import re
 
 from datadog_checks.base.config import is_affirmative
 from datadog_checks.base.utils.common import to_native_string
-from datadog_checks.sqlserver.const import DEFAULT_AUTODISCOVERY_INTERVAL
+from datadog_checks.sqlserver.const import DEFAULT_AUTODISCOVERY_INTERVAL, PROC_CHAR_LIMIT
 
 
 class SQLServerConfig:
@@ -73,6 +73,7 @@ class SQLServerConfig:
         self.log_unobfuscated_queries: bool = is_affirmative(instance.get('log_unobfuscated_queries', False))
         self.log_unobfuscated_plans: bool = is_affirmative(instance.get('log_unobfuscated_plans', False))
         self.database_instance_collection_interval: int = instance.get('database_instance_collection_interval', 1800)
+        self.stored_procedure_characters_limit: int = instance.get('stored_procedure_characters_limit', PROC_CHAR_LIMIT)
         self.connection_host: str = instance['host']
 
     def _compile_valid_patterns(self, patterns: list[str]) -> re.Pattern:

--- a/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/defaults.py
@@ -128,5 +128,9 @@ def instance_server_version():
     return '2014'
 
 
+def instance_stored_procedure_characters_limit():
+    return 500
+
+
 def instance_use_global_custom_queries():
     return 'true'

--- a/sqlserver/datadog_checks/sqlserver/config_models/instance.py
+++ b/sqlserver/datadog_checks/sqlserver/config_models/instance.py
@@ -190,6 +190,7 @@ class InstanceConfig(BaseModel):
     server_version: Optional[str] = None
     service: Optional[str] = None
     stored_procedure: Optional[str] = None
+    stored_procedure_characters_limit: Optional[int] = None
     tags: Optional[tuple[str, ...]] = None
     use_global_custom_queries: Optional[str] = None
     username: Optional[str] = None

--- a/sqlserver/datadog_checks/sqlserver/const.py
+++ b/sqlserver/datadog_checks/sqlserver/const.py
@@ -247,3 +247,5 @@ TEMPDB_FILE_SPACE_USAGE_METRICS = [
     ),
     ('sqlserver.tempdb.file_space_usage.mixed_extent_space', 'sys.dm_db_file_space_usage', 'mixed_extent_space'),
 ]
+
+PROC_CHAR_LIMIT = 500

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -334,7 +334,7 @@ instances:
 
     ## @param stored_procedure_characters_limit - integer - optional - default: 500
     ## Limit the number of characters of the text of a stored procedure that is collected.
-    ## The characters limit is applicable to both query metrics and query activity.
+    ## The characters limit is applicable to both query metrics and query samples.
     ## Increasing this value will increase the amount of data collected from the database,
     ## and increase the amount of data sent to Datadog.
     #

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -335,8 +335,8 @@ instances:
     ## @param stored_procedure_characters_limit - integer - optional - default: 500
     ## Limit the number of characters of the text of a stored procedure that is collected.
     ## The characters limit is applicable to both query metrics and query samples.
-    ## Increasing this value will increase the amount of data collected from the database,
-    ## and increase the amount of data sent to Datadog.
+    ## Please be aware that increasing this value may affect performance,
+    ## as more data will be gathered from the database and sent to Datadog.
     #
     # stored_procedure_characters_limit: 500
 

--- a/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
+++ b/sqlserver/datadog_checks/sqlserver/data/conf.yaml.example
@@ -332,6 +332,14 @@ instances:
         #
         # collection_interval: 10
 
+    ## @param stored_procedure_characters_limit - integer - optional - default: 500
+    ## Limit the number of characters of the text of a stored procedure that is collected.
+    ## The characters limit is applicable to both query metrics and query activity.
+    ## Increasing this value will increase the amount of data collected from the database,
+    ## and increase the amount of data sent to Datadog.
+    #
+    # stored_procedure_characters_limit: 500
+
     ## This block defines the configuration for AWS RDS and Aurora instances.
     ##
     ## Complete this section if you have installed the Datadog AWS Integration

--- a/sqlserver/datadog_checks/sqlserver/statements.py
+++ b/sqlserver/datadog_checks/sqlserver/statements.py
@@ -22,7 +22,7 @@ from datadog_checks.base.utils.db.utils import (
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracking import tracked_method
 from datadog_checks.sqlserver.config import SQLServerConfig
-from datadog_checks.sqlserver.utils import PROC_CHAR_LIMIT, extract_sql_comments_and_procedure_name
+from datadog_checks.sqlserver.utils import extract_sql_comments_and_procedure_name
 
 try:
     import datadog_agent
@@ -282,7 +282,7 @@ class SqlserverStatementMetrics(DBMAsyncJob):
             query_metrics_columns=', '.join(['qs.{} as {}'.format(col, col) for col in available_columns]),
             query_metrics_column_sums=', '.join(['sum(qs.{}) as {}'.format(c, c) for c in available_columns]),
             limit=self.dm_exec_query_stats_row_limit,
-            proc_char_limit=PROC_CHAR_LIMIT,
+            proc_char_limit=self._config.stored_procedure_characters_limit,
         )
         return self._statement_metrics_query
 

--- a/sqlserver/datadog_checks/sqlserver/utils.py
+++ b/sqlserver/datadog_checks/sqlserver/utils.py
@@ -9,7 +9,6 @@ from datadog_checks.sqlserver.const import ENGINE_EDITION_AZURE_MANAGED_INSTANCE
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
 DRIVER_CONFIG_DIR = os.path.join(CURRENT_DIR, 'data', 'driver_config')
-PROC_CHAR_LIMIT = 500
 
 
 # Database is used to store both the name and physical_database_name
@@ -48,9 +47,7 @@ def construct_use_statement(database):
 
 def is_statement_proc(text):
     if text:
-        # take first 500 chars, upper case and split into string
-        # to get individual keywords
-        t = text[0:PROC_CHAR_LIMIT].upper().split()
+        t = text.upper().split()
         idx_create = _get_index_for_keyword(t, 'CREATE')
         idx_proc = _get_index_for_keyword(t, 'PROCEDURE')
         if idx_proc < 0:


### PR DESCRIPTION
### What does this PR do?
This PR adds config option `stored_procedure_characters_limit` (defaults to 500) to set upper limit of stored procedure text collected in query metrics and query activity. 
It replaces the hard coded 500 characters `PROC_CHAR_LIMIT`. 

### Motivation
Stored procedure characters limit was added in #15105. Making the upper configurable provides value to users with large stored procedure, often starts with a block of comments that describes what the procedure does (for example see #16455).

### Additional Notes
Increase the characters limit will have direct impact on the amount of data being transferred between the monitored database to the agent and to Datadog.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
