### PR TITLE
Add recommended monitor

### DIFF
--- a/karpenter/assets/monitors/pod_state.json
+++ b/karpenter/assets/monitors/pod_state.json
@@ -2,7 +2,7 @@
     "version": 2,
     "created_at": "2023-12-19",
     "last_updated_at": "2023-12-19",
-    "title": "High percentage of pods reporting in a non Running or non Succeeded state",,
+    "title": "High percentage of pods reporting in a non Running or non Succeeded state",
     "description": "Karpenter reports the states of pods that it manages. An elevated count of pods not in a Running or Succeeded state may indicate problems with Karpenter's provisioning or scaling activities, impacting the stability and performance of the Kubernetes environment.",
     "definition": {
         "id": 136666207,

--- a/karpenter/assets/monitors/pod_state.json
+++ b/karpenter/assets/monitors/pod_state.json
@@ -2,14 +2,14 @@
     "version": 2,
     "created_at": "2023-12-19",
     "last_updated_at": "2023-12-19",
-    "title": "High number of pods reporting in a non Running or non Succeeded state",
+    "title": "High percentage of pods reporting in a non Running or non Succeeded state",,
     "description": "Karpenter reports the states of pods that it manages. An elevated count of pods not in a Running or Succeeded state may indicate problems with Karpenter's provisioning or scaling activities, impacting the stability and performance of the Kubernetes environment.",
     "definition": {
-        "id": 136665031,
-        "name": "High number of pods reporting in a non Running or non Succeeded state",
+        "id": 136666207,
+        "name": "High percentage of pods stuck in a non Running or non Succeeded state",
         "type": "query alert",
-        "query": "min(last_30m):sum:karpenter.pods.state{NOT phase:running or NOT phase:running} by {namespace,provisioner,host} > 15",
-        "message": "{{#is_alert}} \nKarpenter is reporting a high number of pods not in Running/Succeeded state on host: {{host.name}}.\n{{value}} number of pods by {{provisioner.name}} in {{namespace.name}} namespace are in a non running/succeeded state in the last 30 minutes.\n{{/is_alert}}\n\n{{#is_recovery}}\nKarpenter is reporting that number of pods in non Running/Succeeded state are back below the trigger threshold of {{threshold}} in the last 30 minutes\n{{/is_recovery}}",
+        "query": "min(last_30m):sum:karpenter.pods.state{NOT phase:running or NOT phase:running} by {namespace,provisioner,host} / sum:karpenter.pods.state{*} by {namespace,provisioner,host} * 100 > 15",
+        "message": "{{#is_alert}} \nKarpenter is reporting high percentage of pods in a non Running/Succeeded state on host: {{host.name}}.\n{{value}}% of pods by {{provisioner.name}} in {{namespace.name}} namespace are in a non running/succeeded state in the last 30 minutes.\n{{/is_alert}}\n\n{{#is_recovery}}\nKarpenter is reporting that the percentage of pods in non Running/Succeeded state are back below the trigger threshold of {{threshold}}% in the last 30 minutes\n{{/is_recovery}}",
         "tags": [],
         "options": {
             "thresholds": {

--- a/karpenter/assets/monitors/pod_state.json
+++ b/karpenter/assets/monitors/pod_state.json
@@ -1,0 +1,31 @@
+{
+    "version": 2,
+    "created_at": "2023-12-19",
+    "last_updated_at": "2023-12-19",
+    "title": "High number of pods reporting in a non Running or non Succeeded state",
+    "description": "Karpenter reports the states of pods that it manages. An elevated count of pods not in a Running or Succeeded state may indicate problems with Karpenter's provisioning or scaling activities, impacting the stability and performance of the Kubernetes environment.",
+    "definition": {
+        "id": 136665031,
+        "name": "High number of pods reporting in a non Running or non Succeeded state",
+        "type": "query alert",
+        "query": "min(last_30m):sum:karpenter.pods.state{NOT phase:running or NOT phase:running} by {namespace,provisioner,host} > 20",
+        "message": "{{#is_alert}} \nKarpenter is reporting a high number of pods not in Running/Succeeded state on host: {{host.name}}.\n{{value}} number of pods by {{provisioner.name}} in {{namespace.name}} namespace are in a non running/succeeded state in the last 30 minutes.\n{{/is_alert}}\n\n{{#is_recovery}}\nKarpenter is reporting that number of pods in non Running/Succeeded state are back below the trigger threshold of {{threshold}} in the last 30 minutes\n{{/is_recovery}}",
+        "tags": [],
+        "options": {
+            "thresholds": {
+                "critical": 10
+            },
+            "notify_audit": false,
+            "include_tags": true,
+            "new_group_delay": 60,
+            "notify_no_data": false,
+            "avalanche_window": 10,
+            "silenced": {}
+        },
+        "priority": null,
+        "restricted_roles": null
+    },
+    "tags": [
+        "integration:karpenter"
+    ]
+}

--- a/karpenter/assets/monitors/pod_state.json
+++ b/karpenter/assets/monitors/pod_state.json
@@ -8,12 +8,12 @@
         "id": 136665031,
         "name": "High number of pods reporting in a non Running or non Succeeded state",
         "type": "query alert",
-        "query": "min(last_30m):sum:karpenter.pods.state{NOT phase:running or NOT phase:running} by {namespace,provisioner,host} > 20",
+        "query": "min(last_30m):sum:karpenter.pods.state{NOT phase:running or NOT phase:running} by {namespace,provisioner,host} > 15",
         "message": "{{#is_alert}} \nKarpenter is reporting a high number of pods not in Running/Succeeded state on host: {{host.name}}.\n{{value}} number of pods by {{provisioner.name}} in {{namespace.name}} namespace are in a non running/succeeded state in the last 30 minutes.\n{{/is_alert}}\n\n{{#is_recovery}}\nKarpenter is reporting that number of pods in non Running/Succeeded state are back below the trigger threshold of {{threshold}} in the last 30 minutes\n{{/is_recovery}}",
         "tags": [],
         "options": {
             "thresholds": {
-                "critical": 10
+                "critical": 15
             },
             "notify_audit": false,
             "include_tags": true,

--- a/karpenter/manifest.json
+++ b/karpenter/manifest.json
@@ -47,7 +47,7 @@
       "source": "karpenter"
     },
     "monitors": {
-      "pod states": "assets/pod_state.json"
+      "pod states": "assets/monitors/pod_state.json"
     }
   },
   "author": {

--- a/karpenter/manifest.json
+++ b/karpenter/manifest.json
@@ -45,6 +45,9 @@
     },
     "logs": {
       "source": "karpenter"
+    },
+    "monitors": {
+      "metadata_path": "assets/pod_state.json"
     }
   },
   "author": {

--- a/karpenter/manifest.json
+++ b/karpenter/manifest.json
@@ -47,7 +47,7 @@
       "source": "karpenter"
     },
     "monitors": {
-      "metadata_path": "assets/pod_state.json"
+      "pod states": "assets/pod_state.json"
     }
   },
   "author": {


### PR DESCRIPTION
### What does this PR do?
Adding recommended monitor for the Karpenter integration.

Essentially:
Alert if the percentage of pods that are neither in succeeded or running per provisioner, namespace and host is over 15%.
