### PR TITLE
[DBM] - Add whether a SPID is a user or bg process

### DIFF
--- a/sqlserver/changelog.d/16465.added
+++ b/sqlserver/changelog.d/16465.added
@@ -1,1 +1,1 @@
-Adds whether a SPID is a user or system process and adds transaction start/type/state information to DBM activity events.
+Adds whether a SPID is a user or system process to DBM activity events.

--- a/sqlserver/changelog.d/16465.added
+++ b/sqlserver/changelog.d/16465.added
@@ -1,0 +1,1 @@
+Adds whether a SPID is a user or system process and adds transaction start/type/state information to DBM activity events.

--- a/sqlserver/datadog_checks/sqlserver/activity.py
+++ b/sqlserver/datadog_checks/sqlserver/activity.py
@@ -284,7 +284,7 @@ class SqlserverActivity(DBMAsyncJob):
         available_columns = [c for c in all_expected_columns if c in all_columns]
         missing_columns = set(all_expected_columns) - set(available_columns)
         if missing_columns:
-            self._log.warning("missing the following expected columns from sys.dm_exec_requests: %s", missing_columns)
+            self._log.info("missing the following expected columns from sys.dm_exec_requests: %s", missing_columns)
         self._log.debug("found available sys.dm_exec_requests columns: %s", available_columns)
         return available_columns
 

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -151,6 +151,7 @@ def test_collect_load_activity(
     # the second query should be fred's, which is currently blocked on
     # bob who is holding a table lock
     blocked_row = event['sqlserver_activity'][1]
+    print(blocked_row)
     # assert the data that was collected is correct
     assert blocked_row['user_name'] == "fred", "incorrect user_name"
     assert blocked_row['session_status'] == "running", "incorrect session_status"
@@ -171,6 +172,7 @@ def test_collect_load_activity(
     # assert that the current timestamp is being collected as an ISO timestamp with TZ info
     assert parser.isoparse(blocked_row['now']).tzinfo, "current timestamp not formatted correctly"
     assert blocked_row["query_start"], "missing query_start"
+    assert blocked_row["is_user_process"], "missing is_user_process"
     assert parser.isoparse(blocked_row["query_start"]).tzinfo, "query_start timestamp not formatted correctly"
     for r in DM_EXEC_REQUESTS_COLS:
         assert r in blocked_row
@@ -304,6 +306,9 @@ def test_activity_nested_blocking_transactions(
     assert root_blocker["client_port"]
     assert root_blocker["client_address"]
     assert root_blocker["host_name"]
+    assert root_blocker["transaction_state"]
+    assert root_blocker["transaction_start"]
+    assert root_blocker["transaction_type"]
     # Expect to capture the query signature for the root blocker
     # query text is not captured from the req dmv
     # but available in the connection dmv with most_recent_sql_handle
@@ -331,6 +336,10 @@ def test_activity_nested_blocking_transactions(
     assert tx2["query_start"]
     assert tx2["query_hash"]
     assert tx2["query_plan_hash"]
+    assert tx2["transaction_state"]
+    assert tx2["transaction_start"]
+    assert tx2["transaction_type"]
+
     assert tx3["user_name"] == "fred"
     assert tx3["database_name"] == "datadog_test"
     assert tx3["last_request_start_time"]
@@ -342,6 +351,9 @@ def test_activity_nested_blocking_transactions(
     assert tx3["query_start"]
     assert tx3["query_hash"]
     assert tx3["query_plan_hash"]
+    assert tx3["transaction_state"]
+    assert tx3["transaction_start"]
+    assert tx3["transaction_type"]
 
     assert isinstance(tx2["query_hash"], str)
     assert isinstance(tx2["query_plan_hash"], str)

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -305,9 +305,6 @@ def test_activity_nested_blocking_transactions(
     assert root_blocker["client_port"]
     assert root_blocker["client_address"]
     assert root_blocker["host_name"]
-    assert root_blocker["transaction_state"]
-    assert root_blocker["transaction_start"]
-    assert root_blocker["transaction_type"]
     # Expect to capture the query signature for the root blocker
     # query text is not captured from the req dmv
     # but available in the connection dmv with most_recent_sql_handle
@@ -335,9 +332,6 @@ def test_activity_nested_blocking_transactions(
     assert tx2["query_start"]
     assert tx2["query_hash"]
     assert tx2["query_plan_hash"]
-    assert tx2["transaction_state"]
-    assert tx2["transaction_start"]
-    assert tx2["transaction_type"]
 
     assert tx3["user_name"] == "fred"
     assert tx3["database_name"] == "datadog_test"
@@ -350,9 +344,6 @@ def test_activity_nested_blocking_transactions(
     assert tx3["query_start"]
     assert tx3["query_hash"]
     assert tx3["query_plan_hash"]
-    assert tx3["transaction_state"]
-    assert tx3["transaction_start"]
-    assert tx3["transaction_type"]
 
     assert isinstance(tx2["query_hash"], str)
     assert isinstance(tx2["query_plan_hash"], str)

--- a/sqlserver/tests/test_activity.py
+++ b/sqlserver/tests/test_activity.py
@@ -151,7 +151,6 @@ def test_collect_load_activity(
     # the second query should be fred's, which is currently blocked on
     # bob who is holding a table lock
     blocked_row = event['sqlserver_activity'][1]
-    print(blocked_row)
     # assert the data that was collected is correct
     assert blocked_row['user_name'] == "fred", "incorrect user_name"
     assert blocked_row['session_status'] == "running", "incorrect session_status"


### PR DESCRIPTION
### What does this PR do?

- Adds the `is_user_process` field to our activity events to filter out background processes in the UI

### Motivation

- Customers are seeing background processes in some places in the UI, and these have a disproportionally high duration compared to other samples.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
