### PR TITLE
[DBMON-3220] skip reporting SqlFractionMetric when base_name is None

### DIFF
--- a/sqlserver/changelog.d/16469.fixed
+++ b/sqlserver/changelog.d/16469.fixed
@@ -1,0 +1,1 @@
+[DBMON-3220] skip reporting SqlFractionMetric when base_name is None

--- a/sqlserver/datadog_checks/sqlserver/metrics.py
+++ b/sqlserver/datadog_checks/sqlserver/metrics.py
@@ -157,6 +157,9 @@ class SqlFractionMetric(BaseSqlServerMetric):
         return results, None
 
     def fetch_metric(self, results, columns, values_cache=None):
+        if not self.base_name:
+            self.log.error('Skipping counter. Missing base counter name')
+            return
         num_counters = results.get(self.sql_name.strip())
         base_counters = results.get(self.base_name.strip())
         if not num_counters or not base_counters:

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -647,9 +647,13 @@ class SQLServer(AgentCheck):
                 )
                 try:
                     cursor.execute(BASE_NAME_QUERY, candidates)
-                    base_name = cursor.fetchone().counter_name.strip()
-                    self.log.debug("Got base metric: %s for metric: %s", base_name, counter_name)
-                    self._sql_counter_types[counter_name] = (sql_counter_type, base_name)
+                    row = cursor.fetchone()
+                    if row:
+                        base_name = row.counter_name.strip()
+                        self.log.debug("Got base metric: %s for metric: %s", base_name, counter_name)
+                        self._sql_counter_types[counter_name] = (sql_counter_type, base_name)
+                    else:
+                        self.log.warning("Could not get counter_name of base for metric: %s", counter_name)
                 except Exception as e:
                     self.log.warning("Could not get counter_name of base for metric: %s", e)
 

--- a/sqlserver/datadog_checks/sqlserver/sqlserver.py
+++ b/sqlserver/datadog_checks/sqlserver/sqlserver.py
@@ -653,7 +653,11 @@ class SQLServer(AgentCheck):
                         self.log.debug("Got base metric: %s for metric: %s", base_name, counter_name)
                         self._sql_counter_types[counter_name] = (sql_counter_type, base_name)
                     else:
-                        self.log.warning("Could not get counter_name of base for metric: %s", counter_name)
+                        self.log.warning(
+                            "Could not get counter_name of base for metric %s with candidates %s",
+                            counter_name,
+                            candidates,
+                        )
                 except Exception as e:
                     self.log.warning("Could not get counter_name of base for metric: %s", e)
 

--- a/sqlserver/tests/test_unit.py
+++ b/sqlserver/tests/test_unit.py
@@ -298,7 +298,7 @@ def test_SqlDbIndexUsageStats_fetch_metric(col_val_row_1, col_val_row_2, col_val
     [
         pytest.param('Buffer cache hit ratio base', id='base_name valid'),
         pytest.param(None, id='base_name None'),
-    ]
+    ],
 )
 def test_SqlFractionMetric_base(caplog, base_name):
     Row = namedtuple('Row', ['counter_name', 'cntr_type', 'cntr_value', 'instance_name', 'object_name'])


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug that caused SQLServer SqlFractionMetric failed to report due to base_name equals to None. 

### Motivation
Fix reported error
```
metadata:
    resolved_hostname: D-DEV-DB-L
  Error: 'NoneType' object has no attribute 'strip'
  Traceback (most recent call last):
    File "C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\datadog_checks\\base\\checks\\base.py", line 1235, in run
      self.check(instance)
    File "C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\datadog_checks\\sqlserver\\sqlserver.py", line 779, in check
      self.collect_metrics()
    File "C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\datadog_checks\\sqlserver\\sqlserver.py", line 877, in collect_metrics
      metric.fetch_metric(rows, cols, self.sqlserver_incr_fraction_metric_previous_values)
    File "C:\\Program Files\\Datadog\\Datadog Agent\\embedded3\\lib\\site-packages\\datadog_checks\\sqlserver\\metrics.py", line 158, in fetch_metric
      base_counters = results.get(self.base_name.strip())
  AttributeError: 'NoneType' object has no attribute 'strip'
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
