### PR TITLE
Add a script to generate all the metrics for a given integration

### DIFF
--- a/ddev/changelog.d/16472.added
+++ b/ddev/changelog.d/16472.added
@@ -1,0 +1,1 @@
+Add a script to generate all the metrics for a given integration

--- a/ddev/pyproject.toml
+++ b/ddev/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 dependencies = [
     "click~=8.1.6",
     "coverage",
+    "datadog-api-client==2.20.0",
     "datadog-checks-dev[cli]~=29.0",
     "hatch>=1.8.1",
     "httpx",

--- a/ddev/src/ddev/cli/meta/scripts/__init__.py
+++ b/ddev/src/ddev/cli/meta/scripts/__init__.py
@@ -19,6 +19,6 @@ def scripts():
 
 scripts.add_command(email2ghuser)
 scripts.add_command(metrics2md)
-scripts.add_command(remove_labels)
 scripts.add_command(generate_metrics)
+scripts.add_command(remove_labels)
 scripts.add_command(upgrade_python)

--- a/ddev/src/ddev/cli/meta/scripts/__init__.py
+++ b/ddev/src/ddev/cli/meta/scripts/__init__.py
@@ -6,6 +6,7 @@ from datadog_checks.dev.tooling.commands.meta.scripts.github_user import email2g
 from datadog_checks.dev.tooling.commands.meta.scripts.metrics2md import metrics2md
 from datadog_checks.dev.tooling.commands.meta.scripts.remove_labels import remove_labels
 
+from ddev.cli.meta.scripts.generate_metrics import generate_metrics
 from ddev.cli.meta.scripts.upgrade_python import upgrade_python
 
 
@@ -19,4 +20,5 @@ def scripts():
 scripts.add_command(email2ghuser)
 scripts.add_command(metrics2md)
 scripts.add_command(remove_labels)
+scripts.add_command(generate_metrics)
 scripts.add_command(upgrade_python)

--- a/ddev/src/ddev/cli/meta/scripts/__init__.py
+++ b/ddev/src/ddev/cli/meta/scripts/__init__.py
@@ -18,7 +18,7 @@ def scripts():
 
 
 scripts.add_command(email2ghuser)
-scripts.add_command(metrics2md)
 scripts.add_command(generate_metrics)
+scripts.add_command(metrics2md)
 scripts.add_command(remove_labels)
 scripts.add_command(upgrade_python)

--- a/ddev/src/ddev/cli/meta/scripts/generate_metrics.py
+++ b/ddev/src/ddev/cli/meta/scripts/generate_metrics.py
@@ -1,0 +1,92 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from ddev.cli.application import Application
+
+
+@click.command('generate-metrics', short_help='Generate metrics with fake values for an integration')
+@click.argument('integration')
+@click.option('--api-url', default="api.datadoghq.com", help='The API URL to use, e.g. "api.datadoghq.com"')
+@click.option('--api-key', required=True, help='Your API key')
+@click.pass_obj
+def generate_metrics(app: Application, integration: str, api_url: str, api_key: str):
+    """Generate metrics with fake values for an integration
+
+    \b
+    `$ ddev meta scripts generate-metrics ray --api-url <URL> --api-key <API_KEY>`
+    """
+
+    import random
+    from datetime import datetime
+    from time import sleep
+
+    from datadog_api_client import ApiClient, Configuration
+    from datadog_api_client.v2.api.metrics_api import MetricsApi
+    from datadog_api_client.v2.model.metric_intake_type import MetricIntakeType
+    from datadog_api_client.v2.model.metric_payload import MetricPayload
+    from datadog_api_client.v2.model.metric_point import MetricPoint
+    from datadog_api_client.v2.model.metric_resource import MetricResource
+    from datadog_api_client.v2.model.metric_series import MetricSeries
+    from datadog_checks.dev.utils import get_hostname
+
+    try:
+        intg = app.repo.integrations.get(integration)
+    except OSError:
+        app.abort(f'Unknown target: {intg}')
+
+    configuration = Configuration()
+    configuration.request_timeout = (5, 5)
+    configuration.api_key = {
+        "apiKeyAuth": api_key,
+    }
+    # We manually set the value to allow custom URLs
+    configuration.server_index = 1
+    configuration.server_variables["name"] = api_url
+
+    with ApiClient(configuration) as api_client:
+        api_instance = MetricsApi(api_client)
+
+        while True:
+            series = []
+            for metric in intg.metrics:
+                value = random.randint(0, 100)
+                type = (
+                    MetricIntakeType.GAUGE
+                    if metric.metric_type == 'gauge'
+                    else MetricIntakeType.COUNT
+                    if metric.metric_type == 'counter'
+                    else MetricIntakeType.UNSPECIFIED
+                )
+                app.display_info(f"Metric {metric.metric_name} with value {value} and type {type}")
+
+                series.append(
+                    MetricSeries(
+                        metric=metric.metric_name,
+                        type=type,
+                        points=[
+                            MetricPoint(
+                                timestamp=int(datetime.now().timestamp()),
+                                value=value,
+                            ),
+                        ],
+                        resources=[
+                            MetricResource(
+                                name=get_hostname(),
+                                type="host",
+                            ),
+                        ],
+                    )
+                )
+            app.display_info("Calling the API...")
+            api_instance.submit_metrics(body=MetricPayload(series=series))
+            app.display_info("Done.")
+
+            app.display_info("Sleeping for 10 seconds...")
+            sleep(10)

--- a/ddev/src/ddev/integration/metrics.py
+++ b/ddev/src/ddev/integration/metrics.py
@@ -1,0 +1,18 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+from dataclasses import dataclass
+
+
+@dataclass
+class Metric:
+    metric_name: str
+    metric_type: str
+    interval: int | None
+    unit_name: str
+    per_unit_name: str
+    description: str
+    orientation: int | None
+    integration: str
+    short_name: str
+    curated_metric: str

--- a/ddev/src/ddev/integration/metrics.py
+++ b/ddev/src/ddev/integration/metrics.py
@@ -1,11 +1,10 @@
 # (C) Datadog, Inc. 2023-present
 # All rights reserved
 # Licensed under a 3-clause BSD style license (see LICENSE)
-from dataclasses import dataclass
+from pydantic import BaseModel
 
 
-@dataclass
-class Metric:
+class Metric(BaseModel):
     metric_name: str
     metric_type: str
     interval: int | None

--- a/ddev/tests/cli/meta/scripts/conftest.py
+++ b/ddev/tests/cli/meta/scripts/conftest.py
@@ -48,6 +48,13 @@ python = ["2.7", "{OLD_PYTHON_VERSION}"]
 """,
     )
 
+    write_file(
+        repo_path / 'dummy',
+        'metadata.csv',
+        """metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
+dummy.metric,gauge,,,,description,0,dummy,,""",
+    )
+
     for integration in ('dummy', 'datadog_checks_dependency_provider'):
         write_file(
             repo_path / integration,

--- a/ddev/tests/cli/meta/scripts/test_generate_metrics.py
+++ b/ddev/tests/cli/meta/scripts/test_generate_metrics.py
@@ -1,0 +1,17 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+
+
+def test_generate_metrics(fake_repo, ddev, mocker):
+    mocker.patch('time.sleep', side_effect=KeyboardInterrupt)
+
+    submit_metrics_mock = mocker.patch('datadog_api_client.v2.api.metrics_api.MetricsApi.submit_metrics')
+
+    ddev('meta', 'scripts', 'generate-metrics', 'dummy', '--api-key', '1234')
+
+    assert submit_metrics_mock.call_count == 1
+
+    payload = submit_metrics_mock.call_args_list[0][1]
+    assert len(payload['body']['series']) == 1
+    assert payload['body']['series'][0]['metric'] == 'dummy.metric'

--- a/ddev/tests/integration/conftest.py
+++ b/ddev/tests/integration/conftest.py
@@ -1,0 +1,67 @@
+# (C) Datadog, Inc. 2023-present
+# All rights reserved
+# Licensed under a 3-clause BSD style license (see LICENSE)
+import pytest
+
+from ddev.repo.core import Repository
+
+
+@pytest.fixture
+def fake_repo(tmp_path_factory, config_file, ddev):
+    repo_path = tmp_path_factory.mktemp('integrations-core')
+    repo = Repository('integrations-core', str(repo_path))
+
+    config_file.model.repos['core'] = str(repo.path)
+    config_file.save()
+
+    for integration in ('dummy', 'no_metrics', 'no_metadata_file'):
+        write_file(
+            repo_path / integration,
+            'pyproject.toml',
+            f"""[project]
+    name = "{integration}"
+    classifiers = [
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3.12",
+    ]
+    """,
+        )
+
+        write_file(repo_path / integration, 'manifest.json', "{}")
+
+        write_file(
+            repo_path / integration,
+            'hatch.toml',
+            """[env.collectors.datadog-checks]
+
+        [[envs.default.matrix]]
+        python = ["3.12"]
+
+        """,
+        )
+
+    write_file(
+        repo_path / 'dummy',
+        'metadata.csv',
+        """metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric
+dummy.metric,gauge,10,seconds,object,description,0,dummy,short,""",
+    )
+
+    write_file(
+        repo_path / 'no_metrics',
+        'metadata.csv',
+        "metric_name,metric_type,interval,unit_name,per_unit_name,description,orientation,integration,short_name,curated_metric",
+    )
+
+    yield repo
+
+
+def write_file(folder, file, content):
+    folder.mkdir(exist_ok=True, parents=True)
+    file_path = folder / file
+    file_path.write_text(content)

--- a/ddev/tests/integration/test_core.py
+++ b/ddev/tests/integration/test_core.py
@@ -224,3 +224,30 @@ class TestReleaseTagPattern:
         integration = repo.integrations.get('ddev')
 
         assert integration.release_tag_pattern == r'ddev-v\d+\.\d+\.\d+'
+
+
+class TestMetrics:
+    def test_has_metrics(self, fake_repo):
+        integration = fake_repo.integrations.get('dummy')
+
+        metrics = list(integration.metrics)
+        assert len(metrics) == 1
+        metric = metrics[0]
+        assert metric.metric_name == 'dummy.metric'
+        assert metric.metric_type == 'gauge'
+        assert metric.interval == 10
+        assert metric.unit_name == 'seconds'
+        assert metric.per_unit_name == 'object'
+        assert metric.description == 'description'
+        assert metric.orientation == 0
+        assert metric.integration == 'dummy'
+        assert metric.short_name == 'short'
+        assert metric.curated_metric == ''
+
+    def test_has_no_metrics(self, fake_repo):
+        integration = fake_repo.integrations.get('no_metrics')
+        assert not list(integration.metrics)
+
+    def test_has_no_metadata_file(self, fake_repo):
+        integration = fake_repo.integrations.get('no_metadata_file')
+        assert not list(integration.metrics)


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add a script to generate all the metrics for a given integration

### Motivation
<!-- What inspired you to submit this pull request? -->

I wrote a tiny script to do that for an integration to populate some metrics that are sometimes hard to get, so I thought it would be a good idea to add it to ddev.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

The values are randomly generated, but we could do something smarter in the future I think (hackathon?).

For Ray I get this output: 

```
Metric ray.process.cpu_seconds.count with value 73 and type 0
Metric ray.process.max_fds with value 2 and type 3
Metric ray.process.open_fds with value 12 and type 3
Metric ray.process.resident_memory with value 4 and type 3
Metric ray.process.start_time with value 23 and type 3
Metric ray.process.virtual_memory with value 53 and type 3
Metric ray.python.gc.collections.count with value 88 and type 0
Metric ray.python.gc.objects_collected.count with value 77 and type 0
Metric ray.python.gc.objects_uncollectable.count with value 22 and type 0
Metric ray.actors with value 26 and type 3
Metric ray.cluster.active_nodes with value 1 and type 3
Metric ray.cluster.failed_nodes with value 65 and type 3
Metric ray.cluster.pending_nodes with value 53 and type 3
Metric ray.component.cpu_percentage with value 78 and type 3
Metric ray.component.mem_shared with value 8 and type 3
Metric ray.component.rss with value 76 and type 3
Metric ray.component.uss with value 92 and type 3
Metric ray.gcs.actors with value 82 and type 3
Metric ray.gcs.placement_group with value 88 and type 3
Metric ray.gcs.storage_operation.count with value 56 and type 0
Metric ray.gcs.storage_operation.latency.sum with value 5 and type 0
Metric ray.gcs.storage_operation.latency.count with value 6 and type 0
Metric ray.gcs.storage_operation.latency.bucket with value 69 and type 0
Metric ray.gcs.task_manager.task_events.dropped with value 74 and type 3
Metric ray.gcs.task_manager.task_events.reported with value 53 and type 3
Metric ray.gcs.task_manager.task_events.stored with value 88 and type 3
Metric ray.gcs.task_manager.task_events.stored_bytes with value 79 and type 3
Metric ray.grpc_server.req.finished.count with value 34 and type 0
Metric ray.grpc_server.req.handling.count with value 39 and type 0
Metric ray.grpc_server.req.new.count with value 74 and type 0
Metric ray.grpc_server.req.process_time with value 75 and type 3
Metric ray.health_check.rpc_latency.count with value 91 and type 0
Metric ray.health_check.rpc_latency.sum with value 21 and type 0
Metric ray.health_check.rpc_latency.bucket with value 46 and type 0
Metric ray.internal_num.infeasible_scheduling_classes with value 16 and type 3
Metric ray.internal_num.processes.skipped.job_mismatch with value 46 and type 3
Metric ray.internal_num.processes.skipped.runtime_environment_mismatch with value 66 and type 3
Metric ray.internal_num.processes.started with value 55 and type 3
Metric ray.internal_num.processes.started.from_cache with value 78 and type 3
Metric ray.internal_num.spilled_tasks with value 36 and type 3
Metric ray.memory_manager.worker_eviction with value 74 and type 0
Metric ray.node.cpu with value 26 and type 3
Metric ray.node.cpu_utilization with value 78 and type 3
Metric ray.node.disk.free with value 20 and type 3
Metric ray.node.disk.io.read with value 57 and type 3
Metric ray.node.disk.io.read.count with value 62 and type 3
Metric ray.node.disk.io.read.speed with value 48 and type 3
Metric ray.node.disk.io.write with value 75 and type 3
Metric ray.node.disk.io.write.count with value 80 and type 3
Metric ray.node.disk.io.write.speed with value 72 and type 3
Metric ray.node.disk.read.iops with value 46 and type 3
Metric ray.node.disk.usage with value 82 and type 3
Metric ray.node.disk.utilization with value 100 and type 3
Metric ray.node.disk.write.iops with value 26 and type 3
Metric ray.node.gpus_utilization with value 94 and type 3
Metric ray.node.gram_used with value 59 and type 3
Metric ray.node.mem.available with value 57 and type 3
Metric ray.node.mem.shared with value 15 and type 3
Metric ray.node.mem.total with value 14 and type 3
Metric ray.node.mem.used with value 97 and type 3
Metric ray.node.network.receive.speed with value 85 and type 3
Metric ray.node.network.received with value 83 and type 3
Metric ray.node.network.send.speed with value 83 and type 3
Metric ray.node.network.sent with value 41 and type 3
Metric ray.object_directory.added_locations with value 47 and type 3
Metric ray.object_directory.lookups with value 2 and type 3
Metric ray.object_directory.removed_locations with value 32 and type 3
Metric ray.object_directory.subscriptions with value 22 and type 3
Metric ray.object_directory.updates with value 16 and type 3
Metric ray.object_manager.bytes with value 60 and type 3
Metric ray.object_manager.num_pull_requests with value 35 and type 3
Metric ray.object_manager.received_chunks with value 98 and type 3
Metric ray.object_store.available_memory with value 84 and type 3
Metric ray.object_store.size.count with value 47 and type 0
Metric ray.object_store.size.sum with value 21 and type 0
Metric ray.object_store.size.bucket with value 55 and type 0
Metric ray.object_store.fallback_memory with value 82 and type 3
Metric ray.object_store.memory with value 57 and type 3
Metric ray.object_store.num_local_objects with value 46 and type 3
Metric ray.object_store.used_memory with value 22 and type 3
Metric ray.placement_groups with value 93 and type 3
Metric ray.pull_manager.active_bundles with value 53 and type 3
Metric ray.pull_manager.num_object_pins with value 49 and type 3
Metric ray.pull_manager.object_request_time.count with value 37 and type 0
Metric ray.pull_manager.object_request_time.sum with value 19 and type 0
Metric ray.pull_manager.object_request_time.bucket with value 31 and type 0
Metric ray.pull_manager.requested_bundles with value 16 and type 3
Metric ray.pull_manager.requests with value 54 and type 3
Metric ray.pull_manager.retries_total with value 87 and type 3
Metric ray.pull_manager.usage with value 72 and type 3
Metric ray.push_manager.chunks with value 64 and type 3
Metric ray.push_manager.in_flight_pushes with value 15 and type 3
Metric ray.resources with value 1 and type 3
Metric ray.scheduler.failed_worker_startup with value 4 and type 3
Metric ray.scheduler.placement_time.sum with value 83 and type 0
Metric ray.scheduler.placement_time.count with value 4 and type 0
Metric ray.scheduler.placement_time.bucket with value 51 and type 0
Metric ray.scheduler.tasks with value 12 and type 3
Metric ray.scheduler.unscheduleable_tasks with value 43 and type 3
Metric ray.serve.deployment.error with value 76 and type 3
Metric ray.serve.deployment.processing_latency.count with value 2 and type 0
Metric ray.serve.deployment.processing_latency.sum with value 47 and type 0
Metric ray.serve.deployment.processing_latency.bucket with value 44 and type 0
Metric ray.serve.deployment.queued_queries with value 12 and type 3
Metric ray.serve.deployment.replica.healthy with value 58 and type 3
Metric ray.serve.deployment.replica.starts with value 73 and type 3
Metric ray.serve.deployment.request.counter with value 68 and type 3
Metric ray.serve.handle_request with value 49 and type 3
Metric ray.serve.http_request_latency.count with value 22 and type 0
Metric ray.serve.http_request_latency.sum with value 56 and type 0
Metric ray.serve.http_request_latency.bucket with value 98 and type 0
Metric ray.serve.num_deployment_http_error_requests with value 11 and type 3
Metric ray.serve.num_http_error_requests with value 43 and type 3
Metric ray.serve.num_http_requests with value 47 and type 3
Metric ray.serve.num_router_requests with value 25 and type 3
Metric ray.serve.replica.pending_queries with value 43 and type 3
Metric ray.serve.replica.processing_queries with value 0 and type 3
Metric ray.spill_manager.objects with value 15 and type 3
Metric ray.spill_manager.objects_size with value 94 and type 3
Metric ray.spill_manager.request_total with value 26 and type 3
Metric ray.tasks with value 21 and type 3
Metric ray.unintentional_worker_failures.count with value 58 and type 0
Metric ray.worker.register_time.count with value 69 and type 0
Metric ray.worker.register_time.sum with value 5 and type 0
Metric ray.worker.register_time.bucket with value 20 and type 0
Calling the API...
Done.
Sleeping for 10 seconds...
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
