### PR TITLE
Override the default configuration when environment vars are provided in the `env start` command

### DIFF
--- a/ddev/changelog.d/16474.fixed
+++ b/ddev/changelog.d/16474.fixed
@@ -1,0 +1,1 @@
+Override the default configuration when environment vars are provided in the `env start` command

--- a/ddev/src/ddev/cli/env/start.py
+++ b/ddev/src/ddev/cli/env/start.py
@@ -174,7 +174,6 @@ def _get_agent_env_vars(org_config, metadata, extra_env_vars, dogstatsd):
 
     # Use the environment variables defined by tests as defaults so tooling can override them
     env_vars: dict[str, str] = metadata.get('env_vars', {}).copy()
-    env_vars.update(ev.split('=', maxsplit=1) for ev in extra_env_vars)
 
     if api_key := org_config.get('api_key'):
         env_vars['DD_API_KEY'] = api_key
@@ -199,5 +198,7 @@ def _get_agent_env_vars(org_config, metadata, extra_env_vars, dogstatsd):
     # Enable logs Agent by default if the environment is mounting logs
     if any(ev.startswith(E2EEnvVars.LOGS_DIR_PREFIX) for ev in metadata.get(E2EMetadata.ENV_VARS, {})):
         env_vars.setdefault('DD_LOGS_ENABLED', 'true')
+
+    env_vars.update(ev.split('=', maxsplit=1) for ev in extra_env_vars)
 
     return env_vars

--- a/ddev/tests/cli/env/test_start.py
+++ b/ddev/tests/cli/env/test_start.py
@@ -367,6 +367,65 @@ def test_env_vars(ddev, helpers, data_dir, write_result_file, mocker):
     )
 
 
+def test_env_vars_override_config(ddev, helpers, data_dir, write_result_file, mocker):
+    metadata = {'env_vars': {'FOO': 'BAZ', 'BAZ': 'BAR'}}
+    config = {}
+    mocker.patch('subprocess.run', side_effect=write_result_file({'metadata': metadata, 'config': config}))
+    start = mocker.patch('ddev.e2e.agent.docker.DockerAgent.start')
+
+    integration = 'postgres'
+    environment = 'py3.12'
+    env_data = EnvDataStorage(data_dir).get(integration, environment)
+
+    result = ddev(
+        'env',
+        'start',
+        integration,
+        environment,
+        '-e',
+        'FOO=BAR',
+        '-e',
+        'DD_API_KEY=key',
+        '-e',
+        'DD_SITE=site',
+        '-e',
+        'DD_DD_URL=url',
+        '-e',
+        'DD_LOGS_CONFIG_DD_URL=log_config_url',
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output == helpers.dedent(
+        f"""
+        ─────────────────────────────── Starting: py3.12 ───────────────────────────────
+
+        Stop environment -> ddev env stop {integration} {environment}
+        Execute tests -> ddev env test {integration} {environment}
+        Check status -> ddev env agent {integration} {environment} status
+        Trigger run -> ddev env agent {integration} {environment} check
+        Reload config -> ddev env reload {integration} {environment}
+        Manage config -> ddev env config
+        Config file -> {env_data.config_file}
+        """
+    )
+
+    assert env_data.read_config() == {'instances': [config]}
+    assert env_data.read_metadata() == metadata
+
+    start.assert_called_once_with(
+        agent_build='datadog/agent-dev:master',
+        local_packages={},
+        env_vars={
+            'DD_DD_URL': 'url',
+            'DD_SITE': 'site',
+            'FOO': 'BAR',
+            'BAZ': 'BAR',
+            'DD_LOGS_CONFIG_DD_URL': 'log_config_url',
+            'DD_API_KEY': 'key',
+        },
+    )
+
+
 def test_logs_detection(ddev, helpers, data_dir, write_result_file, mocker):
     metadata = {E2EMetadata.ENV_VARS: {f'{E2EEnvVars.LOGS_DIR_PREFIX}1': 'path'}}
     config = {}


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Override the default configuration when environment vars are provided in the `env start` command

### Motivation
<!-- What inspired you to submit this pull request? -->

CLI params should take precedence

### Additional Notes
<!-- Anything else we should know when reviewing? -->

https://datadoghq.atlassian.net/browse/AITS-323

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
