### PR TITLE
Add endpoint tag to legacy

### DIFF
--- a/envoy/changelog.d/16478.added
+++ b/envoy/changelog.d/16478.added
@@ -1,0 +1,1 @@
+Add a `endpoint` tag to every metric in the legacy version of the check

--- a/envoy/datadog_checks/envoy/envoy.py
+++ b/envoy/datadog_checks/envoy/envoy.py
@@ -53,6 +53,8 @@ class Envoy(AgentCheck):
         if self.stats_url is None:
             raise ConfigurationError('Envoy configuration setting `stats_url` is required')
 
+        self.custom_tags.append("endpoint:{}".format(self.stats_url))
+
         included_metrics = {
             re.sub(r'^envoy\\?\.', '', s, 1)
             for s in self.instance.get(

--- a/envoy/tests/legacy/test_integration.py
+++ b/envoy/tests/legacy/test_integration.py
@@ -28,11 +28,11 @@ def test_success(aggregator, check, dd_run_check):
         if collected_metrics and collected_metrics[0].name not in UNIQUE_METRICS:
             expected_tags = [t for t in METRICS[metric]['tags'] if t]
             for tag_set in expected_tags:
-            # Iterate over the expected tags and check that they're present in the collected_metric's tags.
-            # We iterate over each collected metric and we see if the metric has more than 1 tag. If it does, we
-            # iterate over each tag attached to the metric to see if the tags are in the tag_set of expected_tags.
-            # Since an endpoint tag is added to each metric, checking for the metric specific tags parsed from the
-            # metric, should only be done if the metric has more tags than just the endpoint tag.
+                # Iterate over the expected tags and check that they're present in the collected_metric's tags.
+                # We iterate over each collected metric and we see if the metric has more than 1 tag. If it does, we
+                # iterate over each tag attached to the metric to see if the tags are in the tag_set of expected_tags.
+                # Since an endpoint tag is added to each metric, checking for the metric specific tags parsed from the
+                # metric, should only be done if the metric has more tags than just the endpoint tag.
                 assert all(
                     all(any(tag in mt for mt in m.tags) for tag in tag_set)
                     for m in collected_metrics

--- a/envoy/tests/legacy/test_integration.py
+++ b/envoy/tests/legacy/test_integration.py
@@ -28,11 +28,11 @@ def test_success(aggregator, check, dd_run_check):
         if collected_metrics and collected_metrics[0].name not in UNIQUE_METRICS:
             expected_tags = [t for t in METRICS[metric]['tags'] if t]
             for tag_set in expected_tags:
-                # Iterate over the expected tags and check that they're present in the collect_metric's tags.
-                # We iterate over each collected metric and we see if the metric has more than 1 tag. If it does, we
-                # iterate over each tag attached to the metric to see if the tags are in the tag_set.
-                # Since an endpoint tag is added to each metric, checking for the metric specific tags parsed from the
-                # metric, should only be done if has more than the endpoint tag.
+            # Iterate over the expected tags and check that they're present in the collected_metric's tags.
+            # We iterate over each collected metric and we see if the metric has more than 1 tag. If it does, we
+            # iterate over each tag attached to the metric to see if the tags are in the tag_set of expected_tags.
+            # Since an endpoint tag is added to each metric, checking for the metric specific tags parsed from the
+            # metric, should only be done if the metric has more tags than just the endpoint tag.
                 assert all(
                     all(any(tag in mt for mt in m.tags) for tag in tag_set)
                     for m in collected_metrics

--- a/envoy/tests/legacy/test_integration.py
+++ b/envoy/tests/legacy/test_integration.py
@@ -28,9 +28,17 @@ def test_success(aggregator, check, dd_run_check):
         if collected_metrics and collected_metrics[0].name not in UNIQUE_METRICS:
             expected_tags = [t for t in METRICS[metric]['tags'] if t]
             for tag_set in expected_tags:
+                # Iterate over the expected tags and check that they're present in the collect_metric's tags.
+                # We iterate over each collected metric and we see if the metric has more than 1 tag. If it does, we
+                # iterate over each tag attached to the metric to see if the tags are in the tag_set.
+                # Since an endpoint tag is added to each metric, checking for the metric specific tags parsed from the
+                # metric, should only be done if has more than the endpoint tag.
                 assert all(
-                    all(any(tag in mt for mt in m.tags) for tag in tag_set) for m in collected_metrics if m.tags
+                    all(any(tag in mt for mt in m.tags) for tag in tag_set)
+                    for m in collected_metrics
+                    if len(m.tags) > 1
                 ), ('tags ' + str(expected_tags) + ' not found in ' + metric)
+
         metrics_collected += len(collected_metrics)
     assert metrics_collected >= 445
 

--- a/envoy/tests/legacy/test_unit.py
+++ b/envoy/tests/legacy/test_unit.py
@@ -286,8 +286,8 @@ def test_stats_prefix_optional_tags(
     additional_tags,
 ):
     instance = INSTANCES['main']
-    tags = standard_tags.append('endpoint:{}'.format(instance["stats_url"]))
-    tags_prefix = tags + additional_tags
+    standard_tags.append('endpoint:{}'.format(instance["stats_url"]))
+    tags_prefix = standard_tags + additional_tags
     c = check(instance)
     mock_http_response(file_path=fixture_path(fixture_file)).return_value
     dd_run_check(c)
@@ -301,7 +301,7 @@ def test_stats_prefix_optional_tags(
             value=index + len(metrics),
             tags=tags_prefix,
         )
-        aggregator.assert_metric(metric, value=index, tags=tags)
+        aggregator.assert_metric(metric, value=index, tags=standard_tags)
 
 
 def test_local_rate_limit_metrics(aggregator, fixture_path, mock_http_response, check, dd_run_check):

--- a/envoy/tests/legacy/test_unit.py
+++ b/envoy/tests/legacy/test_unit.py
@@ -256,7 +256,12 @@ def test_metadata_not_collected(datadog_agent, check):
 @pytest.mark.parametrize(
     ('fixture_file', 'metrics', 'standard_tags', 'additional_tags'),
     [
-        ('./legacy/stat_prefix', EXT_METRICS, ['cluster_name:foo', 'envoy_cluster:foo'], ['stat_prefix:bar']),
+        (
+            './legacy/stat_prefix',
+            EXT_METRICS,
+            ['cluster_name:foo', 'envoy_cluster:foo'],
+            ['stat_prefix:bar'],
+        ),
         (
             './legacy/rbac_metric.txt',
             RBAC_METRICS,
@@ -269,7 +274,7 @@ def test_metadata_not_collected(datadog_agent, check):
         "rbac_prefix_shadow",
     ],
 )
-def test_stats_prefix_ext_auth(
+def test_stats_prefix_optional_tags(
     aggregator,
     fixture_path,
     mock_http_response,
@@ -281,7 +286,7 @@ def test_stats_prefix_ext_auth(
     additional_tags,
 ):
     instance = INSTANCES['main']
-    tags = standard_tags
+    tags = standard_tags.append('endpoint:{}'.format(instance["stats_url"]))
     tags_prefix = tags + additional_tags
     c = check(instance)
     mock_http_response(file_path=fixture_path(fixture_file)).return_value


### PR DESCRIPTION
### What does this PR do?
Add the a endpoint tag to the legacy version of the envoy check. 

### Motivation:
While going over the check, I notice that the OpenMetricsV2 implementation has a useful endpoint check. The legacy version however lacks this check. This can cause problems if a single agent were to monitor different stats_url endpoints. There might be no way to distinguish them from one another. 

```
  envoy.server.state                                         gauge  1703021786  0                                                                  
  envoy.server.total_connections                             gauge  1703021786  0                                                                  
  envoy.server.uptime                                        gauge  1703021786  160                                                                
  envoy.server.version                                       gauge  1703021786  10011081    
  ```
  
  to this:
  
  ```
  envoy.server.state                                         gauge  1703087799  0                     endpoint:http://localhost:8001/stats         
  envoy.server.total_connections                             gauge  1703087799  0                     endpoint:http://localhost:8001/stats         
  envoy.server.uptime                                        gauge  1703087799  350                   endpoint:http://localhost:8001/stats         
  envoy.server.version                                       gauge  1703087799  10011081              endpoint:http://localhost:8001/stats 
  ```

Additional changes:
Added papertrail comment in regards to one of the tests.
