### PR TITLE
conditionally enable memory profile for DBMAsyncJob

### DIFF
--- a/datadog_checks_base/changelog.d/16479.added
+++ b/datadog_checks_base/changelog.d/16479.added
@@ -1,0 +1,1 @@
+conditionally enable memory profile for DBMAsyncJob

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -313,11 +313,11 @@ class DBMAsyncJob(object):
                         self._run_job_rate_limited, self._check.init_config, namespaces=[self._check.name, self._job_name],
                     )
 
-                    tags = self._check.get_debug_metric_tags()
-                    tags.append("job_name:{}".format(self._job_name))
+                    tags = self._check.get_debug_metric_tags() + self._job_tags
                     tags.extend(self._check.instance.get('__memory_profiling_tags', []))
                     for m in metrics:
                         self._check.gauge(m.name, m.value, tags=tags, raw=True)
+                    self._check.count("dd.{}.async_job.run".format(self._dbms), 1, tags=self._job_tags, raw=True)
                 else:
                     self._run_job_rate_limited()
         except Exception as e:

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -310,7 +310,9 @@ class DBMAsyncJob(object):
                     from datadog_checks.base.utils.agent.memory import profile_memory
 
                     metrics = profile_memory(
-                        self._run_job_rate_limited, self._check.init_config, namespaces=[self._check.name, self._job_name],
+                        self._run_job_rate_limited,
+                        self._check.init_config,
+                        namespaces=[self._check.name, self._job_name],
                     )
 
                     tags = self._check.get_debug_metric_tags() + self._job_tags

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -19,7 +19,6 @@ from cachetools import TTLCache
 
 from datadog_checks.base import is_affirmative
 from datadog_checks.base.log import get_check_logger
-from datadog_checks.base.utils.agent.utils import should_profile_memory
 from datadog_checks.base.utils.db.types import Transformer  # noqa: F401
 from datadog_checks.base.utils.serialization import json
 from datadog_checks.base.utils.tracing import INTEGRATION_TRACING_SERVICE_NAME, tracing_enabled
@@ -304,21 +303,12 @@ class DBMAsyncJob(object):
                         "dd.{}.async_job.inactive_stop".format(self._dbms), 1, tags=self._job_tags, raw=True
                     )
                     break
-                if 'profile_memory' in self._check.init_config or (
-                    datadog_agent.tracemalloc_enabled() and should_profile_memory(datadog_agent, self._check.name)
-                ):
-                    from datadog_checks.base.utils.agent.memory import profile_memory
-
-                    metrics = profile_memory(
+                if self._check.should_profile_memory():
+                    self._check.profile_memory(
                         self._run_job_rate_limited,
-                        self._check.init_config,
                         namespaces=[self._check.name, self._job_name],
+                        extra_tags=self._job_tags,
                     )
-
-                    tags = self._check.get_debug_metric_tags() + self._job_tags
-                    tags.extend(self._check.instance.get('__memory_profiling_tags', []))
-                    for m in metrics:
-                        self._check.gauge(m.name, m.value, tags=tags, raw=True)
                 else:
                     self._run_job_rate_limited()
         except Exception as e:

--- a/datadog_checks_base/datadog_checks/base/utils/db/utils.py
+++ b/datadog_checks_base/datadog_checks/base/utils/db/utils.py
@@ -319,7 +319,6 @@ class DBMAsyncJob(object):
                     tags.extend(self._check.instance.get('__memory_profiling_tags', []))
                     for m in metrics:
                         self._check.gauge(m.name, m.value, tags=tags, raw=True)
-                    self._check.count("dd.{}.async_job.run".format(self._dbms), 1, tags=self._job_tags, raw=True)
                 else:
                     self._run_job_rate_limited()
         except Exception as e:

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -9,6 +9,7 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from ipaddress import IPv4Address
 
 import mock
+from datadog_checks.base.utils.agent.memory import MemoryProfileMetric
 import pytest
 
 from datadog_checks.base import AgentCheck
@@ -259,6 +260,14 @@ def test_dbm_async_job_inactive_stop(aggregator):
     job.run_job_loop([])
     job._job_loop_future.result()
     aggregator.assert_metric("dd.test-dbms.async_job.inactive_stop", tags=['job:test-job'])
+
+
+def test_dbm_async_job_profile_memory(aggregator):
+    check = AgentCheck(name="testcheck", init_config={"profile_memory": "/tmp"}, instance={})
+    job = TestJob(check)
+    job.run_job_loop([])
+    dummy_memory_profile_metric = MemoryProfileMetric('check_run_alloc', 0)
+    aggregator.assert_metric(dummy_memory_profile_metric.name)
 
 
 @pytest.mark.parametrize(

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -263,9 +263,10 @@ def test_dbm_async_job_inactive_stop(aggregator):
 
 def test_dbm_async_job_profile_memory(aggregator):
     check = AgentCheck(name="testcheck", init_config={"profile_memory": "/tmp"}, instances=[{}])
-    job = TestJob(check)
+    # the job will run for 1 second and then stop due to inactive,
+    # but this is enough to test the memory profiling
+    job = TestJob(check, rate_limit=10, min_collection_interval=1)
     job.run_job_loop([])
-    job.cancel()
     job._job_loop_future.result()
     # memory profile metrics are ignored when running in tests
     # we will assert the async_job.run metric instead

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -9,7 +9,6 @@ from concurrent.futures.thread import ThreadPoolExecutor
 from ipaddress import IPv4Address
 
 import mock
-from datadog_checks.base.utils.agent.memory import MemoryProfileMetric
 import pytest
 
 from datadog_checks.base import AgentCheck

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -263,11 +263,14 @@ def test_dbm_async_job_inactive_stop(aggregator):
 
 
 def test_dbm_async_job_profile_memory(aggregator):
-    check = AgentCheck(name="testcheck", init_config={"profile_memory": "/tmp"}, instance={})
+    check = AgentCheck(name="testcheck", init_config={"profile_memory": "/tmp"}, instances=[{}])
     job = TestJob(check)
     job.run_job_loop([])
-    dummy_memory_profile_metric = MemoryProfileMetric('check_run_alloc', 0)
-    aggregator.assert_metric(dummy_memory_profile_metric.name)
+    job.cancel()
+    job._job_loop_future.result()
+    # memory profile metrics are ignored when running in tests
+    # we will assert the async_job.run metric instead
+    aggregator.assert_metric("dd.test-dbms.async_job.run", tags=['job:test-job'])
 
 
 @pytest.mark.parametrize(

--- a/datadog_checks_base/tests/base/utils/db/test_util.py
+++ b/datadog_checks_base/tests/base/utils/db/test_util.py
@@ -261,18 +261,6 @@ def test_dbm_async_job_inactive_stop(aggregator):
     aggregator.assert_metric("dd.test-dbms.async_job.inactive_stop", tags=['job:test-job'])
 
 
-def test_dbm_async_job_profile_memory(aggregator):
-    check = AgentCheck(name="testcheck", init_config={"profile_memory": "/tmp"}, instances=[{}])
-    # the job will run for 1 second and then stop due to inactive,
-    # but this is enough to test the memory profiling
-    job = TestJob(check, rate_limit=10, min_collection_interval=1)
-    job.run_job_loop([])
-    job._job_loop_future.result()
-    # memory profile metrics are ignored when running in tests
-    # we will assert the async_job.run metric instead
-    aggregator.assert_metric("dd.test-dbms.async_job.run", tags=['job:test-job'])
-
-
 @pytest.mark.parametrize(
     "input",
     [


### PR DESCRIPTION
### What does this PR do?
This PR adds memory profiling to DBMAsyncJob when `profile_memory` is set in check `init_config`. 
The implementation follows the same memory profile [implementation](https://github.com/DataDog/integrations-core/blob/ae4f42ae63a774b7c8c1ea9407d9f5b9a69d1143/datadog_checks_base/datadog_checks/base/checks/base.py#L1221) in check run. 
When memory profiling is enabled, `datadog.agent.profile.memory.check_run_alloc` will be available for DBM async jobs. 

<img width="1174" alt="image" src="https://github.com/DataDog/integrations-core/assets/4964070/8bb8fb80-7bc2-48cd-9734-41e467d13c38">

Memory snapshots & diffs will also be produced per async job on the agent host.
![image](https://github.com/DataDog/integrations-core/assets/4964070/ef8a240f-0bd9-423f-8340-8dd3e486fd84)

### Motivation
The `memory_profile` debug feature is enabled only for check main thread that executes `run` function. During #incident-24014, we manually added [tracemalloc](https://github.com/DataDog/integrations-core/compare/7.49.x...justindd/postgres-tracemalloc-749) to the DBM async threads to trace memory usages. it will be great to support `memory_profile` for the DBM threads OOTB.

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
