### PR TITLE
Add an action to automatically update the agent changelog after a release

### DIFF
--- a/.github/workflows/update-agent-changelog.yml
+++ b/.github/workflows/update-agent-changelog.yml
@@ -69,4 +69,4 @@ jobs:
         labels: bot,qa/skip-qa
         draft: true
       env:
-        AGENT_VERSION: ${{ github.ref_name }}"
+        AGENT_VERSION: ${{ github.ref_name }}

--- a/.github/workflows/update-agent-changelog.yml
+++ b/.github/workflows/update-agent-changelog.yml
@@ -1,0 +1,71 @@
+name: Update the Agent changelog
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  update_agent_changelog:
+    name: Update the Agent Changelog
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: master
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    - name: Install ddev from local folder
+      run: |-
+        pip install -e ./datadog_checks_dev[cli]
+        pip install -e ./ddev
+    - name: Configure ddev
+      run: |-
+        ddev config set repos.core .
+        ddev config set repo core
+    - name: Update the Agent changelog
+      run: |-
+        ddev release agent changelog --write --force
+    - name: Update the Agent integrations file
+      run: |-
+        ddev release agent integrations --write --force
+    - name: Update the integration changelogs
+      run: |-
+        ddev release agent integrations-changelog --write
+    - name: Create Pull Request
+      id: cpr
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.DD_CHANGELOG_CHECK_TOKEN }}
+        commit-message: Finalize Agent release ${{ env.AGENT_VERSION }}
+        body: |
+          ### What does this PR do?
+          Finalize Agent release ${{ env.AGENT_VERSION }} updating the changelog files.
+
+          ### Motivation
+          
+          Agent ${{ env.AGENT_VERSION }} has been released.
+
+          ### Additional Notes
+          <!-- Anything else we should know when reviewing? -->
+          
+          This PR was automatically generated because the tag `${{ env.AGENT_VERSION }}` has been created.
+
+          ### Review checklist (to be filled by reviewers)
+
+          - [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
+          - [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
+          - [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
+        title: Finalize Agent release ${{ env.AGENT_VERSION }}
+        branch: bot/update-agent-changelog-${{ env.AGENT_VERSION }}
+        branch-suffix: timestamp
+        delete-branch: true
+        base: master
+        labels: bot,qa/skip-qa
+        draft: true
+      env:
+        AGENT_VERSION: ${{ github.ref_name }}"

--- a/.github/workflows/update-agent-changelog.yml
+++ b/.github/workflows/update-agent-changelog.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
 
 jobs:
   update_agent_changelog:

--- a/.github/workflows/update-agent-changelog.yml
+++ b/.github/workflows/update-agent-changelog.yml
@@ -54,12 +54,6 @@ jobs:
           <!-- Anything else we should know when reviewing? -->
           
           This PR was automatically generated.
-
-          ### Review checklist (to be filled by reviewers)
-
-          - [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
-          - [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
-          - [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
         title: Finalize Agent release ${{ env.AGENT_VERSION }}
         branch: bot/update-agent-changelog-${{ env.AGENT_VERSION }}
         branch-suffix: timestamp

--- a/.github/workflows/update-agent-changelog.yml
+++ b/.github/workflows/update-agent-changelog.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-  pull_request:
 
 jobs:
   update_agent_changelog:
@@ -67,6 +66,6 @@ jobs:
         delete-branch: true
         base: master
         labels: bot,qa/skip-qa
-        draft: true
+        draft: false
       env:
         AGENT_VERSION: ${{ github.ref_name }}

--- a/.github/workflows/update-agent-changelog.yml
+++ b/.github/workflows/update-agent-changelog.yml
@@ -53,7 +53,7 @@ jobs:
           ### Additional Notes
           <!-- Anything else we should know when reviewing? -->
           
-          This PR was automatically generated because the tag `${{ env.AGENT_VERSION }}` has been created.
+          This PR was automatically generated.
 
           ### Review checklist (to be filled by reviewers)
 


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Add an action to automatically update the agent changelog after a release. This job is triggered when the agent tag is pushed by the RM

### Motivation
<!-- What inspired you to submit this pull request? -->

When the Agent gets released, we create a new tag in integrations-core and then update the changelog. Having a job that does it automatically will save us a bit of time and will be less error prone. 

### Additional Notes
<!-- Anything else we should know when reviewing? -->

I created https://github.com/DataDog/integrations-core/pull/16491 from this PR (and edited the tag name because this PR is not merged yet)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
