### PR TITLE
Update the CHANGELOG file for packages in the `integrations-changelog` command

### DIFF
--- a/ddev/changelog.d/16492.fixed
+++ b/ddev/changelog.d/16492.fixed
@@ -1,0 +1,1 @@
+Update the README file for packages in the `integrations-changelog` command

--- a/ddev/src/ddev/cli/release/agent/integrations_changelog.py
+++ b/ddev/src/ddev/cli/release/agent/integrations_changelog.py
@@ -37,7 +37,7 @@ def integrations_changelog(app: Application, integrations: tuple[str], since: st
 
     # Process all checks if no check is passed
     if not integrations:
-        integrations = [integration.name for integration in app.repo.integrations.iter('all')]
+        integrations = [integration.name for integration in app.repo.integrations.iter_all('all')]
 
     changes_per_agent = get_changes_per_agent(app.repo, since, to)
 

--- a/ddev/tests/cli/release/agent/conftest.py
+++ b/ddev/tests/cli/release/agent/conftest.py
@@ -40,12 +40,16 @@ def repo_with_history(tmp_path_factory):
     write_agent_requirements(repo.path, ["datadog-onlywin==1.0.0; sys_platform == 'win32'"])
     commit('fourth')
     repo.git.run('tag', '7.40.0')
+    write_agent_requirements(repo.path, ["datadog-checks-downloader==4.0.0"])
+    commit('fifth')
+    repo.git.run('tag', '7.41.0')
 
     # Satisfy manifest requirements
     write_dummy_manifest(repo.path, 'foo')
     write_dummy_manifest(repo.path, 'bar')
     write_dummy_manifest(repo.path, 'onlywin')
-    write_dummy_manifest(repo.path, 'datadog_checks_base')
+    write_dummy_pyproject(repo.path, 'datadog_checks_downloader')
+    write_dummy_pyproject(repo.path, 'datadog_checks_base')
 
     yield repo
 
@@ -68,3 +72,23 @@ def write_dummy_manifest(repo_path, integration):
             },
             f,
         )
+
+
+def write_dummy_pyproject(repo_path, integration):
+    (repo_path / integration).mkdir(exist_ok=True)
+
+    file = repo_path / integration / 'pyproject.toml'
+    file.write_text(
+        f"""[project]
+name = "{integration}"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: BSD License",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.12",
+]
+    """
+    )

--- a/ddev/tests/cli/release/agent/test_changelog.py
+++ b/ddev/tests/cli/release/agent/test_changelog.py
@@ -70,8 +70,13 @@ def test_changelog_since_to(fake_changelog, ddev, mocker):
 def repo_with_fake_changelog(repo_with_history, config_file):
     config_file.model.repos['core'] = str(repo_with_history.path)
     config_file.save()
+    # ruff: noqa: E501
     expected_output = (
         """
+## Datadog Agent version [7.41.0](https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7410)
+
+* datadog_checks_downloader [4.0.0](https://github.com/DataDog/integrations-core/blob/master/datadog_checks_downloader/CHANGELOG.md)
+
 ## Datadog Agent version [7.40.0](https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7400)
 
 * onlywin [1.0.0](https://github.com/DataDog/integrations-core/blob/master/onlywin/CHANGELOG.md)

--- a/ddev/tests/cli/release/agent/test_integrations.py
+++ b/ddev/tests/cli/release/agent/test_integrations.py
@@ -58,6 +58,10 @@ def repo_with_fake_integrations(repo_with_history, config_file):
     config_file.model.repos['core'] = str(repo_with_history.path)
     config_file.save()
     expected_output = """
+## Datadog Agent version 7.41.0
+
+* datadog-checks-downloader: 4.0.0
+
 ## Datadog Agent version 7.40.0
 
 * datadog-onlywin: 1.0.0

--- a/ddev/tests/cli/release/agent/test_integrations_changelog.py
+++ b/ddev/tests/cli/release/agent/test_integrations_changelog.py
@@ -9,7 +9,14 @@ def test_integrations_changelog_without_arguments(fake_changelogs, ddev):
     result = ddev('release', 'agent', 'integrations-changelog')
 
     assert result.exit_code == 0
-    expected_output = '\n'.join([fake_changelogs['bar'], fake_changelogs['foo']])
+    expected_output = '\n'.join(
+        [
+            fake_changelogs['datadog_checks_downloader'],
+            fake_changelogs['bar'],
+            fake_changelogs['datadog_checks_base'],
+            fake_changelogs['foo'],
+        ]
+    )
     assert result.output.rstrip('\n') == expected_output.rstrip('\n')
 
 
@@ -29,6 +36,12 @@ def test_integrations_changelog_write(repo_with_fake_changelogs, ddev):
 
     with open(repo.path / 'bar' / 'CHANGELOG.md') as f:
         assert f.read().rstrip('\n') == fake_changelogs['bar'].rstrip('\n')
+
+    with open(repo.path / 'datadog_checks_base' / 'CHANGELOG.md') as f:
+        assert f.read().rstrip('\n') == fake_changelogs['datadog_checks_base'].rstrip('\n')
+
+    with open(repo.path / 'datadog_checks_downloader' / 'CHANGELOG.md') as f:
+        assert f.read().rstrip('\n') == fake_changelogs['datadog_checks_downloader'].rstrip('\n')
 
 
 @pytest.fixture
@@ -69,11 +82,33 @@ def repo_with_fake_changelogs(repo_with_history, config_file):
 * Remove unused `metric_prefix` in init_config ([#11464](https://github.com/DataDog/integrations-core/pull/11464))
 """
     )
+    (repo_root / 'datadog_checks_downloader' / 'CHANGELOG.md').write_text(
+        """# CHANGELOG - datadog_checks_downloader
+## 4.0.0 / 2022-11-16
+
+***Added***:
+
+* Upgrade dependencies ([#11726](https://github.com/DataDog/integrations-core/pull/11726))
+"""
+    )
+    (repo_root / 'datadog_checks_base' / 'CHANGELOG.md').write_text(
+        """# CHANGELOG - datadog_checks_base
+## 3.0.0 / 2022-11-16
+
+***Added***:
+
+* Upgrade dependencies ([#11726](https://github.com/DataDog/integrations-core/pull/11726))
+"""
+    )
     # Turn 'foo' and 'bar' into *valid checks* by giving them an __about__.py file in the right location
     (repo_root / 'foo' / 'datadog_checks' / 'foo').mkdir(parents=True)
     (repo_root / 'foo' / 'datadog_checks' / 'foo' / '__about__.py').touch()
     (repo_root / 'bar' / 'datadog_checks' / 'bar').mkdir(parents=True)
     (repo_root / 'bar' / 'datadog_checks' / 'bar' / '__about__.py').touch()
+    (repo_root / 'datadog_checks_downloader' / 'datadog_checks' / 'downloader').mkdir(parents=True)
+    (repo_root / 'datadog_checks_downloader' / 'datadog_checks' / 'downloader' / '__about__.py').touch()
+    (repo_root / 'datadog_checks_base' / 'datadog_checks' / 'base').mkdir(parents=True)
+    (repo_root / 'datadog_checks_base' / 'datadog_checks' / 'base' / '__about__.py').touch()
 
     # The fixture's value is a dictionary with the expected values for each integration
     expected_changelogs = {
@@ -102,6 +137,20 @@ def repo_with_fake_changelogs(repo_with_history, config_file):
 ***Fixed***:
 
 * Remove unused `metric_prefix` in init_config ([#11464](https://github.com/DataDog/integrations-core/pull/11464))
+""",
+        'datadog_checks_downloader': """# CHANGELOG - datadog_checks_downloader
+## 4.0.0 / 2022-11-16 / Agent 7.41.0
+
+***Added***:
+
+* Upgrade dependencies ([#11726](https://github.com/DataDog/integrations-core/pull/11726))
+""",
+        'datadog_checks_base': """# CHANGELOG - datadog_checks_base
+## 3.0.0 / 2022-11-16 / Agent 7.39.0
+
+***Added***:
+
+* Upgrade dependencies ([#11726](https://github.com/DataDog/integrations-core/pull/11726))
 """,
     }
     return repo_with_history, expected_changelogs


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Update the CHANGELOG file for packages in the `integrations-changelog` command

### Motivation
<!-- What inspired you to submit this pull request? -->

`iter('all')` returns [`integrations`](https://github.com/DataDog/integrations-core/blob/b10e1e0bd7b41cc54f2074cd82851843e881685a/ddev/src/ddev/repo/core.py#L93-L99), which should [contain a manifest](https://github.com/DataDog/integrations-core/blob/master/ddev/src/ddev/integration/core.py#L154). The base check and the downloader don't have any but they should be updated as well since they have a README. We must use `iter_all` instead since they are [`valid`](https://github.com/DataDog/integrations-core/blob/b10e1e0bd7b41cc54f2074cd82851843e881685a/ddev/src/ddev/repo/core.py#L101-L107) (in the `ddev` sense because [they are packaged or have a manifest](https://github.com/DataDog/integrations-core/blob/master/ddev/src/ddev/integration/core.py#L151))

### Additional Notes
<!-- Anything else we should know when reviewing? -->

https://datadoghq.atlassian.net/browse/AITS-285

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
