### PR TITLE
Fix TypeError when tags are undefined

### DIFF
--- a/amazon_msk/changelog.d/16496.fixed
+++ b/amazon_msk/changelog.d/16496.fixed
@@ -1,0 +1,1 @@
+Fix TypeError when tags are undefined

--- a/amazon_msk/datadog_checks/amazon_msk/check.py
+++ b/amazon_msk/datadog_checks/amazon_msk/check.py
@@ -152,7 +152,9 @@ class AmazonMskCheckV2(OpenMetricsBaseCheckV2, ConfigMixin):
             self.log.info('No `region_name` was set, defaulting to `%s` based on the `cluster_arn`', self._region_name)
 
         self._static_tags = (f'cluster_arn:{self.config.cluster_arn}', f'region_name:{self._region_name}')
-        self._service_check_tags = self._static_tags + self.config.tags
+        self._service_check_tags = self._static_tags
+        if self.config.tags:
+            self._service_check_tags += self.config.tags
 
         self._endpoint_prefix = 'https' if self.config.tls_verify else 'http'
         self._exporter_data = (


### PR DESCRIPTION
### What does this PR do?
<!-- A brief description of the change being made with this pull request. -->

Avoid `TypeError`.

### Motivation
<!-- What inspired you to submit this pull request? -->

To Fix this error when `tags` are not defined in `/etc/datadog-agent/conf.d/amazon_msk.d/conf.yaml`.

```
    amazon_msk (4.3.0)
    ------------------
      Instance ID: amazon_msk:3ae8d89697858242 [ERROR]
      Configuration Source: file:/etc/datadog-agent/conf.d/amazon_msk.d/conf.yaml
      Total Runs: 2
      Metric Samples: Last Run: 0, Total: 0
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 0, Total: 0
      Average Execution Time : 1ms
      Last Execution Date : 2023-12-26 11:16:40 UTC (1703589400000)
      Last Successful Execution Date : Never
      Error: can only concatenate tuple (not "NoneType") to tuple
      Traceback (most recent call last):
        File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/datadog_checks/base/checks/base.py", line 1210, in run
          initialization()
        File "/opt/datadog-agent/embedded/lib/python3.9/site-packages/datadog_checks/amazon_msk/check.py", line 155, in parse_config
          self._service_check_tags = self._static_tags + self.config.tags
      TypeError: can only concatenate tuple (not "NoneType") to tuple
```

### Additional Notes
<!-- Anything else we should know when reviewing? -->

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] [Changelog entries](https://datadoghq.dev/integrations-core/guidelines/pr/#changelog-entries) must be created for modifications to shipped code
- [ ] Add the `qa/skip-qa` label if the PR doesn't need to be tested during QA.
